### PR TITLE
fix(desktop): preserve private link labels

### DIFF
--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -129,6 +129,18 @@ describe('external link helpers', () => {
     expect(link.textContent).not.toContain('getyourguide.com')
   })
 
+  it('prefers an explicit fallback label without fetching a title', () => {
+    const bridge = vi.fn().mockResolvedValue('Page not found · GitHub · GitHub')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const url = 'https://github.com/NousResearch/Hermes-Agent/issues/123#issuecomment-456'
+
+    render(<PrettyLink fallbackLabel="maintainer context" href={url} />)
+
+    expect(screen.getByTitle(url).textContent).toBe('maintainer context')
+    expect(bridge).not.toHaveBeenCalled()
+  })
+
   it('shows host/path fallback when title is unavailable', () => {
     installDesktopBridge()
     const url = 'https://www.expedia.com/things-to-do/puerto-rico-el-yunque'
@@ -153,6 +165,19 @@ describe('external link helpers', () => {
     await waitFor(() => {
       expect(link.textContent).toBe('From Fajardo Full Day Cordillera Islands Catamaran Tour')
     })
+  })
+
+  it('ignores not-found fetched titles and falls back to the URL-derived label', async () => {
+    const bridge = vi.fn().mockResolvedValue('Page not found · GitHub · GitHub')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const url = 'https://github.com/NousResearch/Hermes-Agent/issues/123#issuecomment-456'
+
+    expect(await fetchLinkTitle(url)).toBe('')
+
+    render(<PrettyLink href={url} />)
+
+    expect(screen.getByTitle(url).textContent).toBe('Issues')
   })
 
   it('normalizes scheme-less links before opening', () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -23,7 +23,7 @@ const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes)
 const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/i
 
 const ERROR_TITLE_RE =
-  /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|request blocked|too many requests)\b/i
+  /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|not found|request blocked|too many requests)\b/i
 
 export function normalizeExternalUrl(value: string): string {
   const trimmed = value.trim()
@@ -253,8 +253,9 @@ interface PrettyLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
 
 export function PrettyLink({ className, fallbackLabel, href, label, ...rest }: PrettyLinkProps) {
   const target = useMemo(() => normalizeExternalUrl(href), [href])
-  const fetched = useLinkTitle(label ? null : target)
-  const display = fetched || label?.trim() || fallbackLabel?.trim() || urlSlugTitleLabel(target)
+  const explicitLabel = label?.trim() || fallbackLabel?.trim()
+  const fetched = useLinkTitle(explicitLabel ? null : target)
+  const display = explicitLabel || fetched || urlSlugTitleLabel(target)
 
   return (
     <ExternalLink className={cn('wrap-break-word', className)} href={target} title={target} {...rest}>


### PR DESCRIPTION
## Summary

- prefer explicit `label` or `fallbackLabel` text before attempting anonymous page-title resolution
- reject fetched not-found titles such as GitHub's `Page not found` response
- preserve URL-derived fallback text for unlabeled links

## Root cause

`PrettyLink` only suppressed title fetching when `label` was present, so a caller-provided `fallbackLabel` could still be replaced by an anonymous fetch result. The fetched-title error filter also did not recognize not-found page titles.

The fix treats either explicit label as authoritative and extends the existing error-title rejection. Link-title fetching remains anonymous and does not forward authentication or tokens.

## Validation

- `npm run test:ui --workspace apps/desktop -- src/lib/external-link.test.tsx` (15 passed)
- `npm run typecheck --workspace apps/desktop`
- `npm exec --workspace apps/desktop -- eslint src/lib/external-link.tsx src/lib/external-link.test.tsx`
- `git diff --check`

Tested on Windows. No install, rebuild, or desktop restart was performed.