### PR TITLE
fix(cron): lock recurring jobs for full run

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -140,6 +140,17 @@ def use_cron_store(home: Union[str, Path]):
         _cron_store_override.reset(token)
 
 
+def get_cron_store_dir() -> Path:
+    """Return the cron directory for the active profile/store context.
+
+    Scheduler coordination artifacts must use this accessor so they share the
+    exact ContextVar-selected store used by claims, advancement, output, and
+    completion marking. Runtime ``HERMES_HOME`` alone is not sufficient because
+    dashboard/profile calls may temporarily route one process to another store.
+    """
+    return _current_cron_store().cron_dir
+
+
 def get_cron_output_dir() -> Path:
     """Return the output directory for the active cron store context."""
     return _current_cron_store().output_dir
@@ -1655,7 +1666,12 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     return False
 
 
-def advance_next_run(job_id: str) -> bool:
+def advance_next_run(
+    job_id: str,
+    *,
+    expected_next_run_at: Optional[str] = None,
+    expected_schedule_kind: Optional[str] = None,
+) -> bool:
     """Preemptively advance next_run_at for a recurring job before execution.
 
     Call this BEFORE run_job() so that if the process crashes mid-execution,
@@ -1665,13 +1681,27 @@ def advance_next_run(job_id: str) -> bool:
 
     One-shot jobs are left unchanged so they can still retry on restart.
 
-    Returns True if next_run_at was advanced, False otherwise.
+    When expected state is supplied, the transition is compare-and-set: a
+    stale due snapshot, pause/disable, or schedule-kind change returns False
+    without mutating the record. Returns True only when next_run_at advanced.
     """
     with _jobs_lock():
         jobs = load_jobs()
         for job in jobs:
             if job["id"] == job_id:
+                if not job.get("enabled", True) or job.get("state") == "paused":
+                    return False
                 kind = job.get("schedule", {}).get("kind")
+                if (
+                    expected_schedule_kind is not None
+                    and kind != expected_schedule_kind
+                ):
+                    return False
+                if (
+                    expected_next_run_at is not None
+                    and job.get("next_run_at") != expected_next_run_at
+                ):
+                    return False
                 if kind not in {"cron", "interval"}:
                     return False
                 now = _hermes_now().isoformat()
@@ -1701,16 +1731,24 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
+def claim_job_for_fire(
+    job_id: str,
+    *,
+    claim_ttl_seconds: int = 300,
+    expected_schedule_kind: Optional[str] = None,
+) -> bool:
+    """Atomically claim one external fire for bounded retry de-duplication.
 
-    Used by the external-provider fire path (``CronScheduler.fire_due``) when an
-    external scheduler (Chronos) signals a job is due across N gateway replicas:
-    exactly one wins. Single-machine deployments always win.
+    Used by ``CronScheduler.fire_due`` when an external scheduler signals a job
+    across gateway replicas sharing the active store. Exactly one caller wins
+    while the claim is fresh. This is not a renewable full-run distributed
+    lease: after ``claim_ttl_seconds`` a different host may reclaim a still-live
+    run. Same-host recurring full-run ownership is handled separately by the
+    scheduler's per-job advisory lock.
 
-    Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
+    Under the jobs-file lock: reject if the job is missing/disabled/paused or
+    no longer has ``expected_schedule_kind`` (when supplied). If a fresh claim
+    (younger than ``claim_ttl_seconds``) already exists, lose.
     Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
     re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
@@ -1718,9 +1756,9 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
     ``mark_job_run`` clears the claim on completion so a re-armed recurring job
     is claimable again next fire.
 
-    The stale-claim TTL means a machine that crashed after claiming but before
-    completing doesn't wedge the job forever — after the TTL another fire can
-    reclaim it.
+    The stale-claim TTL prevents a crashed caller from wedging external fires
+    forever, but also bounds the cross-host de-duplication window. It deliberately
+    does not claim full-run distributed ownership.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1728,6 +1766,12 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             if job["id"] != job_id:
                 continue
             if not job.get("enabled", True) or job.get("state") == "paused":
+                return False
+            kind = job.get("schedule", {}).get("kind")
+            if (
+                expected_schedule_kind is not None
+                and kind != expected_schedule_kind
+            ):
                 return False
             now = _hermes_now()
             existing = job.get("fire_claim")
@@ -1746,7 +1790,6 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                 except Exception:
                     pass  # malformed claim → overwrite
             job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
-            kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
@@ -1756,7 +1799,7 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
         return False
 
 
-def get_due_jobs() -> List[Dict[str, Any]]:
+def get_due_jobs(*, defer_recurring_advance: bool = False) -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 
     For recurring jobs (cron/interval), if the scheduled time is stale (more
@@ -1767,14 +1810,24 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     still fires ONCE now. This prevents the perpetual-defer loop (#33315) where
     a job whose runtime exceeds ``interval + grace`` would be skipped forever.
 
+    ``defer_recurring_advance`` leaves a stale recurring job's persisted
+    ``next_run_at`` untouched while still returning it as due. The scheduler
+    uses this mode so it can acquire per-job run ownership before the atomic
+    advance; callers that only inspect due jobs retain the historical eager
+    fast-forward behavior by default.
+
     Note: firing once on catch-up flows through ``mark_job_run``, so a job with
     a ``repeat.times`` limit consumes one of its runs on that catch-up fire.
     """
     with _jobs_lock():
-        return _get_due_jobs_locked()
+        return _get_due_jobs_locked(
+            defer_recurring_advance=defer_recurring_advance
+        )
 
 
-def _get_due_jobs_locked() -> List[Dict[str, Any]]:
+def _get_due_jobs_locked(
+    *, defer_recurring_advance: bool = False
+) -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
@@ -2001,31 +2054,32 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     # Job is past its catch-up grace window — skip accumulated
                     # missed runs but still execute once now to avoid deferring
                     # indefinitely (e.g. a long-running job just finished).
-                    new_next = compute_next_run(schedule, now.isoformat())
-                    if new_next:
+                    if defer_recurring_advance:
                         logger.info(
                             "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                            "Running now; next run provisionally set to: %s "
-                            "(re-anchored on completion)",
+                            "Running now after per-job ownership advances the schedule",
                             job.get("name", job.get("id", "?")),
                             next_run,
                             grace,
-                            new_next,
                         )
-                        # Persist the fast-forward to storage now (skip accumulated
-                        # slots). In the built-in ticker path this is shortly
-                        # overwritten by advance_next_run + mark_job_run, but it is
-                        # NOT redundant: it (a) protects the crash window between
-                        # here and mark_job_run, and (b) covers the external
-                        # fire_due provider path, which does not call
-                        # advance_next_run. mark_job_run re-anchors next_run_at off
-                        # the actual completion time, so this value is provisional.
-                        for rj in raw_jobs:
-                            if rj["id"] == job["id"]:
-                                rj["next_run_at"] = new_next
-                                needs_save = True
-                                break
-                        # Fall through to due.append(job) — execute once now
+                    else:
+                        new_next = compute_next_run(schedule, now.isoformat())
+                        if new_next:
+                            logger.info(
+                                "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                                "Running now; next run provisionally set to: %s "
+                                "(re-anchored on completion)",
+                                job.get("name", job.get("id", "?")),
+                                next_run,
+                                grace,
+                                new_next,
+                            )
+                            for rj in raw_jobs:
+                                if rj["id"] == job["id"]:
+                                    rj["next_run_at"] = new_next
+                                    needs_save = True
+                                    break
+                    # Fall through to due.append(job) — execute once now.
 
                 # One-shot dispatch-limit guard (issue #38758): a finite one-shot
                 # claimed via claim_dispatch() but whose tick died before

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4,14 +4,17 @@ Cron job scheduler - executes due jobs.
 Provides tick() which checks for due jobs and runs them. The gateway
 calls this every 60 seconds from a background thread.
 
-Uses a file-based lock (~/.hermes/cron/.tick.lock) so only one tick
-runs at a time if multiple processes overlap.
+Uses ``.tick.lock`` to serialize dispatch and per-job OS locks to prevent a
+recurring invocation from overlapping across same-host scheduler processes that
+share the active cron store. This is not a distributed/NFS ownership protocol.
 """
 
 import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import errno
+import hashlib
 import json
 import logging
 import os
@@ -21,16 +24,17 @@ import subprocess
 import sys
 import threading
 import time
+import weakref
 
-# fcntl is Unix-only; on Windows use msvcrt for file locking
+# fcntl is Unix-only; on Windows use msvcrt for file locking.
 try:
     import fcntl
 except ImportError:
     fcntl = None
-    try:
-        import msvcrt
-    except ImportError:
-        msvcrt = None
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -238,7 +242,16 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_cron_store_dir,
+    get_due_jobs,
+    get_job,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -557,6 +570,154 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+_live_job_run_locks: "weakref.WeakSet[_JobRunLock]" = weakref.WeakSet()
+
+
+class _JobRunLockError(RuntimeError):
+    """The recurring-run lock backend failed (distinct from contention)."""
+
+    def __init__(self, job_id: str, lock_path: Path, cause: BaseException) -> None:
+        self.job_id = job_id
+        self.lock_path = lock_path
+        self.cause = cause
+        super().__init__(
+            f"cron job {job_id!r} cannot establish run ownership at "
+            f"{lock_path}: {cause}"
+        )
+
+
+class _JobRunLock:
+    """A held OS advisory lock for one cron job's full execution lifetime.
+
+    The guarantee is intentionally same-host: independent processes addressing
+    the same active cron store contend on the same local lock inode. The lock
+    file deliberately remains after release; only the live descriptor lock is
+    ownership. Network/distributed filesystem lock semantics are not assumed.
+    """
+
+    def __init__(self, lock_fd) -> None:
+        self._lock_fd = lock_fd
+        _live_job_run_locks.add(self)
+
+    def _close_in_fork_child(self) -> None:
+        """Close the inherited descriptor without unlocking the parent's OFD."""
+        lock_fd, self._lock_fd = self._lock_fd, None
+        if lock_fd is None:
+            return
+        try:
+            lock_fd.close()
+        except OSError:
+            pass
+
+    def release(self) -> None:
+        """Release and close the lock. Idempotent for competing cleanup paths."""
+        lock_fd, self._lock_fd = self._lock_fd, None
+        _live_job_run_locks.discard(self)
+        if lock_fd is None:
+            return
+        try:
+            lock_fd.seek(0)
+            if fcntl is not None:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            elif msvcrt is not None:
+                getattr(msvcrt, "locking")(
+                    lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                )
+        except (OSError, IOError):
+            # close() below also releases advisory locks, including during
+            # interpreter teardown when an explicit unlock can fail.
+            pass
+        finally:
+            try:
+                lock_fd.close()
+            except OSError:
+                pass
+
+
+def _close_job_run_locks_after_fork() -> None:
+    """Do not let a bare-fork child prolong scheduler ownership after death."""
+    for run_lock in tuple(_live_job_run_locks):
+        run_lock._close_in_fork_child()
+    _live_job_run_locks.clear()
+
+
+if hasattr(os, "register_at_fork"):  # POSIX only; opened FDs are also exec-safe.
+    os.register_at_fork(after_in_child=_close_job_run_locks_after_fork)
+
+
+def _job_run_lock_path(job_id: str) -> Path:
+    """Return a traversal-safe lock path in the active cron store context."""
+    digest = hashlib.sha256(str(job_id).encode("utf-8", errors="replace")).hexdigest()
+    return get_cron_store_dir() / ".run-locks" / f"{digest}.lock"
+
+
+def _is_job_run_lock_contention(exc: OSError) -> bool:
+    """Return True only for non-blocking lock-loss errno values."""
+    return exc.errno in {errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK}
+
+
+def _try_acquire_job_run_lock(job_id: str) -> Optional[_JobRunLock]:
+    """Try to own one recurring job for its full run without waiting.
+
+    ``None`` means genuine lock contention. Backend, open, permission, and I/O
+    failures raise ``_JobRunLockError`` so callers can fail closed with an
+    actionable, truthful reason instead of claiming another process is running.
+    """
+    lock_path = _job_run_lock_path(job_id)
+    lock_fd = None
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(lock_path.parent, 0o700)
+        except (OSError, NotImplementedError):
+            pass
+
+        # Binary update mode lets Windows lock a real byte. Two creators may
+        # append two bytes before either locks; all contenders still lock byte 0.
+        lock_fd = open(lock_path, "a+b")
+        lock_fd.seek(0, os.SEEK_END)
+        if lock_fd.tell() == 0:
+            lock_fd.write(b"\0")
+            lock_fd.flush()
+        lock_fd.seek(0)
+    except (OSError, IOError) as exc:
+        if lock_fd is not None:
+            try:
+                lock_fd.close()
+            except OSError:
+                pass
+        raise _JobRunLockError(job_id, lock_path, exc) from exc
+
+    try:
+        if fcntl is not None:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:
+            getattr(msvcrt, "locking")(
+                lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+            )
+        else:  # pragma: no cover - supported runtimes provide one backend
+            raise _JobRunLockError(
+                job_id,
+                lock_path,
+                RuntimeError("no supported OS advisory-lock backend is available"),
+            )
+    except (OSError, IOError) as exc:
+        try:
+            lock_fd.close()
+        except OSError:
+            pass
+        if _is_job_run_lock_contention(exc):
+            return None
+        raise _JobRunLockError(job_id, lock_path, exc) from exc
+    except BaseException:
+        try:
+            lock_fd.close()
+        except OSError:
+            pass
+        raise
+    return _JobRunLock(lock_fd)
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -3394,21 +3555,61 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+def run_one_job(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    _run_lock: Optional[_JobRunLock] = None,
+) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
     that BOTH the built-in ticker and an external provider's ``fire_due`` (e.g.
     Chronos) run the identical sequence — no duplicated correctness.
 
-    It does NOT decide whether the job is due, claim it, or compute the next
-    run — those are the caller's concern (``tick`` advances ``next_run_at``
-    under the file lock before dispatch; an external provider claims via the
-    store CAS). This function only fires the given job once.
+    Built-in and external schedulers acquire recurring-job ownership before
+    advancing/claiming schedule state and pass it through the private
+    ``_run_lock`` argument. Direct/manual callers acquire here instead.
+    One-shots retain their existing durable ``run_claim`` semantics.
 
     Returns True if the job was processed (even if the job itself failed —
-    failure is recorded via ``mark_job_run``), False only if processing raised.
+    failure is recorded via ``mark_job_run``), False if processing raised or a
+    different process already owns this recurring job's run.
     """
+    schedule = job.get("schedule")
+    schedule_kind = schedule.get("kind") if isinstance(schedule, dict) else None
+    if _run_lock is None and schedule_kind in {"cron", "interval"}:
+        try:
+            _run_lock = _try_acquire_job_run_lock(job["id"])
+        except _JobRunLockError as exc:
+            logger.error(
+                "Job '%s' not dispatched: %s; refusing this recurring run "
+                "because same-host ownership cannot be verified",
+                job.get("name", job["id"]),
+                exc,
+            )
+            return False
+        if _run_lock is None:
+            logger.info(
+                "Job '%s' already running in another same-host process using "
+                "cron store %s — skipping",
+                job.get("name", job["id"]),
+                get_cron_store_dir(),
+            )
+            return False
+    try:
+        return _run_one_job_owned(
+            job, adapters=adapters, loop=loop, verbose=verbose
+        )
+    finally:
+        if _run_lock is not None:
+            _run_lock.release()
+
+
+def _run_one_job_owned(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+    """Execute ``job`` after any required full-run ownership is established."""
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -3590,7 +3791,9 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         return 0
 
     try:
-        due_jobs = get_due_jobs()
+        # A due scan may identify a stale recurring slot, but must not advance
+        # that slot before this process owns the per-job full-run lock.
+        due_jobs = get_due_jobs(defer_recurring_advance=True)
 
         if verbose and not due_jobs:
             logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
@@ -3598,14 +3801,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
-
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        # For parallel jobs that are already running, advance_next_run keeps
-        # bumping next_run_at forward so the grace window never expires.
-        # mark_job_run() overwrites next_run_at on completion.
-        for job in due_jobs:
-            advance_next_run(job["id"])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -3634,12 +3829,18 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 _max_workers if _max_workers else "unbounded",
             )
 
-        def _process_job(job: dict) -> bool:
+        def _process_job(job: dict, run_lock: Optional[_JobRunLock]) -> bool:
             """Run one due job end-to-end. Thin wrapper around the shared
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            return run_one_job(
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+                _run_lock=run_lock,
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
@@ -3677,11 +3878,107 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     logger.info("Job '%s' already running — skipping", job.get("name", job_id))
                     return None
                 _running_job_ids.add(job_id)
+
+            # The process-local set above protects sibling threads. Recurring
+            # jobs also need OS-backed ownership across gateway/desktop/daemon
+            # processes for the ENTIRE run. Acquire before advance_next_run so
+            # a losing contender changes neither side effects nor schedule.
+            schedule = job.get("schedule")
+            schedule_kind = schedule.get("kind") if isinstance(schedule, dict) else None
+            run_lock: Optional[_JobRunLock] = None
+            if schedule_kind in {"cron", "interval"}:
+                try:
+                    run_lock = _try_acquire_job_run_lock(job_id)
+                except _JobRunLockError as exc:
+                    with _running_lock:
+                        _running_job_ids.discard(job_id)
+                    logger.error(
+                        "Job '%s' not dispatched: %s; refusing this recurring run "
+                        "because same-host ownership cannot be verified",
+                        job.get("name", job_id),
+                        exc,
+                    )
+                    return None
+                if run_lock is None:
+                    with _running_lock:
+                        _running_job_ids.discard(job_id)
+                    logger.info(
+                        "Job '%s' already running in another same-host process "
+                        "using cron store %s — skipping",
+                        job.get("name", job_id),
+                        get_cron_store_dir(),
+                    )
+                    return None
+
+            try:
+                # Crash safety for recurring jobs: once THIS process owns the
+                # full run, advance before submitting the side effect. A False
+                # result means this stale due snapshot did not transition the
+                # active store, so revalidate for diagnostics and never dispatch.
+                if schedule_kind in {"cron", "interval"}:
+                    assert run_lock is not None
+                    if not advance_next_run(
+                        job_id,
+                        expected_next_run_at=job.get("next_run_at"),
+                        expected_schedule_kind=schedule_kind,
+                    ):
+                        current_job = get_job(job_id)
+                        if current_job is None:
+                            reason = "job no longer exists in the active cron store"
+                        elif (
+                            not current_job.get("enabled", True)
+                            or current_job.get("state") == "paused"
+                        ):
+                            reason = "job is now disabled or paused"
+                        elif current_job.get("schedule", {}).get("kind") != schedule_kind:
+                            reason = "schedule kind changed while the tick was dispatching"
+                        elif current_job.get("next_run_at") != job.get("next_run_at"):
+                            reason = "schedule state changed while the tick was dispatching"
+                        else:
+                            reason = "the recurring schedule could not be advanced"
+                        logger.warning(
+                            "Job '%s' not dispatched after run-lock acquisition: %s",
+                            job.get("name", job_id),
+                            reason,
+                        )
+                        run_lock.release()
+                        with _running_lock:
+                            _running_job_ids.discard(job_id)
+                        return None
+
+                    # The compare-and-set above claims the scheduled slot, not
+                    # the whole job snapshot. Re-read from the active store so
+                    # prompt/script/delivery edits made during the due scan are
+                    # honored, and fail closed if the record changed category.
+                    current_job = get_job(job_id)
+                    if (
+                        current_job is None
+                        or not current_job.get("enabled", True)
+                        or current_job.get("state") == "paused"
+                        or current_job.get("schedule", {}).get("kind")
+                        != schedule_kind
+                    ):
+                        logger.warning(
+                            "Job '%s' not dispatched after schedule advancement: "
+                            "the active record failed revalidation",
+                            job.get("name", job_id),
+                        )
+                        run_lock.release()
+                        with _running_lock:
+                            _running_job_ids.discard(job_id)
+                        return None
+                    job = current_job
+            except BaseException:
+                if run_lock is not None:
+                    run_lock.release()
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
+                raise
             _ctx = contextvars.copy_context()
 
-            def _run_and_release(j=job, ctx=_ctx):
+            def _run_and_release(j=job, ctx=_ctx, owned_lock=run_lock):
                 try:
-                    return ctx.run(_process_job, j)
+                    return ctx.run(_process_job, j, owned_lock)
                 finally:
                     with _running_lock:
                         _running_job_ids.discard(j["id"])
@@ -3689,16 +3986,24 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             try:
                 return pool.submit(_run_and_release)
             except RuntimeError as submit_err:
-                # Interpreter began finalizing between the guard above and the
-                # submit — release the in-flight claim we just took and skip.
+                # Submission failed after ownership was established. Release
+                # both guards so a later healthy tick can recover.
+                if run_lock is not None:
+                    run_lock.release()
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
                 if _interpreter_shutting_down(submit_err):
-                    with _running_lock:
-                        _running_job_ids.discard(job_id)
                     logger.warning(
                         "Job '%s' not dispatched — interpreter is shutting down",
                         job.get("name", job_id),
                     )
                     return None
+                raise
+            except BaseException:
+                if run_lock is not None:
+                    run_lock.release()
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
                 raise
 
         # Sequential pass for env-mutating (workdir) jobs.

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,9 +19,13 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
+import logging
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class CronScheduler(ABC):
@@ -86,23 +90,71 @@ class CronScheduler(ABC):
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
 
-        The default claims the job with a store-level compare-and-set
-        (multi-machine at-most-once), then runs it via the shared
-        ``run_one_job`` body. Built-in never calls this (it has its own tick
-        loop); an external provider routes its inbound fire here.
+        The default uses the store compare-and-set to de-duplicate normal
+        external retries, then runs through the shared ``run_one_job`` body.
+        Recurring jobs first take same-host full-run ownership in the active
+        cron store. The store claim expires after 300 seconds and is not a
+        renewable distributed full-run lease (see the Chronos contract).
 
         Returns True if THIS caller claimed and ran the job, False if the claim
         was lost (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
-        from cron.scheduler import run_one_job
+        from cron.jobs import claim_job_for_fire, get_cron_store_dir, get_job
+        from cron.scheduler import (
+            _JobRunLockError,
+            _try_acquire_job_run_lock,
+            run_one_job,
+        )
 
-        if not claim_job_for_fire(job_id):
-            return False  # another machine already claimed this fire
+        # Inspect first so external one-shots retain their durable store-claim
+        # path without depending on the recurring local-lock backend.
         job = get_job(job_id)
         if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        return run_one_job(job, adapters=adapters, loop=loop)
+            return False
+        schedule = job.get("schedule")
+        schedule_kind = schedule.get("kind") if isinstance(schedule, dict) else None
+
+        run_lock = None
+        if schedule_kind in {"cron", "interval"}:
+            # This lock is same-host ownership for processes sharing the active
+            # cron store. The fire_claim CAS still de-dupes normal external
+            # retries, but it is a 300s expiring claim, not a distributed
+            # full-run lease; see docs/chronos-managed-cron-contract.md.
+            try:
+                run_lock = _try_acquire_job_run_lock(job_id)
+            except _JobRunLockError as exc:
+                logger.error(
+                    "External fire for recurring job '%s' refused: %s; "
+                    "same-host ownership cannot be verified",
+                    job_id,
+                    exc,
+                )
+                return False
+            if run_lock is None:
+                logger.info(
+                    "External fire for recurring job '%s' skipped: another "
+                    "same-host process owns it in cron store %s",
+                    job_id,
+                    get_cron_store_dir(),
+                )
+                return False
+
+        try:
+            if not claim_job_for_fire(
+                job_id, expected_schedule_kind=schedule_kind
+            ):
+                return False
+            claimed_job = get_job(job_id)
+            if claimed_job is None:
+                return False
+            return run_one_job(
+                claimed_job, adapters=adapters, loop=loop, _run_lock=run_lock
+            )
+        finally:
+            if run_lock is not None:
+                # run_one_job also releases after delivery/mark. Idempotence
+                # covers claim/get failures before the run body starts.
+                run_lock.release()
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):

--- a/docs/chronos-managed-cron-contract.md
+++ b/docs/chronos-managed-cron-contract.md
@@ -150,27 +150,36 @@ callback through to the verifier. (Also registered on the optional
   - valid → **202 `{"status": "accepted", "job_id": "..."}`** immediately, and
     the job runs in the background. 202-before-run means a long agent turn never
     trips the relay's HTTP timeout.
-- **At-most-once:** the agent claims the job with a store-level compare-and-set
-  (`claim_job_for_fire`) before running. A relay/scheduler retry that arrives
-  while the first fire is in flight (or after it completed) loses the claim and
-  does not double-run.
+- **Retry de-duplication / ownership scope:** `claim_job_for_fire` is a
+  store-level compare-and-set with a 300-second stale-recovery TTL. It de-dupes
+  ordinary relay retries. Recurring runs additionally hold a full-lifetime
+  advisory lock against the active cron store, but that lock guarantees
+  exclusion only for same-host processes sharing that store on a filesystem
+  with normal local lock semantics. It is **not** a distributed lease: a run
+  longer than 300 seconds can overlap a reclaimed fire on another host, and no
+  full-run guarantee is made for NFS/SMB advisory locking.
 
 ---
 
-## At-most-once & re-arm semantics
+## Claim, ownership & re-arm semantics
 
-- **Recurring (cron/interval):** on fire, the agent advances `next_run_at`
-  (under its store lock) as part of the claim, runs the job, then re-provisions
-  a one-shot for the new `next_run_at`. A duplicate relay for the old `fire_at`
-  finds the claim taken / time advanced and is dropped.
+- **Recurring (cron/interval):** on fire, the agent first takes the same-host
+  per-job advisory lock, then advances `next_run_at` under the store claim, runs
+  through delivery and completion marking, and finally re-provisions a one-shot
+  for the new `next_run_at`. A duplicate relay inside the 300-second claim TTL
+  is dropped. The local lock prevents overlap for same-host processes sharing
+  the active store even when a run exceeds that TTL; it does not extend the TTL
+  into a distributed full-run lease across hosts.
 - **One-shot (`30m`, `+90s`, etc.):** fires once; `mark_job_run` marks it
   completed. No re-arm.
 - **`repeat.times = N`:** `mark_job_run` deletes the job at the limit, so
   `get_job` returns `None` after the final fire → the agent does **not** re-arm
   → the schedule stops cleanly with no orphaned one-shot.
-- **Multi-replica agents:** the store CAS makes the fire at-most-once across N
-  gateway replicas sharing one `HERMES_HOME` — exactly one replica runs each
-  fire.
+- **Multi-replica agents:** the store CAS de-dupes retries while its
+  300-second `fire_claim` is fresh. Same-host replicas sharing the active cron
+  store also get full-run recurring exclusion from the per-job advisory lock.
+  Cross-host full-run exclusion is not provided; deployments that need it must
+  add a renewable distributed lease in the external scheduler/store layer.
 
 ## Reconcile (self-healing)
 

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -1,8 +1,8 @@
 """Tests for the store-level CAS fire claim (Phase 4C).
 
-`claim_job_for_fire` gives multi-machine at-most-once semantics when an external
-scheduler (Chronos) fires a job: across N gateway replicas, exactly ONE wins the
-claim for a given fire. Single-machine deployments always win (unaffected).
+`claim_job_for_fire` gives bounded retry de-duplication when an external
+scheduler (Chronos) fires a job: one gateway replica wins while the expiring
+store claim remains fresh. It is not a renewable distributed full-run lease.
 
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -212,7 +212,7 @@ class TestTickWorkdirPartition:
         workdir_b = {"id": "b", "name": "B", "workdir": str(tmp_path)}
         parallel_job = {"id": "c", "name": "C", "workdir": None}
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_a, workdir_b, parallel_job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [workdir_a, workdir_b, parallel_job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
 
         # Record call order / thread context.

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -82,7 +82,7 @@ class TestRunningJobGuard:
         sched._running_job_ids.add("guard-job")
 
         dispatched = []
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
@@ -115,7 +115,7 @@ class TestSyncMode:
             for i in range(3)
         ]
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: jobs)
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
@@ -151,7 +151,7 @@ class TestSyncMode:
             barrier.wait()  # blocks until test thread also waits
             return True, "out", "resp", None
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
@@ -205,7 +205,7 @@ class TestSequentialPool:
             barrier.wait()
             return True, "out", "resp", None
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
@@ -247,7 +247,7 @@ class TestSequentialPool:
         sched._running_job_ids.add("guard-seq")
 
         dispatched = []
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)

--- a/tests/cron/test_recurring_run_lock.py
+++ b/tests/cron/test_recurring_run_lock.py
@@ -192,6 +192,152 @@ def test_two_scheduler_processes_cannot_overlap_one_recurring_run(tmp_path):
     jobs.fcntl is None and jobs.msvcrt is None,
     reason="platform has no supported advisory file-lock backend",
 )
+def test_losing_immediate_runner_does_not_advance_or_execute(tmp_path):
+    """cronjob(action='run') must own a recurrence before its store claim."""
+    hermes_home = tmp_path / "hermes-home"
+    cron_dir = hermes_home / "cron"
+    scripts_dir = hermes_home / "scripts"
+    cron_dir.mkdir(parents=True)
+    scripts_dir.mkdir(parents=True)
+
+    side_effects = tmp_path / "immediate-side-effects.txt"
+    owner_ready = tmp_path / "immediate-owner-ready"
+    release_owner = tmp_path / "immediate-owner-release"
+    owner_result = tmp_path / "immediate-owner-result.json"
+    script = scripts_dir / "blocking-immediate.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import os
+            import time
+
+            effects = Path({str(side_effects)!r})
+            with effects.open("a", encoding="utf-8") as stream:
+                stream.write(str(os.getpid()) + "\\n")
+                stream.flush()
+            Path({str(owner_ready)!r}).write_text("ready", encoding="utf-8")
+            deadline = time.monotonic() + 20
+            while not Path({str(release_owner)!r}).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("test did not release immediate owner")
+                time.sleep(0.02)
+            print("completed")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    job_id = "immediate-run-lock-regression"
+    job = {
+        "id": job_id,
+        "name": "immediate run lock regression",
+        "prompt": "",
+        "script": script.name,
+        "no_agent": True,
+        "schedule": {"kind": "interval", "minutes": 1},
+        "schedule_display": "every 1m",
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "next_run_at": datetime.now(timezone.utc).isoformat(),
+        "last_run_at": None,
+        "last_status": None,
+        "last_error": None,
+        "deliver": "local",
+    }
+    with jobs.use_cron_store(hermes_home):
+        jobs.save_jobs([job])
+
+    owner_program = tmp_path / "immediate-owner.py"
+    owner_program.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            from pathlib import Path
+            from tools.cronjob_tools import cronjob
+
+            result = json.loads(cronjob(action="run", job_id={job_id!r}))
+            Path({str(owner_result)!r}).write_text(json.dumps(result), encoding="utf-8")
+            job_result = result["job"]
+            raise SystemExit(
+                0 if job_result["executed"] and job_result["execution_success"] else 3
+            )
+            """
+        ),
+        encoding="utf-8",
+    )
+    contender_program = tmp_path / "immediate-contender.py"
+    contender_program.write_text(
+        textwrap.dedent(
+            f"""
+            from tools.cronjob_tools import cronjob
+
+            print(cronjob(action="run", job_id={job_id!r}))
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    owner = subprocess.Popen(
+        [sys.executable, str(owner_program)], env=_child_env(hermes_home)
+    )
+    try:
+        _wait_for(owner_ready.exists, message="immediate owner never entered its script")
+        assert _side_effect_count(side_effects) == 1
+
+        # Let a second immediate invocation reclaim the bounded fire claim while
+        # the first invocation still owns the full-run lock. The loser must be
+        # rejected before claim_job_for_fire can advance this forced-due slot.
+        forced_due = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        with jobs.use_cron_store(hermes_home):
+            stored = jobs.load_jobs()
+            stored[0]["fire_claim"]["at"] = (
+                datetime.now(timezone.utc) - timedelta(seconds=301)
+            ).isoformat()
+            stored[0]["next_run_at"] = forced_due
+            jobs.save_jobs(stored)
+            before = jobs.get_job(job_id)
+        assert before is not None
+
+        contender = subprocess.run(
+            [sys.executable, str(contender_program)],
+            env=_child_env(hermes_home),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert contender.returncode == 0, contender.stderr
+        contender_result = json.loads(contender.stdout.strip())
+        assert contender_result["success"] is True
+        assert contender_result["job"]["executed"] is False
+        assert contender_result["job"]["execution_success"] is False
+        assert _side_effect_count(side_effects) == 1
+
+        with jobs.use_cron_store(hermes_home):
+            after = jobs.get_job(job_id)
+        assert after is not None
+        assert after["next_run_at"] == forced_due
+        assert after["fire_claim"] == before["fire_claim"]
+
+        release_owner.touch()
+        owner.wait(timeout=15)
+        assert owner.returncode == 0
+        completed_result = json.loads(owner_result.read_text(encoding="utf-8"))
+        assert completed_result["job"]["execution_success"] is True
+        assert _side_effect_count(side_effects) == 1
+    finally:
+        release_owner.touch()
+        if owner.poll() is None:
+            owner.kill()
+        owner.wait(timeout=10)
+
+
+@pytest.mark.skipif(
+    jobs.fcntl is None and jobs.msvcrt is None,
+    reason="platform has no supported advisory file-lock backend",
+)
 def test_job_run_lock_is_released_when_owner_process_dies(tmp_path, monkeypatch):
     """The OS, not a stale timestamp, must recover ownership after a crash."""
     from cron import scheduler

--- a/tests/cron/test_recurring_run_lock.py
+++ b/tests/cron/test_recurring_run_lock.py
@@ -1,0 +1,901 @@
+"""Cross-process full-lifetime ownership for cron job executions."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron import jobs
+
+
+_REPO_ROOT = str(Path(jobs.__file__).resolve().parent.parent)
+
+
+def _child_env(hermes_home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (_REPO_ROOT, env.get("PYTHONPATH", "")) if part
+    )
+    return env
+
+
+def _wait_for(predicate, *, timeout: float = 10.0, message: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError(message)
+
+
+def _side_effect_count(path: Path) -> int:
+    try:
+        return len(path.read_text(encoding="utf-8").splitlines())
+    except FileNotFoundError:
+        return 0
+
+
+def test_two_scheduler_processes_cannot_overlap_one_recurring_run(tmp_path):
+    """A later due slot must not run or advance while its prior run is alive."""
+    hermes_home = tmp_path / "hermes-home"
+    cron_dir = hermes_home / "cron"
+    scripts_dir = hermes_home / "scripts"
+    cron_dir.mkdir(parents=True)
+    scripts_dir.mkdir(parents=True)
+
+    side_effects = tmp_path / "side-effects.txt"
+    script_ready = tmp_path / "script-ready"
+    release_script = tmp_path / "release-script"
+    script = scripts_dir / "blocking.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import os
+            import time
+
+            effects = Path({str(side_effects)!r})
+            with effects.open("a", encoding="utf-8") as stream:
+                stream.write(str(os.getpid()) + "\\n")
+                stream.flush()
+            Path({str(script_ready)!r}).write_text("ready", encoding="utf-8")
+            deadline = time.monotonic() + 20
+            while not Path({str(release_script)!r}).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("test did not release blocking cron script")
+                time.sleep(0.02)
+            print("completed")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    now = datetime.now(timezone.utc)
+    job = {
+        "id": "recurring-lock-regression",
+        "name": "recurring lock regression",
+        "prompt": "",
+        "script": script.name,
+        "no_agent": True,
+        "schedule": {"kind": "interval", "minutes": 1},
+        "schedule_display": "every 1m",
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "next_run_at": (now - timedelta(seconds=1)).isoformat(),
+        "last_run_at": None,
+        "last_status": None,
+        "last_error": None,
+        "deliver": "local",
+    }
+    with jobs.use_cron_store(hermes_home):
+        jobs.save_jobs([job])
+
+    owner_started = tmp_path / "owner-started"
+    owner_done = tmp_path / "owner-done"
+    owner_program = tmp_path / "owner.py"
+    owner_program.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import time
+            from cron.scheduler import get_running_job_ids, tick
+
+            result = tick(verbose=False, sync=False)
+            Path({str(owner_started)!r}).write_text(str(result), encoding="utf-8")
+            deadline = time.monotonic() + 25
+            while get_running_job_ids():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("cron worker did not finish")
+                time.sleep(0.02)
+            Path({str(owner_done)!r}).write_text("done", encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+    contender_program = tmp_path / "contender.py"
+    contender_program.write_text(
+        "from cron.scheduler import tick\nraise SystemExit(0 if tick(verbose=False, sync=True) == 0 else 3)\n",
+        encoding="utf-8",
+    )
+
+    owner = subprocess.Popen(
+        [sys.executable, str(owner_program)], env=_child_env(hermes_home)
+    )
+    contender = None
+    try:
+        _wait_for(
+            script_ready.exists,
+            message="first scheduler never began the recurring side effect",
+        )
+        assert _side_effect_count(side_effects) == 1
+
+        # Simulate the next recurrence becoming due before the first invocation
+        # has finished. A second scheduler process can acquire .tick.lock now
+        # because the async first tick released that dispatch-only lock.
+        forced_due = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        with jobs.use_cron_store(hermes_home):
+            stored = jobs.load_jobs()
+            assert stored[0]["next_run_at"] > now.isoformat()
+            stored[0]["next_run_at"] = forced_due
+            jobs.save_jobs(stored)
+
+        contender = subprocess.Popen(
+            [sys.executable, str(contender_program)], env=_child_env(hermes_home)
+        )
+        _wait_for(
+            lambda: contender.poll() is not None or _side_effect_count(side_effects) > 1,
+            timeout=5,
+            message="contending scheduler neither exited nor attempted a duplicate run",
+        )
+
+        assert contender.poll() == 0, "contender dispatched the already-running job"
+        assert _side_effect_count(side_effects) == 1
+        with jobs.use_cron_store(hermes_home):
+            # Losing ownership must happen before advance_next_run().
+            contended_job = jobs.get_job(job["id"])
+            assert contended_job is not None
+            assert contended_job["next_run_at"] == forced_due
+
+        release_script.write_text("release", encoding="utf-8")
+        owner.wait(timeout=15)
+        assert owner.returncode == 0
+        assert owner_done.exists()
+        assert _side_effect_count(side_effects) == 1
+
+        with jobs.use_cron_store(hermes_home):
+            completed = jobs.get_job(job["id"])
+        assert completed is not None
+        assert completed["repeat"]["completed"] == 1
+        assert completed["last_status"] == "ok"
+        assert datetime.fromisoformat(completed["next_run_at"]) > datetime.now(timezone.utc)
+    finally:
+        release_script.touch()
+        for child in (contender, owner):
+            if child is not None and child.poll() is None:
+                child.kill()
+            if child is not None:
+                child.wait(timeout=10)
+
+
+@pytest.mark.skipif(
+    jobs.fcntl is None and jobs.msvcrt is None,
+    reason="platform has no supported advisory file-lock backend",
+)
+def test_job_run_lock_is_released_when_owner_process_dies(tmp_path, monkeypatch):
+    """The OS, not a stale timestamp, must recover ownership after a crash."""
+    from cron import scheduler
+
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setattr(scheduler, "_hermes_home", hermes_home)
+    ready = tmp_path / "lock-ready"
+    holder = tmp_path / "lock-holder.py"
+    holder.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import time
+            from cron.scheduler import _try_acquire_job_run_lock
+
+            lock = _try_acquire_job_run_lock("crash-release-job")
+            if lock is None:
+                raise SystemExit(2)
+            Path({str(ready)!r}).write_text("ready", encoding="utf-8")
+            time.sleep(60)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    child = subprocess.Popen(
+        [sys.executable, str(holder)], env=_child_env(hermes_home)
+    )
+    lock = None
+    try:
+        _wait_for(ready.exists, message="child never acquired the job run lock")
+        with jobs.use_cron_store(hermes_home):
+            assert scheduler._try_acquire_job_run_lock("crash-release-job") is None
+
+        child.kill()
+        child.wait(timeout=10)
+
+        deadline = time.monotonic() + 5
+        while lock is None and time.monotonic() < deadline:
+            with jobs.use_cron_store(hermes_home):
+                lock = scheduler._try_acquire_job_run_lock("crash-release-job")
+            if lock is None:
+                time.sleep(0.02)
+        assert lock is not None, "OS did not release the job lock after owner death"
+    finally:
+        if lock is not None:
+            lock.release()
+        if child.poll() is None:
+            child.kill()
+        child.wait(timeout=10)
+
+
+def test_direct_recurring_run_owns_lock_until_body_returns(monkeypatch):
+    """Manual/direct callers get the same full-lifetime ownership as tick()."""
+    from cron import scheduler
+
+    events: list[str] = []
+
+    class RecordingLock:
+        def release(self):
+            events.append("release")
+
+    monkeypatch.setattr(
+        scheduler,
+        "_try_acquire_job_run_lock",
+        lambda job_id: events.append(f"acquire:{job_id}") or RecordingLock(),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_run_one_job_owned",
+        lambda job, **kwargs: events.append("body") or True,
+    )
+
+    assert scheduler.run_one_job(
+        {"id": "manual-recurring", "schedule": {"kind": "interval"}}
+    ) is True
+    assert events == ["acquire:manual-recurring", "body", "release"]
+
+
+def test_run_lock_releases_on_base_exception(monkeypatch):
+    """KeyboardInterrupt/SystemExit paths cannot leak ownership until process exit."""
+    from cron import scheduler
+
+    released: list[bool] = []
+
+    class RecordingLock(scheduler._JobRunLock):
+        def __init__(self):
+            pass
+
+        def release(self):
+            released.append(True)
+
+    def interrupt(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(scheduler, "_run_one_job_owned", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        scheduler.run_one_job(
+            {"id": "interrupted", "schedule": {"kind": "cron"}},
+            _run_lock=RecordingLock(),
+        )
+    assert released == [True]
+
+
+def test_run_lock_is_held_through_delivery_mark_and_teardown(monkeypatch):
+    """Ownership covers every observable and cleanup phase of the run body."""
+    from agent import secret_scope
+    from cron import scheduler
+
+    events: list[str] = []
+
+    class RecordingLock(scheduler._JobRunLock):
+        released = False
+
+        def __init__(self):
+            pass
+
+        def release(self):
+            self.released = True
+            events.append("release")
+
+    run_lock = RecordingLock()
+
+    def still_owned(event):
+        assert run_lock.released is False
+        events.append(event)
+
+    def fake_run_job(_job, *, defer_agent_teardown):
+        still_owned("execute")
+        defer_agent_teardown.append(object())
+        return True, "output", "final response", None
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", lambda _home: None)
+    monkeypatch.setattr(secret_scope, "set_secret_scope", lambda _scope: object())
+    monkeypatch.setattr(secret_scope, "reset_secret_scope", lambda _token: None)
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(
+        scheduler, "save_job_output", lambda *_args: still_owned("save") or "output.md"
+    )
+    monkeypatch.setattr(
+        scheduler, "_deliver_result", lambda *_args, **_kwargs: still_owned("deliver")
+    )
+    monkeypatch.setattr(
+        scheduler, "_teardown_cron_agent", lambda *_args: still_owned("teardown")
+    )
+    monkeypatch.setattr(
+        scheduler, "mark_job_run", lambda *_args, **_kwargs: still_owned("mark")
+    )
+
+    assert scheduler.run_one_job(
+        {"id": "lifecycle", "schedule": {"kind": "interval"}},
+        _run_lock=run_lock,
+    ) is True
+    assert events == ["execute", "save", "deliver", "teardown", "mark", "release"]
+
+
+def test_one_shot_keeps_existing_run_claim_path(monkeypatch):
+    """One-shots must not be routed away from their durable run_claim semantics."""
+    from cron import scheduler
+
+    monkeypatch.setattr(
+        scheduler,
+        "_try_acquire_job_run_lock",
+        lambda job_id: pytest.fail("one-shot unexpectedly acquired recurring run lock"),
+    )
+    monkeypatch.setattr(scheduler, "_run_one_job_owned", lambda job, **kwargs: True)
+
+    assert scheduler.run_one_job(
+        {"id": "one-shot", "schedule": {"kind": "once"}}
+    ) is True
+
+
+def test_run_lock_isolated_by_active_cron_store(tmp_path):
+    """Equal job IDs in separate profile stores must not block one another."""
+    from cron import scheduler
+
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    with jobs.use_cron_store(profile_a):
+        path_a = scheduler._job_run_lock_path("shared-id")
+        lock_a = scheduler._try_acquire_job_run_lock("shared-id")
+    assert lock_a is not None
+    lock_b = None
+    try:
+        with jobs.use_cron_store(profile_b):
+            path_b = scheduler._job_run_lock_path("shared-id")
+            lock_b = scheduler._try_acquire_job_run_lock("shared-id")
+        assert lock_b is not None
+        assert path_a.parent.parent == profile_a.resolve() / "cron"
+        assert path_b.parent.parent == profile_b.resolve() / "cron"
+        assert path_a != path_b
+    finally:
+        lock_a.release()
+        if lock_b is not None:
+            lock_b.release()
+
+
+def test_run_lock_follows_store_not_process_home(tmp_path, monkeypatch):
+    """Different runtime homes still contend when they address one cron store."""
+    from cron import scheduler
+
+    shared_store_home = tmp_path / "shared-store"
+    with jobs.use_cron_store(shared_store_home):
+        monkeypatch.setattr(scheduler, "_hermes_home", tmp_path / "process-a")
+        path_a = scheduler._job_run_lock_path("same-job")
+        lock_a = scheduler._try_acquire_job_run_lock("same-job")
+        assert lock_a is not None
+        try:
+            monkeypatch.setattr(scheduler, "_hermes_home", tmp_path / "process-b")
+            path_b = scheduler._job_run_lock_path("same-job")
+            assert path_b == path_a
+            assert scheduler._try_acquire_job_run_lock("same-job") is None
+        finally:
+            lock_a.release()
+
+
+def test_different_process_homes_contend_on_same_active_store(tmp_path):
+    """Real processes derive ownership from store context, not HERMES_HOME."""
+    shared_store = tmp_path / "shared-store"
+    ready = tmp_path / "holder-ready"
+    holder = tmp_path / "store-lock-holder.py"
+    holder.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import time
+            from cron import jobs
+            from cron.scheduler import _try_acquire_job_run_lock
+
+            with jobs.use_cron_store({str(shared_store)!r}):
+                lock = _try_acquire_job_run_lock("shared-process-job")
+                if lock is None:
+                    raise SystemExit(2)
+                Path({str(ready)!r}).write_text("ready", encoding="utf-8")
+                time.sleep(30)
+            """
+        ),
+        encoding="utf-8",
+    )
+    contender = tmp_path / "store-lock-contender.py"
+    contender.write_text(
+        textwrap.dedent(
+            f"""
+            from cron import jobs
+            from cron.scheduler import _try_acquire_job_run_lock
+
+            with jobs.use_cron_store({str(shared_store)!r}):
+                lock = _try_acquire_job_run_lock("shared-process-job")
+            raise SystemExit(0 if lock is None else 3)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    owner = subprocess.Popen(
+        [sys.executable, str(holder)], env=_child_env(tmp_path / "process-home-a")
+    )
+    try:
+        _wait_for(ready.exists, message="first process never acquired shared-store lock")
+        result = subprocess.run(
+            [sys.executable, str(contender)],
+            env=_child_env(tmp_path / "process-home-b"),
+            timeout=10,
+            check=False,
+        )
+        assert result.returncode == 0
+    finally:
+        if owner.poll() is None:
+            owner.kill()
+        owner.wait(timeout=10)
+
+
+def test_lock_backend_error_is_not_reported_as_contention(tmp_path, monkeypatch):
+    """Open/permission failures carry a truthful fail-closed reason."""
+    from cron import scheduler
+
+    lock_path = tmp_path / "profile" / "cron" / ".run-locks" / "fake.lock"
+    monkeypatch.setattr(scheduler, "_job_run_lock_path", lambda _job_id: lock_path)
+
+    def deny_open(*_args, **_kwargs):
+        raise PermissionError(errno.EACCES, "permission denied", str(lock_path))
+
+    monkeypatch.setattr(scheduler, "open", deny_open, raising=False)
+    with pytest.raises(scheduler._JobRunLockError) as exc_info:
+        scheduler._try_acquire_job_run_lock("permission-job")
+    message = str(exc_info.value)
+    assert "permission denied" in message.lower()
+    assert str(lock_path) in message
+
+
+def test_direct_run_logs_backend_failure_and_does_not_dispatch(monkeypatch, caplog):
+    """Fail closed on lock errors, but never call the failure 'already running'."""
+    from cron import scheduler
+
+    error = scheduler._JobRunLockError(
+        "backend-job", Path("/blocked/run.lock"), PermissionError("denied")
+    )
+
+    def raise_lock_error(_job_id):
+        raise error
+
+    monkeypatch.setattr(scheduler, "_try_acquire_job_run_lock", raise_lock_error)
+    monkeypatch.setattr(
+        scheduler,
+        "_run_one_job_owned",
+        lambda *_args, **_kwargs: pytest.fail("lock failure dispatched the job"),
+    )
+
+    with caplog.at_level("ERROR"):
+        assert scheduler.run_one_job(
+            {"id": "backend-job", "schedule": {"kind": "interval"}}
+        ) is False
+    assert "/blocked/run.lock" in caplog.text
+    assert "refusing" in caplog.text.lower()
+    assert "already running" not in caplog.text.lower()
+
+
+def test_failed_schedule_advance_revalidates_and_skips_stale_snapshot(
+    tmp_path, monkeypatch, caplog
+):
+    """Ownership without a successful state transition is not a dispatch claim."""
+    from cron import scheduler
+
+    released: list[bool] = []
+
+    class RecordingLock:
+        def release(self):
+            released.append(True)
+
+    job = {
+        "id": "removed-during-advance",
+        "name": "removed during advance",
+        "schedule": {"kind": "interval", "minutes": 1},
+    }
+    monkeypatch.setattr(scheduler, "_hermes_home", tmp_path)
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda **_kwargs: [job])
+    monkeypatch.setattr(
+        scheduler, "_try_acquire_job_run_lock", lambda _job_id: RecordingLock()
+    )
+    monkeypatch.setattr(
+        scheduler, "advance_next_run", lambda _job_id, **_kwargs: False
+    )
+    monkeypatch.setattr(scheduler, "get_job", lambda _job_id: None, raising=False)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_args, **_kwargs: pytest.fail("stale snapshot was dispatched"),
+    )
+
+    with caplog.at_level("WARNING"):
+        assert scheduler.tick(verbose=False, sync=True) == 0
+    assert released == [True]
+    assert "no longer exists" in caplog.text.lower()
+
+
+def test_successful_advance_dispatches_revalidated_active_snapshot(
+    tmp_path, monkeypatch
+):
+    """Edits made after the due scan replace, rather than trail, its snapshot."""
+    from cron import scheduler
+
+    released: list[bool] = []
+    dispatched: list[dict] = []
+
+    class RecordingLock:
+        def release(self):
+            released.append(True)
+
+    stale = {
+        "id": "edited-during-advance",
+        "name": "old name",
+        "prompt": "old prompt",
+        "schedule": {"kind": "interval", "minutes": 1},
+        "next_run_at": "2026-07-11T00:00:00+00:00",
+    }
+    current = {**stale, "name": "new name", "prompt": "new prompt"}
+    monkeypatch.setattr(scheduler, "_hermes_home", tmp_path)
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda **_kwargs: [stale])
+    monkeypatch.setattr(
+        scheduler, "_try_acquire_job_run_lock", lambda _job_id: RecordingLock()
+    )
+    monkeypatch.setattr(
+        scheduler, "advance_next_run", lambda _job_id, **_kwargs: True
+    )
+    monkeypatch.setattr(scheduler, "get_job", lambda _job_id: current)
+
+    def fake_run(job, **kwargs):
+        dispatched.append(job)
+        kwargs["_run_lock"].release()
+        return True
+
+    monkeypatch.setattr(scheduler, "run_one_job", fake_run)
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert dispatched == [current]
+    assert released == [True]
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_forked_child_does_not_inherit_run_ownership(tmp_path):
+    """A bare-fork child must not prolong a dead scheduler's lock lifetime."""
+    from cron import scheduler
+
+    hermes_home = tmp_path / "hermes-home"
+    child_ready = tmp_path / "fork-child-ready"
+    child_pid_file = tmp_path / "fork-child-pid"
+    holder = tmp_path / "fork-holder.py"
+    holder.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import os
+            import time
+            from cron.scheduler import _try_acquire_job_run_lock
+
+            lock = _try_acquire_job_run_lock("fork-release-job")
+            if lock is None:
+                raise SystemExit(2)
+            pid = os.fork()
+            if pid == 0:
+                Path({str(child_pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+                Path({str(child_ready)!r}).write_text("ready", encoding="utf-8")
+                time.sleep(30)
+                os._exit(0)
+            os._exit(0)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    holder_process = subprocess.Popen(
+        [sys.executable, str(holder)], env=_child_env(hermes_home)
+    )
+    lock = None
+    fork_child_pid = None
+    try:
+        _wait_for(child_ready.exists, message="fork child never became ready")
+        holder_process.wait(timeout=10)
+        assert holder_process.returncode == 0
+        fork_child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        with jobs.use_cron_store(hermes_home):
+            lock = scheduler._try_acquire_job_run_lock("fork-release-job")
+        assert lock is not None
+    finally:
+        if lock is not None:
+            lock.release()
+        if fork_child_pid is not None:
+            try:
+                os.kill(fork_child_pid, 9)
+            except ProcessLookupError:
+                pass
+        if holder_process.poll() is None:
+            holder_process.kill()
+        holder_process.wait(timeout=10)
+
+
+def test_external_fire_loses_ownership_before_store_claim(monkeypatch):
+    """A local contender must not let external fire advance schedule via CAS."""
+    from cron import scheduler
+    from cron import scheduler_provider
+
+    claims: list[str] = []
+    monkeypatch.setattr(
+        jobs,
+        "get_job",
+        lambda job_id: {"id": job_id, "schedule": {"kind": "interval"}},
+    )
+    monkeypatch.setattr(scheduler, "_try_acquire_job_run_lock", lambda job_id: None)
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda job_id: claims.append(job_id) or True,
+    )
+
+    assert scheduler_provider.InProcessCronScheduler().fire_due("contended") is False
+    assert claims == []
+
+
+def test_external_recurring_lock_outlives_expired_store_claim(tmp_path, monkeypatch):
+    """Same-host ownership still excludes after the 300s fire claim is stale."""
+    from cron import scheduler
+    from cron import scheduler_provider
+
+    shared_store = tmp_path / "shared-store"
+    owner_ready = tmp_path / "external-owner-ready"
+    release_owner = tmp_path / "external-owner-release"
+    side_effects = tmp_path / "external-side-effects"
+    job_id = "external-long-run"
+    job = {
+        "id": job_id,
+        "enabled": True,
+        "state": "scheduled",
+        "schedule": {"kind": "interval", "minutes": 5},
+        "next_run_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with jobs.use_cron_store(shared_store):
+        jobs.save_jobs([job])
+
+    owner = tmp_path / "external-owner.py"
+    owner.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            import time
+            from cron import jobs, scheduler
+            from cron.scheduler_provider import InProcessCronScheduler
+
+            def fake_run(job, **_kwargs):
+                with Path({str(side_effects)!r}).open("a", encoding="utf-8") as stream:
+                    stream.write("owner\\n")
+                    stream.flush()
+                Path({str(owner_ready)!r}).write_text("ready", encoding="utf-8")
+                deadline = time.monotonic() + 20
+                while not Path({str(release_owner)!r}).exists():
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("test did not release external owner")
+                    time.sleep(0.02)
+                return True
+
+            scheduler.run_one_job = fake_run
+            with jobs.use_cron_store({str(shared_store)!r}):
+                ran = InProcessCronScheduler().fire_due({job_id!r})
+            raise SystemExit(0 if ran else 3)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    owner_process = subprocess.Popen(
+        [sys.executable, str(owner)], env=_child_env(tmp_path / "external-home-a")
+    )
+    try:
+        _wait_for(owner_ready.exists, message="external owner never entered run body")
+        assert _side_effect_count(side_effects) == 1
+
+        # Simulate a cross-host retry arriving after the bounded store claim TTL.
+        # A same-host process must still lose the full-run advisory lock before
+        # it can reclaim or advance the recurring record.
+        with jobs.use_cron_store(shared_store):
+            stored = jobs.load_jobs()
+            stored[0]["fire_claim"]["at"] = (
+                datetime.now(timezone.utc) - timedelta(seconds=301)
+            ).isoformat()
+            jobs.save_jobs(stored)
+            before = jobs.get_job(job_id)
+            assert before is not None
+
+            monkeypatch.setattr(
+                scheduler,
+                "run_one_job",
+                lambda *_args, **_kwargs: pytest.fail("expired retry dispatched"),
+            )
+            assert scheduler_provider.InProcessCronScheduler().fire_due(job_id) is False
+            after = jobs.get_job(job_id)
+
+        assert after is not None
+        assert after["next_run_at"] == before["next_run_at"]
+        assert after["fire_claim"] == before["fire_claim"]
+        assert _side_effect_count(side_effects) == 1
+    finally:
+        release_owner.touch()
+        try:
+            owner_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            owner_process.kill()
+            owner_process.wait(timeout=10)
+            raise
+
+
+def test_external_one_shot_uses_durable_claim_without_run_lock(monkeypatch):
+    """External one-shots must not depend on the recurring lock backend."""
+    from cron import scheduler
+    from cron import scheduler_provider
+
+    one_shot = {"id": "external-once", "schedule": {"kind": "once"}}
+    claims: list[str] = []
+    runs: list[str] = []
+    monkeypatch.setattr(jobs, "get_job", lambda _job_id: one_shot)
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda job_id, **_kwargs: claims.append(job_id) or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_try_acquire_job_run_lock",
+        lambda _job_id: pytest.fail("external one-shot acquired recurring run lock"),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda job, **_kwargs: runs.append(job["id"]) or True,
+    )
+
+    assert scheduler_provider.InProcessCronScheduler().fire_due(one_shot["id"]) is True
+    assert claims == [one_shot["id"]]
+    assert runs == [one_shot["id"]]
+
+
+def test_external_fire_rejects_schedule_kind_race_before_claim_mutation(
+    tmp_path, monkeypatch
+):
+    """A one-shot snapshot cannot claim/advance a newly recurring record."""
+    from cron import scheduler
+    from cron import scheduler_provider
+
+    job_id = "kind-race"
+    initial = {
+        "id": job_id,
+        "enabled": True,
+        "state": "scheduled",
+        "schedule": {"kind": "once", "run_at": "2099-01-01T00:00:00+00:00"},
+        "next_run_at": "2099-01-01T00:00:00+00:00",
+    }
+    changed = {
+        **initial,
+        "schedule": {"kind": "interval", "minutes": 5},
+    }
+
+    with jobs.use_cron_store(tmp_path):
+        jobs.save_jobs([changed])
+        monkeypatch.setattr(jobs, "get_job", lambda _job_id: initial)
+        monkeypatch.setattr(
+            scheduler,
+            "run_one_job",
+            lambda *_args, **_kwargs: pytest.fail("stale schedule snapshot dispatched"),
+        )
+        assert scheduler_provider.InProcessCronScheduler().fire_due(job_id) is False
+
+        stored = jobs.load_jobs()[0]
+    assert stored.get("fire_claim") is None
+    assert stored["next_run_at"] == changed["next_run_at"]
+
+
+def test_stale_due_scan_defers_recurring_advance_until_run_ownership(tmp_path):
+    """The scheduler's due-scan mode leaves a stale slot unchanged for a loser."""
+    stale = datetime.now(timezone.utc) - timedelta(hours=2)
+    job = {
+        "id": "stale-owned-advance",
+        "enabled": True,
+        "state": "scheduled",
+        "schedule": {"kind": "interval", "minutes": 60},
+        "next_run_at": stale.isoformat(),
+    }
+    with jobs.use_cron_store(tmp_path):
+        jobs.save_jobs([job])
+        due = jobs.get_due_jobs(defer_recurring_advance=True)
+        assert [item["id"] for item in due] == [job["id"]]
+        current = jobs.get_job(job["id"])
+        assert current is not None
+        assert current["next_run_at"] == stale.isoformat()
+
+        # Once ownership is established, the compare-and-set advance succeeds.
+        assert jobs.advance_next_run(
+            job["id"],
+            expected_next_run_at=stale.isoformat(),
+            expected_schedule_kind="interval",
+        ) is True
+
+
+def test_advance_compare_and_set_rejects_stale_snapshot(tmp_path):
+    """A changed active record is not advanced from an old due snapshot."""
+    job = {
+        "id": "advance-cas",
+        "enabled": True,
+        "state": "scheduled",
+        "schedule": {"kind": "interval", "minutes": 5},
+        "next_run_at": "2026-07-11T00:00:00+00:00",
+    }
+    with jobs.use_cron_store(tmp_path):
+        jobs.save_jobs([job])
+        assert jobs.advance_next_run(
+            job["id"],
+            expected_next_run_at="2026-07-10T00:00:00+00:00",
+            expected_schedule_kind="interval",
+        ) is False
+        current = jobs.get_job(job["id"])
+        assert current is not None
+        assert current["next_run_at"] == job["next_run_at"]
+
+
+def test_windows_lock_backend_uses_one_stable_byte(tmp_path, monkeypatch):
+    """The Windows path uses non-blocking byte 0 and explicitly unlocks it."""
+    from cron import scheduler
+
+    calls: list[tuple[str, int, int]] = []
+
+    class FakeMsvcrt:
+        LK_NBLCK = "nonblocking"
+        LK_UNLCK = "unlock"
+
+        @staticmethod
+        def locking(fd, mode, count):
+            calls.append((mode, count, os.lseek(fd, 0, os.SEEK_CUR)))
+
+    monkeypatch.setattr(scheduler, "_hermes_home", tmp_path / "hermes-home")
+    monkeypatch.setattr(scheduler, "fcntl", None)
+    monkeypatch.setattr(scheduler, "msvcrt", FakeMsvcrt)
+
+    with jobs.use_cron_store(tmp_path / "hermes-home"):
+        lock = scheduler._try_acquire_job_run_lock("windows-job")
+        assert lock is not None
+        assert calls == [("nonblocking", 1, 0)]
+        lock.release()
+    assert calls == [("nonblocking", 1, 0), ("unlock", 1, 0)]

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -45,7 +45,7 @@ def test_tick_process_job_sequence(monkeypatch):
     """Characterization: a single due job driven through tick() runs the
     sequence run_job → save → deliver → mark, in that order."""
     calls = _patch_pipeline(monkeypatch)
-    monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j1", "name": "t"}])
+    monkeypatch.setattr(s, "get_due_jobs", lambda **_kwargs: [{"id": "j1", "name": "t"}])
     monkeypatch.setattr(s, "advance_next_run", lambda jid: True)
 
     s.tick(verbose=False, sync=True)

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -338,7 +338,9 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
+    monkeypatch.setattr(
+        jobs, "claim_job_for_fire", lambda jid, **_kw: True, raising=False
+    )
     monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -29,8 +29,11 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
-        m_run.assert_called_once()                       # fired via the shared body
+        m_claim.assert_called_once_with(
+            "job-run-1", expected_schedule_kind="cron"
+        )
+        m_run.assert_called_once()
+        assert m_run.call_args.kwargs["_run_lock"] is not None
 
     def test_run_skips_when_claim_lost(self):
         """If the scheduler already holds the fire claim, do NOT double-run."""
@@ -79,3 +82,79 @@ class TestCronjobRunExecutesImmediately:
         assert res["success"] is False
         assert "boom" in res["error"]
         m_mark.assert_called_once()
+
+    def test_recurring_claim_loss_releases_preclaim_run_lock(self):
+        """A recurring loser releases ownership and never enters the run body."""
+        released = []
+
+        class RecordingLock:
+            def release(self):
+                released.append(True)
+
+        with patch(
+            "cron.scheduler._try_acquire_job_run_lock",
+            return_value=RecordingLock(),
+        ), patch(
+            "tools.cronjob_tools.claim_job_for_fire", return_value=False
+        ) as m_claim, patch("cron.scheduler.run_one_job") as m_run, patch(
+            "tools.cronjob_tools.get_job", return_value=dict(_JOB)
+        ):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["claimed"] is False
+        m_claim.assert_called_once_with(
+            "job-run-1", expected_schedule_kind="cron"
+        )
+        m_run.assert_not_called()
+        assert released == [True]
+
+    def test_recurring_claim_exception_releases_preclaim_run_lock(self):
+        """Store failures before a claim cannot leak recurring ownership."""
+        released = []
+
+        class RecordingLock:
+            def release(self):
+                released.append(True)
+
+        with patch(
+            "cron.scheduler._try_acquire_job_run_lock",
+            return_value=RecordingLock(),
+        ), patch(
+            "tools.cronjob_tools.claim_job_for_fire",
+            side_effect=RuntimeError("claim store unavailable"),
+        ), patch("cron.scheduler.run_one_job") as m_run, patch(
+            "tools.cronjob_tools.mark_job_run"
+        ) as m_mark:
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["claimed"] is False
+        assert "claim store unavailable" in res["error"]
+        m_run.assert_not_called()
+        m_mark.assert_not_called()
+        assert released == [True]
+
+    def test_one_shot_immediate_run_keeps_durable_claim_without_run_lock(self):
+        """One-shots retain the existing store-claim path and run semantics."""
+        one_shot = {
+            **_JOB,
+            "schedule": {"kind": "once", "run_at": "2099-01-01T00:00:00+00:00"},
+        }
+        completed = {**one_shot, "last_status": "ok", "last_error": None}
+
+        with patch(
+            "cron.scheduler._try_acquire_job_run_lock",
+            side_effect=AssertionError("one-shot acquired recurring run ownership"),
+        ), patch(
+            "tools.cronjob_tools.claim_job_for_fire", return_value=True
+        ) as m_claim, patch(
+            "cron.scheduler.run_one_job", return_value=True
+        ) as m_run, patch(
+            "tools.cronjob_tools.get_job", return_value=completed
+        ):
+            res = _execute_job_now(one_shot)
+
+        assert res == {"claimed": True, "success": True, "error": None}
+        m_claim.assert_called_once_with(
+            "job-run-1", expected_schedule_kind="once"
+        )
+        m_run.assert_called_once_with(one_shot)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -604,11 +604,11 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
 def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
-    at-most-once CAS the scheduler/external-provider fire path uses — so a
-    concurrently-running gateway ticker cannot also fire it (the claim both
-    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
-    If the claim is lost (another fire is in flight), this is a no-op.
+    Recurring jobs acquire same-host full-run ownership before
+    ``claim_job_for_fire`` can advance their schedule. The held ownership is
+    transferred into ``run_one_job`` and retained through execution, delivery,
+    and completion marking. One-shots keep their existing durable store-claim
+    path without depending on the recurring lock backend.
 
     The actual firing is delegated to ``run_one_job`` — the single shared
     execute→save→deliver→mark body the ticker and external providers use — so
@@ -618,11 +618,35 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    claimed = False
+    run_lock = None
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import (
+            _try_acquire_job_run_lock,
+            run_one_job,
+        )
 
-        # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
+        schedule = job.get("schedule")
+        schedule_kind = schedule.get("kind") if isinstance(schedule, dict) else None
+        recurring = schedule_kind in {"cron", "interval"}
+        if recurring:
+            # Match tick/provider ordering: ownership must precede the store CAS,
+            # because that CAS advances next_run_at for recurring jobs.
+            run_lock = _try_acquire_job_run_lock(job_id)
+            if run_lock is None:
+                return {
+                    "claimed": False,
+                    "success": False,
+                    "error": "Job is already running in another process; not run again.",
+                }
+
+        # Reject a concurrent schedule-kind edit before mutating the store. This
+        # preserves one-shot durable claims while preventing a stale one-shot
+        # snapshot from advancing a record that has become recurring.
+        claimed = claim_job_for_fire(
+            job_id, expected_schedule_kind=schedule_kind
+        )
+        if not claimed:
             # claim_job_for_fire returns False for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
             # (#60703): that message sends the user chasing a phantom
@@ -638,7 +662,10 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        if recurring:
+            processed = run_one_job(job, _run_lock=run_lock)
+        else:
+            processed = run_one_job(job)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {
@@ -649,11 +676,17 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        if claimed:
+            try:
+                mark_job_run(job_id, False, str(e))
+            except Exception:
+                pass
+        return {"claimed": claimed, "success": False, "error": str(e)}
+    finally:
+        if run_lock is not None:
+            # run_one_job releases after the full lifecycle. Idempotence covers
+            # every claim/get/dispatch failure before ownership is transferred.
+            run_lock.release()
 
 
 def cronjob(

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -150,9 +150,11 @@ create/update a cron job
       (authenticated with the agent's existing Nous token)
   → at fire time Nous calls the gateway: POST {callback_url}/api/cron/fire
       (authenticated with a short-lived, purpose-scoped Nous-minted JWT)
-  → the gateway verifies the token, claims the job (store compare-and-set so
-    multi-replica deployments fire at-most-once), runs it, and re-arms the next
-    one-shot
+  → the gateway verifies the token, claims the job (store compare-and-set
+    de-duplicates normal retries during the bounded claim window), runs it, and
+    re-arms the next one-shot. Full-run exclusion is only guaranteed between
+    same-host processes sharing a lock-capable local cron store; the claim is
+    not a renewable distributed lease
 ```
 
 Config (all non-secret; on hosted agents Nous sets these at provision time):
@@ -280,7 +282,21 @@ Cron-run sessions have the `cronjob` toolset disabled. This prevents:
 
 ## Locking
 
-The scheduler uses cross-process file-based locking (`fcntl.flock` on Unix, `msvcrt.locking` on Windows) to prevent overlapping ticks from executing the same due-job batch twice — even between the gateway's in-process ticker and a standalone `hermes cron` / manual `tick()` call. If the lock cannot be acquired, `tick()` returns 0 immediately.
+The short-lived tick lock prevents duplicate dispatch scans. Recurring jobs also
+hold a per-job OS advisory lock from **before** `next_run_at` advancement through
+execution, output save, delivery, and `mark_job_run`. Its path is derived from
+the active `cron.jobs` store context, so equal IDs in two profile stores remain
+independent while callers with different runtime homes still contend when they
+address the same store. One-shots continue to use their durable store claim.
+
+This full-run guarantee is deliberately limited to **same-host processes sharing
+the active cron store on a filesystem with normal local advisory-lock semantics**.
+It is not a distributed lease and does not promise correct full-run ownership on
+NFS/SMB or between hosts. Lock contention skips without mutating the schedule;
+lock open/backend/permission failures are logged with the path and fail that
+recurring dispatch closed. On POSIX, inherited descriptors are closed in a bare
+fork child without issuing an unlock; Python's non-inheritable descriptors also
+prevent ownership leaking through subprocess `exec`.
 
 ## CLI Interface
 


### PR DESCRIPTION
## Summary

Prevent two Hermes scheduler processes on the same host from overlapping the same recurring cron job.

The existing `.tick.lock` serialized only schedule scanning/dispatch. `_running_job_ids` was process-local, and ownership ended before the submitted job ran. A second gateway/scheduler process could therefore advance and execute the same recurring job while the first invocation was still active.

## Fix

- Add a per-job OS advisory lock held for the complete recurring-run lifetime.
- Derive lock paths from the active `cron.jobs` store context, preserving profile isolation and custom `use_cron_store()` contexts.
- Acquire ownership before recurring schedule advancement or external-provider claim mutation.
- Hold ownership through execution, output persistence, delivery, agent teardown, and completion marking.
- Make losing contenders skip without executing or advancing schedule state.
- Distinguish genuine contention from lock open/permission/backend failures; backend failures fail closed with an actionable error.
- Use compare-and-set schedule advancement followed by fresh snapshot reload/revalidation, so pause/removal/schedule changes or failed advancement cannot dispatch a stale job.
- Preserve external one-shot durable claim behavior without requiring the recurring lock backend.
- Close inherited POSIX lock descriptors in bare-fork children; descriptors remain exec-safe. Windows uses stable byte-zero locking.
- Leave lock files in place after release; ownership is the live OS descriptor, avoiding unlink races.

## TDD and verification

The initial two-process regression failed with duplicate recurring side effects. It passed after full-lifetime ownership was introduced.

Final local verification:

```text
700 passed  tests/cron
178 passed  related cron tool/plugin/gateway/CLI/profile suites
27 passed   isolated cron approval suite
```

Additional repeated checks passed:

- two-process contention, five repetitions;
- owner crash/release, three repetitions;
- `compileall` for `cron` and `tests/cron`;
- `git diff --check`;
- independent adversarial review after two correction rounds: **APPROVE**.

Coverage includes:

- separate profile stores;
- the same active store reached under different process homes;
- loser no-run/no-advance behavior;
- direct/manual and external recurring runs;
- external one-shots;
- advancement failure and stale snapshot revalidation;
- process crash, exceptions, daemon threads, and fork cleanup;
- contention versus backend errors;
- Windows locking calls.

## Guarantee and limits

This provides full-run exclusion only for **same-host processes sharing the same lock-capable active cron store**.

The existing external fire claim is a bounded 300-second retry de-duplication mechanism, not a renewable distributed lease. This PR intentionally does not claim cross-host, NFS, or SMB full-run correctness. Deployments requiring that guarantee need a renewable lease in the scheduler/store layer. Both Chronos contract and developer documentation now state this explicitly.

## Compatibility

- Existing one-shot `run_claim` semantics are preserved.
- Recurring schedule schemas and job file formats are unchanged.
- Stale lock files are harmless and are not treated as ownership.
- Built-in and external-provider paths share `run_one_job`; the lock is idempotently released by both the run body and pre-run failure cleanup.
- No network/distributed locking dependency is introduced.
