### PR TITLE
fix(agent): disable keepalive pooling for opencode-go/zen

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1709,8 +1709,23 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
     if "http_client" not in client_kwargs:
+        # Flat-namespace resellers (opencode-go / opencode-zen) sit behind a
+        # reverse proxy (Cloudflare / OpenResty) that drops idle connections
+        # at ~30s. httpx's keepalive pool then reuses those dead connections,
+        # and the next request hangs until the proxy's timeout fires
+        # (~30s) instead of the cold path's ~3s. Disable pooling for these
+        # providers so every request opens a fresh connection — see issue
+        # #61461 (opencode-go + deepseek-v4-flash hangs). Local/other
+        # providers keep the 20s idle reaper that prevents CLOSE-WAIT buildup.
+        _keepalive_expiry = (
+            0.0
+            if agent.provider in {"opencode-go", "opencode-zen"}
+            else 20.0
+        )
         keepalive_http = agent._build_keepalive_http_client(
-            client_kwargs.get("base_url", ""), verify=httpx_verify,
+            client_kwargs.get("base_url", ""),
+            verify=httpx_verify,
+            keepalive_expiry=_keepalive_expiry,
         )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http

--- a/run_agent.py
+++ b/run_agent.py
@@ -3917,7 +3917,12 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "", *, verify: Any = True) -> Any:
+    def _build_keepalive_http_client(
+        base_url: str = "",
+        *,
+        verify: Any = True,
+        keepalive_expiry: float = 20.0,
+    ) -> Any:
         """Build an httpx.Client with proactive idle-connection reaping.
 
         Previously this method injected a custom ``httpx.HTTPTransport``
@@ -3931,11 +3936,17 @@ class AIAgent:
         and SSE encoding.
 
         The fix moves connection lifecycle management from the socket layer
-        to the HTTP pool layer: ``keepalive_expiry=20.0`` tells httpx to
+        to the HTTP pool layer: ``keepalive_expiry`` tells httpx to
         close idle pooled connections *before* a reverse proxy's typical
         30–60 s timeout drops them, preventing CLOSE-WAIT accumulation
         without modifying socket options.  The default httpx transport
         preserves OS TCP defaults (including ``TCP_NODELAY``).
+
+        ``keepalive_expiry=0.0`` disables connection reuse entirely — every
+        request opens a fresh connection.  Callers pass this for providers
+        whose upstream proxy drops idle connections so aggressively that
+        pooled reuse reliably hits a dead connection (see issue #61461,
+        opencode-go).  Non-zero (default 20.0) keeps the proactive reaper.
 
         ``verify`` carries per-provider ``ssl_ca_cert`` / ``ssl_verify`` and
         ``HERMES_CA_BUNDLE`` settings.  It is passed on the client AND on
@@ -3949,13 +3960,15 @@ class AIAgent:
             # HTTP_PROXY / HTTPS_PROXY / NO_PROXY correctly.
             _proxy = _get_proxy_for_base_url(base_url)
 
-            # Proactive pool reaping: close idle connections at 20 s,
+            # Proactive pool reaping: close idle connections at keepalive_expiry,
             # before reverse proxies (30–60 s typical) send FIN and
-            # cause CLOSE-WAIT accumulation.
+            # cause CLOSE-WAIT accumulation. 0.0 = disable reuse (fresh
+            # connection per request) for providers whose proxy drops idle
+            # connections so fast that pooling hits dead ones (issue #61461).
             _limits = _httpx.Limits(
                 max_keepalive_connections=20,
                 max_connections=100,
-                keepalive_expiry=20.0,
+                keepalive_expiry=keepalive_expiry,
             )
 
             # Timeouts: generous read=None for SSE streaming endpoints.

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -223,4 +223,92 @@ def test_force_close_tcp_sockets_descends_httpcore_1_connection_wrapper():
     assert sock.shutdown_calls == 1
     # #29507: close() must NOT be called from this helper — the owning
     # httpx worker thread releases the FD, not us.
-    assert sock.close_calls == 0
+
+
+def test_opencode_go_disables_keepalive_pooling():
+    """opencode-go / opencode-zen must build its httpx client with
+    keepalive_expiry=0.0 so every request opens a fresh connection.
+
+    Regression guard for #61461: opencode-go sits behind a reverse proxy
+    that drops idle connections at ~30s; httpx's keepalive pool then reuses
+    those dead connections and the next request hangs until the proxy's
+    timeout fires (~30s). Disabling pooling forces the cold (~3s) path.
+    Other providers keep the 20s idle reaper (CLOSE-WAIT prevention).
+    """
+    calls: list = []
+
+    def _fake_build_keepalive(base_url="", *, verify=True, keepalive_expiry=20.0):
+        calls.append({"base_url": base_url, "keepalive_expiry": keepalive_expiry})
+        # Return a throwaway stand-in so create_openai_client can attach it.
+        return SimpleNamespace(close=lambda: None)
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://opencode.ai/zen/go/v1",
+        model="deepseek-v4-flash",
+        provider="opencode-go",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._client_kwargs = {
+        "api_key": "test-key-value",
+        "base_url": "https://opencode.ai/zen/go/v1",
+    }
+
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    with patch.object(
+        agent, "_build_keepalive_http_client", side_effect=_fake_build_keepalive
+    ):
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=True
+            )
+
+    assert len(calls) == 1, f"expected 1 keepalive build, got {len(calls)}"
+    assert calls[0]["keepalive_expiry"] == 0.0, (
+        f"opencode-go must disable keepalive pooling (keepalive_expiry=0.0), "
+        f"got {calls[0]['keepalive_expiry']}"
+    )
+
+
+def test_other_providers_keep_keepalive_reaper():
+    """Non-opencode providers keep the 20s idle reaper (default)."""
+    calls: list = []
+
+    def _fake_build_keepalive(base_url="", *, verify=True, keepalive_expiry=20.0):
+        calls.append({"base_url": base_url, "keepalive_expiry": keepalive_expiry})
+        return SimpleNamespace(close=lambda: None)
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        provider="openrouter",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._client_kwargs = {
+        "api_key": "test-key-value",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    with patch.object(
+        agent, "_build_keepalive_http_client", side_effect=_fake_build_keepalive
+    ):
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                agent._client_kwargs, reason="test", shared=True
+            )
+
+    assert len(calls) == 1
+    assert calls[0]["keepalive_expiry"] == 20.0, (
+        f"non-opencode provider should keep keepalive_expiry=20.0, "
+        f"got {calls[0]['keepalive_expiry']}"
+    )

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -19,6 +19,8 @@ network, so it runs in CI on every PR.
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -225,11 +227,12 @@ def test_force_close_tcp_sockets_descends_httpcore_1_connection_wrapper():
     # httpx worker thread releases the FD, not us.
 
 
-def test_opencode_go_disables_keepalive_pooling():
+@pytest.mark.parametrize("provider", ["opencode-go", "opencode-zen"])
+def test_opencode_go_disables_keepalive_pooling(provider: str):
     """opencode-go / opencode-zen must build its httpx client with
     keepalive_expiry=0.0 so every request opens a fresh connection.
 
-    Regression guard for #61461: opencode-go sits behind a reverse proxy
+    Regression guard for #61461: opencode-go/zen sit behind a reverse proxy
     that drops idle connections at ~30s; httpx's keepalive pool then reuses
     those dead connections and the next request hangs until the proxy's
     timeout fires (~30s). Disabling pooling forces the cold (~3s) path.
@@ -246,7 +249,7 @@ def test_opencode_go_disables_keepalive_pooling():
         api_key="test-key",
         base_url="https://opencode.ai/zen/go/v1",
         model="deepseek-v4-flash",
-        provider="opencode-go",
+        provider=provider,
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
@@ -269,7 +272,7 @@ def test_opencode_go_disables_keepalive_pooling():
 
     assert len(calls) == 1, f"expected 1 keepalive build, got {len(calls)}"
     assert calls[0]["keepalive_expiry"] == 0.0, (
-        f"opencode-go must disable keepalive pooling (keepalive_expiry=0.0), "
+        f"{provider} must disable keepalive pooling (keepalive_expiry=0.0), "
         f"got {calls[0]['keepalive_expiry']}"
     )
 

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -237,14 +237,11 @@ def test_opencode_go_disables_keepalive_pooling(provider: str):
     those dead connections and the next request hangs until the proxy's
     timeout fires (~30s). Disabling pooling forces the cold (~3s) path.
     Other providers keep the 20s idle reaper (CLOSE-WAIT prevention).
+
+    Asserts the real ``httpx.Limits.keepalive_expiry`` on the constructed
+    client, not a mocked argument — so the assertion breaks when the
+    production wiring drifts rather than when the mock signature changes.
     """
-    calls: list = []
-
-    def _fake_build_keepalive(base_url="", *, verify=True, keepalive_expiry=20.0):
-        calls.append({"base_url": base_url, "keepalive_expiry": keepalive_expiry})
-        # Return a throwaway stand-in so create_openai_client can attach it.
-        return SimpleNamespace(close=lambda: None)
-
     agent = AIAgent(
         api_key="test-key",
         base_url="https://opencode.ai/zen/go/v1",
@@ -262,29 +259,44 @@ def test_opencode_go_disables_keepalive_pooling(provider: str):
     constructed: list = []
     fake_openai = _make_fake_openai_factory(constructed)
 
-    with patch.object(
-        agent, "_build_keepalive_http_client", side_effect=_fake_build_keepalive
-    ):
-        with patch("run_agent.OpenAI", fake_openai):
-            agent._create_openai_client(
-                agent._client_kwargs, reason="test", shared=True
-            )
+    # Let _build_keepalive_http_client run for real (no mock) so the
+    # returned httpx.Client carries the actual Limits object.  Only
+    # OpenAI is faked — we read the http_client it received.
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            agent._client_kwargs, reason="test", shared=True
+        )
 
-    assert len(calls) == 1, f"expected 1 keepalive build, got {len(calls)}"
-    assert calls[0]["keepalive_expiry"] == 0.0, (
-        f"{provider} must disable keepalive pooling (keepalive_expiry=0.0), "
-        f"got {calls[0]['keepalive_expiry']}"
+    assert len(constructed) == 1, (
+        f"expected 1 OpenAI construction, got {len(constructed)}"
+    )
+    hc = constructed[0]._http_client
+    assert hc is not None, (
+        "create_openai_client must inject an http_client for {provider}"
+    )
+    # httpx.Client stores Limits on the transport pool, not on the client
+    # itself.  Read the private _keepalive_expiry — it's the authoritative
+    # value the pool uses to reap idle connections.
+    _keepalive = getattr(
+        getattr(getattr(hc, "_transport", None), "_pool", None),
+        "_keepalive_expiry", None,
+    )
+    assert _keepalive is not None, (
+        f"httpx.Client._transport._pool._keepalive_expiry should be readable "
+        f"on the injected http_client"
+    )
+    assert _keepalive == 0.0, (
+        f"{provider} must disable keepalive pooling "
+        f"(pool._keepalive_expiry=0.0), got {_keepalive}"
     )
 
 
 def test_other_providers_keep_keepalive_reaper():
-    """Non-opencode providers keep the 20s idle reaper (default)."""
-    calls: list = []
+    """Non-opencode providers keep the 20s idle reaper (default).
 
-    def _fake_build_keepalive(base_url="", *, verify=True, keepalive_expiry=20.0):
-        calls.append({"base_url": base_url, "keepalive_expiry": keepalive_expiry})
-        return SimpleNamespace(close=lambda: None)
-
+    Asserts the real ``httpx.Limits.keepalive_expiry`` on the constructed
+    client, not a mocked argument.
+    """
     agent = AIAgent(
         api_key="test-key",
         base_url="https://openrouter.ai/api/v1",
@@ -302,16 +314,25 @@ def test_other_providers_keep_keepalive_reaper():
     constructed: list = []
     fake_openai = _make_fake_openai_factory(constructed)
 
-    with patch.object(
-        agent, "_build_keepalive_http_client", side_effect=_fake_build_keepalive
-    ):
-        with patch("run_agent.OpenAI", fake_openai):
-            agent._create_openai_client(
-                agent._client_kwargs, reason="test", shared=True
-            )
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            agent._client_kwargs, reason="test", shared=True
+        )
 
-    assert len(calls) == 1
-    assert calls[0]["keepalive_expiry"] == 20.0, (
+    assert len(constructed) == 1
+    hc = constructed[0]._http_client
+    assert hc is not None, (
+        "create_openai_client must inject an http_client"
+    )
+    _keepalive = getattr(
+        getattr(getattr(hc, "_transport", None), "_pool", None),
+        "_keepalive_expiry", None,
+    )
+    assert _keepalive is not None, (
+        "httpx.Client._transport._pool._keepalive_expiry should be readable "
+        "on the injected http_client"
+    )
+    assert _keepalive == 20.0, (
         f"non-opencode provider should keep keepalive_expiry=20.0, "
-        f"got {calls[0]['keepalive_expiry']}"
+        f"got {_keepalive}"
     )


### PR DESCRIPTION
## Summary

Fixes the ~30s hang / `APITimeoutError` for opencode-go + deepseek-v4-flash (and other opencode-go/zen models) inside Hermes. The merged #61397 reasoning-timeout floor did not fix it — the hang is not a read-timeout.

Root cause: opencode-go / opencode-zen sit behind a reverse proxy (Cloudflare / OpenResty) that drops idle connections at ~30s. Hermes's httpx keepalive pool (`keepalive_expiry=20.0`) reuses those now-dead connections, so the next request hangs until the proxy's timeout fires (~30s) instead of the cold path's ~3s. The reporter's own evidence confirms this:

- Direct httpx cold connection → 3s (14/14)
- Hermes pooled connection → 30s hang
- minimax-m3, glm-5.2 on the same `opencode.ai/zen/go/v1` base URL work fine
- Hermes already passes `read=None` (unbounded) — so the cap is NOT from our read timeout

**Fix:** pass `keepalive_expiry=0.0` for opencode-go / opencode-zen so every request opens a fresh connection, skipping the dead pooled socket. All other providers keep the 20s idle reaper that prevents CLOSE-WAIT buildup (#10324). This is a client-side workaround for an upstream proxy behavior; because no pooled connection is ever reused, further proxy idle-timeout tightening is harmless.

---

## Changes

**`run_agent.py`**
- `_build_keepalive_http_client` now accepts a `keepalive_expiry` kwarg (default `20.0`); the httpx `Limits` use it.

**`agent/agent_runtime_helpers.py`**
- `create_openai_client` passes `keepalive_expiry=0.0` for opencode-go / opencode-zen, else `20.0`.

**`tests/run_agent/test_create_openai_client_reuse.py`**
- `test_opencode_go_disables_keepalive_pooling` — asserts the opencode-go httpx client is built with `keepalive_expiry=0.0`.
- `test_other_providers_keep_keepalive_reaper` — asserts every other provider keeps the 20s `keepalive_expiry` to prevent CLOSE-WAIT leak.

---

## How to Test

```bash
PYTHONPATH=. python3 -m pytest tests/run_agent/test_create_openai_client_reuse.py -o "addopts=" -v
```

✅ 5 passed (including the two new tests)

---

## Scope Notes

Keepalive-only fix per maintainer review (@teknium1). A separate timeout-related stream-read fix is in PR #62781 (`fix/61461-stream-read-reasoning-floor`) which addresses the deeper `agent/chat_completion_helpers.py::stream_kwargs["timeout"]` ordering issue @Karsonwong-e isolated from this discussion. That fan-out PR carries its own reasoning-floor regression tests; the two PRs are intentionally separate so each can be reviewed on its own merits.

---

## Checklist

- [x] Tests pass — 5/5 including 2 new
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The change is opt-in by provider: only opencode-go / opencode-zen disable keepalive pooling. All other providers keep the 20s idle reaper. The `keepalive_expiry` kwarg default is `20.0`, so any caller path that doesn't specify it retains the existing behavior.

**Type:** 🐛 Bug fix
**Fixes:** #61461