### PR TITLE
fix(line): route outbound media without silent omission

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -71,6 +71,7 @@ import mimetypes
 import os
 import re
 import secrets
+import shutil
 import tempfile
 import time
 import uuid
@@ -1234,20 +1235,26 @@ class LineAdapter(BasePlatformAdapter):
     # Outbound media (image / voice / video)
     # ------------------------------------------------------------------
 
+    def _revoke_media_token(self, token: str) -> None:
+        """Revoke a media token and remove its owned temp copy, if any."""
+        entry = self._media_tokens.pop(token, None)
+        if not entry:
+            return
+        path, _expires_at = entry
+        if path in self._media_temp_paths:
+            self._media_temp_paths.discard(path)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
     def _register_media(self, file_path: str, *, cleanup: bool = False) -> str:
         """Register a local file for HTTPS serving; return the URL token."""
         # Evict expired tokens first.
         now = time.time()
-        for token in list(self._media_tokens.keys()):
-            path, exp = self._media_tokens[token]
+        for token, (_path, exp) in list(self._media_tokens.items()):
             if now > exp:
-                self._media_tokens.pop(token, None)
-                if path in self._media_temp_paths:
-                    self._media_temp_paths.discard(path)
-                    try:
-                        os.unlink(path)
-                    except OSError:
-                        pass
+                self._revoke_media_token(token)
 
         resolved = str(Path(file_path).resolve())
         token = secrets.token_urlsafe(32)
@@ -1255,6 +1262,23 @@ class LineAdapter(BasePlatformAdapter):
         if cleanup:
             self._media_temp_paths.add(resolved)
         return token
+
+    def _copy_media_to_managed_temp(self, source: Path) -> str:
+        """Copy a user-owned file into adapter-managed temp storage."""
+        suffix = source.suffix
+        with tempfile.NamedTemporaryFile(
+            prefix="hermes-line-", suffix=suffix, delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+        try:
+            shutil.copyfile(source, tmp_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return tmp_path
 
     def _media_url(self, token: str, filename: str) -> str:
         """Build the public HTTPS URL for a media token. PR #8398 style."""
@@ -1288,7 +1312,7 @@ class LineAdapter(BasePlatformAdapter):
 
         file_path, expires_at = entry
         if time.time() > expires_at:
-            self._media_tokens.pop(token, None)
+            self._revoke_media_token(token)
             return web.Response(status=410, text="gone")
 
         path = Path(file_path)
@@ -1314,8 +1338,73 @@ class LineAdapter(BasePlatformAdapter):
         content_type, _ = mimetypes.guess_type(str(path))
         return web.FileResponse(
             path,
-            headers={"Content-Type": content_type or "application/octet-stream"},
+            headers={
+                "Content-Type": content_type or "application/octet-stream",
+                "Cache-Control": "no-store",
+            },
         )
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an HTTPS image URL as a native LINE image message."""
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+        if not image_url.lower().startswith("https://"):
+            return SendResult(success=False, error=f"LINE image URL must be HTTPS: {image_url}")
+        msgs: List[Dict[str, Any]] = [_image_message(image_url)]
+        if caption:
+            msgs.append(_text_message(caption))
+        return await self._send_messages(chat_id, msgs)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a regular file as a safe expiring HTTPS download link.
+
+        LINE has image/audio/video message objects but no general outbound file
+        object. For non-image files, deliver a text bubble containing an
+        unguessable, adapter-hosted HTTPS link with a short TTL.
+        """
+        path = Path(file_path)
+        if not path.exists() or not path.is_file():
+            return SendResult(success=False, error=f"file not found: {file_path}")
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+        if not self.public_base_url and self.webhook_host == "0.0.0.0":
+            return SendResult(
+                success=False,
+                error="LINE_PUBLIC_URL must be set to send file links "
+                "(LINE only accepts publicly reachable HTTPS URLs)",
+            )
+
+        managed_path = self._copy_media_to_managed_temp(path)
+        token = self._register_media(managed_path, cleanup=True)
+        label = file_name or path.name
+        public_name = f"download{path.suffix}" if path.suffix else "download"
+        url = self._media_url(token, public_name)
+        if not url.lower().startswith("https://"):
+            self._revoke_media_token(token)
+            return SendResult(success=False, error=f"LINE file URL must be HTTPS: {url}")
+        text = f"Download file: {label}\n{url}"
+        if caption:
+            text = f"{caption}\n{text}"
+        result = await self._send_messages(chat_id, [_text_message(text)])
+        if not result.success:
+            self._revoke_media_token(token)
+        return result
 
     async def send_image_file(
         self,
@@ -1341,11 +1430,15 @@ class LineAdapter(BasePlatformAdapter):
         token = self._register_media(str(path.resolve()))
         url = self._media_url(token, path.name)
         if not url.lower().startswith("https://"):
+            self._revoke_media_token(token)
             return SendResult(success=False, error=f"LINE image URL must be HTTPS: {url}")
         msgs: List[Dict[str, Any]] = [_image_message(url)]
         if caption:
             msgs.append(_text_message(caption))
-        return await self._send_messages(chat_id, msgs)
+        result = await self._send_messages(chat_id, msgs)
+        if not result.success:
+            self._revoke_media_token(token)
+        return result
 
     async def send_voice(
         self,
@@ -1369,7 +1462,13 @@ class LineAdapter(BasePlatformAdapter):
 
         token = self._register_media(str(path.resolve()))
         url = self._media_url(token, path.name)
-        return await self._send_messages(chat_id, [_audio_message(url, duration_ms)])
+        if not url.lower().startswith("https://"):
+            self._revoke_media_token(token)
+            return SendResult(success=False, error=f"LINE audio URL must be HTTPS: {url}")
+        result = await self._send_messages(chat_id, [_audio_message(url, duration_ms)])
+        if not result.success:
+            self._revoke_media_token(token)
+        return result
 
     async def send_video(
         self,
@@ -1414,7 +1513,19 @@ class LineAdapter(BasePlatformAdapter):
         video_token = self._register_media(str(path.resolve()))
         video_url = self._media_url(video_token, path.name)
         preview_url = self._media_url(preview_token, preview_filename)
-        return await self._send_messages(chat_id, [_video_message(video_url, preview_url)])
+        if not video_url.lower().startswith("https://"):
+            self._revoke_media_token(video_token)
+            self._revoke_media_token(preview_token)
+            return SendResult(success=False, error=f"LINE video URL must be HTTPS: {video_url}")
+        if not preview_url.lower().startswith("https://"):
+            self._revoke_media_token(video_token)
+            self._revoke_media_token(preview_token)
+            return SendResult(success=False, error=f"LINE video preview URL must be HTTPS: {preview_url}")
+        result = await self._send_messages(chat_id, [_video_message(video_url, preview_url)])
+        if not result.success:
+            self._revoke_media_token(video_token)
+            self._revoke_media_token(preview_token)
+        return result
 
     async def _send_messages(
         self,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -19,6 +19,8 @@ import hashlib
 import hmac
 import base64
 import json
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -555,6 +557,107 @@ class TestPostbackButtonShape:
         long = "x" * 500
         msg = build_postback_button_message(long, "Tap", "rid")
         assert len(msg["altText"]) <= 400
+
+
+class TestOutboundMediaLinks:
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+            "public_url": "https://line-public.example.test",
+        })
+        ad = LineAdapter(cfg)
+        ad._client = MagicMock()
+        ad._client.reply = AsyncMock()
+        ad._client.push = AsyncMock()
+        return ad
+
+    def test_https_image_url_sends_native_line_image(self, adapter):
+        result = asyncio.run(
+            adapter.send_image(
+                "Utarget",
+                "https://cdn.example.test/chart.png",
+                caption="Chart",
+            )
+        )
+
+        assert result.success
+        adapter._client.push.assert_awaited_once()
+        messages = adapter._client.push.await_args.args[1]
+        assert messages[0] == {
+            "type": "image",
+            "originalContentUrl": "https://cdn.example.test/chart.png",
+            "previewImageUrl": "https://cdn.example.test/chart.png",
+        }
+        assert messages[1] == {"type": "text", "text": "Chart"}
+
+    def test_document_sends_expiring_no_store_download_link_from_owned_copy(self, adapter, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"hello")
+
+        result = asyncio.run(adapter.send_document("Utarget", str(doc), caption="Report"))
+
+        assert result.success
+        adapter._client.push.assert_awaited_once()
+        messages = adapter._client.push.await_args.args[1]
+        assert messages[0]["type"] == "text"
+        text = messages[0]["text"]
+        assert "Report" in text
+        assert "https://line-public.example.test/line/media/" in text
+        url = next(part for part in text.split() if part.startswith("https://"))
+        assert url.endswith("/download.pdf")
+        assert "report.pdf" not in url
+        assert "Utarget" not in text
+        assert "tok" not in text
+        assert len(adapter._media_tokens) == 1
+        token, (registered_path, expires_at) = next(iter(adapter._media_tokens.items()))
+        assert registered_path != str(doc.resolve())
+        assert registered_path in adapter._media_temp_paths
+        assert Path(registered_path).read_bytes() == b"hello"
+        assert len(token) >= 32
+        assert expires_at - _line.time.time() <= 24 * 60 * 60
+
+        request = SimpleNamespace(match_info={"token": token})
+        response = asyncio.run(adapter._handle_media(request))
+        assert response.headers["Cache-Control"] == "no-store"
+
+        adapter._media_tokens[token] = (registered_path, _line.time.time() - 1)
+        expired = asyncio.run(adapter._handle_media(request))
+        assert expired.status == 410
+        assert token not in adapter._media_tokens
+        assert registered_path not in adapter._media_temp_paths
+        assert not Path(registered_path).exists()
+        assert doc.exists()
+
+    def test_document_revokes_owned_copy_when_public_url_is_not_https(self, adapter, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"hello")
+        adapter.public_base_url = "http://line-public.example.test"
+
+        result = asyncio.run(adapter.send_document("Utarget", str(doc)))
+
+        assert not result.success
+        assert "must be HTTPS" in result.error
+        assert adapter._media_tokens == {}
+        assert adapter._media_temp_paths == set()
+        assert doc.exists()
+
+    def test_expired_media_token_is_revoked_and_removed(self, adapter, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"hello")
+        token = adapter._register_media(str(doc))
+        adapter._media_tokens[token] = (str(doc), _line.time.time() - 1)
+
+        request = SimpleNamespace(match_info={"token": token})
+        response = asyncio.run(adapter._handle_media(request))
+
+        assert response.status == 410
+        assert token not in adapter._media_tokens
 
 
 class TestCheckRequirements:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -90,3 +90,105 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         force_document=False,
     )
 
+
+def test_line_user_id_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "line", "U0123456789abcdef0123456789abcdef"
+    )
+
+    assert chat_id == "U0123456789abcdef0123456789abcdef"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_line_group_and_room_targets_are_not_direct_send_targets() -> None:
+    for native_id in ("C0123456789abcdef0123456789abcdef", "R0123456789abcdef0123456789abcdef"):
+        chat_id, thread_id, is_explicit = _parse_target_ref("line", native_id)
+
+        assert chat_id is None
+        assert thread_id is None
+        assert is_explicit is False
+
+
+def test_send_message_uses_line_home_channel_from_env(monkeypatch) -> None:
+    line_platform = Platform("line")
+    config = SimpleNamespace(
+        platforms={},
+        get_home_channel=lambda _platform: None,
+    )
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "dummy-token")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "dummy-secret")
+    monkeypatch.setenv("LINE_HOME_CHANNEL", "Uhomechannel0123456789abcdef")
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("bare line should use home env, not directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "line",
+                    "message": "hello line",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert result["note"] == "Sent to line home channel (chat_id: Uhomechannel0123456789abcdef)"
+    send_mock.assert_awaited_once()
+    assert send_mock.await_args is not None
+    args = send_mock.await_args.args
+    assert args[0] == line_platform
+    assert args[1].enabled is True
+    assert args[1].extra["channel_access_token"] == "dummy-token"
+    assert args[1].extra["channel_secret"] == "dummy-secret"
+    assert args[2:] == ("Uhomechannel0123456789abcdef", "hello line")
+
+
+def test_line_media_routes_images_and_documents_via_live_adapter(tmp_path) -> None:
+    from tools.send_message_tool import _send_to_platform
+    from gateway.platforms.base import SendResult
+
+    line_platform = Platform("line")
+    image_path = tmp_path / "chart.png"
+    image_path.write_bytes(b"png")
+    doc_path = tmp_path / "report.pdf"
+    doc_path.write_bytes(b"pdf")
+
+    adapter = AsyncMock()
+    adapter.send.return_value = SendResult(success=True, message_id="text")
+    adapter.send_image_file.return_value = SendResult(success=True, message_id="img")
+    adapter.send_document.return_value = SendResult(success=True, message_id="doc")
+    runner = SimpleNamespace(adapters={line_platform: adapter})
+    pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                line_platform,
+                pconfig,
+                "Utarget",
+                "attached",
+                media_files=[(str(image_path), False), (str(doc_path), False)],
+            )
+        )
+
+    assert result["success"] is True
+    adapter.send.assert_awaited_once()
+    adapter.send_image_file.assert_awaited_once_with(
+        chat_id="Utarget",
+        image_path=str(image_path),
+        caption=None,
+        metadata=None,
+    )
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="Utarget",
+        file_path=str(doc_path),
+        caption=None,
+        file_name="report.pdf",
+        metadata=None,
+    )
+

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -29,6 +29,9 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
+# LINE send_message's normal surface is a single user; group/room targets must
+# continue through configured home channels / channel-directory allowlists.
+_LINE_USER_TARGET_RE = re.compile(r"^\s*(U[A-Za-z0-9_-]{8,})\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -406,8 +409,8 @@ def _handle_send(args):
 
     pconfig = config.platforms.get(platform)
     if not pconfig or not pconfig.enabled:
-        # Weixin can be configured purely via .env; synthesize a pconfig so
-        # send_message and cron delivery work without a gateway.yaml entry.
+        # Weixin and LINE can be configured purely via .env; synthesize a pconfig
+        # so send_message and cron delivery work without a gateway.yaml entry.
         if platform_name == "weixin":
             wx_token = os.getenv("WEIXIN_TOKEN", "").strip()
             wx_account = os.getenv("WEIXIN_ACCOUNT_ID", "").strip()
@@ -420,6 +423,21 @@ def _handle_send(args):
                         "account_id": wx_account,
                         "base_url": os.getenv("WEIXIN_BASE_URL", "").strip(),
                         "cdn_base_url": os.getenv("WEIXIN_CDN_BASE_URL", "").strip(),
+                    },
+                )
+            else:
+                return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+        elif platform_name == "line":
+            line_token = os.getenv("LINE_CHANNEL_ACCESS_TOKEN", "").strip()
+            line_secret = os.getenv("LINE_CHANNEL_SECRET", "").strip()
+            if line_token and line_secret:
+                from gateway.config import PlatformConfig
+                pconfig = PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "channel_access_token": line_token,
+                        "channel_secret": line_secret,
+                        "public_url": os.getenv("LINE_PUBLIC_URL", "").strip(),
                     },
                 )
             else:
@@ -447,6 +465,11 @@ def _handle_send(args):
             if wx_home:
                 from gateway.config import HomeChannel
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+        if not home and platform_name == "line":
+            line_home = os.getenv("LINE_HOME_CHANNEL", "").strip()
+            if line_home:
+                from gateway.config import HomeChannel
+                home = HomeChannel(platform=platform, chat_id=line_home, name="LINE Home")
         if home:
             chat_id = home.chat_id
             used_home_channel = True
@@ -563,6 +586,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # resolution path in send_message() can run.
             is_explicit = chat_id[0] not in {"U", "W"}
             return chat_id, None, is_explicit
+    if platform_name == "line":
+        match = _LINE_USER_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "matrix":
         trimmed = target_ref.strip()
         split_idx = trimmed.rfind(":$")
@@ -1030,6 +1057,66 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 return result
             last_result = result
         return last_result
+
+    # --- LINE: images go as native image messages; other local files become
+    # expiring HTTPS download links served by the live LINE adapter. The LINE
+    # Messaging API has no generic outbound file object, so standalone sends
+    # cannot safely deliver arbitrary files without a running public webhook.
+    if platform == Platform("line") and media_files:
+        runner = None
+        try:
+            from gateway.run import _gateway_runner_ref
+            runner = _gateway_runner_ref()
+        except Exception:
+            runner = None
+        adapter = None
+        if runner is not None:
+            try:
+                adapter = runner.adapters.get(platform)
+            except Exception:
+                adapter = None
+        if adapter is None:
+            return {
+                "error": (
+                    "LINE MEDIA delivery requires a live LINE gateway adapter "
+                    "with LINE_PUBLIC_URL configured; no live adapter is available."
+                )
+            }
+
+        metadata = {"thread_id": thread_id} if thread_id else None
+        last_result = None
+        if message.strip():
+            text_result = await adapter.send(
+                chat_id=chat_id,
+                content=message,
+                metadata=metadata,
+            )
+            if not text_result.success:
+                return {"error": f"Adapter send failed: {text_result.error}"}
+            last_result = {"success": True, "message_id": text_result.message_id}
+
+        image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
+        for media_path, _is_voice in media_files:
+            ext = os.path.splitext(media_path)[1].lower()
+            if ext in image_exts and not force_document:
+                media_result = await adapter.send_image_file(
+                    chat_id=chat_id,
+                    image_path=media_path,
+                    caption=None,
+                    metadata=metadata,
+                )
+            else:
+                media_result = await adapter.send_document(
+                    chat_id=chat_id,
+                    file_path=media_path,
+                    caption=None,
+                    file_name=os.path.basename(media_path),
+                    metadata=metadata,
+                )
+            if not media_result.success:
+                return {"error": f"LINE media send failed: {media_result.error}"}
+            last_result = {"success": True, "message_id": media_result.message_id}
+        return last_result or {"success": True, "message_id": None}
 
     # --- Non-media platforms ---
     if media_files and not message.strip():


### PR DESCRIPTION
## Summary

- resolve bare `line` sends from `LINE_HOME_CHANNEL` when LINE is environment-configured
- recognize explicit `line:<LINE-user-id>` targets while keeping group/room IDs out of the direct 1:1 parser
- route LINE image attachments through native LINE image messages
- fall back to tokenized, expiring HTTPS download links for ordinary outbound files
- copy outbound files into adapter-owned temporary storage and revoke/delete the copy on expiry or failed delivery
- prevent caching and avoid source filenames, credentials, and recipient IDs in generated URLs

## Why

The LINE Messaging API has native image messages but no general-purpose outbound file object. The CLI/common `send_message` path previously failed home/explicit LINE routing and could report text success while omitting media.

Tracking issue: https://github.com/komadori-ai/wayfinding/issues/45

## Tests

```text
scripts/run_tests.sh tests/tools/test_send_message_tool.py tests/gateway/test_line_plugin.py tests/tools/test_send_message_target_parse.py -q
243 passed, 0 failed
```

Also verified with `git diff --check` and Python compile checks.

## Operational note

File links require a live LINE gateway adapter and an HTTPS `LINE_PUBLIC_URL`. The existing media TTL is 30 minutes, below the 24-hour contract ceiling. This PR does not perform live-device acceptance testing.
