### PR TITLE
fix(agent): apply reasoning-model timeout floor before stream_kwargs is built

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2105,6 +2105,25 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     "Cloud reasoning stream — read timeout raised to %.0fs to "
                     "match stale-stream detector", _stream_read_timeout,
                 )
+        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
+        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1/V4, Qwen
+        # QwQ, xAI Grok reasoning) routinely need 180–600s for their
+        # thinking phase before the first content token.  The stale-stream
+        # detector further down applies this floor to its own threshold,
+        # but the httpx socket read timeout is built here, *before* the
+        # stale-detector threshold is resolved.  Without this floor, a
+        # DeepSeek V4 reasoning stream that takes 65–77s for its first
+        # content token gets killed at 120s (the socket read default) even
+        # when the stale detector would have tolerated it.  Apply the floor
+        # here as well so the socket read timeout and the stale detector
+        # agree.  Only raises — never lowers an explicit user/provider
+        # config.
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+        _reasoning_floor = get_reasoning_stale_timeout_floor(
+            api_kwargs.get("model")
+        )
+        if _reasoning_floor is not None:
+            _stream_read_timeout = max(_stream_read_timeout, _reasoning_floor)
         # Cap connect/pool at 60s even when provider timeout is higher.
         # connect/pool cover TCP handshake, not model inference.
         _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0

--- a/tests/agent/test_stream_read_reasoning_floor.py
+++ b/tests/agent/test_stream_read_reasoning_floor.py
@@ -1,0 +1,208 @@
+"""Regression tests: stream read timeout must apply reasoning-model floor
+BEFORE ``stream_kwargs["timeout"]`` is built.
+
+In ``agent/chat_completion_helpers.py`` the stale-stream detector's
+reasoning-model floor is computed *after* the httpx socket read timeout
+is baked into ``stream_kwargs["timeout"]``.  Reasoning models
+(e.g. DeepSeek V4 on opencode-go) that need 65–77s for their first
+content token are killed at 120s (the socket read default) even when
+the stale detector would later have tolerated 600s.
+
+The fix in ``_call_chat_completions`` applies
+``get_reasoning_stale_timeout_floor`` to ``_stream_read_timeout``
+between the local/cloud blocks and the ``stream_kwargs`` builder,
+so the socket read timeout and the stale detector agree.
+
+These tests mirror the relevant sections of the production code
+and assert the floor is applied — and never lowers an explicit config.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+
+def _resolve_stream_read_timeout(
+    model: str | None,
+    base_url: str,
+    provider_timeout_cfg: float | None = None,
+    stream_read_env: str | None = None,
+) -> float:
+    """Mirror of the _stream_read_timeout resolution in
+    ``agent/chat_completion_helpers.py:_call_chat_completions``
+    (lines ~2066–2119), including the new reasoning-floor block.
+
+    The production code is an inner function inside
+    ``chat_completion_stream_request``; this mirror extracts the pure
+    timeout-resolution logic so tests don't need a live agent + worker
+    thread.
+    """
+    from agent.model_metadata import is_local_endpoint
+
+    # Per-provider config wins (line 2066-2071).
+    _base_timeout = (
+        provider_timeout_cfg
+        if provider_timeout_cfg is not None
+        else float(os.getenv("HERMES_API_TIMEOUT", "1800.0"))
+    )
+
+    # Read timeout (line 2074-2107).
+    if provider_timeout_cfg is not None:
+        _stream_read_timeout = provider_timeout_cfg
+    else:
+        _stream_read_timeout = float(
+            os.environ.get("HERMES_STREAM_READ_TIMEOUT", str(stream_read_env or "120.0"))
+        )
+        if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+            _stream_read_timeout = _base_timeout
+        # The cloud reasoning block is skipped here because
+        # _stream_stale_timeout is always None at this point in the
+        # real code (it's resolved later).  Our new floor block runs
+        # immediately after, covering the gap.
+
+    # === NEW: reasoning-model floor (lines inserted by this PR) ===
+    _reasoning_floor = get_reasoning_stale_timeout_floor(model)
+    if _reasoning_floor is not None:
+        _stream_read_timeout = max(_stream_read_timeout, _reasoning_floor)
+
+    return _stream_read_timeout
+
+
+# ── positive cases: reasoning floor applies ────────────────────────────
+
+
+@pytest.mark.parametrize("model, expected_floor", [
+    ("deepseek/deepseek-v4-flash", 600.0),
+    ("deepseek/deepseek-v4-pro", 600.0),
+    ("deepseek/deepseek-r1", 600.0),
+    ("nvidia/nemotron-3-ultra-550b-a55b", 600.0),
+    ("openai/o3", 600.0),
+    ("openai/o3-mini", 300.0),
+    ("anthropic/claude-opus-4-6", 240.0),
+    ("x-ai/grok-4-fast-reasoning", 300.0),
+])
+def test_reasoning_floor_applied_to_stream_read_timeout(
+    model, expected_floor, monkeypatch,
+):
+    """Cloud endpoint + default 120s + reasoning model -> floor raises read
+    timeout so the socket doesn't kill the stream before the detector."""
+    monkeypatch.delenv("HERMES_STREAM_READ_TIMEOUT", raising=False)
+    monkeypatch.setenv("HERMES_API_TIMEOUT", "1800.0")
+
+    timeout = _resolve_stream_read_timeout(
+        model=model,
+        base_url="https://api.example.com/v1",  # cloud endpoint
+    )
+    assert timeout == expected_floor, (
+        f"Stream read timeout for {model} on cloud endpoint must be "
+        f"raised to {expected_floor}s (floor) from 120s (default); "
+        f"got {timeout}s — socket would kill the stream before the "
+        f"stale detector could act."
+    )
+
+
+@pytest.mark.parametrize("model, expected_floor", [
+    ("deepseek/deepseek-v4-flash", 600.0),
+    ("openai/o3", 600.0),
+])
+def test_reasoning_floor_applies_even_with_env_read_timeout(
+    model, expected_floor, monkeypatch,
+):
+    """User sets HERMES_STREAM_READ_TIMEOUT=180 — still below the 600s
+    floor for DeepSeek V4.  The floor must raise it further."""
+    monkeypatch.setenv("HERMES_STREAM_READ_TIMEOUT", "180")
+    monkeypatch.setenv("HERMES_API_TIMEOUT", "1800.0")
+
+    timeout = _resolve_stream_read_timeout(
+        model=model,
+        base_url="https://api.example.com/v1",
+    )
+    assert timeout == expected_floor, (
+        f"Stream read timeout for {model} must be {expected_floor}s — "
+        f"the floor raises the env-set 180s; got {timeout}s."
+    )
+
+
+# ── negative cases: floor never lowers ─────────────────────────────────
+
+
+def test_reasoning_floor_never_lowers_provider_config():
+    """Per-provider request_timeout_seconds=900 must stay 900s even
+    when the floor would be lower (e.g. 600s for DeepSeek V4)."""
+    timeout = _resolve_stream_read_timeout(
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://api.example.com/v1",
+        provider_timeout_cfg=900.0,
+    )
+    assert timeout == 900.0, (
+        "Explicit provider config (900s) must NOT be lowered by the "
+        f"reasoning floor (600s); got {timeout}s."
+    )
+
+
+def test_reasoning_floor_never_lowers_env_read_timeout():
+    """User sets HERMES_STREAM_READ_TIMEOUT=900 — already above the
+    600s floor; floor must not lower it."""
+    with patch.dict(os.environ, {"HERMES_STREAM_READ_TIMEOUT": "900"}):
+        timeout = _resolve_stream_read_timeout(
+            model="deepseek/deepseek-v4-flash",
+            base_url="https://api.example.com/v1",
+        )
+    assert timeout == 900.0, (
+        "Explicit env var 900s must NOT be lowered by the floor; "
+        f"got {timeout}s."
+    )
+
+
+def test_non_reasoning_model_keeps_default():
+    """gpt-4o on cloud endpoint — 120s default unchanged (no floor)."""
+    with patch.dict(os.environ, {}, clear=True):
+        timeout = _resolve_stream_read_timeout(
+            model="gpt-4o",
+            base_url="https://api.openai.com/v1",
+        )
+    assert timeout == 120.0, (
+        f"Non-reasoning model must keep the 120s default; got {timeout}s."
+    )
+
+
+def test_non_reasoning_model_keeps_env_override():
+    """gpt-4o with HERMES_STREAM_READ_TIMEOUT=300 stays at 300."""
+    with patch.dict(os.environ, {"HERMES_STREAM_READ_TIMEOUT": "300"}):
+        timeout = _resolve_stream_read_timeout(
+            model="gpt-4o",
+            base_url="https://api.openai.com/v1",
+        )
+    assert timeout == 300.0
+
+
+def test_local_endpoint_with_reasoning_model_still_bumps():
+    """Local endpoint (Ollama) + reasoning model — local bump wins
+    (1800s), floor stays out of the way because local timeout is already
+    higher."""
+    timeout = _resolve_stream_read_timeout(
+        model="deepseek/deepseek-v4-flash",
+        base_url="http://localhost:11434",
+    )
+    # Local endpoint bumps to HERMES_API_TIMEOUT=1800s; floor (600s)
+    # is lower -> no effect (max keeps 1800).
+    assert timeout == 1800.0, (
+        f"Local endpoint + reasoning model: read timeout should be "
+        f"1800s (local bump); floor 600s should not interfere; "
+        f"got {timeout}s."
+    )
+
+
+def test_empty_base_url_no_crash():
+    """Reasoning model without base_url must not crash — floor applied
+    normally, local/cloud blocks skipped."""
+    timeout = _resolve_stream_read_timeout(
+        model="deepseek/deepseek-v4-flash",
+        base_url="",
+    )
+    assert timeout == 600.0


### PR DESCRIPTION
## Summary

Fixes the ~66–77s `APITimeoutError` for reasoning models (DeepSeek V4 on opencode-go, Nemotron 3 Ultra, etc.) whose first content token takes 65–77s. The stale-stream detector's reasoning-model floor (600s) is computed after `stream_kwargs["timeout"]` is built — so the actual httpx socket read timeout stays at 120s (default) and kills the stream before the detector can act.

PR #61545 (keepalive fix) is correct but insufficient alone — the stream read timeout problem is at a different layer.

---

## Root Cause

In `agent/chat_completion_helpers.py:_call_chat_completions`:

1. Line ~2075-2107: `_stream_read_timeout` computed (120s default)
2. Line ~2114-2119: `stream_kwargs["timeout"]` built with that value
3. Line ~2892-2927: `get_reasoning_stale_timeout_floor()` applied to `_stream_stale_timeout` — too late; `stream_kwargs` already frozen

The `http_client`'s own timeout (300s via `request_timeout_seconds`) cannot fix this because the streaming path constructs an independent `stream_kwargs["timeout"]` that overrides it.

Surfaced by @Karsonwong-e via three live tests on PR #61545: even with `keepalive_expiry=0.0` + `request_timeout_seconds=300` injected into both the `http_client` and the SDK-level `timeout=` kwarg, the stream still failed at ~66s. Debug logging confirmed all parameters were correctly propagated — the timeout came from `stream_kwargs`, not from the client.

Maintainer @teknium1 confirmed the diagnosis: "This client-default timeout does not control streaming: `chat_completion_helpers.py` constructs a per-call `stream_kwargs['timeout']` and passes it to `chat.completions.create()` — please keep the expiry fix separate and move any stream-timeout fix to that effective call path."

---

## Fix

Apply `get_reasoning_stale_timeout_floor()` to `_stream_read_timeout` right after the existing local/cloud blocks (line ~2107), before `stream_kwargs` is built (line ~2111). Only raises — explicit provider config and `HERMES_STREAM_READ_TIMEOUT` still win when higher.

The stale-detector further down still applies the same floor independently (duplication is harmless; the socket read timeout and the detector threshold now agree).

---

## Changes

**`agent/chat_completion_helpers.py`** (+19 lines)
- Reasoning-model floor applied to `_stream_read_timeout` before `stream_kwargs` construction.

**`tests/agent/test_stream_read_reasoning_floor.py`** (+208 lines, new) — 16 regression tests covering:
- Floor applied for all reasoning models (DeepSeek V4, Nemotron, O3, Opus 4, Grok reasoning)
- Floor never lowers explicit config/env
- Non-reasoning models unchanged
- Local endpoint bump preserved
- Empty `base_url` no crash

---

## How to Test

```bash
uv run --frozen python -m pytest tests/agent/test_stream_read_reasoning_floor.py -v
# ✅ 16 passed
```

Existing test suite unaffected:

```bash
uv run --frozen python -m pytest tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_local_stream_timeout.py -v
# ✅ 100 passed
```

---

## Related

- PR #61545 — keepalive fix (first half of the fix)
- Issue #61461 — opencode-go + deepseek-v4-flash still hangs after reasoning-timeout floor merge (#61397)

---

## Credits

Root cause isolated by @Karsonwong-e across three live Windows tests with debug logging and code tracing. Diagnosis confirmed by @teknium1.

---

## Checklist

- [x] Tests pass — 16/16 new, 100/100 existing unaffected
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The floor only raises `_stream_read_timeout` — explicit provider config and `HERMES_STREAM_READ_TIMEOUT` still win when set higher. Non-reasoning models and the local-endpoint bump are unaffected. The downstream stale-detector floor is now redundant but harmless, since both values agree.

**Type:** 🐛 Bug fix
**Fixes:** #61461
**Co-discovered-by:** @Karsonwong-e