### PR TITLE
fix(installer): verify SSH clone produced a valid repo before proceeding

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1273,7 +1273,9 @@ clone_repo() {
         # so SSH fails fast instead of hanging when no key is configured.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null \
+           && [ -d "$INSTALL_DIR/.git" ] \
+           && git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone


### PR DESCRIPTION
## Summary

On Lightning.ai Ubuntu VM studios (and potentially other environments), git clone via SSH exits with code 0 but doesn't actually produce a valid clone — no `.git` directory, no checked-out files. Since the script trusted only the exit code, it skipped the HTTPS fallback and the install failed.

## Change

Add two post-clone verification checks after the SSH clone attempt:

1. `[ -d "\$INSTALL_DIR/.git" ]` — verify the .git directory exists
2. `git -C "\$INSTALL_DIR" rev-parse --verify HEAD` — verify the repo has at least one commit

If either check fails, the script treats the SSH clone as failed and falls through to the HTTPS fallback, which was the original intent.

Fixes #62132