### PR TITLE
fix(mcp_oauth): preserve refresh_token when token refresh response omits it

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -366,6 +366,17 @@ class HermesTokenStorage:
                 # Mock tokens or unusual shapes: skip the expires_at write
                 # rather than fail persistence.
                 pass
+        # Per RFC 6749 §6, the token refresh endpoint MAY omit
+        # ``refresh_token`` from the response to indicate the original
+        # refresh token is still valid. When that happens,
+        # ``exclude_none=True`` drops it from the dump above, permanently
+        # losing the refresh token and bricking future refreshes.
+        # Carry forward the old ``refresh_token`` from disk if the new
+        # token response doesn't include one.
+        if "refresh_token" not in payload:
+            existing = _read_json(self._tokens_path())
+            if existing is not None and "refresh_token" in existing:
+                payload["refresh_token"] = existing["refresh_token"]
         _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
 


### PR DESCRIPTION
Fixes #62333

## Problem

Any OAuth-authenticated MCP server stops working ~1 hour after `hermes mcp login`. The next tool call fails with "MCP OAuth ... no cached tokens found".

After the first token refresh, the `refresh_token` is **gone** from the token file (only `access_token` remains). At the next expiry `can_refresh_token()` returns False, so no refresh happens and the server dies until a full re-OAuth.

## Root cause

`HermesTokenStorage.set_tokens` used `tokens.model_dump(mode="json", exclude_none=True)` then overwrote the file. Per RFC 6749 section 6, a token refresh response MAY omit `refresh_token` to indicate the original refresh token is still valid. When that happens, the `refresh_token` field is `None`, `exclude_none=True` drops it from the dump, and the on-disk refresh token is permanently lost.

## Fix

When the new token response doesn't include `refresh_token`, carry forward the existing `refresh_token` from the previous token file on disk before persisting.

## Verification

All 77 existing tests in `tests/tools/test_mcp_oauth.py` pass.
