### PR TITLE
fix(skills): include remote setup_note when setup was skipped (salvage of #3658 by @Git-on-my-level)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -254,12 +254,14 @@ def _build_skill_message(
     _inject_skill_config(loaded_skill, parts)
 
     if loaded_skill.get("setup_skipped"):
-        parts.extend(
-            [
-                "",
-                "[Skill setup note: Required environment setup was skipped. Continue loading the skill and explain any reduced functionality if it matters.]",
-            ]
+        note_text = (
+            "[Skill setup note: Required environment setup was skipped. "
+            "Continue loading the skill and explain any reduced functionality if it matters.]"
         )
+        # For remote backends, also append remote-specific guidance when present.
+        if loaded_skill.get("setup_note"):
+            note_text = f"{note_text} {loaded_skill['setup_note']}"
+        parts.extend(["", note_text])
     elif loaded_skill.get("gateway_setup_hint"):
         parts.extend(
             [

--- a/tests/agent/test_skill_setup_skipped_note.py
+++ b/tests/agent/test_skill_setup_skipped_note.py
@@ -1,0 +1,29 @@
+"""setup_skipped branch should still surface remote setup_note text."""
+
+from agent.skill_commands import _build_skill_message
+
+
+def test_setup_skipped_includes_remote_setup_note():
+    msg = _build_skill_message(
+        loaded_skill={
+            "content": "Skill body.",
+            "setup_skipped": True,
+            "setup_note": "Remote backend needs HERMES_HOME mounted.",
+        },
+        skill_dir=None,
+        activation_note="Activating skill.",
+    )
+    assert "Required environment setup was skipped" in msg
+    assert "Remote backend needs HERMES_HOME mounted." in msg
+
+
+def test_setup_skipped_without_extra_note():
+    msg = _build_skill_message(
+        loaded_skill={
+            "content": "Skill body.",
+            "setup_skipped": True,
+        },
+        skill_dir=None,
+        activation_note="Activating skill.",
+    )
+    assert "Required environment setup was skipped" in msg


### PR DESCRIPTION
## Summary

Salvages #3658 by @Git-on-my-level onto current main.

## What the original PR fixed

When `setup_skipped` is true, the remote-specific `setup_note` was dropped, so users only saw the generic skip text and lost backend guidance.

## Why it needed salvage

Still open/unmerged; reapplied cleanly with unit coverage for both note combinations.

## Changes from original

- Rebased conceptually onto current `_build_skill_message`
- Added unit tests

## Testing

```bash
python3 -m pytest tests/agent/test_skill_setup_skipped_note.py -q
```

Full credit to @Git-on-my-level.