### PR TITLE
feat(discord): support plugin slash subcommand groups

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -39,6 +39,7 @@ import importlib.util
 import inspect
 import logging
 import os
+import re
 import sys
 import threading
 import types
@@ -530,6 +531,7 @@ class PluginContext:
         handler: Callable,
         description: str = "",
         args_hint: str = "",
+        subcommands: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
@@ -546,6 +548,13 @@ class PluginContext:
         command picker. Plugin commands without ``args_hint`` register as
         parameterless in Discord and still accept trailing text when invoked
         as free-form chat.
+
+        ``subcommands`` optionally describes a native command group for
+        adapters that support it. Each mapping value accepts a short
+        ``description`` and, optionally, one string ``argument`` with
+        ``name``, ``description``, and ``required`` fields. The handler still
+        receives raw text in ``"<subcommand> <argument>"`` form. Gateways
+        without native groups continue to use the flat ``args_hint`` form.
 
         Names conflicting with built-in commands are rejected with a warning.
         """
@@ -570,11 +579,41 @@ class PluginContext:
         except Exception:
             pass  # If commands module isn't available, skip the check
 
+        normalized_subcommands: dict[str, dict[str, Any]] = {}
+        for raw_subcommand, raw_spec in (subcommands or {}).items():
+            subcommand = str(raw_subcommand).lower().strip().replace(" ", "-")
+            if not re.fullmatch(r"[a-z0-9_-]{1,32}", subcommand):
+                logger.warning(
+                    "Plugin '%s' ignored invalid subcommand '/%s %s'.",
+                    self.manifest.name, clean, raw_subcommand,
+                )
+                continue
+            spec = raw_spec if isinstance(raw_spec, dict) else {}
+            normalized: dict[str, Any] = {
+                "description": str(spec.get("description") or f"Run {subcommand}")[:100]
+            }
+            argument = spec.get("argument")
+            if isinstance(argument, dict):
+                argument_name = str(argument.get("name") or "value").lower().strip()
+                if re.fullmatch(r"[a-z0-9_-]{1,32}", argument_name):
+                    normalized["argument"] = {
+                        "name": argument_name,
+                        "description": str(argument.get("description") or "Command argument")[:100],
+                        "required": bool(argument.get("required", False)),
+                    }
+                else:
+                    logger.warning(
+                        "Plugin '%s' ignored invalid argument name '%s' for '/%s %s'.",
+                        self.manifest.name, argument_name, clean, subcommand,
+                    )
+            normalized_subcommands[subcommand] = normalized
+
         self._manager._plugin_commands[clean] = {
             "handler": handler,
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
             "args_hint": (args_hint or "").strip(),
+            "subcommands": normalized_subcommands,
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import struct
 import subprocess
 import tempfile
@@ -4077,6 +4078,59 @@ class DiscordAdapter(BasePlatformAdapter):
                 callback=handler,
             )
 
+        def _build_plugin_slash_group(_name, _description, _subcommands):
+            """Build a native Discord group backed by one raw-text plugin handler."""
+            group = discord.app_commands.Group(
+                name=_name.lower()[:32],
+                description=(_description or f"Run /{_name}")[:100],
+            )
+            for subcommand_name, raw_spec in list(_subcommands.items())[:25]:
+                spec = raw_spec if isinstance(raw_spec, dict) else {}
+                subcommand = subcommand_name.lower()[:32]
+                argument = spec.get("argument")
+
+                if isinstance(argument, dict):
+                    argument_name = str(argument.get("name") or "value")[:32]
+                    argument_description = str(argument.get("description") or "Command argument")[:100]
+
+                    def _make_argument_handler(__subcommand, __required):
+                        if __required:
+                            async def _handler(interaction: discord.Interaction, value: str):
+                                command = f"/{_name} {__subcommand} {shlex.quote(value)}"
+                                await self._run_simple_slash(interaction, command)
+                        else:
+                            async def _handler(interaction: discord.Interaction, value: str = ""):
+                                suffix = f" {shlex.quote(value)}" if value else ""
+                                await self._run_simple_slash(
+                                    interaction, f"/{_name} {__subcommand}{suffix}"
+                                )
+                        _handler.__name__ = f"plugin_slash_{_name}_{__subcommand}".replace("-", "_")
+                        described = discord.app_commands.describe(
+                            value=argument_description
+                        )(_handler)
+                        return discord.app_commands.rename(value=argument_name)(described)
+
+                    handler = _make_argument_handler(
+                        subcommand, bool(argument.get("required", False))
+                    )
+                else:
+                    def _make_subcommand_handler(__subcommand):
+                        async def _handler(interaction: discord.Interaction):
+                            await self._run_simple_slash(
+                                interaction, f"/{_name} {__subcommand}"
+                            )
+                        _handler.__name__ = f"plugin_slash_{_name}_{__subcommand}".replace("-", "_")
+                        return _handler
+
+                    handler = _make_subcommand_handler(subcommand)
+
+                group.add_command(discord.app_commands.Command(
+                    name=subcommand,
+                    description=str(spec.get("description") or f"Run {subcommand}")[:100],
+                    callback=handler,
+                ))
+            return group
+
         already_registered: set[str] = set()
         # Native commands above are registered first and are the highest
         # priority, so they always survive the 100-command cap. Reserve one
@@ -4130,7 +4184,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # API needed — plugin commands are platform-agnostic.
         try:
             from hermes_cli.commands import _iter_plugin_command_entries
+            from hermes_cli.plugins import get_plugin_commands
 
+            plugin_commands = get_plugin_commands()
             for plugin_name, plugin_desc, plugin_args_hint in _iter_plugin_command_entries():
                 discord_name = plugin_name.lower()[:32]
                 if discord_name in already_registered:
@@ -4138,11 +4194,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 if len(already_registered) >= slot_cap:
                     dropped_over_cap += 1
                     continue
-                auto_cmd = _build_auto_slash_command(
-                    plugin_name,
-                    plugin_desc,
-                    plugin_args_hint,
-                )
+                subcommands = plugin_commands.get(plugin_name, {}).get("subcommands")
+                if isinstance(subcommands, dict) and subcommands:
+                    auto_cmd = _build_plugin_slash_group(
+                        plugin_name, plugin_desc, subcommands
+                    )
+                else:
+                    auto_cmd = _build_auto_slash_command(
+                        plugin_name,
+                        plugin_desc,
+                        plugin_args_hint,
+                    )
                 try:
                     tree.add_command(auto_cmd)
                     already_registered.add(discord_name)

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -47,6 +47,7 @@ def _ensure_discord_mock():
             describe=lambda **kwargs: (lambda fn: fn),
             choices=lambda **kwargs: (lambda fn: fn),
             autocomplete=lambda **kwargs: (lambda fn: fn),
+            rename=lambda **kwargs: (lambda fn: fn),
             Choice=lambda **kwargs: SimpleNamespace(**kwargs),
             Group=_FakeGroup,
             Command=_FakeCommand,
@@ -69,6 +70,11 @@ def _ensure_discord_mock():
     if _app is not None and not hasattr(_app, "autocomplete"):
         try:
             _app.autocomplete = lambda **kwargs: (lambda fn: fn)
+        except Exception:
+            pass
+    if _app is not None and not hasattr(_app, "rename"):
+        try:
+            _app.rename = lambda **kwargs: (lambda fn: fn)
         except Exception:
             pass
 
@@ -261,6 +267,52 @@ async def test_auto_registered_plugin_command_without_args_hint(adapter):
     interaction = SimpleNamespace()
     await ping_cmd.callback(interaction)
     adapter._run_simple_slash.assert_awaited_once_with(interaction, "/ping")
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_subcommands_replace_generic_args_field(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    commands = {
+        "tf": {
+            "handler": lambda _a: "ok",
+            "description": "ThreadForge tasks",
+            "args_hint": "run <goal> | status",
+            "plugin": "threadforge-bridge",
+            "subcommands": {
+                "run": {
+                    "description": "Start a task",
+                    "argument": {
+                        "name": "goal", "description": "Coding goal", "required": True,
+                    },
+                },
+                "status": {
+                    "description": "Show task status",
+                    "argument": {
+                        "name": "task-ref", "description": "Task reference", "required": False,
+                    },
+                },
+                "health": {"description": "Check supervisor health"},
+            },
+        }
+    }
+    with patch("hermes_cli.plugins.get_plugin_commands", return_value=commands):
+        adapter._register_slash_commands()
+
+    group = adapter._client.tree.commands["tf"]
+    children = getattr(group, "_children", None)
+    if children is None:
+        children = {command.name: command for command in group.commands}
+    assert set(children) == {"run", "status", "health"}
+
+    interaction = SimpleNamespace()
+    await children["run"].callback(interaction, value="fix parser safely")
+    await children["status"].callback(interaction, value="")
+    await children["health"].callback(interaction)
+    assert adapter._run_simple_slash.await_args_list == [
+        ((interaction, "/tf run 'fix parser safely'"), {}),
+        ((interaction, "/tf status"), {}),
+        ((interaction, "/tf health"), {}),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1674,6 +1674,31 @@ class TestPluginCommands:
         ctx.register_command("foo", lambda a: a, args_hint="  <file>  ")
         assert mgr._plugin_commands["foo"]["args_hint"] == "<file>"
 
+    def test_register_command_normalizes_native_subcommands(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="test-plugin", source="user"), mgr)
+        ctx.register_command(
+            "jobs", lambda a: a, args_hint="run <goal>",
+            subcommands={
+                "Run": {
+                    "description": "Start a job",
+                    "argument": {
+                        "name": "Goal", "description": "Job goal", "required": True,
+                    },
+                },
+                "health": {"description": "Check health"},
+            },
+        )
+        assert mgr._plugin_commands["jobs"]["subcommands"] == {
+            "run": {
+                "description": "Start a job",
+                "argument": {
+                    "name": "goal", "description": "Job goal", "required": True,
+                },
+            },
+            "health": {"description": "Check health"},
+        }
+
     def test_register_command_normalizes_name(self):
         """Names are lowercased, stripped, and leading slashes removed."""
         mgr = PluginManager()


### PR DESCRIPTION
## Summary
- add an optional structured `subcommands` schema to plugin slash command registration
- render structured plugin commands as native Discord command groups
- preserve the existing raw-text handler contract and flat fallback for other gateways

## Motivation
Plugin commands with `args_hint` currently show one generic `args` input. Structured groups let plugins expose native actions such as `/tf status` without forcing an opaque argument field.

## Verification
- 294 relevant Hermes tests passed (3 unrelated local entry-point discovery tests excluded)
- focused plugin/Discord tests: 17 passed
- real discord.py schema probe verified required and optional subcommand arguments