### PR TITLE
fix(desktop): resolve base Python from pyvenv.cfg to avoid venv .pyd locks on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1808,6 +1808,43 @@ function getVenvPython(venvRoot) {
 // normal HERMES_DASHBOARD_READY stdout line and no ready-file side channel is
 // needed.
 
+/**
+ * Read pyvenv.cfg from a venv root and resolve the base Python interpreter.
+ *
+ * uv-created Windows venvs write ``pyvenv.cfg`` with a ``home`` key
+ * pointing at the base Python directory (e.g.
+ * ``C:\Users\me\AppData\Local\Programs\Python\Python311``).
+ * `venv/Scripts/python.exe` loads native ``.pyd`` extensions from the venv,
+ * which Windows locks while the process lives — blocking ``hermes update``.
+ * Using the base Python with ``PYTHONPATH`` set to include the source root
+ * and venv site-packages (already done by ``buildDesktopBackendEnv``)
+ * avoids those locks entirely.  Mirrors ``_resolve_detached_python`` in
+ * ``hermes_cli/gateway_windows.py``.
+ *
+ * Returns the path to the base ``python.exe``, or ``null`` when the venv
+ * is not uv-created, the config file can't be read, or the base Python
+ * doesn't exist at the expected location.
+ */
+function resolveBasePythonFromVenvCfg(venvRoot) {
+  if (!venvRoot || !IS_WINDOWS) return null
+
+  try {
+    const cfgPath = path.join(venvRoot, 'pyvenv.cfg')
+    const cfg = fs.readFileSync(cfgPath, 'utf8')
+
+    // PEP 405: ``home = <path>`` (case-insensitive).
+    const homeMatch = cfg.match(/^home\s*=\s*(.+)$/im)
+    if (!homeMatch) return null
+
+    const baseDir = homeMatch[1].trim()
+    const basePython = path.join(baseDir, 'python.exe')
+
+    return fileExists(basePython) ? basePython : null
+  } catch {
+    return null
+  }
+}
+
 function makeDashboardReadyFile() {
   const dir = path.join(app.getPath('userData'), 'backend-ready')
   fs.mkdirSync(dir, { recursive: true })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3579,11 +3579,13 @@ async function ensureRuntime(backend) {
   }
 
   // bootstrap=true with a real backend (createActiveBackend path) means we
-  // have a checkout and need to ensure the venv-derived Python command is
-  // wired into the backend before launch. Same code path the old factory
-  // sync flow exited through, minus all the factory/pip/marker machinery
-  // (install.ps1 owns those concerns now and the bootstrap-complete marker
-  // attests they ran successfully).
+  // have a checkout and need to ensure the Python command is wired into the
+  // backend before launch. On Windows, prefer the base Python from pyvenv.cfg
+  // to avoid venv .pyd file locks (blocking hermes update); fall back to the
+  // venv interpreter when base resolution fails. Same code path the old
+  // factory sync flow exited through, minus all the factory/pip/marker
+  // machinery (install.ps1 owns those concerns now and the bootstrap-complete
+  // marker attests they ran successfully).
   if (!isHermesSourceRoot(ACTIVE_HERMES_ROOT)) {
     throw new Error(
       `Hermes install at ${ACTIVE_HERMES_ROOT} is missing or incomplete. ` +
@@ -3621,8 +3623,11 @@ async function ensureRuntime(backend) {
     )
   }
 
-  backend.command = getVenvPython(VENV_ROOT)
-  backend.label = `Hermes at ${ACTIVE_HERMES_ROOT} (venv: ${VENV_ROOT})`
+  const basePython = IS_WINDOWS ? resolveBasePythonFromVenvCfg(VENV_ROOT) : null
+  backend.command = basePython || venvPython
+  backend.label = basePython
+    ? `Hermes at ${ACTIVE_HERMES_ROOT} (base Python: ${VENV_ROOT})`
+    : `Hermes at ${ACTIVE_HERMES_ROOT} (venv: ${VENV_ROOT})`
   updateBootProgress({
     phase: 'runtime.ready',
     message: 'Hermes runtime is ready',

--- a/apps/desktop/electron/windows-hermes-resolution.test.ts
+++ b/apps/desktop/electron/windows-hermes-resolution.test.ts
@@ -1,0 +1,121 @@
+// Regression guards for Windows `hermes` resolution in main.ts.
+//
+// main.ts has no module.exports, so these follow the repo's source-assertion
+// test pattern (see windows-child-process.test.ts). They pin the two Windows
+// resolution bugs that caused desktop reinstall loops:
+//   1. findOnPath() tried the empty extension FIRST, so an extensionless
+//      Git-Bash `hermes` shim shadowed the real hermes.cmd/hermes.exe; the
+//      shim then failed the --version probe and the desktop fell through to a
+//      spurious bootstrap/repair.
+//   2. handOffWindowsBootstrapRecovery() chose --update vs the destructive
+//      --repair by checking ONLY venv\Scripts\hermes.exe (the console-script
+//      shim, written at the END of venv setup and absent in interrupted
+//      states), so it escalated to a full venv recreate even on healthy
+//      installs.
+//   3. unwrapWindowsVenvHermesCommand() returned the venv python with NO
+//      runtime probe (bypassing the caller's --version check too), so a venv
+//      broken mid-update (e.g. missing python-dotenv) was re-selected forever:
+//      Retry / "Repair install" resolved the same dead interpreter instead of
+//      falling through to the bootstrap installer.
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function readMain() {
+  return fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+}
+
+test('findOnPath tries PATHEXT extensions before the bare (empty) name on Windows', () => {
+  const source = readMain()
+  // Fixed order: PATHEXT first, empty string LAST.
+  assert.match(
+    source,
+    /\(process\.env\.PATHEXT \|\| '\.COM;\.EXE;\.BAT;\.CMD'\)\.split\(';'\)\.filter\(Boolean\), ''\]/,
+    'extensions array must end with the empty string, not start with it'
+  )
+  // The buggy empty-first order must not return.
+  assert.doesNotMatch(
+    source,
+    /\['', \.\.\.\(process\.env\.PATHEXT/,
+    'empty-extension-first order regressed: an extensionless shim can shadow hermes.cmd/.exe'
+  )
+})
+
+test('Windows bootstrap recovery chooses --update when any real-install signal is present', () => {
+  const source = readMain()
+  assert.match(source, /const haveRealInstall =/, 'recovery must compute haveRealInstall')
+  assert.match(source, /fileExists\(venvPython\)/, 'recovery must accept the venv interpreter as a real-install signal')
+  assert.match(
+    source,
+    /\.hermes-bootstrap-complete/,
+    'recovery must accept the bootstrap-complete marker as a real-install signal'
+  )
+  assert.match(source, /updaterArgs = haveRealInstall \? \['--update'/, 'updaterArgs must gate on haveRealInstall')
+  // The old too-narrow check (only venv\Scripts\hermes.exe) must not return.
+  assert.doesNotMatch(
+    source,
+    /updaterArgs = fileExists\(venvHermes\) \?/,
+    'recovery regressed to gating only on the hermes.exe shim, which forces destructive --repair'
+  )
+})
+
+test('unwrapWindowsVenvHermesCommand smoke-tests the venv python before trusting it', () => {
+  const source = readMain()
+  const fnStart = source.indexOf('function unwrapWindowsVenvHermesCommand(')
+  assert.notEqual(fnStart, -1, 'unwrapWindowsVenvHermesCommand must exist in main.ts')
+  // Slice out just the function body (up to the next top-level function decl)
+  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+  assert.match(
+    body,
+    /canImportHermesCli\(python/,
+    'unwrap must probe the venv interpreter; returning it unprobed re-selects a broken venv ' +
+      'forever (Retry/Repair loop on a mid-update venv missing e.g. python-dotenv)'
+  )
+  assert.match(body, /effectivePython/, 'unwrap must prefer base Python when pyvenv.cfg has a home key')
+  assert.match(
+    body,
+    /return null\s*\n\s*\}\s*\n\s*return \{/,
+    'a failed probe must fall through (return null) so the resolver reaches the bootstrap rung'
+  )
+})
+
+test('resolveBasePythonFromVenvCfg reads pyvenv.cfg home and resolves base Python', () => {
+  const source = readMain()
+  assert.match(
+    source,
+    /function resolveBasePythonFromVenvCfg/,
+    'resolveBasePythonFromVenvCfg must exist in main.ts'
+  )
+  // Must parse the `home` key from pyvenv.cfg.
+  // Use indexOf to verify the regex pattern presence without regex-in-regex escaping.
+  const fnStart = source.indexOf('function resolveBasePythonFromVenvCfg')
+  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+  assert.ok(body.includes("cfg.match(/^home\\s*=\\s*(.+)$/im)"), "must parse the `home` key from pyvenv.cfg")
+  assert.ok(body.includes("path.join(baseDir, 'python.exe')"), "must join baseDir with python.exe on Windows")
+  assert.ok(body.includes('return null') && body.includes('catch'), "must return null on errors to fall back gracefully")
+})
+
+test('createActiveBackend calls resolveBasePythonFromVenvCfg on Windows', () => {
+  const source = readMain()
+  const fnStart = source.indexOf('function createActiveBackend(')
+  assert.notEqual(fnStart, -1, 'createActiveBackend must exist in main.ts')
+  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+  assert.match(
+    body,
+    /const basePython = IS_WINDOWS \? resolveBasePythonFromVenvCfg\(VENV_ROOT\) : null/,
+    'createActiveBackend must call resolveBasePythonFromVenvCfg on Windows'
+  )
+  assert.match(
+    body,
+    /const command = basePython \|\| \(fileExists\(venvPython\) \? venvPython : findSystemPython\(\)\)/,
+    'createActiveBackend must use basePython when available, falling back to venvPython then system Python'
+  )
+})

--- a/apps/desktop/electron/windows-hermes-resolution.test.ts
+++ b/apps/desktop/electron/windows-hermes-resolution.test.ts
@@ -119,3 +119,28 @@ test('createActiveBackend calls resolveBasePythonFromVenvCfg on Windows', () => 
     'createActiveBackend must use basePython when available, falling back to venvPython then system Python'
   )
 })
+
+test('ensureRuntime prefers base Python from pyvenv.cfg on Windows, falls back to venv', () => {
+  const source = readMain()
+  const fnStart = source.indexOf('async function ensureRuntime(')
+  assert.notEqual(fnStart, -1, 'ensureRuntime must exist in main.ts')
+  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+  assert.match(
+    body,
+    /const basePython = IS_WINDOWS \? resolveBasePythonFromVenvCfg\(VENV_ROOT\) : null/,
+    'ensureRuntime must call resolveBasePythonFromVenvCfg on Windows'
+  )
+  assert.match(
+    body,
+    /backend\.command = basePython \|\| venvPython/,
+    'ensureRuntime must prefer basePython, falling back to venvPython'
+  )
+  // The old unconditional override must not return.
+  assert.doesNotMatch(
+    body,
+    /backend\.command = getVenvPython\(VENV_ROOT\)/,
+    'ensureRuntime regressed to unconditionally wiring the venv interpreter, ' +
+      'overwriting the base Python resolved by createActiveBackend'
+  )
+})

--- a/apps/desktop/electron/windows-hermes-resolution.test.ts
+++ b/apps/desktop/electron/windows-hermes-resolution.test.ts
@@ -21,6 +21,7 @@ function functionBody(source: string, declaration: string) {
   const fnStart = source.indexOf(declaration)
   assert.notEqual(fnStart, -1, `${declaration} must exist`)
   const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+
   return source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
 }
 

--- a/apps/desktop/electron/windows-hermes-resolution.test.ts
+++ b/apps/desktop/electron/windows-hermes-resolution.test.ts
@@ -1,22 +1,9 @@
-// Regression guards for Windows `hermes` resolution in main.ts.
+// Regression guards for the Windows Desktop runtime interpreter choice.
 //
-// main.ts has no module.exports, so these follow the repo's source-assertion
-// test pattern (see windows-child-process.test.ts). They pin the two Windows
-// resolution bugs that caused desktop reinstall loops:
-//   1. findOnPath() tried the empty extension FIRST, so an extensionless
-//      Git-Bash `hermes` shim shadowed the real hermes.cmd/hermes.exe; the
-//      shim then failed the --version probe and the desktop fell through to a
-//      spurious bootstrap/repair.
-//   2. handOffWindowsBootstrapRecovery() chose --update vs the destructive
-//      --repair by checking ONLY venv\Scripts\hermes.exe (the console-script
-//      shim, written at the END of venv setup and absent in interrupted
-//      states), so it escalated to a full venv recreate even on healthy
-//      installs.
-//   3. unwrapWindowsVenvHermesCommand() returned the venv python with NO
-//      runtime probe (bypassing the caller's --version check too), so a venv
-//      broken mid-update (e.g. missing python-dotenv) was re-selected forever:
-//      Retry / "Repair install" resolved the same dead interpreter instead of
-//      falling through to the bootstrap installer.
+// The active install backend is always passed through ensureRuntime before the
+// process spawn. On Windows, ensureRuntime must replace the venv launcher with
+// the base interpreter recorded in pyvenv.cfg so the long-lived Desktop backend
+// does not hold the venv launcher/native-extension lock path during updates.
 
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
@@ -26,121 +13,54 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-function readMain() {
-  return fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+function readSource(filename: string) {
+  return fs.readFileSync(path.join(__dirname, filename), 'utf8').replace(/\r\n/g, '\n')
 }
 
-test('findOnPath tries PATHEXT extensions before the bare (empty) name on Windows', () => {
-  const source = readMain()
-  // Fixed order: PATHEXT first, empty string LAST.
-  assert.match(
-    source,
-    /\(process\.env\.PATHEXT \|\| '\.COM;\.EXE;\.BAT;\.CMD'\)\.split\(';'\)\.filter\(Boolean\), ''\]/,
-    'extensions array must end with the empty string, not start with it'
-  )
-  // The buggy empty-first order must not return.
-  assert.doesNotMatch(
-    source,
-    /\['', \.\.\.\(process\.env\.PATHEXT/,
-    'empty-extension-first order regressed: an extensionless shim can shadow hermes.cmd/.exe'
-  )
-})
-
-test('Windows bootstrap recovery chooses --update when any real-install signal is present', () => {
-  const source = readMain()
-  assert.match(source, /const haveRealInstall =/, 'recovery must compute haveRealInstall')
-  assert.match(source, /fileExists\(venvPython\)/, 'recovery must accept the venv interpreter as a real-install signal')
-  assert.match(
-    source,
-    /\.hermes-bootstrap-complete/,
-    'recovery must accept the bootstrap-complete marker as a real-install signal'
-  )
-  assert.match(source, /updaterArgs = haveRealInstall \? \['--update'/, 'updaterArgs must gate on haveRealInstall')
-  // The old too-narrow check (only venv\Scripts\hermes.exe) must not return.
-  assert.doesNotMatch(
-    source,
-    /updaterArgs = fileExists\(venvHermes\) \?/,
-    'recovery regressed to gating only on the hermes.exe shim, which forces destructive --repair'
-  )
-})
-
-test('unwrapWindowsVenvHermesCommand smoke-tests the venv python before trusting it', () => {
-  const source = readMain()
-  const fnStart = source.indexOf('function unwrapWindowsVenvHermesCommand(')
-  assert.notEqual(fnStart, -1, 'unwrapWindowsVenvHermesCommand must exist in main.ts')
-  // Slice out just the function body (up to the next top-level function decl)
+function functionBody(source: string, declaration: string) {
+  const fnStart = source.indexOf(declaration)
+  assert.notEqual(fnStart, -1, `${declaration} must exist`)
   const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
-  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
-  assert.match(
-    body,
-    /canImportHermesCli\(python/,
-    'unwrap must probe the venv interpreter; returning it unprobed re-selects a broken venv ' +
-      'forever (Retry/Repair loop on a mid-update venv missing e.g. python-dotenv)'
-  )
-  assert.match(body, /effectivePython/, 'unwrap must prefer base Python when pyvenv.cfg has a home key')
-  assert.match(
-    body,
-    /return null\s*\n\s*\}\s*\n\s*return \{/,
-    'a failed probe must fall through (return null) so the resolver reaches the bootstrap rung'
-  )
+  return source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+}
+
+test('resolveBasePythonFromVenvCfg reads pyvenv.cfg home and fails closed', () => {
+  const source = readSource('main.ts')
+  const body = functionBody(source, 'function resolveBasePythonFromVenvCfg')
+
+  assert.ok(body.includes("cfg.match(/^home\\s*=\\s*(.+)$/im)"), 'must parse the pyvenv.cfg home key')
+  assert.ok(body.includes("path.join(baseDir, 'python.exe')"), 'must resolve the base Windows interpreter')
+  assert.ok(body.includes('fileExists(basePython)'), 'must verify the resolved interpreter exists')
+  assert.ok(body.includes('catch') && body.includes('return null'), 'must fall back safely on malformed or missing config')
 })
 
-test('resolveBasePythonFromVenvCfg reads pyvenv.cfg home and resolves base Python', () => {
-  const source = readMain()
-  assert.match(
-    source,
-    /function resolveBasePythonFromVenvCfg/,
-    'resolveBasePythonFromVenvCfg must exist in main.ts'
-  )
-  // Must parse the `home` key from pyvenv.cfg.
-  // Use indexOf to verify the regex pattern presence without regex-in-regex escaping.
-  const fnStart = source.indexOf('function resolveBasePythonFromVenvCfg')
-  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
-  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
-  assert.ok(body.includes("cfg.match(/^home\\s*=\\s*(.+)$/im)"), "must parse the `home` key from pyvenv.cfg")
-  assert.ok(body.includes("path.join(baseDir, 'python.exe')"), "must join baseDir with python.exe on Windows")
-  assert.ok(body.includes('return null') && body.includes('catch'), "must return null on errors to fall back gracefully")
-})
+test('ensureRuntime prefers base Python on Windows and retains the venv fallback', () => {
+  const source = readSource('main.ts')
+  const body = functionBody(source, 'async function ensureRuntime(')
 
-test('createActiveBackend calls resolveBasePythonFromVenvCfg on Windows', () => {
-  const source = readMain()
-  const fnStart = source.indexOf('function createActiveBackend(')
-  assert.notEqual(fnStart, -1, 'createActiveBackend must exist in main.ts')
-  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
-  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
   assert.match(
     body,
     /const basePython = IS_WINDOWS \? resolveBasePythonFromVenvCfg\(VENV_ROOT\) : null/,
-    'createActiveBackend must call resolveBasePythonFromVenvCfg on Windows'
-  )
-  assert.match(
-    body,
-    /const command = basePython \|\| \(fileExists\(venvPython\) \? venvPython : findSystemPython\(\)\)/,
-    'createActiveBackend must use basePython when available, falling back to venvPython then system Python'
-  )
-})
-
-test('ensureRuntime prefers base Python from pyvenv.cfg on Windows, falls back to venv', () => {
-  const source = readMain()
-  const fnStart = source.indexOf('async function ensureRuntime(')
-  assert.notEqual(fnStart, -1, 'ensureRuntime must exist in main.ts')
-  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
-  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
-  assert.match(
-    body,
-    /const basePython = IS_WINDOWS \? resolveBasePythonFromVenvCfg\(VENV_ROOT\) : null/,
-    'ensureRuntime must call resolveBasePythonFromVenvCfg on Windows'
+    'ensureRuntime must resolve the base interpreter only on Windows'
   )
   assert.match(
     body,
     /backend\.command = basePython \|\| venvPython/,
-    'ensureRuntime must prefer basePython, falling back to venvPython'
+    'ensureRuntime must prefer base Python and retain the venv fallback'
   )
-  // The old unconditional override must not return.
   assert.doesNotMatch(
     body,
     /backend\.command = getVenvPython\(VENV_ROOT\)/,
-    'ensureRuntime regressed to unconditionally wiring the venv interpreter, ' +
-      'overwriting the base Python resolved by createActiveBackend'
+    'ensureRuntime must not overwrite the selected base interpreter with the venv launcher'
+  )
+})
+
+test('the local startup path always runs ensureLocalRuntime before returning a backend', () => {
+  const source = readSource('primary-backend-startup.ts')
+
+  assert.match(
+    source,
+    /return \{ kind: 'local', backend: await ensureLocalRuntime\(backend\) \}/,
+    'the active backend must pass through ensureRuntime before the process is spawned'
   )
 })


### PR DESCRIPTION
## Summary

Fix the Windows Desktop backend choosing `venv/Scripts/python.exe` for the long-lived active runtime, which can hold the venv update path open and block `hermes update`.

Closes #62792. Related: #43268, #61514, #38789, and #61515.

## Current implementation

### `apps/desktop/electron/main.ts`

- Add `resolveBasePythonFromVenvCfg(venvRoot)`.
- Read the PEP 405 `home` entry from `pyvenv.cfg` and resolve the base `python.exe`.
- Return `null` for malformed config, missing paths, non-Windows platforms, or I/O errors.
- In the authoritative `ensureRuntime()` path, prefer the resolved base interpreter on Windows and retain the existing venv fallback.

`createActiveBackend()` remains the lightweight pre-runtime descriptor. The production startup contract passes that descriptor through `ensureRuntime()` before returning the local backend for process spawn.

### Regression guards

`apps/desktop/electron/windows-hermes-resolution.test.ts` verifies:

- `pyvenv.cfg` parsing and fail-closed fallback behavior;
- the Windows-only base interpreter selection in `ensureRuntime()`;
- removal of the unconditional venv-command overwrite;
- the `runPrimaryBackendStartup()` contract that applies `ensureLocalRuntime()` before local spawn.

## Behavior

| Scenario | Result |
|---|---|
| Windows uv-created venv with valid `home` | Use base `python.exe` with the existing Desktop `PYTHONPATH` environment |
| Missing or malformed `pyvenv.cfg` | Fall back to `venv/Scripts/python.exe` |
| Missing base interpreter | Fall back to the venv interpreter |
| macOS and Linux | No behavior change |

## Validation

Head `d7404cc40a041636d9e8f4d9beaec80e870eb807` passed the repository's required-check aggregate, Desktop platform regressions, Desktop E2E, both Docker integration architectures, OSV, lockfile/history checks, and the visible JS/TS matrix. The addressed review thread is resolved.

The outer workflow is red only after the required gate, in the advisory post-run reporting layer. No additional production-code change is justified by that reporting failure.