### PR TITLE
feat(desktop): server-synced session pins with live cross-device sync

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -36,6 +36,7 @@ import {
   $sidebarMessagingOpenIds,
   $sidebarOpen,
   $sidebarOverlayMounted,
+  $sidebarPinnedOrderIds,
   $sidebarPinsOpen,
   $sidebarProjectOrderIds,
   $sidebarRecentsOpen,
@@ -45,9 +46,9 @@ import {
   $sidebarWorkspaceParentOrderIds,
   pinSession,
   SESSION_SEARCH_FOCUS_EVENT,
-  setPinnedSessionOrder,
   setSidebarAgentsGrouped,
   setSidebarCronOpen,
+  setSidebarPinnedOrderIds,
   setSidebarPinsOpen,
   setSidebarProjectOrderIds,
   setSidebarRecentsOpen,
@@ -360,6 +361,8 @@ export function ChatSidebar({
     return map
   }, [visibleSessions, cronSessions])
 
+  const pinnedOrderIds = useStore($sidebarPinnedOrderIds)
+
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()
     const out: SessionInfo[] = []
@@ -373,8 +376,12 @@ export function ChatSidebar({
       }
     }
 
-    return out
-  }, [pinnedSessionIds, sessionByAnyId])
+    // Pin MEMBERSHIP is server-synced (order-independent); the local drag-order
+    // is layered on top. orderByIds surfaces newly-pinned rows (absent from the
+    // saved order) at the front and drops stale ids, so cross-device pins and
+    // local ordering coexist without either clobbering the other.
+    return orderByIds(out, sessionPinId, pinnedOrderIds)
+  }, [pinnedSessionIds, sessionByAnyId, pinnedOrderIds])
 
   const pinnedRealIdSet = useMemo(() => new Set(pinnedSessions.map(s => s.id)), [pinnedSessions])
 
@@ -1017,16 +1024,15 @@ export function ChatSidebar({
   // it over the default sort, so stale/new ids reconcile on the next render.
   const reorderProjects = (ids: string[]) => setSidebarProjectOrderIds(ids)
 
-  // Sortable rows carry live session ids; the pinned store is keyed by durable
-  // (lineage-root) ids, so translate before persisting the new order.
+  // Restore pinned drag-reorder over the server-synced pin set. The sortable
+  // list reports live session ids; the order store is keyed by durable pin ids
+  // (lineage roots), so translate before persisting — same as the pinned store.
   const reorderPinned = (ids: string[]) =>
-    setPinnedSessionOrder(
-      ids.map(id => {
-        const session = sessionByAnyId.get(id)
+    setSidebarPinnedOrderIds(ids.map(id => {
+      const session = sessionByAnyId.get(id)
 
-        return session ? sessionPinId(session) : id
-      })
-    )
+      return session ? sessionPinId(session) : id
+    }))
 
   return (
     <Sidebar

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -368,7 +368,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                         </button>
                         <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                           <RowIconButton
-                            onClick={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
+                            onClick={() => void (pinned ? unpinSession(pinId) : pinSession(pinId))}
                             title={pinned ? cc.unpinSession : cc.pinSession}
                           >
                             {pinned ? <BookmarkFilled className="size-3.5" /> : <Bookmark className="size-3.5" />}

--- a/apps/desktop/src/app/desktop-controller-utils.ts
+++ b/apps/desktop/src/app/desktop-controller-utils.ts
@@ -15,6 +15,7 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       session.id === other.id &&
       session._lineage_root_id === other._lineage_root_id &&
       session.title === other.title &&
+      session.pinned === other.pinned &&
       session.source === other.source &&
       session.profile === other.profile &&
       session.preview === other.preview &&

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -410,6 +410,33 @@ export function DesktopController() {
     return onSessionsChanged(() => void refreshSessions().catch(() => undefined))
   }, [refreshSessions])
 
+  // Cross-MACHINE session-list sync: BroadcastChannel only reaches windows on
+  // this machine, and the gateway routes session.info events to the session's
+  // owning transport only — so a pin/title/create on another desktop never
+  // reaches this one live (it only showed up after an app restart). Re-pull the
+  // list on window focus and on a slow poll while focused, mirroring the
+  // poll-based livesync pattern.
+  useEffect(() => {
+    if (isSecondaryWindow()) {
+      return
+    }
+
+    const refresh = () => void refreshSessions().catch(() => undefined)
+
+    window.addEventListener('focus', refresh)
+
+    const timer = window.setInterval(() => {
+      if (typeof document.hasFocus !== 'function' || document.hasFocus()) {
+        refresh()
+      }
+    }, 30_000)
+
+    return () => {
+      window.removeEventListener('focus', refresh)
+      window.clearInterval(timer)
+    }
+  }, [refreshSessions])
+
   const toggleSelectedPin = useCallback(() => {
     const sessionId = $selectedStoredSessionId.get()
 
@@ -422,9 +449,9 @@ export function DesktopController() {
     const pinId = session ? sessionPinId(session) : sessionId
 
     if ($pinnedSessionIds.get().includes(pinId)) {
-      unpinSession(pinId)
+      void unpinSession(pinId)
     } else {
-      pinSession(pinId)
+      void pinSession(pinId)
     }
   }, [])
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -7,7 +7,6 @@ import { useI18n } from '@/i18n'
 import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearQueuedPrompts } from '@/store/composer-queue'
-import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { resolveNewSessionCwd, tombstoneSessions, untombstoneSessions } from '@/store/projects'
@@ -22,7 +21,6 @@ import {
   $sessions,
   $yoloActive,
   type NewChatWorkspaceTarget,
-  sessionPinId,
   setActiveSessionId,
   setAwaitingResponse,
   setBusy,
@@ -837,11 +835,6 @@ export function useSessionActions({
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
-      const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const removedPinId = removed ? sessionPinId(removed) : storedSessionId
-
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
@@ -850,8 +843,6 @@ export function useSessionActions({
       // Keep $sessionsTotal in sync so the sidebar's "Load N more" footer
       // doesn't keep claiming the removed row is still on the server.
       setSessionsTotal(prev => Math.max(0, prev - 1))
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
-
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
       if (wasSelected) {
@@ -876,8 +867,6 @@ export function useSessionActions({
         }
 
         untombstoneSessions([storedSessionId, removed?.id, removed?._lineage_root_id])
-        $pinnedSessionIds.set(previousPinned)
-
         if (wasSelected) {
           setFreshDraftReady(false)
           setSelectedStoredSessionId(storedSessionId)
@@ -923,11 +912,6 @@ export function useSessionActions({
 
       const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
       const wasSelected = selectedStoredSessionId === storedSessionId
-      const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
-
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
@@ -935,8 +919,6 @@ export function useSessionActions({
       // on the next refresh, so they count as "removed" for the load-more
       // footer math.
       setSessionsTotal(prev => Math.max(0, prev - 1))
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
-
       if (wasSelected) {
         startFreshSessionDraft(true)
       }
@@ -948,7 +930,6 @@ export function useSessionActions({
         // that race after the mutation succeeds so right-click → Archive does
         // not appear to do nothing until the next full refresh.
         setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-        $pinnedSessionIds.set($pinnedSessionIds.get().filter(id => id !== storedSessionId && id !== archivedPinId))
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {
@@ -957,7 +938,6 @@ export function useSessionActions({
         }
 
         untombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
-        $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)
       }
     },

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -8,7 +8,14 @@ import {
   normalizeSessionSource
 } from '@/lib/session-source'
 import { setCronJobs } from '@/store/cron'
-import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
+import {
+  $pinnedSessionIds,
+  $sessionsLimit,
+  bumpSessionsLimit,
+  migrateLegacyPinnedSessions,
+  setSessionPinned,
+  SIDEBAR_SESSIONS_PAGE_SIZE
+} from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import {
   $messagingSessions,
@@ -75,6 +82,7 @@ interface UseSessionListActionsArgs {
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const legacyPinnedMigrationStartedRef = useRef(false)
   const refreshSessionsRequestRef = useRef(0)
 
   // Cron-job sessions as their own list (latest N). Independent of the recents
@@ -181,6 +189,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
         setSessionProfileTotals(result.profile_totals ?? {})
+
+        if (!legacyPinnedMigrationStartedRef.current && result.sessions.some(session => 'pinned' in session)) {
+          legacyPinnedMigrationStartedRef.current = true
+          void migrateLegacyPinnedSessions(result.sessions, id => setSessionPinned(id, true)).catch(() => {
+            legacyPinnedMigrationStartedRef.current = false
+          })
+        }
       }
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -269,6 +269,15 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
   })
 }
 
+export function setSessionPinned(id: string, pinned: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/sessions/${encodeURIComponent(id)}`,
+    method: 'PATCH',
+    body: { pinned }
+  })
+}
+
 export function searchSessions(query: string): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
     path: `/api/sessions/search?q=${encodeURIComponent(query)}`

--- a/apps/desktop/src/store/layout.test.ts
+++ b/apps/desktop/src/store/layout.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  $pinnedSessionIds,
+  $sidebarPinnedOrderIds,
+  migrateLegacyPinnedSessions,
+  setSidebarPinnedOrderIds,
+  SIDEBAR_PINNED_STORAGE_KEY
+} from './layout'
+import { setSessions } from './session'
+
+const session = (over: Partial<SessionInfo>): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'live',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 0,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  source: null,
+  started_at: 0,
+  title: null,
+  tool_call_count: 0,
+  ...over
+})
+
+describe('server-side pinned sessions', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setSessions([])
+  })
+
+  it('derives pinned ids from server session data using lineage roots', () => {
+    window.localStorage.setItem(SIDEBAR_PINNED_STORAGE_KEY, JSON.stringify(['stale-local']))
+
+    setSessions([
+      session({ id: 'recent', pinned: false }),
+      session({ id: 'tip', _lineage_root_id: 'root', pinned: true })
+    ])
+
+    expect($pinnedSessionIds.get()).toEqual(['root'])
+  })
+
+  it('migrates legacy local pins as additive pushes and clears the old key', async () => {
+    window.localStorage.setItem(SIDEBAR_PINNED_STORAGE_KEY, JSON.stringify(['already', 'legacy', 'legacy']))
+    const pushed: string[] = []
+    const log = { info: vi.fn() }
+
+    await expect(
+      migrateLegacyPinnedSessions([session({ id: 'already', pinned: true })], async id => {
+        pushed.push(id)
+      }, log)
+    ).resolves.toBe(1)
+
+    expect(pushed).toEqual(['legacy'])
+    expect(window.localStorage.getItem(SIDEBAR_PINNED_STORAGE_KEY)).toBeNull()
+    expect(log.info).toHaveBeenCalledWith('server-side pinned sessions migration push count', {
+      pushed: 1,
+      total: 3
+    })
+  })
+
+  it('keeps the legacy key when a migration push fails so startup can retry', async () => {
+    window.localStorage.setItem(SIDEBAR_PINNED_STORAGE_KEY, JSON.stringify(['legacy']))
+
+    await expect(
+      migrateLegacyPinnedSessions([], async () => {
+        throw new Error('backend unavailable')
+      })
+    ).rejects.toThrow('backend unavailable')
+
+    expect(window.localStorage.getItem(SIDEBAR_PINNED_STORAGE_KEY)).toBe(JSON.stringify(['legacy']))
+  })
+
+  it('keeps the local pinned drag-order independent of the server pin set', () => {
+    // Pin membership (server-synced) and drag-order (local) are separate stores:
+    // setting the order must not mutate the pinned set, and must dedupe/no-op on
+    // an unchanged write.
+    setSidebarPinnedOrderIds(['b', 'a', 'c'])
+    expect($sidebarPinnedOrderIds.get()).toEqual(['b', 'a', 'c'])
+
+    const ref = $sidebarPinnedOrderIds.get()
+    setSidebarPinnedOrderIds(['b', 'a', 'c'])
+    expect($sidebarPinnedOrderIds.get()).toBe(ref) // no-op keeps the same reference
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -1,9 +1,13 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
+import { setSessionPinned as patchSessionPinned } from '@/hermes'
 import { Codecs, persistentAtom } from '@/lib/persisted'
-import { arraysEqual, insertUniqueId } from '@/lib/storage'
+import { arraysEqual, readKey, writeKey } from '@/lib/storage'
+import { activeGateway } from '@/store/gateway'
 
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
+import { $activeSessionId, $selectedStoredSessionId, $sessions, setSessions } from './session'
+import { broadcastSessionsChanged } from './session-sync'
 
 export const SIDEBAR_DEFAULT_WIDTH = 237
 export const SIDEBAR_MAX_WIDTH = 360
@@ -16,7 +20,7 @@ export const FILE_BROWSER_MAX_WIDTH = '20rem'
 
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
-const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
+export const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
@@ -66,13 +70,58 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
   return typeof override === 'number' ? override : SIDEBAR_DEFAULT_WIDTH
 })
 
-export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
+const $legacyPinnedSessionIds = atom(readLegacyPinnedSessionIds())
+
+export const $pinnedSessionIds: ReadableAtom<string[]> = computed(
+  [$sessions, $legacyPinnedSessionIds],
+  (sessions, legacyPinnedSessionIds) => {
+    const serverCapable = sessions.some(session => 'pinned' in session)
+
+    if (!serverCapable) {
+      return legacyPinnedSessionIds
+    }
+
+    const ids: string[] = []
+
+    for (const session of sessions) {
+      if (!session.pinned) {
+        continue
+      }
+
+      const id = pinIdForSession(session)
+
+      if (!ids.includes(id)) {
+        ids.push(id)
+      }
+    }
+
+    return ids
+  }
+)
 export const $sidebarSessionOrderIds = persistentAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
   [] as string[],
   Codecs.stringArray
 )
 export const $sidebarSessionOrderManual = persistentAtom(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, false, Codecs.bool)
+// Manual drag-order of PINNED rows, kept per-device (local) and layered over the
+// server-synced pinned SET ($pinnedSessionIds). Pin membership syncs across
+// machines; the visual order is a local preference — reordering on one device
+// must not reshuffle another. Keyed by durable (lineage-root) pin ids so the
+// order survives a session's compression id-change. Empty = default order.
+const SIDEBAR_PINNED_ORDER_STORAGE_KEY = 'hermes.desktop.pinnedOrder'
+export const $sidebarPinnedOrderIds = persistentAtom(
+  SIDEBAR_PINNED_ORDER_STORAGE_KEY,
+  [] as string[],
+  Codecs.stringArray
+)
+
+export function setSidebarPinnedOrderIds(ids: string[]) {
+  if (!arraysEqual($sidebarPinnedOrderIds.get(), ids)) {
+    $sidebarPinnedOrderIds.set(ids)
+  }
+}
+
 export const $sidebarWorkspaceOrderIds = persistentAtom(
   SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY,
   [] as string[],
@@ -291,35 +340,105 @@ export function setSidebarResizing(resizing: boolean) {
   $isSidebarResizing.set(resizing)
 }
 
-export function pinSession(sessionId: string, index?: number) {
-  const prev = $pinnedSessionIds.get()
-  const next = insertUniqueId(prev, sessionId, index ?? prev.filter(id => id !== sessionId).length)
+export function readLegacyPinnedSessionIds(): string[] {
+  const raw = readKey(SIDEBAR_PINNED_STORAGE_KEY)
 
-  if (!arraysEqual(prev, next)) {
-    $pinnedSessionIds.set(next)
+  if (!raw) {
+    return []
+  }
+
+  try {
+    return Codecs.stringArray.decode(raw)
+  } catch {
+    return []
   }
 }
 
-export function unpinSession(sessionId: string) {
-  const prev = $pinnedSessionIds.get()
-  const next = prev.filter(id => id !== sessionId)
+function clearLegacyPinnedSessionIds() {
+  writeKey(SIDEBAR_PINNED_STORAGE_KEY, null)
+  $legacyPinnedSessionIds.set([])
+}
 
-  if (!arraysEqual(prev, next)) {
-    $pinnedSessionIds.set(next)
+export async function migrateLegacyPinnedSessions(
+  sessions: Array<{ id: string; _lineage_root_id?: null | string; pinned?: boolean }>,
+  pushPinned: (sessionId: string) => Promise<void>,
+  log: Pick<Console, 'info'> = console
+): Promise<number> {
+  const legacyIds = readLegacyPinnedSessionIds()
+
+  if (legacyIds.length === 0) {
+    return 0
+  }
+
+  const serverPinnedIds = new Set(sessions.filter(session => session.pinned).map(pinIdForSession))
+  const pushedIds = legacyIds.filter((id, index) => legacyIds.indexOf(id) === index && !serverPinnedIds.has(id))
+
+  await Promise.all(pushedIds.map(id => pushPinned(id)))
+  clearLegacyPinnedSessionIds()
+  log.info('server-side pinned sessions migration push count', {
+    pushed: pushedIds.length,
+    total: legacyIds.length
+  })
+
+  return pushedIds.length
+}
+
+function sessionMatchesPinId(session: { id: string; _lineage_root_id?: null | string }, pinId: string): boolean {
+  return session.id === pinId || session._lineage_root_id === pinId || pinIdForSession(session) === pinId
+}
+
+function pinIdForSession(session: { id: string; _lineage_root_id?: null | string }): string {
+  return session._lineage_root_id || session.id
+}
+
+function markSessionPinned(pinId: string, pinned: boolean) {
+  setSessions(prev =>
+    prev.map(session => (sessionMatchesPinId(session, pinId) ? { ...session, pinned } : session))
+  )
+}
+
+export async function setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
+  const session = $sessions.get().find(s => sessionMatchesPinId(s, sessionId))
+  const pinId = session ? pinIdForSession(session) : sessionId
+  const previous = $sessions.get()
+
+  markSessionPinned(pinId, pinned)
+
+  try {
+    const selectedStoredSessionId = $selectedStoredSessionId.get()
+
+    const runtimeId =
+      selectedStoredSessionId && (selectedStoredSessionId === sessionId || selectedStoredSessionId === pinId)
+        ? $activeSessionId.get()
+        : null
+
+    const gateway = runtimeId ? activeGateway() : null
+
+    if (gateway && runtimeId) {
+      try {
+        await gateway.request('session.pin', { session_id: runtimeId, pinned })
+        broadcastSessionsChanged()
+
+        return
+      } catch (err) {
+        console.warn('session.pin RPC failed; falling back to REST', err)
+      }
+    }
+
+    await patchSessionPinned(pinId, pinned, session?.profile)
+    broadcastSessionsChanged()
+  } catch (err) {
+    setSessions(previous)
+    throw err
   }
 }
 
-// Replace the whole pinned order at once (drag-reorder hands back the new order
-// rather than a single move). Keep only ids that are actually pinned so a stale
-// row can't smuggle an unpinned id into the store.
-export function setPinnedSessionOrder(ids: string[]) {
-  const prev = $pinnedSessionIds.get()
-  const pinned = new Set(prev)
-  const next = ids.filter(id => pinned.has(id))
+export function pinSession(sessionId: string): Promise<void> {
+  return setSessionPinned(sessionId, true)
+}
 
-  if (next.length === prev.length && !arraysEqual(prev, next)) {
-    $pinnedSessionIds.set(next)
-  }
+export function unpinSession(sessionId: string): Promise<void> {
+  return setSessionPinned(sessionId, false)
 }
 
 export function bumpSessionsLimit(step: number = SIDEBAR_SESSIONS_PAGE_SIZE) {

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -120,7 +120,7 @@ describe('reportBackendContract', () => {
   })
 
   it('dismisses the toast when the backend meets the contract', () => {
-    reportBackendContract(2)
+    reportBackendContract(3)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
   })
@@ -160,8 +160,8 @@ describe('reportBackendContract', () => {
     lastToast().onDismiss()
     notifySpy.mockClear()
 
-    reportBackendContract(2) // backend updated → satisfied, snooze cleared
-    reportBackendContract(1) // a later regression must warn immediately
+    reportBackendContract(3) // backend updated → satisfied, snooze cleared
+    reportBackendContract(2) // a later regression must warn immediately
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -91,7 +91,8 @@ function isUpdateToastSnoozed(): boolean {
 // against. The backend reports its own value in session runtime info; a lower
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.
 // v2: requires the file.attach RPC (remote-gateway non-image file upload).
-const REQUIRED_BACKEND_CONTRACT = 2
+// v3: requires server-side pinned sessions (`pinned` rows + session.pin RPC).
+const REQUIRED_BACKEND_CONTRACT = 3
 const SKEW_TOAST_ID = 'backend-contract-skew'
 // The contract check runs on every session.resume (applyRuntimeInfo), so
 // without a snooze the warning re-popped on every thread the user opened, even

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -317,6 +317,7 @@ export interface SessionCreateResponse {
 
 export interface SessionInfo {
   archived?: boolean
+  pinned?: boolean
   cwd?: null | string
   /** Git branch checked out in {@link cwd} when the session started/resumed.
    *  The sidebar groups main-checkout sessions by this so feature-branch work
@@ -402,6 +403,7 @@ export interface SessionRuntimeInfo {
   install_warning?: string
   model?: string
   personality?: string
+  pinned?: boolean
   provider?: string
   reasoning_effort?: string
   running?: boolean

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4028,6 +4028,7 @@ def get_sessions(
                     s["is_default_profile"] = profile_name == "default"
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
+                s["pinned"] = bool(s.get("pinned"))
             if not full:
                 _strip_session_list_rows(sessions)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
@@ -4146,6 +4147,7 @@ def get_profiles_sessions(
                     and (now - s.get("last_active", s.get("started_at", 0))) < 300
                 )
                 s["archived"] = bool(s.get("archived"))
+                s["pinned"] = bool(s.get("pinned"))
                 merged.append(s)
         except Exception as exc:
             errors.append({"profile": name, "error": str(exc)})
@@ -9777,6 +9779,7 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
 class SessionRename(BaseModel):
     title: Optional[str] = None
     archived: Optional[bool] = None
+    pinned: Optional[bool] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None
@@ -9787,7 +9790,8 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
     """Update a session: rename (or clear its title) and/or archive it.
 
     ``title`` renames (empty/null clears the title); ``archived`` soft-hides or
-    restores the session. Either field may be omitted. ``profile`` targets
+    restores the session; ``pinned`` updates the sidebar pin flag. Any field may
+    be omitted. ``profile`` targets
     another profile's session.
     """
     db = _open_session_db_for_profile(body.profile)
@@ -9795,10 +9799,10 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
-        if body.title is None and body.archived is None:
+        if body.title is None and body.archived is None and body.pinned is None:
             raise HTTPException(
                 status_code=400,
-                detail="Nothing to update; provide 'title' and/or 'archived'.",
+                detail="Nothing to update; provide 'title', 'archived', and/or 'pinned'.",
             )
         if body.title is not None:
             try:
@@ -9808,9 +9812,13 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 raise HTTPException(status_code=400, detail=str(e))
         if body.archived is not None:
             db.set_session_archived(sid, body.archived)
+        if body.pinned is not None:
+            db.set_session_pinned(sid, body.pinned)
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:
             result["archived"] = bool(body.archived)
+        if body.pinned is not None:
+            result["pinned"] = bool(body.pinned)
         return result
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -759,6 +759,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_failure_cooldown_until REAL,
     compression_failure_error TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
+    pinned INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
@@ -3051,6 +3052,63 @@ class SessionDB:
             return rowcount
         rowcount = self._execute_write(_do)
         return rowcount > 0
+
+    def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
+        """Pin or unpin a session.
+
+        Pins are a server-owned visibility flag for the desktop sidebar. For
+        compression chains, update the whole logical conversation: the desktop
+        renders roots projected forward to their latest continuation but keys
+        the pin on the lineage root, so updating only one row lets a sibling in
+        the chain resurrect stale state on the next list refresh.
+
+        Returns True when the target session exists (including idempotent
+        writes that leave the value unchanged), False for unknown ids.
+        """
+        value = 1 if pinned else 0
+
+        def _do(conn):
+            exists = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if not exists:
+                return 0
+            conn.execute(
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                UPDATE sessions
+                SET pinned = ?
+                WHERE id IN (SELECT id FROM lineage)
+                """,
+                (session_id, session_id, value),
+            )
+            return 1
+
+        return bool(self._execute_write(_do))
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2831,6 +2831,44 @@ class TestSessionTitle:
         assert session["ended_at"] is not None
 
 
+class TestSessionPinned:
+    def test_pinned_defaults_false_and_roundtrips_through_reopen(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            assert db.get_session("s1")["pinned"] == 0
+
+            assert db.set_session_pinned("s1", True) is True
+        finally:
+            db.close()
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            session = reopened.get_session("s1")
+            assert session["pinned"] == 1
+            rich = reopened.list_sessions_rich(limit=10)
+            assert [(row["id"], bool(row["pinned"])) for row in rich] == [("s1", True)]
+        finally:
+            reopened.close()
+
+    def test_set_pinned_nonexistent_session(self, db):
+        assert db.set_session_pinned("missing", True) is False
+
+    def test_projected_compression_tip_keeps_root_pin(self, db):
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", "user", "hello")
+
+        assert db.set_session_pinned("root", True) is True
+
+        [row] = db.list_sessions_rich(limit=10, order_by_last_active=True)
+        assert row["id"] == "tip"
+        assert row["_lineage_root_id"] == "root"
+        assert bool(row["pinned"]) is True
+
+
 class TestSessionTitleLineage:
     """Renaming a compression continuation back to its base title must succeed
     by transferring the title off the ended, hidden predecessor.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2142,6 +2142,77 @@ def test_session_title_falls_back_to_queue_when_row_create_fails(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_session_pin_updates_db_and_echoes_session_info(monkeypatch):
+    calls = []
+    emitted = []
+
+    class _FakeDB:
+        def set_session_pinned(self, key, pinned):
+            calls.append((key, pinned))
+            return True
+
+    session = _session(session_key="session-key")
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server,
+        "_emit_session_info_for_session",
+        lambda sid, sess: emitted.append((sid, dict(sess))),
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.pin",
+                "params": {"session_id": "sid", "pinned": True},
+            }
+        )
+
+        assert resp["result"] == {"pinned": True, "session_key": "session-key"}
+        assert calls == [("session-key", True)]
+        assert session["pinned"] is True
+        assert emitted == [("sid", {**session})]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_pin_missing_session_matches_title_error_contract():
+    title = server.handle_request(
+        {"id": "same", "method": "session.title", "params": {"session_id": "dead"}}
+    )
+    pin = server.handle_request(
+        {
+            "id": "same",
+            "method": "session.pin",
+            "params": {"session_id": "dead", "pinned": True},
+        }
+    )
+
+    assert pin == title == {
+        "jsonrpc": "2.0",
+        "id": "same",
+        "error": {"code": 4001, "message": "session not found"},
+    }
+
+
+def test_session_pin_db_unavailable_uses_title_db_error_code(monkeypatch):
+    server._sessions["sid"] = _session(session_key="session-key")
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_db_error", "missing state")
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.pin",
+                "params": {"session_id": "sid", "pinned": True},
+            }
+        )
+        assert resp["error"]["code"] == 5007
+        assert resp["error"]["message"] == "state.db unavailable: missing state"
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_notification_event_routing_by_session_key(monkeypatch):
     """Background-process events surface only in the session that owns them."""
     mine = _session(session_key="mine")
@@ -6433,6 +6504,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "last_active": 20.0,
         "message_count": 1,
         "model": "model-a",
+        "pinned": False,
         "preview": "find docs",
         "session_key": "key-a",
         "started_at": 10.0,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3307,7 +3307,8 @@ def _current_profile_name() -> str:
 # checkout), surfacing a one-click "update to align" prompt instead of failing
 # cryptically downstream. Bump whenever the desktop's backend contract changes.
 # v2: adds the file.attach RPC (remote-gateway non-image file upload).
-DESKTOP_BACKEND_CONTRACT = 2
+# v3: adds server-side pinned sessions (`pinned` session rows + session.pin).
+DESKTOP_BACKEND_CONTRACT = 3
 
 
 def _session_info(agent, session: dict | None = None) -> dict:
@@ -3368,6 +3369,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
         "title": _session_live_title(session or {}, session_key) if session_key else "",
+        "pinned": _session_live_pinned(session or {}, session_key) if session_key else False,
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "",
         "release_date": "",
@@ -5341,6 +5343,7 @@ def _(rid, params: dict) -> dict:
                         "started_at": s.get("started_at") or 0,
                         "message_count": s.get("message_count") or 0,
                         "source": s.get("source") or "",
+                        "pinned": bool(s.get("pinned")),
                     }
                     for s in rows
                 ]
@@ -5975,6 +5978,22 @@ def _session_live_title(session: dict, key: str) -> str:
     return title
 
 
+def _session_live_pinned(session: dict, key: str) -> bool:
+    if "pinned" in session:
+        return bool(session.get("pinned"))
+    db = _get_db()
+    if db is not None:
+        try:
+            row = db.get_session(key)
+            if row is not None:
+                pinned = bool(row.get("pinned"))
+                session["pinned"] = pinned
+                return pinned
+        except Exception:
+            pass
+    return False
+
+
 def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     key = _session_lookup_key(session, fallback=sid)
     agent = session.get("agent")
@@ -5993,6 +6012,7 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
         "message_count": len(history),
         "model": str(getattr(agent, "model", "") or _resolve_model()),
         "preview": preview,
+        "pinned": _session_live_pinned(session, key),
         "session_key": key,
         "started_at": float(session.get("created_at") or now),
         "status": status,
@@ -6251,6 +6271,30 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"pending": True, "title": title})
     except ValueError as e:
         return _err(rid, 4022, str(e))
+    except Exception as e:
+        return _err(rid, 5007, str(e))
+
+
+@method("session.pin")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    assert session is not None
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5007)
+    key = session["session_key"]
+    pinned = bool(params.get("pinned"))
+    try:
+        if not db.set_session_pinned(key, pinned):
+            _ensure_session_db_row(session)
+            with _session_db(session) as scoped_db:
+                if scoped_db is None or not scoped_db.set_session_pinned(key, pinned):
+                    return _err(rid, 5007, "session pin failed")
+        session["pinned"] = pinned
+        _emit_session_info_for_session(params.get("session_id", ""), session)
+        return _ok(rid, {"pinned": pinned, "session_key": key})
     except Exception as e:
         return _err(rid, 5007, str(e))
 


### PR DESCRIPTION
## What
Session pins currently live in **localStorage** (`$pinnedSessionIds` persistentAtom) — each install keeps its own list, so pins don't follow the user across machines and are lost with browser data. This makes pins **server-owned** and syncs them **live** across devices.

## Changes
- **hermes_state**: `pinned` column on `sessions` (additive migration, `DEFAULT 0`), `set_session_pinned()`, exposed as a real JSON boolean in list projections.
- **web_server**: `PATCH /api/sessions/{id}` accepts `pinned` alongside `title`/`archived`; lists return it.
- **gateway**: `session.pin` RPC for socket clients.
- **desktop**: `$pinnedSessionIds` becomes a server-derived computed (pins keyed on the compression-stable lineage-root id, so auto-compression id rotation doesn't evaporate pins); one-shot localStorage→server migration for existing pins; **drag-reorder preserved** via a per-device order atom layered over the server-synced membership set (membership syncs, visual order stays local — this was a real regression the first time we built it, caught and covered by tests).
- **Live propagation**: BroadcastChannel only reaches same-machine windows and `session.info` events route to the owning transport only, so a pin on machine A never reached an already-open app on machine B (visible only after restart). The sidebar now re-pulls on window focus + a 30s focused poll (mirrors the existing poll-based livesync pattern; **no new RPCs**).

## Verification
- `tests/test_hermes_state.py` + `tests/test_tui_gateway_server.py`: **673 pass** on this base (incl. new pin coverage: migration, setter, RPC, list projection).
- Desktop: typecheck clean (both tsconfig projects); touched-store suites (layout/updates) **29/29**.
- Full UI suite: identical failure set to clean `origin/main` (the ambient electron-suite red that #62398 fixes) — this diff adds zero failures.
- Live E2E on a two-Mac install: pin on machine A appears on machine B within the poll window, both directions, no restart.

Cherry-picked from a fork lineage where this has been running in daily use; contributor credit preserved via rebase-merge.