### PR TITLE
fix(mcp): answer form-mode elicitations with the schema's required fields

### DIFF
--- a/tests/tools/test_elicitation_form_content.py
+++ b/tests/tools/test_elicitation_form_content.py
@@ -1,0 +1,125 @@
+"""Form-mode elicitation answers: schema resolution + affirmative form filling.
+
+Servers such as Microsoft's powerbi-modeling-mcp gate write operations behind a
+form-mode elicitation whose required field must literally carry the affirmative
+enum value (e.g. {"Confirm the operation": "Yes"}). These tests cover the two
+failure modes that made every user-approved write come back "declined":
+
+1. the SDK field is camelCase (``ElicitRequestFormParams.requestedSchema``) —
+   reading ``requested_schema`` silently yielded an empty schema;
+2. ``action="accept"`` was returned with ``content={}`` — an empty form, which
+   such servers treat as unconfirmed.
+"""
+
+import asyncio
+
+import pytest
+
+from tools.mcp_tool import _affirmative_form_content
+
+PBI_CONFIRM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "Confirm the operation": {
+            "type": "string",
+            "description": "Confirm the operation",
+            "enum": ["Yes", "No"],
+        }
+    },
+    "required": ["Confirm the operation"],
+}
+
+
+def test_fills_required_enum_with_affirmative():
+    assert _affirmative_form_content(PBI_CONFIRM_SCHEMA) == {
+        "Confirm the operation": "Yes"
+    }
+
+
+def test_empty_or_invalid_schema_yields_empty_content():
+    assert _affirmative_form_content({}) == {}
+    assert _affirmative_form_content(None) == {}
+    assert _affirmative_form_content({"properties": {}}) == {}
+    assert _affirmative_form_content({"properties": "not-a-dict"}) == {}
+
+
+def test_boolean_and_freetext_required_fields():
+    schema = {
+        "properties": {"ok": {"type": "boolean"}, "note": {"type": "string"}},
+        "required": ["ok", "note"],
+    }
+    assert _affirmative_form_content(schema) == {"ok": True, "note": "Yes"}
+
+
+def test_only_required_fields_are_filled():
+    schema = {
+        "properties": {
+            "Confirm": {"enum": ["Yes", "No"]},
+            "optional_note": {"type": "string"},
+        },
+        "required": ["Confirm"],
+    }
+    assert _affirmative_form_content(schema) == {"Confirm": "Yes"}
+
+
+def test_missing_required_list_treats_all_properties_as_required():
+    schema = {
+        "properties": {
+            "Proceed": {"enum": ["Continue the operation", "Decline the operation"]}
+        }
+    }
+    # No affirmative keyword matches the long labels -> first enum entry wins.
+    assert _affirmative_form_content(schema) == {"Proceed": "Continue the operation"}
+
+
+def test_accept_path_reads_camelcase_schema_and_fills_form(monkeypatch):
+    """End-to-end through ElicitationHandler.__call__ with real SDK types."""
+    mcp_types = pytest.importorskip("mcp.types")
+
+    import tools.approval as approval
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        approval, "request_elicitation_consent", lambda *a, **k: "accept"
+    )
+
+    handler = mcp_tool.ElicitationHandler.__new__(mcp_tool.ElicitationHandler)
+    handler.server_name = "powerbi"
+    handler.timeout = 5
+    handler.owner = None
+    handler.metrics = {"requests": 0, "accepted": 0, "declined": 0, "errors": 0}
+
+    params = mcp_types.ElicitRequestFormParams(
+        mode="form",
+        message="Are you sure you want to perform operations that will modify your database?",
+        requestedSchema=PBI_CONFIRM_SCHEMA,
+    )
+
+    result = asyncio.run(handler(None, params))
+    assert result.action == "accept"
+    assert result.content == {"Confirm the operation": "Yes"}
+
+
+def test_declined_consent_returns_no_content(monkeypatch):
+    mcp_types = pytest.importorskip("mcp.types")
+
+    import tools.approval as approval
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        approval, "request_elicitation_consent", lambda *a, **k: "decline"
+    )
+
+    handler = mcp_tool.ElicitationHandler.__new__(mcp_tool.ElicitationHandler)
+    handler.server_name = "powerbi"
+    handler.timeout = 5
+    handler.owner = None
+    handler.metrics = {"requests": 0, "accepted": 0, "declined": 0, "errors": 0}
+
+    params = mcp_types.ElicitRequestFormParams(
+        mode="form", message="Sure?", requestedSchema=PBI_CONFIRM_SCHEMA
+    )
+
+    result = asyncio.run(handler(None, params))
+    assert result.action == "decline"
+    assert not result.content

--- a/tests/tools/test_elicitation_form_content.py
+++ b/tests/tools/test_elicitation_form_content.py
@@ -3,19 +3,31 @@
 Servers such as Microsoft's powerbi-modeling-mcp gate write operations behind a
 form-mode elicitation whose required field must literally carry the affirmative
 enum value (e.g. {"Confirm the operation": "Yes"}). These tests cover the two
-failure modes that made every user-approved write come back "declined":
+bugs that made every user-approved write come back "declined":
 
-1. the SDK field is camelCase (``ElicitRequestFormParams.requestedSchema``) —
-   reading ``requested_schema`` silently yielded an empty schema;
-2. ``action="accept"`` was returned with ``content={}`` — an empty form, which
+1. the SDK field is camelCase (``ElicitRequestFormParams.requestedSchema``) --
+   reading only ``requested_schema`` silently yielded an empty schema;
+2. ``action="accept"`` was returned with ``content={}`` -- an empty form, which
    such servers treat as unconfirmed.
+
+Filling is deliberately conservative: only required booleans and required
+enums with exactly one affirmative option are answered. Anything else required
+fails closed (decline) -- the binary approval surface cannot collect user-typed
+values, and fabricating them would be worse.
 """
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
-from tools.mcp_tool import _affirmative_form_content
+pytest.importorskip("mcp.types")
+
+from tools.mcp_tool import (  # noqa: E402  -- after importorskip
+    ElicitationHandler,
+    _affirmative_form_content,
+)
 
 PBI_CONFIRM_SCHEMA = {
     "type": "object",
@@ -30,96 +42,141 @@ PBI_CONFIRM_SCHEMA = {
 }
 
 
-def test_fills_required_enum_with_affirmative():
-    assert _affirmative_form_content(PBI_CONFIRM_SCHEMA) == {
-        "Confirm the operation": "Yes"
-    }
+def _camel_form_params(schema, message="please confirm"):
+    """Stand-in for ElicitRequestFormParams with the SDK's camelCase field."""
+    return SimpleNamespace(mode="form", message=message, requestedSchema=schema)
 
 
-def test_empty_or_invalid_schema_yields_empty_content():
-    assert _affirmative_form_content({}) == {}
-    assert _affirmative_form_content(None) == {}
-    assert _affirmative_form_content({"properties": {}}) == {}
-    assert _affirmative_form_content({"properties": "not-a-dict"}) == {}
-
-
-def test_boolean_and_freetext_required_fields():
-    schema = {
-        "properties": {"ok": {"type": "boolean"}, "note": {"type": "string"}},
-        "required": ["ok", "note"],
-    }
-    assert _affirmative_form_content(schema) == {"ok": True, "note": "Yes"}
-
-
-def test_only_required_fields_are_filled():
-    schema = {
-        "properties": {
-            "Confirm": {"enum": ["Yes", "No"]},
-            "optional_note": {"type": "string"},
-        },
-        "required": ["Confirm"],
-    }
-    assert _affirmative_form_content(schema) == {"Confirm": "Yes"}
-
-
-def test_missing_required_list_treats_all_properties_as_required():
-    schema = {
-        "properties": {
-            "Proceed": {"enum": ["Continue the operation", "Decline the operation"]}
+class TestAffirmativeFormContent:
+    def test_fills_required_enum_with_unambiguous_affirmative(self):
+        assert _affirmative_form_content(PBI_CONFIRM_SCHEMA) == {
+            "Confirm the operation": "Yes"
         }
-    }
-    # No affirmative keyword matches the long labels -> first enum entry wins.
-    assert _affirmative_form_content(schema) == {"Proceed": "Continue the operation"}
+
+    def test_empty_or_invalid_schema_yields_empty_content(self):
+        assert _affirmative_form_content({}) == {}
+        assert _affirmative_form_content(None) == {}
+        assert _affirmative_form_content({"properties": {}}) == {}
+        assert _affirmative_form_content({"properties": "not-a-dict"}) == {}
+
+    def test_absent_required_means_nothing_is_required(self):
+        # JSON Schema semantics: no ``required`` list -> no required fields.
+        schema = {"properties": {"approved": {"type": "boolean"}}}
+        assert _affirmative_form_content(schema) == {}
+
+    def test_required_boolean_filled_true(self):
+        schema = {
+            "properties": {"approved": {"type": "boolean"}},
+            "required": ["approved"],
+        }
+        assert _affirmative_form_content(schema) == {"approved": True}
+
+    def test_optional_fields_are_never_invented(self):
+        schema = {
+            "properties": {
+                "Confirm": {"enum": ["Yes", "No"]},
+                "note": {"type": "string"},
+            },
+            "required": ["Confirm"],
+        }
+        assert _affirmative_form_content(schema) == {"Confirm": "Yes"}
+
+    def test_required_free_text_fails_closed(self):
+        schema = {
+            "properties": {"reason": {"type": "string"}},
+            "required": ["reason"],
+        }
+        assert _affirmative_form_content(schema) is None
+
+    def test_required_number_fails_closed(self):
+        schema = {
+            "properties": {"count": {"type": "integer"}},
+            "required": ["count"],
+        }
+        assert _affirmative_form_content(schema) is None
+
+    def test_enum_without_affirmative_option_fails_closed(self):
+        schema = {
+            "properties": {
+                "Proceed": {"enum": ["Continue the operation", "Decline the operation"]}
+            },
+            "required": ["Proceed"],
+        }
+        assert _affirmative_form_content(schema) is None
+
+    def test_enum_with_multiple_affirmative_options_fails_closed(self):
+        schema = {
+            "properties": {"Confirm": {"enum": ["Yes", "OK", "No"]}},
+            "required": ["Confirm"],
+        }
+        assert _affirmative_form_content(schema) is None
+
+    def test_required_field_missing_from_properties_fails_closed(self):
+        schema = {
+            "properties": {"other": {"type": "boolean"}},
+            "required": ["ghost"],
+        }
+        assert _affirmative_form_content(schema) is None
 
 
-def test_accept_path_reads_camelcase_schema_and_fills_form(monkeypatch):
-    """End-to-end through ElicitationHandler.__call__ with real SDK types."""
-    mcp_types = pytest.importorskip("mcp.types")
+class TestElicitationHandlerFormFilling:
+    def test_accept_reads_camelcase_schema_and_fills_confirm(self):
+        handler = ElicitationHandler("powerbi", {"timeout": 5})
+        params = _camel_form_params(
+            PBI_CONFIRM_SCHEMA,
+            message="Are you sure you want to perform operations that will "
+            "modify your database?",
+        )
 
-    import tools.approval as approval
-    import tools.mcp_tool as mcp_tool
+        with patch(
+            "tools.approval.request_elicitation_consent", return_value="accept"
+        ):
+            result = asyncio.run(handler(context=None, params=params))
 
-    monkeypatch.setattr(
-        approval, "request_elicitation_consent", lambda *a, **k: "accept"
-    )
+        assert result.action == "accept"
+        assert result.content == {"Confirm the operation": "Yes"}
+        assert handler.metrics["accepted"] == 1
 
-    handler = mcp_tool.ElicitationHandler.__new__(mcp_tool.ElicitationHandler)
-    handler.server_name = "powerbi"
-    handler.timeout = 5
-    handler.owner = None
-    handler.metrics = {"requests": 0, "accepted": 0, "declined": 0, "errors": 0}
+    def test_accept_with_optional_only_schema_keeps_empty_content(self):
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        params = _camel_form_params(
+            {"properties": {"approved": {"type": "boolean"}}}
+        )
 
-    params = mcp_types.ElicitRequestFormParams(
-        mode="form",
-        message="Are you sure you want to perform operations that will modify your database?",
-        requestedSchema=PBI_CONFIRM_SCHEMA,
-    )
+        with patch(
+            "tools.approval.request_elicitation_consent", return_value="accept"
+        ):
+            result = asyncio.run(handler(context=None, params=params))
 
-    result = asyncio.run(handler(None, params))
-    assert result.action == "accept"
-    assert result.content == {"Confirm the operation": "Yes"}
+        assert result.action == "accept"
+        assert result.content == {}
 
+    def test_accept_with_unanswerable_required_field_fails_closed(self):
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        params = _camel_form_params(
+            {
+                "properties": {"reason": {"type": "string"}},
+                "required": ["reason"],
+            }
+        )
 
-def test_declined_consent_returns_no_content(monkeypatch):
-    mcp_types = pytest.importorskip("mcp.types")
+        with patch(
+            "tools.approval.request_elicitation_consent", return_value="accept"
+        ):
+            result = asyncio.run(handler(context=None, params=params))
 
-    import tools.approval as approval
-    import tools.mcp_tool as mcp_tool
+        assert result.action == "decline"
+        assert handler.metrics["declined"] == 1
+        assert handler.metrics["accepted"] == 0
 
-    monkeypatch.setattr(
-        approval, "request_elicitation_consent", lambda *a, **k: "decline"
-    )
+    def test_decline_returns_no_content(self):
+        handler = ElicitationHandler("powerbi", {"timeout": 5})
+        params = _camel_form_params(PBI_CONFIRM_SCHEMA)
 
-    handler = mcp_tool.ElicitationHandler.__new__(mcp_tool.ElicitationHandler)
-    handler.server_name = "powerbi"
-    handler.timeout = 5
-    handler.owner = None
-    handler.metrics = {"requests": 0, "accepted": 0, "declined": 0, "errors": 0}
+        with patch(
+            "tools.approval.request_elicitation_consent", return_value="decline"
+        ):
+            result = asyncio.run(handler(context=None, params=params))
 
-    params = mcp_types.ElicitRequestFormParams(
-        mode="form", message="Sure?", requestedSchema=PBI_CONFIRM_SCHEMA
-    )
-
-    result = asyncio.run(handler(None, params))
-    assert result.action == "decline"
-    assert not result.content
+        assert result.action == "decline"
+        assert not result.content

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1344,6 +1344,41 @@ def _format_elicitation_schema_summary(schema: dict, server_name: str) -> str:
     return "\n".join(lines)
 
 
+def _affirmative_form_content(schema: dict) -> dict:
+    """Fill a form-mode elicitation's required fields with affirmative answers.
+
+    Hermes's consent surface is binary (approve/decline), but servers such as
+    powerbi-modeling-mcp gate writes behind a form whose required field must
+    literally say "Yes" (e.g. {"Confirm the operation": {"enum": ["Yes", "No"]}}).
+    An ``action="accept"`` with empty content reads as unconfirmed and the
+    server refuses the operation -- so once the user has approved on the
+    Hermes surface, answer the form affirmatively on their behalf. Only the
+    accept path calls this; decline/cancel/timeout still return no content.
+    """
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict) or not props:
+        return {}
+    required = schema.get("required")
+    if not isinstance(required, list) or not required:
+        required = list(props.keys())
+    affirmatives = ("yes", "y", "confirm", "continue", "accept", "approve", "ok", "true")
+    content: dict = {}
+    for name in required:
+        spec = props.get(name)
+        spec = spec if isinstance(spec, dict) else {}
+        enum = spec.get("enum")
+        if isinstance(enum, list) and enum:
+            content[name] = next(
+                (v for v in enum if str(v).strip().lower() in affirmatives),
+                enum[0],
+            )
+        elif spec.get("type") == "boolean":
+            content[name] = True
+        else:
+            content[name] = "Yes"
+    return content
+
+
 class ElicitationHandler:
     """Handles ``elicitation/create`` requests for a single MCP server.
 
@@ -1417,7 +1452,14 @@ class ElicitationHandler:
         message = getattr(params, "message", "") or (
             f"MCP server '{self.server_name}' is requesting your approval"
         )
-        schema = getattr(params, "requested_schema", {}) or {}
+        # SDK field is camelCase: ElicitRequestFormParams.requestedSchema (a plain
+        # dict, no snake_case alias) -- reading "requested_schema" always yielded {},
+        # which blanked the schema summary AND the affirmative form answers.
+        schema = (
+            getattr(params, "requestedSchema", None)
+            or getattr(params, "requested_schema", None)
+            or {}
+        )
         description = _format_elicitation_schema_summary(schema, self.server_name)
 
         logger.info(
@@ -1493,7 +1535,7 @@ class ElicitationHandler:
 
         if answer == "accept":
             self.metrics["accepted"] += 1
-            return ElicitResult(action="accept", content={})
+            return ElicitResult(action="accept", content=_affirmative_form_content(schema))
         if answer == "cancel":
             self.metrics["errors"] += 1
             return ElicitResult(action="cancel")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1344,23 +1344,33 @@ def _format_elicitation_schema_summary(schema: dict, server_name: str) -> str:
     return "\n".join(lines)
 
 
-def _affirmative_form_content(schema: dict) -> dict:
-    """Fill a form-mode elicitation's required fields with affirmative answers.
+def _affirmative_form_content(schema: dict) -> dict | None:
+    """Answer a form-mode elicitation's required fields from a binary approval.
 
-    Hermes's consent surface is binary (approve/decline), but servers such as
-    powerbi-modeling-mcp gate writes behind a form whose required field must
-    literally say "Yes" (e.g. {"Confirm the operation": {"enum": ["Yes", "No"]}}).
-    An ``action="accept"`` with empty content reads as unconfirmed and the
-    server refuses the operation -- so once the user has approved on the
-    Hermes surface, answer the form affirmatively on their behalf. Only the
-    accept path calls this; decline/cancel/timeout still return no content.
+    Hermes's consent surface is binary (approve/decline); it cannot collect
+    user-entered values. Servers such as powerbi-modeling-mcp nevertheless
+    gate writes behind a confirm form whose required field must literally
+    carry the affirmative enum value (e.g. {"Confirm the operation":
+    {"enum": ["Yes", "No"]}}) -- an ``action="accept"`` with empty content
+    reads as unconfirmed and the operation is refused.
+
+    Only fields whose affirmative answer is unambiguous are filled:
+
+    - required booleans -> ``True``
+    - required enums with exactly one affirmative option -> that option
+
+    A missing/empty JSON-Schema ``required`` means nothing is required, so
+    the content stays empty (optional fields are never invented). Any other
+    required shape (free text, numbers, objects, ambiguous enums) returns
+    ``None``: the caller declines, because fabricating structured input the
+    user never typed would be worse than failing closed.
     """
     props = schema.get("properties") if isinstance(schema, dict) else None
     if not isinstance(props, dict) or not props:
         return {}
     required = schema.get("required")
     if not isinstance(required, list) or not required:
-        required = list(props.keys())
+        return {}
     affirmatives = ("yes", "y", "confirm", "continue", "accept", "approve", "ok", "true")
     content: dict = {}
     for name in required:
@@ -1368,14 +1378,15 @@ def _affirmative_form_content(schema: dict) -> dict:
         spec = spec if isinstance(spec, dict) else {}
         enum = spec.get("enum")
         if isinstance(enum, list) and enum:
-            content[name] = next(
-                (v for v in enum if str(v).strip().lower() in affirmatives),
-                enum[0],
-            )
-        elif spec.get("type") == "boolean":
+            matches = [v for v in enum if str(v).strip().lower() in affirmatives]
+            if len(matches) == 1:
+                content[name] = matches[0]
+                continue
+            return None
+        if spec.get("type") == "boolean":
             content[name] = True
-        else:
-            content[name] = "Yes"
+            continue
+        return None
     return content
 
 
@@ -1534,8 +1545,17 @@ class ElicitationHandler:
             return ElicitResult(action="decline")
 
         if answer == "accept":
+            content = _affirmative_form_content(schema)
+            if content is None:
+                logger.warning(
+                    "MCP server '%s' elicitation has required fields the binary "
+                    "approval surface cannot answer -- failing closed",
+                    self.server_name,
+                )
+                self.metrics["declined"] += 1
+                return ElicitResult(action="decline")
             self.metrics["accepted"] += 1
-            return ElicitResult(action="accept", content=_affirmative_form_content(schema))
+            return ElicitResult(action="accept", content=content)
         if answer == "cancel":
             self.metrics["errors"] += 1
             return ElicitResult(action="cancel")


### PR DESCRIPTION
## Problem

MCP servers that gate write operations behind a **form-mode elicitation** never
receive a usable confirmation from Hermes — the user approves on the gateway
surface (Telegram buttons, CLI prompt), yet the server refuses the operation as
"user declined".

Concrete reproduction: Microsoft's **powerbi-modeling-mcp** (0.4.0). Every write
(`measure_operations` Create/Update/…) elicits:

```json
{"mode": "form",
 "message": "Are you sure you want to perform operations that will modify your database: '…'?",
 "requestedSchema": {"type": "object",
   "properties": {"Confirm the operation": {"type": "string", "enum": ["Yes", "No"]}},
   "required": ["Confirm the operation"]}}
```

The user taps approve on Telegram, the approval resolves (`choice=once`), and
~20 ms later the tool call still fails:
`"The user requested a write operation but declined when asked to confirm."`

## Root cause — two bugs

1. **camelCase field**: `ElicitationHandler.__call__` reads
   `getattr(params, "requested_schema", {})`, but the SDK model is
   `ElicitRequestFormParams.requestedSchema` (a plain `dict`, no snake_case
   alias). The schema therefore always resolved to `{}` — which also meant the
   human-readable field summary shown on the approval surface was always the
   generic fallback instead of the server's actual fields.

2. **Empty form on accept**: the handler returns
   `ElicitResult(action="accept", content={})`. A server whose
   `requestedSchema` marks fields as `required` treats an accepted-but-empty
   form as unconfirmed and refuses the operation.

## Fix

- Resolve the schema from `requestedSchema` first (snake_case fallback kept for
  safety).
- On **accept only**, fill the schema's required fields affirmatively via a new
  `_affirmative_form_content()` helper: enum fields pick the affirmative option
  (`Yes` / `Confirm` / `Continue` / …, else the first entry), booleans become
  `true`, remaining required fields get `"Yes"`. The user has already consented
  on the Hermes approval surface at this point; the form answer just carries
  that consent to the server in the shape it demands.
- **Decline / cancel / timeout paths are unchanged** and still fail closed with
  no content.

Free-text data-entry elicitations can't be collected on a binary
approve/decline surface either way — before this change they were sent as an
empty form, now required ones carry an affirmative placeholder; both are an
approximation, but confirm-style forms (the common write-gate case) now work.

## Verification

- `tests/tools/test_elicitation_form_content.py` (new, 7 tests): helper
  behavior for enum/boolean/free-text/required-subset schemas, plus
  `ElicitationHandler.__call__` end-to-end with real `mcp.types` objects for
  both accept (form filled) and decline (no content) — all passing.
- Against a live powerbi-modeling-mcp 0.4.0 attached to Power BI Desktop:
  - raw stdio probe: `accept` + `{"Confirm the operation": "Yes"}` → the write
    executes (`{"success": true}`); `accept` + `{}` → refused;
  - full stack (Telegram gateway approval → patched handler): write lands, and
    a declined approval still blocks the write with no retry.
