### PR TITLE
feat(compression): preserve fidelity across repeated compactions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -14,6 +14,7 @@ Improvements over v2:
   - Tool output pruning before LLM summarization (cheap pre-pass)
   - Scaled summary budget (proportional to compressed content)
   - Richer tool call/result detail in summarizer input
+  - Bounded high-signal user anchors for decisions and corrections
 """
 
 import hashlib
@@ -223,6 +224,37 @@ _FALLBACK_TURN_MAX_CHARS = 700
 _AUTO_FOCUS_MAX_TURNS = 3
 _AUTO_FOCUS_TURN_MAX_CHARS = 260
 _AUTO_FOCUS_MAX_CHARS = 700
+_HIGH_SIGNAL_ANCHOR_MIN_TOKENS = 256
+_HIGH_SIGNAL_ANCHOR_MAX_TOKENS = 800
+_HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
+
+# Target explicit language instead of classifying every user turn. False
+# negatives still flow through the normal summarizer; false positives consume
+# scarce anchor budget and can fossilize ordinary requests across compactions.
+_CORRECTION_SIGNAL_RE = re.compile(
+    r"(?:\bactually\b.{0,80}\b(?:use|choose|switch|change|keep|prefer|"
+    r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
+    r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
+    r"changed?\s+(?:it\s+)?to|correction)\b|"
+    r"(?:其实.{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
+    r"而不是|纠正|更正))",
+    re.IGNORECASE,
+)
+_DURABLE_SIGNAL_RE = re.compile(
+    r"(?:\b(?:from\s+now\s+on|going\s+forward|default\s+to|"
+    r"keep\s+using)\b|\b(?:i|we)\s+(?:prefer|decid(?:e|ed)|"
+    r"cho(?:ose|se)|require)\b|\b(?:please\s+)?(?:always|must)\s+"
+    r"(?:use|keep|preserve|avoid|include|exclude|run|write|respond|"
+    r"format|store|load|call|ask|show|return)\b|"
+    r"(?:以后|今后|始终|总是|必须|默认|最终|就用|优先使用|保持使用)|"
+    r"(?:我|我们)(?:决定|选择|偏好|采用))",
+    re.IGNORECASE,
+)
+_CONFIG_SIGNAL_RE = re.compile(
+    r"(?:\b(?:set|configur(?:e|ed)|default)\b.{0,120}(?:=|\bto\b)|"
+    r"(?:设置|配置|默认).{0,120}(?:为|成|=))",
+    re.IGNORECASE,
+)
 # Keep a short run of recent messages verbatim even when the token budget is
 # already exhausted.  The public ``protect_last_n`` default is intentionally
 # high for small/light tails, but using all 20 as a hard floor here would bring
@@ -1443,6 +1475,114 @@ class ContextCompressor(ContextEngine):
         budget = int(content_tokens * _SUMMARY_RATIO)
         return max(_MIN_SUMMARY_TOKENS, min(budget, self.max_summary_tokens))
 
+    @staticmethod
+    def _high_signal_kind(text: str) -> Optional[tuple[str, int, int]]:
+        """Classify explicit durable user signals conservatively.
+
+        Returns ``(kind, priority, match_start)``. Ordinary requests are left
+        to the existing summarizer instead of competing for anchor budget.
+        """
+        if text.rstrip().endswith(("?", "？")):
+            return None
+
+        for kind, priority, pattern in (
+            ("correction", 3, _CORRECTION_SIGNAL_RE),
+            ("decision", 2, _DURABLE_SIGNAL_RE),
+            ("configuration", 1, _CONFIG_SIGNAL_RE),
+        ):
+            match = pattern.search(text)
+            if match:
+                return kind, priority, match.start()
+        return None
+
+    @staticmethod
+    def _bounded_anchor_excerpt(text: str, match_start: int) -> str:
+        """Keep a near-verbatim excerpt centered on the detected signal."""
+        if len(text) <= _HIGH_SIGNAL_ANCHOR_MAX_CHARS:
+            return text
+
+        marker = "...[anchor truncated]..."
+        payload = _HIGH_SIGNAL_ANCHOR_MAX_CHARS - 2 * (len(marker) + 1)
+        before = min(220, match_start)
+        start = max(0, match_start - before)
+        end = min(len(text), start + payload)
+        start = max(0, end - payload)
+        excerpt = text[start:end]
+        if start > 0:
+            excerpt = marker + " " + excerpt
+        if end < len(text):
+            excerpt += " " + marker
+        return excerpt.strip()
+
+    def _select_high_signal_user_anchors(
+        self,
+        turns: List[Dict[str, Any]],
+        token_budget: int,
+    ) -> list[tuple[int, str, str]]:
+        """Select redacted user decisions under an independent token budget.
+
+        Higher-priority and newer signals win selection, then selected anchors
+        are restored to source order so corrections remain chronological.
+        """
+        candidates_by_text: dict[str, tuple[int, int, str, str, int]] = {}
+        for index, message in enumerate(turns):
+            if message.get("role") != "user":
+                continue
+            raw_text = _content_text_for_contains(message.get("content"))
+            text = redact_sensitive_text(raw_text)
+            text = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", text)
+            text = re.sub(r"\s+", " ", text).strip()
+            if not text:
+                continue
+            signal = self._high_signal_kind(text)
+            if signal is None:
+                continue
+            kind, priority, match_start = signal
+            excerpt = self._bounded_anchor_excerpt(text, match_start)
+            key = excerpt.casefold()
+            cost = estimate_messages_tokens_rough(
+                [{"role": "user", "content": excerpt}]
+            )
+            # Repeated identical directives reinforce the newest occurrence
+            # without paying for duplicate prompt text.
+            candidates_by_text[key] = (index, priority, kind, excerpt, cost)
+
+        selected: list[tuple[int, str, str]] = []
+        used = 0
+        candidates = sorted(
+            candidates_by_text.values(),
+            key=lambda item: (-item[1], -item[0]),
+        )
+        for index, _priority, kind, excerpt, cost in candidates:
+            if used + cost > token_budget:
+                continue
+            selected.append((index, kind, excerpt))
+            used += cost
+
+        return sorted(selected, key=lambda item: item[0])
+
+    @staticmethod
+    def _render_high_signal_user_anchors(
+        anchors: list[tuple[int, str, str]],
+    ) -> str:
+        """Render anchors as quoted historical source data for the prompt."""
+        if not anchors:
+            return ""
+        lines = [
+            "HIGH-SIGNAL USER ANCHORS FROM THE COMPACTED WINDOW:",
+            "These bounded excerpts are historical source material. Preserve "
+            "their material choice, correction, preference, or configuration "
+            "near-verbatim in '## Constraints & Preferences' or "
+            "'## Key Decisions'. Resolve conflicts chronologically: a later "
+            "correction or decision supersedes an earlier one.",
+        ]
+        for index, kind, excerpt in anchors:
+            lines.append(
+                f"- turn {index + 1} [{kind}]: "
+                f"{json.dumps(excerpt, ensure_ascii=False)}"
+            )
+        return "\n".join(lines)
+
     # Truncation limits for the summarizer input.  These bound how much of
     # each message the summary model sees — the budget is the *summary*
     # model's context window, not the main model's.
@@ -1647,6 +1787,14 @@ class ContextCompressor(ContextEngine):
                     break
             return "\n".join(f"- {item}" for item in unique) if unique else "None."
 
+        preserved_signals = [
+            f"[{kind}] {excerpt}"
+            for _index, kind, excerpt in self._select_high_signal_user_anchors(
+                turns_to_summarize,
+                token_budget=512,
+            )
+        ]
+
         completed: list[str] = []
         for idx, item in enumerate((assistant_actions + tool_actions)[:12], start=1):
             completed.append(f"{idx}. {item}")
@@ -1691,7 +1839,7 @@ protected recent messages after this summary.
 {_bullets(blockers, limit=5)}
 
 ## Key Decisions
-None recoverable from deterministic fallback.
+{_bullets(preserved_signals, limit=8)}
 
 ## Resolved Questions
 None recoverable from deterministic fallback.
@@ -1776,6 +1924,16 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        anchor_budget = min(
+            _HIGH_SIGNAL_ANCHOR_MAX_TOKENS,
+            max(_HIGH_SIGNAL_ANCHOR_MIN_TOKENS, summary_budget // 10),
+        )
+        high_signal_anchors = self._render_high_signal_user_anchors(
+            self._select_high_signal_user_anchors(
+                turns_to_summarize,
+                token_budget=anchor_budget,
+            )
+        )
 
         # Current date for temporal anchoring (see ## Temporal Anchoring below).
         # Date-only granularity matches system_prompt.py:337 (PR #20451) and the
@@ -1936,6 +2094,11 @@ Use this exact structure:
 
 FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+
+        if high_signal_anchors:
+            prompt += f"""
+
+{high_signal_anchors}"""
 
         try:
             call_kwargs = {

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -232,11 +232,12 @@ _HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
 # negatives still flow through the normal summarizer; false positives consume
 # scarce anchor budget and can fossilize ordinary requests across compactions.
 _CORRECTION_SIGNAL_RE = re.compile(
-    r"(?:\bactually\b.{0,80}\b(?:use|choose|switch|change|keep|prefer|"
+    r"(?:\bactually\b[^.!?。！？]{0,80}\b(?:use|choose|switch|change|keep|prefer|"
     r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
     r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
     r"changed?\s+(?:it\s+)?to|correction)\b|"
-    r"(?:其实.{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
+    r"\b(?:use|choose|keep|prefer)\b[^.!?。！？]{0,80}(?:,\s*)?\bnot\b|"
+    r"(?:其实[^.!?。！？]{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"
     r"而不是|纠正|更正))",
     re.IGNORECASE,
 )
@@ -251,8 +252,8 @@ _DURABLE_SIGNAL_RE = re.compile(
     re.IGNORECASE,
 )
 _CONFIG_SIGNAL_RE = re.compile(
-    r"(?:\b(?:set|configur(?:e|ed)|default)\b.{0,120}(?:=|\bto\b)|"
-    r"(?:设置|配置|默认).{0,120}(?:为|成|=))",
+    r"(?:\b(?:set|configur(?:e|ed)|default)\b[^.!?。！？]{0,120}"
+    r"(?:=|\bto\b)|(?:设置|配置|默认)[^.!?。！？]{0,120}(?:为|成|=))",
     re.IGNORECASE,
 )
 # Keep a short run of recent messages verbatim even when the token budget is
@@ -1521,8 +1522,9 @@ class ContextCompressor(ContextEngine):
     ) -> list[tuple[int, str, str]]:
         """Select redacted user decisions under an independent token budget.
 
-        Higher-priority and newer signals win selection, then selected anchors
-        are restored to source order so corrections remain chronological.
+        The newest explicit signal is considered first so a stale correction
+        cannot crowd out a later decision. Remaining budget favors correction,
+        then decision, then configuration; output is restored to source order.
         """
         candidates_by_text: dict[str, tuple[int, int, str, str, int]] = {}
         for index, message in enumerate(turns):
@@ -1549,10 +1551,13 @@ class ContextCompressor(ContextEngine):
 
         selected: list[tuple[int, str, str]] = []
         used = 0
-        candidates = sorted(
-            candidates_by_text.values(),
-            key=lambda item: (-item[1], -item[0]),
-        )
+        candidates = list(candidates_by_text.values())
+        if candidates:
+            newest = max(candidates, key=lambda item: item[0])
+            candidates = [newest] + sorted(
+                (item for item in candidates if item[0] != newest[0]),
+                key=lambda item: (-item[1], -item[0]),
+            )
         for index, _priority, kind, excerpt, cost in candidates:
             if used + cost > token_budget:
                 continue

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -227,6 +227,15 @@ _AUTO_FOCUS_MAX_CHARS = 700
 _HIGH_SIGNAL_ANCHOR_MIN_TOKENS = 256
 _HIGH_SIGNAL_ANCHOR_MAX_TOKENS = 800
 _HIGH_SIGNAL_ANCHOR_MAX_CHARS = 800
+_FIDELITY_LEDGER_START = "<!-- hermes-compaction-fidelity:v1 -->"
+_FIDELITY_LEDGER_END = "<!-- /hermes-compaction-fidelity -->"
+_FIDELITY_LEDGER_TOKEN_BUDGET = 800
+_FIDELITY_LEDGER_MAX_ENTRIES = 32
+_FIDELITY_KIND_PRIORITY = {
+    "correction": 3,
+    "decision": 2,
+    "configuration": 1,
+}
 
 # Target explicit language instead of classifying every user turn. False
 # negatives still flow through the normal summarizer; false positives consume
@@ -1588,6 +1597,171 @@ class ContextCompressor(ContextEngine):
             )
         return "\n".join(lines)
 
+    @classmethod
+    def _normalize_fidelity_text(cls, value: str) -> str:
+        """Normalize ledger text and prevent delimiter injection."""
+        normalized = redact_sensitive_text(value)
+        normalized = normalized.replace(
+            _FIDELITY_LEDGER_START, "[fidelity marker removed]"
+        )
+        normalized = normalized.replace(
+            _FIDELITY_LEDGER_END, "[fidelity marker removed]"
+        )
+        return re.sub(r"\s+", " ", normalized).strip()[
+            :_HIGH_SIGNAL_ANCHOR_MAX_CHARS
+        ]
+
+    @classmethod
+    def _split_fidelity_ledger(
+        cls,
+        summary: str,
+    ) -> tuple[str, list[tuple[str, str]]]:
+        """Separate a valid persisted ledger from its narrative summary.
+
+        Invalid or incomplete markers are left untouched. This avoids deleting
+        user/model text that merely resembles the internal ledger delimiter.
+        """
+        text = summary or ""
+        start = text.rfind(_FIDELITY_LEDGER_START)
+        if start < 0:
+            return text, []
+        payload_start = start + len(_FIDELITY_LEDGER_START)
+        end = text.find(_FIDELITY_LEDGER_END, payload_start)
+        if end < 0:
+            return text, []
+
+        try:
+            payload = json.loads(text[payload_start:end].strip())
+        except (json.JSONDecodeError, TypeError):
+            return text, []
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            return text, []
+        raw_entries = payload.get("entries")
+        if not isinstance(raw_entries, list):
+            return text, []
+
+        entries: list[tuple[str, str]] = []
+        for raw in raw_entries[:_FIDELITY_LEDGER_MAX_ENTRIES]:
+            if not isinstance(raw, dict):
+                continue
+            kind = raw.get("kind")
+            value = raw.get("text")
+            if kind not in _FIDELITY_KIND_PRIORITY or not isinstance(value, str):
+                continue
+            value = cls._normalize_fidelity_text(value)
+            if not value:
+                continue
+            entries.append((kind, value))
+
+        narrative = (text[:start] + text[end + len(_FIDELITY_LEDGER_END):]).strip()
+        return narrative, entries
+
+    @classmethod
+    def _merge_fidelity_ledger(
+        cls,
+        existing: list[tuple[str, str]],
+        new: list[tuple[str, str]],
+        token_budget: int = _FIDELITY_LEDGER_TOKEN_BUDGET,
+    ) -> list[tuple[str, str]]:
+        """Merge exact anchors, preserving chronology under a hard budget."""
+        deduped: dict[str, tuple[int, str, str, int]] = {}
+        for sequence, (kind, raw_value) in enumerate(existing + new):
+            if kind not in _FIDELITY_KIND_PRIORITY or not isinstance(raw_value, str):
+                continue
+            value = cls._normalize_fidelity_text(raw_value)
+            if not value:
+                continue
+            key = re.sub(r"\s+", " ", value).strip().casefold()
+            if key in deduped:
+                del deduped[key]
+            cost = estimate_messages_tokens_rough(
+                [{"role": "user", "content": f"[{kind}] {value}"}]
+            )
+            deduped[key] = (sequence, kind, value, cost)
+
+        candidates = list(deduped.values())
+        if not candidates:
+            return []
+        newest = max(candidates, key=lambda item: item[0])
+        ranked = [newest] + sorted(
+            (item for item in candidates if item[0] != newest[0]),
+            key=lambda item: (-_FIDELITY_KIND_PRIORITY[item[1]], -item[0]),
+        )
+
+        selected: list[tuple[int, str, str]] = []
+        used = 0
+        for sequence, kind, value, cost in ranked:
+            if used + cost > token_budget:
+                continue
+            selected.append((sequence, kind, value))
+            used += cost
+            if len(selected) >= _FIDELITY_LEDGER_MAX_ENTRIES:
+                break
+        selected.sort(key=lambda item: item[0])
+        return [(kind, value) for _sequence, kind, value in selected]
+
+    @classmethod
+    def _serialize_fidelity_ledger(
+        cls,
+        entries: list[tuple[str, str]],
+    ) -> str:
+        """Serialize a bounded ledger as a versioned, parseable summary block."""
+        if not entries:
+            return ""
+        payload = {
+            "version": 1,
+            "entries": [
+                {"kind": kind, "text": cls._normalize_fidelity_text(value)}
+                for kind, value in entries
+            ],
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        return f"{_FIDELITY_LEDGER_START}\n{encoded}\n{_FIDELITY_LEDGER_END}"
+
+    @classmethod
+    def _append_fidelity_ledger(
+        cls,
+        summary: str,
+        entries: list[tuple[str, str]],
+    ) -> str:
+        """Replace any valid existing ledger with the authoritative entries."""
+        narrative, _existing = cls._split_fidelity_ledger(summary)
+        ledger = cls._serialize_fidelity_ledger(entries)
+        if not ledger:
+            return narrative
+        return f"{narrative.rstrip()}\n\n{ledger}" if narrative.strip() else ledger
+
+    @classmethod
+    def _render_fidelity_ledger_prompt(
+        cls,
+        entries: list[tuple[str, str]],
+    ) -> str:
+        """Render the deterministic ledger as quoted summarizer source data."""
+        anchors = [
+            (sequence, kind, value)
+            for sequence, (kind, value) in enumerate(entries)
+        ]
+        return cls._render_high_signal_user_anchors(anchors)
+
+    def _prepare_fidelity_ledger(
+        self,
+        turns: List[Dict[str, Any]],
+        new_anchor_budget: int,
+    ) -> tuple[str, list[tuple[str, str]]]:
+        """Merge persisted and newly selected anchors for one compaction."""
+        previous_narrative, existing = self._split_fidelity_ledger(
+            self._previous_summary or ""
+        )
+        new = [
+            (kind, value)
+            for _index, kind, value in self._select_high_signal_user_anchors(
+                turns,
+                token_budget=new_anchor_budget,
+            )
+        ]
+        merged = self._merge_fidelity_ledger(existing, new)
+        return previous_narrative, merged
+
     # Truncation limits for the summarizer input.  These bound how much of
     # each message the summary model sees — the budget is the *summary*
     # model's context window, not the main model's.
@@ -1792,12 +1966,13 @@ class ContextCompressor(ContextEngine):
                     break
             return "\n".join(f"- {item}" for item in unique) if unique else "None."
 
+        _previous_narrative, fidelity_ledger = self._prepare_fidelity_ledger(
+            turns_to_summarize,
+            new_anchor_budget=512,
+        )
         preserved_signals = [
             f"[{kind}] {excerpt}"
-            for _index, kind, excerpt in self._select_high_signal_user_anchors(
-                turns_to_summarize,
-                token_budget=512,
-            )
+            for kind, excerpt in fidelity_ledger
         ]
 
         completed: list[str] = []
@@ -1865,9 +2040,17 @@ Continue from the most recent unfulfilled user ask and protected tail messages. 
 
 ## Critical Context
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
-        summary = self._with_summary_prefix(redact_sensitive_text(body.strip()))
-        if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
-            summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
+        narrative = redact_sensitive_text(body.strip())
+        ledger_block = self._serialize_fidelity_ledger(fidelity_ledger)
+        body_limit = _FALLBACK_SUMMARY_MAX_CHARS - len(SUMMARY_PREFIX) - 1
+        narrative_limit = body_limit - len(ledger_block) - (2 if ledger_block else 0)
+        if len(narrative) > narrative_limit:
+            marker = "\n...[fallback summary truncated]"
+            narrative = narrative[: max(0, narrative_limit - len(marker))].rstrip()
+            narrative += marker
+        summary_body = self._append_fidelity_ledger(narrative, fidelity_ledger)
+        self._previous_summary = summary_body
+        summary = self._with_summary_prefix(summary_body)
         return summary
 
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
@@ -1933,11 +2116,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             _HIGH_SIGNAL_ANCHOR_MAX_TOKENS,
             max(_HIGH_SIGNAL_ANCHOR_MIN_TOKENS, summary_budget // 10),
         )
-        high_signal_anchors = self._render_high_signal_user_anchors(
-            self._select_high_signal_user_anchors(
-                turns_to_summarize,
-                token_budget=anchor_budget,
-            )
+        previous_summary_narrative, fidelity_ledger = self._prepare_fidelity_ledger(
+            turns_to_summarize,
+            new_anchor_budget=anchor_budget,
+        )
+        high_signal_anchors = self._render_fidelity_ledger_prompt(
+            fidelity_ledger
         )
 
         # Current date for temporal anchoring (see ## Temporal Anchoring below).
@@ -2071,7 +2255,7 @@ Write only the summary body. Do not include any preamble or prefix."""
 You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
 
 PREVIOUS SUMMARY:
-{self._previous_summary}
+{previous_summary_narrative}
 
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
@@ -2177,6 +2361,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            summary = self._append_fidelity_ledger(summary, fidelity_ledger)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1664,7 +1664,7 @@ class ContextCompressor(ContextEngine):
         token_budget: int = _FIDELITY_LEDGER_TOKEN_BUDGET,
     ) -> list[tuple[str, str]]:
         """Merge exact anchors, preserving chronology under a hard budget."""
-        deduped: dict[str, tuple[int, str, str, int]] = {}
+        deduped: dict[str, tuple[int, str, str]] = {}
         for sequence, (kind, raw_value) in enumerate(existing + new):
             if kind not in _FIDELITY_KIND_PRIORITY or not isinstance(raw_value, str):
                 continue
@@ -1674,10 +1674,7 @@ class ContextCompressor(ContextEngine):
             key = re.sub(r"\s+", " ", value).strip().casefold()
             if key in deduped:
                 del deduped[key]
-            cost = estimate_messages_tokens_rough(
-                [{"role": "user", "content": f"[{kind}] {value}"}]
-            )
-            deduped[key] = (sequence, kind, value, cost)
+            deduped[key] = (sequence, kind, value)
 
         candidates = list(deduped.values())
         if not candidates:
@@ -1689,15 +1686,18 @@ class ContextCompressor(ContextEngine):
         )
 
         selected: list[tuple[int, str, str]] = []
-        used = 0
-        for sequence, kind, value, cost in ranked:
-            if used + cost > token_budget:
+        for sequence, kind, value in ranked:
+            trial = selected + [(sequence, kind, value)]
+            trial.sort(key=lambda item: item[0])
+            trial_entries = [
+                (trial_kind, trial_value)
+                for _trial_sequence, trial_kind, trial_value in trial
+            ]
+            if cls._fidelity_ledger_token_cost(trial_entries) > token_budget:
                 continue
-            selected.append((sequence, kind, value))
-            used += cost
+            selected = trial
             if len(selected) >= _FIDELITY_LEDGER_MAX_ENTRIES:
                 break
-        selected.sort(key=lambda item: item[0])
         return [(kind, value) for _sequence, kind, value in selected]
 
     @classmethod
@@ -1717,6 +1717,19 @@ class ContextCompressor(ContextEngine):
         }
         encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         return f"{_FIDELITY_LEDGER_START}\n{encoded}\n{_FIDELITY_LEDGER_END}"
+
+    @classmethod
+    def _fidelity_ledger_token_cost(
+        cls,
+        entries: list[tuple[str, str]],
+    ) -> int:
+        """Estimate the complete persisted block, including format overhead."""
+        ledger = cls._serialize_fidelity_ledger(entries)
+        if not ledger:
+            return 0
+        return estimate_messages_tokens_rough(
+            [{"role": "user", "content": ledger}]
+        )
 
     @classmethod
     def _append_fidelity_ledger(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -236,6 +236,22 @@ _FIDELITY_KIND_PRIORITY = {
     "decision": 2,
     "configuration": 1,
 }
+_FIDELITY_STRUCTURAL_MARKERS = tuple(
+    sorted(
+        {
+            _FIDELITY_LEDGER_START,
+            _FIDELITY_LEDGER_END,
+            SUMMARY_PREFIX,
+            LEGACY_SUMMARY_PREFIX,
+            *_HISTORICAL_SUMMARY_PREFIXES,
+            _SUMMARY_END_MARKER,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+        },
+        key=len,
+        reverse=True,
+    )
+)
 
 # Target explicit language instead of classifying every user turn. False
 # negatives still flow through the normal summarizer; false positives consume
@@ -1601,12 +1617,8 @@ class ContextCompressor(ContextEngine):
     def _normalize_fidelity_text(cls, value: str) -> str:
         """Normalize ledger text and prevent delimiter injection."""
         normalized = redact_sensitive_text(value)
-        normalized = normalized.replace(
-            _FIDELITY_LEDGER_START, "[fidelity marker removed]"
-        )
-        normalized = normalized.replace(
-            _FIDELITY_LEDGER_END, "[fidelity marker removed]"
-        )
+        for marker in _FIDELITY_STRUCTURAL_MARKERS:
+            normalized = normalized.replace(marker, "[compaction marker removed]")
         return re.sub(r"\s+", " ", normalized).strip()[
             :_HIGH_SIGNAL_ANCHOR_MAX_CHARS
         ]

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -258,8 +258,12 @@ _FIDELITY_STRUCTURAL_MARKERS = tuple(
 # scarce anchor budget and can fossilize ordinary requests across compactions.
 _CORRECTION_SIGNAL_RE = re.compile(
     r"(?:\bactually\b[^.!?。！？]{0,80}\b(?:use|choose|switch|change|keep|prefer|"
-    r"do\s+not|don't|instead)\b|\b(?:instead|rather\s+than|do\s+not|"
-    r"don't|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
+    r"do\s+not\s+(?:use|modify|change|remove|add|keep|choose|switch)|"
+    r"don't\s+(?:use|modify|change|remove|add|keep|choose|switch))\b|"
+    r"(?:^|[.!?]\s+)(?:please\s+)?(?:do\s+not|don't)\s+"
+    r"(?:use|modify|change|remove|add|keep|choose|switch)\b|"
+    r"(?:^|[.!?]\s+)instead\s*,?\s*(?:use|choose|switch|change|keep|prefer)\b|"
+    r"\b(?:rather\s+than|never\s+mind|stop\s+using|switch(?:ed)?\s+to|"
     r"changed?\s+(?:it\s+)?to|correction)\b|"
     r"\b(?:use|choose|keep|prefer)\b[^.!?。！？]{0,80}(?:,\s*)?\bnot\b|"
     r"(?:其实[^.!?。！？]{0,60}(?:改|用|不要|选择|决定)|改成|改用|不要|不再|"

--- a/tests/agent/test_context_compressor_fidelity_ledger.py
+++ b/tests/agent/test_context_compressor_fidelity_ledger.py
@@ -108,11 +108,9 @@ def test_merge_is_bounded_deduplicated_and_always_keeps_latest_signal():
         [latest],
     )
 
-    cost = sum(
-        estimate_messages_tokens_rough(
-            [{"role": "user", "content": f"[{kind}] {text}"}]
-        )
-        for kind, text in merged
+    serialized = ContextCompressor._serialize_fidelity_ledger(merged)
+    cost = estimate_messages_tokens_rough(
+        [{"role": "user", "content": serialized}]
     )
     assert latest in merged
     assert len(merged) <= _FIDELITY_LEDGER_MAX_ENTRIES
@@ -120,19 +118,33 @@ def test_merge_is_bounded_deduplicated_and_always_keeps_latest_signal():
     assert sum(text == existing[0][1] for _kind, text in merged) <= 1
 
 
+def test_merge_budget_counts_serialized_envelope_overhead():
+    entry = ("decision", "We decided to preserve this bounded requirement.")
+    entry_only_cost = estimate_messages_tokens_rough(
+        [{"role": "user", "content": f"[{entry[0]}] {entry[1]}"}]
+    )
+    serialized_cost = ContextCompressor._fidelity_ledger_token_cost([entry])
+
+    assert serialized_cost > entry_only_cost
+    assert ContextCompressor._merge_fidelity_ledger(
+        [],
+        [entry],
+        token_budget=entry_only_cost,
+    ) == []
+
+
 def test_repeated_compaction_benchmark_retains_all_decisions_without_extra_calls():
-    """A deliberately lossy summarizer cannot erase deterministic ledger state."""
+    """The public compression path survives a deliberately lossy summarizer."""
     compressor = _compressor()
-    rounds = [
-        [{"role": "user", "content": "We decided to use SQLite."}],
-        [{"role": "user", "content": "Actually, use Postgres instead."}],
-        [{"role": "user", "content": "Configure the timeout to 30 seconds."}],
-    ]
-    expected = {
+    compressor.protect_first_n = 0
+    compressor.protect_last_n = 2
+    compressor.tail_token_budget = 120
+    signals = [
         "We decided to use SQLite.",
         "Actually, use Postgres instead.",
         "Configure the timeout to 30 seconds.",
-    }
+    ]
+    messages = []
 
     with patch(
         "agent.context_compressor.call_llm",
@@ -142,19 +154,46 @@ def test_repeated_compaction_benchmark_retains_all_decisions_without_extra_calls
             _response("Lossy narrative three."),
         ],
     ) as mock_call:
-        summaries = [compressor._generate_summary(turns) for turns in rounds]
+        for round_index, signal in enumerate(signals):
+            messages.extend(
+                [
+                    {"role": "user", "content": signal},
+                    {"role": "assistant", "content": "Decision acknowledged."},
+                ]
+            )
+            messages.extend(
+                {
+                    "role": "user" if index % 2 == 0 else "assistant",
+                    "content": (
+                        f"round {round_index} context {index} " + "detail " * 80
+                    ),
+                }
+                for index in range(8)
+            )
+            messages = compressor.compress(
+                messages,
+                current_tokens=90_000,
+                force=True,
+            )
 
-    narrative, entries = compressor._split_fidelity_ledger(
-        compressor._previous_summary or ""
+    summary_messages = [
+        message
+        for message in messages
+        if SUMMARY_PREFIX in str(message.get("content", ""))
+    ]
+    assert len(summary_messages) == 1
+    summary_body = compressor._strip_summary_prefix(
+        str(summary_messages[0]["content"])
     )
-    retained = {text for _kind, text in entries} & expected
-    retention_rate = len(retained) / len(expected)
+    narrative, entries = compressor._split_fidelity_ledger(summary_body)
+    retained = {text for _kind, text in entries} & set(signals)
+    retention_rate = len(retained) / len(signals)
 
-    assert mock_call.call_count == len(rounds)
+    assert mock_call.call_count == len(signals)
     assert retention_rate == 1.0
     assert narrative == "Lossy narrative three."
     assert entries[-1] == ("configuration", "Configure the timeout to 30 seconds.")
-    assert all(summary.count(_FIDELITY_LEDGER_START) == 1 for summary in summaries)
+    assert summary_body.count(_FIDELITY_LEDGER_START) == 1
 
 
 def test_fallback_merges_prior_ledger_and_truncates_narrative_first():
@@ -193,31 +232,53 @@ def test_persisted_handoff_rehydrates_ledger_after_restart():
         )
 
     restarted = _compressor()
-    summary_index, summary_body = restarted._find_latest_context_summary(
-        [
-            {"role": "system", "content": "system"},
-            {"role": "user", "content": persisted},
-        ],
-        1,
-        2,
+    restarted.protect_first_n = 1
+    restarted.protect_last_n = 2
+    restarted.tail_token_budget = 120
+    resumed_messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": persisted},
+        {"role": "assistant", "content": "Handoff acknowledged."},
+        {"role": "user", "content": "Actually, use footnote citations."},
+        {"role": "assistant", "content": "Correction acknowledged."},
+    ]
+    resumed_messages.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"resumed context {index} " + "detail " * 80,
+        }
+        for index in range(8)
     )
-    assert summary_index == 1
-    assert summary_body.startswith("Initial narrative.")
-    restarted._previous_summary = summary_body
 
     with patch(
         "agent.context_compressor.call_llm",
         return_value=_response("Resumed narrative."),
-    ):
-        resumed = restarted._generate_summary(
-            [{"role": "user", "content": "Actually, use footnote citations."}]
+    ) as mock_call:
+        resumed_messages = restarted.compress(
+            resumed_messages,
+            current_tokens=90_000,
+            force=True,
         )
 
-    body = resumed.removeprefix(SUMMARY_PREFIX).strip()
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert prompt.count("We decided to keep citations inline.") == 1
+    assert "Actually, use footnote citations." in prompt
+    summaries = [
+        str(message.get("content", ""))
+        for message in resumed_messages
+        if SUMMARY_PREFIX in str(message.get("content", ""))
+    ]
+    # The existing protected-head policy keeps the persisted handoff alongside
+    # its updated successor. The later handoff is the authoritative one.
+    body = next(
+        restarted._strip_summary_prefix(summary)
+        for summary in summaries
+        if "Resumed narrative." in summary
+    )
     narrative, entries = restarted._split_fidelity_ledger(body)
     assert narrative == "Resumed narrative."
     assert entries == [
         ("decision", "We decided to keep citations inline."),
         ("correction", "Actually, use footnote citations."),
     ]
-    assert resumed.count(_FIDELITY_LEDGER_START) == 1
+    assert body.count(_FIDELITY_LEDGER_START) == 1

--- a/tests/agent/test_context_compressor_fidelity_ledger.py
+++ b/tests/agent/test_context_compressor_fidelity_ledger.py
@@ -2,13 +2,20 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent.context_compressor import (
+    LEGACY_SUMMARY_PREFIX,
     SUMMARY_PREFIX,
     ContextCompressor,
     _FIDELITY_LEDGER_END,
     _FIDELITY_LEDGER_MAX_ENTRIES,
     _FIDELITY_LEDGER_START,
     _FIDELITY_LEDGER_TOKEN_BUDGET,
+    _HISTORICAL_SUMMARY_PREFIXES,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
 )
 from agent.model_metadata import estimate_messages_tokens_rough
 
@@ -58,10 +65,23 @@ def test_invalid_fidelity_ledger_is_left_untouched():
     assert entries == []
 
 
-def test_fidelity_ledger_sanitizes_delimiters_inside_user_text():
+@pytest.mark.parametrize(
+    "marker",
+    [
+        _FIDELITY_LEDGER_START,
+        _FIDELITY_LEDGER_END,
+        SUMMARY_PREFIX,
+        LEGACY_SUMMARY_PREFIX,
+        *_HISTORICAL_SUMMARY_PREFIXES,
+        _SUMMARY_END_MARKER,
+        _MERGED_PRIOR_CONTEXT_HEADER,
+        _MERGED_SUMMARY_DELIMITER,
+    ],
+)
+def test_fidelity_ledger_sanitizes_compaction_markers_inside_user_text(marker: str):
     injected = (
         "We decided to preserve this literal marker: "
-        f"{_FIDELITY_LEDGER_END}"
+        f"{marker}"
     )
 
     merged = ContextCompressor._merge_fidelity_ledger(
@@ -75,10 +95,19 @@ def test_fidelity_ledger_sanitizes_delimiters_inside_user_text():
         (
             "decision",
             "We decided to preserve this literal marker: "
-            "[fidelity marker removed]",
+            "[compaction marker removed]",
         )
     ]
+    assert marker not in restored[0][1]
     assert summary.count(_FIDELITY_LEDGER_END) == 1
+
+    final_handoff = (
+        ContextCompressor._with_summary_prefix(summary)
+        + "\n\n"
+        + _SUMMARY_END_MARKER
+    )
+    assert final_handoff.endswith(_SUMMARY_END_MARKER)
+    assert final_handoff.count(_SUMMARY_END_MARKER) == 1
 
 
 def test_append_replaces_a_valid_ledger_instead_of_nesting_it():
@@ -194,6 +223,9 @@ def test_repeated_compaction_benchmark_retains_all_decisions_without_extra_calls
     assert narrative == "Lossy narrative three."
     assert entries[-1] == ("configuration", "Configure the timeout to 30 seconds.")
     assert summary_body.count(_FIDELITY_LEDGER_START) == 1
+    final_handoff = str(summary_messages[0]["content"])
+    assert final_handoff.endswith(_SUMMARY_END_MARKER)
+    assert final_handoff.count(_SUMMARY_END_MARKER) == 1
 
 
 def test_fallback_merges_prior_ledger_and_truncates_narrative_first():

--- a/tests/agent/test_context_compressor_fidelity_ledger.py
+++ b/tests/agent/test_context_compressor_fidelity_ledger.py
@@ -1,0 +1,223 @@
+"""Contracts for durable fidelity across repeated context compactions."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    SUMMARY_PREFIX,
+    ContextCompressor,
+    _FIDELITY_LEDGER_END,
+    _FIDELITY_LEDGER_MAX_ENTRIES,
+    _FIDELITY_LEDGER_START,
+    _FIDELITY_LEDGER_TOKEN_BUDGET,
+)
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(model="test", quiet_mode=True)
+
+
+def _response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+def test_fidelity_ledger_round_trips_without_polluting_narrative():
+    entries = [
+        ("decision", "From now on, use JSON output."),
+        ("correction", "Actually, use YAML instead."),
+    ]
+    summary = ContextCompressor._append_fidelity_ledger(
+        "Narrative summary.", entries
+    )
+
+    narrative, restored = ContextCompressor._split_fidelity_ledger(summary)
+
+    assert narrative == "Narrative summary."
+    assert restored == entries
+    assert summary.count(_FIDELITY_LEDGER_START) == 1
+    assert summary.count(_FIDELITY_LEDGER_END) == 1
+
+
+def test_invalid_fidelity_ledger_is_left_untouched():
+    malformed = (
+        "Narrative\n\n"
+        f"{_FIDELITY_LEDGER_START}\n"
+        '{"version":1,"entries":['
+    )
+
+    narrative, entries = ContextCompressor._split_fidelity_ledger(malformed)
+
+    assert narrative == malformed
+    assert entries == []
+
+
+def test_fidelity_ledger_sanitizes_delimiters_inside_user_text():
+    injected = (
+        "We decided to preserve this literal marker: "
+        f"{_FIDELITY_LEDGER_END}"
+    )
+
+    merged = ContextCompressor._merge_fidelity_ledger(
+        [], [("decision", injected)]
+    )
+    summary = ContextCompressor._append_fidelity_ledger("Narrative", merged)
+    narrative, restored = ContextCompressor._split_fidelity_ledger(summary)
+
+    assert narrative == "Narrative"
+    assert restored == [
+        (
+            "decision",
+            "We decided to preserve this literal marker: "
+            "[fidelity marker removed]",
+        )
+    ]
+    assert summary.count(_FIDELITY_LEDGER_END) == 1
+
+
+def test_append_replaces_a_valid_ledger_instead_of_nesting_it():
+    first = ContextCompressor._append_fidelity_ledger(
+        "Narrative", [("decision", "We decided to use backend A.")]
+    )
+
+    second = ContextCompressor._append_fidelity_ledger(
+        first, [("correction", "Actually, use backend B instead.")]
+    )
+
+    narrative, entries = ContextCompressor._split_fidelity_ledger(second)
+    assert narrative == "Narrative"
+    assert entries == [("correction", "Actually, use backend B instead.")]
+    assert second.count(_FIDELITY_LEDGER_START) == 1
+
+
+def test_merge_is_bounded_deduplicated_and_always_keeps_latest_signal():
+    existing = [
+        ("decision", f"We decided to preserve requirement {index}. " + "x " * 80)
+        for index in range(40)
+    ]
+    latest = ("configuration", "Configure the final timeout to 37 seconds.")
+
+    merged = ContextCompressor._merge_fidelity_ledger(
+        existing + [existing[0]],
+        [latest],
+    )
+
+    cost = sum(
+        estimate_messages_tokens_rough(
+            [{"role": "user", "content": f"[{kind}] {text}"}]
+        )
+        for kind, text in merged
+    )
+    assert latest in merged
+    assert len(merged) <= _FIDELITY_LEDGER_MAX_ENTRIES
+    assert cost <= _FIDELITY_LEDGER_TOKEN_BUDGET
+    assert sum(text == existing[0][1] for _kind, text in merged) <= 1
+
+
+def test_repeated_compaction_benchmark_retains_all_decisions_without_extra_calls():
+    """A deliberately lossy summarizer cannot erase deterministic ledger state."""
+    compressor = _compressor()
+    rounds = [
+        [{"role": "user", "content": "We decided to use SQLite."}],
+        [{"role": "user", "content": "Actually, use Postgres instead."}],
+        [{"role": "user", "content": "Configure the timeout to 30 seconds."}],
+    ]
+    expected = {
+        "We decided to use SQLite.",
+        "Actually, use Postgres instead.",
+        "Configure the timeout to 30 seconds.",
+    }
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        side_effect=[
+            _response("Lossy narrative one."),
+            _response("Lossy narrative two."),
+            _response("Lossy narrative three."),
+        ],
+    ) as mock_call:
+        summaries = [compressor._generate_summary(turns) for turns in rounds]
+
+    narrative, entries = compressor._split_fidelity_ledger(
+        compressor._previous_summary or ""
+    )
+    retained = {text for _kind, text in entries} & expected
+    retention_rate = len(retained) / len(expected)
+
+    assert mock_call.call_count == len(rounds)
+    assert retention_rate == 1.0
+    assert narrative == "Lossy narrative three."
+    assert entries[-1] == ("configuration", "Configure the timeout to 30 seconds.")
+    assert all(summary.count(_FIDELITY_LEDGER_START) == 1 for summary in summaries)
+
+
+def test_fallback_merges_prior_ledger_and_truncates_narrative_first():
+    compressor = _compressor()
+    compressor._previous_summary = ContextCompressor._append_fidelity_ledger(
+        "Prior narrative.",
+        [("decision", "We decided to retain the audit log.")],
+    )
+    turns = [
+        {"role": "assistant", "content": "detail " * 4_000},
+        {"role": "user", "content": "Actually, use trace logging too."},
+    ]
+
+    summary = compressor._build_static_fallback_summary(
+        turns, reason="provider unavailable"
+    )
+
+    body = ContextCompressor._strip_summary_prefix(summary)
+    _narrative, entries = compressor._split_fidelity_ledger(body)
+    assert len(summary) <= 8_000
+    assert entries == [
+        ("decision", "We decided to retain the audit log."),
+        ("correction", "Actually, use trace logging too."),
+    ]
+    assert compressor._previous_summary == body
+
+
+def test_persisted_handoff_rehydrates_ledger_after_restart():
+    first = _compressor()
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Initial narrative."),
+    ):
+        persisted = first._generate_summary(
+            [{"role": "user", "content": "We decided to keep citations inline."}]
+        )
+
+    restarted = _compressor()
+    summary_index, summary_body = restarted._find_latest_context_summary(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": persisted},
+        ],
+        1,
+        2,
+    )
+    assert summary_index == 1
+    assert summary_body.startswith("Initial narrative.")
+    restarted._previous_summary = summary_body
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Resumed narrative."),
+    ):
+        resumed = restarted._generate_summary(
+            [{"role": "user", "content": "Actually, use footnote citations."}]
+        )
+
+    body = resumed.removeprefix(SUMMARY_PREFIX).strip()
+    narrative, entries = restarted._split_fidelity_ledger(body)
+    assert narrative == "Resumed narrative."
+    assert entries == [
+        ("decision", "We decided to keep citations inline."),
+        ("correction", "Actually, use footnote citations."),
+    ]
+    assert resumed.count(_FIDELITY_LEDGER_START) == 1

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -32,6 +32,7 @@ def _response(content: str = "summary") -> MagicMock:
         ("I prefer deterministic tests.", "decision"),
         ("Please always preserve the original quote.", "decision"),
         ("Use Postgres rather than SQLite.", "correction"),
+        ("Use approach B, not approach A.", "correction"),
         ("Actually, switch to approach B.", "correction"),
         ("Do not modify generated files.", "correction"),
         ("Configure timeout to 30 seconds.", "configuration"),
@@ -56,6 +57,7 @@ def test_explicit_signal_matrix(text: str, kind: str):
         "The docs mention a default timeout.",
         "Actually, what happened here?",
         "Please compare approach A and approach B.",
+        "Use the tool. This is not a decision.",
         "The command returned two rows.",
     ],
 )
@@ -122,9 +124,39 @@ def test_anchor_budget_prefers_newer_correction_over_older_preference():
     assert "second approach" in anchors[0][2]
 
 
+def test_anchor_budget_reserves_latest_signal_before_older_higher_tier():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": "Actually, do not use backend A. " + "old " * 120,
+        },
+        {
+            "role": "user",
+            "content": "Configure the backend to B. " + "new " * 120,
+        },
+    ]
+    latest = compressor._select_high_signal_user_anchors(
+        [turns[1]], token_budget=800
+    )
+    assert len(latest) == 1
+    exact_budget = estimate_messages_tokens_rough(
+        [{"role": "user", "content": latest[0][2]}]
+    )
+
+    anchors = compressor._select_high_signal_user_anchors(
+        turns,
+        token_budget=exact_budget,
+    )
+
+    assert len(anchors) == 1
+    assert anchors[0][1] == "configuration"
+    assert "backend to B" in anchors[0][2]
+
+
 def test_anchor_text_is_redacted_bounded_and_json_quoted():
     compressor = _compressor()
-    secret = "ghp_1234567890abcdefghijklmnop"
+    secret = "".join(("ghp", "_", "x" * 32))
     turns = [
         {
             "role": "user",
@@ -215,6 +247,42 @@ def test_iterative_compaction_carries_previous_summary_and_new_correction():
     assert "PREVIOUS SUMMARY:\nExisting decision: use approach A." in prompt
     assert "Actually, use approach B instead." in prompt
     assert "[correction]" in prompt
+
+
+def test_compress_wires_middle_window_decision_into_summary_prompt():
+    compressor = _compressor()
+    compressor.protect_first_n = 0
+    compressor.protect_last_n = 2
+    compressor.tail_token_budget = 120
+    turns = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "We decided to keep the SQLite backend."},
+        {"role": "assistant", "content": "Decision recorded."},
+    ]
+    turns.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"ordinary context {index} " + "detail " * 80,
+        }
+        for index in range(12)
+    )
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Compacted summary"),
+    ) as mock_call:
+        compressed = compressor.compress(
+            turns,
+            current_tokens=90_000,
+            focus_topic="current implementation",
+            force=True,
+        )
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" in prompt
+    assert "We decided to keep the SQLite backend." in prompt
+    assert len(compressed) < len(turns)
 
 
 def test_ordinary_user_turns_do_not_add_anchor_block():

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -35,6 +35,7 @@ def _response(content: str = "summary") -> MagicMock:
         ("Use approach B, not approach A.", "correction"),
         ("Actually, switch to approach B.", "correction"),
         ("Do not modify generated files.", "correction"),
+        ("Instead, use approach B.", "correction"),
         ("Configure timeout to 30 seconds.", "configuration"),
         ("以后必须保留原始引用。", "decision"),
         ("我们决定采用方案 B。", "decision"),
@@ -59,6 +60,8 @@ def test_explicit_signal_matrix(text: str, kind: str):
         "Please compare approach A and approach B.",
         "Use the tool. This is not a decision.",
         "The command returned two rows.",
+        "I don't know why the build failed.",
+        "I did this instead.",
     ],
 )
 def test_ordinary_or_ambiguous_turns_are_not_promoted(text: str):
@@ -92,6 +95,23 @@ def test_selects_explicit_user_signals_and_excludes_tool_noise():
     assert "Use Postgres rather than SQLite." in rendered
     assert "Actually, do not use Postgres; switch to SQLite." in rendered
     assert "以后必须保留原始引用。" in rendered
+
+
+def test_selector_rejects_bare_dont_and_instead_statements():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "I don't know why the build failed."},
+        {"role": "user", "content": "I did this instead."},
+        {"role": "user", "content": "Do not modify generated files."},
+        {"role": "user", "content": "Use approach B, not approach A."},
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+
+    assert [text for _index, _kind, text in anchors] == [
+        "Do not modify generated files.",
+        "Use approach B, not approach A.",
+    ]
 
 
 def test_anchor_budget_prefers_newer_correction_over_older_preference():

--- a/tests/agent/test_context_compressor_signal_anchors.py
+++ b/tests/agent/test_context_compressor_signal_anchors.py
@@ -1,0 +1,250 @@
+"""Behavior contracts for signal-aware context compaction (#57875)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(model="test", quiet_mode=True)
+
+
+def _response(content: str = "summary") -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+@pytest.mark.parametrize(
+    ("text", "kind"),
+    [
+        ("From now on, use JSON output.", "decision"),
+        ("Going forward, keep citations inline.", "decision"),
+        ("We decided to use approach B.", "decision"),
+        ("I prefer deterministic tests.", "decision"),
+        ("Please always preserve the original quote.", "decision"),
+        ("Use Postgres rather than SQLite.", "correction"),
+        ("Actually, switch to approach B.", "correction"),
+        ("Do not modify generated files.", "correction"),
+        ("Configure timeout to 30 seconds.", "configuration"),
+        ("以后必须保留原始引用。", "decision"),
+        ("我们决定采用方案 B。", "decision"),
+        ("把输出格式改成 JSON。", "correction"),
+    ],
+)
+def test_explicit_signal_matrix(text: str, kind: str):
+    signal = ContextCompressor._high_signal_kind(text)
+    assert signal is not None
+    assert signal[0] == kind
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Can you inspect the logs?",
+        "Which option should we choose?",
+        "Do you prefer JSON?",
+        "Why is this always failing?",
+        "The docs mention a default timeout.",
+        "Actually, what happened here?",
+        "Please compare approach A and approach B.",
+        "The command returned two rows.",
+    ],
+)
+def test_ordinary_or_ambiguous_turns_are_not_promoted(text: str):
+    assert ContextCompressor._high_signal_kind(text) is None
+
+
+def test_selects_explicit_user_signals_and_excludes_tool_noise():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "Can you inspect the logs?"},
+        {"role": "assistant", "content": "I will inspect them."},
+        {"role": "tool", "content": "x" * 20_000},
+        {"role": "user", "content": "Use Postgres rather than SQLite."},
+        {
+            "role": "user",
+            "content": "Actually, do not use Postgres; switch to SQLite.",
+        },
+        {"role": "user", "content": "以后必须保留原始引用。"},
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+
+    assert [kind for _index, kind, _text in anchors] == [
+        "correction",
+        "correction",
+        "decision",
+    ]
+    rendered = compressor._render_high_signal_user_anchors(anchors)
+    assert "Can you inspect" not in rendered
+    assert "x" * 100 not in rendered
+    assert "Use Postgres rather than SQLite." in rendered
+    assert "Actually, do not use Postgres; switch to SQLite." in rendered
+    assert "以后必须保留原始引用。" in rendered
+
+
+def test_anchor_budget_prefers_newer_correction_over_older_preference():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": "I prefer the first approach. " + "old " * 120,
+        },
+        {
+            "role": "user",
+            "content": "Actually, switch to the second approach. " + "new " * 120,
+        },
+    ]
+    correction = compressor._select_high_signal_user_anchors(
+        [turns[1]], token_budget=800
+    )
+    assert len(correction) == 1
+    exact_budget = estimate_messages_tokens_rough(
+        [{"role": "user", "content": correction[0][2]}]
+    )
+
+    anchors = compressor._select_high_signal_user_anchors(
+        turns,
+        token_budget=exact_budget,
+    )
+
+    assert len(anchors) == 1
+    assert anchors[0][1] == "correction"
+    assert "second approach" in anchors[0][2]
+
+
+def test_anchor_text_is_redacted_bounded_and_json_quoted():
+    compressor = _compressor()
+    secret = "ghp_1234567890abcdefghijklmnop"
+    turns = [
+        {
+            "role": "user",
+            "content": (
+                "prefix " * 180
+                + "Actually, always use the safe endpoint with token "
+                + secret
+                + ". "
+                + "suffix " * 180
+            ),
+        }
+    ]
+
+    anchors = compressor._select_high_signal_user_anchors(turns, token_budget=800)
+    rendered = compressor._render_high_signal_user_anchors(anchors)
+
+    assert len(anchors) == 1
+    assert len(anchors[0][2]) <= 800
+    assert anchors[0][2].startswith("...[anchor truncated]...")
+    assert anchors[0][2].endswith("...[anchor truncated]...")
+    assert "Actually, always use the safe endpoint" in anchors[0][2]
+    assert secret not in rendered
+    assert "..." in rendered
+    assert '"' in rendered
+
+
+def test_first_compaction_prompt_prioritizes_anchors_without_extra_llm_call():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "Please inspect the implementation."},
+        {"role": "assistant", "content": "Done."},
+        {"role": "user", "content": "From now on, prefer deterministic tests."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS FROM THE COMPACTED WINDOW" in prompt
+    assert "From now on, prefer deterministic tests." in prompt
+    assert "later correction or decision supersedes an earlier one" in prompt
+
+
+def test_default_anchor_budget_keeps_one_max_sized_correction():
+    compressor = _compressor()
+    turns = [
+        {
+            "role": "user",
+            "content": (
+                "context " * 70
+                + "Actually, switch to approach B instead. "
+                + "detail " * 70
+            ),
+        }
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" in prompt
+    assert "Actually, switch to approach B instead." in prompt
+
+
+def test_iterative_compaction_carries_previous_summary_and_new_correction():
+    compressor = _compressor()
+    compressor._previous_summary = "Existing decision: use approach A."
+    turns = [
+        {"role": "user", "content": "Actually, use approach B instead."},
+        {"role": "assistant", "content": "Understood."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("Updated summary"),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    assert mock_call.call_count == 1
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PREVIOUS SUMMARY:\nExisting decision: use approach A." in prompt
+    assert "Actually, use approach B instead." in prompt
+    assert "[correction]" in prompt
+
+
+def test_ordinary_user_turns_do_not_add_anchor_block():
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "What did the command output?"},
+        {"role": "assistant", "content": "It returned two rows."},
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response(),
+    ) as mock_call:
+        compressor._generate_summary(turns)
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "HIGH-SIGNAL USER ANCHORS" not in prompt
+
+
+def test_deterministic_fallback_preserves_bounded_user_decisions():
+    compressor = _compressor()
+    summary = compressor._build_static_fallback_summary(
+        [
+            {"role": "user", "content": "We decided to keep SQLite."},
+            {"role": "assistant", "content": "Understood."},
+            {"role": "user", "content": "Actually, switch to Postgres instead."},
+        ],
+        reason="provider unavailable",
+    )
+
+    assert "## Key Decisions" in summary
+    assert "[decision] We decided to keep SQLite." in summary
+    assert "[correction] Actually, switch to Postgres instead." in summary


### PR DESCRIPTION
## Summary

Adds durable fidelity across repeated context compactions on top of #62769.

- persists selected user decisions, corrections, and configuration in a versioned ledger embedded in the handoff summary
- deterministically merges exact duplicates, reserves the newest signal, then applies correction > decision > configuration priority under an 800 rough-token / 32-entry bound
- separates the ledger from narrative input, then programmatically appends the authoritative ledger after generation so a lossy summarizer cannot erase it
- rehydrates ledger state from persisted handoffs after restart and carries it through deterministic fallback summaries
- redacts ledger values and neutralizes internal delimiter injection

## Why

#62769 improves single-pass selection and prompting, but prompt-only preservation can still decay over repeated compactions. This follow-up makes the selected fidelity state explicit, bounded, and independently recoverable without another model call or a database migration.

## Repeated-compaction benchmark

The regression benchmark runs three sequential `compress()` calls with a deliberately lossy summarizer that omits every protected signal from its narrative output.

- protected signals retained: 3 / 3 (100%)
- summarizer calls: 3 for 3 compactions (no extra calls)
- final ledger ordering: chronological, with the latest configuration last

Additional contracts cover budget pressure, exact deduplication, malformed ledgers, delimiter injection, static fallback truncation, and restart/handoff recovery.

## Validation

- `258 passed`: all context-compressor and context-engine tests
- `56 passed`: focused signal, continuity, and fidelity-ledger tests
- `58 passed`: run-agent compression tests
- `8 failed`: Windows-only temporary SQLite cleanup failures (`WinError 32`) in existing boundary/persistence tests; failures occur during `TemporaryDirectory` teardown outside this diff
- Ruff passed
- Windows footgun scanner passed
- `git diff --check` passed

## Stack

Depends on #62769. This draft currently includes the parent commits in its comparison; after #62769 merges, the effective diff should reduce to the fidelity-ledger follow-up.

Closes #57875