### PR TITLE
fix(cli): propagate integer exit statuses from command handlers to process exit code (#62810)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14701,15 +14701,15 @@ def main():
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
-        cmd_chat(args)
-        return
+        return cmd_chat(args)
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        return args.func(args)
     else:
         parser.print_help()
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
The top-level Hermes CLI dispatcher calls registered command handlers but discards their integer return values. Commands that fail return 1 or 2, but the process still exits 0 — breaking `set -e`, CI pipelines, `&&` chains, and schedulers.

## Change
1. **`main()` dispatch**: Changed `args.func(args)` → `return args.func(args)` so handler return values propagate up
2. **`main()` fallthrough**: Added `return 0` after `parser.print_help()`
3. **Launcher**: Changed `main()` → `raise SystemExit(main())` so the return value becomes the process exit code. `None` (no-func case, help) → 0

## Verification
275 CLI tests pass (exit/status/launcher).