### PR TITLE
Add openrouter/free to the curated OpenRouter picker list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
+    ("openrouter/free",                        "free — auto-routes to any available free model"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -149,6 +149,10 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
+          "id": "openrouter/free",
+          "description": "free — auto-routes to any available free model"
+        },
+        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },


### PR DESCRIPTION
## Summary
- `openrouter/free` (OpenRouter's Free Models Router — `$0`/`$0` pricing, real tool-calling support) never showed up as selectable in the model/fallback picker.
- Root cause: not a deliberate filter — `fetch_openrouter_models()` (`hermes_cli/models.py`) only ever considers ids already present in a curated allowlist before cross-checking OpenRouter's live `/v1/models` for tool support and free pricing. `openrouter/free` was simply never added to that allowlist, so it never reached the check at all. Confirmed live against OpenRouter's own `/v1/models`: `pricing: {"prompt": "0", "completion": "0"}`, `supported_parameters` includes `"tools"` — it passes the existing filter cleanly once it's a candidate.
- Adds `openrouter/free` to `OPENROUTER_MODELS` in `hermes_cli/models.py`, grouped under "OpenRouter routers" next to `openrouter/pareto-code` (a router alias, not a specific model — distinct from the flat "Free tier" entries below it).

## The remote-manifest question
`fetch_openrouter_models()` tries a network-hosted curated manifest first (`hermes_cli/model_catalog.py`'s `get_curated_openrouter_models()`) and only falls back to the in-repo `OPENROUTER_MODELS` list if that fetch fails. That manifest's fallback URL points at `website/static/api/model-catalog.json` **in this exact repo** — so this PR also fixes that file, keeping both curated lists in sync (they'd drifted apart in a few other entries already; this PR only touches the `openrouter/free` addition, not the pre-existing drift).

Confirmed this is the complete fix, not a partial one: fetched the live production manifest at `https://hermes-agent.nousresearch.com/docs/api/model-catalog.json` while testing — its `updated_at` timestamp matches this file's pre-patch value exactly, confirming the hosted docs site is built directly from this repo's `website/static/api/model-catalog.json`. No separate server-side change needed beyond the normal merge + docs-site rebuild/deploy.

## Test plan
- [x] Confirmed live via OpenRouter's `/v1/models` that `openrouter/free` has `$0`/`$0` pricing and advertises `"tools"` in `supported_parameters`
- [x] Unmocked live run of `fetch_openrouter_models()` correctly did *not* yet show `openrouter/free` — because it fetched the real, still-unpatched hosted manifest over the network (itself a live confirmation of the caveat above)
- [x] With the remote-manifest fetch forced to fail (isolating the in-repo fallback path this PR edits), `fetch_openrouter_models()` now returns `openrouter/free` after cross-checking live pricing/tool-support, same as any other curated entry
- [x] Both touched files parse/load clean (`ast.parse` for the `.py`, `json.load` for the manifest)

## Scope note
Also looked at `openrouter/auto` (general auto-router, also supports tools) as a possible companion addition — deliberately left out. Its pricing is `-1`/`-1` (dynamic passthrough, varies by whatever model it routes to), not `$0`/`$0` like `openrouter/free` — a different enough claim ("routes to *a* model, price varies" vs. "routes to a free one") that it didn't belong bundled into this fix.