### PR TITLE
fix(gateway): expand @ references in routed profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10611,8 +10611,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.model_metadata import get_model_context_length_async
 
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
-                _msg_runtime = _resolve_runtime_agent_kwargs()
                 _msg_config_ctx = None
+                _msg_cfg = None
                 try:
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
@@ -10622,11 +10622,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = int(_msg_raw_ctx)
                 except Exception:
                     pass
+                # Resolve the session's actual model/provider/base_url the
+                # same way the hygiene compression block does (~11080).
+                # GatewayRunner has no self._model/self._base_url attrs
+                # (that was copy-pasted from HermesCLI, which does carry
+                # self.model/self.base_url), so using them here always raised
+                # AttributeError, silently caught below, meaning this feature
+                # never ran.
+                _msg_model, _msg_runtime = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=_msg_cfg,
+                )
                 _msg_ctx_len = await get_model_context_length_async(
-                    self._model,
-                    base_url=self._base_url or _msg_runtime.get("base_url") or "",
+                    _msg_model,
+                    base_url=_msg_runtime.get("base_url") or "",
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
+                    provider=_msg_runtime.get("provider") or "",
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,
@@ -10645,7 +10658,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _ctx_result.expanded:
                     message_text = _ctx_result.message
             except Exception as exc:
-                logger.debug("@ context reference expansion failed: %s", exc)
+                logger.warning("@ context reference expansion failed: %s", exc)
+                logger.debug("@ context reference expansion failure detail", exc_info=True)
 
         return message_text
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19885,7 +19885,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key or "?",
                             exc_info=True,
                         )
-                    next_message = await self._prepare_inbound_message_text(
+                    next_message = await self._prepare_profile_scoped_inbound_message_text(
                         event=pending_event,
                         source=next_source,
                         history=updated_history,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10613,6 +10613,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_config_ctx = None
                 _msg_cfg = None
+                _msg_custom_providers = []
                 try:
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
@@ -10620,6 +10621,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _msg_raw_ctx = _msg_model_cfg.get("context_length")
                         if _msg_raw_ctx is not None:
                             _msg_config_ctx = int(_msg_raw_ctx)
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers
+
+                        _msg_custom_providers = get_compatible_custom_providers(_msg_cfg)
+                    except Exception:
+                        _msg_custom_providers = _msg_cfg.get("custom_providers") or []
                 except Exception:
                     pass
                 # Resolve the session's actual model/provider/base_url the
@@ -10640,6 +10647,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
                     provider=_msg_runtime.get("provider") or "",
+                    custom_providers=_msg_custom_providers,
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,
@@ -10662,6 +10670,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("@ context reference expansion failure detail", exc_info=True)
 
         return message_text
+
+    async def _prepare_profile_scoped_inbound_message_text(
+        self,
+        *,
+        event: MessageEvent,
+        source: SessionSource,
+        history: List[Dict[str, Any]],
+        session_key: Optional[str] = None,
+    ) -> Optional[str]:
+        """Run inbound preprocessing under the routed profile when multiplexed."""
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                return await self._prepare_inbound_message_text(
+                    event=event,
+                    source=source,
+                    history=history,
+                    session_key=session_key,
+                )
+        return await self._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=history,
+            session_key=session_key,
+        )
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
@@ -11505,7 +11537,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
-        message_text = await self._prepare_inbound_message_text(
+        message_text = await self._prepare_profile_scoped_inbound_message_text(
             event=event,
             source=source,
             history=history,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10613,6 +10613,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_config_ctx = None
                 _msg_cfg = None
+                _msg_model_cfg = {}
                 _msg_custom_providers = []
                 try:
                     _msg_cfg = _load_gateway_config()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10641,9 +10641,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key,
                     user_config=_msg_cfg,
                 )
+                _msg_base_url = _msg_runtime.get("base_url") or ""
+                # A global model.context_length belongs to the configured
+                # model, not a session /model or channel override. Prefer a
+                # matching per-custom-provider model limit when available.
+                _msg_configured_model = (
+                    _msg_model_cfg.get("default") or _msg_model_cfg.get("model")
+                    if isinstance(_msg_model_cfg, dict)
+                    else _msg_model_cfg
+                )
+                if _msg_model != _msg_configured_model:
+                    _msg_config_ctx = None
+                if _msg_custom_providers and _msg_base_url:
+                    try:
+                        from hermes_cli.config import get_custom_provider_context_length
+
+                        _msg_custom_ctx = get_custom_provider_context_length(
+                            model=_msg_model,
+                            base_url=_msg_base_url,
+                            custom_providers=_msg_custom_providers,
+                        )
+                        if _msg_custom_ctx:
+                            _msg_config_ctx = _msg_custom_ctx
+                    except Exception:
+                        pass
                 _msg_ctx_len = await get_model_context_length_async(
                     _msg_model,
-                    base_url=_msg_runtime.get("base_url") or "",
+                    base_url=_msg_base_url,
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
                     provider=_msg_runtime.get("provider") or "",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "iganapolsky@gmail.com": "IgorGanapolsky",  # PR #62125 salvage (compaction anti-thrash threshold verification)
+    "tturney1@gmail.com": "TheTom",  # PR #62696 salvage (gateway: expand @ context references under runtime/session model resolution)
     "wilsonkinyuam@gmail.com": "WilsonKinyua",  # PR #62052 (tui: persist unflushed conversations on disconnect/restart)
     "humphreysun98@gmail.com": "HumphreySun98",  # PR #61142 salvage (web: null web/backend config value guards)
     "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -277,3 +277,39 @@ async def test_at_reference_passes_compatible_custom_provider_context(monkeypatc
         event=MessageEvent(text="@file:note", source=source), source=source, history=[]
     )
     assert captured["custom_providers"] == custom_providers
+
+
+@pytest.mark.asyncio
+async def test_at_reference_ignores_global_context_for_session_model_override(monkeypatch):
+    """A session model override must not inherit another model's global limit."""
+    runner = _make_runner()
+    source = _source()
+    captured = {}
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "global/model", "context_length": 128000}},
+    )
+    monkeypatch.setattr(runner, "_resolve_session_agent_runtime", lambda **_kwargs: (
+        "session/model",
+        {"provider": "openai", "api_key": "test", "base_url": "https://api.openai.com/v1"},
+    ))
+
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    async def _fake_get_context(_model, **kwargs):
+        captured["config_context_length"] = kwargs["config_context_length"]
+        return 32768
+
+    async def _passthrough(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_context)
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough)
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@file:note", source=source), source=source, history=[]
+    )
+    assert captured["config_context_length"] is None

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -280,6 +280,52 @@ async def test_at_reference_passes_compatible_custom_provider_context(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_at_reference_applies_custom_runtime_budget_to_preprocessor(monkeypatch):
+    """The custom runtime's real budget must reach reference expansion."""
+    runner = _make_runner()
+    source = _source()
+    captured = {}
+    custom_providers = [{
+        "name": "private",
+        "base_url": "https://private.example/v1",
+        "models": {"session/model": {"context_length": 32768}},
+    }]
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "global/model", "context_length": 128000}, "custom_providers": custom_providers},
+    )
+    monkeypatch.setattr(runner, "_resolve_session_agent_runtime", lambda **_kwargs: (
+        "session/model",
+        {"provider": "custom:private", "api_key": "test", "base_url": "https://private.example/v1"},
+    ))
+
+    import hermes_cli.config as config_mod
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(config_mod, "get_compatible_custom_providers", lambda _cfg: custom_providers)
+    monkeypatch.setattr(config_mod, "get_custom_provider_context_length", lambda **_kwargs: 32768)
+
+    async def _fake_get_context(_model, **kwargs):
+        captured["config_context_length"] = kwargs["config_context_length"]
+        return kwargs["config_context_length"]
+
+    async def _preprocess(message, *, context_length, **_kwargs):
+        captured["preprocessor_budget"] = context_length
+        return ContextReferenceResult(message="expanded", original_message=message, expanded=True)
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_context)
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _preprocess)
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@file:note", source=source), source=source, history=[]
+    )
+    assert result == "expanded"
+    assert captured == {"config_context_length": 32768, "preprocessor_budget": 32768}
+
+
+@pytest.mark.asyncio
 async def test_at_reference_ignores_global_context_for_session_model_override(monkeypatch):
     """A session model override must not inherit another model's global limit."""
     runner = _make_runner()

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -18,6 +18,7 @@ the hygiene-compression block already uses) and must actually reach
 """
 import logging
 import threading
+from contextlib import contextmanager
 
 import pytest
 
@@ -185,3 +186,94 @@ async def test_at_reference_resolves_model_via_session_runtime(monkeypatch):
     assert captured_runtime_call.get("model") == "openai/gpt-4.1-mini"
     assert captured_runtime_call.get("base_url") == "https://api.openai.com/v1"
     assert captured_runtime_call.get("provider") == "openai"
+
+
+@pytest.mark.asyncio
+async def test_at_reference_uses_routed_profile_scope_when_multiplexed(monkeypatch, tmp_path):
+    """Secondary-profile preprocessing must resolve inside that profile scope."""
+    runner = _make_runner()
+    runner.config.multiplex_profiles = True
+    source = _source()
+    source.profile = "secondary"
+    profile_home = tmp_path / "profiles" / "secondary"
+    seen = []
+
+    @contextmanager
+    def _scope(home):
+        seen.append(("enter", home))
+        try:
+            yield
+        finally:
+            seen.append(("exit", home))
+
+    async def _prepared(**kwargs):
+        seen.append(("prepared", kwargs["source"].profile))
+        return "expanded"
+
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", _scope)
+    monkeypatch.setattr(runner, "_resolve_profile_home_for_source", lambda _source: profile_home)
+    monkeypatch.setattr(runner, "_prepare_inbound_message_text", _prepared)
+
+    result = await runner._prepare_profile_scoped_inbound_message_text(
+        event=MessageEvent(text="@file:note", source=source),
+        source=source,
+        history=[],
+        session_key="agent:secondary:telegram:dm:123",
+    )
+
+    assert result == "expanded"
+    assert seen == [
+        ("enter", profile_home),
+        ("prepared", "secondary"),
+        ("exit", profile_home),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_at_reference_passes_compatible_custom_provider_context(monkeypatch):
+    """Per-model custom-provider limits must bound context-reference injection."""
+    runner = _make_runner()
+    source = _source()
+    captured = {}
+    custom_providers = [{
+        "name": "private",
+        "base_url": "https://private.example/v1",
+        "models": {"private/model": {"context_length": 32768}},
+    }]
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "private/model"}, "custom_providers": custom_providers},
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda _cfg=None: "private/model",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "custom:private", "api_key": "test", "base_url": "https://private.example/v1"},
+    )
+
+    import hermes_cli.config as config_mod
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(config_mod, "get_compatible_custom_providers", lambda _cfg: custom_providers)
+
+    async def _fake_get_context(_model, **kwargs):
+        captured["custom_providers"] = kwargs["custom_providers"]
+        return 32768
+
+    async def _passthrough(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_context)
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough)
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@file:note", source=source), source=source, history=[]
+    )
+    assert captured["custom_providers"] == custom_providers

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -1,0 +1,187 @@
+"""Regression test for the "@" context-reference-expansion block in
+``GatewayRunner._prepare_inbound_message_text``.
+
+Bug: the block read ``self._model`` / ``self._base_url`` to resolve the
+model/base_url for ``get_model_context_length_async``. ``GatewayRunner``
+never assigns either attribute (that pattern was copy-pasted from
+``HermesCLI``, which does carry ``self.model``/``self.base_url`` — see
+commit da44c196b). Every message containing "@" raised ``AttributeError``
+inside the ``try`` block, which the surrounding ``except Exception`` silently
+swallowed at debug level, so ``preprocess_context_references_async`` never
+ran in the gateway and @-references (``@file:``, ``@folder:``, ``@diff``,
+etc.) passed through to the model completely unexpanded.
+
+These tests pin the fix: the block must resolve model/provider/base_url via
+``self._resolve_session_agent_runtime`` (the same session-aware resolution
+the hygiene-compression block already uses) and must actually reach
+``preprocess_context_references_async`` with a real context length.
+"""
+import logging
+import threading
+
+import pytest
+
+import gateway.run as gateway_run
+from agent.context_references import ContextReferenceResult
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    # Attrs touched by _resolve_session_agent_runtime on a bare test runner
+    # (mirrors tests/gateway/test_empty_model_recovery.py).
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    runner._service_tier = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+
+
+def _patch_runtime_resolution(monkeypatch) -> None:
+    """Stub the module-level runtime resolution so the test never hits the
+    network — mirrors _patch_resolution() in test_empty_model_recovery.py."""
+    monkeypatch.setattr(
+        gateway_run, "_resolve_gateway_model", lambda cfg=None: "openai/gpt-4.1-mini"
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    # config_context_length is int > 0, so get_model_context_length_async's
+    # config-override short-circuit (agent/model_metadata.py) fires and
+    # returns it directly — no network probe needed.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "openai/gpt-4.1-mini", "context_length": 128000}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_at_reference_reaches_preprocessor_with_real_context_length(
+    monkeypatch, caplog
+):
+    """A message containing "@" must reach preprocess_context_references_async
+    with a real (int > 0) context_length, and the except branch must not
+    fire. This fails on unfixed code with AttributeError:
+    'GatewayRunner' object has no attribute '_model' (swallowed as a debug
+    log, so pre-fix this assertion sees no expansion and no captured call)."""
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    captured: dict = {}
+
+    async def _fake_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+        captured["message"] = message
+        captured["cwd"] = cwd
+        captured["context_length"] = context_length
+        captured["allowed_root"] = allowed_root
+        return ContextReferenceResult(
+            message="[expanded body]",
+            original_message=message,
+            expanded=True,
+        )
+
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _fake_preprocess)
+
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+
+    event = MessageEvent(text="please look at @file:notes.txt", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    # The except branch (AttributeError on self._model/self._base_url,
+    # pre-fix) must not have fired.
+    assert not any(
+        "@ context reference expansion failed" in record.getMessage()
+        for record in caplog.records
+    ), "the except branch swallowed an exception instead of reaching the preprocessor"
+
+    # preprocess_context_references_async must actually have been called,
+    # with a real positive context length (not skipped by the AttributeError).
+    assert captured, "preprocess_context_references_async was never called"
+    assert isinstance(captured["context_length"], int)
+    assert captured["context_length"] > 0
+    assert captured["context_length"] == 128000
+
+    # The expanded result from the (stubbed) preprocessor must have been
+    # adopted as the final message text.
+    assert result == "[expanded body]"
+
+
+@pytest.mark.asyncio
+async def test_at_reference_resolves_model_via_session_runtime(monkeypatch):
+    """The block must source model/provider/base_url from
+    self._resolve_session_agent_runtime (session-aware), not from
+    nonexistent self._model/self._base_url attributes."""
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    captured_runtime_call = {}
+
+    async def _fake_get_ctx_len(model, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
+        captured_runtime_call["model"] = model
+        captured_runtime_call["base_url"] = base_url
+        captured_runtime_call["provider"] = provider
+        captured_runtime_call["config_context_length"] = config_context_length
+        return config_context_length or 128000
+
+    import agent.model_metadata as model_meta_mod
+
+    monkeypatch.setattr(
+        model_meta_mod, "get_model_context_length_async", _fake_get_ctx_len
+    )
+
+    import agent.context_references as ctx_mod
+
+    async def _passthrough_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(
+        ctx_mod, "preprocess_context_references_async", _passthrough_preprocess
+    )
+
+    event = MessageEvent(text="hi @diff", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert captured_runtime_call.get("model") == "openai/gpt-4.1-mini"
+    assert captured_runtime_call.get("base_url") == "https://api.openai.com/v1"
+    assert captured_runtime_call.get("provider") == "openai"


### PR DESCRIPTION
## Summary
Gateway `@file:`, `@folder:`, and `@diff` references now expand using the routed session’s model and profile instead of failing on nonexistent GatewayRunner attributes.

Closes #62695
Closes #62696

## Changes
- Preserve @TheTom’s original gateway runtime-resolution fix.
- Scope normal and queued inbound preprocessing to the routed multiplex profile.
- Use the effective session/channel model’s context budget; matching custom-provider per-model limits override global model settings.
- Add profile, queued-path, custom-provider, and session-override regression coverage.
- Map the contributor’s commit email in `AUTHOR_MAP`.

## Validation
- 71 targeted gateway/runtime/profile tests passed in hermetic environment.
- Real profile-scope E2E passed.
- Real session custom-provider budget E2E: observed `32768`, not global `128000`.
- Mutation against the pre-fix context-reference implementation: 3 expected regression failures.
- Ruff, compile, diff check, contributor audit passed.
- `ty`: 123 diagnostics on branch vs 126 on base; no new type debt.

## Attribution
- @TheTom: original context-reference runtime resolution fix from #62696.
- Maintainer follow-ups: multiplex-profile scope, queued continuation scope, effective custom-provider/session context-budget resolution, and regressions.

Original PR: https://github.com/NousResearch/hermes-agent/pull/62696
