### PR TITLE
fix(mcp): serialize keepalive with active RPCs

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -181,6 +181,36 @@ class TestKeepaliveProbe:
         task.session.send_ping.assert_awaited_once()
         task.session.list_tools.assert_not_called()
 
+    async def test_keepalive_skips_an_active_tool_rpc(self):
+        """An active RPC proves liveness; keepalive must not wait or overlap."""
+        task = MCPServerTask("test")
+        rpc_started = asyncio.Event()
+        release_rpc = asyncio.Event()
+        ping_started = asyncio.Event()
+
+        async def active_tool_rpc():
+            async with task._rpc_lock:
+                rpc_started.set()
+                await release_rpc.wait()
+
+        async def send_ping():
+            ping_started.set()
+
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(),
+            send_ping=AsyncMock(side_effect=send_ping),
+        )
+
+        active_task = asyncio.create_task(active_tool_rpc())
+        await rpc_started.wait()
+        await asyncio.wait_for(task._keepalive_probe(), timeout=0.1)
+
+        assert not ping_started.is_set()
+
+        release_rpc.set()
+        await active_task
+        task.session.send_ping.assert_not_awaited()
+
 
 class TestKeepaliveInterval:
     """The keepalive cadence is configurable so servers with short session

--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -202,14 +202,49 @@ class TestKeepaliveProbe:
         )
 
         active_task = asyncio.create_task(active_tool_rpc())
-        await rpc_started.wait()
-        await asyncio.wait_for(task._keepalive_probe(), timeout=0.1)
+        try:
+            await rpc_started.wait()
+            await asyncio.wait_for(task._keepalive_probe(), timeout=0.1)
 
-        assert not ping_started.is_set()
+            assert not ping_started.is_set()
+            task.session.send_ping.assert_not_awaited()
+            task.session.list_tools.assert_not_awaited()
+        finally:
+            release_rpc.set()
+            await active_task
 
-        release_rpc.set()
-        await active_task
-        task.session.send_ping.assert_not_awaited()
+    async def test_active_keepalive_serializes_a_user_rpc(self):
+        """A user RPC must wait while keepalive owns the shared session lock."""
+        task = MCPServerTask("test")
+        ping_started = asyncio.Event()
+        release_ping = asyncio.Event()
+        rpc_started = asyncio.Event()
+
+        async def send_ping():
+            ping_started.set()
+            await release_ping.wait()
+
+        async def user_rpc():
+            async with task._rpc_lock:
+                rpc_started.set()
+
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(),
+            send_ping=AsyncMock(side_effect=send_ping),
+        )
+
+        keepalive_task = asyncio.create_task(task._keepalive_probe())
+        await ping_started.wait()
+        rpc_task = asyncio.create_task(user_rpc())
+        try:
+            await asyncio.sleep(0)
+            assert not rpc_started.is_set()
+        finally:
+            release_ping.set()
+            await keepalive_task
+            await rpc_task
+
+        assert rpc_started.is_set()
 
 
 class TestKeepaliveInterval:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1556,7 +1556,9 @@ class MCPServerTask:
         # handler calls list_tools while a normal tool call is in flight, the
         # stream can wedge and the user-visible tool call times out. Serialize
         # client-initiated RPCs per server. The lock is also applied to HTTP
-        # transports for conservative per-server ordering.
+        # transports for conservative per-server ordering. Keepalive also
+        # treats ownership as proof of liveness, so every future ClientSession
+        # request must acquire this lock to preserve that invariant.
         self._rpc_lock = asyncio.Lock()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
         # contextvars snapshot of the agent task that's currently in
@@ -1834,9 +1836,16 @@ class MCPServerTask:
         transport connection so a server that gains ping support after a
         reconnect is re-probed with the cheap path.
 
+        When a user RPC owns ``_rpc_lock``, that RPC and its own timeout are the
+        liveness detector; the periodic probe is intentionally skipped.
+
         Raises on a genuine connection failure so the caller triggers a
         reconnect; returns normally when the session is alive.
         """
+        # Session replacement is owned by the lifecycle coroutine that calls
+        # this probe; shutdown waits for that task before clearing the session.
+        # Keep one reference throughout the probe so ping and fallback cannot
+        # accidentally target different sessions.
         session = self.session
         if session is None:
             raise RuntimeError("MCP keepalive requested without an active session")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1837,29 +1837,46 @@ class MCPServerTask:
         Raises on a genuine connection failure so the caller triggers a
         reconnect; returns normally when the session is alive.
         """
-        if not self._ping_unsupported:
-            try:
-                await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
-                return
-            except Exception as exc:
-                # Only a "method not found" means ping is unsupported. Any
-                # other error (timeout, closed transport, session expired) is
-                # a real liveness failure — propagate so we reconnect.
-                if not _is_method_not_found_error(exc):
-                    raise
-                if not self._advertises_tools():
-                    # No ping, no tools → no cheaper probe to fall back to.
-                    raise
-                self._ping_unsupported = True
-                logger.info(
-                    "MCP server '%s': does not implement the optional 'ping' "
-                    "utility (-32601); using 'list_tools' for keepalive on "
-                    "this connection.",
-                    self.name,
-                )
+        session = self.session
+        if session is None:
+            raise RuntimeError("MCP keepalive requested without an active session")
 
-        # Fallback probe for servers without ping support.
-        await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+        # A ClientSession is one JSON-RPC stream. Sending a keepalive while a
+        # tools/call is in flight reproducibly wedges the original request on
+        # some SDK/server combinations even though the ping itself succeeds.
+        # The underlying SDK response-routing mechanism remains unidentified;
+        # this serialization is the durable workaround, not redundant locking.
+        # An active RPC already proves liveness, so skip this cycle rather than
+        # queueing a redundant probe behind a potentially long-running call.
+        if self._rpc_lock.locked():
+            return
+
+        # Every other client-initiated RPC uses this lock, so keepalive must too.
+        # The lock also closes the race with a call that starts after the check.
+        async with self._rpc_lock:
+            if not self._ping_unsupported:
+                try:
+                    await asyncio.wait_for(session.send_ping(), timeout=30.0)
+                    return
+                except Exception as exc:
+                    # Only a "method not found" means ping is unsupported. Any
+                    # other error (timeout, closed transport, session expired) is
+                    # a real liveness failure — propagate so we reconnect.
+                    if not _is_method_not_found_error(exc):
+                        raise
+                    if not self._advertises_tools():
+                        # No ping, no tools → no cheaper probe to fall back to.
+                        raise
+                    self._ping_unsupported = True
+                    logger.info(
+                        "MCP server '%s': does not implement the optional 'ping' "
+                        "utility (-32601); using 'list_tools' for keepalive on "
+                        "this connection.",
+                        self.name,
+                    )
+
+            # Fallback probe for servers without ping support.
+            await asyncio.wait_for(session.list_tools(), timeout=30.0)
 
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.


### PR DESCRIPTION
## What does this PR do?

Prevents MCP keepalive probes from overlapping an active RPC on the same `ClientSession`/JSON-RPC stream.

When `_rpc_lock` is already held, the keepalive cycle now returns immediately because active RPC traffic already proves liveness. Otherwise, the probe acquires the same per-server lock used by `call_tool()` and the other client-initiated RPCs before sending `ping` or its `list_tools` fallback. This closes the check/acquire race without queueing the common keepalive path behind a long-running tool call.

The bounded trade-off is the opposite ordering: if keepalive acquires the lock first against a dead server, a newly arriving user RPC waits behind the probe's existing 30-second timeout before its own timeout starts. The regression suite covers that serialization order explicitly. When a user RPC owns the lock and is itself hung, its own timeout remains the failure detector while the redundant periodic probe stays silent.

The bug was reproduced with a long-running stdio MCP call: a concurrent ping completed while the original `tools/call` remained wedged until the outer timeout. A fresh-process live canary after the fix completed the real call in 10.546 seconds, skipped keepalive during the active call, and completed a post-call keepalive.

### Relationship to #48069

#48069 identified the same in-flight keepalive race and proposed a broader fix that also tracks and cancels orphaned calls during reconnect. Credit to @arminanton for documenting that failure mode first.

That branch is currently 2,923 commits behind `main` and has a content conflict in `tools/mcp_tool.py`. This PR is a narrow current-`main` salvage of only the serialization invariant, with a direct regression in the existing capability-gating suite. It intentionally does not duplicate the broader reconnect/orphan-cancellation behavior from #48069.

## Related Issue

Related to #48069 and #30268.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/mcp_tool.py`
  - skip the periodic probe when `_rpc_lock` already indicates active traffic;
  - serialize both `ping` and the `list_tools` fallback with `_rpc_lock`;
  - document the load-bearing all-client-RPC lock invariant and lifecycle ownership of the session snapshot;
  - snapshot the active session and fail explicitly if no session exists.
- `tests/tools/test_mcp_capability_gating.py`
  - prove keepalive returns promptly and emits neither `ping` nor `list_tools` while another RPC owns the lock;
  - prove a user RPC waits when keepalive owns the lock.

## How to Test

1. Focused regression:

       uv run --extra dev pytest -q tests/tools/test_mcp_capability_gating.py::TestKeepaliveProbe::test_keepalive_skips_an_active_tool_rpc tests/tools/test_mcp_capability_gating.py::TestKeepaliveProbe::test_active_keepalive_serializes_a_user_rpc -o 'addopts='

2. Targeted MCP suites:

       uv run --extra dev pytest -q tests/tools/test_mcp_tool.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_capability_gating.py -o 'addopts='

3. Static checks:

       uv run --extra dev python scripts/check-windows-footguns.py --all
       uv run --extra dev ruff check tools/mcp_tool.py tests/tools/test_mcp_capability_gating.py

Observed locally on macOS 26.5.2 / Apple Silicon:

- focused test: RED before the skip guard, GREEN after;
- targeted MCP suites: 265 passed;
- Windows footgun scan: 756 files, no findings;
- ruff and `py_compile`: passed;
- fresh-process real MCP/Fable canary: `status=ok`, 10.546 s, keepalive skipped during the call, post-call keepalive completed.

I also attempted the repository-wide `scripts/run_tests.sh` in the managed local environment. It did not produce a clean baseline: 39 failures were reported across 17 unrelated test files, 10 files did not run, and `tests/tools/test_browser_homebrew_paths.py` hit the wrapper's 300-second per-file timeout. None of the failures were in the three targeted MCP suites above, so this PR does not claim a clean local full-suite run; fork CI is the authoritative full check.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs and documented the relationship to #48069
- [x] My PR contains only the two files related to this fix
- [ ] I've run a clean complete `pytest tests/ -q` suite locally (repository-wide wrapper was attempted but had unrelated local failures/timeouts; targeted 265-test MCP suite passed; full CI is expected to run on the PR)
- [x] I've added a regression test
- [x] I've tested on macOS 26.5.2 / Apple Silicon

### Documentation & Housekeeping

- [x] Relevant behavior is documented in inline comments; no public config or schema changes
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; the change uses existing `asyncio.Lock` semantics and passes the Windows-footgun scanner
- [x] Tool descriptions/schemas: N/A
