### PR TITLE
fix(sms): add splits_long_messages flag to enable chunked delivery for cron/agent output >4000 chars (#62751)

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -63,6 +63,7 @@ class SmsAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
+    splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)


### PR DESCRIPTION
## Summary
`SmsAdapter.send()` already chunks long content correctly via `self.truncate_message(formatted)`, but the class never sets `splits_long_messages = True`, so it inherits the base default (`False`). This means `gateway/delivery.py`'s cron/agent-output delivery path treats SMS as a non-chunking adapter and hard-truncates messages at 4000 chars.

## Change
Added `splits_long_messages = True` to the `SmsAdapter` class in `plugins/platforms/sms/adapter.py`, matching every other chunking-capable adapter (Telegram, Discord, Slack, WhatsApp, etc.).

## Verification
55 SMS gateway tests pass.