### PR TITLE
fix(models): stop Anthropic context probe credential redirects

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1809,7 +1809,13 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
             "x-api-key": api_key,
             "anthropic-version": "2023-06-01",
         }
-        resp = requests.get(url, headers=headers, timeout=(5, 10), verify=_resolve_requests_verify())
+        resp = requests.get(
+            url,
+            headers=headers,
+            timeout=(5, 10),
+            verify=_resolve_requests_verify(),
+            allow_redirects=False,
+        )
         if resp.status_code != 200:
             return None
         data = resp.json()

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -30,6 +30,7 @@ from agent.model_metadata import (
     save_context_length,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
+    _query_anthropic_context_length,
     estimate_request_tokens_rough,
 )
 
@@ -348,6 +349,35 @@ class TestDefaultContextLengths:
                 "moonshotai/kimi-k2.6", base_url=or_url, provider="openrouter"
             )
             assert ctx != 32768, "Kimi 32k OR underreport must not be accepted"
+
+
+class TestAnthropicContextLengthProbe:
+    def test_anthropic_models_probe_disables_x_api_key_redirects(self, monkeypatch):
+        leaked_headers = []
+
+        class FakeResponse:
+            status_code = 302
+
+            def json(self):
+                return {"data": [{"id": "claude-test", "max_input_tokens": 12345}]}
+
+        def fake_get(url, **kwargs):
+            if kwargs.get("allow_redirects", True):
+                leaked_headers.append(dict(kwargs.get("headers") or {}))
+                response = FakeResponse()
+                response.status_code = 200
+                return response
+            return FakeResponse()
+
+        monkeypatch.setattr("agent.model_metadata.requests.get", fake_get)
+        result = _query_anthropic_context_length(
+            "claude-test",
+            "https://api.anthropic.com",
+            "sk-ant-api03-secret-test",
+        )
+
+        assert result is None
+        assert leaked_headers == []
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Prevent the Anthropic context-length metadata probe from forwarding `x-api-key` across HTTP redirects.

## Problem

`agent/model_metadata.py::_query_anthropic_context_length()` queries Anthropic-compatible `/v1/models` with:

- `x-api-key: <ANTHROPIC_API_KEY>`
- `anthropic-version: 2023-06-01`

The request used `requests.get()` with default redirect behavior. Unlike the standard `Authorization` header, custom credential headers such as `x-api-key` are not stripped by `requests` on cross-origin redirects. A redirected `/v1/models` probe can therefore forward the Anthropic provider key to the redirect target.

This is the same credential-redirect bug class as the recently merged model-catalog hardening, but in the agent-side context-length metadata probe.

## Fix

Disable redirect following for the Anthropic `/v1/models` context probe by passing `allow_redirects=False`.

The probe is opportunistic: it only needs a direct 200 response from the configured endpoint. A redirect should not be followed with provider credentials.

## Tests

Added a regression test proving the Anthropic context probe disables redirects before sending `x-api-key`.

Manual two-server repro:

Before the fix:

```text
result 12345
leak_seen True
x_api_key_at_redirect_target sk-ant-api03-secret-test