### PR TITLE
fix(telegram): normalize em/en dashes in bot command descriptions (salvage of #2927 by @ygd58)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -533,13 +533,16 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            # Telegram BotFather rejects descriptions with Unicode dashes.
+            desc = cmd.description.replace("—", "-").replace("–", "-")
+            result.append((tg_name, desc))
     for name, description, args_hint in _iter_plugin_command_entries():
         if _requires_argument(args_hint):
             continue
         tg_name = _sanitize_telegram_name(name)
         if tg_name:
-            result.append((tg_name, description))
+            desc = description.replace("—", "-").replace("–", "-")
+            result.append((tg_name, desc))
     return result
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -2217,3 +2217,28 @@ class TestPluginCommandEnumeration:
         slack_names = set(slack_subcommand_map())
         assert "status" in tg_names
         assert "status" in slack_names
+
+
+class TestTelegramBotCommandDescriptions:
+    def test_telegram_bot_commands_normalizes_unicode_dashes(self):
+        """Telegram BotFather rejects em/en dashes in command descriptions."""
+        from hermes_cli.commands import CommandDef
+        from hermes_cli import commands as commands_mod
+
+        fake = CommandDef(
+            "zz_dash_test",
+            "Test — with en–dashes",
+            "Info",
+        )
+        original_len = len(commands_mod.COMMAND_REGISTRY)
+        commands_mod.COMMAND_REGISTRY.append(fake)
+        try:
+            pairs = dict(telegram_bot_commands())
+            assert "zz_dash_test" in pairs
+            desc = pairs["zz_dash_test"]
+            assert "—" not in desc
+            assert "–" not in desc
+            assert desc == "Test - with en-dashes"
+        finally:
+            del commands_mod.COMMAND_REGISTRY[original_len:]
+


### PR DESCRIPTION
## Summary

Salvages #2927 by @ygd58 onto current main.

## What the original PR fixed

Telegram BotFather rejects bot command descriptions containing Unicode em dash (U+2014) or en dash (U+2013), causing `setMyCommands` to fail with *"Sorry, the list of commands is invalid."*

## Why it needed salvage

- Original PR is **dirty** / conflicting against current main
- `telegram_bot_commands()` was refactored (plugin entries, sanitizer helpers) so the original one-line patch no longer applied cleanly

## Changes from original

- Rebased conceptually onto current `telegram_bot_commands()` implementation
- Normalize dashes for **both** built-in registry and plugin command menu entries
- Added unit test for the normalization path

## Testing

```bash
python3 -m pytest tests/hermes_cli/test_commands.py::TestTelegramBotCommandDescriptions -q
```

Full credit to @ygd58 for the original fix and root-cause analysis.