### PR TITLE
fix(error_classifier): classify LM Studio "model unloaded" as non-retryable

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -295,6 +295,23 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no endpoints found that support tool use",
 ]
 
+# LM Studio unloads/ejects a model at runtime (JIT disabled, manual eject, or
+# an idle-TTL sweep). The completion cannot succeed, and re-firing it just makes
+# LM Studio JIT-reload the model and burn tokens in a reload loop, so this is
+# non-retryable. Unlike a generic missing model, we also decline fallback:
+# silently swapping to another model hides the real endpoint state (the operator
+# thinks the model is serving when it is not). This is the same
+# non-retryable/no-fallback form as the 409 model-pool-lock case in #34076. Kept
+# separate from _MODEL_NOT_FOUND_PATTERNS so should_fallback=False is not
+# overwritten by the generic model_not_found path (should_fallback=True).
+_MODEL_UNLOADED_PATTERNS = [
+    "model unloaded",
+    "model not loaded",
+    "no model loaded",
+    "no models loaded",
+    "no chat-capable models",
+]
+
 # Request-validation patterns — the request is malformed and will fail
 # identically on every retry. Some OpenAI-compatible gateways (notably
 # codex.nekos.me) return these as 5xx instead of the standard 4xx, which
@@ -926,6 +943,15 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=False,
             )
+        # LM Studio "model unloaded" — non-retryable AND no fallback (see
+        # _MODEL_UNLOADED_PATTERNS). Checked before the generic model-not-found
+        # patterns so should_fallback stays False.
+        if any(p in error_msg for p in _MODEL_UNLOADED_PATTERNS):
+            return result_fn(
+                FailoverReason.model_not_found,
+                retryable=False,
+                should_fallback=False,
+            )
         if any(p in error_msg for p in _MODEL_NOT_FOUND_PATTERNS):
             return result_fn(
                 FailoverReason.model_not_found,
@@ -1198,6 +1224,12 @@ def _classify_400(
             retryable=False,
             should_fallback=False,
         )
+    if any(p in error_msg for p in _MODEL_UNLOADED_PATTERNS):
+        return result_fn(
+            FailoverReason.model_not_found,
+            retryable=False,
+            should_fallback=False,
+        )
     if any(p in error_msg for p in _MODEL_NOT_FOUND_PATTERNS):
         return result_fn(
             FailoverReason.model_not_found,
@@ -1420,6 +1452,15 @@ def _classify_by_message(
     if any(p in error_msg for p in _PROVIDER_POLICY_BLOCKED_PATTERNS):
         return result_fn(
             FailoverReason.provider_policy_blocked,
+            retryable=False,
+            should_fallback=False,
+        )
+
+    # LM Studio "model unloaded" — non-retryable AND no fallback. Checked
+    # before the generic model-not-found patterns so should_fallback stays False.
+    if any(p in error_msg for p in _MODEL_UNLOADED_PATTERNS):
+        return result_fn(
+            FailoverReason.model_not_found,
             retryable=False,
             should_fallback=False,
         )

--- a/tests/agent/test_conversation_loop_fallback_gate.py
+++ b/tests/agent/test_conversation_loop_fallback_gate.py
@@ -1,0 +1,116 @@
+"""Loop-level regression: a ``should_fallback=False`` classification must not
+activate the provider fallback chain.
+
+Context (PR #62765 review by teknium1/hermes-sweeper): the classifier now marks
+LM Studio "model unloaded" errors as ``model_not_found, retryable=False,
+should_fallback=False`` (see ``TestLMStudioModelUnloaded`` in
+``test_error_classifier.py``). But the recovery path in
+``agent/conversation_loop.py`` (the ``if is_client_error:`` block, ~L3722-3742)
+calls ``agent._try_activate_fallback()`` **without** consulting
+``classified.should_fallback`` — so today the fallback chain is walked anyway.
+
+The existing tests only assert classifier *output*. This test asserts *loop
+behaviour*: with a no-fallback classification, ``_try_activate_fallback`` is
+never entered.
+
+The guard that makes this true lives in Omar's PR (NousResearch/hermes-agent
+#34076: ``if classified.should_fallback and agent._try_activate_fallback():`` in
+the same region), which is approved but not yet on ``main``. So this test is
+marked ``xfail(strict=True)``:
+
+  * today (no gate) → ``_try_activate_fallback`` IS called → ``assert_not_called``
+    raises → xfail catches it (reported ``xfailed``).
+  * once #34076 lands → the gate short-circuits → the call is suppressed → the
+    assertion passes → ``XPASS`` → ``strict=True`` turns that into a visible CI
+    failure. That is the intended "living merge detector".
+
+FLIP PLAN — as soon as #34076 is merged: remove the ``xfail`` marker, keep the
+hard assertion, and rebase this branch onto the gated ``main``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from agent.conversation_loop import run_conversation
+
+
+class _LMStudioAPIError(Exception):
+    """Minimal stand-in for an OpenAI SDK APIStatusError, shaped exactly like
+    the ``MockAPIError`` used in ``test_error_classifier.py`` so the *real*
+    ``classify_api_error`` maps it to ``model_not_found`` with
+    ``should_fallback=False`` — we deliberately do NOT patch the classifier, to
+    close the loop back to the PR's actual behaviour.
+    """
+
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+
+
+def _make_agent(fallback_model=None):
+    """Minimal AIAgent with an optional fallback chain (mirrors the helper in
+    tests/run_agent/test_provider_fallback.py)."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://lmstudio.local/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "conversation_loop.py ~L3736 calls _try_activate_fallback() without a "
+        "classified.should_fallback guard; the guard lands in "
+        "NousResearch/hermes-agent#34076. Until it does, a no-fallback "
+        "classification still walks the fallback chain. When #34076 merges this "
+        "XPASSes (strict) -> remove xfail, keep the assert, rebase."
+    ),
+)
+def test_no_fallback_activation_for_model_unloaded():
+    # A fallback chain must exist, otherwise there is nothing to (wrongly)
+    # activate and the assertion would be vacuous.
+    agent = _make_agent(
+        fallback_model=[{"provider": "openai", "model": "gpt-4o"}]
+    )
+    assert agent._has_pending_fallback() is True
+
+    # The real LM Studio "no models loaded" failure: a 404 whose body message
+    # the real classifier routes to model_not_found / retryable=False /
+    # should_fallback=False.
+    err = _LMStudioAPIError("No models loaded", status_code=404)
+
+    # Stub only the leaf API call (both streaming and non-streaming paths) so
+    # the error flows through the real classifier into the recovery branch.
+    # Force _try_activate_fallback to a no-op returning False so, if the loop
+    # does call it, it aborts cleanly instead of resolving a real provider.
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=err),
+        patch.object(agent, "_interruptible_streaming_api_call", side_effect=err),
+        patch.object(
+            agent, "_try_activate_fallback", return_value=False
+        ) as spy_fallback,
+    ):
+        run_conversation(
+            agent,
+            "trigger a model-unloaded error",
+            conversation_history=[],
+            task_id="t",
+        )
+
+    # The heart of the regression: a should_fallback=False classification must
+    # not reach fallback activation at all.
+    spy_fallback.assert_not_called()

--- a/tests/agent/test_conversation_loop_fallback_gate.py
+++ b/tests/agent/test_conversation_loop_fallback_gate.py
@@ -1,48 +1,53 @@
 """Loop-level regression: a ``should_fallback=False`` classification must not
-activate the provider fallback chain.
+activate the provider fallback chain — for BOTH the model-unloaded case (#62765)
+and the 409 model-pool-lock case (NousResearch/hermes-agent #34076).
 
-Context (PR #62765 review by teknium1/hermes-sweeper): the classifier now marks
-LM Studio "model unloaded" errors as ``model_not_found, retryable=False,
-should_fallback=False`` (see ``TestLMStudioModelUnloaded`` in
-``test_error_classifier.py``). But the recovery path in
-``agent/conversation_loop.py`` (the ``if is_client_error:`` block, ~L3722-3742)
+Context (PR #62765 review by teknium1/hermes-sweeper): the recovery path in
+``agent/conversation_loop.py`` (the ``if is_client_error:`` block, ~L3722-3736)
 calls ``agent._try_activate_fallback()`` **without** consulting
-``classified.should_fallback`` — so today the fallback chain is walked anyway.
+``classified.should_fallback`` — so today the chain is walked even for a
+no-fallback classification. The guard that fixes this
+(``if classified.should_fallback and agent._try_activate_fallback():``) lands in
+Omar's #34076, approved but not yet on ``main``. The guard is error-type-agnostic.
 
-The existing tests only assert classifier *output*. This test asserts *loop
-behaviour*: with a no-fallback classification, ``_try_activate_fallback`` is
-never entered.
+This test asserts *loop behaviour* (not classifier output): a
+``should_fallback=False`` classification must not reach ``_try_activate_fallback``
+AND must leave the fallback chain index unchanged.
 
-The guard that makes this true lives in Omar's PR (NousResearch/hermes-agent
-#34076: ``if classified.should_fallback and agent._try_activate_fallback():`` in
-the same region), which is approved but not yet on ``main``. So this test is
-marked ``xfail(strict=True)``:
+Two parametrizations exercise the SAME guard:
 
-  * today (no gate) → ``_try_activate_fallback`` IS called → ``assert_not_called``
-    raises → xfail catches it (reported ``xfailed``).
-  * once #34076 lands → the gate short-circuits → the call is suppressed → the
-    assertion passes → ``XPASS`` → ``strict=True`` turns that into a visible CI
-    failure. That is the intended "living merge detector".
+  * ``model_unloaded`` — a real ``404 "No models loaded"`` through the **real**
+    classifier (#62765 maps it to ``model_not_found, should_fallback=False``). No
+    classifier patch — closes the loop back to the PR's actual behaviour.
+  * ``conflict_409`` — the 409 model-pool-lock case. The 409→``should_fallback=
+    False`` mapping lives in #34076, NOT on this branch, so here we **mock**
+    ``classify_api_error`` to return that classification. Transparent mock
+    boundary: once #34076 lands, lift this to a real 409 trigger (drop the patch).
 
-FLIP PLAN — as soon as #34076 is merged: remove the ``xfail`` marker, keep the
-hard assertion, and rebase this branch onto the gated ``main``.
+Both are ``xfail(strict=True)`` — the shared merge-detector for #34076: today the
+ungated loop calls ``_try_activate_fallback`` → ``assert_not_called`` raises →
+``xfailed``; once #34076 gates it → call suppressed → asserts pass → ``XPASS`` →
+strict turns that into a visible CI failure.
+
+FLIP PLAN when #34076 merges: remove ``xfail``, keep the asserts, lift the 409
+branch to a real trigger, rebase onto the gated ``main``.
 """
 
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from run_agent import AIAgent
 from agent.conversation_loop import run_conversation
+from agent.error_classifier import ClassifiedError, FailoverReason
 
 
 class _LMStudioAPIError(Exception):
-    """Minimal stand-in for an OpenAI SDK APIStatusError, shaped exactly like
-    the ``MockAPIError`` used in ``test_error_classifier.py`` so the *real*
-    ``classify_api_error`` maps it to ``model_not_found`` with
-    ``should_fallback=False`` — we deliberately do NOT patch the classifier, to
-    close the loop back to the PR's actual behaviour.
-    """
+    """Minimal stand-in for an OpenAI SDK APIStatusError, shaped like the
+    ``MockAPIError`` in ``test_error_classifier.py`` so the *real*
+    ``classify_api_error`` maps the model-unloaded case to
+    ``model_not_found`` / ``should_fallback=False``."""
 
     def __init__(self, message, status_code=None, body=None):
         super().__init__(message)
@@ -70,47 +75,81 @@ def _make_agent(fallback_model=None):
         return agent
 
 
+# The 409 model-pool-lock classification #34076 will produce. Mocked here because
+# the 409 -> should_fallback=False mapping is in #34076, not on this branch. reason
+# is a stand-in (model_not_found: same non-retryable/no-fallback form, and it takes
+# the identical loop path as the model-unloaded case); the loop gate keys on
+# should_fallback, not on the reason.
+_CONFLICT_409_NO_FALLBACK = ClassifiedError(
+    reason=FailoverReason.model_not_found,
+    status_code=409,
+    message="model pool locked",
+    retryable=False,
+    should_compress=False,
+    should_fallback=False,
+)
+
+
+@pytest.mark.parametrize(
+    "err, mocked_classification",
+    [
+        pytest.param(
+            _LMStudioAPIError("No models loaded", status_code=404),
+            None,  # real classifier (#62765)
+            id="model_unloaded_404_real_classifier",
+        ),
+        pytest.param(
+            _LMStudioAPIError("model pool locked", status_code=409),
+            _CONFLICT_409_NO_FALLBACK,  # mocked, pending #34076
+            id="conflict_409_mocked_pending_34076",
+        ),
+    ],
+)
 @pytest.mark.xfail(
     strict=True,
     reason=(
         "conversation_loop.py ~L3736 calls _try_activate_fallback() without a "
         "classified.should_fallback guard; the guard lands in "
         "NousResearch/hermes-agent#34076. Until it does, a no-fallback "
-        "classification still walks the fallback chain. When #34076 merges this "
-        "XPASSes (strict) -> remove xfail, keep the assert, rebase."
+        "classification still walks the fallback chain. When #34076 merges both "
+        "params XPASS (strict) -> remove xfail, keep asserts, lift 409 to a real "
+        "trigger, rebase."
     ),
 )
-def test_no_fallback_activation_for_model_unloaded():
+def test_no_fallback_activation_when_should_fallback_false(err, mocked_classification):
     # A fallback chain must exist, otherwise there is nothing to (wrongly)
     # activate and the assertion would be vacuous.
-    agent = _make_agent(
-        fallback_model=[{"provider": "openai", "model": "gpt-4o"}]
-    )
+    agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
     assert agent._has_pending_fallback() is True
+    index_before = agent._fallback_index
 
-    # The real LM Studio "no models loaded" failure: a 404 whose body message
-    # the real classifier routes to model_not_found / retryable=False /
-    # should_fallback=False.
-    err = _LMStudioAPIError("No models loaded", status_code=404)
-
-    # Stub only the leaf API call (both streaming and non-streaming paths) so
-    # the error flows through the real classifier into the recovery branch.
-    # Force _try_activate_fallback to a no-op returning False so, if the loop
-    # does call it, it aborts cleanly instead of resolving a real provider.
-    with (
-        patch.object(agent, "_interruptible_api_call", side_effect=err),
-        patch.object(agent, "_interruptible_streaming_api_call", side_effect=err),
-        patch.object(
-            agent, "_try_activate_fallback", return_value=False
-        ) as spy_fallback,
-    ):
+    # Stub only the leaf API call (streaming + non-streaming) so the error flows
+    # through the recovery branch. Force _try_activate_fallback to a no-op
+    # returning False so, if the loop reaches it, it aborts cleanly instead of
+    # resolving a real provider.
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(agent, "_interruptible_api_call", side_effect=err))
+        stack.enter_context(patch.object(agent, "_interruptible_streaming_api_call", side_effect=err))
+        spy_fallback = stack.enter_context(
+            patch.object(agent, "_try_activate_fallback", return_value=False)
+        )
+        if mocked_classification is not None:
+            # 409 branch: inject the #34076 classification (real classifier on this
+            # branch does not yet map 409 -> should_fallback=False).
+            stack.enter_context(
+                patch("agent.conversation_loop.classify_api_error",
+                      return_value=mocked_classification)
+            )
         run_conversation(
-            agent,
-            "trigger a model-unloaded error",
-            conversation_history=[],
-            task_id="t",
+            agent, "trigger a no-fallback error",
+            conversation_history=[], task_id="t",
         )
 
-    # The heart of the regression: a should_fallback=False classification must
-    # not reach fallback activation at all.
+    # The heart of the regression: a should_fallback=False classification must not
+    # reach fallback activation ...
     spy_fallback.assert_not_called()
+    # ... and the fallback chain must be untouched (Sweeper's explicit wording).
+    # _fallback_index only advances inside _try_activate_fallback, so not-calling
+    # it and an unchanged index are two faces of the same guarantee.
+    assert agent._fallback_index == index_before
+    assert agent._has_pending_fallback() is True

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -2067,3 +2067,51 @@ class Test408RequestTimeout:
         assert result.retryable is True
         assert result.should_compress is False
 
+
+class TestLMStudioModelUnloaded:
+    """LM Studio "model unloaded" / "no models loaded" is non-retryable AND
+    declines fallback (should_fallback=False) — same form as the 409
+    model-pool-lock case. Distinct from a generic missing model, which stays
+    retryable=False but should_fallback=True. See _MODEL_UNLOADED_PATTERNS in
+    agent/error_classifier.py for the rationale.
+    """
+
+    def test_404_model_unloaded_no_fallback(self):
+        e = MockAPIError("Model unloaded", status_code=404)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_400_no_models_loaded_no_fallback(self):
+        e = MockAPIError("No models loaded", status_code=400)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_statusless_no_models_loaded_no_fallback(self):
+        # LM Studio can surface this without an HTTP status (local shim / SSE
+        # error frame), so the message-pattern path must catch it too.
+        e = Exception("No models loaded")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_no_chat_capable_models(self):
+        e = MockAPIError("No chat-capable models are loaded", status_code=404)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_genuine_model_not_found_still_falls_back(self):
+        # Regression: a real missing model keeps should_fallback=True. The
+        # unloaded override is scoped to _MODEL_UNLOADED_PATTERNS only.
+        e = MockAPIError("model not found", status_code=404)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+


### PR DESCRIPTION
## What

LM Studio can unload or eject a configured model at runtime (JIT loading disabled,
manual eject, or an idle-TTL sweep). Retrying the identical request can trigger a
reload loop, while silently choosing a fallback hides the local endpoint state the
operator needs to fix.

This PR adds a dedicated `_MODEL_UNLOADED_PATTERNS` family for:

- `model unloaded`
- `model not loaded`
- `no model loaded`
- `no models loaded`
- `no chat-capable models`

These signals keep the existing `model_not_found` reason but are terminal:
`retryable=False, should_fallback=False`. Generic `model not found` errors remain
eligible for fallback.

The dedicated rule is ordered ahead of the generic model-not-found rule in all
three relevant classifier paths: HTTP 404, HTTP 400, and status-less messages.

## End-to-end behavior

Current `main` already honors `should_fallback=False` in
`settle_unrecovered_error`. The earlier temporary dependency and xfail coverage
for #34076 are therefore no longer needed. This revision replaces them with a
behavioral regression through the real settlement path and proves that an unloaded
LM Studio model neither activates nor advances the configured fallback chain.

## Tests

- Seven classifier cases across 404, 400, status-less, nested-body, and flat-body
  responses.
- Boundary regression: a genuine `model not found` still permits fallback.
- Settlement regression: a pending fallback exists but is not activated or
  advanced for an unloaded model.
- Local focused and adjacent suite: **193 passed, 0 failed**.
- Ruff passes for all changed files.
