### PR TITLE
fix(cli): propagate subcommand handler exit codes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14706,10 +14706,12 @@ def main():
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        result = args.func(args)
+        return result if type(result) is int else 0
     else:
         parser.print_help()
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -511,7 +511,9 @@ class PluginContext:
 
         The *setup_fn* receives an argparse subparser and should add any
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
-        as the default dispatch function via ``set_defaults(func=...)``."""
+        as the default dispatch function via ``set_defaults(func=...)``.
+        Handlers may return an integer process exit status; ``None`` and
+        non-integer results are treated as success for backward compatibility."""
         self._manager._cli_commands[name] = {
             "name": name,
             "help": help,

--- a/tests/hermes_cli/test_plugin_cli_exit_codes.py
+++ b/tests/hermes_cli/test_plugin_cli_exit_codes.py
@@ -1,0 +1,70 @@
+"""Regression coverage for plugin CLI handler exit codes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_exit_code_plugin(hermes_home: Path) -> None:
+    plugin_dir = hermes_home / "plugins" / "exit-code-fixture"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: exit-code-fixture\nprovides_cli:\n  - exit-fixture\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    def setup(parser):\n"
+        "        parser.add_argument('--value', default='unused')\n"
+        "        parser.add_argument('--boolean-result', action='store_true')\n"
+        "    def handler(args):\n"
+        "        return True if args.boolean_result else 7\n"
+        "    ctx.register_cli_command(\n"
+        "        name='exit-fixture',\n"
+        "        help='exit-code fixture',\n"
+        "        setup_fn=setup,\n"
+        "        handler_fn=handler,\n"
+        "    )\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - exit-code-fixture\n",
+        encoding="utf-8",
+    )
+
+
+def test_python_module_propagates_plugin_cli_handler_exit_code(tmp_path: Path):
+    _write_exit_code_plugin(tmp_path)
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "exit-fixture"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 7, result.stderr or result.stdout
+
+
+def test_plugin_cli_boolean_result_preserves_success_exit(tmp_path: Path):
+    _write_exit_code_plugin(tmp_path)
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "exit-fixture", "--boolean-result"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- propagate exact integer subcommand-handler statuses from the top-level CLI dispatcher
- preserve `None`, non-integer, and boolean handler results as success for backward compatibility
- propagate the result for both the generated `hermes` console script and `python -m hermes_cli.main`
- document the plugin CLI handler return contract
- add end-to-end enabled user-plugin subprocess regressions

## Problem

`main()` currently calls `args.func(args)` and discards its return value. Plugin and core handlers can correctly return a nonzero status while the process still exits `0`.

This surfaced in a standalone plugin doctor command that emits `{"success": false}`, returns `1`, and remains unusable as a CI gate because current Hermes exits successfully.

This is also reproducible with an existing built-in command on untouched current `origin/main` (`8121dbb16`):

1. use a temporary `HERMES_HOME` with a tiny checkpoint directory;
2. run `python -m hermes_cli.main checkpoints clear`;
3. answer `n`, causing `cmd_clear()` to return `1` without deleting anything.

Observed process status:

- current `origin/main`: `0`
- patched branch: `1`

At least 14 existing core command handlers explicitly return nonzero statuses (`checkpoints`, `migrate`, secrets, security audit, Slack, and proxy paths), so this is not a plugin-specific contract invented for this PR.

## Compatibility

Only values whose exact type is `int` are propagated. `None`, arbitrary objects, strings, and booleans continue to exit `0`. This avoids changing handlers that may return truthy data rather than a process status.

## Verification

Before the patch:

- enabled user-plugin fixture returning `7`: process exited `0`
- built-in checkpoint abort returning `1`: process exited `0`

After the patch:

- plugin integer-return and boolean-compat subprocess regressions: passed
- focused regression plus `tests/hermes_cli/test_commands.py`: **175 passed**
- built-in checkpoint abort: process exited `1`, temp data preserved
- Ruff, `py_compile`, and `git diff --check`: passed
- broader `tests/hermes_cli -x`: **1,631 passed / 3 skipped** before an unrelated test-isolation failure where `test_sessions_list_and_stats_use_isolated_session_store` read the live session store

## Duplicate search

Searched open and closed issues/PRs for `CLI exit code`, `exit code handler`, `subcommand exit status`, and `args.func return`; no existing report or competing PR covers this dispatcher bug.
