### PR TITLE
fix: forward user args to exec quick commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10016,6 +10016,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Append user args to the exec command so scripts
+                            # receive the query. shlex.quote prevents shell
+                            # injection from user input.
+                            import shlex as _shlex
+                            _user_args = event.get_command_args().strip()
+                            if _user_args:
+                                exec_cmd = f"{exec_cmd} {_shlex.quote(_user_args)}"
                             # Sanitize env to prevent credential leakage —
                             # quick commands run in the gateway process which
                             # has all API keys in os.environ.


### PR DESCRIPTION
## Bug

`type: exec` quick commands (configured in `config.yaml` under `quick_commands`) run the configured shell command **without forwarding the user's arguments**. Commands that require arguments — like a Polymarket search (`/poly <query>`) — receive zero args and print their usage message instead of results.

## Root Cause

In `gateway/run.py`, the exec handler extracts `exec_cmd` from the quick command config and passes it directly to `asyncio.create_subprocess_shell()`. It never calls `event.get_command_args()` to retrieve the user's input.

Zero-argument exec commands (e.g. `/health`, `/speeds`) work fine because they don't need args — which is why this bug went unnoticed. It only surfaces for exec commands that expect user input.

## Fix

Extract user args via `event.get_command_args()`, `shlex.quote()` them for shell injection safety, and append to `exec_cmd` before spawning the subprocess. The append is gated on non-empty args so zero-arg commands are unaffected.

```python
import shlex as _shlex
_user_args = event.get_command_args().strip()
if _user_args:
    exec_cmd = f"{exec_cmd} {_shlex.quote(_user_args)}"
```

## Testing

- Verified `poly.sh "trump"` returns market results when called directly
- Verified `poly.sh` with no args prints usage (existing behavior, unaffected)
- `shlex.quote()` prevents injection on multi-word queries like `/poly white sox`
- Zero-arg exec commands (`/health`, `/speeds`, `/pws`) unaffected — append only fires when args are present
