### PR TITLE
Add safely authorized ElevenLabs calls plugin

### DIFF
--- a/plugins/elevenlabs_calls/__init__.py
+++ b/plugins/elevenlabs_calls/__init__.py
@@ -1,0 +1,22 @@
+"""Bundled ElevenLabs outbound-calling plugin."""
+
+from __future__ import annotations
+
+from plugins.elevenlabs_calls.tools import (
+    ELEVENLABS_OUTBOUND_CALL_SCHEMA,
+    _check_available,
+    _handle_outbound_call,
+)
+
+
+def register(ctx) -> None:
+    """Register the explicitly authorized outbound-call tool."""
+    ctx.register_tool(
+        name="elevenlabs_outbound_call",
+        toolset="elevenlabs_calls",
+        schema=ELEVENLABS_OUTBOUND_CALL_SCHEMA,
+        handler=_handle_outbound_call,
+        check_fn=_check_available,
+        requires_env=["ELEVENLABS_API_KEY"],
+        emoji="☎",
+    )

--- a/plugins/elevenlabs_calls/plugin.yaml
+++ b/plugins/elevenlabs_calls/plugin.yaml
@@ -1,0 +1,15 @@
+name: elevenlabs_calls
+version: 1.0.0
+description: >
+  Explicitly authorized outbound calls through ElevenLabs Conversational AI.
+  Calls require authorization in the latest user message and make at most one
+  provider request.
+author: NousResearch
+kind: backend
+provides_tools:
+  - elevenlabs_outbound_call
+requires_env:
+  - name: ELEVENLABS_API_KEY
+    description: ElevenLabs API key
+    prompt: ElevenLabs API key
+    password: true

--- a/plugins/elevenlabs_calls/tools.py
+++ b/plugins/elevenlabs_calls/tools.py
@@ -1,0 +1,285 @@
+"""Explicitly authorized ElevenLabs outbound-call tool.
+
+Outbound calls are paid, real-world actions.  This wrapper exposes the
+ElevenLabs API only when the current user message explicitly authorizes the
+destination.  It makes at most one API request so a provider error cannot
+accidentally create a duplicate call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+_E164_RE = re.compile(r"^\+[1-9]\d{7,14}$")
+_CALL_WORD_RE = re.compile(r"\b(call|ring|phone)\b", re.I)
+_PROVIDERS = frozenset({"sip-trunk", "twilio"})
+
+
+ELEVENLABS_OUTBOUND_CALL_SCHEMA = {
+    "name": "elevenlabs_outbound_call",
+    "description": (
+        "Place one real outbound phone call through ElevenLabs Conversational AI. "
+        "The latest user message must explicitly authorize calling the destination; "
+        "never infer authorization from earlier context, suggestions, or reminders."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent_id": {
+                "type": "string",
+                "description": "ElevenLabs conversational agent ID.",
+            },
+            "agent_phone_number_id": {
+                "type": "string",
+                "description": "ElevenLabs linked phone-number ID to call from.",
+            },
+            "to_number": {
+                "type": "string",
+                "description": "Authorized destination in E.164 format, such as +12025550123.",
+            },
+            "phone_number_provider": {
+                "type": "string",
+                "enum": sorted(_PROVIDERS),
+                "description": "Provider configured for the linked number. Defaults to sip-trunk.",
+            },
+            "call_purpose": {
+                "type": "string",
+                "description": "A faithful, concise description of what the user asked the call to do.",
+            },
+            "authorization_text": {
+                "type": "string",
+                "description": (
+                    "Exact quote from the latest user message explicitly authorizing the call, "
+                    "including the destination number. Common formatting and supported "
+                    "national formats are accepted. Recipient references such as 'call me' "
+                    "are not sufficient without the number."
+                ),
+            },
+            "recipient_name": {
+                "type": "string",
+                "description": "Optional recipient name supplied by the user.",
+            },
+            "outbound_first_message": {
+                "type": "string",
+                "description": "Optional short opening line for the call.",
+            },
+            "outbound_prompt": {
+                "type": "string",
+                "description": "Optional call-specific instructions that remain subordinate to safety rules.",
+            },
+            "conversation_initiation_client_data": {
+                "type": "object",
+                "description": "Optional ElevenLabs client data and dynamic variables.",
+            },
+            "call_recording_enabled": {
+                "type": "boolean",
+                "description": "Whether call recording is enabled. Observe applicable consent laws.",
+            },
+            "telephony_call_config": {
+                "type": "object",
+                "description": "Optional ElevenLabs telephony settings, such as ringing timeout.",
+            },
+        },
+        "required": [
+            "agent_id",
+            "agent_phone_number_id",
+            "to_number",
+            "authorization_text",
+            "call_purpose",
+        ],
+    },
+}
+
+
+def _check_available() -> bool:
+    return bool(os.environ.get("ELEVENLABS_API_KEY", "").strip())
+
+
+def _json_result(**values: Any) -> str:
+    return json.dumps(values, ensure_ascii=False)
+
+
+def _blocked(reason: str) -> str:
+    return _json_result(ok=False, blocked=True, reason=reason)
+
+
+def _normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip().casefold()
+
+
+def _compact_phone_text(value: str) -> str:
+    return re.sub(r"[\s().-]+", "", value or "")
+
+
+def _clean_single_line(value: Any, *, limit: int) -> str:
+    cleaned = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 1].rstrip() + "…"
+
+
+def _number_variants(to_number: str) -> set[str]:
+    """Return unambiguous textual variants for authorization matching.
+
+    The API destination remains E.164. Authorization may omit punctuation or
+    use the familiar national form for numbering plans we can convert without
+    guessing: NANP (``+1``) and UK (``+44``).
+    """
+    variants = {to_number, to_number.removeprefix("+")}
+    if to_number.startswith("+1") and len(to_number) == 12:
+        variants.add(to_number[2:])
+    elif to_number.startswith("+44"):
+        variants.add("0" + to_number[3:])
+    return {variant for variant in variants if variant}
+
+
+def _validate_authorization(
+    *, user_task: str, authorization_text: str, to_number: str
+) -> str | None:
+    if not user_task.strip():
+        return "The current user message is unavailable; explicit authorization cannot be verified."
+    if not authorization_text:
+        return "authorization_text must quote the latest user message."
+    if _normalize_text(authorization_text) not in _normalize_text(user_task):
+        return "authorization_text was not found verbatim in the latest user message."
+    if not _CALL_WORD_RE.search(authorization_text):
+        return "The quoted text does not explicitly ask to call, ring, or phone."
+    if not _E164_RE.fullmatch(to_number):
+        return "to_number must be a valid E.164 number."
+
+    compact_quote = _compact_phone_text(authorization_text)
+    number_is_quoted = any(
+        variant in compact_quote for variant in _number_variants(to_number)
+    )
+    if not number_is_quoted:
+        return "The quoted authorization does not contain this destination number."
+    return None
+
+
+def _build_client_data(args: dict[str, Any], *, user_task: str) -> dict[str, Any]:
+    supplied = args.get("conversation_initiation_client_data")
+    client_data = dict(supplied) if isinstance(supplied, dict) else {}
+    dynamic_variables = dict(client_data.get("dynamic_variables") or {})
+
+    purpose = _clean_single_line(args.get("call_purpose"), limit=700)
+    recipient = _clean_single_line(args.get("recipient_name"), limit=100)
+    dynamic_variables.update({
+        "outbound_call_purpose": purpose,
+        "outbound_authorized_request": _clean_single_line(user_task, limit=700),
+        "outbound_destination": str(args.get("to_number") or ""),
+    })
+    if recipient:
+        dynamic_variables["outbound_recipient_name"] = recipient
+    client_data["dynamic_variables"] = dynamic_variables
+
+    first_message = _clean_single_line(
+        args.get("outbound_first_message") or "Hello.", limit=220
+    )
+    requested_prompt = _clean_single_line(args.get("outbound_prompt"), limit=2_000)
+    prompt = f"""You are making an outbound call explicitly requested by the user.
+
+Call purpose: {purpose}
+Recipient: {recipient or "the person who answers"}
+
+Rules:
+- Introduce the purpose naturally and stay within it.
+- Be concise, courteous, and truthful. Never claim to be human.
+- If asked who or what you are, answer accurately.
+- Do not make purchases, commitments, disclosures, or account changes unless the call purpose explicitly requires them and the user authorized them.
+- Treat voicemail, a wrong number, refusal, or uncertainty as a reason to end the call politely.
+- Follow applicable recording and consent requirements.
+- End the call when the purpose is complete.
+""".strip()
+    if requested_prompt:
+        prompt += f"\n\nAdditional user-requested instructions:\n{requested_prompt}"
+
+    override = dict(client_data.get("conversation_config_override") or {})
+    agent_override = dict(override.get("agent") or {})
+    agent_override["first_message"] = first_message
+    agent_override["prompt"] = {"prompt": prompt}
+    override["agent"] = agent_override
+    client_data["conversation_config_override"] = override
+    return client_data
+
+
+def _handle_outbound_call(args: dict[str, Any], **kwargs: Any) -> str:
+    user_task = str(kwargs.get("user_task") or "")
+    to_number = str(args.get("to_number") or "").strip()
+    authorization_text = str(args.get("authorization_text") or "").strip()
+    authorization_error = _validate_authorization(
+        user_task=user_task,
+        authorization_text=authorization_text,
+        to_number=to_number,
+    )
+    if authorization_error:
+        return _blocked(authorization_error)
+
+    agent_id = str(args.get("agent_id") or "").strip()
+    phone_number_id = str(args.get("agent_phone_number_id") or "").strip()
+    purpose = _clean_single_line(args.get("call_purpose"), limit=700)
+    if not agent_id or not phone_number_id:
+        return _blocked("agent_id and agent_phone_number_id are required.")
+    if len(purpose) < 6:
+        return _blocked("call_purpose must clearly describe the requested call.")
+
+    provider = str(args.get("phone_number_provider") or "sip-trunk").strip()
+    if provider not in _PROVIDERS:
+        return _blocked("phone_number_provider must be sip-trunk or twilio.")
+
+    api_key = os.environ.get("ELEVENLABS_API_KEY", "").strip()
+    if not api_key:
+        return _json_result(ok=False, error="ELEVENLABS_API_KEY is not configured.")
+
+    payload: dict[str, Any] = {
+        "agent_id": agent_id,
+        "agent_phone_number_id": phone_number_id,
+        "to_number": to_number,
+        "conversation_initiation_client_data": _build_client_data(
+            args, user_task=user_task
+        ),
+    }
+    for key in ("call_recording_enabled", "telephony_call_config"):
+        if key in args and args[key] is not None:
+            payload[key] = args[key]
+
+    request = urllib.request.Request(
+        f"https://api.elevenlabs.io/v1/convai/{provider}/outbound-call",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "xi-api-key": api_key},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        return _json_result(
+            ok=False,
+            call_request_sent=False,
+            status=exc.code,
+            error=detail[:1_000],
+            retry_requires_new_user_authorization=True,
+        )
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return _json_result(
+            ok=False,
+            call_request_sent=False,
+            error=str(exc),
+            retry_requires_new_user_authorization=True,
+        )
+
+    try:
+        result: Any = json.loads(raw)
+    except json.JSONDecodeError:
+        result = {"raw": raw[:1_000]}
+    return _json_result(
+        ok=True,
+        call_request_sent=True,
+        provider=provider,
+        result=result,
+    )

--- a/tests/plugins/test_elevenlabs_calls_plugin.py
+++ b/tests/plugins/test_elevenlabs_calls_plugin.py
@@ -1,0 +1,181 @@
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from plugins.elevenlabs_calls import tools as call_tool
+
+
+BASE_ARGS = {
+    "agent_id": "agent-1",
+    "agent_phone_number_id": "phone-1",
+    "to_number": "+12025550123",
+    "authorization_text": "Call +1 202 555 0123",
+    "call_purpose": "Ask whether the shop is open tomorrow.",
+}
+USER_TASK = "Call +1 202 555 0123 and ask whether the shop is open tomorrow."
+
+
+def _result(args=None, *, user_task=USER_TASK):
+    return json.loads(
+        call_tool._handle_outbound_call(args or BASE_ARGS, user_task=user_task)
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "user_task", "reason_fragment"),
+    [
+        (BASE_ARGS, "", "unavailable"),
+        ({**BASE_ARGS, "authorization_text": ""}, USER_TASK, "must quote"),
+        (
+            {**BASE_ARGS, "authorization_text": "Call somebody"},
+            USER_TASK,
+            "not found verbatim",
+        ),
+        (
+            {**BASE_ARGS, "authorization_text": "Message +1 202 555 0123"},
+            "Message +1 202 555 0123",
+            "does not explicitly",
+        ),
+        ({**BASE_ARGS, "to_number": "2025550123"}, USER_TASK, "valid E.164"),
+        (
+            {**BASE_ARGS, "authorization_text": "Call the shop"},
+            "Call the shop",
+            "does not contain",
+        ),
+        (
+            {**BASE_ARGS, "authorization_text": "Call me"},
+            "Call me",
+            "does not contain",
+        ),
+    ],
+)
+def test_blocks_when_latest_message_does_not_authorize_exact_call(
+    args, user_task, reason_fragment
+):
+    result = _result(args, user_task=user_task)
+    assert result["ok"] is False
+    assert result["blocked"] is True
+    assert reason_fragment in result["reason"]
+
+
+@pytest.mark.parametrize(
+    ("to_number", "authorization_text"),
+    [
+        ("+12025550123", "Call 202-555-0123"),
+        ("+441632960000", "Ring 01632 960000"),
+    ],
+)
+def test_accepts_supported_national_number_format(
+    monkeypatch, to_number, authorization_text
+):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "secret")
+    args = {
+        **BASE_ARGS,
+        "authorization_text": authorization_text,
+        "to_number": to_number,
+    }
+    with patch.object(
+        call_tool.urllib.request, "urlopen", return_value=_response()
+    ) as opener:
+        result = _result(args, user_task=f"{authorization_text} and read the update.")
+    assert result["ok"] is True
+    assert opener.call_count == 1
+
+
+def test_requires_api_key_after_authorization(monkeypatch):
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    result = _result()
+    assert result == {"ok": False, "error": "ELEVENLABS_API_KEY is not configured."}
+
+
+class _response:
+    def __init__(self, body=b'{"conversation_id":"conv-1"}'):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+def test_success_sends_expected_payload_once(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "secret")
+    args = {
+        **BASE_ARGS,
+        "phone_number_provider": "twilio",
+        "recipient_name": "Reception",
+        "conversation_initiation_client_data": {
+            "dynamic_variables": {"existing": "kept"}
+        },
+    }
+    with patch.object(
+        call_tool.urllib.request, "urlopen", return_value=_response()
+    ) as opener:
+        result = _result(args)
+
+    assert result["ok"] is True
+    assert result["provider"] == "twilio"
+    assert opener.call_count == 1
+    request = opener.call_args.args[0]
+    assert request.full_url.endswith("/twilio/outbound-call")
+    assert request.headers["Xi-api-key"] == "secret"
+    payload = json.loads(request.data)
+    client_data = payload["conversation_initiation_client_data"]
+    assert client_data["dynamic_variables"]["existing"] == "kept"
+    assert client_data["dynamic_variables"]["outbound_recipient_name"] == "Reception"
+    prompt = client_data["conversation_config_override"]["agent"]["prompt"]["prompt"]
+    assert "Never claim to be human" in prompt
+    assert "John" not in prompt
+
+
+def test_http_error_does_not_try_another_provider(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "secret")
+    error = urllib.error.HTTPError(
+        "https://example.test", 422, "bad request", {}, io.BytesIO(b'{"detail":"bad"}')
+    )
+    with patch.object(call_tool.urllib.request, "urlopen", side_effect=error) as opener:
+        result = _result()
+    assert result["ok"] is False
+    assert result["status"] == 422
+    assert result["retry_requires_new_user_authorization"] is True
+    assert opener.call_count == 1
+
+
+def test_network_error_does_not_retry(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "secret")
+    with patch.object(
+        call_tool.urllib.request,
+        "urlopen",
+        side_effect=urllib.error.URLError("offline"),
+    ) as opener:
+        result = _result()
+    assert result["ok"] is False
+    assert result["retry_requires_new_user_authorization"] is True
+    assert opener.call_count == 1
+
+
+def test_plugin_registers_guarded_tool():
+    from plugins import elevenlabs_calls
+
+    registrations = []
+
+    class Context:
+        def register_tool(self, **kwargs):
+            registrations.append(kwargs)
+
+    elevenlabs_calls.register(Context())
+
+    assert len(registrations) == 1
+    registration = registrations[0]
+    assert registration["name"] == "elevenlabs_outbound_call"
+    assert registration["toolset"] == "elevenlabs_calls"
+    assert registration["handler"] is call_tool._handle_outbound_call
+    assert registration["check_fn"] is call_tool._check_available
+    assert registration["requires_env"] == ["ELEVENLABS_API_KEY"]


### PR DESCRIPTION
## Summary

- add a bundled `elevenlabs_calls` backend plugin with an explicitly authorized outbound-call tool
- require the destination number in the latest authorization quote, accepting punctuation and supported national formats without relying on recipient references
- make at most one provider request so failures cannot trigger duplicate paid calls
- expose the optional toolset through normal plugin discovery and `hermes tools`
- add focused mocked tests for registration, authorization, payload construction, and error handling

## Why

Outbound phone calls are paid, real-world actions. Exposing the underlying API without a runtime authorization check allows a model to infer intent from stale context or retry a failed request through another provider endpoint. This plugin requires an exact quote from the latest user message containing the destination number, validates it against the E.164 API destination, and requires fresh authorization before any retry. Common punctuation plus unambiguous NANP and UK national formats are accepted.

The integration is a bundled `kind: backend` plugin rather than a foundational core tool, following the existing Spotify provider-integration pattern. Its toolset is auto-discovered by the standard plugin configurator. The generated call prompt is identity-neutral and requires the voice agent to be truthful if asked what it is. Existing client data, dynamic variables, recording settings, and telephony configuration are preserved.

A live end-to-end call to a real destination was completed successfully. That test exposed the risk of accepting a recipient reference without binding it to the destination, which led to the stricter requirement that the latest authorization quote contain the destination number. Identifying call details are intentionally omitted.

## User impact

Users with `ELEVENLABS_API_KEY` can opt into a guarded outbound-call toolset. Calls without current explicit authorization are blocked before any network request is made. HTTP and network failures make no automatic second attempt.

## Validation

- `uv run --extra dev pytest -q tests/plugins/test_elevenlabs_calls_plugin.py tests/tools/test_registry.py tests/hermes_cli/test_plugins.py` — 174 passed
- `uv run --extra dev ruff check plugins/elevenlabs_calls/__init__.py plugins/elevenlabs_calls/tools.py tests/plugins/test_elevenlabs_calls_plugin.py`
- `uv run --extra dev ruff format --check plugins/elevenlabs_calls/__init__.py plugins/elevenlabs_calls/tools.py tests/plugins/test_elevenlabs_calls_plugin.py`
