### PR TITLE
fix(tui_gateway): normalize slash-command case in live-agent mirror

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5520,6 +5520,60 @@ def test_mirror_slash_side_effects_allowed_when_idle(monkeypatch):
     assert applied["model"]
 
 
+def test_mirror_slash_side_effects_normalizes_command_case(monkeypatch):
+    """Mixed-case slash names must mirror onto the live agent.
+
+    The worker dispatch (cli.py ``command.lower()``) and the slash.exec
+    router (``_cmd_base.lower()``) both lowercase the command name, but
+    ``_mirror_slash_side_effects`` used ``parts[0]`` raw. A mixed-case
+    ``/MODEL`` therefore ran in the throwaway worker yet silently skipped
+    the live-agent mirror, leaving the gateway agent on the old model.
+    The arg must stay case-preserving (model IDs are case-sensitive).
+    """
+    import types
+
+    applied = {"arg": None}
+
+    def _fake_apply_model(sid, session, arg):
+        applied["arg"] = arg
+        return {"value": arg, "warning": ""}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply_model)
+
+    session = _session(running=False)
+    session["agent"] = types.SimpleNamespace(model="x")
+
+    warning = server._mirror_slash_side_effects(
+        "sid", session, "/MODEL anthropic/Claude-X"
+    )
+    assert "session busy" not in warning
+    assert applied["arg"] == "anthropic/Claude-X", (
+        "mixed-case /MODEL should mirror onto the live agent with the "
+        "case-preserved model id"
+    )
+
+
+def test_mirror_slash_side_effects_running_guard_is_case_insensitive(monkeypatch):
+    """The in-flight ``_MUTATES_WHILE_RUNNING`` guard must also fire for a
+    mixed-case name — otherwise ``/MODEL`` mutates live agent state mid-turn."""
+    import types
+
+    applied = {"model": False}
+
+    def _fake_apply_model(sid, session, arg):
+        applied["model"] = True
+        return {"value": arg, "warning": ""}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply_model)
+
+    session = _session(running=True)
+    session["agent"] = types.SimpleNamespace(model="x")
+
+    warning = server._mirror_slash_side_effects("sid", session, "/MODEL foo")
+    assert "session busy" in warning
+    assert not applied["model"], "model switch fired mid-turn for mixed-case name"
+
+
 def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     """Regression guard: /compress side effect must not hold history_lock
     when calling _compress_session_history (the helper snapshots under

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12971,7 +12971,14 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     if not parts:
         return ""
     name, arg, agent = (
-        parts[0],
+        # Normalize the command name to match the worker dispatch
+        # (cli.py does ``command.lower()``) and the slash.exec router
+        # (which lowercases ``_cmd_base``).  A mixed-case ``/Model`` would
+        # otherwise match none of the lowercase branches below, silently
+        # skipping the live-agent mirror and bypassing the in-flight
+        # ``_MUTATES_WHILE_RUNNING`` guard.  ``arg`` stays case-preserving
+        # (model IDs / personality names are case-sensitive).
+        parts[0].lower(),
         (parts[1].strip() if len(parts) > 1 else ""),
         session.get("agent"),
     )


### PR DESCRIPTION
## What does this PR do?

Fixes a case-sensitivity bug in `tui_gateway/server.py:_mirror_slash_side_effects()`, which applies slash-command side effects that must also hit the gateway's **live** agent (model / personality / system-prompt / compress).

The function bound `name = parts[0]` raw-case, then compared it against lowercase literals for both the `_MUTATES_WHILE_RUNNING` in-flight guard and every side-effect branch (`if name == "model"`, `elif name == "personality"`, …). The other two legs of the slash path lowercase the name:

- the `slash.exec` router lowercases `_cmd_base` (`server.py`), and
- the throwaway slash worker's `HermesCLI.process_command` does `command.lower().strip()` (`cli.py`).

The call site passes the **raw** command to both `worker.run(cmd)` (which lowercases internally) and `_mirror_slash_side_effects(..., cmd)` (which did not).

So a mixed-case `/Model x`, `/PROMPT`, `/Personality …` — as a worker-routed (desktop-chat) client can emit — ran in the throwaway worker and reported success, but matched **no** branch in the mirror. The gateway's live agent kept the old model / personality / system prompt, and the running-turn `_MUTATES_WHILE_RUNNING` guard (added in #12548) was bypassed, letting the mutation race an in-flight turn.

Mirrors the existing dispatch precedence: both the worker (`cli.py`, `command.lower()`) and the router (`_cmd_base.lower()`) lowercase the name — this normalizes the third leg to match. `arg` is left case-preserving (model IDs and personality names are case-sensitive).

## Related Issue

<!-- Code-originated finding; no filed issue. Re-arms the guard from #12548. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: bind `name = parts[0].lower()` in `_mirror_slash_side_effects` (with a comment noting the parity with the worker / router legs); `arg` unchanged.
- `tests/test_tui_gateway_server.py`: add two regression tests — `test_mirror_slash_side_effects_normalizes_command_case` (mixed-case `/MODEL` mirrors onto the live agent with the case-preserved id) and `test_mirror_slash_side_effects_running_guard_is_case_insensitive` (the in-flight guard fires for `/MODEL` mid-turn).

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/test_tui_gateway_server.py -k mirror_slash -v` — 5 pass.
2. Fail-before/pass-after: revert only the `.lower()` prod hunk and re-run the two new tests — they fail (`assert 'session busy' in ''`; the arg assert never fires). Restore — both pass.
3. Full file: `pytest tests/test_tui_gateway_server.py -q` — 318 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A