### PR TITLE
fix(cli): warn when '-tui' is typed instead of '--tui'

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2246,23 +2246,21 @@ def _resolve_use_tui(args) -> bool:
         return False
 
 
-def _warn_probable_tui_misparsing(args: argparse.Namespace) -> bool:
+def _warn_probable_tui_misparsing(argv: list[str]) -> bool:
     """Detect ``hermes -tui`` (single dash) and offer to relaunch as ``--tui``.
 
     ``-t`` is the short flag for ``--toolsets``, so ``-tui`` silently sets
-    ``toolsets="ui"`` instead of enabling the TUI.  When interactive, prompt
-    the user to correct it.
+    ``toolsets="ui"`` instead of enabling the TUI. Detect the literal argv
+    token rather than the parsed value: ``--toolsets ui`` is valid and must
+    not be treated as a typo. When interactive, prompt the user to correct it.
 
     Returns ``True`` if the user chose to relaunch with ``--tui`` (caller
     should inject the flag and re-parse or set ``args.tui = True``), or
     ``False`` to continue normally.  Calls ``sys.exit(0)`` if the user
     declines and wants to abort.
     """
-    toolsets = getattr(args, "toolsets", None)
-    if toolsets != "ui":
+    if "-tui" not in argv or "--tui" in argv:
         return False
-    if getattr(args, "tui", False):
-        return False  # explicit --tui was also passed, nothing to warn about
     # Non-interactive: just warn and continue (no TTY to prompt)
     try:
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
@@ -12601,7 +12599,7 @@ def _try_termux_fast_cli_launch() -> bool:
 
     # Detect ``hermes -tui`` (single dash) which argparse silently parses as
     # ``--toolsets=ui`` instead of ``--tui``.
-    if _warn_probable_tui_misparsing(args):
+    if _warn_probable_tui_misparsing(argv):
         args.tui = True
         args.toolsets = None
 
@@ -12669,6 +12667,12 @@ def _try_termux_fast_tui_launch() -> bool:
     parser, _subparsers, chat_parser = build_top_level_parser()
     chat_parser.set_defaults(func=cmd_chat)
     args = parser.parse_args(_coalesce_session_name_args(sys.argv[1:]))
+
+    # `-tui` can reach this path when the configured default interface is the
+    # TUI, so correct the literal typo before handing off to cmd_chat().
+    if _warn_probable_tui_misparsing(sys.argv[1:]):
+        args.tui = True
+        args.toolsets = None
 
     # Preserve top-level behaviours whose semantics are not "launch chat/TUI".
     if getattr(args, "version", False) or getattr(args, "oneshot", None):
@@ -14696,7 +14700,7 @@ def main():
 
     # Detect ``hermes -tui`` (single dash) which argparse silently parses as
     # ``--toolsets=ui`` instead of ``--tui``.  Prompt the user to correct it.
-    if _warn_probable_tui_misparsing(args):
+    if _warn_probable_tui_misparsing(_processed_argv):
         args.tui = True
         args.toolsets = None
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2246,6 +2246,54 @@ def _resolve_use_tui(args) -> bool:
         return False
 
 
+def _warn_probable_tui_misparsing(args: argparse.Namespace) -> bool:
+    """Detect ``hermes -tui`` (single dash) and offer to relaunch as ``--tui``.
+
+    ``-t`` is the short flag for ``--toolsets``, so ``-tui`` silently sets
+    ``toolsets="ui"`` instead of enabling the TUI.  When interactive, prompt
+    the user to correct it.
+
+    Returns ``True`` if the user chose to relaunch with ``--tui`` (caller
+    should inject the flag and re-parse or set ``args.tui = True``), or
+    ``False`` to continue normally.  Calls ``sys.exit(0)`` if the user
+    declines and wants to abort.
+    """
+    toolsets = getattr(args, "toolsets", None)
+    if toolsets != "ui":
+        return False
+    if getattr(args, "tui", False):
+        return False  # explicit --tui was also passed, nothing to warn about
+    # Non-interactive: just warn and continue (no TTY to prompt)
+    try:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            print(
+                "Warning: '-tui' sets --toolsets=ui (not the TUI). "
+                "Did you mean 'hermes --tui'?",
+                file=sys.stderr,
+            )
+            return False
+    except Exception:
+        return False
+
+    print(
+        "\n  It looks like you typed 'hermes -tui' (single dash)."
+        "\n  That sets --toolsets=ui instead of launching the TUI."
+        "\n"
+        "\n  (Y)es — continue with --toolsets=ui (tools restricted to 'ui')"
+        "\n  (N)o  — relaunch the TUI (--tui)"
+    )
+    try:
+        answer = input("\n  Continue with -tui? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\n  Cancelled.\n")
+        sys.exit(0)
+    if answer in ("y", "yes"):
+        return False  # user knowingly wants --toolsets=ui
+    # User wants --tui — inject it
+    print("  Launching --tui …\n")
+    return True
+
+
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = _resolve_use_tui(args)
@@ -12551,6 +12599,12 @@ def _try_termux_fast_cli_launch() -> bool:
         _print_version_info(check_updates=False)
         return True
 
+    # Detect ``hermes -tui`` (single dash) which argparse silently parses as
+    # ``--toolsets=ui`` instead of ``--tui``.
+    if _warn_probable_tui_misparsing(args):
+        args.tui = True
+        args.toolsets = None
+
     if getattr(args, "oneshot", None):
         _prepare_agent_startup(args)
         from hermes_cli.oneshot import run_oneshot
@@ -14639,6 +14693,12 @@ def main():
     if args.version:
         cmd_version(args)
         return
+
+    # Detect ``hermes -tui`` (single dash) which argparse silently parses as
+    # ``--toolsets=ui`` instead of ``--tui``.  Prompt the user to correct it.
+    if _warn_probable_tui_misparsing(args):
+        args.tui = True
+        args.toolsets = None
 
     # --yolo: set HERMES_YOLO_MODE *before* plugin discovery.  The call to
     # _prepare_agent_startup() below triggers discover_plugins() → tool

--- a/tests/hermes_cli/test_tui_misparsing.py
+++ b/tests/hermes_cli/test_tui_misparsing.py
@@ -1,13 +1,10 @@
 """Tests for the '-tui' (single-dash) misparsing warning.
 
 ``hermes -tui`` silently sets ``--toolsets=ui`` instead of launching the TUI,
-because ``-t`` is the short flag for ``--toolsets``.  The helper
-``_warn_probable_tui_misparsing`` detects this and offers to relaunch with
-``--tui``.
+because ``-t`` is the short flag for ``--toolsets``. The helper detects the
+literal raw argv token and offers to relaunch with ``--tui``.
 """
 
-import sys
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -18,36 +15,32 @@ from hermes_cli.main import _warn_probable_tui_misparsing
 class TestWarnProbableTuiMisparsing:
     """Unit tests for ``_warn_probable_tui_misparsing``."""
 
-    def test_returns_false_when_toolsets_not_ui(self):
-        """No warning when toolsets is something other than 'ui'."""
-        args = SimpleNamespace(toolsets="terminal,file", tui=False)
-        assert _warn_probable_tui_misparsing(args) is False
+    def test_returns_false_without_literal_typo(self):
+        """A valid explicit --toolsets ui invocation must not be changed."""
+        assert _warn_probable_tui_misparsing(["--toolsets", "ui"]) is False
 
-    def test_returns_false_when_toolsets_none(self):
-        """No warning when --toolsets was not passed at all."""
-        args = SimpleNamespace(toolsets=None, tui=False)
-        assert _warn_probable_tui_misparsing(args) is False
+    def test_parser_distinguishes_typo_from_explicit_toolset(self):
+        """Argparse produces the same value; raw argv preserves the distinction."""
+        from hermes_cli._parser import build_top_level_parser
 
-    def test_returns_false_when_tui_flag_also_set(self):
-        """No warning when both --toolsets=ui and --tui are present.
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        typo = parser.parse_args(["-tui"])
+        explicit = parser.parse_args(["--toolsets", "ui"])
 
-        The user explicitly passed both; they know what they're doing.
-        """
-        args = SimpleNamespace(toolsets="ui", tui=True)
-        assert _warn_probable_tui_misparsing(args) is False
+        assert typo.toolsets == explicit.toolsets == "ui"
+        assert _warn_probable_tui_misparsing(["-tui"]) is False  # non-TTY
+        assert _warn_probable_tui_misparsing(["--toolsets", "ui"]) is False
 
-    def test_returns_false_when_no_toolsets_attr(self):
-        """Graceful when args has no 'toolsets' attribute at all."""
-        args = SimpleNamespace(tui=False)
-        assert _warn_probable_tui_misparsing(args) is False
+    def test_returns_false_when_explicit_tui_flag_is_also_present(self):
+        """An explicit --tui already provides the intended interface."""
+        assert _warn_probable_tui_misparsing(["--tui", "-tui"]) is False
 
     def test_warns_on_stderr_in_noninteractive(self, capsys):
         """In a non-TTY context, prints a warning to stderr and returns False."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         with patch("sys.stdin") as mock_stdin, patch("sys.stdout") as mock_stdout:
             mock_stdin.isatty.return_value = False
             mock_stdout.isatty.return_value = False
-            result = _warn_probable_tui_misparsing(args)
+            result = _warn_probable_tui_misparsing(["-tui"])
         assert result is False
         captured = capsys.readouterr()
         assert "Warning" in captured.err
@@ -55,51 +48,46 @@ class TestWarnProbableTuiMisparsing:
 
     def test_user_accepts_original_toolsets_ui(self, monkeypatch, capsys):
         """User types 'y' → continues with --toolsets=ui, returns False."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _="": "y")
-        result = _warn_probable_tui_misparsing(args)
+        result = _warn_probable_tui_misparsing(["-tui"])
         assert result is False
         captured = capsys.readouterr()
         assert "--toolsets=ui" in captured.out
 
     def test_user_declines_relaunches_tui(self, monkeypatch, capsys):
         """User types 'n' → returns True (caller should set args.tui=True)."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _="": "n")
-        result = _warn_probable_tui_misparsing(args)
+        result = _warn_probable_tui_misparsing(["-tui"])
         assert result is True
         captured = capsys.readouterr()
         assert "Launching --tui" in captured.out
 
     def test_user_enter_defaults_to_no(self, monkeypatch):
         """Empty input (just pressing Enter) defaults to 'No' → relaunch."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _="": "")
-        result = _warn_probable_tui_misparsing(args)
+        result = _warn_probable_tui_misparsing(["-tui"])
         assert result is True
 
     def test_ctrl_c_exits_cleanly(self, monkeypatch):
         """KeyboardInterrupt during input exits with code 0."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _="": (_ for _ in ()).throw(KeyboardInterrupt))
         with pytest.raises(SystemExit) as exc_info:
-            _warn_probable_tui_misparsing(args)
+            _warn_probable_tui_misparsing(["-tui"])
         assert exc_info.value.code == 0
 
     def test_eof_exits_cleanly(self, monkeypatch):
         """EOFError during input exits with code 0."""
-        args = SimpleNamespace(toolsets="ui", tui=False)
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _="": (_ for _ in ()).throw(EOFError))
         with pytest.raises(SystemExit) as exc_info:
-            _warn_probable_tui_misparsing(args)
+            _warn_probable_tui_misparsing(["-tui"])
         assert exc_info.value.code == 0

--- a/tests/hermes_cli/test_tui_misparsing.py
+++ b/tests/hermes_cli/test_tui_misparsing.py
@@ -1,0 +1,105 @@
+"""Tests for the '-tui' (single-dash) misparsing warning.
+
+``hermes -tui`` silently sets ``--toolsets=ui`` instead of launching the TUI,
+because ``-t`` is the short flag for ``--toolsets``.  The helper
+``_warn_probable_tui_misparsing`` detects this and offers to relaunch with
+``--tui``.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.main import _warn_probable_tui_misparsing
+
+
+class TestWarnProbableTuiMisparsing:
+    """Unit tests for ``_warn_probable_tui_misparsing``."""
+
+    def test_returns_false_when_toolsets_not_ui(self):
+        """No warning when toolsets is something other than 'ui'."""
+        args = SimpleNamespace(toolsets="terminal,file", tui=False)
+        assert _warn_probable_tui_misparsing(args) is False
+
+    def test_returns_false_when_toolsets_none(self):
+        """No warning when --toolsets was not passed at all."""
+        args = SimpleNamespace(toolsets=None, tui=False)
+        assert _warn_probable_tui_misparsing(args) is False
+
+    def test_returns_false_when_tui_flag_also_set(self):
+        """No warning when both --toolsets=ui and --tui are present.
+
+        The user explicitly passed both; they know what they're doing.
+        """
+        args = SimpleNamespace(toolsets="ui", tui=True)
+        assert _warn_probable_tui_misparsing(args) is False
+
+    def test_returns_false_when_no_toolsets_attr(self):
+        """Graceful when args has no 'toolsets' attribute at all."""
+        args = SimpleNamespace(tui=False)
+        assert _warn_probable_tui_misparsing(args) is False
+
+    def test_warns_on_stderr_in_noninteractive(self, capsys):
+        """In a non-TTY context, prints a warning to stderr and returns False."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        with patch("sys.stdin") as mock_stdin, patch("sys.stdout") as mock_stdout:
+            mock_stdin.isatty.return_value = False
+            mock_stdout.isatty.return_value = False
+            result = _warn_probable_tui_misparsing(args)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "hermes --tui" in captured.err
+
+    def test_user_accepts_original_toolsets_ui(self, monkeypatch, capsys):
+        """User types 'y' → continues with --toolsets=ui, returns False."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _="": "y")
+        result = _warn_probable_tui_misparsing(args)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "--toolsets=ui" in captured.out
+
+    def test_user_declines_relaunches_tui(self, monkeypatch, capsys):
+        """User types 'n' → returns True (caller should set args.tui=True)."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _="": "n")
+        result = _warn_probable_tui_misparsing(args)
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Launching --tui" in captured.out
+
+    def test_user_enter_defaults_to_no(self, monkeypatch):
+        """Empty input (just pressing Enter) defaults to 'No' → relaunch."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _="": "")
+        result = _warn_probable_tui_misparsing(args)
+        assert result is True
+
+    def test_ctrl_c_exits_cleanly(self, monkeypatch):
+        """KeyboardInterrupt during input exits with code 0."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _="": (_ for _ in ()).throw(KeyboardInterrupt))
+        with pytest.raises(SystemExit) as exc_info:
+            _warn_probable_tui_misparsing(args)
+        assert exc_info.value.code == 0
+
+    def test_eof_exits_cleanly(self, monkeypatch):
+        """EOFError during input exits with code 0."""
+        args = SimpleNamespace(toolsets="ui", tui=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _="": (_ for _ in ()).throw(EOFError))
+        with pytest.raises(SystemExit) as exc_info:
+            _warn_probable_tui_misparsing(args)
+        assert exc_info.value.code == 0

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -269,6 +269,28 @@ def test_termux_fast_tui_launch_uses_light_parser(monkeypatch, main_mod):
     assert captured == {"toolsets": "web,terminal", "tui": True}
 
 
+def test_termux_fast_tui_default_corrects_single_dash_typo(monkeypatch, main_mod, tmp_path):
+    """A TUI default must not bypass the ``-tui`` typo correction."""
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("display:\n  interface: tui\n")
+    monkeypatch.setattr(main_mod, "_EARLY_INTERFACE_CACHE", None)
+    monkeypatch.setattr(sys, "argv", ["hermes", "-tui"])
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _="": "n")
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    assert main_mod._try_termux_fast_tui_launch() is True
+    assert captured == {"toolsets": None, "tui": True}
+
+
 def test_termux_fast_tui_launch_skips_help(monkeypatch, main_mod):
     monkeypatch.setenv("TERMUX_VERSION", "1")
     monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--help"])


### PR DESCRIPTION
## Problem

`hermes -tui` (single dash) silently sets `--toolsets=ui` instead of launching the TUI. This is because `-t` is the short flag for `--toolsets`, so argparse parses `-tui` as `-t ui`.

The user lands in a degraded TUI session with no tools and no indication of what went wrong.

## Fix

Add `_warn_probable_tui_misparsing()` which detects when `toolsets='ui'` is set without `--tui`:

- **Interactive (TTY):** Prompts the user:
  > It looks like you typed 'hermes -tui' (single dash).
  > That sets --toolsets=ui instead of launching the TUI.
  >
  > (Y)es — continue with --toolsets=ui
  > (N)o  — relaunch the TUI (--tui)
  
  Default is No (just pressing Enter relaunches as `--tui`).

- **Non-interactive:** Prints a warning to stderr and continues (no TTY to prompt).

The check is called in both the fast CLI launch path and the normal `main()` path, after arg parsing but before plugin discovery.

## Tests

10 unit tests covering all branches:
- toolsets != 'ui' → no warning
- toolsets=None → no warning
- --tui also set → no warning
- No toolsets attr → no warning
- Non-interactive → stderr warning, returns False
- User accepts → returns False (continues with toolsets=ui)
- User declines → returns True (caller sets args.tui=True)
- Enter defaults to No → relaunches
- Ctrl-C → sys.exit(0)
- EOF → sys.exit(0)

All 23 existing `test_argparse_flag_propagation` tests still pass.

## Before / After

```bash
# Before: silent footgun
$ hermes -tui
# TUI launches with toolsets restricted to 'ui' — no tools work, no error shown

# After: helpful prompt
$ hermes -tui
  It looks like you typed 'hermes -tui' (single dash).
  That sets --toolsets=ui instead of launching the TUI.

  (Y)es — continue with --toolsets=ui (tools restricted to 'ui')
  (N)o  — relaunch the TUI (--tui)

  Continue with -tui? [y/N]
```