### PR TITLE
fix(ssh): add ServerAliveInterval/ServerAliveCountMax keepalives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,10 @@ TERMINAL_LIFETIME_SECONDS=300
 # TERMINAL_SSH_USER=agent
 # TERMINAL_SSH_PORT=22
 # TERMINAL_SSH_KEY=~/.ssh/id_rsa
+# SSH keepalives prevent idle master connections from being silently killed
+# by NAT/firewall idle timeouts. Set interval to 0 to disable.
+# TERMINAL_SSH_SERVER_ALIVE_INTERVAL=60
+# TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX=3
 
 # =============================================================================
 # SUDO SUPPORT (works with ALL terminal backends)

--- a/.env.example
+++ b/.env.example
@@ -224,6 +224,9 @@ TERMINAL_LIFETIME_SECONDS=300
 # TERMINAL_SSH_KEY=~/.ssh/id_rsa
 # SSH keepalives prevent idle master connections from being silently killed
 # by NAT/firewall idle timeouts. Set interval to 0 to disable.
+# Prefer setting these in config.yaml under terminal.ssh_server_alive_interval
+# and terminal.ssh_server_alive_count_max (the env vars below are the
+# internal bridge; config.yaml is the user-facing surface).
 # TERMINAL_SSH_SERVER_ALIVE_INTERVAL=60
 # TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX=3
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -974,6 +974,8 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "user": config.get("ssh_user", ""),
                 "port": config.get("ssh_port", 22),
                 "key": config.get("ssh_key", ""),
+                "server_alive_interval": config.get("ssh_server_alive_interval", 60),
+                "server_alive_count_max": config.get("ssh_server_alive_count_max", 3),
                 "persistent": config.get("ssh_persistent", False),
             }
 

--- a/cli.py
+++ b/cli.py
@@ -622,6 +622,8 @@ def load_cli_config() -> Dict[str, Any]:
         "ssh_user": "TERMINAL_SSH_USER",
         "ssh_port": "TERMINAL_SSH_PORT",
         "ssh_key": "TERMINAL_SSH_KEY",
+        "ssh_server_alive_interval": "TERMINAL_SSH_SERVER_ALIVE_INTERVAL",
+        "ssh_server_alive_count_max": "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX",
         # Container resource config (docker, singularity, modal, daytona -- ignored for local/ssh)
         "container_cpu": "TERMINAL_CONTAINER_CPU",
         "container_memory": "TERMINAL_CONTAINER_MEMORY",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1495,6 +1495,8 @@ if _config_path.exists():
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",
                 "ssh_key": "TERMINAL_SSH_KEY",
+                "ssh_server_alive_interval": "TERMINAL_SSH_SERVER_ALIVE_INTERVAL",
+                "ssh_server_alive_count_max": "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX",
                 "container_cpu": "TERMINAL_CONTAINER_CPU",
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -289,6 +289,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
     "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "TERMINAL_SSH_SERVER_ALIVE_INTERVAL", "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX",
     # Deprecated tool-progress env vars — replaced by display.tool_progress in
     # config.yaml. Kept known here so .env sanitization/reload still handle
     # them for existing users (gateway reads them as a back-compat fallback),
@@ -1255,6 +1256,16 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # SSH keepalives prevent idle ControlMaster sockets from being silently
+        # killed by NAT/firewall idle timeouts (commonly 5-10 min on cloud and
+        # corporate networks).  Defaults: interval=60s (keepalive every 60s,
+        # well under typical NAT idle timeouts), count_max=3 (drop a dead
+        # master in ~180s instead of hanging for terminal.timeout).  Set
+        # interval=0 to disable keepalives entirely (matches ssh's
+        # ServerAliveInterval=0).  Bridged to TERMINAL_SSH_SERVER_ALIVE_*
+        # env vars for the terminal tool.
+        "ssh_server_alive_interval": 60,
+        "ssh_server_alive_count_max": 3,
     },
 
     "web": {
@@ -6826,6 +6837,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",
     "ssh_key": "TERMINAL_SSH_KEY",
+    "ssh_server_alive_interval": "TERMINAL_SSH_SERVER_ALIVE_INTERVAL",
+    "ssh_server_alive_count_max": "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX",
     "container_cpu": "TERMINAL_CONTAINER_CPU",
     "container_memory": "TERMINAL_CONTAINER_MEMORY",
     "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1296,6 +1296,91 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in line
         assert "root" in line
 
+    def test_probe_remote_backend_ssh_forwards_keepalive_config(self, monkeypatch):
+        """The SSH backend probe in ``_probe_remote_backend`` must forward
+        ``server_alive_interval`` / ``server_alive_count_max`` from
+        ``_get_env_config`` into the ``ssh_config`` dict passed to
+        ``_create_environment``.  Without this, a probe-created ControlMaster
+        socket uses the default keepalives even when the user configured custom
+        values or disabled keepalives (interval=0), so the startup probe socket
+        and the real tool sockets diverge in behavior.
+
+        Regression for teknium1's review feedback on PR #62800.
+        """
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "probe-test-host")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "probe-test-user")
+        monkeypatch.setenv("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", "42")
+        monkeypatch.setenv("TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX", "9")
+        _pb._clear_backend_probe_cache()
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/home/probe-test-user\n"
+                        "cwd=/home/probe-test-user\nuser=probe-test-user\n"
+                    ),
+                }
+
+        captured_ssh_config = {}
+
+        def _fake_create_environment(*, env_type, ssh_config=None, **kwargs):
+            captured_ssh_config.update(ssh_config or {})
+            return _FakeEnv()
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
+
+        _pb._probe_remote_backend("ssh")
+
+        assert captured_ssh_config.get("server_alive_interval") == 42, (
+            "The probe must forward the configured keepalive interval to the "
+            "SSHEnvironment, not silently fall back to the default."
+        )
+        assert captured_ssh_config.get("server_alive_count_max") == 9, (
+            "The probe must forward the configured keepalive count to the "
+            "SSHEnvironment, not silently fall back to the default."
+        )
+
+    def test_probe_remote_backend_ssh_keepalive_defaults(self, monkeypatch):
+        """When no keepalive env vars are set, the probe's ssh_config should
+        still include the 60/3 defaults (matching ``_get_env_config`` and the
+        other call sites), not omit the keys entirely.
+        """
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "probe-test-host")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "probe-test-user")
+        monkeypatch.delenv("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", raising=False)
+        monkeypatch.delenv("TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX", raising=False)
+        _pb._clear_backend_probe_cache()
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": "os=Linux\nkernel=6.8.0\nhome=/h\ncwd=/h\nuser=u\n",
+                }
+
+        captured_ssh_config = {}
+
+        def _fake_create_environment(*, env_type, ssh_config=None, **kwargs):
+            captured_ssh_config.update(ssh_config or {})
+            return _FakeEnv()
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
+
+        _pb._probe_remote_backend("ssh")
+
+        assert captured_ssh_config.get("server_alive_interval") == 60
+        assert captured_ssh_config.get("server_alive_count_max") == 3
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -66,6 +66,28 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def test_keepalive_defaults_present(self):
+        """Keepalive options are emitted by default (interval=60, count=3)."""
+        env = SSHEnvironment(host="h", user="u")
+        cmd = " ".join(env._build_ssh_command())
+        assert "ServerAliveInterval=60" in cmd
+        assert "ServerAliveCountMax=3" in cmd
+
+    def test_keepalive_custom_values(self):
+        """Custom keepalive values are honored in the generated command."""
+        env = SSHEnvironment(host="h", user="u",
+                             server_alive_interval=30, server_alive_count_max=5)
+        cmd = " ".join(env._build_ssh_command())
+        assert "ServerAliveInterval=30" in cmd
+        assert "ServerAliveCountMax=5" in cmd
+
+    def test_keepalive_disabled_when_interval_zero(self):
+        """server_alive_interval=0 omits both keepalive options (escape hatch)."""
+        env = SSHEnvironment(host="h", user="u", server_alive_interval=0)
+        cmd = " ".join(env._build_ssh_command())
+        assert "ServerAliveInterval" not in cmd
+        assert "ServerAliveCountMax" not in cmd
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -183,6 +183,31 @@ class TestTerminalToolConfig:
         from tools.terminal_tool import _get_env_config
         assert _get_env_config()["ssh_persistent"] is False
 
+    def test_ssh_keepalive_config_defaults(self, monkeypatch):
+        """_get_env_config returns 60/3 keepalive defaults when env vars unset."""
+        monkeypatch.delenv("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", raising=False)
+        monkeypatch.delenv("TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX", raising=False)
+        from tools.terminal_tool import _get_env_config
+        cfg = _get_env_config()
+        assert cfg["ssh_server_alive_interval"] == 60
+        assert cfg["ssh_server_alive_count_max"] == 3
+
+    def test_ssh_keepalive_config_custom_values(self, monkeypatch):
+        """_get_env_config picks up custom keepalive values from env vars."""
+        monkeypatch.setenv("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", "42")
+        monkeypatch.setenv("TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX", "9")
+        from tools.terminal_tool import _get_env_config
+        cfg = _get_env_config()
+        assert cfg["ssh_server_alive_interval"] == 42
+        assert cfg["ssh_server_alive_count_max"] == 9
+
+    def test_ssh_keepalive_config_disabled(self, monkeypatch):
+        """interval=0 disable path flows through _get_env_config."""
+        monkeypatch.setenv("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", "0")
+        from tools.terminal_tool import _get_env_config
+        cfg = _get_env_config()
+        assert cfg["ssh_server_alive_interval"] == 0
+
 
 class TestSSHPreflight:
     def test_ensure_ssh_available_raises_clear_error_when_missing(self, monkeypatch):

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -25,6 +25,7 @@ mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
 
 import ast
 import inspect
+import os
 
 
 def _extract_dict_values(source: str, dict_name: str) -> set[str]:
@@ -322,3 +323,121 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_ssh_server_alive_interval_is_bridged_everywhere():
+    """Regression pin for ``terminal.ssh_server_alive_interval`` being silently
+    dropped by one of the three bridge paths.
+
+    The SSH keepalive interval is a behavioral setting (not a secret), so per
+    AGENTS.md it must be configurable via config.yaml and bridged to the
+    ``TERMINAL_SSH_SERVER_ALIVE_INTERVAL`` env var that ``terminal_tool`` reads.
+    If any of the three bridge dicts (cli.py env_mappings, gateway/run.py
+    _terminal_env_map, config.py TERMINAL_CONFIG_ENV_MAP) is missing the key,
+    ``terminal.ssh_server_alive_interval: 30`` in config.yaml silently does
+    nothing for that entry point.  Same four-site invariant as the docker keys.
+    """
+    assert "ssh_server_alive_interval" in _cli_env_map_keys()
+    assert "ssh_server_alive_interval" in _gateway_env_map_keys()
+    assert "ssh_server_alive_interval" in _save_config_env_sync_keys()
+    assert "TERMINAL_SSH_SERVER_ALIVE_INTERVAL" in _terminal_tool_env_var_names()
+
+
+def test_ssh_server_alive_count_max_is_bridged_everywhere():
+    """Regression pin for ``terminal.ssh_server_alive_count_max`` — the sibling
+    to ssh_server_alive_interval.  Same four-site bridge invariant.
+    """
+    assert "ssh_server_alive_count_max" in _cli_env_map_keys()
+    assert "ssh_server_alive_count_max" in _gateway_env_map_keys()
+    assert "ssh_server_alive_count_max" in _save_config_env_sync_keys()
+    assert "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX" in _terminal_tool_env_var_names()
+
+
+def test_ssh_keepalive_config_bridges_to_env_var_and_environment(monkeypatch):
+    """End-to-end bridge propagation: config.yaml value → env var → SSHEnvironment.
+
+    Sets ``terminal.ssh_server_alive_interval`` / ``ssh_server_alive_count_max``
+    in a fake config, runs ``apply_terminal_config_to_env`` (the canonical bridge
+    used by CLI, gateway, and ``hermes config set``), then verifies the env vars
+    are set and that ``_get_env_config`` picks them up and that
+    ``_create_environment`` forwards them to ``SSHEnvironment``.
+    """
+    import tools.terminal_tool as _tt
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP, apply_terminal_config_to_env
+
+    # 1. config.yaml value → env vars via the bridge
+    fake_config = {
+        "terminal": {
+            "backend": "ssh",
+            "ssh_host": "testhost",
+            "ssh_user": "testuser",
+            "ssh_server_alive_interval": 45,
+            "ssh_server_alive_count_max": 7,
+        }
+    }
+    # Clean env so we only see what the bridge sets
+    for _k, _v in TERMINAL_CONFIG_ENV_MAP.items():
+        monkeypatch.delenv(_v, raising=False)
+    monkeypatch.delenv("TERMINAL_PERSISTENT_SHELL", raising=False)
+
+    apply_terminal_config_to_env(env=None, config=fake_config, override=True)
+
+    assert os.environ["TERMINAL_SSH_SERVER_ALIVE_INTERVAL"] == "45"
+    assert os.environ["TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX"] == "7"
+
+    # 2. env vars → _get_env_config dict
+    cfg = _tt._get_env_config()
+    assert cfg["ssh_server_alive_interval"] == 45
+    assert cfg["ssh_server_alive_count_max"] == 7
+
+    # 3. _get_env_config → _create_environment → SSHEnvironment
+    #    Mock _SSHEnvironment to capture the kwargs without actually connecting.
+    captured = {}
+
+    class _FakeSSH:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(_tt, "_SSHEnvironment", _FakeSSH)
+    _tt._create_environment(
+        env_type="ssh",
+        image="",
+        cwd="~",
+        timeout=60,
+        ssh_config={
+            "host": "testhost",
+            "user": "testuser",
+            "port": 22,
+            "key": "",
+            "server_alive_interval": cfg["ssh_server_alive_interval"],
+            "server_alive_count_max": cfg["ssh_server_alive_count_max"],
+        },
+        task_id="bridge-test",
+    )
+    assert captured["server_alive_interval"] == 45
+    assert captured["server_alive_count_max"] == 7
+
+
+def test_ssh_keepalive_defaults_when_no_config(monkeypatch):
+    """When config.yaml has no keepalive keys, the bridge leaves env vars unset
+    and ``_get_env_config`` falls back to the 60/3 defaults baked into
+    ``terminal_tool._get_env_config``.
+    """
+    import tools.terminal_tool as _tt
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP, apply_terminal_config_to_env
+
+    fake_config = {"terminal": {"backend": "ssh", "ssh_host": "h", "ssh_user": "u"}}
+    for _k, _v in TERMINAL_CONFIG_ENV_MAP.items():
+        monkeypatch.delenv(_v, raising=False)
+    monkeypatch.delenv("TERMINAL_PERSISTENT_SHELL", raising=False)
+
+    apply_terminal_config_to_env(env=None, config=fake_config, override=True)
+
+    # No config value → bridge should NOT set the env var
+    assert "TERMINAL_SSH_SERVER_ALIVE_INTERVAL" not in os.environ
+    assert "TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX" not in os.environ
+
+    cfg = _tt._get_env_config()
+    assert cfg["ssh_server_alive_interval"] == 60
+    assert cfg["ssh_server_alive_count_max"] == 3
+

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -694,6 +694,8 @@ def _get_or_create_env(task_id: str):
                 "user": config.get("ssh_user", ""),
                 "port": config.get("ssh_port", 22),
                 "key": config.get("ssh_key", ""),
+                "server_alive_interval": config.get("ssh_server_alive_interval", 60),
+                "server_alive_count_max": config.get("ssh_server_alive_count_max", 3),
                 "persistent": config.get("ssh_persistent", False),
             }
 

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -43,12 +43,25 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 server_alive_interval: int = 60, server_alive_count_max: int = 3):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        # Keepalives prevent idle master connections from being silently
+        # killed by NAT/firewall idle timeouts (commonly 5-10 min on cloud
+        # and corporate networks).  Without these, a dead ControlMaster
+        # socket is reused by the next tool call, which hangs until the
+        # terminal timeout fires.  Defaults (60s interval, 3 misses) drop
+        # a truly-dead master in ~180s instead of hanging for the full
+        # terminal.timeout.  Set server_alive_interval=0 to disable (matches
+        # ssh interpretation of ServerAliveInterval=0).  Overridable via
+        # env vars for networks with unusual idle policies (see
+        # TERMINAL_SSH_SERVER_ALIVE_*).
+        self.server_alive_interval = server_alive_interval
+        self.server_alive_count_max = server_alive_count_max
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -88,6 +101,9 @@ class SSHEnvironment(BaseEnvironment):
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
+        if self.server_alive_interval > 0:
+            cmd.extend(["-o", f"ServerAliveInterval={self.server_alive_interval}"])
+            cmd.extend(["-o", f"ServerAliveCountMax={self.server_alive_count_max}"])
         if self.port != 22:
             cmd.extend(["-p", str(self.port)])
         if self.key_path:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1157,6 +1157,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "user": config.get("ssh_user", ""),
                     "port": config.get("ssh_port", 22),
                     "key": config.get("ssh_key", ""),
+                    "server_alive_interval": config.get("ssh_server_alive_interval", 60),
+                    "server_alive_count_max": config.get("ssh_server_alive_count_max", 3),
                     "persistent": config.get("ssh_persistent", False),
                 }
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1340,6 +1340,11 @@ def _get_env_config() -> Dict[str, Any]:
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
         "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        # SSH keepalives prevent idle master sockets from being killed by
+        # NAT/firewall idle timeouts (default 60s interval, 3 misses).
+        # Set TERMINAL_SSH_SERVER_ALIVE_INTERVAL=0 to disable keepalives.
+        "ssh_server_alive_interval": _parse_env_var("TERMINAL_SSH_SERVER_ALIVE_INTERVAL", "60"),
+        "ssh_server_alive_count_max": _parse_env_var("TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX", "3"),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
@@ -1530,6 +1535,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             key_path=ssh_config.get("key", ""),
             cwd=cwd,
             timeout=timeout,
+            server_alive_interval=ssh_config.get("server_alive_interval", 60),
+            server_alive_count_max=ssh_config.get("server_alive_count_max", 3),
         )
 
     else:
@@ -2194,6 +2201,8 @@ def terminal_tool(
                                 "user": config.get("ssh_user", ""),
                                 "port": config.get("ssh_port", 22),
                                 "key": config.get("ssh_key", ""),
+                                "server_alive_interval": config.get("ssh_server_alive_interval", 60),
+                                "server_alive_count_max": config.get("ssh_server_alive_count_max", 3),
                                 "persistent": config.get("ssh_persistent", False),
                             }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -229,6 +229,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TERMINAL_SSH_USER` | SSH username |
 | `TERMINAL_SSH_PORT` | SSH port (default: 22) |
 | `TERMINAL_SSH_KEY` | Path to private key |
+| `TERMINAL_SSH_SERVER_ALIVE_INTERVAL` | SSH keepalive interval in seconds (default: 60; set 0 to disable) |
+| `TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX` | SSH keepalive missed-packet threshold (default: 3) |
 | `TERMINAL_SSH_PERSISTENT` | Override persistent shell for SSH (default: follows `TERMINAL_PERSISTENT_SHELL`) |
 
 ## Container Resources (Docker, Singularity, Modal, Daytona)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -229,8 +229,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TERMINAL_SSH_USER` | SSH username |
 | `TERMINAL_SSH_PORT` | SSH port (default: 22) |
 | `TERMINAL_SSH_KEY` | Path to private key |
-| `TERMINAL_SSH_SERVER_ALIVE_INTERVAL` | SSH keepalive interval in seconds (default: 60; set 0 to disable) |
-| `TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX` | SSH keepalive missed-packet threshold (default: 3) |
+| `TERMINAL_SSH_SERVER_ALIVE_INTERVAL` | SSH keepalive interval in seconds (default: 60; set 0 to disable). Prefer `terminal.ssh_server_alive_interval` in config.yaml. |
+| `TERMINAL_SSH_SERVER_ALIVE_COUNT_MAX` | SSH keepalive missed-packet threshold (default: 3). Prefer `terminal.ssh_server_alive_count_max` in config.yaml. |
 | `TERMINAL_SSH_PERSISTENT` | Override persistent shell for SSH (default: follows `TERMINAL_PERSISTENT_SHELL`) |
 
 ## Container Resources (Docker, Singularity, Modal, Daytona)


### PR DESCRIPTION
Prevents idle SSH master connections from being silently killed by NAT/firewall idle timeouts. See commit message for details.