### PR TITLE
fix: hide Windows environment and computer-use subprocesses

### DIFF
--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -136,6 +136,43 @@ def test_permissions_run_sanitizes_env(monkeypatch):
     _assert_sanitized(captured)
 
 
+def test_windows_status_hides_every_reachable_subprocess(monkeypatch):
+    """The Desktop status API reaches only version + doctor spawns on Windows.
+
+    The permissions grant subprocess is intentionally excluded: its public
+    entry point returns before spawning anywhere except macOS, where
+    ``CREATE_NO_WINDOW`` is not applicable.
+    """
+    from tools.computer_use import permissions
+
+    binary = r"C:\Program Files\cua-driver\cua-driver.exe"
+    calls = []
+    stdout_by_args = {
+        ("--version",): "cua-driver 1.2.3\n",
+        ("doctor", "--json"): json.dumps({"ok": True, "probes": []}),
+    }
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _fake_completed_process(stdout_by_args[tuple(cmd[1:])])
+
+    monkeypatch.setattr(permissions.sys, "platform", "win32")
+    monkeypatch.setattr(permissions.shutil, "which", lambda command: binary)
+    monkeypatch.setattr(permissions.subprocess, "run", fake_run)
+
+    status = permissions.computer_use_status("cua-driver")
+
+    assert status["version"] == "cua-driver 1.2.3"
+    assert status["ready"] is True
+    assert [cmd[1:] for cmd, _ in calls] == [
+        ["--version"],
+        ["doctor", "--json"],
+    ]
+    assert calls, "Windows status must exercise at least one subprocess boundary"
+    for cmd, kwargs in calls:
+        assert kwargs.get("creationflags") == CREATE_NO_WINDOW, cmd
+
+
 def test_doctor_spawn_sanitizes_env_and_hides_console_on_windows(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -157,6 +157,7 @@ def test_windows_status_hides_every_reachable_subprocess(monkeypatch):
         return _fake_completed_process(stdout_by_args[tuple(cmd[1:])])
 
     monkeypatch.setattr(permissions.sys, "platform", "win32")
+    monkeypatch.setattr(permissions, "windows_hide_flags", lambda: CREATE_NO_WINDOW)
     monkeypatch.setattr(permissions.shutil, "which", lambda command: binary)
     monkeypatch.setattr(permissions.subprocess, "run", fake_run)
 

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import MagicMock
 
 SECRET = "sk-super-secret-should-not-leak"
+CREATE_NO_WINDOW = 0x08000000
 
 
 def _fake_completed_process(stdout: str) -> MagicMock:
@@ -31,6 +32,7 @@ def _capture_run(captured, stdout=""):
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
         captured["env"] = kwargs.get("env")
+        captured["creationflags"] = kwargs.get("creationflags")
         return _fake_completed_process(stdout)
     return fake_run
 
@@ -45,6 +47,13 @@ def _assert_sanitized(captured):
     assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
 
 
+def _patch_windows_hide_flags(monkeypatch, module):
+    monkeypatch.setattr(module, "IS_WINDOWS", True, raising=False)
+    monkeypatch.setattr(
+        module, "windows_hide_flags", lambda: CREATE_NO_WINDOW, raising=False
+    )
+
+
 def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
@@ -53,6 +62,7 @@ def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     from tools.computer_use import cua_backend
 
     captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
     manifest = json.dumps({"mcp_invocation": {"command": "cua-driver", "args": ["mcp"]}})
     monkeypatch.setattr(
         cua_backend.subprocess, "run", _capture_run(captured, stdout=manifest)
@@ -61,6 +71,7 @@ def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     cmd, args = cua_backend._resolve_mcp_invocation("cua-driver")
     assert cmd == "cua-driver"
     _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
 
 
 def test_update_check_sanitizes_env(monkeypatch):
@@ -71,6 +82,7 @@ def test_update_check_sanitizes_env(monkeypatch):
     from tools.computer_use import cua_backend
 
     captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
     payload = json.dumps({
         "current_version": "1.0.0",
         "latest_version": "1.0.0",
@@ -82,6 +94,30 @@ def test_update_check_sanitizes_env(monkeypatch):
 
     cua_backend.cua_driver_update_check(timeout=1.0)
     _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
+
+
+def test_cli_fallback_sanitizes_env_and_hides_console_on_windows(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
+
+    from tools.computer_use import cua_backend
+
+    captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        _capture_run(captured, stdout=json.dumps({"tree_markdown": "root"})),
+    )
+
+    session = object.__new__(cua_backend._CuaDriverSession)
+    result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    assert result["isError"] is False
+    _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
 
 
 def test_permissions_run_sanitizes_env(monkeypatch):
@@ -100,21 +136,37 @@ def test_permissions_run_sanitizes_env(monkeypatch):
     _assert_sanitized(captured)
 
 
-def test_doctor_sanitized_env_helper(monkeypatch):
-    """_drive_health_report spawns via Popen; assert the env helper it uses
-    strips secrets (mocking the whole JSON-RPC handshake is not worth it)."""
+def test_doctor_spawn_sanitizes_env_and_hides_console_on_windows(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
 
     from tools.computer_use import doctor
-    import inspect
 
-    env = doctor._sanitized_cua_env()
-    assert "ANTHROPIC_API_KEY" not in env
-    assert env.get("PATH") == "/usr/bin:/bin"
-    assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
+    captured = {}
+    _patch_windows_hide_flags(monkeypatch, doctor)
+    proc = MagicMock()
+    proc.stdout.readline.side_effect = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "structuredContent": {"schema_version": "1", "overall": "ok"}
+            },
+        }),
+    ]
 
-    # The Popen spawn site must actually use the sanitized helper.
-    src = inspect.getsource(doctor._drive_health_report)
-    assert "_sanitized_cua_env()" in src
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env")
+        captured["creationflags"] = kwargs.get("creationflags")
+        return proc
+
+    monkeypatch.setattr(doctor.subprocess, "Popen", fake_popen)
+
+    report = doctor._drive_health_report("cua-driver", timeout=1.0)
+
+    assert report["overall"] == "ok"
+    _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -1,6 +1,8 @@
 """Tests for tools/env_probe.py — local Python toolchain probe."""
 
+import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -141,6 +143,68 @@ class TestCaching:
         # Only the first call probes — caller-counting confirms it.
         # Two calls (python3 + python) on first invocation, zero after.
         assert len(calls) == 2
+
+
+class TestWindowsSubprocesses:
+    def test_warm_probe_hides_every_windows_subprocess(self, monkeypatch):
+        """Every process reached by the async warm path must be windowless."""
+        captured = []
+        create_no_window = 0x08000000
+
+        class ImmediateThread:
+            def __init__(self, *, target, **_kwargs):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        def fake_which(name):
+            return None if name == "uv" else f"C:/bin/{name}.exe"
+
+        def fake_run(cmd, **kwargs):
+            captured.append((cmd, kwargs))
+            if cmd[:3] == ["python3", "-m", "pip"]:
+                stdout = "pip 24.0 from C:/pip (python 3.12)\n"
+            elif cmd == ["pip", "--version"]:
+                stdout = "pip 24.0 from C:/pip (python 3.12)\n"
+            elif "EXTERNALLY-MANAGED" in cmd[-1]:
+                stdout = "no\n"
+            else:
+                stdout = "3.12.4\n"
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(env_probe, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            env_probe,
+            "windows_hide_flags",
+            lambda: create_no_window,
+        )
+        monkeypatch.setattr(env_probe.threading, "Thread", ImmediateThread)
+        monkeypatch.setattr(env_probe.shutil, "which", fake_which)
+        monkeypatch.setattr(env_probe.subprocess, "run", fake_run)
+
+        env_probe.warm_environment_probe_async()
+
+        assert len(captured) == 5, captured
+        commands = [cmd for cmd, _kwargs in captured]
+        assert [cmd[0] for cmd in commands] == [
+            "python3",
+            "python",
+            "python3",
+            "pip",
+            "python3",
+        ]
+        assert commands[2] == ["python3", "-m", "pip", "--version"]
+        assert commands[3] == ["pip", "--version"]
+        assert all(commands[index][1] == "-c" for index in (0, 1, 4))
+        assert all(
+            kwargs.get("creationflags") == create_no_window
+            for _cmd, kwargs in captured
+        ), captured
+        assert all(
+            kwargs.get("stdin") is subprocess.DEVNULL
+            for _cmd, kwargs in captured
+        ), captured
 
 
 class TestRobustness:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -49,6 +49,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.computer_use.backend import (
     ActionResult,
     CaptureResult,
@@ -165,6 +166,7 @@ def _resolve_mcp_invocation(
             [driver_cmd, "manifest"],
             capture_output=True, text=True, timeout=timeout,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
             # cua-driver is a third-party binary — never hand it provider
             # API keys via inherited env (same policy as the MCP and CLI
             # fallback spawns below; #53503/#55709/#58889 lineage).
@@ -259,6 +261,7 @@ def cua_driver_update_check(*, timeout: float = 8.0) -> Optional[Dict[str, Any]]
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
             # so they exit fast instead of blocking until the timeout.
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
             # Sanitized like every other cua-driver spawn: third-party
             # binary, no inherited provider keys (#53503/#55709/#58889).
             env=_sanitize_subprocess_env(cua_driver_child_env()),
@@ -921,6 +924,7 @@ class _CuaDriverSession:
                 try:
                     proc = _subprocess.run(
                         cmd, capture_output=True, text=True, timeout=max(15.0, timeout),
+                        creationflags=windows_hide_flags(),
                         env=_sanitize_subprocess_env(cua_driver_child_env()),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Sequence
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 
 # Match the ALLOWED_STATUS_VALUES + ALLOWED_OVERALL_VALUES the cua-driver
 # integration test pins. If health_report widens its vocabulary, add here.
@@ -104,6 +106,7 @@ def _drive_health_report(
         encoding="utf-8",
         errors="replace",
         bufsize=1,
+        creationflags=windows_hide_flags(),
         env=_sanitized_cua_env(),
     )
     try:

--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -30,6 +30,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 # Platforms with a cua-driver runtime backend (mirrors the toolset platform_gate).
 _RUNTIME_PLATFORMS = frozenset({"darwin", "win32", "linux"})
 _BOOLS = ("accessibility", "screen_recording", "screen_recording_capturable")
@@ -75,6 +77,7 @@ def _run(binary: str, *args: str, timeout: float) -> subprocess.CompletedProcess
         timeout=timeout,
         env=_child_env(),
         stdin=subprocess.DEVNULL,
+        creationflags=windows_hide_flags(),
     )
 
 

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -37,6 +37,8 @@ import sys
 import threading
 from typing import Optional
 
+from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Module-level cache.  The probe result is deterministic for the
@@ -59,6 +61,7 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
     Failures (binary missing, timeout, OSError) return (-1, "", "<reason>").
     """
     try:
+        run_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -66,6 +69,7 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
             timeout=timeout,
             check=False,
             stdin=subprocess.DEVNULL,
+            **run_kwargs,
         )
         return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
     except FileNotFoundError:


### PR DESCRIPTION
## Summary

- Fixes the root cause where environment-probe and cua-driver subprocesses launched from GUI-backed Gateway/Desktop processes can activate OpenConsole/Windows Terminal in the foreground on Windows.
- Adds the canonical `windows_hide_flags()` at six Windows-reachable final subprocess boundaries: environment probe, manifest probe, update checker, CLI version fallback, cua-driver doctor, and cua-driver status/permissions.
- Keeps existing environment, I/O, timeout, and encoding semantics unchanged.

## Validation

- Windows native model: 32 passed
- Linux portability model: 32 passed
- Environment probe suite: 11 passed
- Computer-use suite: 32 passed
- No-window regression suite: 15 passed
- Subprocess footgun scan: 0 findings

The Windows and Linux-model coverage verifies that Windows-only creation flags are applied where required while non-Windows paths remain portable no-ops.

## Scope notes

- The line-length debt in `cua_backend.py` is pre-existing; this PR deliberately does not mix in an unrelated refactor.
- No secrets or local paths are included.