### PR TITLE
fix(api_server): /v1/runs now loads SessionDB history from session_id

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4242,6 +4242,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
+        # If no conversation history was provided via any explicit mechanism
+        # above and a session_id was given, load history from SessionDB so that
+        # /v1/runs is consistent with POST /api/sessions/{session_id}/chat[/stream]
+        # which always loads history via _conversation_history_for_session.
+        if not conversation_history:
+            sid = body.get("session_id")
+            if sid:
+                conversation_history = self._conversation_history_for_session(sid)
+
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated


### PR DESCRIPTION
Fixes #62732

## Problem

`POST /v1/runs` accepts `session_id` but does not automatically restore the corresponding conversation history from SessionDB. When a client provides a valid `session_id` without `conversation_history`, the agent receives an empty history.

## Fix

After exhausting explicit history sources, check whether a `session_id` was provided in the request body. If so, load the history from SessionDB using the existing `_conversation_history_for_session()` method.

Fixes #62732