### PR TITLE
fix(tui): stop double-formatting friendly tool labels (#62796)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -424,6 +424,64 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
     assert "result_text" not in events[1][2]
 
 
+def test_tool_start_ships_raw_context_and_friendly_label(monkeypatch):
+    """#62796: ``tool.start`` keeps ``context`` a bare argument preview and ships
+    the complete friendly phrase in an additive ``label`` field, so a client
+    renders one or the other without wrapping the label a second time (the
+    regression rendered ``Read File("Reading package.json …")``)."""
+    from agent import display
+
+    monkeypatch.setattr(display, "_friendly_tool_labels", True)
+
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        "label-test",
+        {"tool_progress_mode": "all", "tool_started_at": {}},
+    )
+
+    server._on_tool_start("label-test", "tool-1", "read_file", {"path": "package.json"})
+
+    event_type, _sid, payload = events[0]
+    assert event_type == "tool.start"
+    context = payload["context"]
+    label = payload["label"]
+    # context is the bare preview the client wraps itself ("Read File(...)")…
+    assert "package.json" in context
+    assert not context.startswith("Reading")
+    # …and label is the complete phrase the client renders verbatim.
+    assert label.startswith("Reading")
+    assert label != context
+    # Simulate the Ink contract (label wins, else wrap context): no double-format.
+    rendered = label or f'Read File("{context}")'
+    assert rendered == label
+    assert 'Read File("Reading' not in rendered
+
+
+def test_tool_start_omits_label_when_it_is_just_the_preview(monkeypatch):
+    """Custom/plugin tools (and disabled friendly labels) have no curated verb,
+    so ``build_tool_label`` returns the raw preview. The ``label`` field is then
+    omitted so pre-``label`` clients keep wrapping ``context`` unchanged."""
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        "plain-test",
+        {"tool_progress_mode": "all", "tool_started_at": {}},
+    )
+
+    server._on_tool_start("plain-test", "tool-1", "some_custom_mcp_tool", {"foo": "bar"})
+
+    payload = events[0][2]
+    assert payload["name"] == "some_custom_mcp_tool"
+    assert "label" not in payload
+
+
 def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
@@ -933,9 +991,16 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
         {"role": "user", "content": "second prompt"},
     ]
 
+    # context stays the raw preview; the friendly phrase ships in ``label`` so
+    # the client renders it verbatim instead of wrapping it again (#62796).
     assert server._history_to_messages(history) == [
         {"role": "user", "text": "first prompt"},
-        {"context": "Searching files for resume", "name": "search_files", "role": "tool"},
+        {
+            "context": "resume",
+            "label": "Searching files for resume",
+            "name": "search_files",
+            "role": "tool",
+        },
         {"role": "assistant", "text": "first answer"},
         {"role": "user", "text": "second prompt"},
     ]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3436,12 +3436,30 @@ def _session_info(agent, session: dict | None = None) -> dict:
 
 
 def _tool_ctx(name: str, args: dict) -> str:
+    """Raw argument preview (e.g. ``package.json L1-300``) for the ``context``
+    field. Clients wrap this themselves as ``Read File("…")``, so it must stay a
+    bare preview — never a complete friendly label (see :func:`_tool_label`)."""
+    try:
+        from agent.display import build_tool_preview
+
+        return build_tool_preview(name, args, max_len=80) or ""
+    except Exception:
+        return ""
+
+
+def _tool_label(name: str, args: dict, context: str) -> str:
+    """Complete human-phrased label (e.g. ``Reading package.json L1-300``) for
+    the additive ``label`` field. Clients render it verbatim instead of wrapping
+    ``context``. Returns "" when the label is just the raw preview (custom/MCP
+    tools, or friendly labels disabled) so those keep the old wrapped rendering
+    and pre-``label`` clients are unaffected."""
     try:
         from agent.display import build_tool_label
 
-        return build_tool_label(name, args, max_len=80) or ""
+        label = build_tool_label(name, args, max_len=80) or ""
     except Exception:
         return ""
+    return label if label and label != context else ""
 
 
 def _emit_session_info_for_session(sid: str, session: dict) -> None:
@@ -3590,11 +3608,14 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
     if _tool_progress_enabled(sid):
+        context = _tool_ctx(name, args)
         payload = {
             "tool_id": tool_call_id,
             "name": name,
-            "context": _tool_ctx(name, args),
+            "context": context,
         }
+        if label := _tool_label(name, args, context):
+            payload["label"] = label
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:
@@ -4939,9 +4960,11 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             tc_info = tool_call_args.get(tc_id) if tc_id else None
             name = (tc_info[0] if tc_info else None) or m.get("tool_name") or "tool"
             args = (tc_info[1] if tc_info else None) or {}
-            messages.append(
-                {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
-            )
+            context = _tool_ctx(name, args)
+            tool_msg = {"role": "tool", "name": name, "context": context}
+            if label := _tool_label(name, args, context):
+                tool_msg["label"] = label
+            messages.append(tool_msg)
             continue
         # An assistant turn may carry only reasoning/thinking content with no
         # visible text (extended-thinking turns, thinking-only recovery

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -280,7 +280,7 @@ Primary event types the client handles today:
 | `status.update`            | `{ kind, text }`                                                            |
 | `notification.show`        | `{ id, key, kind, level, text, ttl_ms? }`                                   |
 | `notification.clear`       | `{ key }`                                                                   |
-| `tool.start`               | `{ tool_id, name, context?, args_text? }`                                   |
+| `tool.start`               | `{ tool_id, name, context?, label?, args_text? }` — `label?` is the complete friendly label rendered verbatim; `context?` remains the raw preview |
 | `tool.generating`          | `{ name }`                                                                  |
 | `tool.progress`            | `{ name, preview }`                                                         |
 | `tool.complete`            | `{ tool_id, name, error?, summary?, duration_s?, inline_diff?, todos? }`    |

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -26,6 +26,18 @@ describe('toTranscriptMessages', () => {
     ])
     expect(toTranscriptMessages(rows)[1]?.tools?.[0]).toContain('Search Files')
   })
+
+  it('renders a resumed tool row from its friendly label verbatim, not double-formatted (#62796)', () => {
+    const rows = [
+      { role: 'user', text: 'prompt' },
+      { context: 'package.json L1-300', label: 'Reading package.json L1-300', name: 'read_file', role: 'tool', text: '' },
+      { role: 'assistant', text: 'answer' }
+    ]
+
+    const trail = toTranscriptMessages(rows)[1]?.tools?.[0]
+    expect(trail).toContain('Reading package.json L1-300')
+    expect(trail).not.toContain('Read File("Reading')
+  })
 })
 
 describe('MessageLine', () => {

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -8,6 +8,7 @@ import {
   estimateRows,
   estimateTokensRough,
   fmtK,
+  formatToolCall,
   hasAnsi,
   isToolTrailResultLine,
   lastCotTrailIndex,
@@ -28,6 +29,19 @@ describe('isToolTrailResultLine', () => {
   })
 })
 
+describe('formatToolCall', () => {
+  it('wraps the raw preview under the tool label when no friendly label is given', () => {
+    expect(formatToolCall('read_file', 'package.json L1-300')).toBe('Read File("package.json L1-300")')
+  })
+
+  it('renders the gateway friendly label verbatim instead of re-wrapping it (#62796)', () => {
+    // The gateway already phrased this; wrapping it again is the double-format bug.
+    expect(formatToolCall('read_file', 'package.json L1-300', 'Reading package.json L1-300')).toBe(
+      'Reading package.json L1-300'
+    )
+  })
+})
+
 describe('buildToolTrailLine', () => {
   it('puts completion duration inline before the result marker', () => {
     const line = buildToolTrailLine('read_file', 'x', false, '', 0.94)
@@ -35,6 +49,13 @@ describe('buildToolTrailLine', () => {
     expect(line).toBe('Read File("x") (0.9s) ✓')
     expect(parseToolTrailResultLine(line)).toEqual({ call: 'Read File("x") (0.9s)', detail: '', mark: '✓' })
     expect(splitToolDuration('Read File("x") (0.9s)')).toEqual({ label: 'Read File("x")', duration: ' (0.9s)' })
+  })
+
+  it('uses the friendly label verbatim for the trail line when present (#62796)', () => {
+    const line = buildToolTrailLine('read_file', 'package.json L1-300', false, '', 0.9, 'Reading package.json L1-300')
+
+    expect(line).toBe('Reading package.json L1-300 (0.9s) ✓')
+    expect(line).not.toContain('Read File("Reading')
   })
 })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -731,7 +731,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ev.payload.tool_id,
           ev.payload.name ?? 'tool',
           ev.payload.context ?? '',
-          ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined
+          ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined,
+          ev.payload.label
         )
 
         return

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -803,14 +803,16 @@ class TurnController {
             Boolean(error),
             duration ?? fallbackDuration,
             done?.verboseArgs,
-            error || resultText || summary || ''
+            error || resultText || summary || '',
+            done?.label
           )
         : buildToolTrailLine(
             name,
             done?.context || '',
             Boolean(error),
             error || summary || '',
-            duration ?? fallbackDuration
+            duration ?? fallbackDuration,
+            done?.label
           )
 
     this.activeTools = this.activeTools.filter(tool => tool.id !== toolId)
@@ -857,7 +859,7 @@ class TurnController {
     }, STREAM_BATCH_MS)
   }
 
-  recordToolStart(toolId: string, name: string, context: string, verboseArgs?: string) {
+  recordToolStart(toolId: string, name: string, context: string, verboseArgs?: string, label?: string) {
     if (this.interrupted) {
       return
     }
@@ -870,7 +872,7 @@ class TurnController {
     const sample = `${name} ${context}`.trim()
 
     this.toolTokenAcc += sample ? estimateTokensRough(sample) : 0
-    this.activeTools = [...this.activeTools, { context, id: toolId, name, startedAt: Date.now(), verboseArgs }]
+    this.activeTools = [...this.activeTools, { context, id: toolId, label, name, startedAt: Date.now(), verboseArgs }]
 
     patchTurnState({ toolTokens: this.toolTokenAcc, tools: this.activeTools })
   }

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -837,7 +837,7 @@ export const ToolTrail = memo(function ToolTrail({
   }
 
   for (const tool of tools) {
-    const label = formatToolCall(tool.name, tool.context || '')
+    const label = formatToolCall(tool.name, tool.context || '', tool.label)
 
     groups.push({
       color: t.color.text,
@@ -886,7 +886,11 @@ export const ToolTrail = memo(function ToolTrail({
   const toolTokensLabel = toolTokens !== undefined && toolTokens > 0 ? `~${fmtK(toolTokens)} tokens` : undefined
 
   const totalTokensLabel = tokenCount > 0 && toolTokenCount > 0 ? `~${fmtK(totalTokenCount)} total` : null
-  const delegateGroups = groups.filter(g => g.label.startsWith('Delegate Task'))
+  // A delegate_task group renders either wrapped ("Delegate Task(…)") or with
+  // its friendly verb ("Delegating …") depending on display.friendly_tool_labels
+  // (#55166/#62796); match both so the inline subagent tree still attaches.
+  const isDelegateTaskLabel = (label: string) => label.startsWith('Delegate Task') || label.startsWith('Delegating')
+  const delegateGroups = groups.filter(g => isDelegateTaskLabel(g.label))
   const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
 
   const toolLabel = (group: Group) => {
@@ -1063,7 +1067,7 @@ export const ToolTrail = memo(function ToolTrail({
             // Surface the /agents hint the moment a delegate group appears —
             // while it's still in-flight and before any subagent has
             // registered — so users can open the live monitor immediately.
-            const isDelegateGroup = group.label.startsWith('Delegate Task')
+            const isDelegateGroup = isDelegateTaskLabel(group.label)
 
             return (
               <Box flexDirection="column" key={group.key}>

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -44,10 +44,10 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
       continue
     }
 
-    const { context, name, role, text } = row as TranscriptRow
+    const { context, label, name, role, text } = row as TranscriptRow
 
     if (role === 'tool') {
-      pending.push(buildToolTrailLine(name ?? 'tool', context ?? ''))
+      pending.push(buildToolTrailLine(name ?? 'tool', context ?? '', undefined, undefined, undefined, label))
 
       continue
     }
@@ -85,6 +85,7 @@ interface ImageMeta {
 
 interface TranscriptRow {
   context?: string
+  label?: string
   name?: string
   role?: string
   text?: string

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -668,7 +668,7 @@ export type GatewayEvent =
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
-      payload: { args_text?: string; context?: string; name?: string; tool_id: string; todos?: unknown[] }
+      payload: { args_text?: string; context?: string; label?: string; name?: string; tool_id: string; todos?: unknown[] }
       session_id?: string
       type: 'tool.start'
     }

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -195,7 +195,16 @@ export const toolTrailLabel = (name: string) =>
     .map(p => p[0]!.toUpperCase() + p.slice(1))
     .join(' ') || name
 
-export const formatToolCall = (name: string, context = '') => {
+// `friendlyLabel` is the gateway's complete human-phrased label (e.g.
+// "Reading package.json L1-300"). When present it is rendered verbatim instead
+// of wrapping `context` as `Read File("…")` — the gateway already phrased it, so
+// wrapping again double-formats it (#62796). Falls back to the wrapped preview
+// for pre-`label` gateways, custom/MCP tools, and disabled friendly labels.
+export const formatToolCall = (name: string, context = '', friendlyLabel = '') => {
+  if (friendlyLabel) {
+    return friendlyLabel
+  }
+
   const label = toolTrailLabel(name)
   const preview = compactPreview(context, 64)
 
@@ -207,12 +216,13 @@ export const buildToolTrailLine = (
   context: string,
   error?: boolean,
   note?: string,
-  duration?: number
+  duration?: number,
+  friendlyLabel?: string
 ) => {
   const detail = compactPreview(note ?? '', 72)
   const took = duration !== undefined ? ` (${duration.toFixed(1)}s)` : ''
 
-  return `${formatToolCall(name, context)}${took}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
+  return `${formatToolCall(name, context, friendlyLabel)}${took}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
 }
 
 const verboseToolBlock = (label: string, text?: string) => {
@@ -236,7 +246,8 @@ export const buildVerboseToolTrailLine = (
   error?: boolean,
   duration?: number,
   argsText?: string,
-  resultText?: string
+  resultText?: string,
+  friendlyLabel?: string
 ) => {
   const detail = [verboseToolBlock('Args', argsText), verboseToolBlock(error ? 'Error' : 'Result', resultText)]
     .filter(Boolean)
@@ -244,7 +255,7 @@ export const buildVerboseToolTrailLine = (
 
   const took = duration !== undefined ? ` (${duration.toFixed(1)}s)` : ''
 
-  return `${formatToolCall(name, context)}${took}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
+  return `${formatToolCall(name, context, friendlyLabel)}${took}${detail ? ` :: ${detail}` : ''} ${error ? '✗' : '✓'}`
 }
 
 export const isToolTrailResultLine = (line: string) => line.endsWith(' ✓') || line.endsWith(' ✗')

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -1,6 +1,7 @@
 export interface ActiveTool {
   context?: string
   id: string
+  label?: string
   name: string
   verboseArgs?: string
   startedAt?: number


### PR DESCRIPTION
## What does this PR do?

The TUI double-formats built-in tool rows: instead of `Reading package.json L1-300` it shows `Read File("Reading package.json L1-300")` (and likewise `Skill View("Reading skill …")`, `Web Extract("Reading …")`, `Search Files("Searching files for …")`).

Since #55166, the gateway's `_tool_ctx` returned a **complete friendly label** under the wire's `context` field, but `context` is a contract for a **raw argument preview** that clients wrap themselves as `Read File("…")`. Ink dutifully wrapped the already-complete label a second time.

This restores `context` to a raw preview and ships the complete phrase in an additive `label` field. Clients render `label` verbatim when present and otherwise fall back to wrapping `context` — so pre-`label` gateways/clients, custom/plugin/MCP tools (no curated verb), disabled `display.friendly_tool_labels`, and the desktop's own localized rendering are all unaffected. This is the approach suggested by the reporter (@CNSeniorious000) in the issue.

## Related Issue

Fixes #62796

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: `_tool_ctx` now returns the raw preview (`build_tool_preview`) again; new `_tool_label` returns the complete friendly label only when it differs from that preview. Both the live `tool.start` payload and the resumed-history tool message now carry `context` (raw) plus an optional `label`.
- `ui-tui/src/lib/text.ts`: `formatToolCall(name, context, friendlyLabel?)` renders `friendlyLabel` verbatim when present; `buildToolTrailLine` / `buildVerboseToolTrailLine` thread it through so the completed/resumed trail matches the live row.
- `ui-tui/src/app/turnController.ts`, `createGatewayEventHandler.ts`, `domain/messages.ts`, `types.ts`, `gatewayTypes.ts`: carry the new `label` from the gateway event / transcript row to the render helpers.
- `ui-tui/src/components/thinking.tsx`: render the live row from `label`; make the inline-subagent delegate-group detection accept both the wrapped `Delegate Task(…)` and the friendly `Delegating …` phrasings.
- Tests: composition coverage the issue called out as missing — a Python test that runs `_on_tool_start` and asserts `context` stays a bare preview while `label` carries the complete phrase (and is omitted for unlabeled tools), plus TS tests for `formatToolCall`, the trail line, and resumed-transcript rendering. Updated `test_history_to_messages_preserves_tool_calls_for_resume_display` to the corrected contract.

## How to Test

```
scripts/run_tests.sh tests/test_tui_gateway_server.py -q
```
Result: 319 passed (includes the two new composition tests).

TS (from `ui-tui/`, after `npm install` + `npm run build --prefix packages/hermes-ink`):
```
npx vitest run src/__tests__/text.test.ts src/__tests__/messages.test.ts src/__tests__/createGatewayEventHandler.test.ts
```
Result: all pass. (Pre-existing, unrelated failures in `statusRule.test.ts` / `virtualHeights.test.ts` reproduce on clean `upstream/main`.)

Manual: with `display.friendly_tool_labels: true` (default), run `hermes --tui`, trigger `read_file`, and observe the live row, completion trail, and a resumed transcript all show `Reading package.json L1-300` — not `Read File("Reading package.json L1-300")`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (display formatting only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Credits

Root cause and the `context` + additive `label` fix strategy were diagnosed by @CNSeniorious000 in #62796; this PR implements that approach.
