### PR TITLE
fix(dashboard-auth): don't auto-SSO a password-only provider (blank 500 screen)

### DIFF
--- a/hermes_cli/dashboard_auth/base.py
+++ b/hermes_cli/dashboard_auth/base.py
@@ -178,6 +178,16 @@ class DashboardAuthProvider(ABC):
     # supports_token.
     supports_session: bool = True
 
+    # When True, this provider implements the interactive OAuth redirect flow
+    # (``start_login`` returns a real ``LoginStart`` / ``complete_login`` runs
+    # the auth-code exchange). The gate's silent auto-SSO optimization
+    # (``_auto_sso_response``) only fires for such providers; a password-only
+    # provider leaves this False so the gate falls through to the ``/login``
+    # credential form instead of bouncing the browser to ``/auth/login``
+    # (whose ``start_login`` would raise NotImplementedError → HTTP 500).
+    # Mirrors supports_password / supports_token / supports_session.
+    supports_oauth: bool = True
+
     @abstractmethod
     def start_login(self, *, redirect_uri: str) -> LoginStart: ...
 

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # The single provider must actually implement the OAuth redirect flow.
+    # A password-only provider (supports_oauth=False) has no /auth/login
+    # target — bouncing to it raises NotImplementedError → HTTP 500 (blank
+    # screen). Fall through to the /login credential form instead.
+    if not getattr(provider, "supports_oauth", True):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -204,6 +204,9 @@ class BasicAuthProvider(DashboardAuthProvider):
     name = "basic"
     display_name = "Username & Password"
     supports_password = True
+    # Pure-password provider: no OAuth redirect flow (start_login raises).
+    # Tells the gate not to auto-SSO to /auth/login (which would 500).
+    supports_oauth = False
 
     def __init__(
         self,

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -407,6 +407,69 @@ class TestAutoSsoRedirect:
         assert "/auth/login" not in r.headers["location"]
 
 
+class TestPasswordOnlyProviderNoAutoSso:
+    """Regression: a single PASSWORD-ONLY provider (``supports_oauth=False``)
+    must NOT be auto-SSO'd to ``/auth/login``.
+
+    ``/auth/login`` initiates the OAuth redirect flow by calling the
+    provider's ``start_login``. A password-only provider raises
+    ``NotImplementedError`` there, so auto-bouncing to it returned HTTP 500 —
+    a blank ("black") screen for self-hosters using basic-auth without OAuth.
+    The gate must instead fall through to the ``/login`` credential form.
+    """
+
+    @pytest.fixture
+    def gated_pw_app(self):
+        class _PasswordOnlyStub(StubAuthProvider):
+            name = "pwonly"
+            display_name = "Password Only (test)"
+            supports_password = True
+            supports_oauth = False
+
+            def start_login(self, *, redirect_uri: str):
+                # Mirrors the real BasicAuthProvider: no OAuth redirect flow.
+                raise NotImplementedError(
+                    "password-only provider has no OAuth redirect"
+                )
+
+        clear_providers()
+        register_provider(_PasswordOnlyStub())
+        prev_host = getattr(web_server.app.state, "bound_host", None)
+        prev_port = getattr(web_server.app.state, "bound_port", None)
+        prev_required = getattr(web_server.app.state, "auth_required", None)
+        web_server.app.state.bound_host = "fly-app.fly.dev"
+        web_server.app.state.bound_port = 443
+        web_server.app.state.auth_required = True
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev"
+        )
+        yield client
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+    def test_unauth_html_load_falls_through_to_login_not_500(
+        self, gated_pw_app
+    ):
+        """The core regression: unauth HTML load with a lone password-only
+        provider redirects to ``/login`` (the credential form), never to
+        ``/auth/login`` (which would 500)."""
+        r = gated_pw_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
+    def test_following_redirects_reaches_login_form_200(self, gated_pw_app):
+        """End-to-end: following the redirect chain lands on the rendered
+        login form (HTTP 200), not an Internal Server Error."""
+        r = gated_pw_app.get("/", follow_redirects=True)
+        assert r.status_code == 200
+        assert str(r.url).rstrip("/").endswith("/login") or "/login" in str(
+            r.url
+        )
+
+
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A single **password-only** auth provider (the built-in `basic` plugin) makes the dashboard return **HTTP 500 — a blank/black screen** on any unauthenticated page load, with no way to reach the working login form.

The gate's silent auto-SSO optimization (`_auto_sso_response` in `hermes_cli/dashboard_auth/middleware.py`) fires whenever exactly one interactive provider is registered, redirecting an unauthenticated HTML load straight to `/auth/login` (the OAuth redirect-initiation route). It never checked whether that provider actually implements the OAuth flow.

For a password-only provider, `/auth/login` calls `start_login()`, which raises `NotImplementedError` **by design** (the provider POSTs to `/auth/password-login` instead). So the browser gets a 500 and never sees the `/login` credential form.

This breaks the dashboard for the common **self-hosted LAN / homelab** case: bind to a non-loopback interface, configure `dashboard.basic_auth`, no OAuth.

## Root cause

`_auto_sso_response` picks the lone provider and unconditionally builds a `/auth/login?provider=<name>` redirect:

```python
provider = providers[0]
auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
```

`/auth/login` → `provider.start_login()` → `NotImplementedError` → 500.

## Fix

Follows the existing capability-flag pattern (`supports_password` / `supports_token` / `supports_session`):

- Add `supports_oauth: bool = True` to `DashboardAuthProvider` (base.py).
- Set `supports_oauth = False` on `BasicAuthProvider` (basic plugin).
- Guard `_auto_sso_response` on the flag — a provider that doesn't do OAuth falls through to the `/login` credential form instead of being bounced to `/auth/login`.

Behavior change is limited to the password-only case. OAuth providers (`supports_oauth` defaults to `True`) are unaffected; all existing `TestAutoSsoRedirect` tests still pass.

## Testing

New regression class `TestPasswordOnlyProviderNoAutoSso` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py` drives the **real** `gated_auth_middleware` with a lone password-only provider whose `start_login` raises, and asserts:

- unauth HTML load → 302 to `/login` (not `/auth/login`)
- followed redirect chain → 200 (renders the form), not 500

Verified the new tests **fail without** the middleware guard (reproducing the exact production `NotImplementedError`) and **pass with** it.

```
tests/hermes_cli/test_dashboard_auth_401_reauth.py ......... 46 passed
tests/plugins/dashboard_auth/test_basic_provider.py ....... }
tests/hermes_cli/test_dashboard_auth_password_login.py .... } 41 passed
```

## Repro (before this PR)

1. `hermes config set dashboard.basic_auth.username … / password_hash … / secret …`
2. `hermes dashboard --host 0.0.0.0 --port 9119`
3. Open `http://<lan-ip>:9119/` → blank screen; `GET /auth/login?provider=basic` returns 500.
