### PR TITLE
fix(desktop): re-check backend updates when switching between two remote profiles

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -571,4 +571,73 @@ describe('startUpdatePoller', () => {
 
     expect(checkHermesUpdateSpy).toHaveBeenCalled()
   })
+
+  it('discards a stale in-flight response and re-checks after switching to B before A resolves', async () => {
+    // A's check is still in flight when the switch to B happens — B's
+    // trigger is locked out by $backendUpdateChecking. Once A's (now stale)
+    // response lands it must not overwrite the display with A's result, and
+    // B's own check must still run once the lock clears.
+    checkHermesUpdateSpy.mockReset()
+
+    let resolveA: (value: unknown) => void = () => {}
+
+    const aPending = new Promise(resolve => {
+      resolveA = resolve
+    })
+
+    checkHermesUpdateSpy.mockImplementationOnce(() => aPending)
+    checkHermesUpdateSpy.mockResolvedValueOnce({
+      install_method: 'git',
+      current_version: '0.17.0',
+      behind: 4,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    setConnection({
+      baseUrl: 'http://profile-a:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-a:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    startUpdatePoller()
+    // A's checkHermesUpdate() call is now in flight (aPending unresolved).
+    // Switch profiles before it settles.
+
+    setConnection({
+      baseUrl: 'http://profile-b:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-b:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    // Now A's slow response lands.
+    resolveA({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 1,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    // Flush the automatic follow-up check queued for B once A's lock cleared.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkHermesUpdateSpy).toHaveBeenCalledTimes(2)
+    // B's result (behind: 4), not A's stale one (behind: 1).
+    expect($backendUpdateStatus.get()?.behind).toBe(4)
+  })
 })

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -526,4 +526,49 @@ describe('startUpdatePoller', () => {
 
     expect(checkMock).toHaveBeenCalled()
   })
+
+  it('re-checks backend updates when switching directly between two remote profiles', async () => {
+    // Both profiles resolve to mode: 'remote' — only baseUrl differs. A
+    // mode-only comparison would treat this as "no change" and never
+    // re-check, leaving profile A's stale status on screen for profile B.
+    checkHermesUpdateSpy.mockReset()
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 1,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    setConnection({
+      baseUrl: 'http://profile-a:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-a:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+    checkHermesUpdateSpy.mockClear()
+
+    setConnection({
+      baseUrl: 'http://profile-b:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-b:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkHermesUpdateSpy).toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1438,4 +1438,73 @@ describe('startUpdatePoller', () => {
 
     expect(checkHermesUpdateSpy).toHaveBeenCalled()
   })
+
+  it('discards a stale in-flight response and re-checks after switching to B before A resolves', async () => {
+    // A's check is still in flight when the switch to B happens — B's
+    // trigger is locked out by $backendUpdateChecking. Once A's (now stale)
+    // response lands it must not overwrite the display with A's result, and
+    // B's own check must still run once the lock clears.
+    checkHermesUpdateSpy.mockReset()
+
+    let resolveA: (value: unknown) => void = () => {}
+
+    const aPending = new Promise(resolve => {
+      resolveA = resolve
+    })
+
+    checkHermesUpdateSpy.mockImplementationOnce(() => aPending)
+    checkHermesUpdateSpy.mockResolvedValueOnce({
+      install_method: 'git',
+      current_version: '0.17.0',
+      behind: 4,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    setConnection({
+      baseUrl: 'http://profile-a:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-a:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    startUpdatePoller()
+    // A's checkHermesUpdate() call is now in flight (aPending unresolved).
+    // Switch profiles before it settles.
+
+    setConnection({
+      baseUrl: 'http://profile-b:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-b:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    // Now A's slow response lands.
+    resolveA({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 1,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    // Flush the automatic follow-up check queued for B once A's lock cleared.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkHermesUpdateSpy).toHaveBeenCalledTimes(2)
+    // B's result (behind: 4), not A's stale one (behind: 1).
+    expect($backendUpdateStatus.get()?.behind).toBe(4)
+  })
 })

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1393,4 +1393,49 @@ describe('startUpdatePoller', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(checkMock).toHaveBeenCalledTimes(1)
   })
+
+  it('re-checks backend updates when switching directly between two remote profiles', async () => {
+    // Both profiles resolve to mode: 'remote' — only baseUrl differs. A
+    // mode-only comparison would treat this as "no change" and never
+    // re-check, leaving profile A's stale status on screen for profile B.
+    checkHermesUpdateSpy.mockReset()
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 1,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    setConnection({
+      baseUrl: 'http://profile-a:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-a:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+    checkHermesUpdateSpy.mockClear()
+
+    setConnection({
+      baseUrl: 'http://profile-b:9119',
+      isFullscreen: false,
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://profile-b:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkHermesUpdateSpy).toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -298,8 +298,24 @@ function mapBackendCheck(res: BackendUpdateCheckResponse): DesktopUpdateStatus {
   }
 }
 
+// Key of the connection that wants the next check once the in-flight one
+// (if any) clears — set when a check is requested while another is already
+// running for a different target, so that target isn't silently dropped.
+let backendCheckPendingKey: string | undefined
+
 export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null> {
-  if (!isRemoteMode() || $backendUpdateChecking.get()) {
+  if (!isRemoteMode()) {
+    return $backendUpdateStatus.get()
+  }
+
+  // Bind this request to the connection active when it started. Switching
+  // remote targets mid-request must not let a slower, now-stale response
+  // (for the connection we've since left) overwrite the newer one.
+  const requestKey = connectionKey($connection.get())
+
+  if ($backendUpdateChecking.get()) {
+    backendCheckPendingKey = requestKey
+
     return $backendUpdateStatus.get()
   }
 
@@ -307,8 +323,11 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
 
   try {
     const status = mapBackendCheck(await checkHermesUpdate(true))
-    $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+
+    if (connectionKey($connection.get()) === requestKey) {
+      $backendUpdateStatus.set(status)
+      maybeNotifyUpdateAvailable(status)
+    }
 
     return status
   } catch (error) {
@@ -319,11 +338,24 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
       fetchedAt: Date.now()
     }
 
-    $backendUpdateStatus.set(fallback)
+    if (connectionKey($connection.get()) === requestKey) {
+      $backendUpdateStatus.set(fallback)
+    }
 
     return fallback
   } finally {
     $backendUpdateChecking.set(false)
+
+    const pendingKey = backendCheckPendingKey
+
+    backendCheckPendingKey = undefined
+
+    // Someone asked for a check for a different (still-active) target while
+    // this one was in flight — run it now instead of leaving that target
+    // showing whatever this request happened to return.
+    if (pendingKey && pendingKey !== requestKey && pendingKey === connectionKey($connection.get())) {
+      void checkBackendUpdates()
+    }
   }
 }
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -11,7 +11,8 @@ import type {
   DesktopUpdateProgress,
   DesktopUpdateStage,
   DesktopUpdateStatus,
-  DesktopVersionInfo
+  DesktopVersionInfo,
+  HermesConnection
 } from '@/global'
 import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
@@ -640,7 +641,15 @@ let pollerStarted = false
 let backgroundTimer: ReturnType<typeof setInterval> | null = null
 let lastFocusAt = 0
 let connectionUnsub: (() => void) | null = null
-let lastConnectionMode: string | undefined
+let lastConnectionKey: string | undefined
+
+// mode alone can't tell two remote backends apart — switching directly from
+// remote profile A to remote profile B leaves mode === 'remote' both times.
+// Key on the actual backend target so a target change re-checks even when
+// the mode doesn't.
+function connectionKey(conn: HermesConnection | null): string {
+  return conn?.mode === 'remote' ? `remote:${conn.baseUrl}` : String(conn?.mode)
+}
 
 /** Wire up background polling + progress streaming. Idempotent. */
 export function startUpdatePoller(): void {
@@ -662,13 +671,16 @@ export function startUpdatePoller(): void {
 
   // The poller starts at mount, before the gateway connects — so the first
   // backend check above sees mode≠remote and no-ops. Re-check once the
-  // connection resolves to remote.
+  // connection resolves to remote, and again whenever the remote target
+  // itself changes (switching between two remote profiles).
   connectionUnsub = $connection.subscribe(conn => {
-    if (conn?.mode === lastConnectionMode) {
+    const key = connectionKey(conn)
+
+    if (key === lastConnectionKey) {
       return
     }
 
-    lastConnectionMode = conn?.mode
+    lastConnectionKey = key
 
     if (conn?.mode === 'remote') {
       void checkBackendUpdates()
@@ -693,7 +705,7 @@ export function stopUpdatePoller(): void {
 
   connectionUnsub?.()
   connectionUnsub = null
-  lastConnectionMode = undefined
+  lastConnectionKey = undefined
   window.removeEventListener('focus', onFocus)
   pollerStarted = false
 }

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -12,7 +12,8 @@ import type {
   DesktopUpdateProgress,
   DesktopUpdateStage,
   DesktopUpdateStatus,
-  DesktopVersionInfo
+  DesktopVersionInfo,
+  HermesConnection
 } from '@/global'
 import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
@@ -998,7 +999,15 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
 let pollerStarted = false
 let backgroundTimer: ReturnType<typeof setInterval> | null = null
 let connectionUnsub: (() => void) | null = null
-let lastConnectionMode: string | undefined
+let lastConnectionKey: string | undefined
+
+// mode alone can't tell two remote backends apart — switching directly from
+// remote profile A to remote profile B leaves mode === 'remote' both times.
+// Key on the actual backend target so a target change re-checks even when
+// the mode doesn't.
+function connectionKey(conn: HermesConnection | null): string {
+  return conn?.mode === 'remote' ? `remote:${conn.baseUrl}` : String(conn?.mode)
+}
 
 // Passive checks run at most once per day per client. The main process and the
 // backend each keep a 24h cache, so a tick or focus that lands inside the window
@@ -1039,13 +1048,16 @@ export function startUpdatePoller(): void {
 
   // The poller starts at mount, before the gateway connects — so the first
   // backend check above sees mode≠remote and no-ops. Re-check once the
-  // connection resolves to remote.
+  // connection resolves to remote, and again whenever the remote target
+  // itself changes (switching between two remote profiles).
   connectionUnsub = $connection.subscribe(conn => {
-    if (conn?.mode === lastConnectionMode) {
+    const key = connectionKey(conn)
+
+    if (key === lastConnectionKey) {
       return
     }
 
-    lastConnectionMode = conn?.mode
+    lastConnectionKey = key
 
     if (conn?.mode === 'remote') {
       void checkBackendUpdates()
@@ -1064,7 +1076,7 @@ export function stopUpdatePoller(): void {
 
   connectionUnsub?.()
   connectionUnsub = null
-  lastConnectionMode = undefined
+  lastConnectionKey = undefined
   window.removeEventListener('focus', onFocus)
   pollerStarted = false
 }

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -397,10 +397,26 @@ export interface UpdateCheckOptions {
   force?: boolean
 }
 
+// Key of the connection that wants the next check once the in-flight one
+// (if any) clears — set when a check is requested while another is already
+// running for a different target, so that target isn't silently dropped.
+let backendCheckPendingKey: string | undefined
+
 export async function checkBackendUpdates({
   force = false
 }: UpdateCheckOptions = {}): Promise<DesktopUpdateStatus | null> {
-  if (!isRemoteMode() || $backendUpdateChecking.get()) {
+  if (!isRemoteMode()) {
+    return $backendUpdateStatus.get()
+  }
+
+  // Bind this request to the connection active when it started. Switching
+  // remote targets mid-request must not let a slower, now-stale response
+  // (for the connection we've since left) overwrite the newer one.
+  const requestKey = connectionKey($connection.get())
+
+  if ($backendUpdateChecking.get()) {
+    backendCheckPendingKey = requestKey
+
     return $backendUpdateStatus.get()
   }
 
@@ -408,8 +424,11 @@ export async function checkBackendUpdates({
 
   try {
     const status = mapBackendCheck(await checkHermesUpdate(force))
-    $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status, 'backend')
+
+    if (connectionKey($connection.get()) === requestKey) {
+      $backendUpdateStatus.set(status)
+      maybeNotifyUpdateAvailable(status, 'backend')
+    }
 
     return status
   } catch (error) {
@@ -420,11 +439,24 @@ export async function checkBackendUpdates({
       fetchedAt: Date.now()
     }
 
-    $backendUpdateStatus.set(fallback)
+    if (connectionKey($connection.get()) === requestKey) {
+      $backendUpdateStatus.set(fallback)
+    }
 
     return fallback
   } finally {
     $backendUpdateChecking.set(false)
+
+    const pendingKey = backendCheckPendingKey
+
+    backendCheckPendingKey = undefined
+
+    // Someone asked for a check for a different (still-active) target while
+    // this one was in flight — run it now instead of leaving that target
+    // showing whatever this request happened to return.
+    if (pendingKey && pendingKey !== requestKey && pendingKey === connectionKey($connection.get())) {
+      void checkBackendUpdates()
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

The pending-update `(+N)` indicator in the Desktop status bar could keep showing a previously-active remote profile's stale result after switching directly to a different remote profile. `startUpdatePoller()`'s `$connection.subscribe` callback only compared `conn.mode`, and both profiles resolve to `mode: 'remote'` — so the comparison saw "no change" and never re-triggered `checkBackendUpdates()`. The stale indicator lingered until the next background poll (now once a day since `6dfcf15685`), a window-focus refresh past that daily cadence, or a manual check — so the profile-switch re-check is the only timely path.

## Related Issue

Fixes #62770

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Updated after review follow-ups — the list below reflects both commits on this branch. Rebased onto current main (`f8456248d9`): `checkBackendUpdates()` keeps main's `{ force }` option, and the key guard wraps the existing `checkHermesUpdate(force)` call.

- `apps/desktop/src/store/updates.ts`:
  - Added a `connectionKey()` helper that keys on `mode` **and** `baseUrl` (when remote) instead of `mode` alone, so switching between two different remote backends is detected as a real change even though the mode string doesn't change. The tracking variable is renamed `lastConnectionMode` → `lastConnectionKey` accordingly (reset in `stopUpdatePoller()`, same as before).
  - `checkBackendUpdates()` previously guarded only against concurrency via `$backendUpdateChecking`, so switching from remote profile A to B while A's request was still in flight silently locked out B's trigger and then published A's late response as if it were current. Each request is now bound to the connection key active when it started; responses whose key is no longer current are discarded, and a follow-up check is queued for whichever target asked for one while the lock was held.
- `apps/desktop/src/store/updates.test.ts`: a regression test in the `startUpdatePoller` suite that starts the poller connected to remote profile A, switches directly to remote profile B (same `mode`, different `baseUrl`), and asserts the backend update check fires again; plus coverage for the stale-response and queued-follow-up paths above.

## How to Test

1. Configure two profiles pointing at different remote Hermes backends with different update states.
2. Connect to profile A, let the update indicator populate, then switch directly to profile B.
3. Before this fix: the indicator keeps showing profile A's stale `(+N)` count until the next poll/focus/manual check.
4. After this fix: the switch itself triggers a fresh check.
5. `npx vitest run --environment jsdom src/store/updates.test.ts` — 26/26 pass; reverting just the production change in `updates.ts` reproduces the failure on the new test (verified locally via `git stash`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (by issue number and by file/mechanism — `lastConnectionMode`, `checkBackendUpdates`) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `npx vitest run --environment jsdom src/store/updates.test.ts`, `npx tsc -p . --noEmit`, and `npx eslint src/store/updates.ts src/store/updates.test.ts` — all clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.

