### PR TITLE
fix(cron): preserve live one-shot run claims during stale cleanup

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1701,6 +1701,45 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
+def _run_claim_owner_process_alive(claim: Any) -> bool:
+    """Best-effort check that a stale-looking run claim still has a live owner.
+
+    ``run_claim.by`` defaults to ``<hostname>:<pid>``.  Fresh claims are already
+    protected by the TTL check; this helper only covers the edge where a
+    healthy one-shot outlives that TTL while another Hermes process scans the
+    same profile store.  Unknown/custom machine IDs remain recoverable.
+    """
+    if not isinstance(claim, dict):
+        return False
+    owner = str(claim.get("by") or "")
+    host, sep, pid_text = owner.rpartition(":")
+    if not sep or not host or not pid_text.isdecimal():
+        return False
+    try:
+        import socket
+
+        if host != socket.gethostname():
+            return False
+        pid = int(pid_text)
+    except Exception:
+        return False
+
+    try:
+        import psutil  # type: ignore
+
+        try:
+            proc = psutil.Process(pid)
+            return proc.status() != psutil.STATUS_ZOMBIE
+        except psutil.NoSuchProcess:
+            return False
+        except psutil.Error:
+            return psutil.pid_exists(pid)
+    except Exception:
+        # psutil is a core dependency, but if cron is imported in a stripped
+        # environment, do not turn stale-claim recovery into an import failure.
+        return False
+
+
 def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
@@ -2052,6 +2091,16 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                     "Job '%s': dispatch limit reached (%d/%d) "
                                     "but its run is still in flight in this "
                                     "process — keeping entry",
+                                    job.get("name", job.get("id", "?")),
+                                    completed,
+                                    times,
+                                )
+                                continue
+                            if _run_claim_owner_process_alive(job.get("run_claim")):
+                                logger.info(
+                                    "Job '%s': dispatch limit reached (%d/%d) "
+                                    "but its claiming process is still alive — "
+                                    "keeping entry",
                                     job.get("name", job.get("id", "?")),
                                     completed,
                                     times,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,5 +1,8 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
+import socket
+import subprocess
+import sys
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
@@ -1056,6 +1059,48 @@ class TestGetDueJobs:
                             lambda: t0 + timedelta(seconds=ttl + 10))
         recovered = get_due_jobs()
         assert [j["id"] for j in recovered] == ["wedged"]
+
+    def test_expired_one_shot_run_claim_is_preserved_for_live_owner(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A live peer can outlast the stale TTL; do not delete its job record."""
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        from cron.jobs import _hermes_now, _oneshot_run_claim_ttl_seconds
+
+        ttl = _oneshot_run_claim_ttl_seconds()
+        t0 = _hermes_now()
+        run_at = (t0 - timedelta(seconds=5)).isoformat()
+        claim_at = (t0 - timedelta(seconds=ttl + 10)).isoformat()
+        owner = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"]
+        )
+        try:
+            save_jobs([{
+                "id": "live-owner",
+                "name": "Live owner",
+                "prompt": "long one-shot",
+                "schedule": {"kind": "once", "run_at": run_at},
+                "next_run_at": run_at,
+                "enabled": True,
+                "state": "scheduled",
+                "repeat": {"times": 1, "completed": 1},
+                "run_claim": {
+                    "at": claim_at,
+                    "by": f"{socket.gethostname()}:{owner.pid}",
+                },
+            }])
+
+            monkeypatch.setattr("cron.jobs._hermes_now", lambda: t0)
+
+            assert get_due_jobs() == []
+            assert get_job("live-owner") is not None
+        finally:
+            owner.terminate()
+            try:
+                owner.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                owner.kill()
+                owner.wait(timeout=5)
 
     def test_run_claim_ttl_derived_from_cron_timeout(self, tmp_cron_dir, monkeypatch):
         """The stale-recovery TTL tracks HERMES_CRON_TIMEOUT (3x headroom), with


### PR DESCRIPTION
## Summary

This prevents finite one-shot cron jobs from being removed as stale while their claiming process is still alive.

A prior fix added durable `run_claim` state so concurrent schedulers do not double-execute one-shot jobs. The remaining edge case is the stale-cleanup path for finite one-shots: once `repeat.completed >= repeat.times` and the `run_claim` TTL has expired, `_get_due_jobs_locked()` removes the job record unless it can see the job running in the current process.

That current-process check does not cover another live Hermes process using the same profile cron store. If a long-running one-shot outlives the TTL while another process scans the store, the second process can delete the job record underneath the live run. When the original run later calls `mark_job_run()`, the job is gone, so final run state and delivery errors cannot be persisted.

## Changes

- Add a best-effort live owner check for `run_claim.by` values in the default `<hostname>:<pid>` form.
- Use `psutil` for cross-platform PID liveness instead of unsafe `os.kill(pid, 0)`.
- Keep stale recovery behavior unchanged for dead or unknown claim owners.
- Preserve a finite one-shot job record when the expired claim belongs to a live owner process.
- Add regression coverage with a real child process as the live claim owner.

## Tests

```text
python -m pytest tests/cron/test_jobs.py -k "run_claim or live_owner" -q
8 passed, 123 deselected

python -m pytest tests/cron/test_jobs.py -q
131 passed

python -m ruff check cron/jobs.py tests/cron/test_jobs.py