### PR TITLE
fix(desktop): await pooled backend teardown

### DIFF
--- a/apps/desktop/electron/backend-lifecycle.test.ts
+++ b/apps/desktop/electron/backend-lifecycle.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const source = fs
+  .readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'main.ts'), 'utf8')
+  .replace(/\r\n/g, '\n')
+
+test('pool backend teardown waits for bounded exit before dropping lifecycle state', () => {
+  const start = source.indexOf('async function stopPoolBackend(profile)')
+  assert.notEqual(start, -1)
+  const snippet = source.slice(start, start + 1200)
+
+  assert.match(snippet, /poolStops\.get\(profile\)/)
+  assert.match(snippet, /stopBackendChild\(entry\.process\)/)
+  assert.match(snippet, /await waitForBackendExit\(entry\.process\)/)
+  assert.match(snippet, /backendPool\.delete\(profile\)/)
+  assert.ok(
+    snippet.indexOf('await waitForBackendExit(entry.process)') < snippet.indexOf('backendPool.delete(profile)'),
+    'pool state must remain owned until the child exits or is escalated'
+  )
+})
+
+test('repeated pool cleanup reuses one in-flight teardown', () => {
+  const start = source.indexOf('async function stopPoolBackend(profile)')
+  const snippet = source.slice(start, start + 1200)
+
+  assert.match(snippet, /if \(stopping\) \{\s*return stopping\s*\}/)
+  assert.match(snippet, /poolStops\.set\(profile, stop\)/)
+  assert.match(snippet, /poolStops\.delete\(profile\)/)
+
+  const ensure = source.slice(source.indexOf('async function ensureBackend(profile)'), source.indexOf('async function ensureBackend(profile)') + 700)
+  assert.match(ensure, /const stopping = poolStops\.get\(key\)/)
+  assert.match(ensure, /if \(stopping\) \{\s*await stopping\s*\}/)
+})
+
+test('desktop quit waits for primary and pool backend teardown exactly once', () => {
+  const start = source.indexOf("app.on('before-quit'")
+  assert.notEqual(start, -1)
+  const snippet = source.slice(start, start + 1800)
+
+  assert.match(snippet, /event\.preventDefault\(\)/)
+  assert.match(snippet, /if \(backendQuitPromise\)/)
+  assert.match(snippet, /waitForBackendExit\(dying\)/)
+  assert.match(snippet, /stopAllPoolBackends\(\)/)
+  assert.match(snippet, /backendQuitReady = true\s*app\.quit\(\)/)
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6438,6 +6438,12 @@ async function ensureBackend(profile) {
     return startHermes()
   }
 
+  const stopping = poolStops.get(key)
+
+  if (stopping) {
+    await stopping
+  }
+
   const existing = backendPool.get(key)
 
   if (existing) {
@@ -6651,33 +6657,39 @@ async function spawnPoolBackend(profile, entry) {
   }
 }
 
-function stopPoolBackend(profile) {
+const poolStops = new Map()
+
+async function stopPoolBackend(profile) {
+  const stopping = poolStops.get(profile)
+
+  if (stopping) {
+    return stopping
+  }
   const entry = backendPool.get(profile)
 
   if (!entry) {
     return
   }
-  backendPool.delete(profile)
-  stopBackendChild(entry.process)
+  const stop = (async () => {
+    stopBackendChild(entry.process)
+    await waitForBackendExit(entry.process)
+  })().finally(() => {
+    if (backendPool.get(profile) === entry) {
+      backendPool.delete(profile)
+    }
+    poolStops.delete(profile)
+  })
+
+  poolStops.set(profile, stop)
+  return stop
 }
 
-async function teardownPoolBackendAndWait(profile) {
-  const entry = backendPool.get(profile)
-
-  if (!entry) {
-    return
-  }
-  backendPool.delete(profile)
-
-  stopBackendChild(entry.process)
-
-  await waitForBackendExit(entry.process)
+function teardownPoolBackendAndWait(profile) {
+  return stopPoolBackend(profile)
 }
 
 function stopAllPoolBackends() {
-  for (const profile of [...backendPool.keys()]) {
-    stopPoolBackend(profile)
-  }
+  return Promise.all([...backendPool.keys()].map(profile => stopPoolBackend(profile)))
 }
 
 function profileNameFromDeleteRequest(request) {
@@ -9064,7 +9076,19 @@ function configureSpellChecker() {
   }
 }
 
-app.on('before-quit', () => {
+let backendQuitReady = false
+let backendQuitPromise = null
+
+app.on('before-quit', event => {
+  if (backendQuitReady) {
+    return
+  }
+  event.preventDefault()
+
+  if (backendQuitPromise) {
+    return
+  }
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()
@@ -9092,8 +9116,14 @@ app.on('before-quit', () => {
     disposeTerminalSession(id)
   }
 
-  stopBackendChild(hermesProcess)
-  stopAllPoolBackends()
+  const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
+  stopBackendChild(dying)
+  hermesProcess = null
+
+  backendQuitPromise = Promise.all([waitForBackendExit(dying), stopAllPoolBackends()]).finally(() => {
+    backendQuitReady = true
+    app.quit()
+  })
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## What changed

- keep pooled Desktop backend lifecycle state until the child exits
- reuse an in-flight teardown when cleanup is requested repeatedly
- wait for the existing bounded SIGTERM → SIGKILL escalation path
- make reconnect wait for a dying profile backend
- defer Electron quit until primary and pooled backends finish teardown
- add focused regression coverage for teardown ordering and quit gating

## Why

Idle/LRU and app-quit cleanup sent SIGTERM and immediately deleted the pool entry. If the Python backend did not exit promptly, Electron lost the handle and the process survived under PID 1. A live installation accumulated 41 detached profile backends.

## Validation

- `node --test apps/desktop/electron/backend-lifecycle.test.ts`
- Desktop TypeScript typecheck
- ESLint: zero errors in touched files
- live mitigation confirmed 41 existing orphans exited cleanly on SIGTERM
