### PR TITLE
fix(skill_utils): raise extract_skill_description cap 60→1024 (salvage of #13995 by @giwaov, supersedes #52866)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -769,13 +769,19 @@ def resolve_skill_config_values(
 
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a description from parsed frontmatter, capped at 1024 characters.
+
+    The previous 60-character cap truncated most skill descriptions mid-word
+    in the system-prompt skill index, starving the routing model of the
+    detail it needs to pick the right skill. 1024 chars preserves the full
+    intent of typical descriptions while still bounding prompt growth.
+    """
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 1024:
+        return desc[:1021] + "..."
     return desc
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -311,12 +311,19 @@ class TestParseSkillFile:
         is_compat, frontmatter, desc = _parse_skill_file(skill_file)
         assert desc == ""
 
-    def test_long_description_truncated(self, tmp_path):
+    def test_description_under_cap_not_truncated(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
         long_desc = "A" * 100
         skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
         _, _, desc = _parse_skill_file(skill_file)
-        assert len(desc) <= 60
+        assert desc == long_desc
+
+    def test_long_description_truncated(self, tmp_path):
+        skill_file = tmp_path / "SKILL.md"
+        long_desc = "A" * 2000
+        skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
+        _, _, desc = _parse_skill_file(skill_file)
+        assert len(desc) <= 1024
         assert desc.endswith("...")
 
     def test_nonexistent_file_returns_defaults(self, tmp_path):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -8,6 +8,7 @@ from agent.skill_utils import (
     get_external_skills_dirs,
     is_excluded_skill_path,
     is_external_skill_path,
+    extract_skill_description,
     is_skill_support_path,
     iter_skill_index_files,
     resolve_skill_config_values,
@@ -386,3 +387,15 @@ class TestNormalizeSkillLookupName:
         monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
         outside = str(tmp_path / "outside" / "skill")
         assert normalize_skill_lookup_name(outside) == outside
+
+
+def test_extract_skill_description_cap_allows_up_to_1024_chars():
+    medium = "x" * 600
+    assert extract_skill_description({"description": medium}) == medium
+    huge = "y" * 2000
+    out = extract_skill_description({"description": huge})
+    assert len(out) == 1024
+    assert out.endswith("...")
+    assert out[:1021] == "y" * 1021
+    assert extract_skill_description({"description": "short"}) == "short"
+    assert extract_skill_description({}) == ""


### PR DESCRIPTION
## Summary

Supersedes dirty #52866. Salvage of #13995 by @giwaov onto current main.

## What the original PR fixed

`extract_skill_description` truncated to 60 characters, which cut most skill descriptions mid-word in the system-prompt skill index.

## Why #52866 needed a fresh branch

`git rebase origin/main` on the old head exploded in unrelated website/i18n add/add conflicts from intermediate commits. Rebuilt as a clean single-commit patch of the three intended files only.

## Testing

```bash
python3 -m pytest tests/agent/test_skill_utils.py::test_extract_skill_description_cap_allows_up_to_1024_chars tests/agent/test_prompt_builder.py -k description -q
```

Full credit to @giwaov; prior supabase salvage credit also continues on #52866 for history.