### PR TITLE
fix(api-server): bind run approvals to opaque IDs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -645,6 +645,50 @@ def _redact_api_error_text(value: Any, *, limit: int | None = None) -> str:
     return redacted
 
 
+_APPROVAL_ID_PATTERN = re.compile(r"approval_[0-9a-f]{32}")
+_APPROVAL_CHOICES = ["once", "session", "always", "deny"]
+
+
+def _build_run_approval_request_event(run_id: str, approval_data: dict) -> dict:
+    """Build the bounded, allowlisted approval event exposed to API clients."""
+    from gateway.run import _redact_approval_command
+
+    approval_id = approval_data.get("approval_id")
+    if (
+        not isinstance(approval_id, str)
+        or _APPROVAL_ID_PATTERN.fullmatch(approval_id) is None
+    ):
+        raise ValueError("invalid approval ID")
+
+    def display_text(name: str, limit: int) -> str:
+        value = approval_data.get(name, "")
+        if not isinstance(value, str):
+            value = ""
+        return _redact_approval_command(value)[:limit]
+
+    raw_pattern_keys = approval_data.get("pattern_keys", [])
+    if not isinstance(raw_pattern_keys, list):
+        raw_pattern_keys = []
+    pattern_keys = [
+        _redact_approval_command(value)[:256]
+        for value in raw_pattern_keys[:16]
+        if isinstance(value, str)
+    ]
+
+    return {
+        "event": "approval.request",
+        "run_id": run_id,
+        "timestamp": time.time(),
+        "approval_id": approval_id,
+        "command": display_text("command", 4096),
+        "description": display_text("description", 1024),
+        "pattern_key": display_text("pattern_key", 256),
+        "pattern_keys": pattern_keys,
+        "allow_permanent": approval_data.get("allow_permanent") is True,
+        "choices": list(_APPROVAL_CHOICES),
+    }
+
+
 def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
     """OpenAI-style error envelope."""
     return {
@@ -1493,6 +1537,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_approval_ids": True,
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -4299,21 +4344,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
-                    event = dict(approval_data or {})
-                    # Redact credentials from the command before it enters the
-                    # SSE/API event stream — same egress bug as #48456, second
-                    # transport: API/desktop clients would otherwise receive the
-                    # raw command Tirith flagged. Reuse the gateway seam.
-                    if "command" in event:
-                        from gateway.run import _redact_approval_command
-
-                        event["command"] = _redact_approval_command(event.get("command"))
-                    event.update({
-                        "event": "approval.request",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "choices": ["once", "session", "always", "deny"],
-                    })
+                    try:
+                        event = _build_run_approval_request_event(
+                            run_id,
+                            approval_data or {},
+                        )
+                    except (TypeError, ValueError):
+                        logger.error(
+                            "[api_server] rejected malformed approval event for run %s",
+                            run_id,
+                        )
+                        return
                     self._set_run_status(
                         run_id,
                         "waiting_for_approval",
@@ -4587,17 +4628,56 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
-        try:
-            from tools.approval import resolve_gateway_approval
-
-            resolved = resolve_gateway_approval(
-                approval_session_key,
-                choice,
-                resolve_all=resolve_all,
+        approval_id = body.get("approval_id")
+        if approval_id is not None and (
+            not isinstance(approval_id, str)
+            or _APPROVAL_ID_PATTERN.fullmatch(approval_id) is None
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Invalid approval ID",
+                    code="invalid_approval_id",
+                ),
+                status=400,
             )
-        except Exception as exc:
-            logger.exception("[api_server] approval resolution failed for run %s", run_id)
-            return web.json_response(_openai_error(str(exc)), status=500)
+        if approval_id is not None and resolve_all:
+            return web.json_response(
+                _openai_error(
+                    "approval_id cannot be combined with resolve_all",
+                    code="invalid_approval_request",
+                ),
+                status=400,
+            )
+        try:
+            if approval_id is None:
+                from tools.approval import resolve_gateway_approval
+
+                resolved = resolve_gateway_approval(
+                    approval_session_key,
+                    choice,
+                    resolve_all=resolve_all,
+                )
+            else:
+                from tools.approval import resolve_gateway_approval_by_id
+
+                resolved = resolve_gateway_approval_by_id(
+                    approval_session_key,
+                    approval_id,
+                    choice,
+                )
+        except Exception:
+            logger.error(
+                "[api_server] approval resolution failed for run %s",
+                run_id,
+            )
+            return web.json_response(
+                _openai_error(
+                    "Approval resolution failed",
+                    err_type="api_error",
+                    code="approval_resolution_failed",
+                ),
+                status=500,
+            )
 
         if resolved <= 0:
             return web.json_response(
@@ -4612,22 +4692,28 @@ class APIServerAdapter(BasePlatformAdapter):
         q = self._run_streams.get(run_id)
         if q is not None:
             try:
-                q.put_nowait({
+                response_event = {
                     "event": "approval.responded",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
-                })
+                }
+                if approval_id is not None:
+                    response_event["approval_id"] = approval_id
+                q.put_nowait(response_event)
             except Exception:
                 pass
 
-        return web.json_response({
+        response_payload = {
             "object": "hermes.run.approval_response",
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
-        })
+        }
+        if approval_id is not None:
+            response_payload["approval_id"] = approval_id
+        return web.json_response(response_payload)
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4600,6 +4600,14 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(
+                _openai_error(
+                    "Request body must be a JSON object",
+                    code="invalid_json",
+                ),
+                status=400,
+            )
 
         raw_choice = str(body.get("choice", "")).strip().lower()
         aliases = {"approve": "once", "approved": "once", "allow": "once"}
@@ -4688,7 +4696,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=409,
             )
 
-        self._set_run_status(run_id, "running", last_event="approval.responded")
+        from tools.approval import has_blocking_approval
+
+        next_status = (
+            "waiting_for_approval"
+            if has_blocking_approval(approval_session_key)
+            else "running"
+        )
+        self._set_run_status(run_id, next_status, last_event="approval.responded")
         q = self._run_streams.get(run_id)
         if q is not None:
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4698,12 +4698,19 @@ class APIServerAdapter(BasePlatformAdapter):
 
         from tools.approval import has_blocking_approval
 
-        next_status = (
-            "waiting_for_approval"
-            if has_blocking_approval(approval_session_key)
-            else "running"
-        )
+        pending_approval = has_blocking_approval(approval_session_key)
+        next_status = "waiting_for_approval" if pending_approval else "running"
         self._set_run_status(run_id, next_status, last_event="approval.responded")
+        pending_after_write = has_blocking_approval(approval_session_key)
+        if pending_after_write != pending_approval:
+            next_status = (
+                "waiting_for_approval" if pending_after_write else "running"
+            )
+            self._set_run_status(
+                run_id,
+                next_status,
+                last_event="approval.responded",
+            )
         q = self._run_streams.get(run_id)
         if q is not None:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -343,9 +343,22 @@ _APPROVAL_URL_USERINFO_RE = re.compile(
 _APPROVAL_URL_QUERY_VALUE_RE = re.compile(
     r"([?&][^=\s&#'\"<>]+=)([^&#\s'\"<>]*)"
 )
+_APPROVAL_URL_OPAQUE_QUERY_RE = re.compile(
+    r"([?&])([^=&\s#'\"<>]+)(?=(?:&|#|\s|'|\"|<|>|$))"
+)
 _APPROVAL_SECRET_FLAG_RE = re.compile(
     r"(?i)(--(?:password|passwd|passphrase|token|access-token|auth-token|"
-    r"api-key|apikey|secret|client-secret|credential)(?:=|\s+))"
+    r"api-key|apikey|secret|secret-key|client-secret|credential|"
+    r"http-password|https-password|ftp-password|proxy-password)(?:=|\s+))"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
+)
+_APPROVAL_USERINFO_FLAG_RE = re.compile(
+    r"(?i)((?:^|\s)(?:-u|--user)(?:=|\s+))"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
+)
+_APPROVAL_AWS_CONFIG_SECRET_RE = re.compile(
+    r"(?i)(\baws\s+configure\s+set\s+"
+    r"(?:aws_access_key_id|aws_secret_access_key|aws_session_token)\s+)"
     r"(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
 )
 _APPROVAL_PREVIEW_MAX_CHARS = 4096
@@ -371,7 +384,19 @@ def _redact_approval_command(cmd: "str | None") -> str:
         lambda match: f"{match.group(1)}[REDACTED]",
         redacted,
     )
+    redacted = _APPROVAL_URL_OPAQUE_QUERY_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redacted,
+    )
     redacted = _APPROVAL_SECRET_FLAG_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redacted,
+    )
+    redacted = _APPROVAL_USERINFO_FLAG_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redacted,
+    )
+    redacted = _APPROVAL_AWS_CONFIG_SECRET_RE.sub(
         lambda match: f"{match.group(1)}[REDACTED]",
         redacted,
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -337,20 +337,45 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
-def _redact_approval_command(cmd: "str | None") -> str:
-    """Redact credentials from a command before it goes into an approval prompt.
+_APPROVAL_URL_USERINFO_RE = re.compile(
+    r"(?i)\b((?:https?|wss?)://)[^/\s'\"<>]*@"
+)
+_APPROVAL_URL_QUERY_VALUE_RE = re.compile(
+    r"([?&][^=\s&#'\"<>]+=)([^&#\s'\"<>]*)"
+)
+_APPROVAL_SECRET_FLAG_RE = re.compile(
+    r"(?i)(--(?:password|passwd|passphrase|token|access-token|auth-token|"
+    r"api-key|apikey|secret|client-secret|credential)(?:=|\s+))"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
+)
+_APPROVAL_PREVIEW_MAX_CHARS = 4096
 
-    Tirith's *findings* are already redacted, but the gateway approval prompt
-    is built from the raw command string, so a credential-shaped value Tirith
-    flagged would otherwise be echoed verbatim to the chat platform (#48456).
-    Uses ``redact_sensitive_text(force=True)`` — the same Tirith-grade redactor
-    — so the prompt honors redaction even when ``security.redact_secrets`` is
-    off. Module-level so the wiring is unit-testable (the call site is a deeply
-    nested gateway closure that cannot be driven directly).
+
+def _redact_approval_command(cmd: "str | None") -> str:
+    """Build a bounded, aggressively redacted approval-command preview.
+
+    Approval prompts are display-only egress, unlike command execution. In
+    addition to the shared credential-shape pass, mask all web URL userinfo and
+    query values plus values supplied to secret-bearing long flags. This keeps
+    OAuth and magic-link commands executable while preventing those values from
+    being echoed to chat/API clients.
     """
     from agent.redact import redact_sensitive_text
 
-    return redact_sensitive_text(str(cmd or ""), force=True)
+    redacted = redact_sensitive_text(str(cmd or ""), force=True)
+    redacted = _APPROVAL_URL_USERINFO_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]@",
+        redacted,
+    )
+    redacted = _APPROVAL_URL_QUERY_VALUE_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redacted,
+    )
+    redacted = _APPROVAL_SECRET_FLAG_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redacted,
+    )
+    return redacted[:_APPROVAL_PREVIEW_MAX_CHARS]
 
 
 def _gateway_provider_error_reply(text: str) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -361,7 +361,101 @@ _APPROVAL_AWS_CONFIG_SECRET_RE = re.compile(
     r"(?:aws_access_key_id|aws_secret_access_key|aws_session_token)\s+)"
     r"(?:\"[^\"]*\"|'[^']*'|[^\s]+)"
 )
+_APPROVAL_SECRET_OPTION_NAMES = frozenset(
+    {
+        "--password",
+        "--passwd",
+        "--passphrase",
+        "--token",
+        "--access-token",
+        "--auth-token",
+        "--api-key",
+        "--apikey",
+        "--secret",
+        "--secret-key",
+        "--client-secret",
+        "--credential",
+        "--http-password",
+        "--https-password",
+        "--ftp-password",
+        "--proxy-password",
+        "--user",
+        "-u",
+    }
+)
+_APPROVAL_AWS_SECRET_KEY_RE = re.compile(
+    r"(?i)^(?:profile\.[^.]+\.)?"
+    r"(?:aws_access_key_id|aws_secret_access_key|aws_session_token)$"
+)
 _APPROVAL_PREVIEW_MAX_CHARS = 4096
+
+
+def _redact_shell_equivalent_approval_credentials(text: str) -> str:
+    """Mask credential syntax hidden by valid shell quoting/concatenation."""
+    try:
+        tokens = shlex.split(text, posix=True)
+    except ValueError:
+        return text
+
+    changed = False
+    redact_next = False
+    for index, token in enumerate(tokens):
+        lowered = token.lower()
+        if redact_next:
+            redact_next = False
+            if token != "[REDACTED]":
+                tokens[index] = "[REDACTED]"
+                changed = True
+            continue
+
+        if lowered in _APPROVAL_SECRET_OPTION_NAMES:
+            redact_next = True
+            continue
+        if lowered.startswith("-u") and not lowered.startswith("--") and len(token) > 2:
+            tokens[index] = "-u[REDACTED]"
+            changed = True
+            continue
+
+        matched_option = next(
+            (
+                option
+                for option in _APPROVAL_SECRET_OPTION_NAMES
+                if option.startswith("--") and lowered.startswith(f"{option}=")
+            ),
+            None,
+        )
+        if matched_option is not None:
+            replacement = f"{token[:len(matched_option)]}=[REDACTED]"
+            if token != replacement:
+                tokens[index] = replacement
+                changed = True
+            continue
+
+        if re.match(r"(?i)^(?:https?|wss?)://", token) and "?" in token:
+            prefix, query = token.split("?", 1)
+            query_without_fragment = query.split("#", 1)[0]
+            parts = query_without_fragment.split("&") if query_without_fragment else []
+            already_redacted = bool(parts) and all(
+                part == "[REDACTED]" or part.endswith("=[REDACTED]")
+                for part in parts
+            )
+            if query and not already_redacted:
+                fragment = f"#{query.split('#', 1)[1]}" if "#" in query else ""
+                tokens[index] = f"{prefix}?[REDACTED]{fragment}"
+                changed = True
+
+    for index in range(len(tokens) - 4):
+        if (
+            tokens[index].lower() == "aws"
+            and tokens[index + 1].lower() == "configure"
+            and tokens[index + 2].lower() == "set"
+            and _APPROVAL_AWS_SECRET_KEY_RE.fullmatch(tokens[index + 3])
+            and tokens[index + 4] != "[REDACTED]"
+        ):
+            tokens[index + 4] = "[REDACTED]"
+            changed = True
+
+    return shlex.join(tokens) if changed else text
 
 
 def _redact_approval_command(cmd: "str | None") -> str:
@@ -400,6 +494,7 @@ def _redact_approval_command(cmd: "str | None") -> str:
         lambda match: f"{match.group(1)}[REDACTED]",
         redacted,
     )
+    redacted = _redact_shell_equivalent_approval_credentials(redacted)
     return redacted[:_APPROVAL_PREVIEW_MAX_CHARS]
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -885,6 +885,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_approval_ids"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -405,6 +405,30 @@ class TestRunEvents:
         assert sentinel not in caplog.text
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [[], "deny", 1])
+    async def test_approval_rejects_non_object_json(self, adapter, payload, caplog):
+        app = _create_runs_app(adapter)
+        run_id = "run_non_object_json"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_approval_sessions[run_id] = run_id
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json=payload,
+            )
+            data = await response.json()
+
+        assert response.status == 400
+        assert data["error"] == {
+            "message": "Request body must be a JSON object",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_json",
+        }
+        assert "Traceback" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_approval_response_by_id_never_retargets_fifo_head(self, adapter):
         app = _create_runs_app(adapter)
         run_id = "run_exact_approval"
@@ -433,9 +457,56 @@ class TestRunEvents:
         assert not first.event.is_set()
         assert second.event.is_set()
         assert approval_mod._gateway_queues[run_id] == [first]
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
         event = adapter._run_streams[run_id].get_nowait()
         assert event["event"] == "approval.responded"
         assert event["approval_id"] == second.approval_id
+
+    @pytest.mark.asyncio
+    async def test_approval_id_errors_never_consume_pending_entry(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_approval_id_errors"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_approval_sessions[run_id] = run_id
+        pending = approval_mod._ApprovalEntry({"command": "pending"})
+        approval_mod._gateway_queues[run_id] = [pending]
+
+        cases = [
+            (
+                {"choice": "deny", "approval_id": "invalid"},
+                400,
+                "invalid_approval_id",
+            ),
+            (
+                {"choice": "deny", "approval_id": "approval_" + "f" * 32},
+                409,
+                "approval_not_pending",
+            ),
+            (
+                {
+                    "choice": "deny",
+                    "approval_id": pending.approval_id,
+                    "resolve_all": True,
+                },
+                400,
+                "invalid_approval_request",
+            ),
+        ]
+
+        async with TestClient(TestServer(app)) as cli:
+            for payload, expected_status, expected_code in cases:
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json=payload,
+                )
+                data = await response.json()
+
+                assert response.status == expected_status
+                assert data["error"]["code"] == expected_code
+                assert data["error"]["param"] is None
+                assert approval_mod._gateway_queues[run_id] == [pending]
+                assert pending.result is None
+                assert not pending.event.is_set()
 
     @pytest.mark.asyncio
     async def test_approval_string_false_does_not_resolve_all(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    _build_run_approval_request_event,
     cors_middleware,
     security_headers_middleware,
 )
@@ -276,6 +278,43 @@ class TestRunStatus:
 # ---------------------------------------------------------------------------
 
 
+def test_approval_request_event_allowlists_and_redacts_display_fields():
+    sentinel = "opaque" + "Z" * 24
+    approval_id = "approval_" + "a" * 32
+
+    event = _build_run_approval_request_event(
+        "run_safe_event",
+        {
+            "approval_id": approval_id,
+            "command": f"curl 'https://user:{sentinel}@example.com/?key={sentinel}'",
+            "description": f"deploy --password {sentinel}",
+            "pattern_key": f"pattern --token={sentinel}",
+            "pattern_keys": [f"first?value={sentinel}", "second"],
+            "allow_permanent": True,
+            "raw_internal_field": sentinel,
+        },
+    )
+
+    assert set(event) == {
+        "event",
+        "run_id",
+        "timestamp",
+        "approval_id",
+        "command",
+        "description",
+        "pattern_key",
+        "pattern_keys",
+        "allow_permanent",
+        "choices",
+    }
+    assert event["approval_id"] == approval_id
+    assert event["choices"] == ["once", "session", "always", "deny"]
+    assert sentinel not in json.dumps(event)
+    assert len(event["command"]) <= 4096
+    assert len(event["description"]) <= 1024
+    assert len(event["pattern_key"]) <= 256
+
+
 class TestRunEvents:
     @pytest.mark.asyncio
     async def test_events_stream_returns_completed(self, adapter):
@@ -333,6 +372,70 @@ class TestRunEvents:
                     "approval_not_active",
                     "approval_not_pending",
                 }
+
+    @pytest.mark.asyncio
+    async def test_approval_resolution_failure_redacts_exception(self, adapter, caplog):
+        app = _create_runs_app(adapter)
+        run_id = "run_redacted_failure"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_approval_sessions[run_id] = "session-redacted"
+        sentinel = "github_pat_NEVER_EXPOSE_THIS_SENTINEL"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "tools.approval.resolve_gateway_approval",
+                side_effect=RuntimeError(sentinel),
+            ):
+                with caplog.at_level("ERROR", logger="gateway.platforms.api_server"):
+                    response = await cli.post(
+                        f"/v1/runs/{run_id}/approval",
+                        json={"choice": "deny"},
+                    )
+                body = await response.text()
+                data = await response.json()
+
+        assert response.status == 500
+        assert data["error"] == {
+            "message": "Approval resolution failed",
+            "type": "api_error",
+            "param": None,
+            "code": "approval_resolution_failed",
+        }
+        assert sentinel not in body
+        assert sentinel not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_approval_response_by_id_never_retargets_fifo_head(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_exact_approval"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_approval_sessions[run_id] = run_id
+        adapter._run_streams[run_id] = asyncio.Queue()
+        first = approval_mod._ApprovalEntry({"command": "first"})
+        second = approval_mod._ApprovalEntry({"command": "second"})
+        approval_mod._gateway_queues[run_id] = [first, second]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"choice": "deny", "approval_id": second.approval_id},
+            )
+            data = await response.json()
+
+        assert response.status == 200
+        assert data == {
+            "object": "hermes.run.approval_response",
+            "run_id": run_id,
+            "approval_id": second.approval_id,
+            "choice": "deny",
+            "resolved": 1,
+        }
+        assert not first.event.is_set()
+        assert second.event.is_set()
+        assert approval_mod._gateway_queues[run_id] == [first]
+        event = adapter._run_streams[run_id].get_nowait()
+        assert event["event"] == "approval.responded"
+        assert event["approval_id"] == second.approval_id
 
     @pytest.mark.asyncio
     async def test_approval_string_false_does_not_resolve_all(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -314,6 +314,31 @@ def test_approval_request_event_allowlists_and_redacts_display_fields():
     assert len(event["description"]) <= 1024
     assert len(event["pattern_key"]) <= 256
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "curl -uuser:{sentinel} https://example.com",
+        "curl '--user' 'user:{sentinel}' https://example.com",
+        "wget '--http-password' '{sentinel}' https://example.com",
+        "deploy --secret-key'='{sentinel}",
+        "aws configure set 'aws_secret_access_key' '{sentinel}'",
+        "aws configure set profile.prod.aws_secret_access_key {sentinel}",
+        "curl 'https://example.com/callback?'\"{sentinel}\"",
+    ],
+)
+def test_approval_request_event_redacts_shell_equivalent_credentials(command):
+    sentinel = "opaque" + "S" * 24
+
+    event = _build_run_approval_request_event(
+        "run_shell_redaction",
+        {
+            "approval_id": "approval_" + "b" * 32,
+            "command": command.format(sentinel=sentinel),
+        },
+    )
+
+    assert sentinel not in json.dumps(event)
+
 
 class TestRunEvents:
     @pytest.mark.asyncio
@@ -461,6 +486,35 @@ class TestRunEvents:
         event = adapter._run_streams[run_id].get_nowait()
         assert event["event"] == "approval.responded"
         assert event["approval_id"] == second.approval_id
+        approval_mod._gateway_queues.pop(run_id, None)
+
+    @pytest.mark.asyncio
+    async def test_approval_status_rechecks_after_concurrent_enqueue(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_status_recheck"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_approval_sessions[run_id] = run_id
+        approval_id = "approval_" + "a" * 32
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch(
+                    "tools.approval.resolve_gateway_approval_by_id",
+                    return_value=1,
+                ),
+                patch(
+                    "tools.approval.has_blocking_approval",
+                    side_effect=[False, True],
+                ) as mock_pending,
+            ):
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "deny", "approval_id": approval_id},
+                )
+
+        assert response.status == 200
+        assert mock_pending.call_count == 2
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
 
     @pytest.mark.asyncio
     async def test_approval_id_errors_never_consume_pending_entry(self, adapter):
@@ -507,6 +561,7 @@ class TestRunEvents:
                 assert approval_mod._gateway_queues[run_id] == [pending]
                 assert pending.result is None
                 assert not pending.event.is_set()
+        approval_mod._gateway_queues.pop(run_id, None)
 
     @pytest.mark.asyncio
     async def test_approval_string_false_does_not_resolve_all(self, adapter):

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -17,6 +17,8 @@ the redactor regexes so the assertions stay meaningful, but contain no real
 or real-looking key, so secret scanners do not flag this file.
 """
 
+import pytest
+
 from gateway.run import _redact_approval_command
 
 # Synthetic, scanner-safe credential fixtures. Each matches its redactor
@@ -80,6 +82,24 @@ class TestRedactApprovalCommand:
         assert "--password [REDACTED]" in out
         assert "--api-key=[REDACTED]" in out
         assert "--access-token [REDACTED]" in out
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl -u user:{sentinel} https://example.com",
+            "curl --user user:{sentinel} https://example.com",
+            "wget --http-password={sentinel} https://example.com",
+            "deploy --secret-key={sentinel}",
+            "aws configure set aws_secret_access_key {sentinel}",
+            "curl https://example.com/callback?{sentinel}",
+        ],
+    )
+    def test_redacts_additional_credential_forms(self, command):
+        sentinel = "opaque" + "Q" * 24
+
+        out = _redact_approval_command(command.format(sentinel=sentinel))
+
+        assert sentinel not in out
 
     def test_bounds_approval_preview(self):
         assert len(_redact_approval_command("x" * 5000)) == 4096

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -101,6 +101,25 @@ class TestRedactApprovalCommand:
 
         assert sentinel not in out
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl -uuser:{sentinel} https://example.com",
+            "curl '--user' 'user:{sentinel}' https://example.com",
+            "wget '--http-password' '{sentinel}' https://example.com",
+            "deploy --secret-key'='{sentinel}",
+            "aws configure set 'aws_secret_access_key' '{sentinel}'",
+            "aws configure set profile.prod.aws_secret_access_key {sentinel}",
+            "curl 'https://example.com/callback?'\"{sentinel}\"",
+        ],
+    )
+    def test_redacts_shell_equivalent_credential_forms(self, command):
+        sentinel = "opaque" + "R" * 24
+
+        out = _redact_approval_command(command.format(sentinel=sentinel))
+
+        assert sentinel not in out
+
     def test_bounds_approval_preview(self):
         assert len(_redact_approval_command("x" * 5000)) == 4096
 

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -53,6 +53,37 @@ class TestRedactApprovalCommand:
         raw = "ls -la /tmp && echo hello"
         assert _redact_approval_command(raw) == raw
 
+    def test_redacts_web_url_userinfo_and_all_query_values(self):
+        sentinel = "opaque" + "X" * 24
+        raw = (
+            f"curl 'https://user:{sentinel}@example.com/run"
+            f"?token={sentinel}&label=public'"
+        )
+
+        out = _redact_approval_command(raw)
+
+        assert sentinel not in out
+        assert "example.com/run" in out
+        assert "token=[REDACTED]" in out
+        assert "label=[REDACTED]" in out
+
+    def test_redacts_secret_bearing_cli_flag_values(self):
+        sentinel = "opaque" + "Y" * 24
+        raw = (
+            f"deploy --password {sentinel} --api-key={sentinel} "
+            f"--access-token '{sentinel}'"
+        )
+
+        out = _redact_approval_command(raw)
+
+        assert sentinel not in out
+        assert "--password [REDACTED]" in out
+        assert "--api-key=[REDACTED]" in out
+        assert "--access-token [REDACTED]" in out
+
+    def test_bounds_approval_preview(self):
+        assert len(_redact_approval_command("x" * 5000)) == 4096
+
     def test_forces_redaction_even_when_disabled(self, monkeypatch):
         """force=True must redact even if security.redact_secrets is off -- the
         approval prompt is a hard secret-egress boundary regardless of config."""
@@ -77,13 +108,19 @@ class TestApprovalCommandWiring:
     benign refactor doesn't cause a false failure, and so a discarded-result
     call (`_redact(cmd); send(cmd)`) does NOT pass."""
 
-    def _assert_redacts_then_uses(self, module, func_name: str, sink_substr: str):
-        """Parse `module`'s full AST, locate the (possibly nested) function
-        `func_name`, and assert it contains an assignment
-        `<x> = _redact_approval_command(...)` whose result is then used by a
-        statement matching `sink_substr` on a LATER line. Walking the real AST
-        (not a source slice) is refactor-robust and rejects discarded-result
-        calls (the call must be an assignment, not a bare expression)."""
+    def _assert_redacts_then_uses(
+        self,
+        module,
+        func_name: str,
+        sink_substr: str,
+        helper_name: str = "_redact_approval_command",
+    ):
+        """Assert a helper result is assigned before the named egress sink.
+
+        Walking the real AST (not a source slice) is refactor-robust and rejects
+        discarded-result calls: the helper call must be an assignment, not a
+        bare expression.
+        """
         import ast
         import inspect
 
@@ -100,10 +137,10 @@ class TestApprovalCommandWiring:
         for node in ast.walk(target_fn):
             if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
                 fn = node.value.func
-                if isinstance(fn, ast.Name) and fn.id == "_redact_approval_command":
+                if isinstance(fn, ast.Name) and fn.id == helper_name:
                     redact_line = node.lineno
         assert redact_line is not None, (
-            f"{func_name} must assign the result of _redact_approval_command(...) "
+            f"{func_name} must assign the result of {helper_name}(...) "
             "(a discarded-result call would still leak the raw command)"
         )
 
@@ -125,4 +162,9 @@ class TestApprovalCommandWiring:
     def test_sse_api_path_redacts_before_enqueue(self):
         from gateway.platforms import api_server
 
-        self._assert_redacts_then_uses(api_server, "_approval_notify", "put_nowait")
+        self._assert_redacts_then_uses(
+            api_server,
+            "_approval_notify",
+            "put_nowait",
+            helper_name="_build_run_approval_request_event",
+        )

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -189,6 +189,93 @@ class TestBlockingGatewayApproval:
         assert not first.event.is_set()
         assert _gateway_queues[session_key] == [first]
 
+    def test_resolve_by_id_publishes_result_under_queue_lock(self, monkeypatch):
+        from tools import approval as approval_module
+
+        class TrackingLock:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+                self.held = False
+
+            def __enter__(self):
+                self.wrapped.acquire()
+                self.held = True
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                self.held = False
+                self.wrapped.release()
+
+        tracking_lock = TrackingLock(approval_module._lock)
+        monkeypatch.setattr(approval_module, "_lock", tracking_lock)
+        session_key = "test-exact-id-atomic"
+        entry = approval_module._ApprovalEntry({"command": "command"})
+        approval_module._gateway_queues[session_key] = [entry]
+        original_set = entry.event.set
+        observed = {}
+
+        def assert_atomic_set():
+            observed["lock_owned"] = tracking_lock.held
+            observed["result"] = entry.result
+            original_set()
+
+        entry.event.set = assert_atomic_set
+
+        assert approval_module.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "once",
+        ) == 1
+        assert observed == {"lock_owned": True, "result": "once"}
+
+    def test_timeout_boundary_adopts_committed_id_resolution(self, monkeypatch):
+        from tools import approval as approval_module
+
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"gateway_timeout": 1},
+        )
+        resolver_result = {}
+        monkeypatch.setattr(
+            approval_module.time,
+            "monotonic",
+            lambda: 2.0 if resolver_result else 0.0,
+        )
+
+        def notify(_data):
+            entry = approval_module._gateway_queues["timeout-boundary"][0]
+
+            class BoundaryEvent:
+                def wait(self, timeout):
+                    resolver_result["count"] = (
+                        approval_module.resolve_gateway_approval_by_id(
+                            "timeout-boundary",
+                            entry.approval_id,
+                            "once",
+                        )
+                    )
+                    return False
+
+                def set(self):
+                    return None
+
+            entry.event = BoundaryEvent()
+
+        result = approval_module._await_gateway_decision(
+            "timeout-boundary",
+            notify,
+            {
+                "command": "dangerous-command",
+                "description": "test",
+                "pattern_key": "test",
+                "pattern_keys": ["test"],
+            },
+        )
+
+        assert resolver_result == {"count": 1}
+        assert result == {"resolved": True, "choice": "once", "reason": None}
+
     def test_gateway_notify_receives_approval_id(self, monkeypatch):
         from tools import approval as approval_module
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -155,6 +155,65 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_resolve_by_id_never_retargets_fifo_head(self):
+        from tools.approval import (
+            resolve_gateway_approval_by_id,
+            _ApprovalEntry,
+            _gateway_queues,
+        )
+        session_key = "test-exact-id"
+        first = _ApprovalEntry({"command": "first"})
+        second = _ApprovalEntry({"command": "second"})
+        _gateway_queues[session_key] = [first, second]
+
+        assert first.approval_id.startswith("approval_")
+        assert len(first.approval_id) == len("approval_") + 32
+        assert first.data["approval_id"] == first.approval_id
+        assert first.approval_id != second.approval_id
+
+        assert resolve_gateway_approval_by_id(
+            session_key,
+            second.approval_id,
+            "deny",
+        ) == 1
+        assert not first.event.is_set()
+        assert second.event.is_set()
+        assert second.result == "deny"
+        assert _gateway_queues[session_key] == [first]
+
+        assert resolve_gateway_approval_by_id(
+            session_key,
+            second.approval_id,
+            "once",
+        ) == 0
+        assert not first.event.is_set()
+        assert _gateway_queues[session_key] == [first]
+
+    def test_gateway_notify_receives_approval_id(self, monkeypatch):
+        from tools import approval as approval_module
+
+        captured = {}
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"gateway_timeout": 0},
+        )
+
+        result = approval_module._await_gateway_decision(
+            "notify-with-id",
+            lambda data: captured.update(data),
+            {
+                "command": "dangerous-command",
+                "description": "test",
+                "pattern_key": "test",
+                "pattern_keys": ["test"],
+            },
+        )
+
+        assert captured["approval_id"].startswith("approval_")
+        assert len(captured["approval_id"]) == len("approval_") + 32
+        assert result == {"resolved": False, "choice": None, "reason": None}
+
     def test_unregister_signals_all_entries(self):
         """unregister_gateway_notify signals all waiting entries to prevent hangs."""
         from tools.approval import (

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -1419,11 +1420,13 @@ _permanent_approved: set = set()
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("approval_id", "event", "data", "result", "reason")
 
     def __init__(self, data: dict):
+        self.approval_id = f"approval_{uuid.uuid4().hex}"
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.data = dict(data)    # command, description, pattern_keys, …
+        self.data["approval_id"] = self.approval_id
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -1494,6 +1497,40 @@ def resolve_gateway_approval(session_key: str, choice: str,
             entry.reason = reason
         entry.event.set()
     return len(targets)
+
+
+def resolve_gateway_approval_by_id(session_key: str, approval_id: str,
+                                   choice: str,
+                                   reason: Optional[str] = None) -> int:
+    """Resolve exactly one pending approval without FIFO retargeting.
+
+    A stale or unknown ID resolves nothing, even when another approval is
+    pending in the same session. This identity-bound path is intended for
+    external UIs whose response can arrive after the queue has changed.
+    """
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+        entry = next(
+            (
+                candidate
+                for candidate in queue
+                if candidate.approval_id == approval_id
+            ),
+            None,
+        )
+        if entry is None:
+            return 0
+        queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+    entry.result = choice
+    if reason:
+        entry.reason = reason
+    entry.event.set()
+    return 1
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -2462,7 +2499,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(entry.data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1442,9 +1442,10 @@ def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
     The callback signature is ``cb(approval_data: dict) -> None`` where
-    *approval_data* contains ``command``, ``description``, and
-    ``pattern_keys``.  The callback bridges sync→async (runs in the agent
-    thread, must schedule the actual send on the event loop).
+    *approval_data* contains the opaque ``approval_id`` plus ``command``,
+    ``description``, and ``pattern_keys``. The callback bridges sync→async
+    (runs in the agent thread, must schedule the actual send on the event
+    loop).
     """
     with _lock:
         _gateway_notify_cbs[session_key] = cb
@@ -1488,14 +1489,14 @@ def resolve_gateway_approval(session_key: str, choice: str,
             queue.clear()
         else:
             targets = [queue.pop(0)]
+        for entry in targets:
+            entry.result = choice
+            if reason:
+                entry.reason = reason
+            entry.event.set()
         if not queue:
             _gateway_queues.pop(session_key, None)
 
-    for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
     return len(targets)
 
 
@@ -1522,14 +1523,14 @@ def resolve_gateway_approval_by_id(session_key: str, approval_id: str,
         )
         if entry is None:
             return 0
+        entry.result = choice
+        if reason:
+            entry.reason = reason
+        entry.event.set()
         queue.remove(entry)
         if not queue:
             _gateway_queues.pop(session_key, None)
 
-    entry.result = choice
-    if reason:
-        entry.reason = reason
-    entry.event.set()
     return 1
 
 
@@ -2477,13 +2478,15 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 
-    def _drop_entry() -> None:
+    def _drop_entry() -> bool:
         with _lock:
             queue = _gateway_queues.get(session_key, [])
-            if entry in queue:
+            removed = entry in queue
+            if removed:
                 queue.remove(entry)
             if not queue:
                 _gateway_queues.pop(session_key, None)
+            return removed
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -2551,7 +2554,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         if touch_activity_if_due is not None:
             touch_activity_if_due(_activity_state, "waiting for user approval")
 
-    _drop_entry()
+    waiter_removed_entry = _drop_entry()
+    if not resolved and not waiter_removed_entry and entry.result is not None:
+        # The resolver won the timeout boundary: it published the result and
+        # removed this exact entry under the queue lock. Honor that committed
+        # decision rather than reporting a contradictory timeout.
+        resolved = True
 
     choice = entry.result
     # Normalize outcome for the post hook. Unresolved (timeout) and None both

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -274,7 +274,20 @@ Interrupt a running agent turn. The endpoint returns immediately with `{"status"
 
 ### POST /v1/runs/\{run_id\}/approval
 
-Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
+Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). Each `approval.request` event includes an opaque `approval_id`; external UIs should retain that ID with the displayed request and send it back with the decision:
+
+```json
+{
+  "approval_id": "approval_0123456789abcdef0123456789abcdef",
+  "choice": "once"
+}
+```
+
+When `approval_id` is present, Hermes atomically resolves only that exact pending entry. A stale or unknown ID returns `409` and never falls through to another queued approval. The successful `approval.responded` event and HTTP acknowledgement echo the same ID. Legacy callers that omit the field retain FIFO behavior for compatibility, but detached or asynchronous UIs must not rely on that path.
+
+Approval event display fields are allowlisted, aggressively redacted, and bounded before they leave Hermes. They remain potentially sensitive operational context and should not be logged or cached by clients.
+
+Require `features.run_approval_ids == true` from `/v1/capabilities` before surfacing identity-bound controls. `features.run_approval_response` only indicates that the older response endpoint exists.
 
 ## Jobs API (background scheduled work)
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -214,6 +214,8 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
+    "run_approval_response": true,
+    "run_approval_ids": true,
     "run_stop": true
   }
 }


### PR DESCRIPTION
## Problem

Detached API clients currently resolve approvals by implicit FIFO. If an approval times out or the queue changes before a delayed browser response arrives, that response can resolve a different pending command. Resolver exceptions also cross the HTTP/log boundary as raw text, and approval previews preserve opaque URL/CLI credentials.

## Changes

- generate an opaque ID for every blocking gateway approval
- include the ID in API approval request/responded events
- add exact-ID queue resolution that never falls through to FIFO
- publish decisions and queue removal atomically, including the timeout boundary
- accept and echo `approval_id` on `POST /v1/runs/{run_id}/approval`
- keep run status `waiting_for_approval` while any queue entry remains
- reject valid non-object JSON with a controlled `400` response
- advertise `features.run_approval_ids` for fail-closed client discovery
- allowlist and bound API approval display fields
- aggressively redact URL userinfo/query values, curl/wget credentials, AWS configure credentials, and secret-bearing CLI flags in display-only approval previews
- replace raw resolver exception responses/tracebacks with a stable sanitized error
- preserve legacy FIFO and resolve-all behavior when `approval_id` is omitted

## Safety contract

A stale or unknown `approval_id` resolves zero entries and returns `409`; it cannot retarget the current FIFO head. At the timeout boundary, exactly one side owns removal: either the waiter times out and a later response gets `409`, or the resolver commits and the waiter adopts that decision. API clients should require `run_approval_ids` and always echo the ID they displayed.

## Verification

- strict RED→GREEN regressions for exact-ID queue/API behavior, timeout atomicity, remaining-queue status, notifier propagation, bounded allowlisted egress, credential variants, malformed payloads, capability discovery, and exception non-disclosure
- changed API modules: 280 passed
- all approval-related suites plus run API with declared ACP extra: 649 passed
- focused security/concurrency and API-boundary set: 15 passed
- targeted Ruff lint and Python compilation: passed
- `git diff --check`: passed

The repository-wide suite is too large for the bounded local runner; normal upstream CI remains authoritative.