### PR TITLE
fix(gateway): restore SessionDB history in /v1/runs when session_id is provided

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4278,7 +4278,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
+        client_session_id = body.get("session_id")
+        session_id = client_session_id or stored_session_id or run_id
+        # If no conversation_history was resolved from any of the explicit
+        # sources (body.conversation_history, previous_response_id, or multi-
+        # message input), but the client provided a session_id, restore the
+        # conversation history from SessionDB — mirroring the behaviour of
+        # /api/sessions/{session_id}/chat/stream (see #62732).
+        if not conversation_history and client_session_id:
+            conversation_history = self._conversation_history_for_session(client_session_id)
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4235,7 +4235,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
+        # Track field *presence* separately from an empty resolved list so
+        # that an explicit "conversation_history": [] is honoured (and not
+        # overwritten by SessionDB fallback). See issue #62732 review.
         conversation_history: List[Dict[str, str]] = []
+        conversation_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -4285,7 +4289,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # message input), but the client provided a session_id, restore the
         # conversation history from SessionDB — mirroring the behaviour of
         # /api/sessions/{session_id}/chat/stream (see #62732).
-        if not conversation_history and client_session_id:
+        #
+        # Only fall back when the field was *omitted* entirely; an explicit
+        # "conversation_history": [] means "start fresh" and must not be
+        # overwritten by SessionDB history.
+        if not conversation_history_provided and not conversation_history and client_session_id:
             conversation_history = self._conversation_history_for_session(client_session_id)
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -22,6 +22,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
 from tools import approval as approval_mod
 
 
@@ -85,8 +86,23 @@ def _make_slow_agent(**kwargs):
 
 
 @pytest.fixture
-def adapter():
-    return _make_adapter()
+def session_db(tmp_path):
+    """Temporary on-disk SessionDB for real-path regression tests."""
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+
+@pytest.fixture
+def adapter(session_db):
+    """Adapter wired to a real temporary SessionDB."""
+    adapter = _make_adapter()
+    adapter._session_db = session_db
+    return adapter
 
 
 @pytest.fixture
@@ -191,13 +207,16 @@ class TestStartRun:
                 assert resp.status == 202
 
     @pytest.mark.asyncio
-    async def test_run_restores_history_from_session_id(self, adapter):
+    async def test_run_restores_history_from_session_id(self, adapter, session_db):
         """When session_id is provided without conversation_history,
-        the handler should load history from SessionDB (#62732)."""
+        the handler should load history from SessionDB (#62732).
+
+        Uses a *real* SessionDB — not a mock — to exercise the full
+        resolution path from append_message → get_messages_as_conversation.
+        """
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create, \
-                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+            with patch.object(adapter, "_create_agent") as mock_create:
                 mock_agent = MagicMock()
                 mock_agent.run_conversation.return_value = {"final_response": "done"}
                 mock_agent.session_prompt_tokens = 0
@@ -205,11 +224,10 @@ class TestStartRun:
                 mock_agent.session_total_tokens = 0
                 mock_create.return_value = mock_agent
 
-                loaded_history = [
-                    {"role": "user", "content": "previous question"},
-                    {"role": "assistant", "content": "previous answer"},
-                ]
-                mock_hist.return_value = loaded_history
+                # Seed real messages into SessionDB
+                session_db.create_session("my-session", "test")
+                session_db.append_message("my-session", "user", "previous question")
+                session_db.append_message("my-session", "assistant", "previous answer")
 
                 resp = await cli.post(
                     "/v1/runs",
@@ -218,24 +236,30 @@ class TestStartRun:
                 assert resp.status == 202
                 await asyncio.sleep(0.3)
 
-                mock_hist.assert_called_once_with("my-session")
                 mock_agent.run_conversation.assert_called_once()
-                assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == loaded_history
+                history = mock_agent.run_conversation.call_args.kwargs["conversation_history"]
+                assert len(history) == 2
+                assert history[0]["role"] == "user"
+                assert history[0]["content"] == "previous question"
+                assert history[1]["role"] == "assistant"
+                assert history[1]["content"] == "previous answer"
 
     @pytest.mark.asyncio
-    async def test_explicit_history_takes_precedence_over_session_db(self, adapter):
+    async def test_explicit_history_takes_precedence_over_session_db(self, adapter, session_db):
         """Explicit conversation_history should win over SessionDB loading."""
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create, \
-                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+            with patch.object(adapter, "_create_agent") as mock_create:
                 mock_agent = MagicMock()
                 mock_agent.run_conversation.return_value = {"final_response": "done"}
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
                 mock_create.return_value = mock_agent
-                mock_hist.return_value = [{"role": "user", "content": "from db"}]
+
+                # Seed DB with history that should NOT be used
+                session_db.create_session("my-session", "test")
+                session_db.append_message("my-session", "user", "from db")
 
                 explicit_history = [{"role": "user", "content": "explicit"}]
                 resp = await cli.post(
@@ -249,30 +273,63 @@ class TestStartRun:
                 assert resp.status == 202
                 await asyncio.sleep(0.3)
 
-                mock_hist.assert_not_called()
                 mock_agent.run_conversation.assert_called_once()
                 assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == explicit_history
 
     @pytest.mark.asyncio
-    async def test_no_session_id_does_not_load_from_db(self, adapter):
-        """Without session_id the handler must not attempt SessionDB lookup."""
+    async def test_explicit_empty_history_not_overwritten_by_session_db(self, adapter, session_db):
+        """An explicit "conversation_history": [] means "start fresh" and
+        must NOT be overwritten by SessionDB history (#62732 review)."""
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create, \
-                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+            with patch.object(adapter, "_create_agent") as mock_create:
                 mock_agent = MagicMock()
                 mock_agent.run_conversation.return_value = {"final_response": "done"}
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
                 mock_create.return_value = mock_agent
-                mock_hist.return_value = [{"role": "user", "content": "from db"}]
+
+                # Seed DB with history that must NOT leak through
+                session_db.create_session("my-session", "test")
+                session_db.append_message("my-session", "user", "from db")
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "my-session",
+                        "conversation_history": [],
+                    },
+                )
+                assert resp.status == 202
+                await asyncio.sleep(0.3)
+
+                mock_agent.run_conversation.assert_called_once()
+                assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_does_not_load_from_db(self, adapter, session_db):
+        """Without session_id the handler must not attempt SessionDB lookup."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                # Seed DB — even if session_id happened to be generated,
+                # it should never collide with real stored data here.
+                session_db.create_session("other-session", "test")
+                session_db.append_message("other-session", "user", "from db")
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
                 assert resp.status == 202
                 await asyncio.sleep(0.3)
 
-                mock_hist.assert_not_called()
                 mock_agent.run_conversation.assert_called_once()
                 assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == []
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -190,6 +190,92 @@ class TestStartRun:
                 )
                 assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_run_restores_history_from_session_id(self, adapter):
+        """When session_id is provided without conversation_history,
+        the handler should load history from SessionDB (#62732)."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create, \
+                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                loaded_history = [
+                    {"role": "user", "content": "previous question"},
+                    {"role": "assistant", "content": "previous answer"},
+                ]
+                mock_hist.return_value = loaded_history
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "follow up", "session_id": "my-session"},
+                )
+                assert resp.status == 202
+                await asyncio.sleep(0.3)
+
+                mock_hist.assert_called_once_with("my-session")
+                mock_agent.run_conversation.assert_called_once()
+                assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == loaded_history
+
+    @pytest.mark.asyncio
+    async def test_explicit_history_takes_precedence_over_session_db(self, adapter):
+        """Explicit conversation_history should win over SessionDB loading."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create, \
+                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                mock_hist.return_value = [{"role": "user", "content": "from db"}]
+
+                explicit_history = [{"role": "user", "content": "explicit"}]
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "my-session",
+                        "conversation_history": explicit_history,
+                    },
+                )
+                assert resp.status == 202
+                await asyncio.sleep(0.3)
+
+                mock_hist.assert_not_called()
+                mock_agent.run_conversation.assert_called_once()
+                assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == explicit_history
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_does_not_load_from_db(self, adapter):
+        """Without session_id the handler must not attempt SessionDB lookup."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create, \
+                 patch.object(adapter, "_conversation_history_for_session") as mock_hist:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                mock_hist.return_value = [{"role": "user", "content": "from db"}]
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                await asyncio.sleep(0.3)
+
+                mock_hist.assert_not_called()
+                mock_agent.run_conversation.assert_called_once()
+                assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == []
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status


### PR DESCRIPTION
## Problem

`/v1/runs` accepts `session_id` but does not automatically restore the corresponding conversation history from SessionDB when `conversation_history` is omitted. This makes it behave differently from `POST /api/sessions/{session_id}/chat/stream`, which loads history via `_conversation_history_for_session(session_id)`.

Fixes #62732

## Root Cause

In `gateway/platforms/api_server.py`, the `_handle_runs()` method resolves `conversation_history` from three sources: explicit body field, `previous_response_id` via ResponseStore, and multi-message input array. However, when none of these provide history and the client supplies a valid `session_id`, the handler does not fall back to SessionDB.

## Fix

After resolving `session_id`, if `conversation_history` is still empty and the client explicitly provided a `session_id`, call `_conversation_history_for_session(client_session_id)` to load history from SessionDB. Precedence: explicit `conversation_history` > `previous_response_id` > multi-message input > SessionDB fallback.

## Testing

All 26 tests pass (`pytest tests/gateway/test_api_server_runs.py`).
