### PR TITLE
Config-driven override for the Gemma picker-visibility filter

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -564,11 +564,33 @@ _GOOGLE_HIDDEN_MODELS = frozenset({
 })
 
 
+def _google_show_hidden_overrides() -> frozenset:
+    """Model IDs the user opted to un-hide via config.yaml's
+    ``models.show_hidden_google_models``.
+
+    Config-driven so the override survives a `hermes update` — unlike
+    editing _GOOGLE_HIDDEN_MODELS directly, which gets overwritten by the
+    next source update. Any failure to load config (missing file, bad
+    config on a first-run path, etc.) just means no overrides, same as an
+    empty list — never raises into the caller.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        overrides = cfg.get("models", {}).get("show_hidden_google_models", [])
+        return frozenset(
+            (m or "").strip().lower() for m in overrides if isinstance(m, str)
+        )
+    except Exception:
+        return frozenset()
+
+
 def _should_hide_from_provider_catalog(provider: str, model_id: str) -> bool:
     provider_lower = (provider or "").strip().lower()
     model_lower = (model_id or "").strip().lower()
     if provider_lower in {"gemini", "google"} and model_lower in _GOOGLE_HIDDEN_MODELS:
-        return True
+        return model_lower not in _google_show_hidden_overrides()
     return False
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -538,9 +538,18 @@ _NOISE_PATTERNS: re.Pattern = re.compile(
 # Gemma models whose TPM quotas are too small for normal Hermes agent traffic.
 # Keep capability metadata available for direct/manual use, but hide these from
 # the Gemini model catalogs we surface in setup and model selection.
-_GOOGLE_HIDDEN_MODELS = frozenset({
-    # Low-TPM Gemma models that trip Google input-token quota walls under
-    # agent-style traffic despite advertising large context windows.
+#
+# Split into two sets because only one of them is a "default for typical
+# users" judgment call the user might reasonably want to override — the
+# other is models.yaml's own filter working correctly around a fact, not a
+# posture, and un-hiding it just breaks the picker.
+
+# Low-TPM Gemma models that trip Google input-token quota walls under
+# agent-style traffic despite advertising large context windows. Hidden by
+# default as a reasonable posture for most users; config.yaml's
+# ``models.show_hidden_google_models`` can override this per user (see
+# _google_show_hidden_overrides below).
+_GOOGLE_LOW_TPM_MODELS = frozenset({
     "gemma-4-31b-it",
     "gemma-4-26b-it",
     "gemma-4-26b-a4b-it",
@@ -554,8 +563,13 @@ _GOOGLE_HIDDEN_MODELS = frozenset({
     "gemma-3-12b-it",
     "gemma-3-27b",
     "gemma-3-27b-it",
-    # Stale/retired Google slugs that still surface through models.dev-backed
-    # Gemini selection but 404 on the current Google endpoints.
+})
+
+# Stale/retired Google slugs that still surface through models.dev-backed
+# Gemini selection but 404 on the current Google endpoints. Not a posture —
+# these don't work, full stop — so they're never eligible for the
+# show_hidden_google_models override.
+_GOOGLE_STALE_MODELS = frozenset({
     "gemini-1.5-flash",
     "gemini-1.5-pro",
     "gemini-1.5-flash-8b",
@@ -563,16 +577,23 @@ _GOOGLE_HIDDEN_MODELS = frozenset({
     "gemini-2.0-flash-lite",
 })
 
+_GOOGLE_HIDDEN_MODELS = _GOOGLE_LOW_TPM_MODELS | _GOOGLE_STALE_MODELS
+
 
 def _google_show_hidden_overrides() -> frozenset:
     """Model IDs the user opted to un-hide via config.yaml's
     ``models.show_hidden_google_models``.
 
     Config-driven so the override survives a `hermes update` — unlike
-    editing _GOOGLE_HIDDEN_MODELS directly, which gets overwritten by the
+    editing _GOOGLE_LOW_TPM_MODELS directly, which gets overwritten by the
     next source update. Any failure to load config (missing file, bad
     config on a first-run path, etc.) just means no overrides, same as an
     empty list — never raises into the caller.
+
+    Only entries that are also in _GOOGLE_LOW_TPM_MODELS take effect — see
+    _should_hide_from_provider_catalog. A stale/retired slug in this list
+    (typo, copy-paste from an old config, whatever) is silently ignored
+    rather than un-hiding a model that 404s.
     """
     try:
         from hermes_cli.config import load_config_readonly
@@ -589,7 +610,13 @@ def _google_show_hidden_overrides() -> frozenset:
 def _should_hide_from_provider_catalog(provider: str, model_id: str) -> bool:
     provider_lower = (provider or "").strip().lower()
     model_lower = (model_id or "").strip().lower()
-    if provider_lower in {"gemini", "google"} and model_lower in _GOOGLE_HIDDEN_MODELS:
+    if provider_lower not in {"gemini", "google"}:
+        return False
+    if model_lower in _GOOGLE_STALE_MODELS:
+        # Always hidden — these 404 on Google's current endpoints regardless
+        # of what the user configures.
+        return True
+    if model_lower in _GOOGLE_LOW_TPM_MODELS:
         return model_lower not in _google_show_hidden_overrides()
     return False
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1063,16 +1063,6 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
-        # Skill self-patching guidance — controls whether the model is told
-        # to call skill_manage(action='patch') on its own initiative when it
-        # notices a loaded skill is outdated/incomplete/wrong (True, default
-        # — preserves existing behavior), or told to only patch a skill when
-        # the user explicitly asks for that change in the current turn
-        # (False). Positive feedback on a task's *output* ("that worked",
-        # "nice job") is not treated as authorization to edit skill files
-        # either way once this is False. Set False for a more deterministic,
-        # no-surprise-edits posture.
-        "skill_auto_patch": True,
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -979,6 +979,19 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "models": {
+        # Google/Gemini model IDs to force-show in the interactive model and
+        # fallback pickers despite agent/models_dev.py's built-in
+        # _GOOGLE_HIDDEN_MODELS filter (which hides some Gemma IDs by
+        # default — their low TPM quotas trip under agent-style traffic for
+        # most users, a reasonable default, just not a universal one).
+        # Config-driven so an override survives `hermes update` instead of
+        # needing a source patch to _GOOGLE_HIDDEN_MODELS reapplied every
+        # release. Only affects picker visibility — raw config entries
+        # (fallback_providers, a manually-typed model id, etc.) already
+        # bypass the filter entirely and always worked. Case-insensitive.
+        "show_hidden_google_models": [],
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
@@ -1050,6 +1063,16 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
+        # Skill self-patching guidance — controls whether the model is told
+        # to call skill_manage(action='patch') on its own initiative when it
+        # notices a loaded skill is outdated/incomplete/wrong (True, default
+        # — preserves existing behavior), or told to only patch a skill when
+        # the user explicitly asks for that change in the current turn
+        # (False). Positive feedback on a task's *output* ("that worked",
+        # "nice job") is not treated as authorization to edit skill files
+        # either way once this is False. Set False for a more deterministic,
+        # no-surprise-edits posture.
+        "skill_auto_patch": True,
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -354,3 +354,77 @@ class TestGeminiModelsDev:
         assert "gemma-3-27b-it" not in result
         assert "gemini-1.5-pro" not in result
         assert "gemini-2.0-flash" not in result
+
+    def test_show_hidden_google_models_unhides_configured_gemma(self):
+        """models.show_hidden_google_models un-hides only the configured
+        low-TPM Gemma id(s) - everything else stays hidden as before."""
+        mock_data = {
+            "google": {
+                "models": {
+                    "gemini-2.5-pro": {},
+                    "gemma-4-31b-it": {},
+                    "gemma-3-27b-it": {},
+                }
+            }
+        }
+        mock_config = {"models": {"show_hidden_google_models": ["gemma-4-31b-it"]}}
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data), \
+             patch("hermes_cli.config.load_config_readonly", return_value=mock_config):
+            from agent.models_dev import list_provider_models
+
+            result = list_provider_models("gemini")
+
+        assert "gemini-2.5-pro" in result
+        assert "gemma-4-31b-it" in result       # un-hidden via override
+        assert "gemma-3-27b-it" not in result   # not in override list - still hidden
+
+    def test_show_hidden_google_models_cannot_unhide_stale_slugs(self):
+        """A stale/retired Google slug in show_hidden_google_models is
+        ignored - these 404 on Google's endpoints regardless of config, so
+        the override only ever applies to the low-TPM Gemma set."""
+        mock_data = {
+            "google": {
+                "models": {
+                    "gemini-2.5-pro": {},
+                    "gemini-1.5-pro": {},
+                    "gemini-2.0-flash": {},
+                    "gemma-4-31b-it": {},
+                }
+            }
+        }
+        mock_config = {
+            "models": {
+                "show_hidden_google_models": [
+                    "gemini-1.5-pro", "gemini-2.0-flash", "gemma-4-31b-it",
+                ]
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data), \
+             patch("hermes_cli.config.load_config_readonly", return_value=mock_config):
+            from agent.models_dev import list_provider_models
+
+            result = list_provider_models("gemini")
+
+        assert "gemini-2.5-pro" in result
+        assert "gemma-4-31b-it" in result        # low-TPM: override applies
+        assert "gemini-1.5-pro" not in result    # stale: override ignored
+        assert "gemini-2.0-flash" not in result  # stale: override ignored
+
+    def test_show_hidden_google_models_empty_by_default(self):
+        """No config.yaml override configured - default behavior unchanged."""
+        mock_data = {
+            "google": {
+                "models": {
+                    "gemini-2.5-pro": {},
+                    "gemma-4-31b-it": {},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data), \
+             patch("hermes_cli.config.load_config_readonly", return_value={}):
+            from agent.models_dev import list_provider_models
+
+            result = list_provider_models("gemini")
+
+        assert "gemini-2.5-pro" in result
+        assert "gemma-4-31b-it" not in result


### PR DESCRIPTION
## Summary
- `_GOOGLE_HIDDEN_MODELS` (`agent/models_dev.py`) hides several Gemma IDs from the interactive model/fallback picker by default — their low TPM quotas trip under agent-style traffic for most users, which is a reasonable default.
- The only way to see a hidden model in the picker was editing the frozenset directly in source. A `hermes update` resets that file to upstream, silently wiping the edit — a user who deliberately wants one of these models has to reapply a source patch after every release, with no warning it happened.
- Adds `models.show_hidden_google_models` to `config.yaml` (default `[]`, no behavior change unless set): a list of model IDs to force-show despite the built-in filter. Config lives outside the package, so it survives updates.
- Raw config entries (`fallback_providers`, a manually-typed model id) already bypassed this filter entirely and worked fine — this only changes what the *picker UI* shows, matching the intent of the original filter (a default for typical users, not a hard block).

## Test plan
- [x] Both touched files parse clean (`ast.parse`)
- [x] Verified directly: with no override, a hidden Gemma id stays hidden; with `models.show_hidden_google_models` containing it, it's shown; an unrelated hidden id (not in the override list) stays hidden; a non-Google provider is unaffected; a config-load failure fails safe (stays hidden, no exception)
- [x] Confirmed end-to-end against a real local `config.yaml` with the override set — picker filter correctly un-hides only the configured ids
- [ ] Reviewer: confirm `models.show_hidden_google_models` is the right home/name for this vs. e.g. folding it into the existing `providers` config dict