### PR TITLE
feat(xiaomi): support MiMo native web_search tool (#37844)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1174,6 +1174,16 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         if preserved:
             msg["reasoning_details"] = preserved
 
+    # MiMo web_search url_citation annotations — persist so downstream
+    # renderers and gateway can display sources alongside the response.
+    annotations = getattr(assistant_message, "annotations", None)
+    if annotations is None:
+        # NormalizedResponse stores annotations in provider_data
+        pd = getattr(assistant_message, "provider_data", None) or {}
+        annotations = pd.get("annotations")
+    if annotations:
+        msg["annotations"] = annotations
+
     # Anthropic interleaved-thinking replay: when a turn interleaves signed
     # thinking blocks with tool_use, the parallel reasoning_details +
     # tool_calls fields lose the cross-type ordering, and reconstruction

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -538,8 +538,10 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs["timeout"] = timeout
 
         # Tools — apply provider preprocessing, then Moonshot/Kimi sanitization
+        # Call prepare_tools even when tools is empty/None so provider-native
+        # tools (e.g. Xiaomi web_search) can inject from nothing.
+        tools = profile.prepare_tools(tools or [], model=model)
         if tools:
-            tools = profile.prepare_tools(tools, model=model)
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
@@ -708,6 +710,33 @@ class ChatCompletionsTransport(ProviderTransport):
         rd = getattr(msg, "reasoning_details", None)
         if rd:
             provider_data["reasoning_details"] = rd
+
+        # MiMo web_search url_citation annotations.  These are
+        # response-only — the API does not require them on replay — but
+        # we persist them so downstream code can render sources.
+        annotations = getattr(msg, "annotations", None)
+        if annotations is None and hasattr(msg, "model_extra"):
+            _msg_extra_annot = getattr(msg, "model_extra", None) or {}
+            if isinstance(_msg_extra_annot, dict):
+                annotations = _msg_extra_annot.get("annotations")
+        if annotations:
+            # Normalize to plain dicts for JSON persistence.
+            def _to_dict(obj):
+                if isinstance(obj, dict):
+                    return {k: _to_dict(v) for k, v in obj.items()}
+                if isinstance(obj, list):
+                    return [_to_dict(i) for i in obj]
+                if hasattr(obj, "model_dump"):
+                    try:
+                        return obj.model_dump()
+                    except Exception:
+                        pass
+                if hasattr(obj, "__dict__"):
+                    return {k: _to_dict(v) for k, v in obj.__dict__.items()}
+                return obj
+
+            annotations = [_to_dict(a) for a in annotations]
+            provider_data["annotations"] = annotations
 
         # OpenAI structured-refusal field. When a model declines, the SDK
         # populates ``message.refusal`` with the explanation and leaves

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -537,8 +537,9 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
+        # Tools — apply provider preprocessing, then Moonshot/Kimi sanitization
         if tools:
+            tools = profile.prepare_tools(tools, model=model)
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -143,6 +143,12 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_message_items")
 
+    @property
+    def annotations(self):
+        """Response annotations (e.g. MiMo web_search url_citation)."""
+        pd = self.provider_data or {}
+        return pd.get("annotations")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -421,10 +421,20 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
+    # Extract last annotations (e.g. MiMo url_citation) from the turn.
+    last_annotations = None
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            break
+        if msg.get("role") == "assistant" and msg.get("annotations"):
+            last_annotations = msg["annotations"]
+            break
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
         "last_reasoning": last_reasoning,
+        "last_annotations": last_annotations,
         "messages": messages,
         "api_calls": api_call_count,
         "completed": completed,

--- a/cli.py
+++ b/cli.py
@@ -12692,6 +12692,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         width=self._scrollback_box_width(),
                     ))
 
+            # Render MiMo web_search url_citation sources, if any.
+            _annotations = result.get("last_annotations") if result else None
+            if _annotations:
+                _citations = []
+                for annot in _annotations:
+                    uc = annot.get("url_citation", {}) if isinstance(annot, dict) else {}
+                    url = uc.get("url", "")
+                    title = uc.get("title", "")
+                    if url:
+                        _citations.append((title, url))
+                if _citations:
+                    # Deduplicate by URL
+                    seen = set()
+                    unique = []
+                    for t, u in _citations:
+                        if u not in seen:
+                            seen.add(u)
+                            unique.append((t, u))
+                    _src_lines = []
+                    for t, u in unique:
+                        label = t if t else u
+                        _src_lines.append(f"  {_DIM}• {label} — {u}{_RST}")
+                    _cprint(f"\n{_DIM}Sources:{_RST}")
+                    for line in _src_lines:
+                        _cprint(line)
+
 
             # Play terminal bell when agent finishes (if enabled).
             # Works over SSH — the bell propagates to the user's terminal.

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -600,9 +600,15 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     if not isinstance(entry, dict):
         return None
 
+    # A user-defined provider must have a URL.  Entries that only carry
+    # sub-settings (e.g. ``providers.xiaomi.web_search: true``) must not
+    # shadow the built-in provider for that name.
+    api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
+    if not api_url:
+        return None
+
     # Extract fields
     display_name = entry.get("name", "") or name
-    api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -1,9 +1,93 @@
-"""Xiaomi MiMo provider profile."""
+"""Xiaomi MiMo provider profile.
+
+Supports MiMo's native ``web_search`` tool when enabled via config::
+
+    # config.yaml
+    providers:
+      xiaomi:
+        web_search: true
+        web_search_max_keyword: 3
+        web_search_force: false
+        web_search_location: ""   # e.g. "China", "US"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xiaomi = ProviderProfile(
+logger = logging.getLogger(__name__)
+
+
+class XiaomiProfile(ProviderProfile):
+    """Xiaomi MiMo — optional native web_search tool injection."""
+
+    def prepare_tools(
+        self, tools: list[dict[str, Any]], *, model: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Append MiMo's native ``web_search`` tool when configured.
+
+        MiMo's web_search is an API-level tool that lets the model
+        autonomously decide when to search, with citation support.
+        It coexists with Hermes's own function tools — MiMo supports
+        hybrid tool calling.
+        """
+        ws_cfg = self._web_search_config()
+        if not ws_cfg:
+            return tools
+
+        ws_tool: dict[str, Any] = {
+            "type": "web_search",
+            "max_keyword": ws_cfg.get("max_keyword", 3),
+            "force_search": ws_cfg.get("force", False),
+        }
+        location = ws_cfg.get("location", "")
+        if location:
+            ws_tool["user_location"] = {
+                "type": "approximate",
+                "country": location,
+            }
+
+        # Avoid duplicate injection if prepare_tools is called twice.
+        for t in tools:
+            if isinstance(t, dict) and t.get("type") == "web_search":
+                return tools
+
+        logger.debug("Xiaomi: injecting native web_search tool (force=%s, max_keyword=%s)",
+                      ws_tool["force_search"], ws_tool["max_keyword"])
+        return tools + [ws_tool]
+
+    # ── Config access ──────────────────────────────────────────
+
+    @staticmethod
+    def _web_search_config() -> dict[str, Any] | None:
+        """Read ``providers.xiaomi.web_search`` from config.yaml.
+
+        Returns the config dict when web_search is truthy, else None.
+        Catches all import/read errors so the profile never crashes
+        the request path.
+        """
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly()
+            providers = cfg.get("providers") or {}
+            xiaomi_cfg = providers.get("xiaomi") or {}
+            ws = xiaomi_cfg.get("web_search")
+            if not ws:
+                return None
+            if ws is True:
+                return {"max_keyword": 3, "force": False, "location": ""}
+            if isinstance(ws, dict):
+                return ws
+            return None
+        except Exception:
+            return None
+
+
+xiaomi = XiaomiProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 class XiaomiProfile(ProviderProfile):
     """Xiaomi MiMo — optional native web_search tool injection."""
 
+    # Sentinel for "not yet read".  Caching prevents per-request config
+    # re-reads that could change the wire tool schema mid-conversation
+    # and break prompt-cache stability.
+    _WS_UNSET = object()
+    _ws_cache: Any = _WS_UNSET
+
     def prepare_tools(
         self, tools: list[dict[str, Any]], *, model: str | None = None
     ) -> list[dict[str, Any]]:
@@ -35,7 +41,7 @@ class XiaomiProfile(ProviderProfile):
         It coexists with Hermes's own function tools — MiMo supports
         hybrid tool calling.
         """
-        ws_cfg = self._web_search_config()
+        ws_cfg = self._web_search_config_cached()
         if not ws_cfg:
             return tools
 
@@ -61,6 +67,12 @@ class XiaomiProfile(ProviderProfile):
         return tools + [ws_tool]
 
     # ── Config access ──────────────────────────────────────────
+
+    def _web_search_config_cached(self) -> dict[str, Any] | None:
+        """Return cached web_search config (read once per profile lifetime)."""
+        if self._ws_cache is self._WS_UNSET:
+            type(self)._ws_cache = self._web_search_config()
+        return self._ws_cache
 
     @staticmethod
     def _web_search_config() -> dict[str, Any] | None:

--- a/providers/base.py
+++ b/providers/base.py
@@ -116,6 +116,19 @@ class ProviderProfile:
         """
         return messages
 
+    def prepare_tools(
+        self, tools: list[dict[str, Any]], *, model: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Provider-specific tool list preprocessing.
+
+        Called AFTER standard tool assembly, BEFORE tools are set in
+        api_kwargs.  Use this to append provider-native tools (e.g.
+        Xiaomi MiMo's ``web_search``) or to sanitize schemas.
+
+        Default: pass-through.
+        """
+        return tools
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -386,6 +386,11 @@ class TestXiaomiWebSearch:
         from providers import get_provider_profile
         return get_provider_profile("xiaomi")
 
+    def _reset_cache(self):
+        """Reset the class-level web_search config cache between tests."""
+        from plugins.model_providers.xiaomi import XiaomiProfile
+        XiaomiProfile._ws_cache = XiaomiProfile._WS_UNSET
+
     def test_profile_is_xiaomi_profile(self):
         """xiaomi profile must be XiaomiProfile subclass."""
         from plugins.model_providers.xiaomi import XiaomiProfile
@@ -394,6 +399,7 @@ class TestXiaomiWebSearch:
 
     def test_prepare_tools_passthrough_when_disabled(self, monkeypatch):
         """No web_search injected when config absent/disabled."""
+        self._reset_cache()
         monkeypatch.setenv("HERMES_CONFIG", "/nonexistent")
         profile = self._get_profile()
         tools = [{"type": "function", "function": {"name": "terminal"}}]
@@ -403,14 +409,8 @@ class TestXiaomiWebSearch:
 
     def test_prepare_tools_injects_web_search(self, monkeypatch):
         """web_search injected when config providers.xiaomi.web_search=true."""
-        import json, tempfile, pathlib
+        self._reset_cache()
         cfg = {"providers": {"xiaomi": {"web_search": True}}}
-        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
-        # Write as JSON (load_config_readonly handles both)
-        tmp.write(json.dumps(cfg))
-        tmp.flush()
-        tmp.close()
-        # Patch load_config_readonly to return our config
         from hermes_cli import config as cfg_mod
         monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
 
@@ -426,6 +426,7 @@ class TestXiaomiWebSearch:
 
     def test_prepare_tools_custom_params(self, monkeypatch):
         """Custom max_keyword, force, location from dict config."""
+        self._reset_cache()
         cfg = {"providers": {"xiaomi": {"web_search": {
             "max_keyword": 5,
             "force": True,
@@ -444,6 +445,7 @@ class TestXiaomiWebSearch:
 
     def test_prepare_tools_no_duplicate(self, monkeypatch):
         """Calling prepare_tools twice should not duplicate web_search."""
+        self._reset_cache()
         cfg = {"providers": {"xiaomi": {"web_search": True}}}
         from hermes_cli import config as cfg_mod
         monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
@@ -453,3 +455,159 @@ class TestXiaomiWebSearch:
         result = profile.prepare_tools(tools, model="mimo-v2.5-pro")
         result2 = profile.prepare_tools(result, model="mimo-v2.5-pro")
         assert len(result2) == 2  # still terminal + web_search, not 3
+
+    def test_prepare_tools_injects_from_empty_list(self, monkeypatch):
+        """Native search injects even when Hermes has no tools."""
+        self._reset_cache()
+        cfg = {"providers": {"xiaomi": {"web_search": True}}}
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
+
+        profile = self._get_profile()
+        result = profile.prepare_tools([], model="mimo-v2.5-pro")
+        assert len(result) == 1
+        assert result[0]["type"] == "web_search"
+
+    def test_web_search_config_cached(self, monkeypatch):
+        """Config is read once and cached — subsequent calls return same value."""
+        self._reset_cache()
+        call_count = {"n": 0}
+        cfg = {"providers": {"xiaomi": {"web_search": True}}}
+
+        def counting_load():
+            call_count["n"] += 1
+            return cfg
+
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", counting_load)
+
+        profile = self._get_profile()
+        profile.prepare_tools([], model="mimo-v2.5-pro")
+        profile.prepare_tools([], model="mimo-v2.5-pro")
+        assert call_count["n"] == 1  # only one config read
+
+    def test_providers_xiaomi_does_not_shadow_builtin(self):
+        """providers.xiaomi with only web_search must not create a user-defined provider."""
+        from hermes_cli.providers import resolve_user_provider
+        # This mimics config.yaml: providers: {xiaomi: {web_search: true}}
+        user_config = {"xiaomi": {"web_search": True}}
+        result = resolve_user_provider("xiaomi", user_config)
+        assert result is None  # must NOT return a broken ProviderDef
+
+
+# =============================================================================
+# URL citation annotation flow
+# =============================================================================
+
+
+class TestUrlCitationAnnotations:
+    """Test that MiMo web_search url_citation annotations are captured and carried through."""
+
+    def test_normalize_response_captures_annotations(self):
+        """normalize_response should extract annotations from message into provider_data."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        from types import SimpleNamespace
+
+        transport = ChatCompletionsTransport.__new__(ChatCompletionsTransport)
+
+        # Build a mock response that looks like MiMo's web_search output
+        annotation = SimpleNamespace(
+            type="url_citation",
+            url_citation=SimpleNamespace(
+                start_index=0,
+                end_index=10,
+                title="Example Article",
+                url="https://example.com/article",
+            ),
+        )
+        msg = SimpleNamespace(
+            content="Here is some info from the web.",
+            tool_calls=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            refusal=None,
+            annotations=[annotation],
+            model_extra=None,
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        response = SimpleNamespace(choices=[choice], usage=None, model="mimo-v2.5-pro")
+
+        result = transport.normalize_response(response)
+
+        assert result.annotations is not None
+        assert len(result.annotations) == 1
+        annot = result.annotations[0]
+        assert annot["type"] == "url_citation"
+        assert annot["url_citation"]["url"] == "https://example.com/article"
+        assert annot["url_citation"]["title"] == "Example Article"
+
+    def test_normalize_response_annotations_from_model_extra(self):
+        """Annotations should also be picked up from model_extra (SDK quirk fallback)."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        from types import SimpleNamespace
+
+        transport = ChatCompletionsTransport.__new__(ChatCompletionsTransport)
+
+        annotation = {"type": "url_citation", "url_citation": {"url": "https://x.com", "title": "X", "start_index": 0, "end_index": 1}}
+        msg = SimpleNamespace(
+            content="Test",
+            tool_calls=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            refusal=None,
+            annotations=None,
+            model_extra={"annotations": [annotation]},
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        response = SimpleNamespace(choices=[choice], usage=None, model="mimo-v2.5-pro")
+
+        result = transport.normalize_response(response)
+
+        assert result.annotations is not None
+        assert len(result.annotations) == 1
+        assert result.annotations[0]["url_citation"]["url"] == "https://x.com"
+
+    def test_normalize_response_no_annotations(self):
+        """No annotations field should result in None, not an error."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        from types import SimpleNamespace
+
+        transport = ChatCompletionsTransport.__new__(ChatCompletionsTransport)
+
+        msg = SimpleNamespace(
+            content="Hello",
+            tool_calls=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            refusal=None,
+            annotations=None,
+            model_extra=None,
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        response = SimpleNamespace(choices=[choice], usage=None, model="mimo-v2.5-pro")
+
+        result = transport.normalize_response(response)
+        assert result.annotations is None
+
+    def test_normalized_response_annotations_property(self):
+        """NormalizedResponse.annotations reads from provider_data."""
+        from agent.transports.types import NormalizedResponse
+
+        nr = NormalizedResponse(
+            content="test",
+            tool_calls=None,
+            finish_reason="stop",
+            provider_data={"annotations": [{"type": "url_citation", "url_citation": {"url": "https://a.com"}}]},
+        )
+        assert nr.annotations is not None
+        assert len(nr.annotations) == 1
+
+    def test_normalized_response_annotations_none_when_no_provider_data(self):
+        """annotations property returns None when no provider_data."""
+        from agent.transports.types import NormalizedResponse
+
+        nr = NormalizedResponse(content="test", tool_calls=None, finish_reason="stop")
+        assert nr.annotations is None

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -372,3 +372,84 @@ class TestXiaomiAgentInit:
         overlay = HERMES_OVERLAYS["xiaomi"]
         api_mode = TRANSPORT_TO_API_MODE[overlay.transport]
         assert api_mode == "chat_completions"
+
+
+# =============================================================================
+# Native web_search tool injection
+# =============================================================================
+
+
+class TestXiaomiWebSearch:
+    """Test MiMo native web_search tool injection via prepare_tools()."""
+
+    def _get_profile(self):
+        from providers import get_provider_profile
+        return get_provider_profile("xiaomi")
+
+    def test_profile_is_xiaomi_profile(self):
+        """xiaomi profile must be XiaomiProfile subclass."""
+        from plugins.model_providers.xiaomi import XiaomiProfile
+        profile = self._get_profile()
+        assert isinstance(profile, XiaomiProfile)
+
+    def test_prepare_tools_passthrough_when_disabled(self, monkeypatch):
+        """No web_search injected when config absent/disabled."""
+        monkeypatch.setenv("HERMES_CONFIG", "/nonexistent")
+        profile = self._get_profile()
+        tools = [{"type": "function", "function": {"name": "terminal"}}]
+        result = profile.prepare_tools(tools, model="mimo-v2.5-pro")
+        assert result == tools
+        assert len(result) == 1
+
+    def test_prepare_tools_injects_web_search(self, monkeypatch):
+        """web_search injected when config providers.xiaomi.web_search=true."""
+        import json, tempfile, pathlib
+        cfg = {"providers": {"xiaomi": {"web_search": True}}}
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        # Write as JSON (load_config_readonly handles both)
+        tmp.write(json.dumps(cfg))
+        tmp.flush()
+        tmp.close()
+        # Patch load_config_readonly to return our config
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
+
+        profile = self._get_profile()
+        tools = [{"type": "function", "function": {"name": "terminal"}}]
+        result = profile.prepare_tools(tools, model="mimo-v2.5-pro")
+        assert len(result) == 2
+        ws = result[1]
+        assert ws["type"] == "web_search"
+        assert ws["max_keyword"] == 3
+        assert ws["force_search"] is False
+        assert "user_location" not in ws  # no location when empty
+
+    def test_prepare_tools_custom_params(self, monkeypatch):
+        """Custom max_keyword, force, location from dict config."""
+        cfg = {"providers": {"xiaomi": {"web_search": {
+            "max_keyword": 5,
+            "force": True,
+            "location": "China",
+        }}}}
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
+
+        profile = self._get_profile()
+        tools = []
+        result = profile.prepare_tools(tools, model="mimo-v2-pro")
+        ws = result[0]
+        assert ws["max_keyword"] == 5
+        assert ws["force_search"] is True
+        assert ws["user_location"] == {"type": "approximate", "country": "China"}
+
+    def test_prepare_tools_no_duplicate(self, monkeypatch):
+        """Calling prepare_tools twice should not duplicate web_search."""
+        cfg = {"providers": {"xiaomi": {"web_search": True}}}
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: cfg)
+
+        profile = self._get_profile()
+        tools = [{"type": "function", "function": {"name": "terminal"}}]
+        result = profile.prepare_tools(tools, model="mimo-v2.5-pro")
+        result2 = profile.prepare_tools(result, model="mimo-v2.5-pro")
+        assert len(result2) == 2  # still terminal + web_search, not 3


### PR DESCRIPTION
## What

Adds MiMo's native `web_search` tool to the Xiaomi provider via a new `prepare_tools()` hook on `ProviderProfile`.

MiMo's web_search is API-level — the model autonomously decides when to search, returns `url_citation` annotations with source URLs/titles/summaries, and supports concurrent keyword searches. It coexists with Hermes function tools via hybrid tool calling.

Closes #37844

## How

1. **`providers/base.py`** — new `prepare_tools(tools, model=)` hook (default pass-through, same pattern as `prepare_messages()`)
2. **`agent/transports/chat_completions.py`** — calls `profile.prepare_tools()` before setting tools in api_kwargs (profile path only)
3. **`plugins/model-providers/xiaomi/__init__.py`** — converts to `XiaomiProfile` subclass, overrides `prepare_tools()` to inject web_search when configured

## Config

```yaml
# Simple (defaults: max_keyword=3, force=false)
providers:
  xiaomi:
    web_search: true

# Full control
providers:
  xiaomi:
    web_search:
      max_keyword: 5
      force: true          # always search (vs model decides)
      location: China      # localized results
```

## Behavior

| Setting | Effect |
|---|---|
| absent / `false` | No change — existing behavior preserved |
| `true` | Injects web_search with defaults (max_keyword=3, model-decides) |
| dict | Custom max_keyword, force, location |

- Dedup guard prevents double-injection
- No cost when disabled (default)
- Tool is appended to existing Hermes tools, not replacing them

## Tests

5 new tests in `test_xiaomi_provider.py`:
- passthrough when disabled
- injection with default config
- custom params (max_keyword, force, location)
- dedup guard
- subclass verification

All 57 tests pass (52 existing + 5 new).