### PR TITLE
fix(acp): prevent AttributeError when cancel produces None final_response

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1510,6 +1510,17 @@ class HermesACPAgent(acp.Agent):
             previous_session_id = os.environ.get("HERMES_SESSION_ID")
             os.environ["HERMES_SESSION_ID"] = session_id
             try:
+                # Clear any stale interrupt flag from a prior cancel()
+                # before starting a new agent turn. Without this, a cancel
+                # on an idle session (or a race between cancel cleanup and
+                # the next prompt) causes the agent to self-interrupt
+                # immediately. The TUI gateway does the same thing before
+                # each turn (tui_gateway/server.py ~L8461).
+                if hasattr(agent, "clear_interrupt"):
+                    try:
+                        agent.clear_interrupt()
+                    except Exception:
+                        pass
                 result = agent.run_conversation(
                     user_message=user_content,
                     conversation_history=state.history,
@@ -1596,7 +1607,7 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response", "") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,


### PR DESCRIPTION
When Xcode cancels an ACP session and immediately re-prompts on the same session, the agent loop may break with `final_response=None` before producing output. `result.get("final_response", "")` returns `None` when the key exists with a null value, causing `None.startswith()` to raise `AttributeError` at line 1606, which the ACP dispatcher wraps as `RequestError: Internal error`.

Also ensures `agent.clear_interrupt()` is called before each agent turn to prevent a stale interrupt flag from a prior `cancel()` from poisoning the next run — the TUI gateway already does this (`tui_gateway/server.py`), but the ACP adapter was missing it.

Completes the sentinel-guard work started in 9b631e4ae.

## Test Results
`pytest tests/acp/test_server.py -v`: 80/80 passed, no regressions.