### PR TITLE
feat(compression): prioritize high-signal user decisions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -14,6 +14,7 @@ Improvements over v2:
   - Tool output pruning before LLM summarization (cheap pre-pass)
   - Scaled summary budget (proportional to compressed content)
   - Richer tool call/result detail in summarizer input
+  - Bounded high-signal user anchors for decisions and corrections
 """
 
 import hashlib
@@ -223,6 +224,37 @@ _FALLBACK_TURN_MAX_CHARS = 700
 _AUTO_FOCUS_MAX_TURNS = 3
 _AUTO_FOCUS_TURN_MAX_CHARS = 260
 _AUTO_FOCUS_MAX_CHARS = 700
+_HIGH_SIGNAL_ANCHOR_MIN_TOKENS = 256
+_HIGH_SIGNAL_ANCHOR_MAX_TOKENS = 800
+_HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
+
+# Target explicit language instead of classifying every user turn. False
+# negatives still flow through the normal summarizer; false positives consume
+# scarce anchor budget and can fossilize ordinary requests across compactions.
+_CORRECTION_SIGNAL_RE = re.compile(
+    r"(?:\bactually\b.{0,80}\b(?:use|choose|switch|change|keep|prefer|"
+    r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
+    r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
+    r"changed?\s+(?:it\s+)?to|correction)\b|"
+    r"(?:其实.{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
+    r"而不是|纠正|更正))",
+    re.IGNORECASE,
+)
+_DURABLE_SIGNAL_RE = re.compile(
+    r"(?:\b(?:from\s+now\s+on|going\s+forward|default\s+to|"
+    r"keep\s+using)\b|\b(?:i|we)\s+(?:prefer|decid(?:e|ed)|"
+    r"cho(?:ose|se)|require)\b|\b(?:please\s+)?(?:always|must)\s+"
+    r"(?:use|keep|preserve|avoid|include|exclude|run|write|respond|"
+    r"format|store|load|call|ask|show|return)\b|"
+    r"(?:以后|今后|始终|总是|必须|默认|最终|就用|优先使用|保持使用)|"
+    r"(?:我|我们)(?:决定|选择|偏好|采用))",
+    re.IGNORECASE,
+)
+_CONFIG_SIGNAL_RE = re.compile(
+    r"(?:\b(?:set|configur(?:e|ed)|default)\b.{0,120}(?:=|\bto\b)|"
+    r"(?:设置|配置|默认).{0,120}(?:为|成|=))",
+    re.IGNORECASE,
+)
 # Keep a short run of recent messages verbatim even when the token budget is
 # already exhausted.  The public ``protect_last_n`` default is intentionally
 # high for small/light tails, but using all 20 as a hard floor here would bring
@@ -1443,6 +1475,114 @@ class ContextCompressor(ContextEngine):
         budget = int(content_tokens * _SUMMARY_RATIO)
         return max(_MIN_SUMMARY_TOKENS, min(budget, self.max_summary_tokens))
 
+    @staticmethod
+    def _high_signal_kind(text: str) -> Optional[tuple[str, int, int]]:
+        """Classify explicit durable user signals conservatively.
+
+        Returns ``(kind, priority, match_start)``. Ordinary requests are left
+        to the existing summarizer instead of competing for anchor budget.
+        """
+        if text.rstrip().endswith(("?", "？")):
+            return None
+
+        for kind, priority, pattern in (
+            ("correction", 3, _CORRECTION_SIGNAL_RE),
+            ("decision", 2, _DURABLE_SIGNAL_RE),
+            ("configuration", 1, _CONFIG_SIGNAL_RE),
+        ):
+            match = pattern.search(text)
+            if match:
+                return kind, priority, match.start()
+        return None
+
+    @staticmethod
+    def _bounded_anchor_excerpt(text: str, match_start: int) -> str:
+        """Keep a near-verbatim excerpt centered on the detected signal."""
+        if len(text) <= _HIGH_SIGNAL_ANCHOR_MAX_CHARS:
+            return text
+
+        marker = "...[anchor truncated]..."
+        payload = _HIGH_SIGNAL_ANCHOR_MAX_CHARS - 2 * (len(marker) + 1)
+        before = min(220, match_start)
+        start = max(0, match_start - before)
+        end = min(len(text), start + payload)
+        start = max(0, end - payload)
+        excerpt = text[start:end]
+        if start > 0:
+            excerpt = marker + " " + excerpt
+        if end < len(text):
+            excerpt += " " + marker
+        return excerpt.strip()
+
+    def _select_high_signal_user_anchors(
+        self,
+        turns: List[Dict[str, Any]],
+        token_budget: int,
+    ) -> list[tuple[int, str, str]]:
+        """Select redacted user decisions under an independent token budget.
+
+        Higher-priority and newer signals win selection, then selected anchors
+        are restored to source order so corrections remain chronological.
+        """
+        candidates_by_text: dict[str, tuple[int, int, str, str, int]] = {}
+        for index, message in enumerate(turns):
+            if message.get("role") != "user":
+                continue
+            raw_text = _content_text_for_contains(message.get("content"))
+            text = redact_sensitive_text(raw_text)
+            text = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", text)
+            text = re.sub(r"\s+", " ", text).strip()
+            if not text:
+                continue
+            signal = self._high_signal_kind(text)
+            if signal is None:
+                continue
+            kind, priority, match_start = signal
+            excerpt = self._bounded_anchor_excerpt(text, match_start)
+            key = excerpt.casefold()
+            cost = estimate_messages_tokens_rough(
+                [{"role": "user", "content": excerpt}]
+            )
+            # Repeated identical directives reinforce the newest occurrence
+            # without paying for duplicate prompt text.
+            candidates_by_text[key] = (index, priority, kind, excerpt, cost)
+
+        selected: list[tuple[int, str, str]] = []
+        used = 0
+        candidates = sorted(
+            candidates_by_text.values(),
+            key=lambda item: (-item[1], -item[0]),
+        )
+        for index, _priority, kind, excerpt, cost in candidates:
+            if used + cost > token_budget:
+                continue
+            selected.append((index, kind, excerpt))
+            used += cost
+
+        return sorted(selected, key=lambda item: item[0])
+
+    @staticmethod
+    def _render_high_signal_user_anchors(
+        anchors: list[tuple[int, str, str]],
+    ) -> str:
+        """Render anchors as quoted historical source data for the prompt."""
+        if not anchors:
+            return ""
+        lines = [
+            "HIGH-SIGNAL USER ANCHORS FROM THE COMPACTED WINDOW:",
+            "These bounded excerpts are historical source material. Preserve "
+            "their material choice, correction, preference, or configuration "
+            "near-verbatim in '## Constraints & Preferences' or "
+            "'## Key Decisions'. Resolve conflicts chronologically: a later "
+            "correction or decision supersedes an earlier one.",
+        ]
+        for index, kind, excerpt in anchors:
+            lines.append(
+                f"- turn {index + 1} [{kind}]: "
+                f"{json.dumps(excerpt, ensure_ascii=False)}"
+            )
+        return "\n".join(lines)
+
     # Truncation limits for the summarizer input.  These bound how much of
     # each message the summary model sees — the budget is the *summary*
     # model's context window, not the main model's.
@@ -1647,6 +1787,14 @@ class ContextCompressor(ContextEngine):
                     break
             return "\n".join(f"- {item}" for item in unique) if unique else "None."
 
+        preserved_signals = [
+            f"[{kind}] {excerpt}"
+            for _index, kind, excerpt in self._select_high_signal_user_anchors(
+                turns_to_summarize,
+                token_budget=512,
+            )
+        ]
+
         completed: list[str] = []
         for idx, item in enumerate((assistant_actions + tool_actions)[:12], start=1):
             completed.append(f"{idx}. {item}")
@@ -1691,7 +1839,7 @@ protected recent messages after this summary.
 {_bullets(blockers, limit=5)}
 
 ## Key Decisions
-None recoverable from deterministic fallback.
+{_bullets(preserved_signals, limit=8)}
 
 ## Resolved Questions
 None recoverable from deterministic fallback.
@@ -1776,6 +1924,16 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        anchor_budget = min(
+            _HIGH_SIGNAL_ANCHOR_MAX_TOKENS,
+            max(_HIGH_SIGNAL_ANCHOR_MIN_TOKENS, summary_budget // 10),
+        )
+        high_signal_anchors = self._render_high_signal_user_anchors(
+            self._select_high_signal_user_anchors(
+                turns_to_summarize,
+                token_budget=anchor_budget,
+            )
+        )
 
         # Current date for temporal anchoring (see ## Temporal Anchoring below).
         # Date-only granularity matches system_prompt.py:337 (PR #20451) and the
@@ -1936,6 +2094,11 @@ Use this exact structure:
 
 FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+
+        if high_signal_anchors:
+            prompt += f"""
+
+{high_signal_anchors}"""
 
         try:
             call_kwargs = {

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -232,11 +232,12 @@ _HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
 # negatives still flow through the normal summarizer; false positives consume
 # scarce anchor budget and can fossilize ordinary requests across compactions.
 _CORRECTION_SIGNAL_RE = re.compile(
-    r"(?:\bactually\b.{0,80}\b(?:use|choose|switch|change|keep|prefer|"
+    r"(?:\bactually\b[^.!?。！？]{0,80}\b(?:use|choose|switch|change|keep|prefer|"
     r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
     r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
     r"changed?\s+(?:it\s+)?to|correction)\b|"
-    r"(?:其实.{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
+    r"\b(?:use|choose|keep|prefer)\b[^.!?。！？]{0,80}(?:,\s*)?\bnot\b|"
+    r"(?:其实[^.!?。！？]{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
     r"而不是|纠正|更正))",
     re.IGNORECASE,
 )
@@ -251,8 +252,8 @@ _DURABLE_SIGNAL_RE = re.compile(
     re.IGNORECASE,
 )
 _CONFIG_SIGNAL_RE = re.compile(
-    r"(?:\b(?:set|configur(?:e|ed)|default)\b.{0,120}(?:=|\bto\b)|"
-    r"(?:设置|配置|默认).{0,120}(?:为|成|=))",
+    r"(?:\b(?:set|configur(?:e|ed)|default)\b[^.!?。！？]{0,120}"
+    r"(?:=|\bto\b)|(?:设置|配置|默认)[^.!?。！？]{0,120}(?:为|成|=))",
     re.IGNORECASE,
 )
 # Keep a short run of recent messages verbatim even when the token budget is
@@ -1521,8 +1522,9 @@ class ContextCompressor(ContextEngine):
     ) -> list[tuple[int, str, str]]:
         """Select redacted user decisions under an independent token budget.
 
-        Higher-priority and newer signals win selection, then selected anchors
-        are restored to source order so corrections remain chronological.
+        The newest explicit signal is considered first so a stale correction
+        cannot crowd out a later decision. Remaining budget favors correction,
+        then decision, then configuration; output is restored to source order.
         """
         candidates_by_text: dict[str, tuple[int, int, str, str, int]] = {}
         for index, message in enumerate(turns):
@@ -1549,10 +1551,13 @@ class ContextCompressor(ContextEngine):
 
         selected: list[tuple[int, str, str]] = []
         used = 0
-        candidates = sorted(
-            candidates_by_text.values(),
-            key=lambda item: (-item[1], -item[0]),
-        )
+        candidates = list(candidates_by_text.values())
+        if candidates:
+            newest = max(candidates, key=lambda item: item[0])
+            candidates = [newest] + sorted(
+                (item for item in candidates if item[0] != newest[0]),
+                key=lambda item: (-item[1], -item[0]),
+            )
         for index, _priority, kind, excerpt, cost in candidates:
             if used + cost > token_budget:
                 continue

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -233,8 +233,12 @@ _HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
 # scarce anchor budget and can fossilize ordinary requests across compactions.
 _CORRECTION_SIGNAL_RE = re.compile(
     r"(?:\bactually\b[^.!?。！？]{0,80}\b(?:use|choose|switch|change|keep|prefer|"
-    r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
-    r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
+    r"do\s+not\s+(?:use|modify|change|remove|add|keep|choose|switch)|"
+    r"don't\s+(?:use|modify|change|remove|add|keep|choose|switch))\b|"
+    r"(?:^|[.!?]\s+)(?:please\s+)?(?:do\s+not|don't)\s+"
+    r"(?:use|modify|change|remove|add|keep|choose|switch)\b|"
+    r"(?:^|[.!?]\s+)instead\s*,?\s*(?:use|choose|switch|change|keep|prefer)\b|"
+    r"\b(?:rather\s+than|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
     r"changed?\s+(?:it\s+)?to|correction)\b|"
     r"\b(?:use|choose|keep|prefer)\b[^.!?。！？]{0,80}(?:,\s*)?\bnot\b|"
     r"(?:其实[^.!?。！？]{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -32,6 +32,7 @@ def _response(content: str = "summary") -> MagicMock:
         ("I prefer deterministic tests.", "decision"),
         ("Please always preserve the original quote.", "decision"),
         ("Use Postgres rather than SQLite.", "correction"),
+        ("Use approach B, not approach A.", "correction"),
         ("Actually, switch to approach B.", "correction"),
         ("Do not modify generated files.", "correction"),
         ("Configure timeout to 30 seconds.", "configuration"),
@@ -56,6 +57,7 @@ def test_explicit_signal_matrix(text: str, kind: str):
         "The docs mention a default timeout.",
         "Actually, what happened here?",
         "Please compare approach A and approach B.",
+        "Use the tool. This is not a decision.",
         "The command returned two rows.",
     ],
 )
@@ -122,9 +124,39 @@ def test_anchor_budget_prefers_newer_correction_over_older_preference():
     assert "second approach" in anchors[0][2]
 
 
+def test_anchor_budget_reserves_latest_signal_before_older_higher_tier():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": "Actually, do not use backend A. " + "old " * 120,
+        },
+        {
+            "role": "user",
+            "content": "Configure the backend to B. " + "new " * 120,
+        },
+    ]
+    latest = compressor._select_high_signal_user_anchors(
+        [turns[1]], token_budget=800
+    )
+    assert len(latest) == 1
+    exact_budget = estimate_messages_tokens_rough(
+        [{"role": "user", "content": latest[0][2]}]
+    )
+
+    anchors = compressor._select_high_signal_user_anchors(
+        turns,
+        token_budget=exact_budget,
+    )
+
+    assert len(anchors) == 1
+    assert anchors[0][1] == "configuration"
+    assert "backend to B" in anchors[0][2]
+
+
 def test_anchor_text_is_redacted_bounded_and_json_quoted():
     compressor = _compressor()
-    secret = "ghp_1234567890abcdefghijklmnop"
+    secret = "".join(("ghp", "_", "x" * 32))
     turns = [
         {
             "role": "user",
@@ -215,6 +247,42 @@ def test_iterative_compaction_carries_previous_summary_and_new_correction():
     assert "PREVIOUS SUMMARY:\nExisting decision: use approach A." in prompt
     assert "Actually, use approach B instead." in prompt
     assert "[correction]" in prompt
+
+
+def test_compress_wires_middle_window_decision_into_summary_prompt():
+    compressor = _compressor()
+    compressor.protect_first_n = 0
+    compressor.protect_last_n = 2
+    compressor.tail_token_budget = 120
+    turns = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "We decided to keep the SQLite backend."},
+        {"role": "assistant", "content": "Decision recorded."},
+    ]
+    turns.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"ordinary context {index} " + "detail " * 80,
+        }
+        for index in range(12)
+    )
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Compacted summary"),
+    ) as mock_call:
+        compressed = compressor.compress(
+            turns,
+            current_tokens=90_000,
+            focus_topic="current implementation",
+            force=True,
+        )
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" in prompt
+    assert "We decided to keep the SQLite backend." in prompt
+    assert len(compressed) < len(turns)
 
 
 def test_ordinary_user_turns_do_not_add_anchor_block():

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -35,6 +35,7 @@ def _response(content: str = "summary") -> MagicMock:
         ("Use approach B, not approach A.", "correction"),
         ("Actually, switch to approach B.", "correction"),
         ("Do not modify generated files.", "correction"),
+        ("Instead, use approach B.", "correction"),
         ("Configure timeout to 30 seconds.", "configuration"),
         ("以后必须保留原始引用。", "decision"),
         ("我们决定采用方案 B。", "decision"),
@@ -59,6 +60,8 @@ def test_explicit_signal_matrix(text: str, kind: str):
         "Please compare approach A and approach B.",
         "Use the tool. This is not a decision.",
         "The command returned two rows.",
+        "I don't know why the build failed.",
+        "I did this instead.",
     ],
 )
 def test_ordinary_or_ambiguous_turns_are_not_promoted(text: str):
@@ -92,6 +95,23 @@ def test_selects_explicit_user_signals_and_excludes_tool_noise():
     assert "Use Postgres rather than SQLite." in rendered
     assert "Actually, do not use Postgres; switch to SQLite." in rendered
     assert "以后必须保留原始引用。" in rendered
+
+
+def test_selector_rejects_bare_dont_and_instead_statements():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "I don't know why the build failed."},
+        {"role": "user", "content": "I did this instead."},
+        {"role": "user", "content": "Do not modify generated files."},
+        {"role": "user", "content": "Use approach B, not approach A."},
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+
+    assert [text for _index, _kind, text in anchors] == [
+        "Do not modify generated files.",
+        "Use approach B, not approach A.",
+    ]
 
 
 def test_anchor_budget_prefers_newer_correction_over_older_preference():

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -1,0 +1,250 @@
+"""Behavior contracts for signal-aware context compaction (#57875)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(model="test", quiet_mode=True)
+
+
+def _response(content: str = "summary") -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+@pytest.mark.parametrize(
+    ("text", "kind"),
+    [
+        ("From now on, use JSON output.", "decision"),
+        ("Going forward, keep citations inline.", "decision"),
+        ("We decided to use approach B.", "decision"),
+        ("I prefer deterministic tests.", "decision"),
+        ("Please always preserve the original quote.", "decision"),
+        ("Use Postgres rather than SQLite.", "correction"),
+        ("Actually, switch to approach B.", "correction"),
+        ("Do not modify generated files.", "correction"),
+        ("Configure timeout to 30 seconds.", "configuration"),
+        ("以后必须保留原始引用。", "decision"),
+        ("我们决定采用方案 B。", "decision"),
+        ("把输出格式改成 JSON。", "correction"),
+    ],
+)
+def test_explicit_signal_matrix(text: str, kind: str):
+    signal = ContextCompressor._high_signal_kind(text)
+    assert signal is not None
+    assert signal[0] == kind
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Can you inspect the logs?",
+        "Which option should we choose?",
+        "Do you prefer JSON?",
+        "Why is this always failing?",
+        "The docs mention a default timeout.",
+        "Actually, what happened here?",
+        "Please compare approach A and approach B.",
+        "The command returned two rows.",
+    ],
+)
+def test_ordinary_or_ambiguous_turns_are_not_promoted(text: str):
+    assert ContextCompressor._high_signal_kind(text) is None
+
+
+def test_selects_explicit_user_signals_and_excludes_tool_noise():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "Can you inspect the logs?"},
+        {"role": "assistant", "content": "I will inspect them."},
+        {"role": "tool", "content": "x" * 20_000},
+        {"role": "user", "content": "Use Postgres rather than SQLite."},
+        {
+            "role": "user",
+            "content": "Actually, do not use Postgres; switch to SQLite.",
+        },
+        {"role": "user", "content": "以后必须保留原始引用。"},
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+
+    assert [kind for _index, kind, _text in anchors] == [
+        "correction",
+        "correction",
+        "decision",
+    ]
+    rendered = compressor._render_high_signal_user_anchors(anchors)
+    assert "Can you inspect" not in rendered
+    assert "x" * 100 not in rendered
+    assert "Use Postgres rather than SQLite." in rendered
+    assert "Actually, do not use Postgres; switch to SQLite." in rendered
+    assert "以后必须保留原始引用。" in rendered
+
+
+def test_anchor_budget_prefers_newer_correction_over_older_preference():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": "I prefer the first approach. " + "old " * 120,
+        },
+        {
+            "role": "user",
+            "content": "Actually, switch to the second approach. " + "new " * 120,
+        },
+    ]
+    correction = compressor._select_high_signal_user_anchors(
+        [turns[1]], token_budget=800
+    )
+    assert len(correction) == 1
+    exact_budget = estimate_messages_tokens_rough(
+        [{"role": "user", "content": correction[0][2]}]
+    )
+
+    anchors = compressor._select_high_signal_user_anchors(
+        turns,
+        token_budget=exact_budget,
+    )
+
+    assert len(anchors) == 1
+    assert anchors[0][1] == "correction"
+    assert "second approach" in anchors[0][2]
+
+
+def test_anchor_text_is_redacted_bounded_and_json_quoted():
+    compressor = _compressor()
+    secret = "ghp_1234567890abcdefghijklmnop"
+    turns = [
+        {
+            "role": "user",
+            "content": (
+                "prefix " * 180
+                + "Actually, always use the safe endpoint with token "
+                + secret
+                + ". "
+                + "suffix " * 180
+            ),
+        }
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+    rendered = compressor._render_high_signal_user_anchors(anchors)
+
+    assert len(anchors) == 1
+    assert len(anchors[0][2]) <= 800
+    assert anchors[0][2].startswith("...[anchor truncated]...")
+    assert anchors[0][2].endswith("...[anchor truncated]...")
+    assert "Actually, always use the safe endpoint" in anchors[0][2]
+    assert secret not in rendered
+    assert "..." in rendered
+    assert '"' in rendered
+
+
+def test_first_compaction_prompt_prioritizes_anchors_without_extra_llm_call():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "Please inspect the implementation."},
+        {"role": "assistant", "content": "Done."},
+        {"role": "user", "content": "From now on, prefer deterministic tests."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS FROM THE COMPACTED WINDOW" in prompt
+    assert "From now on, prefer deterministic tests." in prompt
+    assert "later correction or decision supersedes an earlier one" in prompt
+
+
+def test_default_anchor_budget_keeps_one_max_sized_correction():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": (
+                "context " * 70
+                + "Actually, switch to approach B instead. "
+                + "detail " * 70
+            ),
+        }
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" in prompt
+    assert "Actually, switch to approach B instead." in prompt
+
+
+def test_iterative_compaction_carries_previous_summary_and_new_correction():
+    compressor = _compressor()
+    compressor._previous_summary = "Existing decision: use approach A."
+    turns = [
+        {"role": "user", "content": "Actually, use approach B instead."},
+        {"role": "assistant", "content": "Understood."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Updated summary"),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PREVIOUS SUMMARY:\nExisting decision: use approach A." in prompt
+    assert "Actually, use approach B instead." in prompt
+    assert "[correction]" in prompt
+
+
+def test_ordinary_user_turns_do_not_add_anchor_block():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "What did the command output?"},
+        {"role": "assistant", "content": "It returned two rows."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" not in prompt
+
+
+def test_deterministic_fallback_preserves_bounded_user_decisions():
+    compressor = _compressor()
+    summary = compressor._build_static_fallback_summary(
+        [
+            {"role": "user", "content": "We decided to keep SQLite."},
+            {"role": "assistant", "content": "Understood."},
+            {"role": "user", "content": "Actually, switch to Postgres instead."},
+        ],
+        reason="provider unavailable",
+    )
+
+    assert "## Key Decisions" in summary
+    assert "[decision] We decided to keep SQLite." in summary
+    assert "[correction] Actually, switch to Postgres instead." in summary


### PR DESCRIPTION
## What does this PR do?

Adds bounded, content-aware prioritization for explicit user decisions during context compaction.

Current `main` already has the other major pieces discussed in #57875: old tool-result pruning, structured summaries, token-budget tail protection, and iterative merging of the previous compaction summary. The remaining user-decision gap is that a one-line correction and a large contextual/tool turn still reach the summarizer without an explicit priority distinction.

This change adds a conservative high-signal anchor pass before the existing summary call:

- recognizes explicit user corrections, durable decisions/preferences, and concrete configuration choices;
- excludes assistant/tool content and leaves ordinary, ambiguous, or question-shaped turns on the normal summarization path;
- redacts and whitespace-normalizes candidates, bounds each excerpt to 800 characters, and JSON-quotes it as historical source data;
- always considers the newest explicit signal first so an older correction cannot crowd out a later decision/configuration;
- uses remaining budget for corrections before decisions before configuration, then restores selected anchors to source order so chronological supersession remains visible;
- appends the bounded anchor block to both first-pass and iterative summary prompts without adding another LLM call;
- reuses the same selection in the deterministic fallback so `## Key Decisions` is no longer always empty when the summary provider is unavailable.

## Why conservative matching?

Promoting every user message would turn ordinary requests into durable state and spend the same scarce budget this change is intended to protect. The classifier therefore targets explicit language and constrains contrast/configuration matches to one sentence. False negatives still remain in the full transcript sent to the existing summarizer; false positives would be more harmful because they could be carried across repeated compactions.

## Cost and compatibility

- no additional LLM calls;
- no config, schema, provider, persistence, or message-wire changes;
- no mutation of the live conversation or cached prefix;
- anchor excerpts are selected under an independent 256-800 rough-token budget, plus a small fixed instruction header;
- existing summary output budgeting and previous-summary merge behavior are unchanged.

## Validation

- New issue-focused signal/selection/prompt/fallback/wiring suite: **36 passed**
- Compression and context-engine regression group: **241 passed**
- Additional run-agent compression group: **55 passed**
- Ruff on changed Python files: passed
- Windows footgun scanner on changed Python files: passed
- credential-shaped/conflict-marker source scan: clean
- `git diff --check`: passed

A broader Windows run also produced 61 passes and 8 existing temporary-SQLite cleanup failures in `test_compression_boundary_hook.py` and `test_compression_persistence.py`; all failures were `WinError 32` file-handle cleanup errors in unchanged paths.

Addresses the signal-tiered user-decision portion of #57875.