### PR TITLE
feat: add Telegram review queue cards

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4708,19 +4708,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            text = f"❓ {_html.escape(question)}"
+            # Keep clarify prompts visually close to the agent-provided card.
+            # Do not prepend emoji or render a numbered duplicate of the inline
+            # buttons: Telegram already shows the choices as actual buttons, and
+            # workflows like thesis review need compact metadata cards.
+            text = _html.escape(question)
             thread_id = self._metadata_thread_id(metadata)
-
-            if choices:
-                # Render full option text in the message body so mobile
-                # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
-                option_lines = "\n".join(
-                    f"{i + 1}. {_html.escape(str(c))}"
-                    for i, c in enumerate(choices)
-                )
-                text += f"\n\n{option_lines}"
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),
@@ -4733,10 +4726,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
                 # short.
                 rows = []
-                for idx in range(len(choices)):
+                for idx, choice in enumerate(choices):
+                    label = str(choice).strip() or str(idx + 1)
+                    # Telegram clients truncate long button labels visually;
+                    # keep labels compact while preserving exact short actions.
+                    if len(label) > 40:
+                        label = label[:37].rstrip() + "…"
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            label,
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])
@@ -4764,6 +4762,66 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_review_card(
+        self,
+        chat_id: str,
+        card_id: str,
+        kind: str,
+        thesis: str,
+        body: str,
+        person: str = "",
+        url: str = "",
+        source: str = "",
+        thread_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a persistent Antidote thesis-review card with rq: callbacks."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            from tools import review_queue_cards as rq
+
+            metadata = metadata or {}
+            thread_id = thread_id or self._metadata_thread_id(metadata)
+            card = rq.create_card(
+                card_id=card_id,
+                kind=kind,
+                thesis=thesis,
+                body=body,
+                person=person,
+                url=url,
+                source=source,
+                telegram_chat_id=str(chat_id),
+                telegram_thread_id=str(thread_id or ""),
+            )
+            rows = [
+                [InlineKeyboardButton(label, callback_data=cb) for label, cb in row]
+                for row in rq.build_button_rows(card)
+            ]
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": _html.escape(rq.render_card_text(card)),
+                "parse_mode": ParseMode.HTML,
+                "reply_markup": InlineKeyboardMarkup(rows) if rows else None,
+                **self._link_preview_kwargs(),
+            }
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+            kwargs["reply_to_message_id"] = reply_to_id
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                )
+            )
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            rq.set_telegram_message_id(card_id, str(msg.message_id))
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_review_card failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
     async def send_model_picker(
@@ -5313,6 +5371,221 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    def _review_queue_ops_target(self, source_chat_id: str = "") -> tuple[Any, Optional[str]]:
+        target = os.getenv("REVIEW_QUEUE_OPS_TARGET", "telegram:-1003915682412:63").strip()
+        if target.startswith("telegram:"):
+            target = target.split(":", 1)[1]
+        parts = target.split(":") if target else []
+        chat_id = parts[0] if parts and parts[0] else (source_chat_id or "-1003915682412")
+        thread_id = parts[1] if len(parts) > 1 and parts[1] else None
+        chat_value: Any = int(chat_id) if str(chat_id).lstrip("-").isdigit() else chat_id
+        return chat_value, thread_id
+
+    async def _send_review_queue_ops_notification(self, card: Dict[str, Any], *, source_chat_id: str = "") -> None:
+        if not self._bot:
+            return
+        kind = str(card.get("kind") or "").strip().lower()
+        status = str(card.get("status") or "").strip().lower()
+        if kind not in {"evidence", "expert"} or status not in {"accepted_no_note", "elaborated"}:
+            return
+        title = card.get("person") or card.get("id") or "candidate"
+        path = card.get("obsidian_path") or ""
+        text = (
+            f"✅ Review Queue accepted {kind}: {title}\n"
+            f"Card: {card.get('id') or ''}\n"
+            f"Thesis: {card.get('thesis') or ''}"
+        )
+        if path:
+            text += f"\nObsidian: {path}"
+        try:
+            chat_id, thread_id = self._review_queue_ops_target(source_chat_id)
+            kwargs: Dict[str, Any] = {
+                "chat_id": chat_id,
+                "text": text,
+                **self._notification_kwargs(None),
+                **self._link_preview_kwargs(),
+            }
+            if thread_id:
+                kwargs["message_thread_id"] = int(thread_id) if str(thread_id).isdigit() else thread_id
+            await self._bot.send_message(**kwargs)
+        except Exception as exc:
+            logger.debug("[%s] review-card Ops notification failed: %s", self.name, exc)
+
+    async def _handle_review_queue_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id=None,
+        query_chat_type=None,
+        query_thread_id=None,
+        query_user_name=None,
+    ) -> None:
+        """Resolve persistent Antidote review-card inline buttons."""
+        parts = data.split(":", 2)
+        if len(parts) != 3:
+            await query.answer(text="Invalid review-card action.")
+            return
+        _, action, card_id = parts
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to review this card.")
+            return
+
+        try:
+            from tools import review_queue_cards as rq
+
+            user_display = getattr(query.from_user, "first_name", "User")
+            card = rq.resolve_card(card_id, action, user=user_display)
+            rows = [
+                [InlineKeyboardButton(label, callback_data=cb) for label, cb in row]
+                for row in rq.build_button_rows(card)
+            ]
+            await query.answer(text=rq.callback_label(action, card)[:200])
+            try:
+                kind = str(card.get("kind") or "").strip().lower()
+                status = str(card.get("status") or "").strip().lower()
+                delete_final_evidence_or_expert = (
+                    kind in {"evidence", "expert"}
+                    and status in {"denied", "denied_with_note", "accepted_no_note", "elaborated"}
+                )
+                delete_skipped_job_or_application = (
+                    kind in {"job", "startup"}
+                    and status == "skipped"
+                )
+                if (delete_final_evidence_or_expert or delete_skipped_job_or_application) and query.message:
+                    # Keep the durable DB row so future review-queue production won't
+                    # re-send this candidate, but only remove the noisy Telegram card
+                    # after a final decision is resolved.
+                    await query.message.delete()
+                else:
+                    await query.edit_message_text(
+                        text=_html.escape(rq.render_card_text(card)),
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=InlineKeyboardMarkup(rows) if rows else None,
+                        **self._link_preview_kwargs(),
+                    )
+            except Exception as exc:
+                logger.warning("[%s] review-card message update/delete failed: %s", self.name, exc)
+            await self._send_review_queue_ops_notification(
+                card,
+                source_chat_id=str(query_chat_id or (getattr(query.message, "chat_id", "") if query.message else "")),
+            )
+        except KeyError:
+            await query.answer(text="Review card not found.")
+        except Exception as exc:
+            logger.error("[%s] review-card callback failed: %s", self.name, exc, exc_info=True)
+            await query.answer(text="Review-card action failed.")
+
+    async def _handle_flat_hunt_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id=None,
+        query_chat_type=None,
+        query_thread_id=None,
+        query_user_name=None,
+    ) -> None:
+        """Resolve Zurich flat-hunt inline buttons and draft outreach on interest."""
+        parts = data.split(":", 2)
+        if len(parts) != 3:
+            await query.answer(text="Invalid flat-hunt action.")
+            return
+        _, action, listing_id = parts
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to review this flat.")
+            return
+
+        import sqlite3
+        from pathlib import Path
+
+        db_path = Path(os.getenv("FLAT_HUNT_DB", str(Path.home() / ".hermes" / "flat_hunt.db"))).expanduser()
+        con = sqlite3.connect(db_path)
+        con.row_factory = sqlite3.Row
+        try:
+            row = con.execute("SELECT * FROM listings WHERE id = ?", (listing_id,)).fetchone()
+            if row is None:
+                await query.answer(text="Flat card not found.")
+                return
+            user_display = getattr(query.from_user, "first_name", "User")
+            status = "interested" if action == "y" else "skipped" if action == "n" else "needs_rescore"
+            draft = ""
+            if status == "interested":
+                title = row["title"] or "the apartment"
+                address = row["address"] or ""
+                agent = row["agent_name"] or "the leasing team"
+                object_line = title
+                details = []
+                if address:
+                    details.append(address)
+                if row["rooms"]:
+                    details.append(f"{row['rooms']} rooms")
+                if row["price_chf"]:
+                    details.append(f"CHF {int(row['price_chf']):,}/month".replace(",", "'"))
+                if row["url"]:
+                    details.append(row["url"])
+                if details:
+                    object_line += " (" + "; ".join(str(x) for x in details) + ")"
+                draft = (
+                    f"Subject: Interesse an {title}\n\n"
+                    f"Dear {agent},\n\n"
+                    f"I am interested in the following rental object: {object_line}.\n\n"
+                    "Could you please let me know whether it is still available and what the next steps are for applying or arranging a viewing?\n\n"
+                    "Best regards,\n"
+                    "Antidote"
+                )
+            con.execute(
+                "UPDATE listings SET status = ?, decided_by = ?, outreach_draft = ?, updated_at = ? WHERE id = ?",
+                (status, user_display, draft, datetime.now(tz=timezone.utc).isoformat(timespec="seconds"), listing_id),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        label = "✅ Interested — outreach drafted" if status == "interested" else "❌ Skipped"
+        await query.answer(text=label)
+        try:
+            if status == "skipped" and query.message:
+                # Keep the DB row as skipped so the crawler never re-flags this URL,
+                # but remove the noisy card from the Telegram topic.
+                await query.message.delete()
+            else:
+                original_text = (query.message.text or "") if query.message else ""
+                await query.edit_message_text(text=f"{original_text}\n\n— {label} by {user_display}", reply_markup=None)
+        except Exception:
+            pass
+        if status == "interested" and draft and query.message:
+            send_kwargs: Dict[str, Any] = {
+                "chat_id": int(query.message.chat_id),
+                "text": f"Draft outreach for {listing_id}:\n\n{draft}",
+                **self._link_preview_kwargs(),
+            }
+            thread_id = getattr(query.message, "message_thread_id", None)
+            if thread_id is not None:
+                send_kwargs.update(
+                    self._thread_kwargs_for_send(
+                        str(query.message.chat_id),
+                        str(thread_id),
+                        {"thread_id": str(thread_id)},
+                        reply_to_mode=self._reply_to_mode,
+                    )
+                )
+            await self._send_message_with_thread_fallback(**send_kwargs)
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -5333,6 +5606,30 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- Persistent review-queue callbacks (rq:action:card_id) ---
+        if data.startswith("rq:"):
+            await self._handle_review_queue_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
+        # --- Zurich flat-hunt callbacks (fh:action:listing_id) ---
+        if data.startswith("fh:"):
+            await self._handle_flat_hunt_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
 
         # --- Gmail-triage callbacks (gt:verb:arg) ---
@@ -7500,6 +7797,77 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _capture_review_queue_note_if_pending(self, message: Message) -> bool:
+        """Consume the next topic text as a review-card Elaborate note, if pending."""
+        text = (getattr(message, "text", None) or "").strip()
+        if not text:
+            return False
+        chat = getattr(message, "chat", None)
+        user = getattr(message, "from_user", None)
+        chat_id = str(getattr(chat, "id", "") or "")
+        thread_id = str(getattr(message, "message_thread_id", "") or "")
+        user_name = getattr(user, "full_name", None) or getattr(user, "first_name", None) or ""
+        user_id = str(getattr(user, "id", "") or "")
+        chat_type = getattr(chat, "type", None)
+        if not chat_id:
+            return False
+        if not self._is_callback_user_authorized(
+            user_id,
+            chat_id=chat_id,
+            chat_type=str(chat_type) if chat_type is not None else None,
+            thread_id=thread_id or None,
+            user_name=user_name or None,
+        ):
+            return False
+        try:
+            from tools import review_queue_cards as rq
+
+            card = rq.capture_pending_note(
+                telegram_chat_id=chat_id,
+                telegram_thread_id=thread_id,
+                user=user_name,
+                note=text,
+            )
+        except Exception as exc:
+            logger.warning("[%s] failed to capture review-card note: %s", self.name, exc)
+            return False
+        if not card:
+            return False
+        try:
+            if self._bot and card.get("telegram_message_id"):
+                kind = str(card.get("kind") or "").strip().lower()
+                status = str(card.get("status") or "").strip().lower()
+                chat_id_value = int(chat_id) if chat_id.lstrip("-").isdigit() else chat_id
+                message_id_value = int(card["telegram_message_id"])
+                if status in {"denied_with_note", "elaborated"} and kind in {"evidence", "expert"}:
+                    await self._bot.delete_message(chat_id=chat_id_value, message_id=message_id_value)
+                else:
+                    rows = [
+                        [InlineKeyboardButton(label, callback_data=cb) for label, cb in row]
+                        for row in rq.build_button_rows(card)
+                    ]
+                    await self._bot.edit_message_text(
+                        chat_id=chat_id_value,
+                        message_id=message_id_value,
+                        text=_html.escape(rq.render_card_text(card)),
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=InlineKeyboardMarkup(rows) if rows else None,
+                        **self._link_preview_kwargs(),
+                    )
+            if self._bot:
+                kwargs: Dict[str, Any] = {
+                    "chat_id": int(chat_id) if chat_id.lstrip("-").isdigit() else chat_id,
+                    "text": f"Captured note for review card {card['id']}.",
+                    **self._notification_kwargs(None),
+                }
+                if thread_id:
+                    kwargs["message_thread_id"] = int(thread_id) if thread_id.isdigit() else thread_id
+                await self._bot.send_message(**kwargs)
+            await self._send_review_queue_ops_notification(card, source_chat_id=chat_id)
+        except Exception as exc:
+            logger.debug("[%s] review-card note acknowledgement/edit failed: %s", self.name, exc)
+        return True
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -7520,6 +7888,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "from_user", None), "id", None),
                 getattr(getattr(msg, "chat", None), "id", None),
             )
+            return
+        if await self._capture_review_queue_note_if_pending(msg):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -98,10 +98,11 @@ class TestTelegramSendClarify:
         kwargs = adapter._bot.send_message.call_args[1]
         assert kwargs["chat_id"] == 12345
         assert "Which option?" in kwargs["text"]
-        # Full option text rendered in the message body (not just buttons)
-        assert "1. alpha" in kwargs["text"]
-        assert "2. beta" in kwargs["text"]
-        assert "3. gamma" in kwargs["text"]
+        # Choices are rendered only as inline buttons, not duplicated as a
+        # numbered text list in the message body.
+        assert "1. alpha" not in kwargs["text"]
+        assert "2. beta" not in kwargs["text"]
+        assert "3. gamma" not in kwargs["text"]
         # InlineKeyboardMarkup with N+1 buttons (3 choices + Other)
         markup = kwargs["reply_markup"]
         assert markup is not None
@@ -146,9 +147,8 @@ class TestTelegramSendClarify:
         assert result.success is False
 
     @pytest.mark.asyncio
-    async def test_long_choice_rendered_in_body_not_truncated(self):
-        """Long choice text appears in full in the message body;
-        button labels stay short numeric (1, 2, …)."""
+    async def test_long_choice_not_duplicated_in_body(self):
+        """Long choices are not duplicated in the body; button labels truncate."""
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 102
@@ -164,11 +164,8 @@ class TestTelegramSendClarify:
         )
         assert result.success is True
         kwargs = adapter._bot.send_message.call_args[1]
-        # The full long choice text appears in the message body
-        assert long_choice in kwargs["text"]
-        # The button label should be short ("1"), not the long choice
-        # (we can't inspect mock button labels directly, but the send
-        # succeeded — old truncation code could raise on edge cases)
+        # The full long choice text should not be duplicated in the message body.
+        assert long_choice not in kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):

--- a/tests/gateway/test_telegram_review_queue_buttons.py
+++ b/tests/gateway/test_telegram_review_queue_buttons.py
@@ -1,0 +1,498 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_send_review_card_renders_review_buttons(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    adapter = _make_adapter()
+    msg = MagicMock()
+    msg.message_id = 222
+    adapter._bot.send_message = AsyncMock(return_value=msg)
+
+    result = await adapter.send_review_card(
+        chat_id="-1003915682412",
+        thread_id="3930",
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        person="@cfm_sol",
+        url="https://x.com/cfm_sol/status/2066780746610831667",
+        source="test",
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args[1]
+    assert kwargs["chat_id"] == -1003915682412
+    assert kwargs["message_thread_id"] == 3930
+    assert "Agentic VCs" in kwargs["text"]
+    assert kwargs["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_review_queue_callback_accept_updates_card_and_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+    )
+
+    adapter = _make_adapter()
+    query = AsyncMock()
+    query.data = "rq:a:831667"
+    query.message = MagicMock()
+    query.message.chat_id = -1003915682412
+    query.message.message_thread_id = 3930
+    query.message.text = "card text"
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+
+    card = rq.get_card("831667")
+    assert card["status"] == "accepted"
+    query.answer.assert_called_once()
+    query.edit_message_text.assert_called_once()
+    _, kwargs = query.edit_message_text.call_args
+    assert kwargs["reply_markup"] is not None  # Add accepted note / No note next step
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["evidence", "expert"])
+async def test_review_queue_evidence_and_expert_have_no_skip_and_deny_prompts_for_note(tmp_path, monkeypatch, kind):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind=kind,
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim" if kind == "evidence" else "Person: @source\nRationale: thesis-relevant source",
+        target="telegram:-1003915682412:3930",
+    )
+    card = rq.get_card("831667")
+    assert card is not None
+    buttons = rq.build_button_rows(card)
+    callback_data = [cb for row in buttons for _, cb in row]
+    assert not any(cb.startswith("rq:s:") for cb in callback_data)
+    assert f"rq:d:831667" in callback_data
+
+    adapter = _make_adapter()
+    query = AsyncMock()
+    query.data = "rq:d:831667"
+    query.message = MagicMock()
+    query.message.chat_id = -1003915682412
+    query.message.message_thread_id = 3930
+    query.message.text = "card text"
+    query.message.chat.type = "supergroup"
+    query.message.delete = AsyncMock()
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+
+    card = rq.get_card("831667")
+    assert card is not None
+    assert card["status"] == "denied_pending_note"
+    query.answer.assert_called_once()
+    query.message.delete.assert_not_called()
+    query.edit_message_text.assert_called_once()
+    _, kwargs = query.edit_message_text.call_args
+    assert kwargs["reply_markup"] is not None
+    next_callbacks = [cb for row in rq.build_button_rows(card) for _, cb in row]
+    assert f"rq:dn:831667" in next_callbacks
+    assert f"rq:nn:831667" in next_callbacks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["evidence", "expert"])
+async def test_review_queue_evidence_and_expert_deny_no_note_deletes(tmp_path, monkeypatch, kind):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="deny-no-note-card",
+        kind=kind,
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim" if kind == "evidence" else "Person: @source\nRationale: thesis-relevant source",
+        target="telegram:-1003915682412:3930",
+    )
+
+    adapter = _make_adapter()
+
+    async def press(callback_data):
+        query = AsyncMock()
+        query.data = callback_data
+        query.message = MagicMock()
+        query.message.chat_id = -1003915682412
+        query.message.message_thread_id = 3930
+        query.message.text = "card text"
+        query.message.chat.type = "supergroup"
+        query.message.delete = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+        return query
+
+    deny_query = await press("rq:d:deny-no-note-card")
+    denied_pending = rq.get_card("deny-no-note-card")
+    assert denied_pending is not None
+    assert denied_pending["status"] == "denied_pending_note"
+    deny_query.message.delete.assert_not_called()
+    deny_query.edit_message_text.assert_called_once()
+
+    no_note_query = await press("rq:nn:deny-no-note-card")
+    denied_card = rq.get_card("deny-no-note-card")
+    assert denied_card is not None
+    assert denied_card["status"] == "denied"
+    no_note_query.message.delete.assert_awaited_once()
+    no_note_query.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["evidence", "expert"])
+async def test_review_queue_evidence_and_expert_accept_no_note_deletes(tmp_path, monkeypatch, kind):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="accept-no-note-card",
+        kind=kind,
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim" if kind == "evidence" else "Person: @source\nRationale: thesis-relevant source",
+        target="telegram:-1003915682412:3930",
+    )
+
+    adapter = _make_adapter()
+
+    async def press(callback_data):
+        query = AsyncMock()
+        query.data = callback_data
+        query.message = MagicMock()
+        query.message.chat_id = -1003915682412
+        query.message.message_thread_id = 3930
+        query.message.text = "card text"
+        query.message.chat.type = "supergroup"
+        query.message.delete = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+        return query
+
+    accept_query = await press("rq:a:accept-no-note-card")
+    accepted_card = rq.get_card("accept-no-note-card")
+    assert accepted_card is not None
+    assert accepted_card["status"] == "accepted"
+    accept_query.message.delete.assert_not_called()
+    accept_query.edit_message_text.assert_called_once()
+
+    no_note_query = await press("rq:n:accept-no-note-card")
+    no_note_card = rq.get_card("accept-no-note-card")
+    assert no_note_card is not None
+    assert no_note_card["status"] == "accepted_no_note"
+    no_note_query.message.delete.assert_awaited_once()
+    no_note_query.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["job", "startup"])
+async def test_review_queue_skip_deletes_job_and_application_cards(tmp_path, monkeypatch, kind):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id=f"skip-{kind}-card",
+        kind=kind,
+        thesis="Jobs & Applications",
+        body="Company: TestCo\nRole: Operator\nFit: relevant enough to review",
+        target="telegram:-1003915682412:1524",
+    )
+    card = rq.get_card(f"skip-{kind}-card")
+    assert card is not None
+    callbacks = [cb for row in rq.build_button_rows(card) for _, cb in row]
+    assert f"rq:s:skip-{kind}-card" in callbacks
+
+    adapter = _make_adapter()
+    query = AsyncMock()
+    query.data = f"rq:s:skip-{kind}-card"
+    query.message = MagicMock()
+    query.message.chat_id = -1003915682412
+    query.message.message_thread_id = 1524
+    query.message.text = "card text"
+    query.message.chat.type = "supergroup"
+    query.message.delete = AsyncMock()
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+
+    skipped_card = rq.get_card(f"skip-{kind}-card")
+    assert skipped_card is not None
+    assert skipped_card["status"] == "skipped"
+    query.message.delete.assert_awaited_once()
+    query.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_review_queue_callback_denies_unknown_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    adapter = _make_adapter()
+    query = AsyncMock()
+    query.data = "rq:d:missing"
+    query.message = MagicMock()
+    query.message.chat_id = -1003915682412
+    query.message.message_thread_id = 3930
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+
+    assert "not found" in query.answer.call_args[1]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_review_queue_elaborate_captures_next_text_note(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    (thesis_dir / "Review queue.md").write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    (thesis_dir / "Agentic VCs.md").write_text("# Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+        telegram_message_id="222",
+    )
+
+    adapter = _make_adapter()
+    assert adapter._bot is not None
+    adapter._bot.delete_message = AsyncMock()
+    query = AsyncMock()
+    query.data = "rq:e:831667"
+    query.message = MagicMock()
+    query.message.chat_id = -1003915682412
+    query.message.message_thread_id = 3930
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+
+    msg = MagicMock()
+    msg.text = "this test works"
+    msg.chat.id = -1003915682412
+    msg.chat.type = "supergroup"
+    msg.chat.is_forum = True
+    msg.chat.title = "Axel & Ant1dote"
+    msg.message_thread_id = 3930
+    msg.is_topic_message = True
+    msg.message_id = 999
+    msg.date = None
+    msg.from_user.id = 777
+    msg.from_user.full_name = "Tester"
+    msg.from_user.first_name = "Tester"
+    msg.reply_to_message = None
+    update2 = MagicMock()
+    update2.update_id = 1234
+    update2.message = msg
+    update2.effective_message = msg
+
+    adapter.handle_message = AsyncMock()
+    adapter._enqueue_text_event = MagicMock()
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_text_message(update2, MagicMock())
+
+    card = rq.get_card("831667")
+    assert card["status"] == "elaborated"
+    assert card["decision_note"] == "this test works"
+    adapter._bot.delete_message.assert_awaited_once_with(chat_id=-1003915682412, message_id=222)
+    adapter.handle_message.assert_not_called()
+    adapter._enqueue_text_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_review_queue_deny_note_capture_deletes_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    (thesis_dir / "Review queue.md").write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="deny-note-card",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+        telegram_message_id="222",
+    )
+
+    adapter = _make_adapter()
+    assert adapter._bot is not None
+    adapter._bot.delete_message = AsyncMock()
+
+    async def press(callback_data):
+        query = AsyncMock()
+        query.data = callback_data
+        query.message = MagicMock()
+        query.message.chat_id = -1003915682412
+        query.message.message_thread_id = 3930
+        query.message.chat.type = "supergroup"
+        query.message.delete = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+        return query
+
+    deny_query = await press("rq:d:deny-note-card")
+    denied_pending_card = rq.get_card("deny-note-card")
+    assert denied_pending_card is not None
+    assert denied_pending_card["status"] == "denied_pending_note"
+    deny_query.message.delete.assert_not_called()
+    deny_query.edit_message_text.assert_called_once()
+
+    note_query = await press("rq:dn:deny-note-card")
+    note_requested_card = rq.get_card("deny-note-card")
+    assert note_requested_card is not None
+    assert note_requested_card["status"] == "deny_note_requested"
+    note_query.message.delete.assert_not_called()
+    note_query.edit_message_text.assert_called_once()
+
+    msg = MagicMock()
+    msg.text = "too generic; tighten filter to primary sources only"
+    msg.chat.id = -1003915682412
+    msg.chat.type = "supergroup"
+    msg.chat.is_forum = True
+    msg.chat.title = "Axel & Ant1dote"
+    msg.message_thread_id = 3930
+    msg.is_topic_message = True
+    msg.message_id = 999
+    msg.date = None
+    msg.from_user.id = 777
+    msg.from_user.full_name = "Tester"
+    msg.from_user.first_name = "Tester"
+    msg.reply_to_message = None
+    update2 = MagicMock()
+    update2.update_id = 1234
+    update2.message = msg
+    update2.effective_message = msg
+
+    adapter.handle_message = AsyncMock()
+    adapter._enqueue_text_event = MagicMock()
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+        await adapter._handle_text_message(update2, MagicMock())
+
+    card = rq.get_card("deny-note-card")
+    assert card is not None
+    assert card["status"] == "denied_with_note"
+    assert card["decision_note"] == "too generic; tighten filter to primary sources only"
+    adapter._bot.delete_message.assert_awaited_once_with(chat_id=-1003915682412, message_id=222)
+    adapter.handle_message.assert_not_called()
+    adapter._enqueue_text_event.assert_not_called()

--- a/tests/tools/test_review_queue_cards.py
+++ b/tests/tools/test_review_queue_cards.py
@@ -1,0 +1,262 @@
+import os
+import sys
+from pathlib import Path
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def test_store_create_and_resolve_card_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    from tools import review_queue_cards as rq
+
+    card = rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+        person="@cfm_sol",
+        url="https://x.com/cfm_sol/status/2066780746610831667",
+        source="test",
+    )
+
+    assert card["status"] == "pending"
+    assert card["telegram_chat_id"] == "-1003915682412"
+    assert card["telegram_thread_id"] == "3930"
+
+    resolved = rq.resolve_card("831667", "accept", user="Tester")
+    assert resolved["status"] == "accepted"
+    assert resolved["decided_by"] == "Tester"
+
+    loaded = rq.get_card("831667")
+    assert loaded["status"] == "accepted"
+
+
+def test_render_buttons_transitions_after_accept():
+    from tools import review_queue_cards as rq
+
+    pending = {"id": "abc123", "status": "pending"}
+    assert rq.button_rows_for_card(pending) == [
+        [("✅ Accept", "rq:a:abc123"), ("❌ Deny", "rq:d:abc123")],
+        [("🔁 Rescore", "rq:r:abc123"), ("⏭ Skip", "rq:s:abc123")],
+    ]
+
+    accepted = {"id": "abc123", "status": "accepted"}
+    assert rq.button_rows_for_card(accepted) == [
+        [("📝 Add accepted note", "rq:e:abc123"), ("✓ No note", "rq:n:abc123")]
+    ]
+
+    denied_pending_note = {"id": "abc123", "status": "denied_pending_note"}
+    assert rq.button_rows_for_card(denied_pending_note) == [
+        [("📝 Add denial reason", "rq:dn:abc123"), ("✓ No note", "rq:nn:abc123")]
+    ]
+
+
+def test_render_evidence_freeform_body_is_not_duplicated():
+    from tools import review_queue_cards as rq
+
+    body = (
+        "Thesis Decentralized pre-training\n"
+        "ID 745937\n"
+        "Person [@mignano](https://x.com/mignano)\n"
+        "Post https://x.com/i/web/status/2070190552725745937\n"
+        "Rationale USV partner says pressure is building away from frontier labs."
+    )
+    text = rq.render_card_text(
+        {
+            "id": "evidence-20260626-745937",
+            "kind": "evidence",
+            "thesis": "Decentralized pre-training",
+            "person": "@mignano",
+            "url": "https://x.com/i/web/status/2070190552725745937",
+            "source": "weekly expert timeline: @mignano",
+            "body": body,
+            "status": "pending",
+            "decision_note": "",
+        }
+    )
+
+    assert text.count("Thesis Decentralized pre-training") == 1
+    assert text.count("Rationale USV partner") == 1
+    assert "Status: Pending" in text
+
+
+def test_startup_card_accept_creates_startup_note(tmp_path, monkeypatch):
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    (thesis_dir / "Review queue.md").write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="startup-test",
+        kind="startup",
+        thesis="Agentic VCs",
+        body=(
+            "Startup: Fairmint\n"
+            "Website: https://fairmint.co\n"
+            "Taxonomy fit: AI-native fundraising rails\n"
+            "Market map: agentic VC market map search\n"
+            "Founders: founder background TBD\n"
+            "Rationale: candidate company in the thesis-adjacent startup landscape."
+        ),
+        target="telegram:-1003915682412:3930",
+        url="https://fairmint.co",
+        source="market map search",
+    )
+    card = rq.resolve_card("startup-test", "accept", user="Tester")
+
+    assert card["status"] == "accepted"
+    note = thesis_dir / "Startups" / "Fairmint.md"
+    assert note.exists()
+    text = note.read_text(encoding="utf-8")
+    assert "AI-native fundraising rails" in text
+    assert "market map search" in text
+    assert (thesis_dir / "Startups" / "Startup map.md").exists()
+
+
+def test_expert_accept_promotes_pending_display_name_note(tmp_path, monkeypatch):
+    vault = tmp_path / "Antidote" / "Thesis"
+    people_pending = vault / "Expert Seeds" / "People" / "Pending"
+    people_pending.mkdir(parents=True)
+    pending = people_pending / "Haseeb Qureshi.md"
+    pending.write_text("# Haseeb Qureshi\n\n- Review status: pending review\n", encoding="utf-8")
+    for thesis in ("Agentic VCs", "Decentralized pre-training"):
+        (vault / thesis).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="expert-hosseeb-20260709",
+        kind="expert",
+        thesis="Agentic VCs, Decentralized pre-training",
+        person="Haseeb Qureshi / @hosseeb",
+        url="https://x.com/hosseeb/status/1",
+        body=(
+            "Pending expert/source candidate: Haseeb Qureshi, @hosseeb\n\n"
+            "CV note: [[Antidote/Thesis/Expert Seeds/People/hosseeb|hosseeb]]\n"
+            "Wikilink: [[Antidote/Thesis/Expert Seeds/People/Pending/Haseeb Qureshi|Haseeb Qureshi]]\n"
+            "Credentials / provenance: Dragonfly."
+        ),
+        target="telegram:-1003915682412:3930",
+    )
+    card = rq.resolve_card("expert-hosseeb-20260709", "no_note", user="Tester")
+
+    accepted = vault / "Expert Seeds" / "People" / "Haseeb Qureshi.md"
+    assert accepted.exists()
+    assert not pending.exists()
+    assert card["status"] == "accepted_no_note"
+    loaded = rq.get_card("expert-hosseeb-20260709")
+    assert loaded is not None
+    assert loaded["obsidian_path"] == str(accepted)
+    assert "Haseeb Qureshi" in loaded["body"]
+    assert "from:hosseeb" in (vault / "Agentic VCs" / "Expert seeds.md").read_text(encoding="utf-8")
+
+
+def test_apply_decision_to_obsidian_appends_review_line(tmp_path, monkeypatch):
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    rq_file = thesis_dir / "Review queue.md"
+    rq_file.write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+    )
+    card = rq.resolve_card("831667", "deny", user="Tester")
+    rq.apply_decision_to_obsidian(card, action="deny")
+
+    text = rq_file.read_text(encoding="utf-8")
+    assert "Telegram review decisions" in text
+    assert "831667" in text
+    assert "deny" in text
+    assert "Tester" in text
+
+
+def test_capture_pending_elaboration_note_updates_card_and_obsidian(tmp_path, monkeypatch):
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    (thesis_dir / "Review queue.md").write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    thesis_note = thesis_dir / "Agentic VCs.md"
+    thesis_note.write_text("# Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+    )
+    rq.resolve_card("831667", "elaborate", user="Tester")
+
+    card = rq.capture_pending_note(
+        telegram_chat_id="-1003915682412",
+        telegram_thread_id="3930",
+        user="Tester",
+        note="this test works",
+    )
+
+    assert card is not None
+    assert card["status"] == "elaborated"
+    assert card["decision_note"] == "this test works"
+    assert "this test works" in (thesis_dir / "Review queue.md").read_text(encoding="utf-8")
+    assert "this test works" not in thesis_note.read_text(encoding="utf-8")
+
+
+def test_capture_pending_denial_note_updates_card_and_obsidian(tmp_path, monkeypatch):
+    vault = tmp_path / "Antidote" / "Thesis"
+    thesis_dir = vault / "Agentic VCs"
+    thesis_dir.mkdir(parents=True)
+    rq_file = thesis_dir / "Review queue.md"
+    rq_file.write_text("# Review queue — Agentic VCs\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_REVIEW_QUEUE_DB", str(tmp_path / "rq.db"))
+    monkeypatch.setenv("ANTIDOTE_THESIS_ROOT", str(vault))
+
+    from tools import review_queue_cards as rq
+
+    rq.create_card(
+        card_id="831667",
+        kind="evidence",
+        thesis="Agentic VCs",
+        body="FAIR multi-agent AI venture fund claim",
+        target="telegram:-1003915682412:3930",
+    )
+    card = rq.resolve_card("831667", "deny", user="Tester")
+    assert card["status"] == "denied_pending_note"
+
+    note_requested = rq.resolve_card("831667", "deny_note", user="Tester")
+    assert note_requested["status"] == "deny_note_requested"
+
+    captured = rq.capture_pending_note(
+        telegram_chat_id="-1003915682412",
+        telegram_thread_id="3930",
+        user="Tester",
+        note="too generic; tighten filter to primary sources only",
+    )
+
+    assert captured is not None
+    assert captured["status"] == "denied_with_note"
+    assert captured["decision_note"] == "too generic; tighten filter to primary sources only"
+    text = rq_file.read_text(encoding="utf-8")
+    assert "denied_with_note" in text
+    assert "tighten filter" in text

--- a/tools/review_queue_cards.py
+++ b/tools/review_queue_cards.py
@@ -1,0 +1,946 @@
+"""Persistent review-queue cards for Telegram/Obsidian workflows."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover
+    def get_hermes_home() -> Path:
+        return Path(os.getenv("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+Card = Dict[str, Any]
+ButtonRows = List[List[Tuple[str, str]]]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS cards (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    thesis TEXT NOT NULL,
+    person TEXT,
+    url TEXT,
+    body TEXT NOT NULL,
+    source TEXT,
+    status TEXT NOT NULL,
+    obsidian_path TEXT,
+    telegram_chat_id TEXT,
+    telegram_thread_id TEXT,
+    telegram_message_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    decided_by TEXT,
+    decision_note TEXT
+);
+"""
+
+_COLUMNS = [
+    "id", "kind", "thesis", "person", "url", "body", "source", "status",
+    "obsidian_path", "telegram_chat_id", "telegram_thread_id", "telegram_message_id",
+    "created_at", "updated_at", "decided_by", "decision_note",
+]
+
+_ACTION_TO_STATUS = {
+    "a": "accepted",
+    "accept": "accepted",
+    "d": "denied_pending_note",
+    "deny": "denied_pending_note",
+    "r": "needs_rescore",
+    "rescore": "needs_rescore",
+    "s": "skipped",
+    "skip": "skipped",
+
+    "e": "elaborate_requested",
+    "elaborate": "elaborate_requested",
+    "n": "accepted_no_note",
+    "no_note": "accepted_no_note",
+    "no-note": "accepted_no_note",
+    "dn": "deny_note_requested",
+    "deny_note": "deny_note_requested",
+    "deny-note": "deny_note_requested",
+    "nn": "denied",
+    "deny_no_note": "denied",
+    "deny-no-note": "denied",
+}
+
+_STATUS_LABELS = {
+    "pending": "Pending",
+    "accepted": "Accepted — add note / No note",
+    "accepted_pending_note": "Accepted — add note / No note",
+    "denied": "Denied — no note",
+    "denied_pending_note": "Denied — add reason / No note",
+    "deny_note_requested": "Denied — write reason as next message",
+    "denied_with_note": "Denied — reason captured",
+    "needs_rescore": "Needs rescore",
+    "skipped": "Skipped",
+
+    "elaborate_requested": "Accepted — write note as next message",
+    "elaborated": "Accepted — note captured",
+    "accepted_no_note": "Accepted — no note",
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def db_path() -> Path:
+    override = os.getenv("HERMES_REVIEW_QUEUE_DB", "").strip()
+    if override:
+        path = Path(override).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+    home = Path(get_hermes_home())
+    home.mkdir(parents=True, exist_ok=True)
+    return home / "review_queue.db"
+
+
+def _parse_telegram_target(target: str) -> Tuple[str, str]:
+    target = (target or "").strip()
+    if target.startswith("telegram:"):
+        target = target.split(":", 1)[1]
+    parts = target.split(":") if target else []
+    if parts and parts[0].lstrip("-").isdigit():
+        return parts[0], parts[1] if len(parts) > 1 else ""
+    return "", ""
+
+
+def _connect() -> sqlite3.Connection:
+    con = sqlite3.connect(db_path())
+    con.row_factory = sqlite3.Row
+    con.execute(_SCHEMA)
+    return con
+
+
+def _row_to_card(row: sqlite3.Row | None) -> Optional[Card]:
+    if row is None:
+        return None
+    return {k: row[k] for k in _COLUMNS}
+
+
+def _thesis_root() -> Path:
+    return Path(os.getenv("ANTIDOTE_THESIS_ROOT", "/root/obsidian-vault/Antidote/Thesis")).expanduser()
+
+
+def _safe_thesis_dir(thesis: str) -> Path:
+    # Thesis names are existing Obsidian folder labels. Avoid path traversal.
+    clean = thesis.replace("/", "-").replace("\\", "-").strip() or "Inbox"
+    return _thesis_root() / clean
+
+
+def _split_theses(thesis: str) -> List[str]:
+    """Return per-thesis labels from a card's thesis field.
+
+    Expert/source cards are canonical global people/sources, and one expert can
+    be relevant to several theses. The SQLite schema still stores that as one
+    text column, so multi-thesis relevance is represented as a comma-separated
+    label list.
+    """
+    parts = [p.strip() for p in re.split(r"\s*,\s*", str(thesis or "")) if p.strip()]
+    return parts or ["Inbox"]
+
+
+def _card_theses(card: Card) -> List[str]:
+    return _split_theses(str(card.get("thesis") or ""))
+
+
+def _review_queue_path(thesis: str) -> Path:
+    return _safe_thesis_dir(thesis) / "Review queue.md"
+
+
+def _thesis_note_path(thesis: str) -> Path:
+    return _safe_thesis_dir(thesis) / f"{thesis}.md"
+
+
+_EXPERT_ACCEPTED_STATUSES = {"accepted", "accepted_no_note", "elaborated"}
+_EXPERT_PENDING_STATUSES = {"pending", "needs_rescore", "accepted_pending_note", "elaborate_requested", "denied_pending_note", "deny_note_requested"}
+_STARTUP_ACCEPTED_STATUSES = {"accepted", "accepted_no_note", "elaborated"}
+
+
+def _people_root() -> Path:
+    return _thesis_root() / "Expert Seeds" / "People"
+
+
+def _slugify_person(text: str) -> str:
+    text = (text or "").strip().lower()
+    text = text.split("/", 1)[0].strip() if "/" in text else text
+    text = text.lstrip("@")
+    text = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return text or "unknown-source"
+
+
+def _safe_expert_filename(text: str) -> str:
+    """Return a display-name filename for an expert/source note."""
+    text = (text or "").strip()
+    text = text.split("/", 1)[0].strip() if "/" in text else text
+    text = re.sub(r"^@", "", text).strip()
+    text = re.sub(r"[\\/:*?\"<>|]+", "-", text)
+    text = re.sub(r"\s+", " ", text).strip(" .-")
+    return text[:120] or "Unknown source"
+
+
+def _expert_note_filename(card: Card) -> str:
+    """Canonical People filename, preferring human names over handle slugs."""
+    body = str(card.get("body") or "")
+    for label in ("Wikilink", "People note", "Expert note"):
+        m = re.search(rf"^{label}:\s*\[\[[^\]|]*(?:/|^)([^/\]|]+)(?:\|([^\]]+))?\]\]", body, re.IGNORECASE | re.MULTILINE)
+        if m:
+            return _safe_expert_filename(m.group(2) or m.group(1))
+    person = str(card.get("person") or "")
+    if person:
+        return _safe_expert_filename(person)
+    m = re.search(r"Candidate:\s*([^\n]+)", body, re.IGNORECASE)
+    if m:
+        return _safe_expert_filename(m.group(1))
+    return _safe_expert_filename(_expert_note_slug(card))
+
+
+def _expert_note_slug(card: Card) -> str:
+    body = str(card.get("body") or "")
+    m = re.search(r"CV note:\s*\[\[[^\]|]*(?:/|^)([^/\]|]+)\|?[^\]]*\]\]", body, re.IGNORECASE)
+    if m:
+        return _slugify_person(m.group(1))
+    url = str(card.get("url") or "")
+    m = re.search(r"x\.com/([^/?#]+)", url, re.IGNORECASE)
+    if m:
+        return _slugify_person(m.group(1))
+    person = str(card.get("person") or "")
+    m = re.search(r"@([A-Za-z0-9_]+)", person)
+    if m:
+        return _slugify_person(m.group(1))
+    return _slugify_person(person or str(card.get("id") or "expert"))
+
+
+def _expert_note_target_dir(status: str) -> Path:
+    status = (status or "pending").strip().lower()
+    root = _people_root()
+    if status in _EXPERT_ACCEPTED_STATUSES:
+        return root
+    if status.startswith("denied") or status == "skipped":
+        return root / "Denied"
+    return root / "Pending"
+
+
+def _find_expert_note(slug: str, filename: str = "") -> Path | None:
+    root = _people_root()
+    candidates = {
+        slug,
+        slug.replace("-", "_"),
+        slug.replace("_", "-"),
+    }
+    if filename:
+        candidates.update({
+            filename,
+            filename.replace(" ", "-"),
+            filename.replace(" ", "_"),
+        })
+    for base in (root, root / "Pending", root / "Denied"):
+        for cand in candidates:
+            p = base / f"{cand}.md"
+            if p.exists():
+                return p
+    wanted = {c.lower() + ".md" for c in candidates}
+    for p in root.rglob("*.md"):
+        if p.name.lower() in wanted:
+            return p
+    return None
+
+
+def _update_status_line(text: str, status: str, card_id: str) -> str:
+    label = {
+        "accepted": "accepted — active expert seed",
+        "accepted_no_note": "accepted — active expert seed",
+        "elaborated": "accepted — active expert seed",
+        "skipped": "denied/skipped — not an active expert seed",
+    }.get(status, "denied — not an active expert seed" if status.startswith("denied") else "pending review")
+    line = f"- Review status: {label}; card `{card_id}`"
+    if re.search(r"^- (?:Review )?Status: .*$", text, flags=re.MULTILINE):
+        return re.sub(r"^- (?:Review )?Status: .*$", line, text, count=1, flags=re.MULTILINE)
+    parts = text.splitlines()
+    if parts and parts[0].startswith("# "):
+        parts.insert(1, "")
+        parts.insert(2, line)
+        return "\n".join(parts).rstrip() + "\n"
+    return line + "\n\n" + text.rstrip() + "\n"
+
+
+def _ensure_expert_seed_link(card: Card, note_path: Path) -> None:
+    status = str(card.get("status") or "")
+    if status not in _EXPERT_ACCEPTED_STATUSES:
+        return
+    for thesis in _card_theses(card):
+        path = _safe_thesis_dir(thesis) / "Expert seeds.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else f"# Expert seeds — {thesis}\n\n"
+        rel = note_path.relative_to(_thesis_root()).with_suffix("").as_posix()
+        link = f"[[Antidote/Thesis/{rel}|{card.get('person') or note_path.stem}]]"
+        if note_path.stem.lower() in existing.lower() or str(card.get("url") or "") in existing:
+            path.write_text(existing, encoding="utf-8")
+            continue
+        block = (
+            "\n\n"
+            f"### {link}\n"
+            "- Domain: accepted expert/source seed from Review Queue.\n"
+            f"- Why this person/source matters: accepted for [[{thesis}]]; use this source's timeline/posts in future acquisition runs.\n"
+            f"- Profile: {card.get('url') or ''}\n"
+            f"- Review status: accepted; card `{card.get('id')}`.\n"
+            "- Query seeds:\n"
+            f"  - `from:{_expert_note_slug(card)}`\n"
+        )
+        path.write_text(existing.rstrip() + block + "\n", encoding="utf-8")
+
+
+def _apply_expert_decision_to_people_note(card: Card) -> None:
+    if str(card.get("kind") or "").lower() != "expert":
+        return
+    status = str(card.get("status") or "pending").strip().lower()
+    slug = _expert_note_slug(card)
+    filename = _expert_note_filename(card)
+    target_dir = _expert_note_target_dir(status)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    source = _find_expert_note(slug, filename)
+    target = target_dir / f"{filename}.md"
+    if source is None:
+        related = "\n".join(
+            f"  - [[Antidote/Thesis/{thesis}/{thesis}|{thesis}]]"
+            for thesis in _card_theses(card)
+        )
+        target.write_text(
+            f"# {card.get('person') or slug}\n\n"
+            f"- Profile: {card.get('url') or ''}\n"
+            f"- Related theses:\n{related}\n"
+            "- Review status: pending review\n\n"
+            "## CV-quality profile\n\nPending CV/provenance research.\n\n"
+            "## Sources\n\n"
+            f"- Review Queue card: `{card.get('id')}`\n",
+            encoding="utf-8",
+        )
+    else:
+        if source.resolve() != target.resolve():
+            if target.exists():
+                target.write_text(source.read_text(encoding="utf-8", errors="ignore"), encoding="utf-8")
+                source.unlink()
+            else:
+                source.rename(target)
+    text = target.read_text(encoding="utf-8", errors="ignore")
+    text = _update_status_line(text, status, str(card.get("id") or ""))
+    target.write_text(text, encoding="utf-8")
+    _ensure_expert_seed_link(card, target)
+
+    rel = target.relative_to(_thesis_root()).with_suffix("").as_posix()
+    cv_link = f"CV note: [[Antidote/Thesis/{rel}|{target.stem}]]"
+    body = str(card.get("body") or "")
+    if re.search(r"^CV note:.*$", body, flags=re.MULTILINE):
+        body = re.sub(r"^CV note:.*$", cv_link, body, count=1, flags=re.MULTILINE)
+    elif body.strip():
+        body = body.rstrip() + "\n" + cv_link
+    else:
+        body = cv_link
+
+    now = _now()
+    with _connect() as con:
+        con.execute(
+            "UPDATE cards SET obsidian_path = ?, body = ?, updated_at = ? WHERE id = ?",
+            (str(target), body, now, str(card.get("id") or "")),
+        )
+
+
+def _startup_root(thesis: str) -> Path:
+    return _safe_thesis_dir(thesis) / "Startups"
+
+
+def _startup_note_target_dir(thesis: str, status: str) -> Path:
+    status = (status or "pending").strip().lower()
+    root = _startup_root(thesis)
+    if status in _STARTUP_ACCEPTED_STATUSES:
+        return root
+    if status.startswith("denied") or status == "skipped":
+        return root / "Denied"
+    return root / "Pending"
+
+
+def _safe_note_filename(text: str) -> str:
+    text = re.sub(r"[\\/:*?\"<>|]+", "-", (text or "").strip())
+    text = re.sub(r"\s+", " ", text).strip(" .-")
+    return text[:120] or "Unknown startup"
+
+
+def _startup_name(card: Card) -> str:
+    fields, _ = _body_fields(str(card.get("body") or ""))
+    name = fields.get("startup") or fields.get("company") or str(card.get("person") or "").strip()
+    if name:
+        return _safe_note_filename(name.lstrip("@"))
+    url = str(card.get("url") or "")
+    m = re.search(r"https?://(?:www\.)?([^/?#]+)", url, re.IGNORECASE)
+    if m:
+        host = m.group(1).split(":", 1)[0]
+        return _safe_note_filename(host.removesuffix(".com"))
+    return _safe_note_filename(str(card.get("id") or "Unknown startup"))
+
+
+def _find_startup_note(thesis: str, name: str) -> Path | None:
+    root = _startup_root(thesis)
+    wanted = f"{name}.md".lower()
+    for base in (root, root / "Pending", root / "Denied"):
+        p = base / f"{name}.md"
+        if p.exists():
+            return p
+    if root.exists():
+        for p in root.rglob("*.md"):
+            if p.name.lower() == wanted:
+                return p
+    return None
+
+
+def _startup_status_label(status: str) -> str:
+    status = (status or "pending").strip().lower()
+    if status in _STARTUP_ACCEPTED_STATUSES:
+        return "accepted — active startup map entry"
+    if status.startswith("denied") or status == "skipped":
+        return "denied/skipped — not active"
+    return "pending review"
+
+
+def _apply_startup_decision_to_note(card: Card) -> None:
+    fields, _ = _body_fields(str(card.get("body") or ""))
+    status = str(card.get("status") or "pending")
+    for thesis in _card_theses(card):
+        name = _startup_name(card)
+        target_dir = _startup_note_target_dir(thesis, status)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        existing = _find_startup_note(thesis, name)
+        target = target_dir / f"{name}.md"
+        if existing and existing != target:
+            target.write_text(existing.read_text(encoding="utf-8", errors="ignore"), encoding="utf-8")
+            try:
+                existing.unlink()
+            except OSError:
+                pass
+        website = fields.get("website") or fields.get("profile") or str(card.get("url") or "")
+        taxonomy = fields.get("taxonomy fit") or fields.get("taxonomy") or fields.get("category")
+        market_map = fields.get("market map")
+        founders = fields.get("founders") or fields.get("credentials / provenance")
+        backers = fields.get("backers")
+        traction = fields.get("traction") or fields.get("stage")
+        existing_text = target.read_text(encoding="utf-8", errors="ignore") if target.exists() else ""
+        body = str(card.get("body") or "").strip()
+        note = (
+            f"# {name}\n\n"
+            f"- Review status: {_startup_status_label(status)}; card `{card.get('id')}`\n"
+            f"- Thesis: [[{thesis}]]\n"
+            f"- Website / profile: {website}\n"
+            f"- Found via: {card.get('source') or ''}\n"
+            f"- Taxonomy fit: {taxonomy or 'TBD'}\n"
+            f"- Market map source: {market_map or ''}\n"
+            f"- Founders / provenance: {founders or ''}\n"
+            f"- Backers: {backers or ''}\n"
+            f"- Traction / stage: {traction or ''}\n"
+            f"- Decision note: {card.get('decision_note') or ''}\n\n"
+            "## Research notes\n\n"
+            f"{body}\n\n"
+            "## Open questions\n\n"
+            "- What exact taxonomy bucket should this startup sit in?\n"
+            "- Is it a primary thesis signal, adjacent company, competitor, or reject?\n"
+            "- What evidence proves traction: revenue, usage, funding, founder pedigree, customer logos, or technical demo?\n"
+        )
+        if existing_text and "## Review history" in existing_text:
+            note += "\n" + existing_text.split("## Review history", 1)[1].lstrip()
+        note += f"\n## Review history\n\n- {_now()} — {status}; decided by {card.get('decided_by') or ''}; note: {card.get('decision_note') or ''}.\n"
+        target.write_text(note.rstrip() + "\n", encoding="utf-8")
+        _ensure_startup_index_link(thesis, target, card, taxonomy)
+        with _connect() as con:
+            con.execute(
+                "UPDATE cards SET obsidian_path = ?, updated_at = ? WHERE id = ?",
+                (str(target), _now(), str(card.get("id") or "")),
+            )
+
+
+def _ensure_startup_index_link(thesis: str, note_path: Path, card: Card, taxonomy: str | None = None) -> None:
+    index = _startup_root(thesis) / "Startup map.md"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    existing = index.read_text(encoding="utf-8", errors="ignore") if index.exists() else f"# Startup map — {thesis}\n\n## Taxonomy\n\n## Startups\n"
+    rel = note_path.relative_to(_thesis_root()).with_suffix("").as_posix()
+    link = f"[[Antidote/Thesis/{rel}|{note_path.stem}]]"
+    if note_path.stem.lower() in existing.lower():
+        return
+    if "## Startups" not in existing:
+        existing = existing.rstrip() + "\n\n## Startups\n"
+    line = f"\n- {link} — {taxonomy or 'TBD'}; status `{card.get('status')}`; card `{card.get('id')}`."
+    index.write_text(existing.rstrip() + line + "\n", encoding="utf-8")
+
+
+def create_card(
+    *,
+    card_id: str,
+    kind: str,
+    thesis: str,
+    body: str,
+    person: str = "",
+    url: str = "",
+    source: str = "",
+    target: str = "",
+    telegram_chat_id: str = "",
+    telegram_thread_id: str = "",
+    telegram_message_id: str = "",
+    obsidian_path: str = "",
+) -> Card:
+    """Create or update a persistent review-card row."""
+    card_id = str(card_id).strip()
+    if not card_id:
+        raise ValueError("card_id is required")
+    kind = (kind or "evidence").strip().lower()
+    if kind not in {"evidence", "expert", "startup", "job"}:
+        raise ValueError("kind must be evidence, expert, startup, or job")
+    if target and (not telegram_chat_id or not telegram_thread_id):
+        parsed_chat_id, parsed_thread_id = _parse_telegram_target(target)
+        telegram_chat_id = telegram_chat_id or parsed_chat_id
+        telegram_thread_id = telegram_thread_id or parsed_thread_id
+    now = _now()
+    with _connect() as con:
+        existing = get_card(card_id)
+        created_at = existing["created_at"] if existing else now
+        status = existing["status"] if existing else "pending"
+        values = {
+            "id": card_id,
+            "kind": kind,
+            "thesis": thesis.strip() or "Inbox",
+            "person": person or "",
+            "url": url or "",
+            "body": body.strip(),
+            "source": source or "",
+            "status": status,
+            "obsidian_path": obsidian_path or "",
+            "telegram_chat_id": str(telegram_chat_id or ""),
+            "telegram_thread_id": str(telegram_thread_id or ""),
+            "telegram_message_id": str(telegram_message_id or ""),
+            "created_at": created_at,
+            "updated_at": now,
+            "decided_by": existing.get("decided_by", "") if existing else "",
+            "decision_note": existing.get("decision_note", "") if existing else "",
+        }
+        placeholders = ", ".join([":" + c for c in _COLUMNS])
+        updates = ", ".join([f"{c}=excluded.{c}" for c in _COLUMNS if c != "id"])
+        con.execute(
+            f"INSERT INTO cards ({', '.join(_COLUMNS)}) VALUES ({placeholders}) "
+            f"ON CONFLICT(id) DO UPDATE SET {updates}",
+            values,
+        )
+    card = get_card(card_id)
+    assert card is not None
+    return card
+
+
+def get_card(card_id: str) -> Optional[Card]:
+    with _connect() as con:
+        row = con.execute("SELECT * FROM cards WHERE id = ?", (str(card_id),)).fetchone()
+    return _row_to_card(row)
+
+
+def set_telegram_message_id(card_id: str, message_id: str) -> Optional[Card]:
+    now = _now()
+    with _connect() as con:
+        con.execute(
+            "UPDATE cards SET telegram_message_id = ?, updated_at = ? WHERE id = ?",
+            (str(message_id), now, str(card_id)),
+        )
+    return get_card(card_id)
+
+
+def resolve_card(card_id: str, action: str, user: str = "", note: str = "") -> Card:
+    action_key = (action or "").strip().lower()
+    status = _ACTION_TO_STATUS.get(action_key)
+    if not status:
+        raise ValueError(f"unknown review-card action: {action}")
+    now = _now()
+    with _connect() as con:
+        row = con.execute("SELECT * FROM cards WHERE id = ?", (str(card_id),)).fetchone()
+        if row is None:
+            raise KeyError(f"review card not found: {card_id}")
+        con.execute(
+            "UPDATE cards SET status = ?, updated_at = ?, decided_by = ?, decision_note = ? WHERE id = ?",
+            (status, now, user or "", note or "", str(card_id)),
+        )
+    card = get_card(card_id)
+    assert card is not None
+    _append_obsidian_decision(card)
+    return card
+
+
+def capture_pending_note(
+    *,
+    telegram_chat_id: str,
+    telegram_thread_id: str = "",
+    user: str = "",
+    note: str,
+) -> Optional[Card]:
+    """Attach a typed note to the newest review card awaiting a typed note in a topic."""
+    note = (note or "").strip()
+    if not note:
+        return None
+    chat_id = str(telegram_chat_id or "")
+    thread_id = str(telegram_thread_id or "")
+    with _connect() as con:
+        row = con.execute(
+            """
+            SELECT * FROM cards
+            WHERE status IN ('elaborate_requested', 'deny_note_requested')
+              AND telegram_chat_id = ?
+              AND COALESCE(telegram_thread_id, '') = ?
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            (chat_id, thread_id),
+        ).fetchone()
+        if row is None:
+            return None
+        card_id = row["id"]
+        next_status = "denied_with_note" if row["status"] == "deny_note_requested" else "elaborated"
+        now = _now()
+        con.execute(
+            "UPDATE cards SET status = ?, updated_at = ?, decided_by = ?, decision_note = ? WHERE id = ?",
+            (next_status, now, user or row["decided_by"] or "", note, card_id),
+        )
+    card = get_card(card_id)
+    if card is not None:
+        _append_obsidian_decision(card)
+    return card
+
+
+def status_label(card: Card) -> str:
+    return _STATUS_LABELS.get(card.get("status") or "pending", str(card.get("status") or "pending"))
+
+
+def _display_card_id(card_id: str) -> str:
+    """Return a readable identifier while keeping the full ID in callback data."""
+    card_id = str(card_id or "").strip()
+    if not card_id:
+        return ""
+    if len(card_id) <= 32:
+        return card_id
+    # Long slugs make Telegram cards unreadable. Show a stable short handle instead.
+    import hashlib
+
+    return f"…{card_id[-12:]} · {hashlib.sha1(card_id.encode()).hexdigest()[:6]}"
+
+
+def _body_fields(body: str) -> Tuple[Dict[str, str], str]:
+    """Parse common `Label: value` card bodies and return remaining free text."""
+    fields: Dict[str, str] = {}
+    free: List[str] = []
+    current_key = ""
+    known = {
+        "evidence id", "expert id", "startup id", "startup", "company", "person", "post", "profile", "website", "found via",
+        "candidate", "rationale", "background/cv", "credentials / provenance",
+        "cv note", "recommendation", "why follow", "source", "fit / caveats",
+        "caveat", "source strength", "why it matters", "top thesis-adjacent posts",
+        "category", "taxonomy", "taxonomy fit", "market map", "founders", "backers",
+        "traction", "stage", "competitors", "watch for", "job title", "role", "location",
+        "work mode", "alert", "alert settings", "job id", "signals", "fit", "why interesting",
+    }
+    for raw in str(body or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+            norm = key.strip().lower()
+            if norm in known:
+                current_key = norm
+                fields[current_key] = value.strip()
+                continue
+        if current_key:
+            sep = "\n" if current_key in {"top thesis-adjacent posts", "background/cv", "credentials / provenance"} else " "
+            fields[current_key] = (fields[current_key] + sep + line).strip()
+        else:
+            free.append(line)
+    return fields, "\n".join(free).strip()
+
+
+def render_card_text(card: Card) -> str:
+    kind = (card.get("kind") or "evidence").strip().lower()
+    fields, free_body = _body_fields(str(card.get("body") or ""))
+    title = "🧑 Expert seed candidate" if kind == "expert" else "🏢 Startup candidate" if kind == "startup" else "💼 Job opportunity" if kind == "job" else "🧾 Evidence candidate"
+    thesis_label = "Theses" if kind == "expert" or len(_card_theses(card)) > 1 else "Thesis"
+    lines = [title, f"{thesis_label}: {card.get('thesis', '')}".strip()]
+
+    person = fields.get("person") or str(card.get("person") or "").strip()
+    if person:
+        lines.append(f"Person: {person}")
+
+    if kind == "job":
+        role = fields.get("job title") or fields.get("role") or fields.get("candidate") or free_body
+        company = fields.get("company") or person
+        location = fields.get("location")
+        work_mode = fields.get("work mode")
+        alert = fields.get("alert") or str(card.get("source") or "").strip()
+        alert_settings = fields.get("alert settings")
+        job_id = fields.get("job id")
+        signals = fields.get("signals")
+        fit = fields.get("fit") or fields.get("why interesting") or fields.get("rationale")
+        caveat = fields.get("caveat") or fields.get("fit / caveats")
+        link = str(card.get("url") or "").strip()
+
+        if role:
+            lines.append(f"Role: {role}")
+        if company:
+            lines.append(f"Company: {company}")
+        if location:
+            suffix = f" ({work_mode})" if work_mode else ""
+            lines.append(f"Location: {location}{suffix}")
+        elif work_mode:
+            lines.append(f"Work mode: {work_mode}")
+        if link:
+            lines.append(f"Link: {link}")
+        if job_id:
+            lines.append(f"LinkedIn job ID: {job_id}")
+        if alert:
+            lines.append(f"Alert: {alert}")
+        if alert_settings:
+            lines.append(f"Alert settings: {alert_settings}")
+        if signals:
+            lines.append(f"Signals: {signals}")
+        if fit:
+            lines.extend(["", f"Why interesting: {fit}"])
+        if caveat:
+            lines.append(f"Caveat: {caveat}")
+    elif kind == "expert":
+        profile = fields.get("profile") or str(card.get("url") or "").strip()
+        found_via = fields.get("found via") or str(card.get("source") or "").strip()
+        candidate = fields.get("rationale") or fields.get("candidate") or free_body
+        background = fields.get("background/cv") or fields.get("credentials / provenance")
+        cv_note = fields.get("cv note")
+        recommendation = fields.get("recommendation")
+        why_follow = fields.get("why follow")
+        top_posts = fields.get("top thesis-adjacent posts")
+        source_strength = fields.get("source strength")
+        caveat = fields.get("caveat") or fields.get("fit / caveats")
+
+        if profile:
+            lines.append(f"Profile: {profile}")
+        if found_via and found_via != profile:
+            lines.append(f"Found via: {found_via}")
+        if cv_note:
+            lines.append(f"CV note: {cv_note}")
+        if recommendation:
+            lines.extend(["", f"Recommendation: {recommendation}"])
+        if candidate:
+            lines.extend(["", f"Rationale: {candidate}"])
+        if background:
+            lines.extend(["", "Credentials / provenance:", background])
+        if top_posts:
+            lines.extend(["", "Top thesis-adjacent posts:", top_posts])
+        if why_follow:
+            lines.extend(["", f"Watch for: {why_follow}"])
+        if source_strength:
+            lines.append(f"Source strength: {source_strength}")
+        if caveat:
+            lines.append(f"Caveat: {caveat}")
+    elif kind == "startup":
+        startup = fields.get("startup") or fields.get("company") or person
+        website = fields.get("website") or fields.get("profile") or str(card.get("url") or "").strip()
+        found_via = fields.get("found via") or str(card.get("source") or "").strip()
+        candidate = fields.get("rationale") or fields.get("candidate") or free_body
+        taxonomy = fields.get("taxonomy fit") or fields.get("taxonomy") or fields.get("category")
+        market_map = fields.get("market map")
+        founders = fields.get("founders") or fields.get("credentials / provenance")
+        backers = fields.get("backers")
+        traction = fields.get("traction") or fields.get("stage")
+        competitors = fields.get("competitors")
+        why = fields.get("why it matters")
+        caveat = fields.get("caveat") or fields.get("fit / caveats")
+        watch = fields.get("watch for") or fields.get("why follow")
+
+        if startup:
+            lines.append(f"Startup: {startup}")
+        if website:
+            lines.append(f"Website: {website}")
+        if found_via and found_via != website:
+            lines.append(f"Found via: {found_via}")
+        if taxonomy:
+            lines.append(f"Taxonomy fit: {taxonomy}")
+        if market_map:
+            lines.append(f"Market map: {market_map}")
+        if candidate:
+            lines.extend(["", f"Rationale: {candidate}"])
+        if why:
+            lines.append(f"Why it matters: {why}")
+        if founders:
+            lines.extend(["", "Founders / provenance:", founders])
+        if backers:
+            lines.append(f"Backers: {backers}")
+        if traction:
+            lines.append(f"Traction / stage: {traction}")
+        if competitors:
+            lines.append(f"Competitors: {competitors}")
+        if watch:
+            lines.append(f"Watch for: {watch}")
+        if caveat:
+            lines.append(f"Caveat: {caveat}")
+    else:
+        post = fields.get("post") or str(card.get("url") or "").strip()
+        found_via = fields.get("found via") or str(card.get("source") or "").strip()
+        candidate = fields.get("rationale") or fields.get("candidate") or free_body
+        why = fields.get("why it matters")
+        caveats = fields.get("fit / caveats")
+
+        if post:
+            lines.append(f"Post: {post}")
+        if found_via and found_via != post:
+            lines.append(f"Found via: {found_via}")
+        if candidate:
+            lines.extend(["", f"Rationale: {candidate}"])
+        if why:
+            lines.append(f"Why it matters: {why}")
+        if caveats:
+            lines.append(f"Caveats: {caveats}")
+
+    # If the body had no explicit Rationale/Candidate field, free_body was already
+    # rendered above as the Rationale. Only append free-form leftovers when a
+    # structured rationale/candidate field existed and free_body is truly extra.
+    if free_body and (fields.get("rationale") or fields.get("candidate")) and kind != "expert":
+        lines.extend(["", free_body])
+    if card.get("decision_note"):
+        lines.extend(["", f"Note: {card['decision_note']}"])
+
+    display_id = _display_card_id(str(card.get("id") or ""))
+    footer = f"Status: {status_label(card)}"
+    if display_id:
+        footer += f" · Card: {display_id}"
+    lines.extend(["", footer])
+    return "\n".join(line for line in lines if line is not None).strip()
+
+
+def build_button_rows(card: Card) -> ButtonRows:
+    card_id = str(card["id"])
+    if (card.get("kind") or "").strip().lower() == "job":
+        if card.get("status") in {"pending", "needs_rescore"}:
+            return [[("✅ Accept", f"rq:n:{card_id}"), ("⏭ Skip", f"rq:s:{card_id}")]]
+        return []
+    if card.get("status") in {"accepted", "accepted_pending_note"}:
+        return [[("📝 Add accepted note", f"rq:e:{card_id}"), ("✓ No note", f"rq:n:{card_id}")]]
+    if card.get("status") == "denied_pending_note":
+        return [[("📝 Add denial reason", f"rq:dn:{card_id}"), ("✓ No note", f"rq:nn:{card_id}")]]
+    if card.get("status") in {"pending", "needs_rescore"}:
+        kind = (card.get("kind") or "").strip().lower()
+        if kind in {"evidence", "expert"}:
+            return [
+                [("✅ Accept", f"rq:a:{card_id}"), ("❌ Deny", f"rq:d:{card_id}")],
+                [("🔁 Rescore", f"rq:r:{card_id}")],
+            ]
+        return [
+            [("✅ Accept", f"rq:a:{card_id}"), ("❌ Deny", f"rq:d:{card_id}")],
+            [("🔁 Rescore", f"rq:r:{card_id}"), ("⏭ Skip", f"rq:s:{card_id}")],
+        ]
+    return []
+
+
+def render_keyboard_rows(card: Card) -> ButtonRows:
+    """Backward-compatible/readable alias for review-card button rows."""
+    return build_button_rows(card)
+
+
+def button_rows_for_card(card: Card) -> ButtonRows:
+    """Compatibility alias used by tests and older callers."""
+    return build_button_rows(card)
+
+
+def apply_decision_to_obsidian(card: Card, action: str = "") -> None:
+    """Compatibility wrapper for appending review decisions to Obsidian."""
+    if action:
+        card = dict(card)
+        card["decision_note"] = (card.get("decision_note") or f"action: {action}")
+    _append_obsidian_decision(card)
+
+
+def callback_label(action: str, card: Card) -> str:
+    return status_label(card)
+
+
+def _launch_job_accept_workflow(card: Card) -> None:
+    """Start Antidote's job-accept side effects without blocking Telegram callbacks."""
+    status = str(card.get("status") or "").strip().lower()
+    if status not in {"accepted", "accepted_no_note", "elaborated"}:
+        return
+    card_id = str(card.get("id") or "").strip()
+    if not card_id:
+        return
+    script = Path(os.getenv("JOB_ACCEPT_WORKFLOW_SCRIPT", str(get_hermes_home() / "scripts" / "job_accept_workflow.py"))).expanduser()
+    if not script.exists():
+        return
+    log_dir = Path(get_hermes_home()) / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "job_accept_workflow.log"
+    try:
+        log = log_path.open("ab")
+        env = os.environ.copy()
+        env.setdefault("HERMES_HOME", str(get_hermes_home()))
+        import subprocess
+
+        subprocess.Popen(
+            [os.getenv("PYTHON", "python"), str(script), card_id],
+            cwd="/usr/local/lib/hermes-agent" if Path("/usr/local/lib/hermes-agent").exists() else None,
+            env=env,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+    except Exception:
+        # Callback UX must not fail just because a background side-effect failed.
+        return
+
+
+def _append_obsidian_decision(card: Card) -> None:
+    kind = str(card.get("kind") or "").lower()
+    if kind == "job":
+        _launch_job_accept_workflow(card)
+        return
+    if kind == "expert":
+        _apply_expert_decision_to_people_note(card)
+        return
+    if kind == "startup":
+        _apply_startup_decision_to_note(card)
+    for thesis in _card_theses(card):
+        _append_obsidian_decision_for_thesis(card, thesis)
+
+
+def _append_obsidian_decision_for_thesis(card: Card, thesis: str) -> None:
+    path = _review_queue_path(thesis)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stamp = _now()
+    existing_text = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+    block = [""]
+    if "Telegram review decisions" not in existing_text:
+        block.append("## Telegram review decisions")
+    block.extend([
+        f"### {stamp} — {card['id']} — {card['status']}",
+        f"- Type: {card['kind']}",
+        f"- Theses: {card.get('thesis') or thesis}",
+        f"- Person: {card.get('person') or ''}",
+        f"- URL: {card.get('url') or ''}",
+        f"- Decided by: {card.get('decided_by') or ''}",
+        f"- Decision note: {card.get('decision_note') or ''}",
+        f"- Body: {card.get('body') or ''}",
+    ])
+    with path.open("a", encoding="utf-8") as f:
+        f.write("\n".join(block) + "\n")
+
+    # Evidence review-card decisions belong in the local Review queue log.
+    # Do not append "Evidence to elaborate" / free-text elaboration blocks to the
+    # thesis page itself: accepted evidence is promoted into the thesis evidence
+    # callout by the review/evidence synthesis workflow, while notes stay attached
+    # to the review decision for that card.
+
+
+def list_cards(status: Optional[str] = None) -> List[Card]:
+    with _connect() as con:
+        if status:
+            rows = con.execute("SELECT * FROM cards WHERE status = ? ORDER BY created_at DESC", (status,)).fetchall()
+        else:
+            rows = con.execute("SELECT * FROM cards ORDER BY created_at DESC").fetchall()
+    return [c for c in (_row_to_card(row) for row in rows) if c is not None]

--- a/tools/review_queue_tool.py
+++ b/tools/review_queue_tool.py
@@ -1,0 +1,192 @@
+"""Tool for sending persistent Telegram thesis review cards."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from typing import Any, Dict, List, Tuple
+
+from tools.registry import registry, tool_error
+
+
+SEND_REVIEW_CARD_SCHEMA = {
+    "name": "send_review_card",
+    "description": "Send a persistent Telegram thesis-review card with Accept/Deny/Rescore/Skip buttons.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target": {"type": "string", "description": "Telegram target, e.g. telegram:-1003915682412:3930"},
+            "card_id": {"type": "string"},
+            "kind": {"type": "string", "enum": ["evidence", "expert", "startup", "job"]},
+            "thesis": {"type": "string", "description": "For evidence: one target thesis. For expert/source cards: comma-separated relevant theses, or 'Generalist / cross-thesis watchlist'; this is relevance/routing, not ownership."},
+            "body": {"type": "string"},
+            "person": {"type": "string"},
+            "url": {"type": "string"},
+            "source": {"type": "string"},
+        },
+        "required": ["target", "card_id", "kind", "thesis", "body"],
+    },
+}
+
+
+def _check_send_review_card() -> bool:
+    return True
+
+
+def _callback_safe_card_id(card_id: str, kind: str) -> str:
+    """Keep Telegram callback_data within the 64-byte Bot API limit.
+
+    Callback data is shaped like `rq:a:<card_id>`, so card_id must be short.
+    Preserve already-short IDs; compact long cron-generated slugs deterministically.
+    Original evidence/expert IDs should live in the card body.
+    """
+    card_id = str(card_id or "").strip()
+    if len(f"rq:a:{card_id}".encode("utf-8")) <= 64:
+        return card_id
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", card_id.lower()).strip("-")[:18] or "card"
+    digest = hashlib.sha1(card_id.encode("utf-8")).hexdigest()[:10]
+    kind_key = str(kind).lower()
+    prefix = "ex" if kind_key == "expert" else "su" if kind_key == "startup" else "jb" if kind_key == "job" else "ev"
+    return f"rq-{prefix}-{slug}-{digest}"
+
+
+_TWEET_ID_RE = re.compile(r"(?:x\.com|twitter\.com)/(?:i/web/status/|[^\s/]+/status/)(\d+)")
+
+
+def _extract_tweet_ids(*parts: str) -> List[str]:
+    seen: set[str] = set()
+    ids: List[str] = []
+    for part in parts:
+        for tweet_id in _TWEET_ID_RE.findall(str(part or "")):
+            if tweet_id not in seen:
+                seen.add(tweet_id)
+                ids.append(tweet_id)
+    return ids
+
+
+def _validate_x_post_links(*parts: str) -> Tuple[bool, Dict[str, Any]]:
+    """Validate embedded X post links before sending Review Queue cards.
+
+    Review Queue cards are action items; dead X links make them unusable. If an
+    x.com/twitter.com status URL is present, require X API hydration to find it.
+    """
+    tweet_ids = _extract_tweet_ids(*parts)
+    if not tweet_ids:
+        return True, {"checked": 0, "valid_ids": [], "invalid_ids": []}
+    endpoint = (
+        "/2/tweets?ids=" + ",".join(tweet_ids)
+        + "&tweet.fields=created_at,author_id,public_metrics,entities,referenced_tweets"
+    )
+    env = {**os.environ, "HOME": os.environ.get("HOME") or "/root"}
+    if env.get("HOME") in {"", "/"}:
+        env["HOME"] = "/root"
+    try:
+        proc = subprocess.run(
+            ["xurl", endpoint],
+            cwd="/usr/local/lib/hermes-agent" if os.path.exists("/usr/local/lib/hermes-agent") else None,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=45,
+        )
+    except Exception as exc:
+        return False, {"checked": len(tweet_ids), "error": f"xurl validation failed: {exc}", "invalid_ids": tweet_ids}
+    if proc.returncode != 0:
+        return False, {
+            "checked": len(tweet_ids),
+            "error": "xurl validation failed",
+            "stderr": proc.stderr[-500:],
+            "stdout": proc.stdout[-500:],
+            "invalid_ids": tweet_ids,
+        }
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except Exception as exc:
+        return False, {"checked": len(tweet_ids), "error": f"invalid xurl JSON: {exc}", "invalid_ids": tweet_ids}
+    valid_ids = {str(item.get("id")) for item in (payload.get("data") or []) if item.get("id")}
+    invalid_ids = [tid for tid in tweet_ids if tid not in valid_ids]
+    errors = []
+    for err in payload.get("errors") or []:
+        errors.append({k: err.get(k) for k in ("value", "title", "detail", "type") if err.get(k)})
+    return not invalid_ids, {
+        "checked": len(tweet_ids),
+        "valid_ids": sorted(valid_ids),
+        "invalid_ids": invalid_ids,
+        "errors": errors,
+    }
+
+
+def send_review_card_tool(args: Dict[str, Any], **kw) -> str:
+    target = str(args.get("target") or "").strip()
+    if not target.startswith("telegram:"):
+        return tool_error("send_review_card currently requires a telegram:<chat_id>:<thread_id> target")
+    try:
+        from gateway.config import Platform, load_gateway_config
+        from gateway.platforms.telegram import TelegramAdapter, Bot
+        from model_tools import _run_async
+        from tools.send_message_tool import _parse_target_ref
+
+        chat_id, thread_id, explicit = _parse_target_ref("telegram", target.split(":", 1)[1])
+        if not explicit or not chat_id:
+            return tool_error("Invalid Telegram target. Use telegram:<chat_id>:<thread_id>.")
+
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.TELEGRAM)
+        if not pconfig or not pconfig.enabled or not pconfig.token:
+            return tool_error("Telegram is not configured.")
+
+        adapter = TelegramAdapter(pconfig)
+        adapter._bot = Bot(token=pconfig.token)
+        safe_card_id = _callback_safe_card_id(str(args["card_id"]), str(args["kind"]))
+        links_ok, link_validation = _validate_x_post_links(
+            str(args.get("url") or ""),
+            str(args.get("body") or ""),
+            str(args.get("source") or ""),
+        )
+        if not links_ok:
+            return json.dumps({
+                "error": "x_post_link_invalid",
+                "message": "Review card not sent because at least one X post link is unavailable/not found.",
+                "card_id": safe_card_id,
+                "original_card_id": str(args["card_id"]),
+                "validation": link_validation,
+            })
+        result = _run_async(
+            adapter.send_review_card(
+                chat_id=str(chat_id),
+                card_id=safe_card_id,
+                kind=str(args["kind"]),
+                thesis=str(args["thesis"]),
+                body=str(args["body"]),
+                person=str(args.get("person") or ""),
+                url=str(args.get("url") or ""),
+                source=str(args.get("source") or ""),
+                metadata={"thread_id": str(thread_id or "")},
+            )
+        )
+        if result.success:
+            return json.dumps({
+                "success": True,
+                "platform": "telegram",
+                "chat_id": str(chat_id),
+                "thread_id": str(thread_id or ""),
+                "message_id": result.message_id,
+                "card_id": safe_card_id,
+                "original_card_id": str(args["card_id"]),
+            })
+        return json.dumps({"error": result.error or "send_review_card failed"})
+    except Exception as e:
+        return json.dumps({"error": f"send_review_card failed: {e}"})
+
+
+registry.register(
+    name="send_review_card",
+    toolset="review_queue",
+    schema=SEND_REVIEW_CARD_SCHEMA,
+    handler=send_review_card_tool,
+    check_fn=_check_send_review_card,
+    emoji="🗳️",
+)

--- a/tools/telegram_admin_tool.py
+++ b/tools/telegram_admin_tool.py
@@ -1,0 +1,340 @@
+"""Telegram admin tools for pinning/unpinning messages.
+
+Uses the configured Telegram bot token from the Hermes gateway config or
+TELEGRAM_BOT_TOKEN environment variable. Never returns or logs the token.
+"""
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+from agent.redact import redact_sensitive_text
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API_BASE = "https://api.telegram.org/bot"
+
+
+def _sanitize_error_text(text: Any) -> str:
+    return redact_sensitive_text(str(text))
+
+
+def _error(message: str) -> str:
+    return json.dumps({"success": False, "error": _sanitize_error_text(message)})
+
+
+def _get_telegram_token() -> Optional[str]:
+    """Resolve Telegram bot token from gateway config/env without exposing it."""
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.TELEGRAM)
+        if pconfig and pconfig.enabled and pconfig.token:
+            return str(pconfig.token).strip()
+    except Exception:
+        logger.debug("Could not load Telegram token from gateway config", exc_info=True)
+
+    # Fallback: environment only. Do not print this value.
+    try:
+        import os
+
+        token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+        return token or None
+    except Exception:
+        return None
+
+
+def _check_telegram_admin_requirements() -> bool:
+    return bool(_get_telegram_token())
+
+
+def _telegram_api_request(method: str, payload: Dict[str, Any], timeout: int = 20) -> Dict[str, Any]:
+    token = _get_telegram_token()
+    if not token:
+        raise RuntimeError("Telegram bot token is not configured")
+
+    url = f"{TELEGRAM_API_BASE}{token}/{method}"
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "Hermes-Agent TelegramAdminTool",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        try:
+            parsed = json.loads(body) if body else {}
+        except Exception:
+            parsed = {"description": body}
+        return {
+            "ok": False,
+            "error_code": exc.code,
+            "description": parsed.get("description") or f"HTTP {exc.code}",
+        }
+
+
+def _parse_telegram_target(target: str = "", chat_id: str = "", thread_id: str = "") -> Tuple[Optional[str], Optional[str]]:
+    """Resolve a Telegram target string to (chat_id, thread_id)."""
+    target = (target or "").strip()
+    chat_id = (chat_id or "").strip()
+    thread_id = str(thread_id or "").strip() or None
+
+    if target:
+        if target.startswith("telegram:"):
+            ref = target.split(":", 1)[1]
+        elif target == "telegram":
+            ref = ""
+        else:
+            ref = target
+
+        if ref:
+            # Numeric explicit Telegram target: chat_id[:thread_id]
+            parts = ref.split(":")
+            if len(parts) >= 1 and parts[0].lstrip("-").isdigit():
+                chat_id = parts[0]
+                if len(parts) >= 2 and parts[1].isdigit():
+                    thread_id = parts[1]
+            else:
+                try:
+                    from gateway.channel_directory import resolve_channel_name
+
+                    resolved = resolve_channel_name("telegram", ref)
+                    if resolved:
+                        parts = str(resolved).split(":")
+                        chat_id = parts[0]
+                        if len(parts) >= 2 and parts[1].isdigit():
+                            thread_id = parts[1]
+                except Exception:
+                    pass
+
+    if not chat_id:
+        try:
+            from gateway.config import Platform, load_gateway_config
+
+            config = load_gateway_config()
+            home = config.get_home_channel(Platform.TELEGRAM)
+            if home:
+                chat_id = str(home.chat_id)
+        except Exception:
+            pass
+
+    return (chat_id or None), thread_id
+
+
+def _extract_message_id(send_result: Dict[str, Any]) -> Optional[int]:
+    mid = send_result.get("message_id")
+    if mid is None:
+        return None
+    try:
+        return int(mid)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pin(chat_id: str, message_id: int, disable_notification: bool = True) -> Dict[str, Any]:
+    payload = {
+        "chat_id": int(chat_id) if str(chat_id).lstrip("-").isdigit() else chat_id,
+        "message_id": int(message_id),
+        "disable_notification": bool(disable_notification),
+    }
+    resp = _telegram_api_request("pinChatMessage", payload)
+    if resp.get("ok"):
+        return {
+            "success": True,
+            "action": "pin_message",
+            "platform": "telegram",
+            "chat_id": str(chat_id),
+            "message_id": str(message_id),
+        }
+    return {
+        "success": False,
+        "action": "pin_message",
+        "platform": "telegram",
+        "chat_id": str(chat_id),
+        "message_id": str(message_id),
+        "error": _sanitize_error_text(resp.get("description") or resp),
+        "error_code": resp.get("error_code"),
+    }
+
+
+def _unpin(chat_id: str, message_id: Optional[int] = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "chat_id": int(chat_id) if str(chat_id).lstrip("-").isdigit() else chat_id,
+    }
+    if message_id is not None:
+        payload["message_id"] = int(message_id)
+    resp = _telegram_api_request("unpinChatMessage", payload)
+    if resp.get("ok"):
+        return {
+            "success": True,
+            "action": "unpin_message",
+            "platform": "telegram",
+            "chat_id": str(chat_id),
+            "message_id": str(message_id) if message_id is not None else None,
+        }
+    return {
+        "success": False,
+        "action": "unpin_message",
+        "platform": "telegram",
+        "chat_id": str(chat_id),
+        "message_id": str(message_id) if message_id is not None else None,
+        "error": _sanitize_error_text(resp.get("description") or resp),
+        "error_code": resp.get("error_code"),
+    }
+
+
+def telegram_admin_tool(args, **kw) -> str:
+    """Registry-compatible handler for Telegram admin actions."""
+    action = (args.get("action") or "").strip()
+    target = args.get("target") or ""
+    chat_id_arg = args.get("chat_id") or ""
+    thread_id_arg = args.get("thread_id") or ""
+    message_id = args.get("message_id")
+    disable_notification = args.get("disable_notification", True)
+    message = args.get("message") or ""
+
+    chat_id, thread_id = _parse_telegram_target(target, chat_id_arg, thread_id_arg)
+    if not chat_id:
+        return _error("No Telegram chat_id resolved. Provide target='telegram:CHAT_ID[:THREAD_ID]' or chat_id.")
+
+    if action == "pin_message":
+        if message_id in (None, ""):
+            return _error("message_id is required for pin_message")
+        try:
+            result = _pin(chat_id, int(message_id), bool(disable_notification))
+            return json.dumps(result)
+        except Exception as exc:
+            logger.exception("Telegram pin_message failed")
+            return _error(f"Telegram pin_message failed: {exc}")
+
+    if action == "unpin_message":
+        try:
+            mid = int(message_id) if message_id not in (None, "") else None
+            result = _unpin(chat_id, mid)
+            return json.dumps(result)
+        except Exception as exc:
+            logger.exception("Telegram unpin_message failed")
+            return _error(f"Telegram unpin_message failed: {exc}")
+
+    if action == "send_and_pin":
+        if not message:
+            return _error("message is required for send_and_pin")
+        try:
+            from tools.send_message_tool import _handle_send
+
+            send_target = f"telegram:{chat_id}"
+            if thread_id:
+                send_target += f":{thread_id}"
+            send_raw = _handle_send({"target": send_target, "message": message})
+            try:
+                send_result = json.loads(send_raw)
+            except Exception:
+                return _error(f"send_message returned non-JSON result: {send_raw}")
+            if not send_result.get("success"):
+                return json.dumps({
+                    "success": False,
+                    "action": "send_and_pin",
+                    "send_result": send_result,
+                    "error": _sanitize_error_text(send_result.get("error") or "send_message failed"),
+                })
+            sent_message_id = _extract_message_id(send_result)
+            if sent_message_id is None:
+                return json.dumps({
+                    "success": False,
+                    "action": "send_and_pin",
+                    "send_result": send_result,
+                    "error": "send_message succeeded but no message_id was returned to pin",
+                })
+            pin_result = _pin(chat_id, sent_message_id, bool(disable_notification))
+            return json.dumps({
+                "success": bool(pin_result.get("success")),
+                "action": "send_and_pin",
+                "platform": "telegram",
+                "chat_id": str(chat_id),
+                "thread_id": str(thread_id) if thread_id else None,
+                "message_id": str(sent_message_id),
+                "send_result": send_result,
+                "pin_result": pin_result,
+                "error": pin_result.get("error"),
+            })
+        except Exception as exc:
+            logger.exception("Telegram send_and_pin failed")
+            return _error(f"Telegram send_and_pin failed: {exc}")
+
+    return json.dumps({
+        "success": False,
+        "error": f"Unknown action: {action}",
+        "available_actions": ["pin_message", "unpin_message", "send_and_pin"],
+    })
+
+
+TELEGRAM_ADMIN_SCHEMA = {
+    "name": "telegram_admin",
+    "description": (
+        "Telegram admin actions for pinning/unpinning messages. Requires the Telegram bot "
+        "to be an admin with Pin Messages permission. For existing messages, use action='pin_message' "
+        "with chat_id/target and message_id. To send a new pinned message, use action='send_and_pin'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["pin_message", "unpin_message", "send_and_pin"],
+                "description": "Admin action to perform.",
+            },
+            "target": {
+                "type": "string",
+                "description": "Telegram target, e.g. 'telegram:-1001234567890:63' or a resolvable Telegram channel/topic name.",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": "Telegram chat ID, e.g. -1001234567890. Alternative to target.",
+            },
+            "thread_id": {
+                "type": "string",
+                "description": "Optional Telegram forum topic/thread ID for send_and_pin targeting.",
+            },
+            "message_id": {
+                "type": "integer",
+                "description": "Telegram message_id to pin/unpin. Not needed for send_and_pin.",
+            },
+            "message": {
+                "type": "string",
+                "description": "Message text to send when action='send_and_pin'. Supports the same markdown/media handling as send_message.",
+            },
+            "disable_notification": {
+                "type": "boolean",
+                "description": "Whether to pin silently without notifying everyone. Defaults to true.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+registry.register(
+    name="telegram_admin",
+    toolset="telegram_admin",
+    schema=TELEGRAM_ADMIN_SCHEMA,
+    handler=telegram_admin_tool,
+    check_fn=_check_telegram_admin_requirements,
+    requires_env=["TELEGRAM_BOT_TOKEN"],
+    emoji="📌",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -65,6 +65,12 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
+    # Cross-platform messaging (gated on gateway running via check_fn)
+    "send_message",
+    # Narrow persistent-review card sender. Kept outside the broad messaging
+    # toolset so cron jobs can send review cards without gaining generic
+    # cross-platform message sending.
+    "send_review_card",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is
@@ -186,7 +192,18 @@ TOOLSETS = {
         "tools": ["cronjob"],
         "includes": []
     },
-    
+
+    "messaging": {
+        "description": "Cross-platform messaging for Telegram, Discord, Slack, SMS, etc.",
+        "tools": ["send_message"],
+        "includes": []
+    },
+
+    "review_queue": {
+        "description": "Persistent human review queue cards with Telegram inline actions",
+        "tools": ["send_review_card"],
+        "includes": []
+    },
 
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",


### PR DESCRIPTION
## Summary
- Add persistent Telegram review-card tool with Accept/Deny/Rescore/Skip callbacks
- Persist review-card state in SQLite and apply accepted/denied decisions to Obsidian thesis queues/People/Startups notes
- Add Telegram admin pin/unpin tool and review_queue toolset registration
- Compact clarify button rendering for review workflows

## Test plan
- pytest tests/tools/test_review_queue_cards.py tests/gateway/test_telegram_review_queue_buttons.py tests/gateway/test_telegram_clarify_buttons.py -q