### PR TITLE
fix(gateway): reliably notify after external supervisor restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4803,17 +4803,18 @@ class GatewayRunner:
 
         # Notify the chat that initiated /restart that the gateway is back.
         planned_restart_notification_pending = _planned_restart_notification_pending()
-        await self._send_restart_notification()
+        restart_notification_target = await self._send_restart_notification()
 
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
+        # An external signal may have both an interrupted active chat and one
+        # or more configured home channels. Preserve the precise active-chat
+        # reply, but do not send a second generic startup ping to that same
+        # platform/chat/topic. Other configured homes can still receive the
+        # recovery notification.
         if planned_restart_notification_pending:
+            skip_targets = {restart_notification_target} if restart_notification_target else None
             try:
                 await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
+                    skip_targets=skip_targets,
                 )
             finally:
                 _clear_planned_restart_notification()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6765,14 +6765,36 @@ class GatewayRunner:
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            should_notify_home_on_next_boot = (
+                # Normal Hermes-managed restarts with no specific originating
+                # chat should announce the comeback to configured home channels.
+                (self._restart_requested and self._restart_command_source is None)
+                # External SIGTERM under supervisors such as systemd also comes
+                # back automatically, but it bypasses request_restart() and used
+                # to send only the shutdown half of the lifecycle. Persist the
+                # same marker so the next process can say it is back online.
+                or (
+                    getattr(self, "_signal_initiated_shutdown", False)
+                    and not self._restart_requested
+                )
+            )
+            if should_notify_home_on_next_boot:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
                         {
                             "requested_at": time.time(),
-                            "via_service": bool(self._restart_via_service),
+                            "via_service": bool(
+                                self._restart_via_service
+                                or getattr(self, "_signal_initiated_shutdown", False)
+                            ),
                             "detached": bool(self._restart_detached),
+                            "reason": (
+                                "external_signal"
+                                if getattr(self, "_signal_initiated_shutdown", False)
+                                and not self._restart_requested
+                                else "planned_restart"
+                            ),
                         },
                         indent=None,
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6799,14 +6799,11 @@ class GatewayRunner:
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            active_origin_notification_queued = False
             if (
                 getattr(self, "_signal_initiated_shutdown", False)
                 and not self._restart_requested
             ):
-                active_origin_notification_queued = (
-                    self._queue_restart_notification_for_active_origin(active_agents)
-                )
+                self._queue_restart_notification_for_active_origin(active_agents)
 
             should_notify_home_on_next_boot = (
                 # Normal Hermes-managed restarts with no specific originating
@@ -6814,12 +6811,12 @@ class GatewayRunner:
                 (self._restart_requested and self._restart_command_source is None)
                 # External SIGTERM under supervisors such as systemd also comes
                 # back automatically, but it bypasses request_restart() and used
-                # to send only the shutdown half of the lifecycle. Persist the
-                # same marker so the next process can say it is back online.
+                # to send only the shutdown half of the lifecycle. Always persist
+                # the home-channel marker, even when a specific active session is
+                # also queued for a reply, so the restart cannot go unannounced.
                 or (
                     getattr(self, "_signal_initiated_shutdown", False)
                     and not self._restart_requested
-                    and not active_origin_notification_queued
                 )
             )
             if should_notify_home_on_next_boot:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6725,7 +6725,6 @@ class GatewayRunner:
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):
                 self._busy_ack_ts.clear()
-            self._shutdown_event.set()
 
             # Global cleanup: kill any remaining tool subprocesses not tied
             # to a specific agent (catch-all for zombie prevention). On the
@@ -6862,6 +6861,10 @@ class GatewayRunner:
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 
             self._draining = False
+            # Let start_gateway() continue only after lifecycle markers are
+            # durable. Otherwise a SIGTERM restart can exit the process before
+            # the next boot sees .restart_pending.json.
+            self._shutdown_event.set()
             self._update_runtime_status("stopped", self._exit_reason)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Dict, Optional, Any, List, Union, Iterable
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -4182,6 +4182,40 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)
 
+    def _queue_restart_notification_for_active_origin(
+        self, active_session_keys: Optional[Iterable[str]] = None
+    ) -> bool:
+        """Persist a restart reply target when exactly one turn is active.
+
+        A service-level restart has no command event of its own. If it interrupts
+        one active turn, that turn is its unambiguous initiator, so the next
+        gateway process should acknowledge the restart in that chat/topic rather
+        than broadcasting to a configured home channel.
+        """
+        active_keys = list(
+            active_session_keys
+            if active_session_keys is not None
+            else self._snapshot_running_agents()
+        )
+        if len(active_keys) != 1:
+            return False
+        source = self._get_cached_session_source(active_keys[0])
+        if source is None or not getattr(source, "chat_id", None):
+            return False
+        try:
+            payload = {
+                "platform": source.platform.value,
+                "chat_id": str(source.chat_id),
+                "chat_type": source.chat_type,
+            }
+            if source.thread_id:
+                payload["thread_id"] = str(source.thread_id)
+            atomic_json_write(_hermes_home / ".restart_notify.json", payload, indent=None)
+            return True
+        except Exception as exc:
+            logger.debug("Failed to persist active restart origin: %s", exc)
+            return False
+
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:
             return False
@@ -6765,6 +6799,15 @@ class GatewayRunner:
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
+            active_origin_notification_queued = False
+            if (
+                getattr(self, "_signal_initiated_shutdown", False)
+                and not self._restart_requested
+            ):
+                active_origin_notification_queued = (
+                    self._queue_restart_notification_for_active_origin(active_agents)
+                )
+
             should_notify_home_on_next_boot = (
                 # Normal Hermes-managed restarts with no specific originating
                 # chat should announce the comeback to configured home channels.
@@ -6776,6 +6819,7 @@ class GatewayRunner:
                 or (
                     getattr(self, "_signal_initiated_shutdown", False)
                     and not self._restart_requested
+                    and not active_origin_notification_queued
                 )
             )
             if should_notify_home_on_next_boot:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4216,6 +4216,10 @@ class GatewayRunner:
             logger.debug("Failed to persist active restart origin: %s", exc)
             return False
 
+    def mark_signal_initiated_shutdown(self) -> None:
+        """Record an external signal so stop() persists the startup marker."""
+        self._signal_initiated_shutdown = True
+
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:
             return False
@@ -19857,6 +19861,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             )
         else:
             _signal_initiated_shutdown = True
+            runner.mark_signal_initiated_shutdown()
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -183,7 +183,7 @@ async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_external_signal_replies_to_sole_active_session_not_home(tmp_path, monkeypatch):
+async def test_external_signal_notifies_active_session_and_writes_home_startup_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
@@ -204,7 +204,11 @@ async def test_external_signal_replies_to_sole_active_session_not_home(tmp_path,
         "chat_type": "dm",
         "thread_id": "current-topic",
     }
-    assert not (tmp_path / ".restart_pending.json").exists()
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["reason"] == "external_signal"
+    assert payload["via_service"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -192,6 +192,28 @@ async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_shutdown_event_waits_for_external_restart_marker(tmp_path, monkeypatch):
+    """The process must not exit before the startup marker is durable."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._signal_initiated_shutdown = True
+    original_write = gateway_run.atomic_json_write
+
+    def assert_event_is_not_set(path, *args, **kwargs):
+        assert path == tmp_path / ".restart_pending.json"
+        assert runner._shutdown_event.is_set() is False
+        return original_write(path, *args, **kwargs)
+
+    monkeypatch.setattr(gateway_run, "atomic_json_write", assert_event_is_not_set)
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert runner._shutdown_event.is_set() is True
+    assert (tmp_path / ".restart_pending.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_external_signal_notifies_active_session_and_writes_home_startup_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -183,6 +183,31 @@ async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_external_signal_replies_to_sole_active_session_not_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.0
+    source = make_restart_source(chat_id="current-chat", thread_id="current-topic")
+    session_key = build_session_key(source)
+    runner._cache_session_source(session_key, source)
+    runner._running_agents = {session_key: MagicMock()}
+    runner._signal_initiated_shutdown = True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    payload = json.loads((tmp_path / ".restart_notify.json").read_text())
+    assert payload == {
+        "platform": "telegram",
+        "chat_id": "current-chat",
+        "chat_type": "dm",
+        "thread_id": "current-topic",
+    }
+    assert not (tmp_path / ".restart_pending.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_restart_shutdown_warning_uses_restart_command_reply_anchor_for_active_session():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -164,6 +164,15 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
+def test_external_signal_marks_runner_before_shutdown():
+    """The signal handler must set the instance flag consumed by stop()."""
+    runner, _adapter = make_restart_runner()
+
+    runner.mark_signal_initiated_shutdown()
+
+    assert runner._signal_initiated_shutdown is True
+
+
 @pytest.mark.asyncio
 async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatch):
     """External supervisor restarts should send the missing 'back online' half."""

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -161,6 +162,24 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_unexpected_signal_writes_home_startup_marker(tmp_path, monkeypatch):
+    """External supervisor restarts should send the missing 'back online' half."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._signal_initiated_shutdown = True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["reason"] == "external_signal"
+    assert payload["via_service"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -45,6 +45,26 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     assert gateway_run._planned_restart_notification_pending() is False
 
 
+def test_external_restart_queues_notification_for_only_active_origin(tmp_path, monkeypatch):
+    """A service restart returns to the sole chat whose active turn caused it."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="current-chat", thread_id="current-topic")
+    session_key = build_session_key(source)
+    runner._cache_session_source(session_key, source)
+    runner._running_agents[session_key] = MagicMock()
+
+    assert runner._queue_restart_notification_for_active_origin() is True
+
+    data = json.loads((tmp_path / ".restart_notify.json").read_text())
+    assert data == {
+        "platform": "telegram",
+        "chat_id": "current-chat",
+        "chat_type": "dm",
+        "thread_id": "current-topic",
+    }
+
+
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes a real external-signal restart path: a supervisor/systemd `SIGTERM` can now hand off a durable recovery notification before the old gateway process is allowed to exit.

- Keep the precise restart notification for one interrupted active chat/topic.
- Independently persist a home-channel recovery marker for the externally restarted gateway.
- Wire external signal state to `GatewayRunner`, which is the state the shutdown path actually reads.
- Persist lifecycle markers *before* releasing the shutdown event, so the replacement process cannot race past the handoff.
- Skip the generic home notification when it targets the same platform/chat/topic already served by the precise restart reply. Other configured home channels still receive the recovery notice.

## Why this is narrower and safer than nearby PRs

This is deliberately **not** an "announce every cold start" change.

- [#62523](https://github.com/NousResearch/hermes-agent/pull/62523), [#62546](https://github.com/NousResearch/hermes-agent/pull/62546), and [#62742](https://github.com/NousResearch/hermes-agent/pull/62742) broaden startup notifications to markerless starts. They evaluate the chat restart marker after `_send_restart_notification()` consumes it, so a chat `/restart` can receive a duplicate home ping. This PR snapshots the durable home handoff before delivery and skips the already-notified target.
- [#62390](https://github.com/NousResearch/hermes-agent/pull/62390) introduced the home marker but did not wire the real SIGTERM handler to `GatewayRunner._signal_initiated_shutdown`, and allowed shutdown completion before the marker was durable. This PR fixes both production-path gaps.
- [#59079](https://github.com/NousResearch/hermes-agent/pull/59079) covers broader launchd/systemd fallback paths but carries unrelated files and can treat ordinary stops as restart events. Those platform fallback paths should be reviewed separately.
- [#59501](https://github.com/NousResearch/hermes-agent/pull/59501) is complementary: it fixes the Windows CLI restart path, which this PR does not touch.

## Test plan

```text
PYTHONPATH=/tmp/hermes-pr-62767 /home/cmcejas/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py \
  -o 'addopts=' -q
# 46 passed

/home/cmcejas/.hermes/hermes-agent/venv/bin/python -B -m compileall -q \
  gateway/run.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py

git diff --check
```

The shutdown regression coverage exercises active-origin marker handling, real signal-to-runner state propagation, and marker durability ordering. Restart notification coverage includes topic-aware targets and generic-home target de-duplication.
