### PR TITLE
fix(browser): guard Camofox command-timeout cache against concurrent-read race

### DIFF
--- a/tests/tools/test_browser_camofox_timeout.py
+++ b/tests/tools/test_browser_camofox_timeout.py
@@ -67,3 +67,27 @@ class TestCamofoxCommandTimeout:
 
         with patch("tools.browser_camofox.read_raw_config", side_effect=Exception("no config")):
             assert _get_command_timeout() == 30
+
+    def test_never_returns_none_under_concurrent_race_state(self):
+        """A concurrent reader must never observe resolved=True with a None cache.
+
+        The tail of ``_get_command_timeout`` used to flip ``_cmd_timeout_resolved``
+        to True *before* assigning ``_cached_cmd_timeout``, with a GIL-releasing
+        ``read_raw_config()`` file read in between. A second thread hitting the
+        early-return guard in that window saw ``resolved=True`` and returned the
+        still-``None`` cache, which flows straight into
+        ``requests(..., timeout=None)`` — an indefinite hang. Reproduce the
+        corrupted intermediate state directly: the guard must re-derive a real
+        value instead of returning ``None``.
+        """
+        import tools.browser_camofox as mod
+
+        mod._cmd_timeout_resolved = True
+        mod._cached_cmd_timeout = None
+
+        with patch("tools.browser_camofox.read_raw_config", return_value={}):
+            result = mod._get_command_timeout()
+
+        assert result == 30
+        assert isinstance(result, int)
+        assert mod._get_command_timeout() is not None

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -64,10 +64,9 @@ def _get_command_timeout() -> int:
     Result is cached after the first call.
     """
     global _cached_cmd_timeout, _cmd_timeout_resolved
-    if _cmd_timeout_resolved:
-        return _cached_cmd_timeout  # type: ignore[return-value]
+    if _cmd_timeout_resolved and _cached_cmd_timeout is not None:
+        return _cached_cmd_timeout
 
-    _cmd_timeout_resolved = True
     result = _DEFAULT_TIMEOUT
     try:
         cfg = read_raw_config()
@@ -76,7 +75,11 @@ def _get_command_timeout() -> int:
             result = max(int(val), 5)  # floor at 5s
     except Exception as exc:
         logger.debug("Could not read browser.command_timeout: %s", exc)
+    # Assign the cached value BEFORE flipping the resolved flag so a
+    # concurrent reader cannot observe ``resolved=True`` while the cache
+    # is still ``None`` (see issue #14331).
     _cached_cmd_timeout = result
+    _cmd_timeout_resolved = True
     return result
 
 


### PR DESCRIPTION
## This is a sibling follow-up to #14331

- **What #14331 covered:** hardened `tools.browser_tool._get_command_timeout` so a concurrent reader can never observe `resolved=True` with a `None` cache (assign the cache before flipping the flag; guard the early return with `and _cached_command_timeout is not None`).
- **What #14331 did NOT touch:** the Camofox twin `tools.browser_camofox._get_command_timeout`, which was added later to mirror `browser_tool` (per its own docstring) but never received the #14331 hardening.
- **What this adds:** the same race guard on the Camofox resolver.

## What does this PR do?

Fixes a concurrent-read race in `tools/browser_camofox.py:_get_command_timeout()`. The function flipped `_cmd_timeout_resolved = True` **before** assigning `_cached_cmd_timeout = result`, with a GIL-releasing `read_raw_config()` file read in between. A second thread hitting the early-return guard during that window saw `resolved=True` and returned the still-`None` cache.

That `None` is not benign here: every Camofox HTTP helper (`_post`, `_get`, `_get_raw`, `_delete`, `_ensure_tab`) defaults its timeout to `_get_command_timeout()`, so a `None` result becomes `requests.post(..., timeout=None)` — an **indefinite hang** rather than the intended 30s default. These helpers are invoked concurrently by subagents, so the window is reachable in normal operation. (The pre-fix `browser_tool` twin failed loudly with `TypeError` on `max(None, ...)`; the Camofox path fails silently by hanging, which is strictly worse.)

The fix mirrors the sibling `browser_tool._get_command_timeout` exactly:
- require a non-`None` cache in the resolved-guard, and
- assign `_cached_cmd_timeout` **before** setting `_cmd_timeout_resolved = True`, with the same `# ... (see issue #14331)` comment.

A concurrent reader now either sees `resolved=False` (recomputes) or `resolved=True` with a fully-populated non-`None` cache. Never `None`.

## Related Issue

<!-- Code-originated finding; no filed issue. Sibling of #14331. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_camofox.py`: guard the early return with `_cmd_timeout_resolved and _cached_cmd_timeout is not None`; assign the cache before flipping the resolved flag (mirrors `browser_tool`, references #14331).
- `tests/tools/test_browser_camofox_timeout.py`: add `test_never_returns_none_under_concurrent_race_state`, which sets the corrupted intermediate state (`resolved=True`, cache `None`) and asserts the resolver re-derives a real value instead of returning `None`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_browser_camofox_timeout.py -v` — 6 pass.
2. Fail-before/pass-after: revert only the prod hunk and re-run the new test — it fails with `assert None == 30`. Restore the hunk — it passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A