### PR TITLE
fix: gate mem0 system-prompt block on enabled_toolsets

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -523,12 +523,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
+    # External memory provider system prompt block (additive to built-in).
+    # Gated the same way as the tool schemas themselves (memory_provider_tools_enabled)
+    # so a restricted-toolset session never advertises mem0_search/mem0_add/etc. in its
+    # prompt while the actual tool schemas are withheld.
     if agent._memory_manager:
         try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
-            if _ext_mem_block:
-                volatile_parts.append(_ext_mem_block)
+            from agent.memory_manager import memory_provider_tools_enabled
+            if memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None)):
+                _ext_mem_block = agent._memory_manager.build_system_prompt()
+                if _ext_mem_block:
+                    volatile_parts.append(_ext_mem_block)
         except Exception:
             pass
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -266,3 +266,59 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class _FakeMemoryManager:
+    """Minimal memory-manager stand-in exposing only build_system_prompt()."""
+
+    def __init__(self, block: str):
+        self._block = block
+
+    def build_system_prompt(self) -> str:
+        return self._block
+
+
+def _volatile_prompt(agent):
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        return build_system_prompt_parts(agent)["volatile"]
+
+
+class TestMemoryProviderPromptGate:
+    """The external memory-provider prompt block must respect enabled_toolsets
+    the same way inject_memory_provider_tools() gates the tool schemas
+    (agent/memory_manager.py's memory_provider_tools_enabled) — otherwise a
+    toolset-restricted session (e.g. api_server scoped to ["engram"]) would
+    advertise mem0_search/mem0_add/etc. in its own system prompt while the
+    tool schemas themselves are withheld from its tool roster.
+    """
+
+    _BLOCK = "# Mem0 Memory\nUse mem0_search to find memories."
+
+    def test_none_toolsets_includes_block(self):
+        """enabled_toolsets=None (no filter) — backward compat, block included."""
+        agent = _make_agent(_memory_manager=_FakeMemoryManager(self._BLOCK), enabled_toolsets=None)
+        assert self._BLOCK in _volatile_prompt(agent)
+
+    def test_memory_in_toolsets_includes_block(self):
+        agent = _make_agent(_memory_manager=_FakeMemoryManager(self._BLOCK), enabled_toolsets=["memory"])
+        assert self._BLOCK in _volatile_prompt(agent)
+
+    def test_toolsets_without_memory_excludes_block(self):
+        """A restricted toolset (e.g. api_server's ["engram"]) must not
+        advertise mem0 tools in the prompt when the tool schemas themselves
+        are withheld — this is the exact bug the gate fixes."""
+        agent = _make_agent(_memory_manager=_FakeMemoryManager(self._BLOCK), enabled_toolsets=["engram"])
+        assert self._BLOCK not in _volatile_prompt(agent)
+
+    def test_empty_toolsets_excludes_block(self):
+        agent = _make_agent(_memory_manager=_FakeMemoryManager(self._BLOCK), enabled_toolsets=[])
+        assert self._BLOCK not in _volatile_prompt(agent)
+
+    def test_no_memory_manager_no_block(self):
+        agent = _make_agent(_memory_manager=None, enabled_toolsets=None)
+        assert self._BLOCK not in _volatile_prompt(agent)


### PR DESCRIPTION
## Summary
- `build_system_prompt()` in agent/system_prompt.py injected the external
  memory provider's prompt block unconditionally, while
  `inject_memory_provider_tools()` correctly gates the actual tool schemas
  on `memory_provider_tools_enabled(agent.enabled_toolsets)`.
- A toolset-restricted session (e.g. api_server, scoped to a narrow
  toolset that excludes "memory") would see "Use mem0_search..." in its
  own system prompt with none of those tools actually present in its
  tool roster — confusing and wrong.
- Fix: gate the prompt-block injection in `build_system_prompt_parts()`
  with the same `memory_provider_tools_enabled()` check already used for
  tool-schema injection, so the prompt and the tool roster never
  disagree.

## Test plan
- [ ] Existing memory_manager / system_prompt test suite passes
- [ ] Manual: session with a toolset excluding "memory" no longer shows
      the mem0 prompt block; session with "memory" enabled still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)