### PR TITLE
fix(desktop): validate WebSocket token before backend ready

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6638,6 +6638,17 @@ async function spawnPoolBackend(profile, entry) {
 
   entry.token = authToken
 
+  // Verify the WebSocket session token before declaring backend ready.
+  // HTTP /api/status can pass while WS auth fails (separate transport, separate guards).
+  const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
+  const wsProbe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+  if (!wsProbe.ok) {
+    throw new Error(
+      `Hermes backend for profile "${profile}" is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason}`
+    )
+  }
+
   return {
     baseUrl,
     mode: 'local',
@@ -6645,7 +6656,7 @@ async function spawnPoolBackend(profile, entry) {
     authMode: 'token',
     token: authToken,
     profile,
-    wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
+    wsUrl,
     logs: hermesLog.slice(-80),
     ...getWindowState()
   }
@@ -6920,6 +6931,16 @@ async function startHermes() {
       rememberLog
     })
 
+    // Verify the WebSocket session token before declaring backend ready.
+    const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
+    const wsProbe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+    if (!wsProbe.ok) {
+      throw new Error(
+        `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason}`
+      )
+    }
+
     updateBootProgress({
       phase: 'backend.ready',
       message: 'Hermes backend is ready. Finalizing desktop startup',
@@ -6934,7 +6955,7 @@ async function startHermes() {
       source: 'local',
       authMode: 'token',
       token: authToken,
-      wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
+      wsUrl,
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }


### PR DESCRIPTION
## Summary

Fixes #62666.

This patch validates the resolved local Desktop WebSocket session token before declaring the local backend ready.

In both local backend boot paths, after HTTP readiness and `adoptServedDashboardToken(...)` complete, Desktop now builds the `/api/ws?token=...` URL and probes it with the existing `probeGatewayWebSocket(...)` helper. If the WebSocket token is rejected or the probe fails, boot now fails closed with a clear error instead of entering a false-ready state.

## Why

With modern headless `hermes serve`, `GET /` intentionally returns the headless “web UI disabled” 404 instead of serving SPA HTML. Desktop already falls back to the spawn token in that case, but it previously marked the backend ready without proving that `/api/ws?token=<token>` accepted that token.

This closes that validation gap.

## Changes

* Add WebSocket auth validation in the pool backend boot path.
* Add WebSocket auth validation in the main local Desktop boot path.
* Reuse the existing `probeGatewayWebSocket(...)` helper.
* Replace duplicated inline `wsUrl` literals with the already-probed `wsUrl`.

## Validation

* `git diff --cached --check` passed before commit.
* Verified the patch contains exactly two new WebSocket probe call sites.
* Verified no old inline local `wsUrl` literals remain.
* Manual Windows Desktop log inspection showed the headless `serve` 404 token-scrape path described in #62666.

## Tests

No new unit test was added.

`probeGatewayWebSocket` is already covered directly, and this patch wires the existing helper into two local boot paths. A meaningful boot-path integration test would require exporting private Desktop boot internals or spawning a real backend child process, which would be disproportionate for this narrow wiring patch.
