### PR TITLE
fix(gateway): honor /model + channel_overrides in /new and /status banner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12319,19 +12319,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source=source)
+        return self._format_session_info(source=source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(
+        self, source: Optional["SessionSource"] = None
+    ) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When ``source`` is provided, applies the same resolution chain as
+        ``_resolve_session_agent_runtime`` (``/model`` session override →
+        ``channel_overrides`` → global default) so the banner agrees with
+        the model the next agent turn will actually use. Without ``source``
+        the banner falls back to the global default — fine for CLI
+        introspection where no channel context exists.
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
         model = _resolve_gateway_model()
+
+        # Apply /model session override + channel_overrides so the banner
+        # reports the model the next agent turn will actually use, not the
+        # raw config default. Mirrors the priority chain in
+        # _resolve_session_agent_runtime.
+        if source is not None:
+            sess_override: Optional[dict] = None
+            try:
+                sk = self._session_key_for_source(source)
+            except Exception:
+                sk = None
+            if sk:
+                # Rehydrate persisted /model override (the in-memory dict
+                # is empty right after /new cleared it on disk too).
+                try:
+                    self._rehydrate_session_model_override(sk)
+                except Exception:
+                    pass
+                sess_override = self._session_model_overrides.get(sk)
+                if sess_override and sess_override.get("model"):
+                    model = sess_override["model"]
+            cfg = getattr(self, "config", None)
+            if cfg is not None:
+                ch = _get_channel_override(
+                    cfg,
+                    source.platform,
+                    str(source.chat_id) if source.chat_id else "",
+                    thread_id=(
+                        str(source.thread_id) if getattr(source, "thread_id", None) else None
+                    ),
+                    parent_id=(
+                        str(source.parent_chat_id)
+                        if getattr(source, "parent_chat_id", None)
+                        else None
+                    ),
+                )
+                if ch and ch.model:
+                    # channel_overrides loses to /model but wins over global
+                    if not (sess_override and sess_override.get("model")):
+                        model = ch.model
+
         config_context_length = None
         provider = None
         base_url = None

--- a/tests/gateway/test_format_session_info_overrides.py
+++ b/tests/gateway/test_format_session_info_overrides.py
@@ -1,0 +1,147 @@
+"""Regression: _format_session_info must honour channel_overrides + /model session
+overrides so the /new banner and /status reflect the model the next turn will
+actually use. Before the fix, it read model.default directly and reported
+``super-super-model`` even when channel_overrides pinned the thread to a
+different model.
+
+Reported by a user running a Telegram thread pinned via channel_overrides to a
+custom provider model. The /new auto-reset notice kept advertising the global
+``super-super-model`` default, which contradicted the model the next turn
+actually ran on. The same banner appears for /status, so any thread using
+channel_overrides or a /model session override was affected — not just
+custom-provider setups. The bug was in the gateway, not in the user's
+provider config; the per-thread override just made it visible.
+
+Fix: _format_session_info accepts an optional ``source`` and runs the same
+priority chain as _resolve_session_agent_runtime (``/model`` session
+override → channel_overrides → global default). _reset_notice_session_info,
+the only production caller from the reset path, passes its source through.
+The no-source path is preserved for CLI introspection where no channel
+context exists."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import (
+    ChannelOverride,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+)
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner(home: Path) -> GatewayRunner:
+    """Build a GatewayRunner without going through the heavy __init__ chain.
+
+    _format_session_info only touches a handful of attributes — we stub the
+    rest with ``object.__new__`` so the test stays fast and hermetic.
+    """
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                channel_overrides={
+                    "2147": ChannelOverride(model="ol/minimax-m3"),
+                    "9999": ChannelOverride(model="openrouter/healer-alpha"),
+                },
+            ),
+        },
+    )
+    runner._session_model_overrides = {}
+    return runner
+
+
+def _telegram_source(thread_id: str | None) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1004295889073",
+        chat_type="group",
+        user_id="ddky",
+        thread_id=thread_id,
+    )
+
+
+def test_format_session_info_no_source_uses_global_default(home: Path):
+    runner = _make_runner(home)
+    out = runner._format_session_info()
+    # Without a source we cannot resolve channel context, so the banner shows
+    # the raw config default. This is intentional — _format_session_info() is
+    # also called for CLI introspection where no channel exists.
+    assert "super-super-model" in out
+
+
+def test_format_session_info_applies_channel_override(home: Path):
+    """Thread 2147 pinned to ol/minimax-m3 must surface in the banner."""
+    runner = _make_runner(home)
+    src = _telegram_source("2147")
+
+    # Stub the helper hooks the banner also needs so the test focuses on the
+    # override resolution — these helpers read config the runner doesn't own.
+    with patch(
+        "gateway.run._resolve_gateway_model", return_value="super-super-model"
+    ), patch(
+        "gateway.run._load_gateway_config", return_value={}
+    ), patch(
+        "gateway.run._resolve_runtime_agent_kwargs", return_value={}
+    ):
+        out = runner._format_session_info(source=src)
+
+    assert "ol/minimax-m3" in out, f"expected ol/minimax-m3, got: {out!r}"
+    assert "super-super-model" not in out
+
+
+def test_format_session_info_no_override_thread_falls_back(home: Path):
+    """A thread that has no override should still report the global default."""
+    runner = _make_runner(home)
+    src = _telegram_source("8888")  # not in channel_overrides
+
+    with patch(
+        "gateway.run._resolve_gateway_model", return_value="super-super-model"
+    ), patch(
+        "gateway.run._load_gateway_config", return_value={}
+    ), patch(
+        "gateway.run._resolve_runtime_agent_kwargs", return_value={}
+    ):
+        out = runner._format_session_info(source=src)
+
+    assert "super-super-model" in out
+
+
+def test_format_session_info_session_model_wins_over_channel_override(home: Path):
+    """Priority: session /model > channel_overrides > global. Regression
+    guard for the docstring claim at line 3752."""
+    runner = _make_runner(home)
+    src = _telegram_source("2147")
+    sk = "agent:main:telegram:group:-1004295889073:2147"
+    runner._session_model_overrides[sk] = {"model": "ol/special-override"}
+
+    with patch(
+        "gateway.run._resolve_gateway_model", return_value="super-super-model"
+    ), patch(
+        "gateway.run._load_gateway_config", return_value={}
+    ), patch(
+        "gateway.run._resolve_runtime_agent_kwargs", return_value={}
+    ), patch.object(
+        GatewayRunner, "_session_key_for_source", return_value=sk
+    ), patch.object(
+        GatewayRunner, "_rehydrate_session_model_override", lambda self, k: None
+    ):
+        out = runner._format_session_info(source=src)
+
+    assert "ol/special-override" in out, f"expected /model override, got: {out!r}"
+    assert "ol/minimax-m3" not in out
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path) -> Path:
+    """Route HERMES_HOME at a temp dir so the runner's config + session lookups
+    stay hermetic. Tests that don't touch the filesystem don't care, but the
+    session-key builder does, and we want a clean baseline."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path


### PR DESCRIPTION
## What does this PR do?

`_format_session_info` was reading `model.default` directly, so the `/new` auto-reset notice and `/status` banner advertised the global default even when the thread was pinned via `channel_overrides` or had a `/model` session override. The next agent turn ran on the override model, but the banner showed a different one — misleading at best, wrong at worst.

Fix: `_format_session_info` accepts an optional `source` and runs the same priority chain as `_resolve_session_agent_runtime` (`/model` session override → `channel_overrides` → global default). `_reset_notice_session_info` passes its `source` through. The no-source path is preserved for CLI introspection where no channel context exists.

## Related Issue

Reported by a user running a Telegram thread pinned via `channel_overrides` to a custom provider model. The `/new` notice kept advertising the global default while the next turn ran on the pinned model. The bug was in the gateway, not the provider config; the per-thread override just made it visible. Any thread using `channel_overrides` or a `/model` session override was affected.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_format_session_info(source=None)` now applies the priority chain (`/model` → `channel_overrides` → global) when `source` is provided. `_reset_notice_session_info` is updated to pass its `source` through. Multiplex-profile gating in the reset path is preserved.
- `tests/gateway/test_format_session_info_overrides.py` — 4 new tests covering: no source (CLI introspection path), channel override applies, no override thread falls back to global, `/model` session override wins over channel override.

## How to Test

1. Apply the patch, run `venv/bin/python -m pytest tests/gateway/test_format_session_info_overrides.py -v` → 4 passed
2. Run the broader session-info + model-override regression suite: `venv/bin/python -m pytest tests/gateway/test_session_info.py tests/gateway/test_session_model_override_persistence.py tests/gateway/test_session_model_override_credential_pool.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_session_model_reset.py tests/gateway/test_session_reset_notify.py tests/gateway/test_format_session_info_overrides.py -q` → 50 passed
3. Manual: pin a Telegram thread via `channel_overrides`, send `/new`, confirm the banner reports the pinned model rather than the global default

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, docstring in `_format_session_info` was updated inline
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, gateway logic is platform-agnostic