### PR TITLE
fix(gateway): send startup notification on cold starts too

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7300,11 +7300,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         await self._send_restart_notification()
 
         # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
+        # channels on every startup EXCEPT chat-originated /restart (which
+        # already has a precise reply target in .restart_notify.json, so keep
+        # that lifecycle in the originating chat/topic instead of also leaking
+        # it to the configured home channel).
+        # Covers: cold starts (hermes gateway start), planned restarts
+        # (terminal/SIGUSR1/service paths), and automatic crash recovery.
+        if not _restart_notification_pending():
             try:
                 await self._send_home_channel_startup_notifications(
                     skip_targets=None,


### PR DESCRIPTION
Fixes #62512

## Problem

The gateway sends a "♻️ Gateway online" notification only on planned restarts (terminal/SIGUSR1/service paths) because the condition checks for the planned restart marker (`.restart_pending.json`). Cold starts via `hermes gateway start` never set this marker, so the notification is silently skipped — leaving the user unaware that the gateway has come back online.

## Fix

Change the guard from `if planned_restart_notification_pending` to `if not _restart_notification_pending()`. This sends the startup notification on all starts EXCEPT chat-originated /restart (which already has a precise reply target in `.restart_notify.json`).

The `_send_restart_notification()` call above this block already handles the targeted reply for chat-originated restarts. The `_clear_planned_restart_notification()` cleanup still runs unconditionally to remove any stale marker.