### PR TITLE
fix(gateway): declare splits_long_messages on SmsAdapter

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -165,7 +165,7 @@ class SmsAdapter(BasePlatformAdapter):
         import aiohttp
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted)
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_result = SendResult(success=True)
 
         url = f"{TWILIO_API_BASE}/{self._account_sid}/Messages.json"

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -63,6 +63,7 @@ class SmsAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
+    splits_long_messages = True  # send() chunks via truncate_message(MAX_SMS_LENGTH)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -163,6 +163,73 @@ class TestSmsChunkingCapabilityFlag:
         # chunking via truncate_message(MAX_SMS_LENGTH).
         assert sent["content"] == long_content
 
+    @pytest.mark.asyncio
+    async def test_send_chunks_bounded_by_max_sms_length(self, monkeypatch):
+        """send() must bound each Twilio body at MAX_SMS_LENGTH (1600), not
+        the generic truncate_message() default of 4096 — a bare
+        self.truncate_message(formatted) call silently picks up the base
+        default and can emit chunks Twilio's real segment limit rejects."""
+        from plugins.platforms.sms.adapter import SmsAdapter, MAX_SMS_LENGTH
+
+        class _FakeFormData:
+            def __init__(self):
+                self.fields = {}
+
+            def add_field(self, name, value):
+                self.fields[name] = value
+
+        class _FakeResponse:
+            def __init__(self):
+                self.status = 201
+
+            async def json(self):
+                return {"sid": "SMfake"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeSession:
+            def __init__(self):
+                self.posted_bodies = []
+
+            def post(self, url, data=None, headers=None):
+                self.posted_bodies.append(data.fields["Body"])
+                return _FakeResponse()
+
+            async def close(self):
+                pass
+
+        monkeypatch.setattr("aiohttp.FormData", _FakeFormData)
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        }
+        with patch.dict(os.environ, env):
+            adapter = object.__new__(SmsAdapter)
+            adapter.config = PlatformConfig(enabled=True, api_key="tok")
+            adapter._platform = Platform.SMS
+            adapter._account_sid = "ACtest"
+            adapter._auth_token = "tok"
+            adapter._from_number = "+15550001111"
+
+        fake_session = _FakeSession()
+        adapter._http_session = fake_session
+
+        # Bigger than MAX_SMS_LENGTH (1600) but smaller than the generic
+        # truncate_message() default (4096) — under the bug this stays in
+        # a single oversized chunk instead of being split at 1600.
+        long_content = "y" * 3000
+        result = await adapter.send("+15559998888", long_content)
+
+        assert result.success is True
+        assert len(fake_session.posted_bodies) >= 2
+        assert all(len(body) <= MAX_SMS_LENGTH for body in fake_session.posted_bodies)
+
 
 # ── Echo prevention ────────────────────────────────────────────────
 

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -108,6 +108,62 @@ class TestSmsFormatAndTruncate:
         assert result == "a\n\nb"
 
 
+# ── Chunking capability flag (regression) ───────────────────────────
+
+class TestSmsChunkingCapabilityFlag:
+    """SmsAdapter.send() already chunks via truncate_message(), but the
+    class must also declare splits_long_messages=True or gateway.delivery
+    treats it as a non-chunking adapter and hard-truncates oversized
+    cron/agent output instead of letting send() split it into segments."""
+
+    def test_declares_splits_long_messages(self):
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        assert SmsAdapter.splits_long_messages is True
+
+    @pytest.mark.asyncio
+    async def test_delivery_router_preserves_full_content_for_sms(self, tmp_path, monkeypatch):
+        """End-to-end: DeliveryRouter must hand send() the untruncated
+        content for SMS, exactly like the other chunking-capable adapters."""
+        from gateway.config import GatewayConfig
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        }
+        with patch.dict(os.environ, env):
+            adapter = object.__new__(SmsAdapter)
+            adapter.config = PlatformConfig(enabled=True, api_key="tok")
+            adapter._platform = Platform.SMS
+            adapter._account_sid = "ACtest"
+            adapter._auth_token = "tok"
+            adapter._from_number = "+15550001111"
+
+        sent = {}
+
+        async def _fake_send(chat_id, content, reply_to=None, metadata=None):
+            sent["content"] = content
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True)
+
+        adapter.send = _fake_send
+
+        router = DeliveryRouter(GatewayConfig(), adapters={Platform.SMS: adapter})
+        target = DeliveryTarget.parse("sms:+15559998888")
+
+        long_content = "x" * 5000
+        await router._deliver_to_platform(target, long_content, metadata={"job_id": "job-sms"})
+
+        # Full content must reach send() untruncated — send() does its own
+        # chunking via truncate_message(MAX_SMS_LENGTH).
+        assert sent["content"] == long_content
+
+
 # ── Echo prevention ────────────────────────────────────────────────
 
 class TestSmsEchoPrevention:


### PR DESCRIPTION
## What does this PR do?

`SmsAdapter.send()` already chunks long content correctly via `self.truncate_message(formatted)`, iterating chunks and posting each as a separate Twilio message — but the class never set `splits_long_messages = True` like every other chunking-capable adapter (Telegram, Discord, Slack, WhatsApp, Matrix, Feishu, Teams, Mattermost, BlueBubbles, weixin, WhatsApp Cloud, Yuanbao all declare it explicitly). `gateway/delivery.py`'s cron/agent-output delivery path gates truncation on that flag (`gateway/delivery.py:431`), so it was treating SMS as non-chunking and hard-truncating any output over 4000 chars with a "saved to file" footer instead of letting `send()` split it into proper Twilio segments.

## Related Issue

Fixes #62751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Updated after review follow-ups — the list below reflects both commits on this branch.

- `plugins/platforms/sms/adapter.py`:
  - Set `splits_long_messages = True` on `SmsAdapter`.
  - `send()` called `truncate_message(formatted)` with no `max_length`, so it silently picked up the base class's generic 4096 default instead of the adapter's own `MAX_SMS_LENGTH` (1600). Now that full content reaches `send()`, the bound is passed explicitly so chunks can't exceed Twilio's real per-segment limit.
- `tests/gateway/test_sms.py`: added `TestSmsChunkingCapabilityFlag` — a direct class-attribute check plus an end-to-end test that runs the real `SmsAdapter` through `DeliveryRouter._deliver_to_platform` and confirms the full untruncated content reaches `send()` (mirroring the chunking-vs-non-chunking pattern in `tests/gateway/test_delivery.py`, but exercising the actual adapter class rather than a fake); plus coverage for the `MAX_SMS_LENGTH` bound above.

## How to Test

1. Before this fix: route >4000 chars of cron/agent output to an SMS-connected user — the delivered message is truncated with a "... [truncated, full output saved to ...]" footer even though `SmsAdapter.send()` is fully capable of chunking it into multiple Twilio segments.
2. After this fix: `pytest tests/gateway/test_sms.py -k Chunking -v` passes; reverting just the one-line `adapter.py` change reproduces the original truncated-footer behavior in the new tests (verified locally).
3. `pytest tests/gateway/test_sms.py tests/gateway/test_delivery.py -q` — 71 passed, no regressions.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (by issue number and by file/mechanism — `splits_long_messages`) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_sms.py tests/gateway/test_delivery.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11.3

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.
