### PR TITLE
fix(gateway): resolve @ references for active runtime

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10611,8 +10611,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.model_metadata import get_model_context_length_async
 
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
-                _msg_runtime = _resolve_runtime_agent_kwargs()
                 _msg_config_ctx = None
+                _msg_cfg = None
                 try:
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
@@ -10622,11 +10622,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = int(_msg_raw_ctx)
                 except Exception:
                     pass
+                # Resolve the session's actual model/provider/base_url the
+                # same way the hygiene compression block does (~11080).
+                # GatewayRunner has no self._model/self._base_url attrs
+                # (that was copy-pasted from HermesCLI, which does carry
+                # self.model/self.base_url), so using them here always raised
+                # AttributeError, silently caught below, meaning this feature
+                # never ran.
+                _msg_model, _msg_runtime = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=_msg_cfg,
+                )
                 _msg_ctx_len = await get_model_context_length_async(
-                    self._model,
-                    base_url=self._base_url or _msg_runtime.get("base_url") or "",
+                    _msg_model,
+                    base_url=_msg_runtime.get("base_url") or "",
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
+                    provider=_msg_runtime.get("provider") or "",
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,
@@ -10645,7 +10658,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _ctx_result.expanded:
                     message_text = _ctx_result.message
             except Exception as exc:
-                logger.debug("@ context reference expansion failed: %s", exc)
+                logger.warning("@ context reference expansion failed: %s", exc)
+                logger.debug("@ context reference expansion failure detail", exc_info=True)
 
         return message_text
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10355,6 +10355,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         history: List[Dict[str, Any]],
         session_key: Optional[str] = None,
     ) -> Optional[str]:
+        """Prepare inbound text in the source profile's runtime scope."""
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return await self._prepare_inbound_message_text_inner(
+                event=event,
+                source=source,
+                history=history,
+                session_key=session_key,
+            )
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        with _profile_runtime_scope(profile_home):
+            return await self._prepare_inbound_message_text_inner(
+                event=event,
+                source=source,
+                history=history,
+                session_key=session_key,
+            )
+
+    async def _prepare_inbound_message_text_inner(
+        self,
+        *,
+        event: MessageEvent,
+        source: SessionSource,
+        history: List[Dict[str, Any]],
+        session_key: Optional[str] = None,
+    ) -> Optional[str]:
         """Prepare inbound event text for the agent.
 
         Keep the normal inbound path and the queued follow-up path on the same
@@ -10613,6 +10639,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_config_ctx = None
                 _msg_cfg = None
+                _msg_custom_providers = []
                 try:
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
@@ -10620,6 +10647,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _msg_raw_ctx = _msg_model_cfg.get("context_length")
                         if _msg_raw_ctx is not None:
                             _msg_config_ctx = int(_msg_raw_ctx)
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        _msg_custom_providers = get_compatible_custom_providers(_msg_cfg)
+                    except Exception:
+                        _raw_custom_providers = _msg_cfg.get("custom_providers")
+                        if isinstance(_raw_custom_providers, list):
+                            _msg_custom_providers = _raw_custom_providers
                 except Exception:
                     pass
                 # Resolve the session's actual model/provider/base_url the
@@ -10634,12 +10668,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key,
                     user_config=_msg_cfg,
                 )
+                # ``model.context_length`` configures the gateway's default
+                # model. A session or channel override may target a model with
+                # a different window, so do not let the default's explicit
+                # override mask resolution for the active session model.
+                _msg_default_model = _resolve_gateway_model(_msg_cfg)
+                _msg_default_runtime = _resolve_runtime_agent_kwargs()
+                _msg_runtime_changed = (
+                    _msg_runtime.get("provider") != _msg_default_runtime.get("provider")
+                    or str(_msg_runtime.get("base_url") or "").rstrip("/").lower()
+                    != str(_msg_default_runtime.get("base_url") or "").rstrip("/").lower()
+                )
+                if (
+                    _msg_config_ctx is not None
+                    and (_msg_model != _msg_default_model or _msg_runtime_changed)
+                ):
+                    _msg_config_ctx = None
                 _msg_ctx_len = await get_model_context_length_async(
                     _msg_model,
                     base_url=_msg_runtime.get("base_url") or "",
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
                     provider=_msg_runtime.get("provider") or "",
+                    custom_providers=_msg_custom_providers,
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -888,6 +888,7 @@ AUTHOR_MAP = {
     "foxion37@gmail.com": "foxion37",
     "bloodcarter@gmail.com": "bloodcarter",
     "scott@scotttrinh.com": "scotttrinh",
+    "tturney1@gmail.com": "TheTom",
     "quocanh261997@gmail.com": "quocanh261997",
     "savanne.kham@protonmail.com": "savanne-kham",  # PR #28958 salvage (strip tool_name for strict providers)
     # contributors (from noreply pattern)

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -18,6 +18,7 @@ the hygiene-compression block already uses) and must actually reach
 """
 import logging
 import threading
+from contextlib import contextmanager
 
 import pytest
 
@@ -156,6 +157,7 @@ async def test_at_reference_resolves_model_via_session_runtime(monkeypatch):
         captured_runtime_call["base_url"] = base_url
         captured_runtime_call["provider"] = provider
         captured_runtime_call["config_context_length"] = config_context_length
+        captured_runtime_call["custom_providers"] = custom_providers
         return config_context_length or 128000
 
     import agent.model_metadata as model_meta_mod
@@ -185,3 +187,209 @@ async def test_at_reference_resolves_model_via_session_runtime(monkeypatch):
     assert captured_runtime_call.get("model") == "openai/gpt-4.1-mini"
     assert captured_runtime_call.get("base_url") == "https://api.openai.com/v1"
     assert captured_runtime_call.get("provider") == "openai"
+    assert captured_runtime_call.get("custom_providers") == []
+
+
+@pytest.mark.asyncio
+async def test_at_reference_passes_compatible_custom_providers(monkeypatch):
+    runner = _make_runner()
+    source = _source()
+    expected_custom_providers = [
+        {
+            "base_url": "https://custom.example/v1",
+            "models": {"custom-model": {"context_length": 222222}},
+        }
+    ]
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "custom-model"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers",
+        lambda _cfg: expected_custom_providers,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_kwargs: (
+            "custom-model",
+            {
+                "provider": "custom:example",
+                "api_key": "test-key",
+                "base_url": "https://custom.example/v1",
+            },
+        ),
+    )
+
+    captured = {}
+
+    async def _fake_get_ctx_len(model, **kwargs):
+        captured["model"] = model
+        captured.update(kwargs)
+        return 222222
+
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_ctx_len)
+
+    async def _passthrough_preprocess(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough_preprocess)
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hi @diff", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert captured["model"] == "custom-model"
+    assert captured["base_url"] == "https://custom.example/v1"
+    assert captured["provider"] == "custom:example"
+    assert captured["custom_providers"] == expected_custom_providers
+
+
+@pytest.mark.asyncio
+async def test_at_reference_session_model_override_ignores_default_context_length(monkeypatch):
+    runner = _make_runner()
+    source = _source()
+    session_key = "session-with-model-override"
+    _patch_runtime_resolution(monkeypatch)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "openai/gpt-4.1-mini", "context_length": 111111}},
+    )
+    monkeypatch.setattr(runner, "_rehydrate_session_model_override", lambda _key: None)
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-4.1",
+        "provider": "openai",
+        "api_key": "override-key",
+        "base_url": "https://api.openai.com/v1",
+        "api_mode": "chat_completions",
+    }
+
+    captured = {}
+
+    async def _fake_get_ctx_len(model, **kwargs):
+        captured["model"] = model
+        captured.update(kwargs)
+        return 1047576
+
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_ctx_len)
+
+    async def _passthrough_preprocess(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough_preprocess)
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hi @diff", source=source),
+        source=source,
+        history=[],
+        session_key=session_key,
+    )
+
+    assert result is not None
+    assert captured["model"] == "gpt-4.1"
+    assert captured["config_context_length"] is None
+
+
+@pytest.mark.asyncio
+async def test_at_reference_provider_override_ignores_default_context_length(monkeypatch):
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "shared-model", "context_length": 111111}},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "shared-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "default-key",
+            "base_url": "https://api.openai.com/v1",
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_kwargs: (
+            "shared-model",
+            {
+                "provider": "custom:channel",
+                "api_key": "channel-key",
+                "base_url": "https://channel.example/v1",
+            },
+        ),
+    )
+
+    captured = {}
+
+    async def _fake_get_ctx_len(model, **kwargs):
+        captured["model"] = model
+        captured.update(kwargs)
+        return 222222
+
+    import agent.model_metadata as model_meta_mod
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_ctx_len)
+
+    async def _passthrough_preprocess(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough_preprocess)
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hi @diff", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert captured["model"] == "shared-model"
+    assert captured["base_url"] == "https://channel.example/v1"
+    assert captured["provider"] == "custom:channel"
+    assert captured["config_context_length"] is None
+
+
+@pytest.mark.asyncio
+async def test_at_reference_uses_source_profile_runtime_scope(monkeypatch, tmp_path):
+    runner = _make_runner()
+    runner.config.multiplex_profiles = True
+    source = _source()
+    source.profile = "secondary"
+    profile_home = tmp_path / "profiles" / "secondary"
+    entered = []
+
+    @contextmanager
+    def _scope(home):
+        entered.append(home)
+        yield
+
+    async def _inner(**_kwargs):
+        return "prepared"
+
+    monkeypatch.setattr(runner, "_resolve_profile_home_for_source", lambda _source: profile_home)
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", _scope)
+    monkeypatch.setattr(runner, "_prepare_inbound_message_text_inner", _inner)
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hi @diff", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result == "prepared"
+    assert entered == [profile_home]

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -1,0 +1,187 @@
+"""Regression test for the "@" context-reference-expansion block in
+``GatewayRunner._prepare_inbound_message_text``.
+
+Bug: the block read ``self._model`` / ``self._base_url`` to resolve the
+model/base_url for ``get_model_context_length_async``. ``GatewayRunner``
+never assigns either attribute (that pattern was copy-pasted from
+``HermesCLI``, which does carry ``self.model``/``self.base_url`` — see
+commit da44c196b). Every message containing "@" raised ``AttributeError``
+inside the ``try`` block, which the surrounding ``except Exception`` silently
+swallowed at debug level, so ``preprocess_context_references_async`` never
+ran in the gateway and @-references (``@file:``, ``@folder:``, ``@diff``,
+etc.) passed through to the model completely unexpanded.
+
+These tests pin the fix: the block must resolve model/provider/base_url via
+``self._resolve_session_agent_runtime`` (the same session-aware resolution
+the hygiene-compression block already uses) and must actually reach
+``preprocess_context_references_async`` with a real context length.
+"""
+import logging
+import threading
+
+import pytest
+
+import gateway.run as gateway_run
+from agent.context_references import ContextReferenceResult
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    # Attrs touched by _resolve_session_agent_runtime on a bare test runner
+    # (mirrors tests/gateway/test_empty_model_recovery.py).
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    runner._service_tier = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+
+
+def _patch_runtime_resolution(monkeypatch) -> None:
+    """Stub the module-level runtime resolution so the test never hits the
+    network — mirrors _patch_resolution() in test_empty_model_recovery.py."""
+    monkeypatch.setattr(
+        gateway_run, "_resolve_gateway_model", lambda cfg=None: "openai/gpt-4.1-mini"
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    # config_context_length is int > 0, so get_model_context_length_async's
+    # config-override short-circuit (agent/model_metadata.py) fires and
+    # returns it directly — no network probe needed.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "openai/gpt-4.1-mini", "context_length": 128000}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_at_reference_reaches_preprocessor_with_real_context_length(
+    monkeypatch, caplog
+):
+    """A message containing "@" must reach preprocess_context_references_async
+    with a real (int > 0) context_length, and the except branch must not
+    fire. This fails on unfixed code with AttributeError:
+    'GatewayRunner' object has no attribute '_model' (swallowed as a debug
+    log, so pre-fix this assertion sees no expansion and no captured call)."""
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    captured: dict = {}
+
+    async def _fake_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+        captured["message"] = message
+        captured["cwd"] = cwd
+        captured["context_length"] = context_length
+        captured["allowed_root"] = allowed_root
+        return ContextReferenceResult(
+            message="[expanded body]",
+            original_message=message,
+            expanded=True,
+        )
+
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _fake_preprocess)
+
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+
+    event = MessageEvent(text="please look at @file:notes.txt", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    # The except branch (AttributeError on self._model/self._base_url,
+    # pre-fix) must not have fired.
+    assert not any(
+        "@ context reference expansion failed" in record.getMessage()
+        for record in caplog.records
+    ), "the except branch swallowed an exception instead of reaching the preprocessor"
+
+    # preprocess_context_references_async must actually have been called,
+    # with a real positive context length (not skipped by the AttributeError).
+    assert captured, "preprocess_context_references_async was never called"
+    assert isinstance(captured["context_length"], int)
+    assert captured["context_length"] > 0
+    assert captured["context_length"] == 128000
+
+    # The expanded result from the (stubbed) preprocessor must have been
+    # adopted as the final message text.
+    assert result == "[expanded body]"
+
+
+@pytest.mark.asyncio
+async def test_at_reference_resolves_model_via_session_runtime(monkeypatch):
+    """The block must source model/provider/base_url from
+    self._resolve_session_agent_runtime (session-aware), not from
+    nonexistent self._model/self._base_url attributes."""
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    captured_runtime_call = {}
+
+    async def _fake_get_ctx_len(model, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
+        captured_runtime_call["model"] = model
+        captured_runtime_call["base_url"] = base_url
+        captured_runtime_call["provider"] = provider
+        captured_runtime_call["config_context_length"] = config_context_length
+        return config_context_length or 128000
+
+    import agent.model_metadata as model_meta_mod
+
+    monkeypatch.setattr(
+        model_meta_mod, "get_model_context_length_async", _fake_get_ctx_len
+    )
+
+    import agent.context_references as ctx_mod
+
+    async def _passthrough_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(
+        ctx_mod, "preprocess_context_references_async", _passthrough_preprocess
+    )
+
+    event = MessageEvent(text="hi @diff", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert captured_runtime_call.get("model") == "openai/gpt-4.1-mini"
+    assert captured_runtime_call.get("base_url") == "https://api.openai.com/v1"
+    assert captured_runtime_call.get("provider") == "openai"


### PR DESCRIPTION
## Summary
Gateway `@file:`, `@folder:`, and `@diff` references now expand using the active session/channel runtime instead of failing on nonexistent runner attributes.

This salvages #62696 and closes #62695.

## Changes
- Preserve @TheTom's fix for the swallowed `GatewayRunner._model` / `_base_url` failure.
- Resolve custom-provider context limits for the active endpoint.
- Keep a default model's `context_length` from masking a distinct session or channel runtime.
- Scope inbound preprocessing to the routed profile before loading config or credentials in multiplexed gateways.

## Validation
- 58 targeted gateway tests passed: context-reference runtime, empty-model recovery, multiplex profile, and channel override coverage.
- Real async custom-provider context resolution returned the configured 222222-token limit.
- Final-head Phase 2 review found no critical issues or warnings.
- Ruff/ty checks: no new diagnostics.

## Credit
Salvaged from #62696 by @TheTom; the original commit retains contributor authorship.

Closes #62696
Fixes #62695
