### PR TITLE
feat(browser): add per-thread headed Camofox instances

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -257,6 +257,12 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def resolve_browser_scope(browser_scope: Optional[str], session_id: str) -> str:
+    """Return the immutable browser owner for a new or resumed conversation."""
+    explicit = str(browser_scope or "").strip()
+    return explicit or str(session_id or "").strip()
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -287,6 +293,7 @@ def init_agent(
     provider_data_collection: str = None,
     openrouter_min_coding_score: Optional[float] = None,
     session_id: str = None,
+    browser_scope: str = None,
     tool_progress_callback: callable = None,
     tool_start_callback: callable = None,
     tool_complete_callback: callable = None,
@@ -1226,6 +1233,12 @@ def init_agent(
         timestamp_str = agent.session_start.strftime("%Y%m%d_%H%M%S")
         short_uuid = uuid.uuid4().hex[:6]
         agent.session_id = f"{timestamp_str}_{short_uuid}"
+
+    # Browser ownership is a conversation invariant, unlike task_id (which may
+    # be per-turn) and session_id (which may rotate during compression).  Keep
+    # the initial durable session identity unless an embedding supplies an
+    # explicit scope.
+    agent.browser_scope = resolve_browser_scope(browser_scope, agent.session_id)
 
     # Expose session ID to tools (terminal, execute_code) so agents can
     # reference their own session for --resume commands, cross-session

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2336,6 +2336,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(
                 function_name, next_args, effective_task_id,
+                browser_scope=getattr(agent, "browser_scope", None),
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
                 turn_id=getattr(agent, "_current_turn_id", "") or "",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1937,11 +1937,8 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup VM for task {task_id}: {e}")
-    try:
-        _ra().cleanup_browser(task_id)
-    except Exception as e:
-        if agent.verbose_logging:
-            logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
+    # Browsers are conversation-scoped and intentionally survive turns.  They
+    # are closed by the owning frontend at a true session/process boundary.
 
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1474,6 +1474,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 function_result = _ra().handle_function_call(
                     function_name, function_args, effective_task_id,
+                    browser_scope=getattr(agent, "browser_scope", None),
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
@@ -1516,6 +1517,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 function_result = _ra().handle_function_call(
                     function_name, function_args, effective_task_id,
+                    browser_scope=getattr(agent, "browser_scope", None),
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -48,6 +48,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -106,9 +107,14 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 
 
 def _build_server() -> Any:
-    """Create the FastMCP server with Hermes tools attached. Lazy imports
-    so the module can be imported without the mcp package installed
-    (we degrade to a clear error only when actually run)."""
+    """Build FastMCP with one stable browser scope per MCP process.
+
+    Imports stay lazy so importing this module does not require the MCP package.
+    """
+    mcp_browser_scope = (
+        os.getenv("HERMES_BROWSER_SCOPE", "").strip()
+        or f"hermes-tools-mcp-{uuid.uuid4().hex}"
+    )
     try:
         from mcp.server.fastmcp import FastMCP
     except ImportError as exc:  # pragma: no cover - install hint
@@ -162,7 +168,12 @@ def _build_server() -> Any:
         def _make_handler(tool_name: str):
             def _dispatch(**kwargs: Any) -> str:
                 try:
-                    return handle_function_call(tool_name, kwargs or {})
+                    return handle_function_call(
+                        tool_name,
+                        kwargs or {},
+                        task_id=mcp_browser_scope,
+                        browser_scope=mcp_browser_scope,
+                    )
                 except Exception as exc:
                     logger.exception("tool %s raised", tool_name)
                     return json.dumps({"error": str(exc), "tool": tool_name})

--- a/cli.py
+++ b/cli.py
@@ -7025,6 +7025,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
+        old_browser_scope = getattr(self.agent, "browser_scope", old_session_id) if self.agent else old_session_id
         _boundary_snapshot = None
         if self.agent and self.conversation_history:
             # Deliver the context-engine boundary synchronously and get back
@@ -7071,7 +7072,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _sync_process_session_id(self.session_id)
 
         if self.agent:
+            try:
+                cleanup_browser(old_browser_scope)
+            except Exception:
+                pass
             self.agent.session_id = self.session_id
+            self.agent.browser_scope = self.session_id
             self.agent.session_start = self.session_start
             self.agent.reset_session_state()
             if hasattr(self.agent, "_last_flushed_db_idx"):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1048,6 +1048,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    browser_scope: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1124,6 +1125,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_browser_scope = str(browser_scope or "").strip() or None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1213,6 +1215,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "browser_scope": normalized_browser_scope,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3074,6 +3074,7 @@ def run_job(
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
+            browser_scope=job.get("browser_scope"),
         )
         
         # Run the agent with an *inactivity*-based timeout: the job can run

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1286,10 +1286,23 @@ DEFAULT_CONFIG = {
         "dialog_policy": "must_respond",  # must_respond | auto_dismiss | auto_accept
         "dialog_timeout_s": 300,  # Safety auto-dismiss after N seconds under must_respond
         "camofox": {
+            # standard preserves the legacy flags. visible_isolated separates
+            # contexts; per_thread_instances separates entire headed servers.
+            "mode": "standard",
+            "server_dir": "~/src/camofox-browser",
+            "instance_port_start": 19400,
+            "instance_port_end": 19999,
+            "instance_startup_timeout": 60,
+            "instance_popup_viewer": True,
+            "viewer_executable": "~/.cache/camoufox/camoufox",
+            "viewer_profile_root": "~/.camoufox-hermes-thread-viewers",
             # When true, Hermes sends a stable profile-scoped userId to Camofox
             # so the server maps it to a persistent Firefox profile automatically.
             # When false (default), each session gets a random userId (ephemeral).
             "managed_persistence": False,
+            # Give each browser task its own stable userId/context. This keeps
+            # concurrent conversations in separate visible browser windows.
+            "isolate_tasks": False,
             # Optional externally managed Camofox identity. Useful when another
             # app owns the visible browser and Hermes should operate in it.
             "user_id": "",

--- a/model_tools.py
+++ b/model_tools.py
@@ -232,7 +232,7 @@ _LEGACY_TOOLSET_MAP = {
     "image_tools": ["image_generate"],
     "skills_tools": ["skills_list", "skill_view", "skill_manage"],
     "browser_tools": [
-        "browser_navigate", "browser_snapshot", "browser_click",
+        "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",
         "browser_press", "browser_get_images",
         "browser_vision", "browser_console"

--- a/model_tools.py
+++ b/model_tools.py
@@ -1026,6 +1026,7 @@ def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
     task_id: Optional[str] = None,
+    browser_scope: Optional[str] = None,
     tool_call_id: Optional[str] = None,
     session_id: Optional[str] = None,
     turn_id: Optional[str] = None,
@@ -1044,7 +1045,8 @@ def handle_function_call(
     Args:
         function_name: Name of the function to call.
         function_args: Arguments for the function.
-        task_id: Unique identifier for terminal/browser session isolation.
+        task_id: Unique identifier for task-scoped tools such as terminal.
+        browser_scope: Stable conversation identifier for browser isolation.
         user_task: The user's original task (for browser_snapshot context).
         enabled_tools: Tool names enabled for this session.  When provided,
                        execute_code uses this list to determine which sandbox
@@ -1132,6 +1134,7 @@ def handle_function_call(
                 function_name=underlying_name,
                 function_args=underlying_args,
                 task_id=task_id,
+                browser_scope=browser_scope,
                 tool_call_id=tool_call_id,
                 session_id=session_id,
                 user_task=user_task,
@@ -1257,6 +1260,9 @@ def handle_function_call(
         except Exception:
             reset_current_observability_context = None
         try:
+            dispatch_task_id = browser_scope if function_name.startswith("browser_") else task_id
+            if function_name.startswith("browser_") and not dispatch_task_id:
+                return json.dumps({"error": "browser scope is required for browser tools"})
             if function_name == "execute_code":
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
@@ -1264,15 +1270,16 @@ def handle_function_call(
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,
-                        task_id=task_id,
+                        task_id=dispatch_task_id,
                         session_id=session_id,
+                        browser_scope=browser_scope,
                         enabled_tools=sandbox_enabled,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,
-                        task_id=task_id,
+                        task_id=dispatch_task_id,
                         session_id=session_id,
                         user_task=user_task,
                     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -443,6 +443,7 @@ class AIAgent:
         provider_data_collection: str = None,
         openrouter_min_coding_score: Optional[float] = None,
         session_id: str = None,
+        browser_scope: str = None,
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
         tool_complete_callback: callable = None,
@@ -519,6 +520,7 @@ class AIAgent:
             provider_data_collection=provider_data_collection,
             openrouter_min_coding_score=openrouter_min_coding_score,
             session_id=session_id,
+            browser_scope=browser_scope,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -3486,6 +3488,7 @@ class AIAgent:
         independently guarded so a failure in one does not prevent the rest.
         """
         task_id = getattr(self, "session_id", None) or ""
+        browser_scope = getattr(self, "browser_scope", None) or task_id
 
         # 1. Kill background processes for this task
         try:
@@ -3502,7 +3505,7 @@ class AIAgent:
 
         # 3. Clean browser daemon sessions
         try:
-            cleanup_browser(task_id)
+            cleanup_browser(browser_scope)
         except Exception:
             pass
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2858,6 +2858,7 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("web_search", {"q": "test"}, "task-1")
             mock_hfc.assert_called_once_with(
                 "web_search", {"q": "test"}, "task-1",
+                browser_scope=agent.browser_scope,
                 tool_call_id=None,
                 session_id=agent.session_id,
                 turn_id="",

--- a/tests/test_browser_scope_lifecycle.py
+++ b/tests/test_browser_scope_lifecycle.py
@@ -1,0 +1,85 @@
+import json
+from types import SimpleNamespace
+
+
+def test_two_sessions_dispatch_to_distinct_browser_scopes(monkeypatch):
+    import model_tools
+
+    seen = []
+    monkeypatch.setattr(
+        model_tools.registry,
+        "dispatch",
+        lambda name, args, **kw: seen.append((name, kw["task_id"])) or "ok",
+    )
+
+    assert model_tools.handle_function_call(
+        "browser_navigate", {"url": "https://example.com"},
+        task_id="turn-1", browser_scope="session-a",
+        skip_pre_tool_call_hook=True, skip_tool_request_middleware=True,
+    ) == "ok"
+    assert model_tools.handle_function_call(
+        "browser_navigate", {"url": "https://example.com"},
+        task_id="turn-1", browser_scope="session-b",
+        skip_pre_tool_call_hook=True, skip_tool_request_middleware=True,
+    ) == "ok"
+    assert seen == [
+        ("browser_navigate", "session-a"),
+        ("browser_navigate", "session-b"),
+    ]
+
+
+def test_resume_reuses_browser_identity_and_compression_does_not_rotate_it():
+    from agent.agent_init import resolve_browser_scope
+
+    first = resolve_browser_scope(None, "resumed-session")
+    resumed = resolve_browser_scope(None, "resumed-session")
+    assert resumed == first
+
+    agent = SimpleNamespace(session_id="resumed-session", browser_scope=resumed)
+    agent.session_id = "compression-continuation"
+    assert agent.browser_scope == "resumed-session"
+
+
+def test_browser_dispatch_without_scope_fails_closed(monkeypatch):
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools.registry, "dispatch",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+    )
+    result = model_tools.handle_function_call(
+        "browser_snapshot", {}, task_id="turn-only",
+        skip_pre_tool_call_hook=True, skip_tool_request_middleware=True,
+    )
+    assert json.loads(result) == {"error": "browser scope is required for browser tools"}
+
+
+def test_per_thread_mode_disables_shared_camofox_url(monkeypatch):
+    from tools import browser_camofox
+
+    monkeypatch.setenv("CAMOFOX_URL", "http://127.0.0.1:9377")
+    monkeypatch.setattr(
+        browser_camofox, "_get_camofox_config",
+        lambda: {"mode": "per_thread_instances"},
+    )
+    browser_camofox._request_base_url.set(None)
+    assert browser_camofox.get_camofox_url() == ""
+    assert browser_camofox.is_camofox_mode() is True
+
+
+def test_per_turn_cleanup_preserves_browser(monkeypatch):
+    from agent import chat_completion_helpers
+
+    monkeypatch.setattr(chat_completion_helpers, "is_persistent_env", lambda _: False)
+    monkeypatch.setattr(
+        chat_completion_helpers, "_ra",
+        lambda: SimpleNamespace(
+            cleanup_vm=lambda _: None,
+            cleanup_browser=lambda _: (_ for _ in ()).throw(
+                AssertionError("browser cleanup is a session-boundary operation")
+            ),
+        ),
+    )
+    chat_completion_helpers.cleanup_task_resources(
+        SimpleNamespace(verbose_logging=False), "turn-id"
+    )

--- a/tests/test_camofox_recovery.py
+++ b/tests/test_camofox_recovery.py
@@ -1,0 +1,221 @@
+import json
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+def _http_error(status, message):
+    import requests
+    response = Mock(status_code=status, text=json.dumps({"error": message}))
+    response.json.return_value = {"error": message}
+    return requests.HTTPError(response=response)
+
+
+@pytest.mark.parametrize("status,message", [
+    (404, "Tab not found"),
+    (410, "Tab not found"),
+    (503, "Target page, context or browser has been closed"),
+])
+def test_navigate_recreates_stale_tab_once(monkeypatch, status, message):
+    from tools import browser_camofox as mod
+    instance = object()
+    session = {
+        "tab_id": "old", "user_id": "user", "session_key": "scope",
+        "instance": instance,
+    }
+    pool = Mock()
+    monkeypatch.setattr(mod, "_get_session", lambda task_id: session)
+    monkeypatch.setattr(mod, "_rewrite_loopback_url_for_camofox", lambda url: (url, None))
+    monkeypatch.setattr(mod, "get_vnc_url", lambda: None)
+    monkeypatch.setattr(mod, "_get_camofox_config", lambda: {"mode": "per_thread_instances"})
+    monkeypatch.setattr(mod, "_get_instance_pool", lambda cfg: pool)
+    monkeypatch.setattr(mod, "_post", Mock(side_effect=_http_error(status, message)))
+    monkeypatch.setattr(mod, "_ensure_tab", Mock(side_effect=lambda task_id, url: {**session, "tab_id": "fresh"}))
+    monkeypatch.setattr(mod, "_get", Mock(return_value={"snapshot": "ok", "refsCount": 1}))
+    result = json.loads(mod.camofox_navigate("https://example.com", "declared-scope"))
+    assert result["success"] is True
+    mod._ensure_tab.assert_called_once_with("declared-scope", "https://example.com")
+    pool.ensure_viewer.assert_called_once_with(instance, force=True)
+
+
+def test_firefox_import_is_domain_scoped_and_merges_exact_profile(tmp_path, monkeypatch):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    db = sqlite3.connect(profile / "cookies.sqlite")
+    db.execute("CREATE TABLE moz_cookies (name, value, host, path, expiry, isSecure, isHttpOnly, sameSite)")
+    db.executemany("INSERT INTO moz_cookies VALUES (?,?,?,?,?,?,?,?)", [
+        ("c_user", "secret-a", ".facebook.com", "/", 123, 1, 1, 1),
+        ("xs", "secret-b", ".facebook.com", "/", 123, 1, 1, 2),
+        ("other", "do-not-copy", ".example.com", "/", 123, 0, 0, 0),
+    ])
+    db.commit(); db.close()
+    from tools import browser_camofox, camofox_auth
+    profile_root = tmp_path / "camofox-profiles"
+    monkeypatch.setattr(browser_camofox, "camofox_identity_for_scope", lambda scope: {"user_id": "derived"})
+    stop = Mock()
+    monkeypatch.setattr(browser_camofox, "stop_camofox_scope", stop)
+    monkeypatch.setattr(browser_camofox, "_get_camofox_config", lambda: {"profile_dir": str(profile_root)})
+    assert camofox_auth.import_firefox_cookies(
+        profile, task_id="declared-scope", domains=["facebook.com"],
+        required_names=["c_user", "xs"],
+    ) == 2
+    stop.assert_called_once_with("declared-scope")
+    path = camofox_auth._profile_state_path(profile_root, "derived")
+    state = json.loads(path.read_text())
+    assert {c["name"] for c in state["cookies"]} == {"c_user", "xs"}
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_navigate_cannot_restart_same_scope_until_cookie_import_finishes(tmp_path, monkeypatch):
+    from tools import browser_camofox, camofox_auth
+    from tools.camofox_instance_pool import CamofoxInstancePool
+
+    server_dir = tmp_path / "server"
+    server_dir.mkdir()
+    (server_dir / "server.js").write_text("// test")
+    source = tmp_path / "firefox"
+    source.mkdir()
+    db = sqlite3.connect(source / "cookies.sqlite")
+    db.execute("CREATE TABLE moz_cookies (name, value, host, path, expiry, isSecure, isHttpOnly, sameSite)")
+    db.execute("INSERT INTO moz_cookies VALUES (?,?,?,?,?,?,?,?)", (
+        "session", "secret", ".example.com", "/", 123, 1, 1, 1,
+    ))
+    db.commit()
+    db.close()
+
+    pool = CamofoxInstancePool(server_dir, log_root=tmp_path / "logs")
+    processes = [Mock(pid=101), Mock(pid=102)]
+    for process in processes:
+        process.poll.return_value = None
+    cfg = {
+        "mode": "per_thread_instances",
+        "server_dir": str(server_dir),
+        "profile_dir": str(tmp_path / "profiles"),
+    }
+    monkeypatch.setattr(browser_camofox, "_get_camofox_config", lambda: cfg)
+    monkeypatch.setattr(browser_camofox, "_get_instance_pool", lambda ignored: pool)
+    monkeypatch.setattr(browser_camofox, "camofox_identity_for_scope", lambda scope: {"user_id": "derived"})
+    monkeypatch.setattr(browser_camofox, "_sessions", {})
+    monkeypatch.setattr(browser_camofox, "get_vnc_url", lambda: None)
+    monkeypatch.setattr(browser_camofox, "_get", lambda *args, **kwargs: {"snapshot": "", "refsCount": 0})
+
+    def create_tab(task_id, url):
+        session = browser_camofox._sessions[task_id]
+        session["tab_id"] = "new-tab"
+        return session
+
+    monkeypatch.setattr(browser_camofox, "_ensure_tab", create_tab)
+
+    merge_entered = threading.Event()
+    allow_merge = threading.Event()
+    real_merge = camofox_auth._atomic_merge_storage_state
+
+    def blocking_merge(path, cookies):
+        merge_entered.set()
+        assert allow_merge.wait(timeout=5)
+        real_merge(path, cookies)
+
+    popen = Mock(side_effect=processes)
+    with monkeypatch.context() as context:
+        context.setattr(camofox_auth, "_atomic_merge_storage_state", blocking_merge)
+        context.setattr("tools.camofox_instance_pool.subprocess.Popen", popen)
+        context.setattr(pool, "_wait_until_ready", Mock())
+        context.setattr("tools.camofox_instance_pool.os.getpgid", lambda pid: pid)
+        context.setattr("tools.camofox_instance_pool.os.killpg", Mock())
+        pool.get_or_start("scope")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            importing = executor.submit(
+                camofox_auth.import_firefox_cookies, source, task_id="scope",
+                domains=["example.com"], required_names=["session"],
+            )
+            assert merge_entered.wait(timeout=5)
+            navigating = executor.submit(
+                browser_camofox.camofox_navigate, "https://example.com", "scope"
+            )
+            time.sleep(0.05)
+            assert not navigating.done()
+            assert popen.call_count == 1
+            allow_merge.set()
+            assert importing.result(timeout=5) == 1
+            assert json.loads(navigating.result(timeout=5))["success"] is True
+            assert browser_camofox._sessions["scope"]["instance"].process is processes[1]
+
+
+def test_cookie_import_requires_explicit_source_profile():
+    from tools import camofox_auth
+    with pytest.raises(ValueError, match="explicit Firefox source_profile"):
+        camofox_auth._handle_import(
+            {"domains": ["facebook.com"], "required_names": ["c_user"]},
+            task_id="scope",
+        )
+
+
+def test_storage_state_merge_preserves_origins_and_unrelated_cookies(tmp_path):
+    from tools.camofox_auth import _atomic_merge_storage_state
+    path = tmp_path / "profile" / "storage-state.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps({
+        "cookies": [
+            {"name": "keep", "value": "old", "domain": ".example.com", "path": "/"},
+            {"name": "xs", "value": "stale", "domain": ".facebook.com", "path": "/"},
+        ],
+        "origins": [{"origin": "https://example.com", "localStorage": []}],
+    }))
+    _atomic_merge_storage_state(path, [
+        {"name": "xs", "value": "fresh", "domain": ".facebook.com", "path": "/"},
+    ])
+    state = json.loads(path.read_text())
+    assert [(c["name"], c["value"]) for c in state["cookies"]] == [("keep", "old"), ("xs", "fresh")]
+    assert state["origins"][0]["origin"] == "https://example.com"
+
+
+def test_stop_scope_invalidates_tab_and_stops_only_scope(monkeypatch):
+    from tools import browser_camofox as mod
+    session = {"tab_id": "old"}
+    pool = Mock()
+    monkeypatch.setattr(mod, "_sessions", {"scope-a": session, "scope-b": {"tab_id": "other"}})
+    monkeypatch.setattr(mod, "_get_camofox_config", lambda: {"mode": "per_thread_instances"})
+    monkeypatch.setattr(mod, "_get_instance_pool", lambda cfg: pool)
+    mod.stop_camofox_scope("scope-a")
+    pool.stop.assert_called_once_with("scope-a")
+    assert session["tab_id"] is None
+    assert "scope-a" not in mod._sessions
+    assert mod._sessions["scope-b"]["tab_id"] == "other"
+
+
+def test_cached_session_restarts_dead_server_and_invalidates_tab(monkeypatch):
+    from tools import browser_camofox as mod
+    old_instance, new_instance = object(), Mock(api_url="http://new", viewer_url="http://viewer")
+    session = {"tab_id": "old", "instance": old_instance, "api_url": "http://old", "adopt_existing_tab": False}
+    pool = Mock()
+    pool.get_or_start.return_value = new_instance
+    pool.scope_lifecycle.side_effect = lambda scope: nullcontext()
+    monkeypatch.setattr(mod, "_sessions", {"scope": session})
+    monkeypatch.setattr(mod, "_get_camofox_config", lambda: {"mode": "per_thread_instances"})
+    monkeypatch.setattr(mod, "_get_instance_pool", lambda cfg: pool)
+    recovered = mod._get_session("scope")
+    assert recovered["tab_id"] is None
+    assert recovered["api_url"] == "http://new"
+    pool.ensure_viewer.assert_called_once_with(new_instance, force=True)
+
+
+def test_cron_job_persists_browser_scope(tmp_path, monkeypatch):
+    from cron import jobs
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "jobs.json")
+    monkeypatch.setattr(jobs, "compute_next_run", lambda schedule: "2099-01-01T00:00:00")
+    job = jobs.create_job("continue browser work", "every 1h", browser_scope="facebook-leo")
+    assert job["browser_scope"] == "facebook-leo"
+
+
+def test_cron_current_browser_scope_resolves_or_refuses():
+    from tools.cronjob_tools import _resolve_cron_browser_scope
+    assert _resolve_cron_browser_scope("current", "session-scope") == "session-scope"
+    with pytest.raises(ValueError, match="active browser scope"):
+        _resolve_cron_browser_scope("current", None)

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -132,6 +132,72 @@ class TestManagedPersistenceMode:
             assert s1["user_id"] == s2["user_id"]
             assert s1["session_key"] != s2["session_key"]
 
+    def test_isolate_tasks_uses_distinct_managed_users(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        config = {
+            "browser": {
+                "camofox": {
+                    "managed_persistence": True,
+                    "isolate_tasks": True,
+                }
+            }
+        }
+
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            s1 = _get_session("task-a")
+            s2 = _get_session("task-b")
+            assert s1["user_id"] != s2["user_id"]
+            assert s1["session_key"] != s2["session_key"]
+
+    def test_visible_isolated_mode_uses_distinct_stable_managed_users(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        config = {"browser": {"camofox": {"mode": "visible_isolated"}}}
+
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            first = _get_session("task-a")
+            second = _get_session("task-b")
+            _drop_session("task-a")
+            restored = _get_session("task-a")
+
+        assert first["managed"] is True
+        assert first["user_id"] != second["user_id"]
+        assert first["session_key"] != second["session_key"]
+        assert restored["user_id"] == first["user_id"]
+        assert restored["session_key"] == first["session_key"]
+        assert first["adopt_existing_tab"] is False
+
+    def test_visible_isolated_mode_soft_cleanup_preserves_server_context(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = {"browser": {"camofox": {"mode": "visible_isolated"}}}
+
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            first = _get_session("thread-a")
+            assert camofox_soft_cleanup("thread-a") is True
+            restored = _get_session("thread-a")
+
+        assert restored["user_id"] == first["user_id"]
+
+    def test_per_thread_instances_route_sessions_to_distinct_servers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = {"browser": {"camofox": {"mode": "per_thread_instances"}}}
+        pool = MagicMock()
+        pool.get_or_start.side_effect = [
+            MagicMock(api_url="http://127.0.0.1:19401", viewer_url="http://127.0.0.1:19403/vnc.html"),
+            MagicMock(api_url="http://127.0.0.1:19404", viewer_url="http://127.0.0.1:19406/vnc.html"),
+        ]
+
+        with patch("tools.browser_camofox.load_config", return_value=config), patch(
+            "tools.browser_camofox._get_instance_pool", return_value=pool
+        ):
+            first = _get_session("thread-a")
+            second = _get_session("thread-b")
+
+        assert first["api_url"] != second["api_url"]
+        assert first["viewer_url"] != second["viewer_url"]
+        assert pool.get_or_start.call_count == 2
+
     def test_different_profiles_get_different_user_ids(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
 

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -6,6 +6,7 @@ dedicated persistent Firefox profile on the server side.
 """
 
 import json
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -183,6 +184,7 @@ class TestManagedPersistenceMode:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         config = {"browser": {"camofox": {"mode": "per_thread_instances"}}}
         pool = MagicMock()
+        pool.scope_lifecycle.side_effect = lambda scope: nullcontext()
         pool.get_or_start.side_effect = [
             MagicMock(api_url="http://127.0.0.1:19401", viewer_url="http://127.0.0.1:19403/vnc.html"),
             MagicMock(api_url="http://127.0.0.1:19404", viewer_url="http://127.0.0.1:19406/vnc.html"),

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -33,6 +33,21 @@ class TestCamofoxIdentity:
             assert a["user_id"] == b["user_id"]
             assert a["session_key"] != b["session_key"]
 
+    def test_isolated_identity_uses_distinct_users_per_task(self, tmp_path):
+        state = _load_module()
+        with patch.object(state, "get_hermes_home", return_value=tmp_path):
+            a = state.get_camofox_identity("task-a", isolate_task=True)
+            b = state.get_camofox_identity("task-b", isolate_task=True)
+            assert a["user_id"] != b["user_id"]
+            assert a["session_key"] != b["session_key"]
+
+    def test_isolated_identity_is_stable_for_same_task(self, tmp_path):
+        state = _load_module()
+        with patch.object(state, "get_hermes_home", return_value=tmp_path):
+            first = state.get_camofox_identity("task-a", isolate_task=True)
+            second = state.get_camofox_identity("task-a", isolate_task=True)
+            assert first == second
+
     def test_identity_differs_by_profile(self, tmp_path):
         state = _load_module()
         with patch.object(state, "get_hermes_home", return_value=tmp_path / "profile-a"):
@@ -56,7 +71,9 @@ class TestCamofoxConfigDefaults:
         from hermes_cli.config import DEFAULT_CONFIG
 
         browser_cfg = DEFAULT_CONFIG["browser"]
+        assert browser_cfg["camofox"]["mode"] == "standard"
         assert browser_cfg["camofox"]["managed_persistence"] is False
+        assert browser_cfg["camofox"]["isolate_tasks"] is False
         assert browser_cfg["camofox"]["user_id"] == ""
         assert browser_cfg["camofox"]["session_key"] == ""
         assert browser_cfg["camofox"]["adopt_existing_tab"] is False

--- a/tests/tools/test_camofox_instance_pool.py
+++ b/tests/tools/test_camofox_instance_pool.py
@@ -39,6 +39,20 @@ def test_concurrent_same_task_waits_for_one_ready_instance(tmp_path):
     popen.assert_called_once()
 
 
+def test_scope_lifecycle_does_not_block_a_different_task(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    process = MagicMock()
+    process.poll.return_value = None
+    pool = CamofoxInstancePool(tmp_path)
+
+    with patch("tools.camofox_instance_pool.subprocess.Popen", return_value=process), patch.object(
+        pool, "_wait_until_ready"
+    ), pool.scope_lifecycle("thread-a"):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            other = executor.submit(pool.get_or_start, "thread-b")
+            assert other.result(timeout=1).task_id == "thread-b"
+
+
 def test_different_tasks_get_distinct_port_triples(tmp_path):
     pool = CamofoxInstancePool(tmp_path)
     with patch.object(pool, "_port_available", return_value=True):
@@ -145,6 +159,57 @@ def test_popup_viewer_uses_dedicated_profile_and_instance_url(tmp_path):
     assert "--profile" in viewer_args
     assert instance.viewer_url == viewer_args[-1]
     assert instance.viewer_process is viewer_process
+
+
+def test_force_viewer_relaunch_waits_for_ready_then_reaps_old_popup(tmp_path):
+    executable = tmp_path / "camoufox"
+    executable.write_text("")
+    pool = CamofoxInstancePool(
+        tmp_path, launch_viewer=True, viewer_executable=executable,
+        viewer_profile_root=tmp_path / "profiles",
+    )
+    from tools.camofox_instance_pool import CamofoxInstance
+    server = MagicMock()
+    old_viewer = MagicMock(pid=101)
+    old_viewer.poll.return_value = None
+    new_viewer = MagicMock(pid=102)
+    new_viewer.poll.return_value = None
+    instance = CamofoxInstance(
+        "thread-a", 19401, 19402, 19403, server, viewer_process=old_viewer,
+    )
+
+    events = []
+    response = MagicMock(status_code=200)
+    with patch("tools.camofox_instance_pool.requests.get", side_effect=lambda *a, **k: events.append("ready") or response), patch(
+        "tools.camofox_instance_pool.os.getpgid", return_value=777
+    ), patch("tools.camofox_instance_pool.os.killpg", side_effect=lambda *a: events.append("stop")), patch(
+        "tools.camofox_instance_pool.subprocess.Popen", side_effect=lambda *a, **k: events.append("launch") or new_viewer
+    ):
+        pool.ensure_viewer(instance, force=True)
+
+    assert events == ["ready", "stop", "launch"]
+    old_viewer.wait.assert_called_once_with(timeout=5)
+    assert instance.viewer_process is new_viewer
+
+
+def test_force_viewer_relaunch_keeps_old_popup_when_novnc_is_not_ready(tmp_path):
+    pool = CamofoxInstancePool(tmp_path, launch_viewer=True, startup_timeout=0)
+    from tools.camofox_instance_pool import CamofoxInstance
+    old_viewer = MagicMock(pid=101)
+    old_viewer.poll.return_value = None
+    instance = CamofoxInstance(
+        "thread-a", 19401, 19402, 19403, MagicMock(), viewer_process=old_viewer,
+    )
+
+    with patch.object(pool, "_terminate_viewer") as terminate, patch.object(
+        pool, "_launch_viewer"
+    ) as launch:
+        with pytest.raises(RuntimeError, match="noVNC did not become ready"):
+            pool.ensure_viewer(instance, force=True)
+
+    terminate.assert_not_called()
+    launch.assert_not_called()
+    assert instance.viewer_process is old_viewer
 
 
 def test_missing_server_fails_before_spawn(tmp_path):

--- a/tests/tools/test_camofox_instance_pool.py
+++ b/tests/tools/test_camofox_instance_pool.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,22 @@ def test_same_task_reuses_live_instance(tmp_path):
     ):
         first = pool.get_or_start("thread-a")
         second = pool.get_or_start("thread-a")
+
+    assert first is second
+    popen.assert_called_once()
+
+
+def test_concurrent_same_task_waits_for_one_ready_instance(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    process = MagicMock()
+    process.poll.return_value = None
+    pool = CamofoxInstancePool(tmp_path)
+
+    with patch("tools.camofox_instance_pool.subprocess.Popen", return_value=process) as popen, patch.object(
+        pool, "_wait_until_ready"
+    ):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first, second = executor.map(pool.get_or_start, ["thread-a", "thread-a"])
 
     assert first is second
     popen.assert_called_once()
@@ -66,6 +83,33 @@ def test_start_failure_terminates_process(tmp_path):
             pool.get_or_start("thread-a")
 
     killpg.assert_called_once_with(4321, 15)
+
+
+def test_dead_server_reaps_viewer_and_closes_log_before_replacement(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    dead = MagicMock(pid=100)
+    dead.poll.return_value = 1
+    viewer = MagicMock(pid=101)
+    viewer.poll.return_value = None
+    log_file = MagicMock()
+    pool = CamofoxInstancePool(tmp_path)
+    from tools.camofox_instance_pool import CamofoxInstance
+    pool._instances["thread-a"] = CamofoxInstance(
+        "thread-a", 19401, 19402, 19403, dead,
+        viewer_process=viewer, log_file=log_file,
+    )
+    replacement = MagicMock()
+    replacement.poll.return_value = None
+
+    with patch("tools.camofox_instance_pool.subprocess.Popen", return_value=replacement), patch.object(
+        pool, "_wait_until_ready"
+    ), patch("tools.camofox_instance_pool.os.getpgid", return_value=777), patch(
+        "tools.camofox_instance_pool.os.killpg"
+    ) as killpg:
+        pool.get_or_start("thread-a")
+
+    killpg.assert_called_once_with(777, 15)
+    log_file.close.assert_called_once()
 
 
 def test_popup_viewer_uses_dedicated_profile_and_instance_url(tmp_path):

--- a/tests/tools/test_camofox_instance_pool.py
+++ b/tests/tools/test_camofox_instance_pool.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.camofox_instance_pool import CamofoxInstancePool
+
+
+def test_same_task_reuses_live_instance(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    process = MagicMock()
+    process.poll.return_value = None
+    pool = CamofoxInstancePool(tmp_path)
+
+    with patch("tools.camofox_instance_pool.subprocess.Popen", return_value=process) as popen, patch.object(
+        pool, "_wait_until_ready"
+    ):
+        first = pool.get_or_start("thread-a")
+        second = pool.get_or_start("thread-a")
+
+    assert first is second
+    popen.assert_called_once()
+
+
+def test_different_tasks_get_distinct_port_triples(tmp_path):
+    pool = CamofoxInstancePool(tmp_path)
+    with patch.object(pool, "_port_available", return_value=True):
+        first = set(pool._ports_for_task("thread-a"))
+        second = set(pool._ports_for_task("thread-b"))
+
+    assert first.isdisjoint(second)
+
+
+def test_spawn_sets_independent_api_and_vnc_ports(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    process = MagicMock()
+    process.poll.return_value = None
+    pool = CamofoxInstancePool(tmp_path)
+
+    with patch.object(pool, "_ports_for_task", return_value=(19401, 19402, 19403)), patch(
+        "tools.camofox_instance_pool.subprocess.Popen", return_value=process
+    ) as popen, patch.object(pool, "_wait_until_ready"):
+        instance = pool.get_or_start("thread-a")
+
+    env = popen.call_args.kwargs["env"]
+    assert env["CAMOFOX_PORT"] == "19401"
+    assert env["VNC_PORT"] == "19402"
+    assert env["NOVNC_PORT"] == "19403"
+    assert env["VNC_BIND"] == "127.0.0.1"
+    assert instance.api_url == "http://127.0.0.1:19401"
+    assert instance.viewer_url.startswith("http://127.0.0.1:19403/vnc.html")
+
+
+def test_start_failure_terminates_process(tmp_path):
+    (tmp_path / "server.js").write_text("// test")
+    process = MagicMock()
+    process.poll.return_value = None
+    pool = CamofoxInstancePool(tmp_path)
+
+    with patch("tools.camofox_instance_pool.subprocess.Popen", return_value=process), patch.object(
+        pool, "_wait_until_ready", side_effect=RuntimeError("boom")
+    ), patch("tools.camofox_instance_pool.os.getpgid", return_value=4321), patch(
+        "tools.camofox_instance_pool.os.killpg"
+    ) as killpg:
+        with pytest.raises(RuntimeError, match="boom"):
+            pool.get_or_start("thread-a")
+
+    killpg.assert_called_once_with(4321, 15)
+
+
+def test_popup_viewer_uses_dedicated_profile_and_instance_url(tmp_path):
+    server_dir = tmp_path / "server"
+    server_dir.mkdir()
+    (server_dir / "server.js").write_text("// test")
+    executable = tmp_path / "camoufox"
+    executable.write_text("")
+    server_process = MagicMock()
+    server_process.poll.return_value = None
+    viewer_process = MagicMock()
+    viewer_process.poll.return_value = None
+    pool = CamofoxInstancePool(
+        server_dir,
+        launch_viewer=True,
+        viewer_executable=executable,
+        viewer_profile_root=tmp_path / "profiles",
+    )
+
+    with patch.object(pool, "_ports_for_task", return_value=(19401, 19402, 19403)), patch(
+        "tools.camofox_instance_pool.subprocess.Popen",
+        side_effect=[server_process, viewer_process],
+    ) as popen, patch.object(pool, "_wait_until_ready"), patch(
+        "tools.camofox_instance_pool.requests.get"
+    ) as get:
+        get.return_value.status_code = 200
+        instance = pool.get_or_start("thread-a")
+        pool.ensure_viewer(instance)
+
+    viewer_args = popen.call_args_list[1].args[0]
+    assert viewer_args[0] == str(executable)
+    assert "--new-instance" in viewer_args
+    assert "--profile" in viewer_args
+    assert instance.viewer_url == viewer_args[-1]
+    assert instance.viewer_process is viewer_process
+
+
+def test_missing_server_fails_before_spawn(tmp_path):
+    pool = CamofoxInstancePool(Path(tmp_path))
+    with patch("tools.camofox_instance_pool.subprocess.Popen") as popen:
+        with pytest.raises(RuntimeError, match="server.js not found"):
+            pool.get_or_start("thread-a")
+    popen.assert_not_called()

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -25,6 +25,7 @@ container as ``http://host.docker.internal:3000``.
 
 from __future__ import annotations
 
+import atexit
 import base64
 import contextvars
 import json
@@ -131,6 +132,7 @@ def _get_instance_pool(camofox_cfg: Dict[str, Any]) -> CamofoxInstancePool:
                     str(camofox_cfg.get("viewer_profile_root") or "~/.camoufox-hermes-thread-viewers")
                 ),
             )
+            atexit.register(_instance_pool.stop_all)
         return _instance_pool
 
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -105,6 +105,11 @@ def get_camofox_url() -> str:
     # that clear the session map must immediately fall back to configuration.
     if scoped and any(session.get("api_url") == scoped for session in _sessions.values()):
         return scoped
+    # A shared URL is a legacy global-server escape hatch.  Never fall back to
+    # it in per-thread mode: the owning browser call must first bind the URL of
+    # its scoped instance through _get_session().
+    if _per_thread_instances_mode(_get_camofox_config()):
+        return ""
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
 
 
@@ -170,12 +175,19 @@ def is_camofox_mode() -> bool:
         return False
     if _config_cdp_url():
         return False
+    if _per_thread_instances_mode(_get_camofox_config()):
+        return True
     return bool(get_camofox_url())
 
 
 def check_camofox_available() -> bool:
     """Verify the Camofox server is reachable."""
     global _vnc_url, _vnc_url_checked
+    camofox_cfg = _get_camofox_config()
+    if _per_thread_instances_mode(camofox_cfg):
+        import shutil
+        server_dir = Path(str(camofox_cfg.get("server_dir") or "~/src/camofox-browser")).expanduser()
+        return shutil.which("node") is not None and (server_dir / "server.js").is_file()
     url = get_camofox_url()
     if not url:
         return False
@@ -408,6 +420,9 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
     derived from the Hermes profile so the Camofox server can map it
     to the same persistent browser profile across restarts.
     """
+    camofox_cfg = _get_camofox_config()
+    if _per_thread_instances_mode(camofox_cfg) and not str(task_id or "").strip():
+        raise ValueError("browser scope is required in Camofox per_thread_instances mode")
     task_id = task_id or "default"
     with _sessions_lock:
         if task_id in _sessions:
@@ -415,7 +430,6 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
             _request_base_url.set(session.get("api_url"))
             return session
 
-        camofox_cfg = _get_camofox_config()
         instance = None
         if _per_thread_instances_mode(camofox_cfg):
             instance = _get_instance_pool(camofox_cfg).get_or_start(task_id)
@@ -505,11 +519,27 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
     :func:`camofox_close`.
     """
     camofox_cfg = _get_camofox_config()
+    # A per-thread server is itself the scoped resource; persistence may keep
+    # its profile on disk, but must not keep the process alive past the owning
+    # conversation boundary.
+    if _per_thread_instances_mode(camofox_cfg):
+        return False
     if _managed_persistence_enabled() or _camofox_identity_override(task_id, camofox_cfg):
         _drop_session(task_id)
         logger.debug("Camofox soft cleanup for task %s (managed persistence)", task_id)
         return True
     return False
+
+
+def cleanup_all_camofox_sessions() -> None:
+    """Close every process-local Camofox session at process shutdown."""
+    with _sessions_lock:
+        scopes = list(_sessions)
+    for scope in scopes:
+        camofox_close(scope)
+    pool = _instance_pool
+    if pool is not None:
+        pool.stop_all()
 
 
 # ---------------------------------------------------------------------------
@@ -1020,6 +1050,3 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
-
-

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -414,18 +414,36 @@ def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
+    """Acquire the per-scope lifecycle before touching shared session state."""
+    camofox_cfg = _get_camofox_config()
+    if _per_thread_instances_mode(camofox_cfg):
+        if not str(task_id or "").strip():
+            raise ValueError("browser scope is required in Camofox per_thread_instances mode")
+        pool = _get_instance_pool(camofox_cfg)
+        with pool.scope_lifecycle(task_id):
+            return _get_session_impl(task_id, camofox_cfg)
+    return _get_session_impl(task_id, camofox_cfg)
+
+
+def _get_session_impl(task_id: Optional[str], camofox_cfg: Dict[str, Any]) -> Dict[str, Any]:
     """Get or create a camofox session for the given task.
 
     When managed persistence is enabled, uses a deterministic userId
     derived from the Hermes profile so the Camofox server can map it
     to the same persistent browser profile across restarts.
     """
-    camofox_cfg = _get_camofox_config()
-    if _per_thread_instances_mode(camofox_cfg) and not str(task_id or "").strip():
-        raise ValueError("browser scope is required in Camofox per_thread_instances mode")
     task_id = task_id or "default"
     with _sessions_lock:
         if task_id in _sessions:
+            if _per_thread_instances_mode(camofox_cfg):
+                pool = _get_instance_pool(camofox_cfg)
+                instance = pool.get_or_start(task_id)
+                if _sessions[task_id].get("instance") is not instance:
+                    _sessions[task_id]["instance"] = instance
+                    _sessions[task_id]["api_url"] = instance.api_url
+                    _sessions[task_id]["viewer_url"] = instance.viewer_url
+                    _sessions[task_id]["tab_id"] = None
+                    pool.ensure_viewer(instance, force=True)
             session = _adopt_existing_tab(_sessions[task_id])
             _request_base_url.set(session.get("api_url"))
             return session
@@ -469,9 +487,41 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
             else os.getenv("CAMOFOX_URL", "").rstrip("/")
         )
         session["viewer_url"] = instance.viewer_url if instance else None
+        session["instance"] = instance
         _sessions[task_id] = session
         _request_base_url.set(session["api_url"])
         return _adopt_existing_tab(session)
+
+
+def camofox_identity_for_scope(task_id: str) -> Dict[str, str]:
+    """Derive a scope's identity without starting or selecting a server."""
+    scope = str(task_id or "").strip()
+    if not scope:
+        raise ValueError("browser scope is required")
+    cfg = _get_camofox_config()
+    override = _camofox_identity_override(scope, cfg)
+    if override:
+        return override
+    return get_camofox_identity(
+        scope,
+        isolate_task=_visible_isolated_mode(cfg) or bool(cfg.get("isolate_tasks")),
+    )
+
+
+def stop_camofox_scope(task_id: str) -> None:
+    """Stop only one scoped instance and invalidate its process-local tab."""
+    scope = str(task_id or "").strip()
+    if not scope:
+        raise ValueError("browser scope is required")
+    cfg = _get_camofox_config()
+    with _sessions_lock:
+        session = _sessions.get(scope)
+        if session is not None:
+            session["tab_id"] = None
+    if _per_thread_instances_mode(cfg):
+        _get_instance_pool(cfg).stop(scope)
+    _drop_session(scope)
+    _request_base_url.set(None)
 
 
 def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
@@ -600,7 +650,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
+            # Navigate existing tab — recover once from an invalidated tab.
             try:
                 data = _post(
                     f"/tabs/{session['tab_id']}/navigate",
@@ -608,14 +658,34 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
+                response = e.response
+                status = response.status_code if response is not None else None
+                body = ""
+                if response is not None:
+                    try:
+                        body = str(response.json().get("error") or "").lower()
+                    except (TypeError, ValueError, AttributeError):
+                        body = str(response.text or "").lower()
+                stale = status in {404, 410} or (
+                    status == 503
+                    and any(marker in body for marker in (
+                        "target page", "context", "browser has been closed", "tab not found",
+                    ))
+                )
+                if stale:
                     logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
-                        "Creating a fresh tab.",
-                        session["tab_id"],
+                        "Camofox tab became stale (HTTP %s); creating one fresh tab "
+                        "in the same browser scope.", status,
                     )
                     session["tab_id"] = None
                     session = _ensure_tab(task_id, browser_url)
+                    recovery_cfg = _get_camofox_config()
+                    if _per_thread_instances_mode(recovery_cfg):
+                        instance = session.get("instance")
+                        if instance is not None:
+                            _get_instance_pool(recovery_cfg).ensure_viewer(
+                                instance, force=True
+                            )
                     data = {"ok": True, "url": browser_url}
                 else:
                     raise

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -26,11 +26,13 @@ container as ``http://host.docker.internal:3000``.
 from __future__ import annotations
 
 import base64
+import contextvars
 import json
 import logging
 import os
 import threading
 import uuid
+from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
@@ -38,6 +40,7 @@ import requests
 
 from hermes_cli.config import cfg_get, load_config, read_raw_config
 from tools.browser_camofox_state import get_camofox_identity
+from tools.camofox_instance_pool import CamofoxInstancePool
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,11 @@ _vnc_url_checked = False  # only probe once per process
 # Cached command timeout from config (resolved lazily, like browser_tool)
 _cached_cmd_timeout: Optional[int] = None
 _cmd_timeout_resolved = False
+_request_base_url: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "camofox_request_base_url", default=None
+)
+_instance_pool: Optional[CamofoxInstancePool] = None
+_instance_pool_lock = threading.Lock()
 
 
 def _get_command_timeout() -> int:
@@ -90,7 +98,40 @@ def _auth_headers() -> Dict[str, str]:
 
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
+    scoped = _request_base_url.get()
+    # Context variables outlive a single call on worker threads. Only honor a
+    # scoped URL while its owning session is still registered; cleanup/tests
+    # that clear the session map must immediately fall back to configuration.
+    if scoped and any(session.get("api_url") == scoped for session in _sessions.values()):
+        return scoped
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
+
+
+def _per_thread_instances_mode(camofox_cfg: Dict[str, Any]) -> bool:
+    """Return whether each Hermes task owns a separate Camofox server."""
+    return str(camofox_cfg.get("mode") or "standard").strip().lower() == "per_thread_instances"
+
+
+def _get_instance_pool(camofox_cfg: Dict[str, Any]) -> CamofoxInstancePool:
+    """Build the process-local task-scoped Camofox pool lazily."""
+    global _instance_pool
+    with _instance_pool_lock:
+        if _instance_pool is None:
+            server_dir = str(camofox_cfg.get("server_dir") or "~/src/camofox-browser")
+            _instance_pool = CamofoxInstancePool(
+                Path(server_dir),
+                port_start=int(camofox_cfg.get("instance_port_start") or 19400),
+                port_end=int(camofox_cfg.get("instance_port_end") or 19999),
+                startup_timeout=float(camofox_cfg.get("instance_startup_timeout") or 60),
+                launch_viewer=bool(camofox_cfg.get("instance_popup_viewer", True)),
+                viewer_executable=Path(
+                    str(camofox_cfg.get("viewer_executable") or "~/.cache/camoufox/camoufox")
+                ),
+                viewer_profile_root=Path(
+                    str(camofox_cfg.get("viewer_profile_root") or "~/.camoufox-hermes-thread-viewers")
+                ),
+            )
+        return _instance_pool
 
 
 def _config_cdp_url() -> str:
@@ -172,6 +213,11 @@ def _get_camofox_config() -> Dict[str, Any]:
     return camofox_cfg if isinstance(camofox_cfg, dict) else {}
 
 
+def _visible_isolated_mode(camofox_cfg: Dict[str, Any]) -> bool:
+    """Return whether Camofox should create one persistent context per task."""
+    return str(camofox_cfg.get("mode") or "standard").strip().lower() == "visible_isolated"
+
+
 def _managed_persistence_enabled() -> bool:
     """Return whether Hermes-managed persistence is enabled for Camofox.
 
@@ -181,7 +227,8 @@ def _managed_persistence_enabled() -> bool:
 
     Controlled by ``browser.camofox.managed_persistence`` in config.yaml.
     """
-    return bool(_get_camofox_config().get("managed_persistence"))
+    camofox_cfg = _get_camofox_config()
+    return _visible_isolated_mode(camofox_cfg) or bool(camofox_cfg.get("managed_persistence"))
 
 
 def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, Any]) -> Optional[Dict[str, str]]:
@@ -362,9 +409,15 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
     task_id = task_id or "default"
     with _sessions_lock:
         if task_id in _sessions:
-            return _adopt_existing_tab(_sessions[task_id])
+            session = _adopt_existing_tab(_sessions[task_id])
+            _request_base_url.set(session.get("api_url"))
+            return session
 
         camofox_cfg = _get_camofox_config()
+        instance = None
+        if _per_thread_instances_mode(camofox_cfg):
+            instance = _get_instance_pool(camofox_cfg).get_or_start(task_id)
+            _request_base_url.set(instance.api_url)
         identity_override = _camofox_identity_override(task_id, camofox_cfg)
         if identity_override:
             session = {
@@ -374,8 +427,11 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "managed": True,
                 "adopt_existing_tab": _adopt_existing_tab_enabled(camofox_cfg),
             }
-        elif bool(camofox_cfg.get("managed_persistence")):
-            identity = get_camofox_identity(task_id)
+        elif _visible_isolated_mode(camofox_cfg) or bool(camofox_cfg.get("managed_persistence")):
+            identity = get_camofox_identity(
+                task_id,
+                isolate_task=_visible_isolated_mode(camofox_cfg) or bool(camofox_cfg.get("isolate_tasks")),
+            )
             session = {
                 "user_id": identity["user_id"],
                 "tab_id": None,
@@ -391,7 +447,14 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "managed": False,
                 "adopt_existing_tab": False,
             }
+        session["api_url"] = (
+            instance.api_url
+            if instance
+            else os.getenv("CAMOFOX_URL", "").rstrip("/")
+        )
+        session["viewer_url"] = instance.viewer_url if instance else None
         _sessions[task_id] = session
+        _request_base_url.set(session["api_url"])
         return _adopt_existing_tab(session)
 
 
@@ -414,6 +477,12 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     resp.raise_for_status()
     data = resp.json()
     session["tab_id"] = data.get("tabId")
+    camofox_cfg = _get_camofox_config()
+    if _per_thread_instances_mode(camofox_cfg):
+        pool = _get_instance_pool(camofox_cfg)
+        instance = pool._instances.get(task_id or "default")
+        if instance:
+            pool.ensure_viewer(instance)
     return session
 
 
@@ -434,7 +503,7 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
     :func:`camofox_close`.
     """
     camofox_cfg = _get_camofox_config()
-    if bool(camofox_cfg.get("managed_persistence")) or _camofox_identity_override(task_id, camofox_cfg):
+    if _managed_persistence_enabled() or _camofox_identity_override(task_id, camofox_cfg):
         _drop_session(task_id)
         logger.debug("Camofox soft cleanup for task %s (managed persistence)", task_id)
         return True
@@ -771,6 +840,11 @@ def camofox_close(task_id: Optional[str] = None) -> str:
     try:
         session = _drop_session(task_id)
         if not session:
+            return json.dumps({"success": True, "closed": True})
+
+        camofox_cfg = _get_camofox_config()
+        if _per_thread_instances_mode(camofox_cfg):
+            _get_instance_pool(camofox_cfg).stop(task_id)
             return json.dumps({"success": True, "closed": True})
 
         _delete(

--- a/tools/browser_camofox_state.py
+++ b/tools/browser_camofox_state.py
@@ -24,18 +24,20 @@ def get_camofox_state_dir() -> Path:
     return get_hermes_home() / CAMOFOX_STATE_DIR_NAME / CAMOFOX_STATE_SUBDIR
 
 
-def get_camofox_identity(task_id: Optional[str] = None) -> Dict[str, str]:
+def get_camofox_identity(task_id: Optional[str] = None, *, isolate_task: bool = False) -> Dict[str, str]:
     """Return the stable Hermes-managed Camofox identity for this profile.
 
-    The user identity is profile-scoped (same Hermes profile = same userId).
-    The session key is scoped to the logical browser task so newly created
-    tabs within the same profile reuse the same identity contract.
+    The default user identity is profile-scoped. With ``isolate_task=True`` it
+    is task-scoped, giving each conversation its own Camofox browser context
+    (and therefore its own visible window) while remaining stable on restart.
+    The session key is always scoped to the logical browser task.
     """
     scope_root = str(get_camofox_state_dir())
     logical_scope = task_id or "default"
+    user_scope = f"{scope_root}:{logical_scope}" if isolate_task else scope_root
     user_digest = uuid.uuid5(
         uuid.NAMESPACE_URL,
-        f"camofox-user:{scope_root}",
+        f"camofox-user:{user_scope}",
     ).hex[:10]
     session_digest = uuid.uuid5(
         uuid.NAMESPACE_URL,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4370,6 +4370,14 @@ def cleanup_all_browsers() -> None:
     for task_id in task_ids:
         cleanup_browser(task_id)
 
+    # Camofox sessions are tracked by their REST backend rather than in
+    # _active_sessions, so a pure-Camofox process may have no task_ids above.
+    try:
+        from tools.browser_camofox import cleanup_all_camofox_sessions
+        cleanup_all_camofox_sessions()
+    except Exception:
+        pass
+
     # Tear down CDP supervisors for all tasks so background threads exit.
     try:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]

--- a/tools/camofox_auth.py
+++ b/tools/camofox_auth.py
@@ -1,0 +1,168 @@
+"""Import selected Firefox cookies into one Hermes-managed Camofox profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_CAMOFOX_PROFILE_ROOT = Path("~/.camofox/profiles")
+
+
+def _profile_state_path(profile_root: Path, user_id: str) -> Path:
+    digest = hashlib.sha256(str(user_id).encode()).hexdigest()[:32]
+    return Path(profile_root).expanduser() / digest / "storage-state.json"
+
+
+def _read_firefox_cookies(profile: Path, domains: set[str]) -> list[dict]:
+    source = profile.expanduser() / "cookies.sqlite"
+    if not source.is_file():
+        raise FileNotFoundError(f"Firefox cookies database not found under {source.parent}")
+    with tempfile.TemporaryDirectory(prefix="hermes-camofox-auth-") as tmp:
+        copied = Path(tmp) / "cookies.sqlite"
+        shutil.copy2(source, copied)
+        for suffix in ("-wal", "-shm"):
+            companion = Path(f"{source}{suffix}")
+            if companion.is_file():
+                shutil.copy2(companion, Path(f"{copied}{suffix}"))
+        conn = sqlite3.connect(f"file:{copied}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                "SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite "
+                "FROM moz_cookies"
+            ).fetchall()
+        finally:
+            conn.close()
+
+    selected = []
+    same_site = {0: "None", 1: "Lax", 2: "Strict"}
+    for name, value, host, path, expiry, secure, http_only, site in rows:
+        normalized_host = str(host or "").lower().lstrip(".")
+        if not any(normalized_host == d or normalized_host.endswith(f".{d}") for d in domains):
+            continue
+        selected.append({
+            "name": str(name), "value": str(value), "domain": str(host),
+            "path": str(path or "/"), "expires": int(expiry) if int(expiry or 0) > 0 else -1,
+            "secure": bool(secure), "httpOnly": bool(http_only),
+            "sameSite": same_site.get(int(site or 0), "None"),
+        })
+    return selected
+
+
+def _atomic_merge_storage_state(path: Path, cookies: list[dict]) -> None:
+    state = {"cookies": [], "origins": []}
+    if path.is_file():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict) or not isinstance(loaded.get("cookies"), list):
+            raise ValueError("Existing Camofox storage state is invalid")
+        state = loaded
+        state.setdefault("origins", [])
+    replacements = {(c["name"], c["domain"], c.get("path", "/")) for c in cookies}
+    state["cookies"] = [
+        c for c in state["cookies"]
+        if (c.get("name"), c.get("domain"), c.get("path", "/")) not in replacements
+    ] + cookies
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+        os.chmod(path, 0o600)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+def import_firefox_cookies(
+    firefox_profile: Path,
+    *,
+    task_id: str,
+    domains: Iterable[str],
+    required_names: Iterable[str],
+) -> int:
+    """Merge selected cookies into exactly one stopped, deterministic profile."""
+    scope = str(task_id or "").strip()
+    if not scope:
+        raise ValueError("A non-empty browser scope is required")
+    allowed = {str(domain).strip().lower().lstrip(".") for domain in domains}
+    allowed.discard("")
+    required = {str(name).strip() for name in required_names}
+    required.discard("")
+    if not allowed or not required:
+        raise ValueError("Explicit domains and required cookie names are required")
+    selected = _read_firefox_cookies(Path(firefox_profile), allowed)
+    present = {cookie["name"] for cookie in selected}
+    missing = required - present
+    if missing:
+        raise ValueError(f"Required authentication cookies are absent ({len(missing)} missing)")
+    if not selected:
+        raise ValueError("No cookies matched the requested domains")
+
+    from tools import browser_camofox
+    user_id = browser_camofox.camofox_identity_for_scope(scope)["user_id"]
+    cfg = browser_camofox._get_camofox_config()
+    root = Path(os.getenv("CAMOFOX_PROFILE_DIR") or cfg.get("profile_dir") or DEFAULT_CAMOFOX_PROFILE_ROOT)
+    if browser_camofox._per_thread_instances_mode(cfg):
+        pool = browser_camofox._get_instance_pool(cfg)
+        with pool.scope_lifecycle(scope):
+            browser_camofox.stop_camofox_scope(scope)
+            _atomic_merge_storage_state(_profile_state_path(root, user_id), selected)
+    else:
+        browser_camofox.stop_camofox_scope(scope)
+        _atomic_merge_storage_state(_profile_state_path(root, user_id), selected)
+    return len(selected)
+
+
+def _handle_import(args, **kwargs):
+    source_profile = str(args.get("source_profile") or "").strip()
+    if not source_profile:
+        raise ValueError("An explicit Firefox source_profile is required")
+    count = import_firefox_cookies(
+        Path(source_profile),
+        task_id=kwargs.get("task_id"),
+        domains=args.get("domains") or (),
+        required_names=args.get("required_names") or (),
+    )
+    return json.dumps({"success": True, "imported": count, "values_returned": False})
+
+
+def _check_import_available() -> bool:
+    from tools.browser_camofox import is_camofox_mode
+    return is_camofox_mode()
+
+
+IMPORT_COOKIES_SCHEMA = {
+    "name": "browser_import_cookies",
+    "description": "Securely import explicitly selected Firefox cookies into the current scoped Camofox browser profile. Stops only this browser scope; the next browser_navigate starts it with a fresh tab. Cookie values are never returned.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source_profile": {"type": "string", "minLength": 1},
+            "domains": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "required_names": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        },
+        "required": ["source_profile", "domains", "required_names"],
+        "additionalProperties": False,
+    },
+}
+
+
+from tools.registry import registry
+registry.register(
+    name="browser_import_cookies", toolset="browser", schema=IMPORT_COOKIES_SCHEMA,
+    handler=_handle_import, check_fn=_check_import_available, emoji="🔐",
+)

--- a/tools/camofox_instance_pool.py
+++ b/tools/camofox_instance_pool.py
@@ -1,0 +1,215 @@
+"""Task-scoped Camofox server process pool.
+
+Each Hermes conversation gets a dedicated Camofox API server.  Because each
+server launches its own Camoufox process and Xvfb display, browser focus,
+contexts, and VNC input cannot cross conversation boundaries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import signal
+import socket
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+
+@dataclass
+class CamofoxInstance:
+    task_id: str
+    api_port: int
+    vnc_port: int
+    novnc_port: int
+    process: subprocess.Popen
+    viewer_process: Optional[subprocess.Popen] = None
+
+    @property
+    def api_url(self) -> str:
+        return f"http://127.0.0.1:{self.api_port}"
+
+    @property
+    def viewer_url(self) -> str:
+        return (
+            f"http://127.0.0.1:{self.novnc_port}/vnc.html"
+            "?autoconnect=1&reconnect=1&reconnect_delay=2000&resize=scale"
+        )
+
+
+class CamofoxInstancePool:
+    """Own one independent headed Camofox server per Hermes task."""
+
+    def __init__(
+        self,
+        server_dir: Path,
+        *,
+        port_start: int = 19400,
+        port_end: int = 19999,
+        startup_timeout: float = 60.0,
+        launch_viewer: bool = False,
+        viewer_executable: Path = Path("~/.cache/camoufox/camoufox"),
+        viewer_profile_root: Path = Path("~/.camoufox-hermes-thread-viewers"),
+    ) -> None:
+        self.server_dir = Path(server_dir).expanduser().resolve()
+        self.port_start = port_start
+        self.port_end = port_end
+        self.startup_timeout = startup_timeout
+        self.launch_viewer = launch_viewer
+        self.viewer_executable = Path(viewer_executable).expanduser().resolve()
+        self.viewer_profile_root = Path(viewer_profile_root).expanduser().resolve()
+        self._instances: Dict[str, CamofoxInstance] = {}
+        self._lock = threading.RLock()
+
+    def _ports_for_task(self, task_id: str) -> tuple[int, int, int]:
+        slots = (self.port_end - self.port_start + 1) // 3
+        if slots < 1:
+            raise ValueError("Camofox instance port range must contain at least three ports")
+        initial = int.from_bytes(hashlib.sha256(task_id.encode()).digest()[:4], "big") % slots
+        for offset in range(slots):
+            slot = (initial + offset) % slots
+            ports = tuple(self.port_start + slot * 3 + index for index in range(3))
+            if all(self._port_available(port) for port in ports):
+                return ports  # type: ignore[return-value]
+        raise RuntimeError("No free task-scoped Camofox port triple is available")
+
+    @staticmethod
+    def _port_available(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                return False
+        return True
+
+    def get_or_start(self, task_id: Optional[str]) -> CamofoxInstance:
+        key = task_id or "default"
+        with self._lock:
+            current = self._instances.get(key)
+            if current and current.process.poll() is None:
+                return current
+            if current:
+                self._instances.pop(key, None)
+
+            if not (self.server_dir / "server.js").is_file():
+                raise RuntimeError(f"Camofox server.js not found under {self.server_dir}")
+
+            api_port, vnc_port, novnc_port = self._ports_for_task(key)
+            env = os.environ.copy()
+            env.update({
+                "CAMOFOX_PORT": str(api_port),
+                "VNC_PORT": str(vnc_port),
+                "NOVNC_PORT": str(novnc_port),
+                "VNC_BIND": "127.0.0.1",
+                "NODE_ENV": "production",
+            })
+            process = subprocess.Popen(
+                ["node", "server.js"],
+                cwd=self.server_dir,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            instance = CamofoxInstance(key, api_port, vnc_port, novnc_port, process)
+            self._instances[key] = instance
+
+        try:
+            self._wait_until_ready(instance)
+        except Exception:
+            self.stop(key)
+            raise
+        return instance
+
+    def ensure_viewer(self, instance: CamofoxInstance) -> None:
+        """Launch the popup only after this instance's noVNC endpoint is live."""
+        if not self.launch_viewer or (
+            instance.viewer_process and instance.viewer_process.poll() is None
+        ):
+            return
+        deadline = time.monotonic() + self.startup_timeout
+        last_error = "not ready"
+        while time.monotonic() < deadline:
+            try:
+                response = requests.get(instance.viewer_url, timeout=1)
+                if response.status_code == 200:
+                    self._launch_viewer(instance)
+                    return
+                last_error = f"HTTP {response.status_code}"
+            except requests.RequestException as exc:
+                last_error = str(exc)
+            time.sleep(0.2)
+        raise RuntimeError(f"Task-scoped Camofox noVNC did not become ready: {last_error}")
+
+    def _launch_viewer(self, instance: CamofoxInstance) -> None:
+        """Open a dedicated native popup showing this instance's VNC display."""
+        if not self.viewer_executable.is_file():
+            raise RuntimeError(f"Camoufox viewer executable not found: {self.viewer_executable}")
+        digest = hashlib.sha256(instance.task_id.encode()).hexdigest()[:16]
+        profile_dir = self.viewer_profile_root / digest
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        instance.viewer_process = subprocess.Popen(
+            [
+                str(self.viewer_executable),
+                "--new-instance",
+                "--profile",
+                str(profile_dir),
+                instance.viewer_url,
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def _wait_until_ready(self, instance: CamofoxInstance) -> None:
+        deadline = time.monotonic() + self.startup_timeout
+        last_error = "not ready"
+        while time.monotonic() < deadline:
+            if instance.process.poll() is not None:
+                raise RuntimeError(
+                    f"Task-scoped Camofox exited during startup ({instance.process.returncode})"
+                )
+            try:
+                response = requests.get(f"{instance.api_url}/health", timeout=1)
+                if response.status_code == 200:
+                    return
+                last_error = f"HTTP {response.status_code}"
+            except requests.RequestException as exc:
+                last_error = str(exc)
+            time.sleep(0.2)
+        raise RuntimeError(f"Task-scoped Camofox did not become ready: {last_error}")
+
+    def stop(self, task_id: Optional[str]) -> None:
+        key = task_id or "default"
+        with self._lock:
+            instance = self._instances.pop(key, None)
+        if not instance or instance.process.poll() is not None:
+            return
+        if instance.viewer_process and instance.viewer_process.poll() is None:
+            os.killpg(os.getpgid(instance.viewer_process.pid), signal.SIGTERM)
+            try:
+                instance.viewer_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(instance.viewer_process.pid), signal.SIGKILL)
+                instance.viewer_process.wait(timeout=5)
+        if instance.process.poll() is None:
+            os.killpg(os.getpgid(instance.process.pid), signal.SIGTERM)
+        try:
+            instance.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(instance.process.pid), signal.SIGKILL)
+            instance.process.wait(timeout=5)
+
+    def stop_all(self) -> None:
+        with self._lock:
+            task_ids = list(self._instances)
+        for task_id in task_ids:
+            self.stop(task_id)

--- a/tools/camofox_instance_pool.py
+++ b/tools/camofox_instance_pool.py
@@ -16,7 +16,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, IO, Optional
 
 import requests
 
@@ -29,6 +29,7 @@ class CamofoxInstance:
     novnc_port: int
     process: subprocess.Popen
     viewer_process: Optional[subprocess.Popen] = None
+    log_file: Optional[IO[bytes]] = None
 
     @property
     def api_url(self) -> str:
@@ -55,6 +56,7 @@ class CamofoxInstancePool:
         launch_viewer: bool = False,
         viewer_executable: Path = Path("~/.cache/camoufox/camoufox"),
         viewer_profile_root: Path = Path("~/.camoufox-hermes-thread-viewers"),
+        log_root: Path = Path("~/.hermes/logs/camofox-instances"),
     ) -> None:
         self.server_dir = Path(server_dir).expanduser().resolve()
         self.port_start = port_start
@@ -63,6 +65,7 @@ class CamofoxInstancePool:
         self.launch_viewer = launch_viewer
         self.viewer_executable = Path(viewer_executable).expanduser().resolve()
         self.viewer_profile_root = Path(viewer_profile_root).expanduser().resolve()
+        self.log_root = Path(log_root).expanduser().resolve()
         self._instances: Dict[str, CamofoxInstance] = {}
         self._lock = threading.RLock()
 
@@ -95,7 +98,7 @@ class CamofoxInstancePool:
             if current and current.process.poll() is None:
                 return current
             if current:
-                self._instances.pop(key, None)
+                self.stop(key)
 
             if not (self.server_dir / "server.js").is_file():
                 raise RuntimeError(f"Camofox server.js not found under {self.server_dir}")
@@ -109,24 +112,31 @@ class CamofoxInstancePool:
                 "VNC_BIND": "127.0.0.1",
                 "NODE_ENV": "production",
             })
+            self.log_root.mkdir(parents=True, exist_ok=True)
+            digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+            log_file = (self.log_root / f"{digest}.log").open("ab", buffering=0)
             process = subprocess.Popen(
                 ["node", "server.js"],
                 cwd=self.server_dir,
                 env=env,
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
                 start_new_session=True,
             )
-            instance = CamofoxInstance(key, api_port, vnc_port, novnc_port, process)
+            instance = CamofoxInstance(
+                key, api_port, vnc_port, novnc_port, process, log_file=log_file
+            )
             self._instances[key] = instance
-
-        try:
-            self._wait_until_ready(instance)
-        except Exception:
-            self.stop(key)
-            raise
-        return instance
+            try:
+                # Serialize same-process acquisition until the published
+                # instance is actually ready. A second caller must never
+                # receive a merely-spawned server that can still fail startup.
+                self._wait_until_ready(instance)
+            except Exception:
+                self.stop(key)
+                raise
+            return instance
 
     def ensure_viewer(self, instance: CamofoxInstance) -> None:
         """Launch the popup only after this instance's noVNC endpoint is live."""
@@ -191,7 +201,7 @@ class CamofoxInstancePool:
         key = task_id or "default"
         with self._lock:
             instance = self._instances.pop(key, None)
-        if not instance or instance.process.poll() is not None:
+        if not instance:
             return
         if instance.viewer_process and instance.viewer_process.poll() is None:
             os.killpg(os.getpgid(instance.viewer_process.pid), signal.SIGTERM)
@@ -202,11 +212,13 @@ class CamofoxInstancePool:
                 instance.viewer_process.wait(timeout=5)
         if instance.process.poll() is None:
             os.killpg(os.getpgid(instance.process.pid), signal.SIGTERM)
-        try:
-            instance.process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            os.killpg(os.getpgid(instance.process.pid), signal.SIGKILL)
-            instance.process.wait(timeout=5)
+            try:
+                instance.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(instance.process.pid), signal.SIGKILL)
+                instance.process.wait(timeout=5)
+        if instance.log_file:
+            instance.log_file.close()
 
     def stop_all(self) -> None:
         with self._lock:

--- a/tools/camofox_instance_pool.py
+++ b/tools/camofox_instance_pool.py
@@ -14,6 +14,7 @@ import socket
 import subprocess
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, IO, Optional
@@ -68,6 +69,19 @@ class CamofoxInstancePool:
         self.log_root = Path(log_root).expanduser().resolve()
         self._instances: Dict[str, CamofoxInstance] = {}
         self._lock = threading.RLock()
+        self._scope_locks: Dict[str, threading.RLock] = {}
+
+    def _scope_lock(self, task_id: Optional[str]) -> threading.RLock:
+        key = task_id or "default"
+        with self._lock:
+            return self._scope_locks.setdefault(key, threading.RLock())
+
+    @contextmanager
+    def scope_lifecycle(self, task_id: Optional[str]):
+        """Exclude start/stop/profile mutation for exactly one browser scope."""
+        lock = self._scope_lock(task_id)
+        with lock:
+            yield
 
     def _ports_for_task(self, task_id: str) -> tuple[int, int, int]:
         slots = (self.port_end - self.port_start + 1) // 3
@@ -93,70 +107,91 @@ class CamofoxInstancePool:
 
     def get_or_start(self, task_id: Optional[str]) -> CamofoxInstance:
         key = task_id or "default"
-        with self._lock:
-            current = self._instances.get(key)
-            if current and current.process.poll() is None:
-                return current
-            if current:
-                self.stop(key)
+        with self.scope_lifecycle(key):
+            with self._lock:
+                current = self._instances.get(key)
+                if current and current.process.poll() is None:
+                    return current
+                if current:
+                    self.stop(key)
 
-            if not (self.server_dir / "server.js").is_file():
-                raise RuntimeError(f"Camofox server.js not found under {self.server_dir}")
+                if not (self.server_dir / "server.js").is_file():
+                    raise RuntimeError(f"Camofox server.js not found under {self.server_dir}")
 
-            api_port, vnc_port, novnc_port = self._ports_for_task(key)
-            env = os.environ.copy()
-            env.update({
-                "CAMOFOX_PORT": str(api_port),
-                "VNC_PORT": str(vnc_port),
-                "NOVNC_PORT": str(novnc_port),
-                "VNC_BIND": "127.0.0.1",
-                "NODE_ENV": "production",
-            })
-            self.log_root.mkdir(parents=True, exist_ok=True)
-            digest = hashlib.sha256(key.encode()).hexdigest()[:16]
-            log_file = (self.log_root / f"{digest}.log").open("ab", buffering=0)
-            process = subprocess.Popen(
-                ["node", "server.js"],
-                cwd=self.server_dir,
-                env=env,
-                stdin=subprocess.DEVNULL,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
-            instance = CamofoxInstance(
-                key, api_port, vnc_port, novnc_port, process, log_file=log_file
-            )
-            self._instances[key] = instance
-            try:
-                # Serialize same-process acquisition until the published
-                # instance is actually ready. A second caller must never
-                # receive a merely-spawned server that can still fail startup.
-                self._wait_until_ready(instance)
-            except Exception:
-                self.stop(key)
-                raise
-            return instance
+                api_port, vnc_port, novnc_port = self._ports_for_task(key)
+                env = os.environ.copy()
+                env.update({
+                    "CAMOFOX_PORT": str(api_port),
+                    "VNC_PORT": str(vnc_port),
+                    "NOVNC_PORT": str(novnc_port),
+                    "VNC_BIND": "127.0.0.1",
+                    "NODE_ENV": "production",
+                })
+                self.log_root.mkdir(parents=True, exist_ok=True)
+                digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+                log_file = (self.log_root / f"{digest}.log").open("ab", buffering=0)
+                process = subprocess.Popen(
+                    ["node", "server.js"],
+                    cwd=self.server_dir,
+                    env=env,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+                instance = CamofoxInstance(
+                    key, api_port, vnc_port, novnc_port, process, log_file=log_file
+                )
+                self._instances[key] = instance
+                try:
+                    # Serialize same-process acquisition until the published
+                    # instance is actually ready. A second caller must never
+                    # receive a merely-spawned server that can still fail startup.
+                    self._wait_until_ready(instance)
+                except Exception:
+                    self.stop(key)
+                    raise
+                return instance
 
-    def ensure_viewer(self, instance: CamofoxInstance) -> None:
-        """Launch the popup only after this instance's noVNC endpoint is live."""
-        if not self.launch_viewer or (
-            instance.viewer_process and instance.viewer_process.poll() is None
-        ):
+    def ensure_viewer(self, instance: CamofoxInstance, *, force: bool = False) -> None:
+        """Launch this instance's popup after noVNC is live.
+
+        ``force`` replaces a still-running popup whose URL can point at an old
+        Xvfb display after browser recovery.  Readiness is established before
+        the old popup is stopped, and the pool lock serializes replacement so
+        two callers cannot leave duplicate viewers behind.
+        """
+        if not self.launch_viewer:
             return
-        deadline = time.monotonic() + self.startup_timeout
-        last_error = "not ready"
-        while time.monotonic() < deadline:
-            try:
-                response = requests.get(instance.viewer_url, timeout=1)
-                if response.status_code == 200:
-                    self._launch_viewer(instance)
-                    return
-                last_error = f"HTTP {response.status_code}"
-            except requests.RequestException as exc:
-                last_error = str(exc)
-            time.sleep(0.2)
+        with self._lock:
+            viewer = instance.viewer_process
+            if not force and viewer and viewer.poll() is None:
+                return
+            deadline = time.monotonic() + self.startup_timeout
+            last_error = "not ready"
+            while time.monotonic() < deadline:
+                try:
+                    response = requests.get(instance.viewer_url, timeout=1)
+                    if response.status_code == 200:
+                        if viewer and viewer.poll() is None:
+                            self._terminate_viewer(viewer)
+                        instance.viewer_process = None
+                        self._launch_viewer(instance)
+                        return
+                    last_error = f"HTTP {response.status_code}"
+                except requests.RequestException as exc:
+                    last_error = str(exc)
+                time.sleep(0.2)
         raise RuntimeError(f"Task-scoped Camofox noVNC did not become ready: {last_error}")
+
+    @staticmethod
+    def _terminate_viewer(viewer: subprocess.Popen) -> None:
+        os.killpg(os.getpgid(viewer.pid), signal.SIGTERM)
+        try:
+            viewer.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(viewer.pid), signal.SIGKILL)
+            viewer.wait(timeout=5)
 
     def _launch_viewer(self, instance: CamofoxInstance) -> None:
         """Open a dedicated native popup showing this instance's VNC display."""
@@ -199,26 +234,22 @@ class CamofoxInstancePool:
 
     def stop(self, task_id: Optional[str]) -> None:
         key = task_id or "default"
-        with self._lock:
-            instance = self._instances.pop(key, None)
-        if not instance:
-            return
-        if instance.viewer_process and instance.viewer_process.poll() is None:
-            os.killpg(os.getpgid(instance.viewer_process.pid), signal.SIGTERM)
-            try:
-                instance.viewer_process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                os.killpg(os.getpgid(instance.viewer_process.pid), signal.SIGKILL)
-                instance.viewer_process.wait(timeout=5)
-        if instance.process.poll() is None:
-            os.killpg(os.getpgid(instance.process.pid), signal.SIGTERM)
-            try:
-                instance.process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                os.killpg(os.getpgid(instance.process.pid), signal.SIGKILL)
-                instance.process.wait(timeout=5)
-        if instance.log_file:
-            instance.log_file.close()
+        with self.scope_lifecycle(key):
+            with self._lock:
+                instance = self._instances.pop(key, None)
+            if not instance:
+                return
+            if instance.viewer_process and instance.viewer_process.poll() is None:
+                self._terminate_viewer(instance.viewer_process)
+            if instance.process.poll() is None:
+                os.killpg(os.getpgid(instance.process.pid), signal.SIGTERM)
+                try:
+                    instance.process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    os.killpg(os.getpgid(instance.process.pid), signal.SIGKILL)
+                    instance.process.wait(timeout=5)
+            if instance.log_file:
+                instance.log_file.close()
 
     def stop_all(self) -> None:
         with self._lock:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -493,6 +493,7 @@ def _rpc_server_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    browser_scope: Optional[str] = None,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -585,9 +586,10 @@ def _rpc_server_loop(
                     try:
                         sys.stdout = devnull
                         sys.stderr = devnull
-                        result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
-                        )
+                        dispatch_kw = {"task_id": task_id}
+                        if browser_scope:
+                            dispatch_kw["browser_scope"] = browser_scope
+                        result = handle_function_call(tool_name, tool_args, **dispatch_kw)
                     finally:
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
                         devnull.close()
@@ -770,6 +772,7 @@ def _rpc_poll_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    browser_scope: Optional[str] = None,
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -867,9 +870,10 @@ def _rpc_poll_loop(
                         try:
                             sys.stdout = devnull
                             sys.stderr = devnull
-                            tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
-                            )
+                            dispatch_kw = {"task_id": task_id}
+                            if browser_scope:
+                                dispatch_kw["browser_scope"] = browser_scope
+                            tool_result = handle_function_call(tool_name, tool_args, **dispatch_kw)
                         finally:
                             sys.stdout, sys.stderr = _real_stdout, _real_stderr
                             devnull.close()
@@ -914,6 +918,7 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    browser_scope: Optional[str] = None,
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -986,7 +991,7 @@ def _execute_remote(
             args=(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
-                sandbox_tools, stop_event, rpc_token,
+                sandbox_tools, stop_event, rpc_token, browser_scope,
             ),
             daemon=True,
         )
@@ -1115,6 +1120,7 @@ def _execute_remote(
 def execute_code(
     code: str,
     task_id: Optional[str] = None,
+    browser_scope: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
 ) -> str:
     """
@@ -1177,7 +1183,7 @@ def execute_code(
         clear_current_thread_interrupt()
 
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        return _execute_remote(code, task_id, enabled_tools, browser_scope=browser_scope)
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1272,6 +1278,7 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
+                browser_scope,
             ),
             daemon=True,
         )
@@ -1903,6 +1910,7 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
+        browser_scope=kw.get("browser_scope"),
         enabled_tools=kw.get("enabled_tools")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -677,6 +677,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    browser_scope: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +751,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                browser_scope=browser_scope,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +925,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if browser_scope is not None:
+                updates["browser_scope"] = str(browser_scope).strip() or None
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -978,6 +982,9 @@ Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
+Browser state is also isolated unless `browser_scope` explicitly names a durable scope.
+If a task claims it will continue an existing browser session, set `browser_scope`; otherwise
+do not schedule it as though login or open tabs will carry over.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
 On update, passing skills=[] clears attached skills.
 
@@ -1085,6 +1092,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "browser_scope": {
+                "type": "string",
+                "description": "Optional browser scope to reuse across cron runs. Use 'current' to persist the active interactive browser scope (recommended for timed continuation), or provide a previously declared opaque scope label. Required when the job is intended to continue authenticated browser work; omit for a fresh isolated browser. Never pass a tab ID or profile path."
+            },
         },
         "required": ["action"]
     }
@@ -1111,6 +1122,16 @@ def check_cronjob_requirements() -> bool:
         or env_var_enabled("HERMES_GATEWAY_SESSION")
         or env_var_enabled("HERMES_EXEC_ASK")
     )
+
+
+def _resolve_cron_browser_scope(requested: Optional[str], current: Optional[str]) -> Optional[str]:
+    value = str(requested or "").strip()
+    if value.lower() == "current":
+        resolved = str(current or "").strip()
+        if not resolved:
+            raise ValueError("browser_scope='current' requires an active browser scope")
+        return resolved
+    return value or None
 
 
 # --- Registry ---
@@ -1140,6 +1161,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        browser_scope=_resolve_cron_browser_scope(args.get("browser_scope"), kw.get("browser_scope")),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/toolsets.py
+++ b/toolsets.py
@@ -44,7 +44,7 @@ _HERMES_CORE_TOOLS = [
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
-    "browser_navigate", "browser_snapshot", "browser_click",
+    "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_get_images",
     "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
@@ -172,7 +172,7 @@ TOOLSETS = {
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
         "tools": [
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
@@ -351,7 +351,7 @@ TOOLSETS = {
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
@@ -383,7 +383,7 @@ TOOLSETS = {
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
@@ -408,7 +408,7 @@ TOOLSETS = {
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_import_cookies", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -208,6 +208,16 @@ Or configure via `hermes tools` → Browser Automation → Camofox.
 
 When `CAMOFOX_URL` is set, all browser tools automatically route through Camofox instead of Browserbase or agent-browser.
 
+For authenticated Facebook browsing, use Hermes' `browser_navigate` and the
+other `browser_*` tools. Do not launch a separate Playwright/Selenium browser
+or call a shared Camofox REST server directly: those paths bypass Hermes'
+conversation scope and can mix login state between threads.
+
+When `browser.camofox.mode: per_thread_instances` is configured, Hermes starts
+and owns one Camofox server per conversation. In that mode `CAMOFOX_URL` is
+intentionally ignored as a shared fallback; browser calls without a stable
+conversation scope fail closed.
+
 #### Persistent browser sessions
 
 By default, each Camofox session gets a random identity — cookies and logins don't survive across agent restarts. To enable persistent browser sessions, add the following to `~/.hermes/config.yaml`:


### PR DESCRIPTION
## Summary
- add a `per_thread_instances` Camofox mode with one REST server, Camoufox process, Xvfb display, VNC/noVNC endpoint, and popup viewer per Hermes task
- route browser requests through the task-scoped API URL
- wait for noVNC HTTP readiness before opening the native viewer, preventing disconnected popup races
- terminate full server/viewer process groups during cleanup

## Validation
- `scripts/run_tests.sh tests/tools/test_camofox_instance_pool.py tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_camofox_state.py --tb=short` (45 passed)
- live navigation created a task-scoped API endpoint and noVNC endpoint returning HTTP 200 before the popup launched
- native `noVNC — Camoufox` window verified on the GNOME X11 desktop
- API/VNC/noVNC ports verified closed after task cleanup