### PR TITLE
fix(langfuse): capture reasoning_content for DeepSeek and other providers

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -531,9 +531,16 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 
 
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
+    # Providers use different attribute names for reasoning:
+    #   - .reasoning          (Qwen, some OpenRouter paths)
+    #   - .reasoning_content  (DeepSeek, Moonshot/Kimi, Novita, OpenAI)
+    reasoning = (
+        getattr(message, "reasoning", None)
+        or getattr(message, "reasoning_content", None)
+    )
     return {
         "content": _safe_value(getattr(message, "content", None)),
-        "reasoning": _safe_value(getattr(message, "reasoning", None)),
+        "reasoning": _safe_value(reasoning),
         "tool_calls": _serialize_tool_calls(getattr(message, "tool_calls", None)),
     }
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1021,3 +1021,59 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# _serialize_assistant_message reasoning field extraction
+# ---------------------------------------------------------------------------
+
+class TestSerializeAssistantMessage:
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_serialize_reasoning_field(self):
+        """message.reasoning is serialized when present."""
+        mod = self._make_mod()
+
+        class _Msg:
+            content = "hello"
+            reasoning = "let me think..."
+
+        result = mod._serialize_assistant_message(_Msg())
+        assert result["reasoning"] == "let me think..."
+        assert result["content"] == "hello"
+
+    def test_serialize_reasoning_content_field(self):
+        """message.reasoning_content is serialized when .reasoning is absent."""
+        mod = self._make_mod()
+
+        class _Msg:
+            content = "hello"
+            reasoning_content = "deepseek thinking..."
+
+        result = mod._serialize_assistant_message(_Msg())
+        assert result["reasoning"] == "deepseek thinking..."
+
+    def test_reasoning_wins_over_reasoning_content(self):
+        """When both fields are present, .reasoning takes precedence."""
+        mod = self._make_mod()
+
+        class _Msg:
+            content = "hello"
+            reasoning = "qwen reasoning"
+            reasoning_content = "should not be used"
+
+        result = mod._serialize_assistant_message(_Msg())
+        assert result["reasoning"] == "qwen reasoning"
+
+    def test_no_reasoning_fields(self):
+        """When neither field is present, reasoning is None."""
+        mod = self._make_mod()
+
+        class _Msg:
+            content = "plain text"
+
+        result = mod._serialize_assistant_message(_Msg())
+        assert result["reasoning"] is None
+        assert result["content"] == "plain text"


### PR DESCRIPTION
## Summary

DeepSeek (and some other providers like Moonshot/Kimi, Novita, and OpenAI) use the attribute name `.reasoning_content` for reasoning blocks instead of `.reasoning` (used by Qwen and some OpenRouter paths).

The langfuse observability plugin's `_serialize_assistant_message` was only checking `.reasoning`, so DeepSeek reasoning blocks were silently dropped from langfuse traces.

## Fix

Check both `.reasoning` and `.reasoning_content` attribute names when serializing assistant messages for langfuse, falling back in order:
1. `.reasoning` (Qwen, some OpenRouter paths)
2. `.reasoning_content` (DeepSeek, Moonshot/Kimi, Novita, OpenAI)

## Test Plan

- [ ] Verify DeepSeek provider runs show reasoning in langfuse traces after this change