### PR TITLE
fix(mcp): enforce authoritative Hermes tool schemas

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -49,7 +49,9 @@ import json
 import logging
 import os
 import sys
+from importlib.metadata import version as distribution_version
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -149,12 +151,122 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 )
 
 
+class _FastMCP126SchemaAdapter:
+    """Install authoritative schemas on FastMCP 1.26's internal Tools.
+
+    FastMCP 1.26.0 has no public API for registering a callable with an
+    independent JSON Schema. Keep the unavoidable private access here and fail
+    closed if either the exact reviewed SDK version or its internal shape
+    changes. Calls are validated with the same schema that ``tools/list``
+    advertises; Pydantic only bridges the validated flat object to the existing
+    ``**kwargs`` Hermes dispatcher.
+    """
+
+    _SUPPORTED_VERSION = "1.26.0"
+
+    def __init__(self, server: Any) -> None:
+        installed = distribution_version("mcp")
+        if installed != self._SUPPORTED_VERSION:
+            raise RuntimeError(
+                "Hermes authoritative MCP schema adapter requires "
+                f"mcp=={self._SUPPORTED_VERSION}; found {installed}. "
+                "Re-review FastMCP's explicit-schema API and Tool internals "
+                "before changing the project pin."
+            )
+
+        manager = getattr(server, "_tool_manager", None)
+        get_tool = getattr(manager, "get_tool", None)
+        if manager is None or not callable(get_tool):
+            raise RuntimeError(
+                "mcp==1.26.0 compatibility failure: expected "
+                "FastMCP._tool_manager.get_tool"
+            )
+        self._get_tool = get_tool
+
+    def install(self, tool_name: str, schema: dict[str, Any]) -> None:
+        """Advertise and enforce ``schema`` on one registered FastMCP Tool."""
+        from jsonschema import FormatChecker, validators
+        from pydantic import ConfigDict, model_validator
+
+        # Private import is deliberately confined to this pinned-version adapter.
+        from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase
+
+        registered_tool: Any = self._get_tool(tool_name)
+        metadata = getattr(registered_tool, "fn_metadata", None)
+        if (
+            registered_tool is None
+            or not isinstance(getattr(registered_tool, "parameters", None), dict)
+            or metadata is None
+            or not hasattr(metadata, "arg_model")
+        ):
+            raise RuntimeError(
+                "mcp==1.26.0 compatibility failure: registered Tool must expose "
+                "mutable parameters and fn_metadata.arg_model "
+                f"({tool_name!r})"
+            )
+
+        validator_type = validators.validator_for(schema)
+        validator_type.check_schema(schema)
+        format_checker = FormatChecker()
+
+        # jsonschema's RFC URI checker is an optional extra and is absent from
+        # mcp==1.26.0's dependency set. Register the minimum protocol-relevant
+        # check explicitly so advertised ``format: uri`` constraints are not
+        # silently ignored on a standard Hermes installation.
+        @format_checker.checks("uri")
+        def _is_uri(value: object) -> bool:
+            if not isinstance(value, str):
+                return True
+            parsed = urlsplit(value)
+            return bool(parsed.scheme) and not any(char.isspace() for char in value)
+
+        validator = validator_type(schema, format_checker=format_checker)
+
+        class _ValidatedHermesArguments(ArgModelBase):
+            model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+            @model_validator(mode="before")
+            @classmethod
+            def _validate_authoritative_schema(cls, value: Any) -> Any:
+                error = next(validator.iter_errors(value), None)
+                if error is None:
+                    return value
+                path = "$" + "".join(
+                    f"[{part}]" if isinstance(part, int) else f".{part}"
+                    for part in error.absolute_path
+                )
+                raise ValueError(
+                    f"{tool_name} arguments fail JSON Schema at {path}: {error.message}"
+                )
+
+            def model_dump_one_level(self) -> dict[str, Any]:
+                return dict(self.__pydantic_extra__ or {})
+
+        try:
+            registered_tool.parameters = schema
+            metadata.arg_model = _ValidatedHermesArguments
+        except Exception as exc:
+            raise RuntimeError(
+                "mcp==1.26.0 compatibility failure: could not install Tool "
+                f"schema/argument model ({tool_name!r})"
+            ) from exc
+        if (
+            registered_tool.parameters != schema
+            or metadata.arg_model is not _ValidatedHermesArguments
+        ):
+            raise RuntimeError(
+                "mcp==1.26.0 compatibility failure: Tool schema/argument model "
+                f"mutation did not stick ({tool_name!r})"
+            )
+
+
 def _build_server() -> Any:
     """Create the FastMCP server with Hermes tools attached. Lazy imports
     so the module can be imported without the mcp package installed
     (we degrade to a clear error only when actually run)."""
     try:
         from mcp.server.fastmcp import FastMCP
+        from mcp.types import CallToolResult, TextContent
     except ImportError as exc:  # pragma: no cover - install hint
         raise ImportError(
             f"hermes-tools MCP server requires the 'mcp' package: {exc}"
@@ -177,6 +289,37 @@ def _build_server() -> Any:
         ),
     )
 
+    def _convert_result(result: Any) -> Any:
+        """Translate Hermes' JSON-string convention to MCP result semantics."""
+        if isinstance(result, CallToolResult):
+            return result
+
+        decoded = result
+        if isinstance(result, str):
+            try:
+                decoded = json.loads(result)
+            except (json.JSONDecodeError, TypeError):
+                return result
+
+        if isinstance(decoded, dict):
+            # structuredContent must be JSON-native. Normalize native Hermes
+            # values (for example datetimes) while preserving Unicode.
+            normalized = json.loads(
+                json.dumps(decoded, ensure_ascii=False, default=str)
+            )
+            text = (
+                result
+                if isinstance(result, str)
+                else json.dumps(normalized, ensure_ascii=False)
+            )
+            return CallToolResult(
+                content=[TextContent(type="text", text=text)],
+                structuredContent=normalized,
+                isError="error" in decoded,
+            )
+
+        return result
+
     # Pull authoritative Hermes tool schemas for the ones we expose, so
     # MCP clients see the same parameter docs Hermes gives the model.
     all_defs = {
@@ -184,56 +327,49 @@ def _build_server() -> Any:
         for td in (get_tool_definitions(quiet_mode=True) or [])
         if isinstance(td, dict) and td.get("type") == "function"
     }
+    schema_adapter = _FastMCP126SchemaAdapter(mcp)
 
     exposed_count = 0
 
     for name in EXPOSED_TOOLS:
         spec = all_defs.get(name)
         if spec is None:
-            logger.debug(
-                "skipping %s — not registered in this Hermes process", name
-            )
+            logger.debug("skipping %s — not registered in this Hermes process", name)
             continue
 
         description = spec.get("description") or f"Hermes {name} tool"
-        params_schema = spec.get("parameters") or {"type": "object", "properties": {}}
+        params_schema = spec.get("parameters")
+        if not isinstance(params_schema, dict):
+            raise RuntimeError(
+                f"Hermes tool {name!r} has no authoritative object JSON Schema"
+            )
 
         # FastMCP wants a Python callable. Build a closure that takes the
-        # arguments dict, dispatches via handle_function_call, and returns
-        # the result string. We use add_tool() for full control over the
-        # input schema (FastMCP's @tool() decorator inspects type hints,
-        # which we can't get from a JSON schema at runtime).
-        def _make_handler(tool_name: str, schema: dict | None):
-            sig, annots = _signature_from_schema(schema)
-
-            def _dispatch(**kwargs: Any) -> str:
+        # arguments dict and dispatches through Hermes. The SDK initially
+        # inspects this callable, then we replace that synthetic argument model
+        # and schema with validating pass-through plumbing plus Hermes'
+        # authoritative JSON Schema. This avoids lossy
+        # JSON-Schema-to-Python-signature translation.
+        def _make_handler(tool_name: str, tool_description: str) -> Any:
+            def _dispatch(**kwargs: Any) -> Any:
                 try:
-                    # Filter out None values before dispatch so unset optionals
-                    # aren't forwarded to the handler.
-                    args = {k: v for k, v in kwargs.items() if v is not None}
-                    return handle_function_call(tool_name, args or {})
+                    result = handle_function_call(tool_name, kwargs or {})
+                    return _convert_result(result)
                 except Exception as exc:
                     logger.exception("tool %s raised", tool_name)
-                    return json.dumps({"error": str(exc), "tool": tool_name})
+                    return _convert_result({"error": str(exc), "tool": tool_name})
 
             _dispatch.__name__ = tool_name
-            _dispatch.__doc__ = description
-            _dispatch.__signature__ = sig
-            _dispatch.__annotations__ = {**annots, "return": str}
+            _dispatch.__doc__ = tool_description
             return _dispatch
 
-        try:
-            mcp.add_tool(
-                _make_handler(name, params_schema),
-                name=name,
-                description=description,
-            )
-        except TypeError:
-            # Older mcp SDK signature — fall back to decorator-style. The
-            # synthesized __signature__ on the handler still drives schema
-            # generation there.
-            handler = _make_handler(name, params_schema)
-            handler = mcp.tool(name=name, description=description)(handler)
+        mcp.add_tool(
+            _make_handler(name, description),
+            name=name,
+            description=description,
+        )
+
+        schema_adapter.install(name, params_schema)
 
         exposed_count += 1
 
@@ -263,7 +399,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     try:
         server = _build_server()
-    except ImportError as exc:
+    except (ImportError, RuntimeError) as exc:
         sys.stderr.write(f"hermes-tools MCP server cannot start: {exc}\n")
         return 2
 

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -1,139 +1,448 @@
 """Tests for the hermes-tools-as-MCP server module surface.
 
-We don't run a live MCP session in unit tests — that requires the codex
-subprocess + client + an event loop. These tests pin the static
-contract: the module imports, the EXPOSED_TOOLS list is sane, and the
-build helper assembles a server when the SDK is present.
+The focused contract tests build the real FastMCP server and drive it through
+an in-memory MCP client session. Static tests also pin the curated tool subset
+and entry-point behavior.
 """
 
 from __future__ import annotations
 
-import inspect
-from typing import get_args
+import asyncio
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
 
-from agent.transports.hermes_tools_mcp_server import (
-    _signature_from_schema,
-)
+import pytest
 
 
-class TestSignatureFromSchema:
-    """Test the JSON Schema -> Python signature conversion."""
+AUTHORITATIVE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "urls": {
+            "type": "array",
+            "items": {"type": "string", "format": "uri"},
+            "minItems": 1,
+            "maxItems": 5,
+        },
+        "mode": {"type": "string", "enum": ["fast", "thorough"]},
+        "filters": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "domains": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        }
+                    },
+                    "required": ["domains"],
+                    "additionalProperties": False,
+                },
+                {"type": "null"},
+            ]
+        },
+    },
+    "required": ["urls", "mode"],
+    "additionalProperties": False,
+}
 
-    def test_simple_required_string_param(self):
-        """A required string param becomes str with no default."""
-        schema = {
-            "type": "object",
-            "properties": {"query": {"type": "string"}},
-            "required": ["query"],
-        }
-        sig, annots = _signature_from_schema(schema)
 
-        assert len(sig.parameters) == 1
-        param = sig.parameters["query"]
-        assert param.name == "query"
-        assert param.kind == inspect.Parameter.KEYWORD_ONLY
-        assert annots["query"] == str
-        assert param.default is inspect.Parameter.empty
+@pytest.fixture
+def authoritative_server(monkeypatch):
+    """Build a real FastMCP server around deterministic Hermes definitions."""
+    import model_tools
+    from agent.transports import hermes_tools_mcp_server as m
 
-    def test_optional_integer_param(self):
-        """An optional param gets Optional[type] with default=None."""
-        schema = {
-            "type": "object",
-            "properties": {"limit": {"type": "integer"}},
-        }
-        sig, annots = _signature_from_schema(schema)
-
-        param = sig.parameters["limit"]
-        # Optional[type] is type | None in Python 3.10+
-        assert param.default is None
-
-    def test_multiple_params_mixed_required_optional(self):
-        """Mixed required and optional params are handled correctly."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"},
-                "limit": {"type": "integer"},
-                "offset": {"type": "integer"},
+    definitions = []
+    for name, schema in (
+        ("schema_probe", AUTHORITATIVE_SCHEMA),
+        ("error_probe", {"type": "object", "properties": {}}),
+        ("non_string_error_probe", {"type": "object", "properties": {}}),
+        ("raised_probe", {"type": "object", "properties": {}}),
+        ("text_probe", {}),
+        ("object_probe", {"type": "object", "properties": {}}),
+        ("scalar_probe", {"type": "object", "properties": {}}),
+        ("list_probe", {"type": "object", "properties": {}}),
+        ("prebuilt_error_probe", {"type": "object", "properties": {}}),
+        ("prebuilt_success_probe", {"type": "object", "properties": {}}),
+    ):
+        definitions.append({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Authoritative description for {name}",
+                "parameters": schema,
             },
-            "required": ["query"],
+        })
+
+    calls = []
+
+    def dispatch(name, arguments):
+        from mcp.types import CallToolResult, TextContent
+
+        calls.append((name, arguments))
+        if name == "error_probe":
+            return json.dumps(
+                {
+                    "error": "échec upstream",
+                    "code": "E_UPSTREAM",
+                    "retry": {"allowed": True, "after_seconds": 30},
+                    "tool": name,
+                },
+                ensure_ascii=False,
+            )
+        if name == "non_string_error_probe":
+            return {
+                "error": {"message": "window elapsed"},
+                "code": "E_WINDOW",
+                "observed_at": datetime(2026, 7, 11, tzinfo=timezone.utc),
+            }
+        if name == "raised_probe":
+            raise RuntimeError("dispatcher exploded")
+        if name == "text_probe":
+            return "plain text result"
+        if name == "object_probe":
+            return {"ok": True, "source": "native object"}
+        if name == "scalar_probe":
+            return "42"
+        if name == "list_probe":
+            return '[1, {"nested": true}]'
+        if name == "prebuilt_error_probe":
+            return CallToolResult(
+                content=[TextContent(type="text", text="prebuilt failure")],
+                isError=True,
+            )
+        if name == "prebuilt_success_probe":
+            return CallToolResult(
+                content=[TextContent(type="text", text="prebuilt success")],
+                structuredContent={"prebuilt": True},
+            )
+        return json.dumps({"ok": True, "received": arguments})
+
+    monkeypatch.setattr(
+        m, "EXPOSED_TOOLS", tuple(item["function"]["name"] for item in definitions)
+    )
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions", lambda **_kwargs: definitions
+    )
+    monkeypatch.setattr(model_tools, "handle_function_call", dispatch)
+    return m._build_server(), calls
+
+
+async def _list_tools(server):
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(server) as client:
+        return await client.list_tools()
+
+
+async def _call_tool(server, name, arguments):
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(server) as client:
+        return await client.call_tool(name, arguments)
+
+
+class TestAuthoritativeFastMCPSurface:
+    def test_list_tools_preserves_authoritative_schema_exactly(
+        self, authoritative_server
+    ):
+        server, _calls = authoritative_server
+
+        listed = asyncio.run(_list_tools(server))
+        tools = {tool.name: tool for tool in listed.tools}
+
+        assert tools["schema_probe"].inputSchema == AUTHORITATIVE_SCHEMA
+        assert "kwargs" not in tools["schema_probe"].inputSchema.get("properties", {})
+        assert tools["text_probe"].inputSchema == {}
+        for name, tool in tools.items():
+            assert tool.description == f"Authoritative description for {name}"
+
+    def test_protocol_call_forwards_nested_arguments_and_returns_structured_success(
+        self, authoritative_server
+    ):
+        server, calls = authoritative_server
+        arguments = {
+            "urls": ["https://example.com/a", "https://example.com/b"],
+            "mode": "thorough",
+            "filters": {"domains": ["example.com", "example.org"]},
         }
-        sig, annots = _signature_from_schema(schema)
 
-        assert len(sig.parameters) == 3
+        result = asyncio.run(_call_tool(server, "schema_probe", arguments))
 
-        # query: required str
-        assert annots["query"] == str
-        assert sig.parameters["query"].default is inspect.Parameter.empty
+        assert result.isError is False
+        assert result.structuredContent == {"ok": True, "received": arguments}
+        content = result.content[0]
+        assert content.type == "text"
+        assert json.loads(content.text) == result.structuredContent
+        assert calls == [("schema_probe", arguments)]
 
-        # limit: optional int
-        assert sig.parameters["limit"].default is None
+    @pytest.mark.parametrize(
+        "invalid_arguments",
+        [
+            pytest.param({}, id="required"),
+            pytest.param(
+                {"urls": ["https://example.com"], "mode": "invalid"}, id="enum"
+            ),
+            pytest.param(
+                {
+                    "urls": ["https://example.com"],
+                    "mode": "fast",
+                    "unexpected": True,
+                },
+                id="additional-properties",
+            ),
+            pytest.param(
+                {"urls": "https://example.com", "mode": "fast"}, id="array-type"
+            ),
+            pytest.param({"urls": [], "mode": "fast"}, id="array-bounds"),
+            pytest.param(
+                {
+                    "urls": ["https://example.com"],
+                    "mode": "fast",
+                    "filters": {},
+                },
+                id="nested-required-and-one-of",
+            ),
+            pytest.param(
+                {
+                    "urls": ["https://example.com"],
+                    "mode": "fast",
+                    "filters": {"domains": [1]},
+                },
+                id="nested-array-items",
+            ),
+            pytest.param({"urls": ["not a uri"], "mode": "fast"}, id="uri-format"),
+        ],
+    )
+    def test_protocol_rejects_schema_invalid_calls_without_dispatch(
+        self, authoritative_server, invalid_arguments
+    ):
+        server, calls = authoritative_server
 
-        # offset: optional int
-        assert sig.parameters["offset"].default is None
+        result = asyncio.run(_call_tool(server, "schema_probe", invalid_arguments))
 
-    def test_skip_private_params(self):
-        """Params starting with '_' are excluded from the signature."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"},
-                "_internal": {"type": "string"},
-            },
-            "required": ["query", "_internal"],
+        assert result.isError is True
+        assert calls == []
+
+    def test_protocol_maps_hermes_error_object_to_mcp_error(self, authoritative_server):
+        server, calls = authoritative_server
+
+        result = asyncio.run(_call_tool(server, "error_probe", {}))
+
+        assert result.isError is True
+        content = result.content[0]
+        assert content.type == "text"
+        diagnostic = {
+            "error": "échec upstream",
+            "code": "E_UPSTREAM",
+            "retry": {"allowed": True, "after_seconds": 30},
+            "tool": "error_probe",
         }
-        sig, annots = _signature_from_schema(schema)
+        assert content.text == json.dumps(diagnostic, ensure_ascii=False)
+        assert result.structuredContent == diagnostic
+        assert calls == [("error_probe", {})]
 
-        assert "_internal" not in sig.parameters
-        assert "_internal" not in annots
-        assert "query" in sig.parameters
+    def test_protocol_preserves_non_string_non_json_native_error_diagnostics(
+        self, authoritative_server
+    ):
+        server, calls = authoritative_server
 
-    def test_all_json_types(self):
-        """All JSON schema types map to correct Python types."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "s": {"type": "string"},
-                "i": {"type": "integer"},
-                "n": {"type": "number"},
-                "b": {"type": "boolean"},
-                "a": {"type": "array"},
-                "o": {"type": "object"},
-            },
-            "required": ["s", "i", "n", "b", "a", "o"],
+        result = asyncio.run(_call_tool(server, "non_string_error_probe", {}))
+
+        assert result.isError is True
+        content = result.content[0]
+        assert content.type == "text"
+        diagnostic = json.loads(content.text)
+        assert diagnostic == {
+            "error": {"message": "window elapsed"},
+            "code": "E_WINDOW",
+            "observed_at": "2026-07-11 00:00:00+00:00",
         }
-        sig, annots = _signature_from_schema(schema)
+        assert result.structuredContent == diagnostic
+        assert calls == [("non_string_error_probe", {})]
 
-        assert annots["s"] == str
-        assert annots["i"] == int
-        assert annots["n"] == float
-        assert annots["b"] == bool
-        assert annots["a"] == list
-        assert annots["o"] == dict
+    def test_protocol_maps_dispatch_exceptions_to_structured_mcp_error(
+        self, authoritative_server
+    ):
+        server, calls = authoritative_server
 
-    def test_empty_schema(self):
-        """Empty schema returns empty signature."""
-        sig, annots = _signature_from_schema(None)
-        assert len(sig.parameters) == 0
-        assert len(annots) == 0
+        result = asyncio.run(_call_tool(server, "raised_probe", {}))
 
-    def test_return_annotation_is_str(self):
-        """All generated signatures have str as return type."""
-        schema = {
-            "type": "object",
-            "properties": {"query": {"type": "string"}},
+        diagnostic = {"error": "dispatcher exploded", "tool": "raised_probe"}
+        assert result.isError is True
+        content = result.content[0]
+        assert content.type == "text"
+        assert json.loads(content.text) == diagnostic
+        assert result.structuredContent == diagnostic
+        assert calls == [("raised_probe", {})]
+
+    def test_protocol_keeps_plain_string_results_compatible(self, authoritative_server):
+        server, calls = authoritative_server
+
+        result = asyncio.run(_call_tool(server, "text_probe", {}))
+
+        assert result.isError is False
+        assert result.structuredContent is None
+        content = result.content[0]
+        assert content.type == "text"
+        assert content.text == "plain text result"
+        assert calls == [("text_probe", {})]
+
+    def test_protocol_keeps_native_object_results_structured(
+        self, authoritative_server
+    ):
+        server, calls = authoritative_server
+
+        result = asyncio.run(_call_tool(server, "object_probe", {}))
+
+        assert result.isError is False
+        assert result.structuredContent == {"ok": True, "source": "native object"}
+        assert calls == [("object_probe", {})]
+
+    @pytest.mark.parametrize(
+        ("tool_name", "expected_text"),
+        [("scalar_probe", "42"), ("list_probe", '[1, {"nested": true}]')],
+    )
+    def test_protocol_keeps_json_scalar_and_list_strings_as_text(
+        self, authoritative_server, tool_name, expected_text
+    ):
+        server, calls = authoritative_server
+
+        result = asyncio.run(_call_tool(server, tool_name, {}))
+
+        assert result.isError is False
+        assert result.structuredContent is None
+        content = result.content[0]
+        assert content.type == "text"
+        assert content.text == expected_text
+        assert calls == [(tool_name, {})]
+
+    @pytest.mark.parametrize(
+        ("tool_name", "is_error", "text", "structured"),
+        [
+            ("prebuilt_error_probe", True, "prebuilt failure", None),
+            ("prebuilt_success_probe", False, "prebuilt success", {"prebuilt": True}),
+        ],
+    )
+    def test_protocol_preserves_existing_call_tool_results(
+        self, authoritative_server, tool_name, is_error, text, structured
+    ):
+        server, calls = authoritative_server
+
+        result = asyncio.run(_call_tool(server, tool_name, {}))
+
+        assert result.isError is is_error
+        content = result.content[0]
+        assert content.type == "text"
+        assert content.text == text
+        assert result.structuredContent == structured
+        assert calls == [(tool_name, {})]
+
+
+class TestCodexFacingBoundary:
+    def test_codex_app_server_ingests_authoritative_schema(self, tmp_path, monkeypatch):
+        """Have Codex ingest the real stdio server's ``tools/list``.
+
+        ``mcpServerStatus/list`` is the smallest supported app-server boundary
+        that returns Codex's parsed tool inventory; no provider/model turn is
+        needed. Skip only when the optional Codex CLI is unavailable.
+        """
+        codex_bin = shutil.which("codex")
+        if codex_bin is None:
+            pytest.skip("Codex CLI is not installed")
+
+        import model_tools
+        from agent.transports.codex_app_server import (
+            CodexAppServerClient,
+            check_codex_binary,
+        )
+        from hermes_cli.codex_runtime_plugin_migration import migrate
+
+        ok, detail = check_codex_binary(codex_bin)
+        if not ok:
+            pytest.skip(detail)
+
+        definitions = {
+            item["function"]["name"]: item["function"]
+            for item in model_tools.get_tool_definitions(quiet_mode=True)
+            if item.get("type") == "function"
         }
-        sig, annots = _signature_from_schema(schema)
-        assert sig.return_annotation == str
+        # Skills are dependency-free and therefore present even when optional
+        # web/browser providers are not configured in CI.
+        tool_name = "skills_list"
+        authoritative = definitions[tool_name]["parameters"]
 
+        # The generated stdio entry must import this worktree rather than any
+        # separately installed Hermes checkout.
+        monkeypatch.setenv("PYTHONPATH", str(Path(__file__).parents[3]))
+        codex_home = tmp_path / "codex-home"
+        report = migrate(
+            {},
+            codex_home=codex_home,
+            discover_plugins=False,
+            default_permission_profile=None,
+            expose_hermes_tools=True,
+        )
+        assert report.errors == []
 
+        client = CodexAppServerClient(codex_bin=codex_bin, codex_home=str(codex_home))
+        try:
+            client.initialize(timeout=15)
+            status = client.request(
+                "mcpServerStatus/list",
+                {"detail": "toolsAndAuthOnly"},
+                timeout=60,
+            )
+        finally:
+            client.close()
 
-
+        servers = {item["name"]: item for item in status["data"]}
+        codex_schema = servers["hermes-tools"]["tools"][tool_name]["inputSchema"]
+        assert codex_schema == authoritative
+        assert "kwargs" not in codex_schema.get("properties", {})
 
 
 class TestModuleSurface:
+    def test_fastmcp_adapter_rejects_unreviewed_sdk_version(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.setattr(m, "distribution_version", lambda _name: "1.26.1")
+
+        with pytest.raises(
+            RuntimeError, match=r"requires mcp==1\.26\.0; found 1\.26\.1"
+        ):
+            m._FastMCP126SchemaAdapter(object())
+
+    def test_fastmcp_adapter_rejects_missing_private_shape(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.setattr(m, "distribution_version", lambda _name: "1.26.0")
+
+        with pytest.raises(RuntimeError, match="_tool_manager.get_tool"):
+            m._FastMCP126SchemaAdapter(object())
+
+    def test_fastmcp_adapter_rejects_changed_registered_tool_shape(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        class Manager:
+            @staticmethod
+            def get_tool(_name):
+                return object()
+
+        class Server:
+            _tool_manager = Manager()
+
+        monkeypatch.setattr(m, "distribution_version", lambda _name: "1.26.0")
+        adapter = m._FastMCP126SchemaAdapter(Server())
+
+        with pytest.raises(RuntimeError, match="parameters and fn_metadata.arg_model"):
+            adapter.install("probe", {})
+
     def test_module_imports_clean(self):
         from agent.transports import hermes_tools_mcp_server as m
+
         assert callable(m.main)
         assert callable(m._build_server)
         assert isinstance(m.EXPOSED_TOOLS, tuple)
@@ -145,9 +454,15 @@ class TestModuleSurface:
         Specifically: no terminal/shell, no read_file/write_file, no
         patch — those are codex's built-in tools."""
         from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
         forbidden = {
-            "terminal", "shell", "read_file", "write_file", "patch",
-            "search_files", "process",
+            "terminal",
+            "shell",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "process",
         }
         leaked = forbidden & set(EXPOSED_TOOLS)
         assert not leaked, (
@@ -159,6 +474,7 @@ class TestModuleSurface:
         """The Hermes-specific tools should be present so users on the
         codex runtime keep access to them."""
         from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
         for required in (
             "web_search",
             "web_extract",
@@ -174,6 +490,7 @@ class TestModuleSurface:
         running AIAgent context to dispatch, so a stateless MCP callback
         can't drive them. They must NOT be in EXPOSED_TOOLS."""
         from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
         for agent_loop_tool in ("delegate_task", "memory", "session_search", "todo"):
             assert agent_loop_tool not in EXPOSED_TOOLS, (
                 f"{agent_loop_tool!r} requires the agent loop context "
@@ -187,6 +504,7 @@ class TestModuleSurface:
         the MCP callback to report back to the kernel. Without these
         tools available, the worker would hang at completion time."""
         from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
         # Worker handoff tools — every dispatched worker uses at least
         # one of {complete, block, comment} to close out its task.
         for worker_tool in (
@@ -205,6 +523,7 @@ class TestModuleSurface:
         board, and unblock/link tasks. Exposed so an orchestrator on
         codex_app_server can do its job."""
         from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
         for orch_tool in (
             "kanban_create",
             "kanban_show",
@@ -218,13 +537,16 @@ class TestModuleSurface:
 
 
 class TestMain:
-    def test_main_returns_2_when_mcp_unavailable(self, monkeypatch):
-        """When the mcp package isn't installed, main() should exit
-        cleanly with code 2 and an install hint, not crash."""
+    @pytest.mark.parametrize(
+        "error",
+        [ImportError("mcp not installed"), RuntimeError("unsupported mcp shape")],
+    )
+    def test_main_returns_2_when_server_cannot_build(self, monkeypatch, error):
+        """Dependency and compatibility failures should not start the server."""
         import agent.transports.hermes_tools_mcp_server as m
 
         def boom_build(*a, **kw):
-            raise ImportError("mcp not installed")
+            raise error
 
         monkeypatch.setattr(m, "_build_server", boom_build)
         rc = m.main(["--verbose"])


### PR DESCRIPTION
## Summary

Expose and enforce Hermes' authoritative tool schemas in the Codex `hermes-tools` MCP bridge.

The bridge registered every handler as `def tool(**kwargs)`. FastMCP therefore advertised and validated a synthetic schema:

```json
{"type":"object","properties":{"kwargs":{}},"required":["kwargs"]}
```

A Codex call matching that advertised schema lost the real arguments, while a call matching Hermes' real schema failed FastMCP validation before reaching Hermes.

## Fix

- Preserve each authoritative Hermes `parameters` schema exactly in MCP `tools/list`.
- Validate calls against the same schema before dispatch, including nested objects/arrays, required fields, enums, combinators, formats, and `additionalProperties`.
- Pass the validated top-level argument object to Hermes unchanged.
- Convert Hermes `{"error": ...}` results and raised exceptions to MCP `isError=true` while retaining the complete structured diagnostic object.
- Preserve existing plain-text, structured success, and prebuilt `CallToolResult` compatibility.

### FastMCP compatibility boundary

FastMCP 1.26.0 has no public registration API for supplying an independent exact JSON Schema. The private SDK dependency is therefore isolated in `_FastMCP126SchemaAdapter` and fails closed unless:

- the installed MCP version is exactly the reviewed project pin, `1.26.0`;
- `_tool_manager.get_tool`, mutable `Tool.parameters`, and `fn_metadata.arg_model` have the expected shape;
- both schema and validating model replacements are successfully installed.

This avoids a lossy JSON-Schema-to-Python-signature translation and makes a future MCP upgrade fail explicitly rather than silently restoring the broken `kwargs` contract. `jsonschema` is already a declared dependency of MCP 1.26.0.

## TDD and verification

Initial regression state:

- authoritative schema/error tests: **4 failed, 9 passed**;
- exact empty-schema preservation: **1 failed, 13 passed**.

Final verification:

```text
33 passed   tests/agent/transports/test_hermes_tools_mcp_server.py
378 passed  tests/agent/transports/
```

Also passed:

- Ruff lint and format check;
- `py_compile`;
- `git diff --check`;
- live registry `web_extract` list/call round trip;
- independent adversarial review: **APPROVE, no concrete blockers**.

Negative protocol tests assert that invalid calls return MCP errors and never reach `handle_function_call`.

## Scope and compatibility

- No Hermes tool schemas were changed.
- No Codex tool selection or exposure list was broadened.
- No general FastMCP fork or abstraction was introduced.
- Handler name/description closure binding remains per-tool.
- MCP SDK versions other than the repository's reviewed pin intentionally fail fast and require adapter review.
