### PR TITLE
fix(gateway): keep internal wakes from extending sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15579,7 +15579,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # on error. Let the user drive the next turn.
                 if _final_text.strip():
                     try:
-                        session_entry = await self.async_session_store.get_or_create_session(source)
+                        session_entry = await self.async_session_store.get_or_create_session(
+                            source,
+                            touch_activity=not is_internal,
+                        )
                     except Exception:
                         session_entry = None
                     if session_entry is not None:
@@ -16175,7 +16178,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        # Internal wakes must observe reset policy without becoming user
+        # activity themselves. Otherwise periodic Kanban/process notifications
+        # keep the stable routing key alive across every daily/idle boundary.
+        session_entry = await self.async_session_store.get_or_create_session(
+            source,
+            touch_activity=not bool(getattr(event, "internal", False)),
+        )
         session_key = session_entry.session_key
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
@@ -17925,6 +17934,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.async_session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                touch_activity=not bool(getattr(event, "internal", False)),
             )
 
             # Re-baseline the cached agent's message_count snapshot now that

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16583,7 +16583,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # on error. Let the user drive the next turn.
                 if _final_text.strip():
                     try:
-                        session_entry = await self.async_session_store.get_or_create_session(source)
+                        session_entry = await self.async_session_store.get_or_create_session(
+                            source,
+                            touch_activity=not is_internal,
+                        )
                     except Exception:
                         session_entry = None
                     if session_entry is not None:
@@ -17433,7 +17436,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
         else:
-            session_entry = await self.async_session_store.get_or_create_session(source)
+            # Internal wakes must observe reset policy without becoming user
+            # activity themselves. Otherwise periodic Kanban/process
+            # notifications keep the stable routing key alive across every
+            # daily/idle boundary.
+            session_entry = await self.async_session_store.get_or_create_session(
+                source,
+                touch_activity=not bool(getattr(event, "internal", False)),
+            )
         session_key = session_entry.session_key
         if not strict_session and pinned_session_id:
             resolved_entry = await self._resolve_async_delegation_session(
@@ -19234,6 +19244,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.async_session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                touch_activity=not bool(getattr(event, "internal", False)),
             )
 
             # Re-baseline the cached agent's message_count snapshot now that

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2292,12 +2292,15 @@ class SessionStore:
         self,
         source: SessionSource,
         force_new: bool = False,
+        touch_activity: bool = True,
     ) -> SessionEntry:
         """Single-flight session lookup/create per routing key.
 
         Calls for different keys remain concurrent. Overlapping calls for the
         same key share the owner's result, including concurrent ``force_new``
         deliveries, so only one routing transition and SQLite row is created.
+        ``touch_activity=False`` still evaluates reset policy but preserves the
+        prior user-activity clock when an internal/system event reuses a session.
         """
         session_key = self._generate_session_key(source)
         inflight_lock = getattr(self, "_inflight_lock", None)
@@ -2320,10 +2323,16 @@ class SessionStore:
             if slot.error is not None:
                 raise slot.error
             assert slot.result is not None
+            if touch_activity:
+                self.update_session(slot.result.session_key)
             return slot.result
 
         try:
-            result = self._get_or_create_session_impl(source, force_new=force_new)
+            result = self._get_or_create_session_impl(
+                source,
+                force_new=force_new,
+                touch_activity=touch_activity,
+            )
             slot.result = result
             return result
         except BaseException as exc:
@@ -2338,6 +2347,7 @@ class SessionStore:
         self,
         source: SessionSource,
         force_new: bool = False,
+        touch_activity: bool = True,
     ) -> SessionEntry:
         """Perform one session routing transition for the single-flight owner.
 
@@ -2511,10 +2521,12 @@ class SessionStore:
                     _needs_recover = True
                 elif entry.session_id != _stale_session_id:
                     # Another thread handled this entry during our lock-free
-                    # window.  Treat as healthy -- bump updated_at and save.
-                    entry.updated_at = now
-                    _needs_save = True
-                    _metadata_only_save = not _healed
+                    # window. Treat as healthy; internal/system events preserve
+                    # the prior user-activity clock used by reset policy.
+                    if touch_activity:
+                        entry.updated_at = now
+                    _needs_save = touch_activity or _healed
+                    _metadata_only_save = touch_activity and not _healed
                 else:
                     # Stale check clean.  Apply reset decision.
                     if _reset_reason:
@@ -2527,9 +2539,10 @@ class SessionStore:
                         entry = None
                         _needs_recover = True
                     else:
-                        entry.updated_at = now
-                        _needs_save = True
-                        _metadata_only_save = not _healed
+                        if touch_activity:
+                            entry.updated_at = now
+                        _needs_save = touch_activity or _healed
+                        _metadata_only_save = touch_activity and not _healed
             else:
                 if not force_new:
                     _needs_recover = True
@@ -2639,14 +2652,20 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        touch_activity: bool = True,
     ) -> None:
-        """Update lightweight session metadata after an interaction."""
+        """Update lightweight session metadata after an interaction.
+
+        Internal/system turns can persist token metadata without advancing the
+        user-activity clock that drives idle and daily reset policy.
+        """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
                 return
-            entry.updated_at = _now()
+            if touch_activity:
+                entry.updated_at = _now()
             if last_prompt_tokens is not None:
                 entry.last_prompt_tokens = last_prompt_tokens
             # Snapshot peer fields while still holding _lock: a concurrent

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2429,12 +2429,15 @@ class SessionStore:
         self,
         source: SessionSource,
         force_new: bool = False,
+        touch_activity: bool = True,
     ) -> SessionEntry:
         """Single-flight session lookup/create per routing key.
 
         Calls for different keys remain concurrent. Overlapping calls for the
         same key share the owner's result, including concurrent ``force_new``
         deliveries, so only one routing transition and SQLite row is created.
+        ``touch_activity=False`` still evaluates reset policy but preserves the
+        prior user-activity clock when an internal/system event reuses a session.
         """
         session_key = self._generate_session_key(source)
         inflight_lock = getattr(self, "_inflight_lock", None)
@@ -2457,10 +2460,16 @@ class SessionStore:
             if slot.error is not None:
                 raise slot.error
             assert slot.result is not None
+            if touch_activity:
+                self.update_session(slot.result.session_key)
             return slot.result
 
         try:
-            result = self._get_or_create_session_impl(source, force_new=force_new)
+            result = self._get_or_create_session_impl(
+                source,
+                force_new=force_new,
+                touch_activity=touch_activity,
+            )
             slot.result = result
             return result
         except BaseException as exc:
@@ -2475,6 +2484,7 @@ class SessionStore:
         self,
         source: SessionSource,
         force_new: bool = False,
+        touch_activity: bool = True,
     ) -> SessionEntry:
         """Perform one session routing transition for the single-flight owner.
 
@@ -2648,10 +2658,12 @@ class SessionStore:
                     _needs_recover = True
                 elif entry.session_id != _stale_session_id:
                     # Another thread handled this entry during our lock-free
-                    # window.  Treat as healthy -- bump updated_at and save.
-                    entry.updated_at = now
-                    _needs_save = True
-                    _metadata_only_save = not _healed
+                    # window. Treat as healthy; internal/system events preserve
+                    # the prior user-activity clock used by reset policy.
+                    if touch_activity:
+                        entry.updated_at = now
+                    _needs_save = touch_activity or _healed
+                    _metadata_only_save = touch_activity and not _healed
                 else:
                     # Stale check clean.  Apply reset decision.
                     if _reset_reason:
@@ -2664,9 +2676,10 @@ class SessionStore:
                         entry = None
                         _needs_recover = True
                     else:
-                        entry.updated_at = now
-                        _needs_save = True
-                        _metadata_only_save = not _healed
+                        if touch_activity:
+                            entry.updated_at = now
+                        _needs_save = touch_activity or _healed
+                        _metadata_only_save = touch_activity and not _healed
             else:
                 if not force_new:
                     _needs_recover = True
@@ -2819,14 +2832,20 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        touch_activity: bool = True,
     ) -> None:
-        """Update lightweight session metadata after an interaction."""
+        """Update lightweight session metadata after an interaction.
+
+        Internal/system turns can persist token metadata without advancing the
+        user-activity clock that drives idle and daily reset policy.
+        """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
                 return
-            entry.updated_at = _now()
+            if touch_activity:
+                entry.updated_at = _now()
             if last_prompt_tokens is not None:
                 entry.last_prompt_tokens = last_prompt_tokens
             # Snapshot peer fields while still holding _lock: a concurrent

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -8,6 +8,7 @@ Verifies that:
 - resume_pending_expired auto-reset sets the correct reason and DB end_reason
 """
 
+import json
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -109,6 +110,52 @@ class TestSessionEntryReason:
         entry2 = store.get_or_create_session(source)
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
+
+
+class TestInternalActivityResetPolicy:
+    def test_internal_turn_does_not_advance_activity_clock(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=60),
+            tmp_path,
+        )
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        prior_activity = datetime.now() - timedelta(minutes=10)
+        entry.updated_at = prior_activity
+        store._save()
+
+        reused = store.get_or_create_session(source, touch_activity=False)
+        store.update_session(
+            reused.session_key,
+            last_prompt_tokens=123,
+            touch_activity=False,
+        )
+
+        assert reused.session_id == entry.session_id
+        assert reused.updated_at == prior_activity
+        assert reused.last_prompt_tokens == 123
+        rows = store._db.load_gateway_routing_entries(
+            scope=store._routing_scope()
+        )
+        durable = json.loads(rows[reused.session_key])
+        assert durable["updated_at"] == prior_activity.isoformat()
+        assert durable["last_prompt_tokens"] == 123
+
+    def test_internal_turn_still_triggers_due_reset(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        entry.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        reset = store.get_or_create_session(source, touch_activity=False)
+
+        assert reset.session_id != entry.session_id
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "idle"
 
 
 # ---------------------------------------------------------------------------
@@ -282,4 +329,3 @@ class TestResumePendingExpiredAutoReset:
         db.promote_to_session_reset.assert_called_once()
         _, ended_reason = db.promote_to_session_reset.call_args.args
         assert ended_reason == "idle"
-

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -81,7 +81,7 @@ def _make_runner(session_db=None):
         group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),
         thread_sessions_per_user=getattr(runner.config, "thread_sessions_per_user", False),
     )
-    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False: SessionEntry(
+    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False, **_kwargs: SessionEntry(
         session_key=build_session_key(
             source,
             group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),


### PR DESCRIPTION
## What does this PR do?

Prevents synthetic internal events, including Kanban completion wakes and background-process notifications, from advancing the `SessionEntry.updated_at` clock used by idle/daily `session_reset` policy.

The session store now accepts `touch_activity=False`: reset policy is still evaluated before routing, but a healthy existing session keeps its prior user-activity timestamp. The same flag is applied after the turn so token metadata remains persisted without turning machine traffic into user activity. A wake that arrives after a reset boundary therefore creates a fresh session and current system prompt instead of keeping the old session alive.

Real user messages retain the existing behavior. New sessions still receive their creation timestamp.

## Related Issue

Fixes #62785

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `touch_activity` to `SessionStore.get_or_create_session()` and `update_session()`.
- Preserve reset-policy timestamps for internal events at pre-turn routing, post-turn metadata persistence, and post-turn goal lookup.
- Preserve single-flight correctness: a real user waiter still touches the shared result if an internal event owns the lookup.
- Add regressions proving internal turns do not advance activity, still persist token metadata, and still trigger an already-due reset.

## How to Test

1. Create a session under an idle/daily reset policy and age `updated_at` without crossing the boundary. Process an internal turn; the timestamp remains unchanged while token metadata updates.
2. Age the session past the boundary and process an internal turn; a fresh auto-reset session is created with the expected reset reason.
3. Run:
   - `uv run --extra dev pytest -q tests/gateway/test_session_reset_notify.py tests/gateway/test_session.py tests/gateway/test_async_session_store.py` (131 passed)
   - `uv run --extra dev pytest -q tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_internal_event_bypass_pairing.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_session_reset_notify.py tests/gateway/test_async_session_store.py` (48 passed)
   - `uv run --extra dev pytest -q tests/gateway/test_session.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_session_store_runtime_stale_guard.py` (130 passed)
   - `uv run --extra dev pytest -q tests/gateway/test_session_race_guard.py` (19 passed)
   - `uv run ruff check gateway/session.py gateway/run.py tests/gateway/test_session_reset_notify.py`
   - `uv run python scripts/check-windows-footguns.py` on staged files

## Overlap Audit

The open `session_reset` PRs were inspected before work and publishing. #61242/#58935 handle expiry finalization reason/notice, #60935 clears processes, #61682 preserves hard-reset boundaries, and #40130 routes clear as reset. None distinguishes internal events from user activity.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and manually inspected keyword overlaps
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused/adjacent suites above passed)
- [x] I've added tests for the bug and reset boundary
- [x] I've tested on macOS, Apple Silicon

### Documentation & Housekeeping

- [x] Documentation update: N/A; public method docstrings describe the new contract
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; Windows footgun scan passed
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

No visual changes.
