### PR TITLE
fix(secrets): pass OP_LOAD_DESKTOP_APP_SETTINGS through to the op child env

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -98,6 +98,9 @@ _OP_ENV_ALLOWLIST = (
     "OP_ACCOUNT",
     "OP_CONNECT_HOST",
     "OP_CONNECT_TOKEN",
+    # Lets a user skip op's desktop-app integration probe (which can hang with
+    # no timeout on a wedged desktop container) and go straight to token auth.
+    "OP_LOAD_DESKTOP_APP_SETTINGS",
 )
 
 

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -214,6 +214,31 @@ def test_fetch_child_env_is_allowlisted(monkeypatch, tmp_path):
     assert env.get("NO_COLOR") == "1"
 
 
+def test_fetch_child_env_passes_load_desktop_app_settings(monkeypatch, tmp_path):
+    """OP_LOAD_DESKTOP_APP_SETTINGS must reach the op child when the user sets it.
+
+    On a headless box with a valid service-account token but a wedged 1Password
+    desktop app, `op read` hangs on the desktop-settings probe unless
+    OP_LOAD_DESKTOP_APP_SETTINGS=false is passed through. It's an allowlisted
+    var, so a user who exports it should see it in the op child env.
+    """
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_tok")
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _ok("v")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, binary=fake_op, use_cache=False
+    )
+    assert captured["env"].get("OP_LOAD_DESKTOP_APP_SETTINGS") == "false"
+
+
 # ---------------------------------------------------------------------------
 # Caching
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds `OP_LOAD_DESKTOP_APP_SETTINGS` to the 1Password secret source's `_OP_ENV_ALLOWLIST` so the variable actually reaches the `op read` child process.

`agent/secret_sources/onepassword.py` builds a deliberately minimal, allowlisted environment for the `op` child (good defense-in-depth — the post-dotenv parent env holds every provider credential). But the allowlist omits `OP_LOAD_DESKTOP_APP_SETTINGS`, so a user who exports it in their shell / `.env` / service unit sees it **silently stripped** before it reaches `op`. That variable is exactly the documented escape hatch for a headless hang, and it currently has no effect on the machines that need it.

## Related Issue

No existing issue/PR (searched open + closed PRs and issues for `OP_LOAD_DESKTOP_APP_SETTINGS`, "onepassword allowlist env", "op child env allowlist" — none found).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/secret_sources/onepassword.py`: add `OP_LOAD_DESKTOP_APP_SETTINGS` to `_OP_ENV_ALLOWLIST`, with a comment explaining the failure mode.
- `tests/test_onepassword_secrets.py`: add `test_fetch_child_env_passes_load_desktop_app_settings` alongside the existing `test_fetch_child_env_is_allowlisted` (which continues to assert unrelated provider creds are NOT inherited).

## Background — why this matters

When the 1Password **desktop app** is installed, the `op` CLI probes the desktop app's settings/socket at startup to decide whether to integrate with it — **before** it evaluates service-account auth. If the desktop app's group container is in a wedged state (a recurring macOS failure where operations on `~/Library/Group Containers/2BUA8C4S2C.com.1password/` return `Interrupted system call`), that probe **blocks with no timeout**, so `op read` hangs indefinitely — even though a perfectly valid `OP_SERVICE_ACCOUNT_TOKEN` is present and would authenticate fine.

`op`'s documented fix is `OP_LOAD_DESKTOP_APP_SETTINGS=false`, which tells it to skip the desktop probe and go straight to token auth. On a headless box (gateway under launchd/systemd, no interactive desktop session) this is the correct and necessary setting. But because Hermes strips it from the child env, exporting it has no effect — the hang persists, and the only workaround is wrapping the `op` binary itself, which is brittle (a `brew upgrade`/reinstall of the CLI silently removes the wrapper).

This is a passthrough-only change: it does not set the variable, change any default, or alter behavior when the variable is unset. It just stops discarding a documented `op` env var that a user explicitly provided.

## How to Test

1. On a machine with the 1Password desktop app installed and its group container in the wedged state (or simulate by any condition that makes the desktop probe block), export a valid `OP_SERVICE_ACCOUNT_TOKEN` and an `op://` reference in `secrets.onepassword.env`.
2. Without this change: `op read` (and thus gateway startup secret resolution) hangs indefinitely even with `OP_LOAD_DESKTOP_APP_SETTINGS=false` exported, because Hermes strips the var before spawning `op`. (Observed: 600s+ hang / timeout.)
3. With this change: the var reaches `op`, the desktop probe is skipped, and `op read` returns in a few seconds. (Observed: ~4s, exit 0.)

Automated:
```
pytest tests/test_onepassword_secrets.py -q
```
`test_fetch_child_env_passes_load_desktop_app_settings` asserts the var reaches the child env when set; `test_fetch_child_env_is_allowlisted` continues to assert unrelated provider creds are not inherited. All 24 tests in the file pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(secrets):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected tests and they pass (`tests/test_onepassword_secrets.py`, 24 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comment on the allowlist entry documents the failure mode) — the var is `op`'s own, no Hermes config key added, so `cli-config.yaml.example` is N/A
- [x] `cli-config.yaml.example` — N/A (no new/changed Hermes config key; this is a pre-existing `op` CLI env var)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — allowlist entry is inert on platforms/sessions that don't set the var; the desktop-probe hang is macOS-specific but the passthrough is harmless everywhere
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

A/B on an affected macOS machine (SA token present, desktop container wedged), same `op://` reference:

- **Without** `OP_LOAD_DESKTOP_APP_SETTINGS` reaching `op`: `op read` timed out (600s+).
- **With** it reaching `op` (`OP_LOAD_DESKTOP_APP_SETTINGS=false`): `real 4.47s`, exit 0, correct value returned.
