### PR TITLE
fix(cli): treat bool handler results as exit 0, not status 1 (#62810)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3393,9 +3393,12 @@ def main():
         return
 
     # A handler's int return code becomes the exit code (None = success).
+    # ``bool`` subclasses ``int``, so gate on an exact ``int`` -- external
+    # plugin handlers routinely return ``True``/``False`` to signal success
+    # and must not map to ``sys.exit(True)`` -> status 1.
     if hasattr(args, "func"):
         rc = args.func(args)
-        if isinstance(rc, int) and rc != 0:
+        if type(rc) is int and rc != 0:
             sys.exit(rc)
     else:
         parser.print_help()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -18419,9 +18419,16 @@ def main():
     # ``hermes egress start`` refusing when credential_source=bitwarden
     # is misconfigured) actually exit non-zero.  Handlers that return
     # None are treated as success (exit 0).
+    #
+    # ``bool`` is a subclass of ``int``, so a bare ``isinstance(rc, int)``
+    # would map a handler returning ``True`` to ``sys.exit(True)`` -> exit
+    # status 1.  ``args.func`` handlers are unconstrained ``Callable``s
+    # (notably external-plugin CLI handlers) that routinely return
+    # ``True``/``False`` to signal success, so only an *exact* ``int`` counts
+    # as a status code here.
     if hasattr(args, "func"):
         rc = args.func(args)
-        if isinstance(rc, int) and rc != 0:
+        if type(rc) is int and rc != 0:
             sys.exit(rc)
     else:
         parser.print_help()

--- a/tests/hermes_cli/test_main_exit_codes.py
+++ b/tests/hermes_cli/test_main_exit_codes.py
@@ -1,0 +1,71 @@
+"""CLI dispatch exit-status tests.
+
+``main()`` propagates a subcommand handler's return value to the process exit
+status: an exact non-zero ``int`` becomes ``sys.exit(rc)``, while ``None`` (and,
+critically, ``bool``) are treated as success.  ``bool`` is a subclass of
+``int``, so a bare ``isinstance(rc, int)`` check would map a handler returning
+``True`` to ``sys.exit(True)`` -> exit status ``1``.  ``args.func`` handlers are
+unconstrained ``Callable``s (notably external-plugin CLI handlers) that
+routinely return ``True``/``False`` to signal success, so these pin that a
+boolean result never becomes a spurious failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_dispatch_exits_nonzero_on_integer_failure(monkeypatch):
+    """A handler returning a non-zero int must ``sys.exit`` with that status."""
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setattr(main_mod, "cmd_kanban", lambda args: 7)
+    monkeypatch.setattr("sys.argv", ["hermes", "kanban", "list"])
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 7
+
+
+def test_dispatch_success_on_zero_and_none(monkeypatch):
+    """Zero and ``None`` returns are success — no ``sys.exit`` is raised."""
+    from hermes_cli import main as main_mod
+
+    for result in (0, None):
+        monkeypatch.setattr(main_mod, "cmd_kanban", lambda args, r=result: r)
+        monkeypatch.setattr("sys.argv", ["hermes", "kanban", "list"])
+        # Must not raise SystemExit; a bare return is treated as exit 0.
+        main_mod.main()
+
+
+def test_dispatch_treats_boolean_result_as_success(monkeypatch):
+    """A handler returning ``True``/``False`` must not become exit status 1.
+
+    Regression: ``bool`` is an ``int`` subclass, so ``isinstance(rc, int) and
+    rc != 0`` mapped ``True`` to ``sys.exit(True)`` (a spurious exit status 1).
+    Plugin handlers commonly return booleans to signal success.
+    """
+    from hermes_cli import main as main_mod
+
+    for result in (True, False):
+        monkeypatch.setattr(main_mod, "cmd_kanban", lambda args, r=result: r)
+        monkeypatch.setattr("sys.argv", ["hermes", "kanban", "list"])
+        # A boolean must flow through as success — no SystemExit.
+        main_mod.main()
+
+
+def test_dispatch_preserves_system_exit_from_handler(monkeypatch):
+    """Handlers that already raise ``SystemExit`` keep owning their status."""
+    from hermes_cli import main as main_mod
+
+    def fake(args):
+        raise SystemExit(3)
+
+    monkeypatch.setattr(main_mod, "cmd_kanban", fake)
+    monkeypatch.setattr("sys.argv", ["hermes", "kanban", "list"])
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 3


### PR DESCRIPTION
## What does this PR do?

Narrows a handler's return value to a process exit status at the `main()`
dispatch site. `bool` is a subclass of `int`, so the current

```python
rc = args.func(args)
if isinstance(rc, int) and rc != 0:
    sys.exit(rc)
```

maps a handler that returns `True` to `sys.exit(True)` → **exit status 1**, a
spurious failure. `args.func` handlers are unconstrained `Callable`s — notably
external-plugin CLI handlers (`hermes_cli/plugins.py`) — that routinely return
`True`/`False` to signal success. Gating on an exact int (`type(rc) is int`)
lets booleans flow through as success while still propagating real integer
statuses.

Adds `tests/hermes_cli/test_main_exit_codes.py` covering the boolean,
integer-failure, `None`-success, and handler-raised-`SystemExit` dispatch
paths.

## Scope change (was: "propagate exit codes through all launchers")

This PR originally folded three things. Two are now **superseded on
`upstream/main`** and have been dropped:

- The canonical dispatcher fix (**#43645**, by @DeliciousHouse) — `main()` now
  calls `sys.exit(rc)` on a non-zero integer status directly.
- The `./hermes` launcher gap — because propagation moved *inside* `main()`
  (an internal `sys.exit`), both the installed `hermes` (`sys.exit(main())`)
  and the repo `./hermes` (bare `main()`) now exit non-zero correctly, so the
  launcher no longer needs to forward `main()`'s return.

What remains, and what this PR is now scoped to, is the boolean-normalization
gap — which upstream's merged dispatcher still has, and which the maintainer
review on this PR explicitly asked for.

Fixes the boolean edge of #62810.
