### PR TITLE
fix(docker): create re-seeded auth.json at 0o600 to close a credential-exposure window

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -437,9 +437,19 @@ if [ ! -f "$HERMES_HOME/auth.json" ] && [ -n "${HERMES_AUTH_JSON_BOOTSTRAP:-}" ]
     if refuse_symlinked_path "seed" "$HERMES_HOME/auth.json"; then
         :
     else
-        printf '%s' "$HERMES_AUTH_JSON_BOOTSTRAP" > "$HERMES_HOME/auth.json"
-        chown hermes:hermes "$HERMES_HOME/auth.json" 2>/dev/null || true
-        chmod 600 "$HERMES_HOME/auth.json"
+        # The bootstrap contains bearer tokens. Set the temporary file's mode
+        # before printf serializes any bytes, then rename within HERMES_HOME.
+        auth_tmp="$(mktemp "$HERMES_HOME/.auth.json.bootstrap.XXXXXX")"
+        if ! chmod 600 "$auth_tmp" || \
+                ! printf '%s' "$HERMES_AUTH_JSON_BOOTSTRAP" > "$auth_tmp"; then
+            rm -f "$auth_tmp"
+            exit 1
+        fi
+        chown hermes:hermes "$auth_tmp" 2>/dev/null || true
+        if ! mv -f "$auth_tmp" "$HERMES_HOME/auth.json"; then
+            rm -f "$auth_tmp"
+            exit 1
+        fi
     fi
 fi
 

--- a/scripts/docker_rebootstrap_nous_session.py
+++ b/scripts/docker_rebootstrap_nous_session.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -187,10 +188,32 @@ def reseed_if_terminal(auth_path: str, seed_raw: str) -> str:
     # Surgical replacement: swap ONLY providers.nous, preserve everything else.
     providers["nous"] = seed_nous
 
-    tmp_path = f"{auth_path}.rebootstrap.tmp"
-    with open(tmp_path, "w", encoding="utf-8") as fh:
-        json.dump(store, fh)
-    os.replace(tmp_path, auth_path)
+    # Create the temp file with 0o600 atomically via os.open(O_EXCL) so the
+    # freshly-seeded Nous refresh_token (plus every preserved provider token in
+    # ``store``) is never written to a world-/group-readable file, even
+    # transiently. A plain open() created it at the process umask — this runs
+    # as an early Docker boot-hook subprocess, typically root with umask 0 or
+    # 022, so the tokens hit disk at 0o666/0o644 — and the post-replace chmod
+    # both left a disclosure window before it ran and, on any volume/overlay
+    # where chmod is unsupported or denied, left the file permanently loose
+    # (the except below silently swallows that). Mirrors the O_EXCL/0o600
+    # hardening in hermes_cli/auth.py (#19673, #21148). A per-process random
+    # suffix avoids a fixed-name collision making O_EXCL raise on a stale temp.
+    tmp_path = f"{auth_path}.rebootstrap.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(store, fh)
+        os.replace(tmp_path, auth_path)
+    finally:
+        try:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+        except OSError:
+            pass
+    # Defense in depth: the O_EXCL create above already guarantees 0o600 and
+    # os.replace preserves that mode, so this cannot widen the window — kept
+    # only to re-tighten if some future caller reuses an existing auth.json.
     try:
         os.chmod(auth_path, 0o600)
     except OSError:

--- a/scripts/docker_rebootstrap_nous_session.py
+++ b/scripts/docker_rebootstrap_nous_session.py
@@ -202,7 +202,21 @@ def reseed_if_terminal(auth_path: str, seed_raw: str) -> str:
     tmp_path = f"{auth_path}.rebootstrap.{os.getpid()}.{uuid.uuid4().hex}.tmp"
     fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        # os.fdopen did NOT take ownership of the descriptor (it can raise
+        # before returning, e.g. ENOMEM allocating the stream buffer), so the
+        # `with` below never runs and can't close it. Close the raw fd here to
+        # avoid leaking it, drop the just-created temp file, then re-raise so
+        # the caller's fail-safe handler still sees the error.
+        os.close(fd)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    try:
+        with fh:
             json.dump(store, fh)
         os.replace(tmp_path, auth_path)
     finally:

--- a/tests/tools/test_docker_rebootstrap_nous_session.py
+++ b/tests/tools/test_docker_rebootstrap_nous_session.py
@@ -354,6 +354,56 @@ def test_reseeded_file_is_0600_even_when_chmod_fails(tmp_path, monkeypatch):
         os.umask(old_umask)
 
 
+def test_fdopen_failure_closes_fd_and_removes_temp(tmp_path, monkeypatch):
+    """If os.fdopen() raises after os.open() succeeds, the raw descriptor must
+    be closed (not leaked) and the just-created temp file removed, and the error
+    must propagate.
+
+    Before the fix os.fdopen was called directly in the `with` header, so a
+    raise there never handed the fd to the context manager: the `with`'s
+    __exit__ never ran, the `finally` only unlinked tmp_path, and the raw fd
+    leaked for the life of the process."""
+    auth = _write_auth(tmp_path, {"nous": _terminal_nous_state()})
+
+    opened_fds: list[int] = []
+    closed_fds: list[int] = []
+
+    real_open = mod.os.open
+    real_close = mod.os.close
+
+    def _spy_open(path, flags, *a, **k):
+        fd = real_open(path, flags, *a, **k)
+        # Only track the rebootstrap temp descriptor, not unrelated opens.
+        if str(path).endswith(".tmp"):
+            opened_fds.append(fd)
+        return fd
+
+    def _spy_close(fd, *a, **k):
+        closed_fds.append(fd)
+        return real_close(fd, *a, **k)
+
+    def _boom_fdopen(*_a, **_k):
+        raise OSError("Cannot allocate memory")
+
+    monkeypatch.setattr(mod.os, "open", _spy_open)
+    monkeypatch.setattr(mod.os, "close", _spy_close)
+    monkeypatch.setattr(mod.os, "fdopen", _boom_fdopen)
+
+    with pytest.raises(OSError, match="Cannot allocate memory"):
+        mod.reseed_if_terminal(auth, _FRESH_SEED)
+
+    # The temp fd was opened exactly once...
+    assert len(opened_fds) == 1, "expected the rebootstrap temp file to be opened once"
+    # ...and that exact fd was closed (no leak).
+    assert opened_fds[0] in closed_fds, "raw fd from os.open was leaked on fdopen failure"
+    # The just-created temp file was cleaned up.
+    leftover = list(tmp_path.glob("auth.json.rebootstrap.*.tmp"))
+    assert leftover == [], f"temp file left behind after fdopen failure: {leftover}"
+    # The original auth.json was left exactly as-is (still terminal).
+    store = json.loads(Path(auth).read_text())
+    assert store["providers"]["nous"]["last_auth_error"]["relogin_required"] is True
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
 def test_reseeded_temp_is_never_created_group_or_world_readable(tmp_path, monkeypatch):
     """The tokens must never touch disk at a loose mode, even transiently.

--- a/tests/tools/test_docker_rebootstrap_nous_session.py
+++ b/tests/tools/test_docker_rebootstrap_nous_session.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import stat
 from pathlib import Path
+
+import pytest
 
 # Import the stdlib-only boot helper by path (it lives under scripts/, not an
 # installed package) — mirrors the repo's other scripts/-helper tests.
@@ -325,3 +329,56 @@ def test_terminal_entry_missing_marker_is_not_terminal(tmp_path):
     entry) → not terminal, no re-seed."""
     auth = _write_auth(tmp_path, {"nous": {"client_id": "hermes-cli-vps"}})
     assert mod.reseed_if_terminal(auth, _FRESH_SEED) == "not_terminal"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
+def test_reseeded_file_is_0600_even_when_chmod_fails(tmp_path, monkeypatch):
+    """The re-seeded auth.json must be 0o600 even if the post-write chmod
+    raises. Before the fix the file was created with a plain open() at the
+    process umask (0o666 under umask 0) and only tightened by a chmod whose
+    OSError was silently swallowed — so a chmod failure left the fresh Nous
+    refresh_token permanently world-readable."""
+    old_umask = os.umask(0)
+    try:
+        auth = _write_auth(tmp_path, {"nous": _terminal_nous_state()})
+
+        def _no_chmod(*_a, **_k):
+            raise OSError("chmod unsupported on this volume")
+
+        monkeypatch.setattr(mod.os, "chmod", _no_chmod)
+
+        assert mod.reseed_if_terminal(auth, _FRESH_SEED) == "reseeded"
+        mode = stat.S_IMODE(os.stat(auth).st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    finally:
+        os.umask(old_umask)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file-mode semantics")
+def test_reseeded_temp_is_never_created_group_or_world_readable(tmp_path, monkeypatch):
+    """The tokens must never touch disk at a loose mode, even transiently.
+
+    Spy on os.replace to capture the temp file's mode at rename time (i.e.
+    the mode the secrets were written at). Before the fix the temp file was
+    created via plain open() at the process umask, so this window was 0o666
+    under umask 0."""
+    old_umask = os.umask(0)
+    try:
+        auth = _write_auth(tmp_path, {"nous": _terminal_nous_state()})
+
+        real_replace = mod.os.replace
+        captured = {}
+
+        def _spy_replace(src, dst, *a, **k):
+            captured["mode"] = stat.S_IMODE(os.stat(src).st_mode)
+            return real_replace(src, dst, *a, **k)
+
+        monkeypatch.setattr(mod.os, "replace", _spy_replace)
+
+        assert mod.reseed_if_terminal(auth, _FRESH_SEED) == "reseeded"
+        assert captured["mode"] == 0o600, (
+            f"tokens written to a temp file at {oct(captured['mode'])} — "
+            "must be 0o600 with no group/world bits"
+        )
+    finally:
+        os.umask(old_umask)

--- a/tests/tools/test_stage2_hook_seed_one_symlinks.py
+++ b/tests/tools/test_stage2_hook_seed_one_symlinks.py
@@ -140,7 +140,7 @@ def test_auth_bootstrap_serializes_only_after_owner_mode_is_set(
         "printf() {\n"
         '    for target in "$HERMES_HOME"/auth.json "$HERMES_HOME"/.auth.json.bootstrap.*; do\n'
         '        [ -f "$target" ] || continue\n'
-        '        mode="$(stat -f \'%Lp\' "$target" 2>/dev/null || stat -c \'%a\' "$target")"\n'
+        '        mode="$(stat -c \'%a\' "$target" 2>/dev/null || stat -f \'%Lp\' "$target")"\n'
         '        if [ "$mode" != 600 ]; then\n'
         '            command printf \'%s\\n\' "$mode" > "$MODE_LOG"\n'
         "            return 1\n"

--- a/tests/tools/test_stage2_hook_seed_one_symlinks.py
+++ b/tests/tools/test_stage2_hook_seed_one_symlinks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 
@@ -31,6 +32,12 @@ def _seed_one_function(text: str) -> str:
 def _path_guard_functions(text: str) -> str:
     start = text.index("path_has_symlink_component() {")
     end = text.index("\n\nchown_hermes_tree() {", start)
+    return text[start:end]
+
+
+def _auth_bootstrap_block(text: str) -> str:
+    start = text.index('if [ ! -f "$HERMES_HOME/auth.json" ]')
+    end = text.index("\n\n# auth.json: re-seed", start)
     return text[start:end]
 
 
@@ -108,3 +115,49 @@ def test_seed_one_is_quiet_for_existing_symlinked_files(
     assert proc.returncode == 0, proc.stderr
     assert outside_env.read_text() == "EXISTING=1\n"
     assert proc.stdout == ""
+
+
+def test_auth_bootstrap_serializes_only_after_owner_mode_is_set(
+    stage2_text: str,
+    tmp_path: Path,
+) -> None:
+    shell = shutil.which("sh")
+    if shell is None:
+        pytest.skip("sh not available")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    observed_mode = tmp_path / "observed-mode"
+    auth_path = home / "auth.json"
+    script = (
+        "set -eu\n"
+        "umask 000\n"
+        f'HERMES_HOME="{home}"\n'
+        "HERMES_AUTH_JSON_BOOTSTRAP='{\"access_token\":\"secret\"}'\n"
+        f'MODE_LOG="{observed_mode}"\n'
+        'as_hermes() { "$@"; }\n'
+        "chown() { :; }\n"
+        "printf() {\n"
+        '    for target in "$HERMES_HOME"/auth.json "$HERMES_HOME"/.auth.json.bootstrap.*; do\n'
+        '        [ -f "$target" ] || continue\n'
+        '        mode="$(stat -f \'%Lp\' "$target" 2>/dev/null || stat -c \'%a\' "$target")"\n'
+        '        if [ "$mode" != 600 ]; then\n'
+        '            command printf \'%s\\n\' "$mode" > "$MODE_LOG"\n'
+        "            return 1\n"
+        "        fi\n"
+        "    done\n"
+        '    command printf "$@"\n'
+        "}\n"
+        f"{_path_guard_functions(stage2_text)}\n"
+        f"{_auth_bootstrap_block(stage2_text)}\n"
+    )
+    script_path = tmp_path / "harness.sh"
+    script_path.write_text(script)
+
+    proc = subprocess.run([shell, str(script_path)], capture_output=True, text=True)
+
+    assert proc.returncode == 0, proc.stderr
+    assert not observed_mode.exists()
+    assert auth_path.read_text() == '{"access_token":"secret"}'
+    assert stat.S_IMODE(auth_path.stat().st_mode) == 0o600
+    assert not list(home.glob(".auth.json.bootstrap.*"))


### PR DESCRIPTION
## What does this PR do?

Closes a credential-exposure window in `scripts/docker_rebootstrap_nous_session.py`. The boot-time re-seed (`reseed_if_terminal`) writes the full multi-provider token store — a **freshly-issued Nous `refresh_token`/`access_token`** plus every other provider's preserved tokens — to a temp file at the process umask, then tightens the mode with a post-`os.replace` `chmod(0o600)`:

```python
tmp_path = f"{auth_path}.rebootstrap.tmp"
with open(tmp_path, "w", encoding="utf-8") as fh:   # created at umask → 0o666/0o644
    json.dump(store, fh)                            # secrets hit disk here
os.replace(tmp_path, auth_path)                     # auth.json inherits the loose mode
try:
    os.chmod(auth_path, 0o600)                      # tightened only AFTER
except OSError:
    pass                                            # chmod-fail → file left loose, silently
```

**Severity: medium (local credential disclosure).** This is a net-new finding, not a mechanical denylist widen.

### Attack flow
1. `stage2-hook.sh` invokes this script as an early boot subprocess — typically **root with umask 0 or 022**, so the temp file (and, after `os.replace`, `auth.json` itself) is created **0o666 / 0o644**: group- and world-readable.
2. The file now contains a live Nous `refresh_token` and every preserved provider token.
3. Any co-tenant UID / less-privileged process in the container (a compromised app worker, a sidecar, a non-root service user) can `open()` and read the tokens during the window between `os.replace` and `chmod`.
4. On any volume/overlay where `chmod` is unsupported or denied, the `except OSError: pass` swallows the failure and the file stays **permanently 0o666** — the window never closes.

### Fix
Create the temp file with `0o600` atomically via `os.open(..., O_WRONLY|O_CREAT|O_EXCL, 0o600)` + `os.fdopen`, using a per-process random suffix (`os.getpid()` + `uuid4().hex`) so a stale fixed-name temp can't make `O_EXCL` raise. The tokens are then never written to a loose-mode file even transiently, and the resulting `auth.json` no longer depends on the post-write `chmod` succeeding (kept as harmless defense-in-depth). This mirrors the exact O_EXCL/0o600 hardening already applied to `hermes_cli/auth.py` under #19673 / #21148 — this script was added later as a stdlib-only boot helper and re-implemented the write from scratch, missing the pattern.

## Related Issue

<!-- Code-originated security finding; no filed issue. Mirrors the auth.py hardening in #19673 / #21148. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `scripts/docker_rebootstrap_nous_session.py`: replace the plain `open()` temp write with an `os.open(O_EXCL, 0o600)` + `os.fdopen` create using a per-process random temp suffix, wrapped in `try/finally` cleanup; `import uuid`. Post-replace `chmod` retained as defense-in-depth.
- `tests/tools/test_docker_rebootstrap_nous_session.py`: add two POSIX regression tests under `umask(0)` — `test_reseeded_file_is_0600_even_when_chmod_fails` (chmod monkeypatched to raise → file still 0o600) and `test_reseeded_temp_is_never_created_group_or_world_readable` (spy on `os.replace` captures the temp mode at rename time → 0o600, no group/world bits).

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_docker_rebootstrap_nous_session.py -v` — 12 pass.
2. Fail-before/pass-after: revert only the prod hunk and re-run the two new tests — both fail (`tokens written to a temp file at 0o666`). Restore — both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11); tests guarded `skipif` on Windows (POSIX file-mode semantics)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A