### PR TITLE
feat: add Hermes reliability spine

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -22,6 +22,8 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
+from agent.turn_outcome import classify_turn_outcome
+
 logger = logging.getLogger(__name__)
 
 
@@ -497,22 +499,31 @@ def run_codex_app_server_turn(
 
     # External memory provider sync (mirrors line ~15439). Skipped on
     # interrupt/error to avoid feeding partial transcripts to memory.
-    if not turn.interrupted and turn.error is None:
+    turn_outcome = classify_turn_outcome(
+        final_response=turn.final_text,
+        failed=turn.error is not None,
+        interrupted=turn.interrupted,
+        unresolved=getattr(turn, "should_retire", False) and turn.error is None,
+        verification_status=getattr(agent, "_turn_verification_status", None),
+    )
+    if turn_outcome["outcome"] == "verified":
         try:
             agent._sync_external_memory_for_turn(
                 original_user_message=original_user_message,
                 final_response=turn.final_text,
-                interrupted=False,
+                interrupted=turn.interrupted,
                 messages=messages,
+                turn_outcome=turn_outcome["outcome"],
             )
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)
 
     # Background review fork — same cadence + signature as the default
     # path (line ~15449). Only fires when a trigger actually tripped AND
-    # we have a real final response.
+    # we have a verified final response.
     if (
-        turn.final_text
+        turn_outcome["outcome"] == "verified"
+        and turn.final_text
         and not turn.interrupted
         and (should_review_memory or should_review_skills)
     ):

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -497,8 +497,9 @@ def run_codex_app_server_turn(
         should_review_skills = True
         agent._iters_since_skill = 0
 
-    # External memory provider sync (mirrors line ~15439). Skipped on
-    # interrupt/error to avoid feeding partial transcripts to memory.
+    # External memory provider sync. The helper applies the explicit policy:
+    # verified always syncs; completed_unverified syncs only when Codex reports
+    # no tool activity and the projected messages contain no tool effects.
     turn_outcome = classify_turn_outcome(
         final_response=turn.final_text,
         failed=turn.error is not None,
@@ -506,7 +507,7 @@ def run_codex_app_server_turn(
         unresolved=getattr(turn, "should_retire", False) and turn.error is None,
         verification_status=getattr(agent, "_turn_verification_status", None),
     )
-    if turn_outcome["outcome"] == "verified":
+    if turn_outcome["outcome"] in {"verified", "completed_unverified"}:
         try:
             agent._sync_external_memory_for_turn(
                 original_user_message=original_user_message,
@@ -514,6 +515,7 @@ def run_codex_app_server_turn(
                 interrupted=turn.interrupted,
                 messages=messages,
                 turn_outcome=turn_outcome["outcome"],
+                turn_had_tool_activity=turn.tool_iterations > 0,
             )
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -862,7 +862,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         elif r is None:
             # Tool was cancelled (interrupt) or thread didn't return
             if i in cancelled_indices:
-                function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                cancelled_by_timeout = i in timed_out_indices
+                cancellation_reason = "timeout" if cancelled_by_timeout else "user interrupt"
+                function_result = f"[Tool execution cancelled — {name} was skipped due to {cancellation_reason}]"
                 effect_disposition = "none"
                 _emit_terminal_post_tool_call(
                     agent,
@@ -872,8 +874,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     effective_task_id=effective_task_id,
                     tool_call_id=getattr(tc, "id", "") or "",
                     status="cancelled",
-                    error_type="keyboard_interrupt",
-                    error_message="Tool execution cancelled by user interrupt",
+                    error_type="tool_timeout_cancelled" if cancelled_by_timeout else "keyboard_interrupt",
+                    error_message=f"Tool execution cancelled by {cancellation_reason}",
                     middleware_trace=list(middleware_trace),
                 )
             elif agent._interrupt_requested:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -838,7 +838,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # loop. Prefer that real result over a fabricated timeout message — the
         # tool genuinely succeeded, just slightly late.
         effect_disposition = None
-        if i in timed_out_indices and r is None:
+        if i in timed_out_indices and i not in cancelled_indices and r is None:
             suffix = f"{timeout_s:.1f}s" if timeout_s is not None else "the configured timeout"
             function_result = (
                 f"Error executing tool '{name}': timed out after {suffix}; "

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -664,6 +664,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         futures = []
         future_to_index = {}
         timed_out_indices: set[int] = set()
+        cancelled_indices: set[int] = set()
         timeout_s = _resolve_concurrent_tool_timeout()
         deadline = time.monotonic() + timeout_s if timeout_s is not None else None
         if runnable_calls:
@@ -785,7 +786,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                 force=True,
                             )
                         for f in not_done:
-                            f.cancel()
+                            if f.cancel():
+                                index = future_to_index.get(f)
+                                if index is not None:
+                                    cancelled_indices.add(index)
                         # Give already-running tools a moment to notice the
                         # per-thread interrupt signal and exit gracefully.
                         concurrent.futures.wait(not_done, timeout=3.0)
@@ -813,6 +817,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     wait=not abandon_executor,
                     cancel_futures=abandon_executor,
                 )
+        cancelled_indices.update(
+            future_to_index[f]
+            for f in futures
+            if f.cancelled() and f in future_to_index
+        )
     finally:
         if spinner:
             # Build a summary message for the spinner stop
@@ -831,7 +840,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         effect_disposition = None
         if i in timed_out_indices and r is None:
             suffix = f"{timeout_s:.1f}s" if timeout_s is not None else "the configured timeout"
-            function_result = f"Error executing tool '{name}': timed out after {suffix}"
+            function_result = (
+                f"Error executing tool '{name}': timed out after {suffix}; "
+                "[UNRESOLVED] the operation may have executed and its effect is UNKNOWN. "
+                "Do not retry blindly; inspect current state before retrying."
+            )
             effect_disposition = "unknown"
             _emit_terminal_post_tool_call(
                 agent,
@@ -848,8 +861,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_duration = float(timeout_s or 0.0)
         elif r is None:
             # Tool was cancelled (interrupt) or thread didn't return
-            if agent._interrupt_requested:
+            if i in cancelled_indices:
                 function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                effect_disposition = "none"
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
@@ -860,6 +874,25 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     status="cancelled",
                     error_type="keyboard_interrupt",
                     error_message="Tool execution cancelled by user interrupt",
+                    middleware_trace=list(middleware_trace),
+                )
+            elif agent._interrupt_requested:
+                function_result = (
+                    f"[UNRESOLVED] Tool execution for '{name}' was interrupted before a result "
+                    "was observed. The operation may have executed and its effect is UNKNOWN. "
+                    "Do not retry blindly; inspect current state before retrying."
+                )
+                effect_disposition = "unknown"
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=name,
+                    function_args=args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                    status="unresolved",
+                    error_type="tool_interrupt_unresolved",
+                    error_message=function_result,
                     middleware_trace=list(middleware_trace),
                 )
             else:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -533,6 +533,7 @@ def build_turn_context(
     agent._turn_file_mutation_paths = set()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
+    agent._turn_verification_status = None
 
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -146,16 +146,17 @@ def finalize_turn(
                     exc_info=True,
                 )
 
-    # Determine if conversation completed successfully
-    normal_text_response = str(_turn_exit_reason).startswith("text_response(")
-    completed = (
-        final_response is not None
-        and not failed
-        and (
-            api_call_count < agent.max_iterations
-            or normal_text_response
-        )
+    # Determine completion from the canonical terminal outcome, not response
+    # presence. A failed/interrupted/partial/blocked/unresolved/cancelled exit
+    # can still carry assistant text, but that text is not a completed turn.
+    _turn_outcome = classify_turn_outcome(
+        final_response=final_response,
+        failed=failed,
+        interrupted=interrupted,
+        _turn_exit_reason=_turn_exit_reason,
+        verification_status=getattr(agent, "_turn_verification_status", None),
     )
+    completed = _turn_outcome["outcome"] in {"verified", "completed_unverified"}
 
     # Post-loop cleanup must never lose the response.  Trajectory save,
     # resource teardown, and session persistence all touch fallible
@@ -422,13 +423,8 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
-    _turn_outcome = classify_turn_outcome(
-        final_response=final_response,
-        failed=failed,
-        interrupted=interrupted,
-        _turn_exit_reason=_turn_exit_reason,
-        verification_status=getattr(agent, "_turn_verification_status", None),
-    )
+    # ``_turn_outcome`` was computed before cleanup so trajectory persistence
+    # receives the same canonical completion decision as the returned result.
 
     # Build result with interrupt info if applicable
     result = {

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -495,17 +495,23 @@ def finalize_turn(
         _should_review_skills = True
         agent._iters_since_skill = 0
 
-    # External memory provider: sync the completed turn + queue next prefetch.
+    # External memory provider: sync only a verified turn + queue next prefetch.
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
         final_response=final_response,
         interrupted=interrupted,
         messages=messages,
+        turn_outcome=_turn_outcome["outcome"],
     )
 
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
-    if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+    if (
+        _turn_outcome["outcome"] == "verified"
+        and final_response
+        and not interrupted
+        and (_should_review_memory or _should_review_skills)
+    ):
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.turn_outcome import classify_turn_outcome
 
 
 def finalize_turn(
@@ -421,6 +422,14 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
+    _turn_outcome = classify_turn_outcome(
+        final_response=final_response,
+        failed=failed,
+        interrupted=interrupted,
+        _turn_exit_reason=_turn_exit_reason,
+        verification_status=getattr(agent, "_turn_verification_status", None),
+    )
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
@@ -428,6 +437,8 @@ def finalize_turn(
         "messages": messages,
         "api_calls": api_call_count,
         "completed": completed,
+        "outcome": _turn_outcome["outcome"],
+        "outcome_reason": _turn_outcome["reason"],
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls

--- a/agent/turn_outcome.py
+++ b/agent/turn_outcome.py
@@ -67,6 +67,17 @@ def classify_turn_outcome(
         return {"outcome": "blocked", "reason": "approval blocked"}
     if cancelled or exit_reason in {"cancelled", "canceled"}:
         return {"outcome": "cancelled", "reason": "turn cancelled"}
+    if exit_reason == "guardrail_halt":
+        return {"outcome": "blocked", "reason": "guardrail halted"}
+    if (
+        exit_reason.startswith("error_near_max_iterations")
+        or exit_reason in {
+            "all_retries_exhausted_no_response",
+            "ollama_runtime_context_too_small",
+            "provider_failure",
+        }
+    ):
+        return {"outcome": "failed", "reason": "turn failed"}
     if (
         exit_reason == "budget_exhausted"
         or exit_reason.startswith("max_iterations_reached")
@@ -75,6 +86,7 @@ def classify_turn_outcome(
             "partial_stream_recovery",
             "fallback_prior_turn_content",
             "empty_response_exhausted",
+            "pending_tool_result",
         }
     ):
         return {"outcome": "partial", "reason": "iteration budget or turn completion was partial"}

--- a/agent/turn_outcome.py
+++ b/agent/turn_outcome.py
@@ -1,0 +1,95 @@
+"""Pure terminal classification for one agent turn."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+TurnOutcomeName = Literal[
+    "verified",
+    "completed_unverified",
+    "partial",
+    "blocked",
+    "failed",
+    "interrupted",
+    "unresolved",
+    "cancelled",
+]
+TURN_OUTCOMES = (
+    "verified",
+    "completed_unverified",
+    "partial",
+    "blocked",
+    "failed",
+    "interrupted",
+    "unresolved",
+    "cancelled",
+)
+
+
+class TurnOutcome(TypedDict):
+    outcome: TurnOutcomeName
+    reason: str
+
+
+def _status_value(verification_status: object) -> str:
+    if isinstance(verification_status, dict):
+        verification_status = verification_status.get("status")
+    return str(verification_status or "").strip().lower()
+
+
+def classify_turn_outcome(
+    final_response: object = None,
+    failed: bool = False,
+    interrupted: bool = False,
+    _turn_exit_reason: object = "unknown",
+    timeout: bool = False,
+    unresolved: bool = False,
+    verification_status: object = None,
+    blocked: bool = False,
+    cancelled: bool = False,
+) -> TurnOutcome:
+    """Classify terminal turn facts without consulting runtime state."""
+    exit_reason = str(_turn_exit_reason or "").strip().lower()
+
+    if failed:
+        return {"outcome": "failed", "reason": "turn failed"}
+    if interrupted:
+        return {"outcome": "interrupted", "reason": "turn interrupted"}
+    if unresolved or timeout or any(
+        marker in exit_reason for marker in ("unresolved", "timeout", "timed_out")
+    ):
+        return {"outcome": "unresolved", "reason": "side effect outcome unresolved"}
+    if blocked or "blocked" in exit_reason or (
+        "approval" in exit_reason
+        and any(marker in exit_reason for marker in ("deny", "block", "required"))
+    ):
+        return {"outcome": "blocked", "reason": "approval blocked"}
+    if cancelled or exit_reason in {"cancelled", "canceled"}:
+        return {"outcome": "cancelled", "reason": "turn cancelled"}
+    if (
+        exit_reason == "budget_exhausted"
+        or exit_reason.startswith("max_iterations_reached")
+        or "iteration" in exit_reason and "limit" in exit_reason
+        or exit_reason in {
+            "partial_stream_recovery",
+            "fallback_prior_turn_content",
+            "empty_response_exhausted",
+        }
+    ):
+        return {"outcome": "partial", "reason": "iteration budget or turn completion was partial"}
+
+    status = _status_value(verification_status)
+    if status in {"failed", "error"}:
+        return {"outcome": "failed", "reason": "verification failed"}
+    if final_response:
+        if status in {"passed", "verified", "success", "ok"}:
+            return {"outcome": "verified", "reason": "verification passed"}
+        return {
+            "outcome": "completed_unverified",
+            "reason": "response completed without verification",
+        }
+    return {"outcome": "partial", "reason": "no final response"}
+
+
+__all__ = ["TURN_OUTCOMES", "TurnOutcome", "TurnOutcomeName", "classify_turn_outcome"]

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4361,19 +4361,27 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval, has_blocking_approval, has_pending_approval,
         )
 
-        if not has_blocking_approval(session_key):
+        if not (has_blocking_approval(session_key) or has_pending_approval(session_key)):
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
-        # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
-        resolve_all = "all" in args
-        remaining = [a for a in args if a != "all"]
+        # Parse args: support an exact request id plus the legacy choices.
+        raw_args = event.get_command_args().strip().split()
+        args = [arg.lower() for arg in raw_args]
+        request_id = next(
+            (raw for raw, arg in zip(raw_args, args) if arg != "all" and arg not in {
+                "once", "approve", "approved", "allow", "session", "ses",
+                "always", "permanent", "permanently",
+            }),
+            None,
+        )
+        resolve_all = "all" in args and request_id is None
+        remaining = [a for a in args if a not in {"all", request_id}]
 
         if any(a in {"always", "permanent", "permanently"} for a in remaining):
             choice = "always"
@@ -4382,7 +4390,9 @@ class GatewaySlashCommandsMixin:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        count = resolve_gateway_approval(
+            session_key, choice, resolve_all=resolve_all, request_id=request_id,
+        )
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -4391,7 +4401,10 @@ class GatewaySlashCommandsMixin:
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
 
-        logger.info("User approved %d dangerous command(s) via /approve (%s)", count, choice)
+        logger.info(
+            "User approved %d dangerous command(s) via /approve (%s, request_id=%s)",
+            count, choice, request_id or "session_fifo",
+        )
         plural = "plural" if count > 1 else "singular"
         return t(f"gateway.approve.{choice}_{plural}", count=count)
 
@@ -4410,22 +4423,29 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval, has_blocking_approval, has_pending_approval,
+            get_pending_approval,
         )
 
-        if not has_blocking_approval(session_key):
+        if not (has_blocking_approval(session_key) or has_pending_approval(session_key)):
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
-        # Parse args: a leading "all" token denies every pending command;
-        # anything after it (or the whole arg string when "all" is absent) is
-        # captured verbatim as the optional deny reason relayed to the agent.
+        # A request id is accepted before the legacy free-text deny reason.
         raw_args = event.get_command_args().strip()
         tokens = raw_args.split()
-        resolve_all = bool(tokens) and tokens[0].lower() == "all"
+        request_id = None
+        if tokens and (
+            len(tokens[0]) == 32 and all(c in "0123456789abcdefABCDEF" for c in tokens[0])
+            or has_pending_approval(session_key) and get_pending_approval(tokens[0]) is not None
+        ):
+            request_id = tokens[0]
+        resolve_all = bool(tokens) and tokens[0].lower() == "all" and request_id is None
         if resolve_all:
+            reason = raw_args[len(tokens[0]):].strip()
+        elif request_id:
             reason = raw_args[len(tokens[0]):].strip()
         else:
             reason = raw_args
@@ -4435,7 +4455,7 @@ class GatewaySlashCommandsMixin:
 
         count = resolve_gateway_approval(
             session_key, "deny", resolve_all=resolve_all,
-            reason=reason or None,
+            reason=reason or None, request_id=request_id,
         )
         if not count:
             return t("gateway.deny.no_pending")
@@ -4446,8 +4466,8 @@ class GatewaySlashCommandsMixin:
             _adapter.resume_typing_for_chat(source.chat_id)
 
         logger.info(
-            "User denied %d dangerous command(s) via /deny%s",
-            count, " (with reason)" if reason else "",
+            "User denied %d dangerous command(s) via /deny%s (request_id=%s)",
+            count, " (with reason)" if reason else "", request_id or "session_fifo",
         )
         if reason:
             if count > 1:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4362,6 +4362,7 @@ class GatewaySlashCommandsMixin:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval, has_pending_approval,
+            get_pending_approval,
         )
 
         if not (has_blocking_approval(session_key) or has_pending_approval(session_key)):
@@ -4370,18 +4371,25 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
-        # Parse args: support an exact request id plus the legacy choices.
+        # Parse args: accept an exact request id only when it is a live request
+        # owned by this session; arbitrary free text remains legacy choice text.
         raw_args = event.get_command_args().strip().split()
         args = [arg.lower() for arg in raw_args]
         request_id = next(
-            (raw for raw, arg in zip(raw_args, args) if arg != "all" and arg not in {
-                "once", "approve", "approved", "allow", "session", "ses",
-                "always", "permanent", "permanently",
-            }),
+            (
+                raw for raw, arg in zip(raw_args, args)
+                if arg not in {"all", "once", "approve", "approved", "allow",
+                                "session", "ses", "always", "permanent",
+                                "permanently"}
+                and (get_pending_approval(raw) or {}).get("session_key") == session_key
+            ),
             None,
         )
         resolve_all = "all" in args and request_id is None
-        remaining = [a for a in args if a not in {"all", request_id}]
+        remaining = [
+            arg for arg in args
+            if arg in {"always", "permanent", "permanently", "session", "ses"}
+        ]
 
         if any(a in {"always", "permanent", "permanently"} for a in remaining):
             choice = "always"
@@ -4437,11 +4445,10 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip()
         tokens = raw_args.split()
         request_id = None
-        if tokens and (
-            len(tokens[0]) == 32 and all(c in "0123456789abcdefABCDEF" for c in tokens[0])
-            or has_pending_approval(session_key) and get_pending_approval(tokens[0]) is not None
-        ):
-            request_id = tokens[0]
+        if tokens:
+            candidate = get_pending_approval(tokens[0]) or {}
+            if candidate.get("session_key") == session_key:
+                request_id = tokens[0]
         resolve_all = bool(tokens) and tokens[0].lower() == "all" and request_id is None
         if resolve_all:
             reason = raw_args[len(tokens[0]):].strip()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2266,7 +2266,8 @@ def resolve_pre_tool_block(
                 arguments=args,
                 requester=session_id,
                 channel=task_id,
-                request_id=tool_call_id or api_request_id or turn_id,
+                # turn/API IDs can cover multiple calls; submit_pending mints UUIDs.
+                request_id=tool_call_id,
             )
         except Exception:
             # Fail-closed: if the gate itself errors, block rather than

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2255,12 +2255,18 @@ def resolve_pre_tool_block(
     if details.action == "block":
         return details.message
     if details.action == "approve":
+        if not isinstance(args, dict):
+            return f"BLOCKED: plugin approval requires call arguments for {tool_name}"
         try:
             from tools.approval import request_tool_approval
             result = request_tool_approval(
                 tool_name,
                 details.message or "",
                 rule_key=details.rule_key or tool_name,
+                arguments=args,
+                requester=session_id,
+                channel=task_id,
+                request_id=tool_call_id or api_request_id or turn_id,
             )
         except Exception:
             # Fail-closed: if the gate itself errors, block rather than

--- a/run_agent.py
+++ b/run_agent.py
@@ -243,6 +243,25 @@ def _is_ephemeral_scaffolding(msg: Any) -> bool:
     )
 
 
+def _turn_has_tool_activity(messages: Optional[List[Dict[str, Any]]]) -> bool:
+    """Conservatively detect tool calls/effects in the current user turn."""
+    if not messages:
+        return True
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "user":
+            return False
+        if (
+            message.get("role") in {"tool", "function"}
+            or message.get("tool_calls")
+            or message.get("function_call")
+            or message.get("tool_call_id")
+        ):
+            return True
+    return True
+
+
 _MAX_TOOL_WORKERS = 8
 
 # Intrinsic marker stamped on a message dict once it has been written to the
@@ -3372,6 +3391,7 @@ class AIAgent:
         interrupted: bool,
         messages: list | None = None,
         turn_outcome: str | None = None,
+        turn_had_tool_activity: Optional[bool] = None,
     ) -> None:
         """Mirror a completed turn into external memory providers.
 
@@ -3394,16 +3414,22 @@ class AIAgent:
         the same intent, and a prefetch keyed on the interrupted turn
         would fire against stale context.
 
-        Only the canonical ``verified`` outcome is durable in this phase.
-        ``completed_unverified`` stays denied until a later policy explicitly
-        permits it.  External memory providers remain best-effort.
+        Only ``verified`` always permits durable sync.  The explicit
+        ``completed_unverified`` exception is limited to a conversational turn
+        with no tool calls/effects; response text never supplies verification.
+        Background review remains a separate verified-only gate.  External
+        memory providers remain best-effort.
 
         Verified turns still sync as before.  The whole body is
         wrapped in ``try/except Exception`` because external memory
         providers are strictly best-effort — a misconfigured or offline
         backend must not block the user from seeing their response.
         """
-        if interrupted or turn_outcome != "verified":
+        if interrupted or turn_outcome not in {"verified", "completed_unverified"}:
+            return
+        if turn_outcome == "completed_unverified" and (
+            turn_had_tool_activity or _turn_has_tool_activity(messages)
+        ):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -3371,6 +3371,7 @@ class AIAgent:
         final_response: Any,
         interrupted: bool,
         messages: list | None = None,
+        turn_outcome: str | None = None,
     ) -> None:
         """Mirror a completed turn into external memory providers.
 
@@ -3393,12 +3394,16 @@ class AIAgent:
         the same intent, and a prefetch keyed on the interrupted turn
         would fire against stale context.
 
-        Normal completed turns still sync as before.  The whole body is
+        Only the canonical ``verified`` outcome is durable in this phase.
+        ``completed_unverified`` stays denied until a later policy explicitly
+        permits it.  External memory providers remain best-effort.
+
+        Verified turns still sync as before.  The whole body is
         wrapped in ``try/except Exception`` because external memory
         providers are strictly best-effort — a misconfigured or offline
         backend must not block the user from seeing their response.
         """
-        if interrupted:
+        if interrupted or turn_outcome != "verified":
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -2845,6 +2845,20 @@ class AIAgent:
         state dict hasn't been initialised yet (e.g. a tool dispatched
         outside ``run_conversation``).
         """
+        try:
+            parsed_result = json.loads(result) if isinstance(result, str) else result
+            evidence = (
+                parsed_result.get("verification_evidence")
+                if isinstance(parsed_result, dict)
+                else None
+            )
+            if isinstance(evidence, dict):
+                self._turn_verification_status = (
+                    evidence if evidence.get("status") == "passed" else None
+                )
+        except (TypeError, ValueError):
+            pass
+
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
         state = getattr(self, "_turn_failed_file_mutations", None)
@@ -2855,6 +2869,7 @@ class AIAgent:
             return
         landed = file_mutation_result_landed(tool_name, result)
         if landed:
+            self._turn_verification_status = None
             changed = getattr(self, "_turn_file_mutation_paths", None)
             if changed is not None:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))

--- a/run_agent.py
+++ b/run_agent.py
@@ -1921,6 +1921,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    effect_disposition=msg.get("effect_disposition"),
                     timestamp=_row_timestamp,
                 )
                 msg[_DB_PERSISTED_MARKER] = True

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -267,6 +267,45 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert agent._handle_max_iterations_called is False
 
 
+@pytest.mark.parametrize(
+    ("exit_reason", "failed", "interrupted", "expected_outcome"),
+    [
+        ("provider_failure", False, False, "failed"),
+        ("error_near_max_iterations(provider error)", False, False, "failed"),
+        ("interrupted_by_user", False, True, "interrupted"),
+        ("tool_timeout", False, False, "unresolved"),
+        ("unresolved_side_effect", False, False, "unresolved"),
+        ("guardrail_halt", False, False, "blocked"),
+        ("cancelled", False, False, "cancelled"),
+        ("partial_stream_recovery", False, False, "partial"),
+    ],
+)
+def test_non_empty_response_cannot_make_terminal_non_success_completed(
+    monkeypatch, exit_reason, failed, interrupted, expected_outcome
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent(budget_remaining=59)
+
+    result = finalize_turn(
+        agent,
+        final_response="response emitted before the terminal exit",
+        api_call_count=1,
+        interrupted=interrupted,
+        failed=failed,
+        messages=[{"role": "user", "content": "task"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason=exit_reason,
+    )
+
+    assert result["completed"] is False
+    assert result["outcome"] == expected_outcome
+
+
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")

--- a/tests/agent/test_turn_finalizer_memory_gating.py
+++ b/tests/agent/test_turn_finalizer_memory_gating.py
@@ -71,14 +71,22 @@ class _FinalizerAgent:
         self.background_reviews.append(kwargs)
 
 
-def _finalize(agent, *, final_response="Done.", failed=False, interrupted=False, reason="text_response(finish_reason=stop)"):
+def _finalize(
+    agent,
+    *,
+    final_response="Done.",
+    failed=False,
+    interrupted=False,
+    reason="text_response(finish_reason=stop)",
+    messages=None,
+):
     return finalize_turn(
         agent,
         final_response=final_response,
         api_call_count=1,
         interrupted=interrupted,
         failed=failed,
-        messages=[{"role": "user", "content": "do it"}],
+        messages=messages or [{"role": "user", "content": "do it"}],
         conversation_history=[],
         effective_task_id="task",
         turn_id="turn",
@@ -92,7 +100,6 @@ def _finalize(agent, *, final_response="Done.", failed=False, interrupted=False,
 @pytest.mark.parametrize(
     "outcome, verification_status, kwargs",
     [
-        ("completed_unverified", "unverified", {}),
         ("partial", "passed", {"reason": "max_iterations_reached(90/90)"}),
         ("blocked", "passed", {"reason": "approval_blocked"}),
         ("failed", "passed", {"failed": True, "reason": "provider_failure"}),
@@ -127,5 +134,36 @@ def test_verified_turn_syncs_and_spawns_review(monkeypatch):
     assert len(agent.background_reviews) == 1
 
 
-# completed_unverified is intentionally not durable until a later policy
-# explicitly permits it; this phase only allows the verified outcome.
+def test_completed_unverified_no_tool_turn_syncs_without_background_review(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_k: [])
+    agent = _FinalizerAgent("unverified")
+
+    result = _finalize(agent)
+
+    assert result["outcome"] == "completed_unverified"
+    agent._memory_manager.sync_all.assert_called_once()
+    agent._memory_manager.queue_prefetch_all.assert_called_once()
+    assert agent.background_reviews == []
+
+
+def test_completed_unverified_tool_turn_does_not_sync(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_k: [])
+    agent = _FinalizerAgent("unverified")
+    messages = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call-1", "type": "function", "function": {"name": "terminal"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "ok"},
+    ]
+
+    result = _finalize(agent, messages=messages)
+
+    assert result["outcome"] == "completed_unverified"
+    agent._memory_manager.sync_all.assert_not_called()
+    agent._memory_manager.queue_prefetch_all.assert_not_called()
+    assert agent.background_reviews == []

--- a/tests/agent/test_turn_finalizer_memory_gating.py
+++ b/tests/agent/test_turn_finalizer_memory_gating.py
@@ -1,0 +1,131 @@
+"""Memory and background-review gates consume the canonical turn outcome."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
+
+
+class _FinalizerAgent:
+    def __init__(self, verification_status):
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=89, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self._turn_verification_status = verification_status
+        self._memory_manager = MagicMock()
+        self.background_reviews = []
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, _messages):
+        pass
+
+    def _persist_session(self, *_args, **_kwargs):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **kwargs):
+        return getattr(AIAgent, "_sync_external_memory_for_turn")(self, **kwargs)
+
+    def _spawn_background_review(self, **kwargs):
+        self.background_reviews.append(kwargs)
+
+
+def _finalize(agent, *, final_response="Done.", failed=False, interrupted=False, reason="text_response(finish_reason=stop)"):
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=interrupted,
+        failed=failed,
+        messages=[{"role": "user", "content": "do it"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=True,
+        _turn_exit_reason=reason,
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome, verification_status, kwargs",
+    [
+        ("completed_unverified", "unverified", {}),
+        ("partial", "passed", {"reason": "max_iterations_reached(90/90)"}),
+        ("blocked", "passed", {"reason": "approval_blocked"}),
+        ("failed", "passed", {"failed": True, "reason": "provider_failure"}),
+        ("interrupted", "passed", {"interrupted": True, "reason": "interrupted_by_user"}),
+        ("unresolved", "passed", {"reason": "tool_timeout"}),
+        ("cancelled", "passed", {"reason": "cancelled"}),
+    ],
+)
+def test_non_verified_outcomes_do_not_sync_or_spawn_review(
+    monkeypatch, outcome, verification_status, kwargs
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_k: [])
+    agent = _FinalizerAgent(verification_status)
+
+    result = _finalize(agent, **kwargs)
+
+    assert result["outcome"] == outcome
+    agent._memory_manager.sync_all.assert_not_called()
+    agent._memory_manager.queue_prefetch_all.assert_not_called()
+    assert agent.background_reviews == []
+
+
+def test_verified_turn_syncs_and_spawns_review(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_k: [])
+    agent = _FinalizerAgent("passed")
+
+    result = _finalize(agent)
+
+    assert result["outcome"] == "verified"
+    agent._memory_manager.sync_all.assert_called_once()
+    agent._memory_manager.queue_prefetch_all.assert_called_once()
+    assert len(agent.background_reviews) == 1
+
+
+# completed_unverified is intentionally not durable until a later policy
+# explicitly permits it; this phase only allows the verified outcome.

--- a/tests/agent/test_turn_outcome.py
+++ b/tests/agent/test_turn_outcome.py
@@ -1,0 +1,88 @@
+import json
+
+from agent.turn_outcome import TURN_OUTCOMES, classify_turn_outcome
+
+
+def _classify(**overrides):
+    facts = {
+        "final_response": "answer",
+        "failed": False,
+        "interrupted": False,
+        "_turn_exit_reason": "text_response(finish_reason=stop)",
+        "verification_status": None,
+        "timeout": False,
+        "unresolved": False,
+    }
+    facts.update(overrides)
+    return classify_turn_outcome(**facts)
+
+
+def test_normal_verified_response_has_canonical_serializable_outcome():
+    result = _classify(verification_status="passed")
+
+    assert result == {"outcome": "verified", "reason": "verification passed"}
+    assert json.loads(json.dumps(result)) == result
+
+
+def test_iteration_budget_fallback_is_partial_even_with_response_text():
+    result = _classify(
+        _turn_exit_reason="max_iterations_reached(60/60)",
+    )
+
+    assert result["outcome"] == "partial"
+    assert "iteration budget" in result["reason"]
+
+
+def test_provider_failure_with_response_text_is_failed():
+    result = _classify(
+        failed=True,
+        _turn_exit_reason="provider_failure",
+    )
+
+    assert result["outcome"] == "failed"
+
+
+def test_interrupt_with_response_text_is_interrupted():
+    result = _classify(
+        interrupted=True,
+        _turn_exit_reason="interrupted_by_user",
+    )
+
+    assert result["outcome"] == "interrupted"
+
+
+def test_blocked_approval_with_response_text_is_blocked():
+    result = _classify(
+        _turn_exit_reason="approval_blocked",
+    )
+
+    assert result["outcome"] == "blocked"
+
+
+def test_unresolved_timeout_with_response_text_is_unresolved():
+    result = _classify(
+        _turn_exit_reason="tool_timeout",
+        timeout=True,
+        unresolved=True,
+    )
+
+    assert result["outcome"] == "unresolved"
+
+
+def test_completed_but_unverified_response_is_not_verified():
+    result = _classify(verification_status="unverified")
+
+    assert result["outcome"] == "completed_unverified"
+
+
+def test_outcome_vocabulary_is_finite():
+    assert TURN_OUTCOMES == (
+        "verified",
+        "completed_unverified",
+        "partial",
+        "blocked",
+        "failed",
+        "interrupted",
+        "unresolved",
+        "cancelled",
+    )

--- a/tests/agent/test_turn_outcome.py
+++ b/tests/agent/test_turn_outcome.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from agent.turn_outcome import TURN_OUTCOMES, classify_turn_outcome
 
 
@@ -40,6 +42,27 @@ def test_provider_failure_with_response_text_is_failed():
     )
 
     assert result["outcome"] == "failed"
+
+
+@pytest.mark.parametrize(
+    ("exit_reason", "expected_outcome"),
+    [
+        ("guardrail_halt", "blocked"),
+        ("error_near_max_iterations(repeated failure)", "failed"),
+        ("all_retries_exhausted_no_response", "failed"),
+        ("ollama_runtime_context_too_small", "failed"),
+        ("partial_stream_recovery", "partial"),
+        ("fallback_prior_turn_content", "partial"),
+        ("empty_response_exhausted", "partial"),
+        ("pending_tool_result", "partial"),
+    ],
+)
+def test_known_non_success_exit_reason_overrides_response_text(
+    exit_reason, expected_outcome
+):
+    result = _classify(_turn_exit_reason=exit_reason)
+
+    assert result["outcome"] == expected_outcome
 
 
 def test_interrupt_with_response_text_is_interrupted():

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -74,6 +74,7 @@ def _clear_approval_state():
     mod._session_approved.clear()
     mod._permanent_approved.clear()
     mod._pending.clear()
+    getattr(mod, "_pending_by_session", {}).clear()
 
 
 # ------------------------------------------------------------------
@@ -703,6 +704,25 @@ class TestFallbackNoCallback:
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
 
+    @pytest.mark.asyncio
+    async def test_exact_request_id_approves_fallback_request(self):
+        """An exact fallback request id resolves only that request."""
+        from tools import approval as mod
+
+        runner = _make_runner()
+        session_key = runner._session_key_for_source(_make_source())
+        request = mod.submit_pending(session_key, {
+            "operation": "terminal",
+            "arguments": {"command": "rm -rf /tmp/a"},
+            "pattern_key": "recursive delete",
+            "command": "rm -rf /tmp/a",
+        })
+
+        await runner._handle_approve_command(
+            _make_event(f"/approve {request['request_id']}")
+        )
+
+        assert mod._pending[request["request_id"]]["resolution"] == "once"
 
 # ------------------------------------------------------------------
 # Regression: cross-session approval routing isolation (#24100)

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -219,6 +219,21 @@ class TestApproveCommand:
         assert entry.event.is_set()
 
     @pytest.mark.asyncio
+    async def test_approve_arbitrary_text_keeps_legacy_fifo(self):
+        """Free text is not a request id unless it names a live request."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        entry = _ApprovalEntry({"command": "test"})
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_approve_command(_make_event("/approve please"))
+        assert "approved" in result.lower()
+        assert entry.event.is_set()
+
+    @pytest.mark.asyncio
     async def test_approve_all_resolves_multiple(self):
         """/approve all resolves all pending approvals."""
         from tools.approval import _ApprovalEntry, _gateway_queues

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1011,6 +1011,86 @@ class TestResolvePreToolBlock:
         assert resolve_pre_tool_block("write_file", {}) is None
         assert seen["rule_key"] == "write_file"
 
+    def test_approve_without_arguments_fails_closed(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "approve", "message": "why"}],
+        )
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: pytest.fail("missing arguments must not reach the gate"),
+        )
+
+        assert resolve_pre_tool_block("write_file", None) == (
+            "BLOCKED: plugin approval requires call arguments for write_file"
+        )
+
+    def test_approve_does_not_reuse_resolved_identity_for_different_args(self, monkeypatch):
+        import tools.approval as approval
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        session = "plugin-identity-session"
+        with approval._lock:
+            approval._gateway_queues.clear()
+            approval._gateway_notify_cbs.clear()
+            approval._session_approved.clear()
+            approval._permanent_approved.clear()
+            approval._pending.clear()
+            approval._pending_by_session.clear()
+        token = approval.set_current_session_key(session)
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setattr(approval, "is_approved", lambda *args: False)
+        monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "approve", "message": "same reason"}],
+        )
+        try:
+            first_block = resolve_pre_tool_block(
+                "write_file",
+                {"path": "one"},
+                task_id="task-1",
+                session_id=session,
+                tool_call_id="tool-1",
+            )
+            assert first_block is not None
+            request = approval.get_pending_approval("tool-1")
+            assert request is not None
+            assert request["arguments"] == {"path": "one"}
+            assert request["requester"] == session
+            assert request["channel"] == "task-1"
+
+            assert approval.resolve_gateway_approval(
+                session,
+                "once",
+                request_id="tool-1",
+                request_hash=request["argument_hash"],
+            ) == 1
+
+            second_block = resolve_pre_tool_block(
+                "write_file",
+                {"path": "two"},
+                task_id="task-1",
+                session_id=session,
+                tool_call_id="tool-2",
+            )
+            assert second_block is not None
+            remaining = approval.get_pending_approval("tool-1")
+            assert remaining is not None
+            assert remaining["status"] == "resolved"
+        finally:
+            approval.reset_current_session_key(token)
+            with approval._lock:
+                approval._gateway_queues.clear()
+                approval._gateway_notify_cbs.clear()
+                approval._session_approved.clear()
+                approval._permanent_approved.clear()
+                approval._pending.clear()
+                approval._pending_by_session.clear()
+
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1091,6 +1091,82 @@ class TestResolvePreToolBlock:
                 approval._pending.clear()
                 approval._pending_by_session.clear()
 
+    def test_plugin_fallback_generates_distinct_ids_for_same_turn(self, monkeypatch):
+        import tools.approval as approval
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        session = "same-turn-plugin-session"
+        with approval._lock:
+            approval._gateway_queues.clear()
+            approval._gateway_notify_cbs.clear()
+            approval._session_approved.clear()
+            approval._permanent_approved.clear()
+            approval._pending.clear()
+            approval._pending_by_session.clear()
+        token = approval.set_current_session_key(session)
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        monkeypatch.setattr(approval, "is_approved", lambda *args: False)
+        monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "approve", "message": "why"}],
+        )
+        try:
+            for path in ("one", "two"):
+                assert resolve_pre_tool_block(
+                    "write_file",
+                    {"path": path},
+                    session_id=session,
+                    turn_id="shared-turn",
+                    api_request_id="shared-api-request",
+                ) is not None
+
+            request_ids = approval._pending_by_session[session]
+            assert len(request_ids) == 2
+            assert len(set(request_ids)) == 2
+            assert set(request_ids).isdisjoint({"shared-turn", "shared-api-request"})
+        finally:
+            approval.reset_current_session_key(token)
+            with approval._lock:
+                approval._gateway_queues.clear()
+                approval._gateway_notify_cbs.clear()
+                approval._session_approved.clear()
+                approval._permanent_approved.clear()
+                approval._pending.clear()
+                approval._pending_by_session.clear()
+
+    def test_pending_request_id_collision_is_rejected_across_sessions(self):
+        import tools.approval as approval
+
+        request = approval.submit_pending(
+            "session-one",
+            {
+                "request_id": "shared-request",
+                "operation": "write_file",
+                "tool_name": "write_file",
+                "arguments": {"path": "one"},
+            },
+        )
+        try:
+            collision = approval.submit_pending(
+                "session-two",
+                {
+                    "request_id": "shared-request",
+                    "operation": "write_file",
+                    "tool_name": "write_file",
+                    "arguments": {"path": "two"},
+                },
+            )
+            assert collision is None
+            request = approval.get_pending_approval("shared-request")
+            assert request is not None
+            assert request["session_key"] == "session-one"
+        finally:
+            with approval._lock:
+                approval._pending.clear()
+                approval._pending_by_session.clear()
+
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block
         monkeypatch.setattr(

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -213,6 +213,46 @@ class TestRunConversationCodexPath:
         agent._memory_manager.sync_all.assert_called_once()
         assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
 
+    def test_unverified_no_tool_turn_is_synced_to_external_memory(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text=f"echo: {user_input}",
+                projected_messages=[{"role": "assistant", "content": f"echo: {user_input}"}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-no-tools-1",
+                thread_id="thread-no-tools-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-no-tools-1"
+        )
+        agent = _make_codex_agent()
+        agent._turn_verification_status = "unverified"
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+
+        with patch.object(agent, "_spawn_background_review", return_value=None) as spawn:
+            agent.run_conversation("hello")
+
+        agent._memory_manager.sync_all.assert_called_once()
+        agent._memory_manager.queue_prefetch_all.assert_called_once()
+        spawn.assert_not_called()
+
+    def test_unverified_tool_turn_is_not_synced_to_external_memory(self, fake_session):
+        agent = _make_codex_agent()
+        agent._turn_verification_status = "unverified"
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        agent._memory_manager.sync_all.assert_not_called()
+        agent._memory_manager.queue_prefetch_all.assert_not_called()
+
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across
         turns. The memory nudge counter is gated on memory being configured

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -53,7 +53,7 @@ def _make_codex_agent(**kwargs):
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
-    return run_agent.AIAgent(
+    agent = run_agent.AIAgent(
         api_key="stub",
         base_url="https://stub.invalid",
         provider="openai",
@@ -63,6 +63,9 @@ def _make_codex_agent(**kwargs):
         skip_memory=True,
         **kwargs,
     )
+    # Fake Codex responses represent the explicitly verified positive path.
+    setattr(agent, "_turn_verification_status", "passed")
+    return agent
 
 
 class TestApiModeAccepted:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -63,8 +63,6 @@ def _make_codex_agent(**kwargs):
         skip_memory=True,
         **kwargs,
     )
-    # Fake Codex responses represent the explicitly verified positive path.
-    setattr(agent, "_turn_verification_status", "passed")
     return agent
 
 
@@ -202,16 +200,16 @@ class TestRunConversationCodexPath:
                  and m.get("content") == "echo: hello"]
         assert final, f"expected final assistant message in {msgs}"
 
-    def test_projected_messages_are_synced_to_external_memory(self, fake_session):
+    def test_unverified_tool_turn_is_not_synced_to_external_memory(self, fake_session):
         agent = _make_codex_agent()
         agent._memory_manager = MagicMock()
         agent._memory_manager.build_system_prompt.return_value = ""
 
         with patch.object(agent, "_spawn_background_review", return_value=None):
-            result = agent.run_conversation("hello")
+            agent.run_conversation("hello")
 
-        agent._memory_manager.sync_all.assert_called_once()
-        assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
+        agent._memory_manager.sync_all.assert_not_called()
+        agent._memory_manager.queue_prefetch_all.assert_not_called()
 
     def test_unverified_no_tool_turn_is_synced_to_external_memory(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -241,17 +239,6 @@ class TestRunConversationCodexPath:
         agent._memory_manager.queue_prefetch_all.assert_called_once()
         spawn.assert_not_called()
 
-    def test_unverified_tool_turn_is_not_synced_to_external_memory(self, fake_session):
-        agent = _make_codex_agent()
-        agent._turn_verification_status = "unverified"
-        agent._memory_manager = MagicMock()
-        agent._memory_manager.build_system_prompt.return_value = ""
-
-        with patch.object(agent, "_spawn_background_review", return_value=None):
-            agent.run_conversation("hello")
-
-        agent._memory_manager.sync_all.assert_not_called()
-        agent._memory_manager.queue_prefetch_all.assert_not_called()
 
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across
@@ -300,12 +287,10 @@ class TestRunConversationCodexPath:
         # args after every turn, which would crash with TypeError).
         assert not spawn.called
 
-    def test_background_review_skill_trigger_fires_above_threshold(
+    def test_background_review_skill_trigger_requires_verification(
         self, monkeypatch
     ):
-        """When tool iterations cross the skill nudge interval, the
-        background review fires with review_skills=True and the right
-        messages_snapshot signature."""
+        """Tool iterations alone must not trigger an unverified review."""
         from agent.transports.codex_app_server_session import (
             CodexAppServerSession, TurnResult,
         )
@@ -336,23 +321,12 @@ class TestRunConversationCodexPath:
                           return_value=None) as spawn:
             agent.run_conversation("do tool work")
 
-        assert spawn.called, "skill threshold tripped but review didn't fire"
-        # Verify the call signature matches what _spawn_background_review
-        # actually expects — this is the regression guard for the original
-        # bug where the codex path called it with no args at all.
-        call = spawn.call_args
-        assert "messages_snapshot" in call.kwargs
-        assert isinstance(call.kwargs["messages_snapshot"], list)
-        assert call.kwargs["review_skills"] is True
-        # Counter should be reset after the review fires
-        assert agent._iters_since_skill == 0
+        # The threshold is crossed, but Codex supplied no passed verification
+        # evidence, so the verified-only review gate must suppress the spawn.
+        spawn.assert_not_called()
 
-    def test_background_review_signature_never_breaks(self, fake_session):
-        """Even when no trigger fires, the helper must never call
-        _spawn_background_review with the wrong signature. Run a turn,
-        then run another turn after manually tripping the skill counter
-        and confirm the call shape is the kwargs-only form the function
-        actually accepts."""
+    def test_background_review_unverified_tool_turn_is_gated(self, fake_session):
+        """An unverified tool turn must not reach the review helper."""
         agent = _make_codex_agent()
         agent._skill_nudge_interval = 1  # very low so any iter trips it
         agent._iters_since_skill = 0
@@ -362,18 +336,9 @@ class TestRunConversationCodexPath:
         with patch.object(agent, "_spawn_background_review",
                           return_value=None) as spawn:
             agent.run_conversation("first")
-        # The fake session reports tool_iterations=1, which trips
-        # _skill_nudge_interval=1. So review should fire.
-        assert spawn.called
-        # Critical invariant: positional args must be empty, all real
-        # args must be kwargs (matching _spawn_background_review's
-        # actual signature).
-        call = spawn.call_args
-        assert call.args == (), (
-            f"expected no positional args, got {call.args!r} — "
-            "would crash _spawn_background_review at runtime"
-        )
-        assert "messages_snapshot" in call.kwargs
+        # tool_iterations is not verification evidence; the verified-only
+        # background-review gate must suppress the helper call.
+        spawn.assert_not_called()
 
     def test_chat_completions_loop_is_not_entered(self, fake_session):
         """The early-return must bypass the regular API call loop entirely.

--- a/tests/run_agent/test_current_turn_verification.py
+++ b/tests/run_agent/test_current_turn_verification.py
@@ -1,0 +1,146 @@
+"""Current-turn verification status is produced from tool evidence."""
+
+import json
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _response(content="", *, tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls" if tool_calls else "stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _tool_call(call_id):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments='{"command":"scripts/run_tests.sh"}'),
+    )
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "description": "terminal",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            session_id="verification-status-test",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance._cached_system_prompt = "stable test prompt"
+    instance._session_db = None
+    instance._session_json_enabled = False
+    instance.save_trajectories = False
+    instance.compression_enabled = False
+    instance._cleanup_task_resources = lambda *_a, **_kw: None
+    instance._save_trajectory = lambda *_a, **_kw: None
+    return instance
+
+
+def _run(agent, responses, *, tool_result=None):
+    agent._interruptible_api_call = lambda _kwargs: next(responses)
+    patches = [
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+        patch.object(agent, "_persist_session"),
+    ]
+    if tool_result is not None:
+        patches.append(patch("run_agent.handle_function_call", return_value=tool_result))
+    with ExitStack() as stack:
+        for context in patches:
+            stack.enter_context(context)
+        return agent.run_conversation("do it")
+
+
+def test_turn_boundary_resets_stale_verification_status(agent):
+    agent._turn_verification_status = {"status": "passed"}
+
+    result = _run(agent, iter([_response("plain answer")]))
+
+    assert result["outcome"] == "completed_unverified"
+    assert result["completed"] is True
+
+
+def test_no_tool_turn_is_completed_unverified(agent):
+    result = _run(agent, iter([_response("plain answer")]))
+
+    assert result["outcome"] == "completed_unverified"
+    assert result["completed"] is True
+
+
+def test_passed_terminal_evidence_produces_verified_outcome(agent):
+    evidence_result = json.dumps(
+        {
+            "output": "1 passed",
+            "exit_code": 0,
+            "error": None,
+            "verification_evidence": {
+                "status": "passed",
+                "kind": "test",
+                "scope": "repository",
+                "canonical_command": "scripts/run_tests.sh",
+            },
+        }
+    )
+    result = _run(
+        agent,
+        iter([_response(tool_calls=[_tool_call("c1")]), _response("verified answer")]),
+        tool_result=evidence_result,
+    )
+
+    assert result["outcome"] == "verified"
+    assert result["completed"] is True
+
+
+def test_failed_terminal_evidence_never_verifies(agent):
+    failed_result = json.dumps(
+        {
+            "output": "1 failed",
+            "exit_code": 1,
+            "error": None,
+            "verification_evidence": {
+                "status": "failed",
+                "kind": "test",
+                "scope": "repository",
+                "canonical_command": "scripts/run_tests.sh",
+            },
+        }
+    )
+    result = _run(
+        agent,
+        iter([_response(tool_calls=[_tool_call("c1")]), _response("answer")]),
+        tool_result=failed_result,
+    )
+
+    assert result["outcome"] == "completed_unverified"
+    assert result["completed"] is True

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -10,7 +10,7 @@ class _CapturingSessionDB:
         self.rows = []
 
     def append_message(self, session_id, role, content=None, **kwargs):
-        self.rows.append({"role": role, "content": content})
+        self.rows.append({"role": role, "content": content, **kwargs})
         return len(self.rows)
 
 
@@ -174,3 +174,18 @@ def test_flush_skips_thinking_prefill_scaffolding():
     agent._flush_messages_to_session_db(messages, conversation_history=[])
 
     assert [r["content"] for r in agent._session_db.rows] == ["hi", "Hello!"]
+
+
+def test_flush_persists_timeout_cancellation_effect_disposition():
+    agent = _agent_with_capturing_db()
+    messages = [{
+        "role": "tool",
+        "content": "[Tool execution cancelled — write_file was skipped due to timeout]",
+        "tool_name": "write_file",
+        "tool_call_id": "call-1",
+        "effect_disposition": "none",
+    }]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    assert agent._session_db.rows[0]["effect_disposition"] == "none"

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -81,6 +81,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="What's the weather in Paris?",
             final_response="It's sunny and 22°C.",
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_called_once_with(
             "What's the weather in Paris?", "It's sunny and 22°C.",
@@ -120,6 +121,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="run tests",
             final_response="tests passed",
             interrupted=False,
+            turn_outcome="verified",
             messages=messages,
         )
 
@@ -151,6 +153,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message=skill_message,
             final_response="Done.",
             interrupted=False,
+            turn_outcome="verified",
         )
 
         agent._memory_manager.sync_all.assert_called_once_with(
@@ -173,6 +176,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="Hello",
             final_response=None,
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_not_called()
 
@@ -185,6 +189,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message=None,
             final_response="Proactive notification text",
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_not_called()
 
@@ -201,6 +206,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="hi",
             final_response="hey",
             interrupted=False,
+            turn_outcome="verified",
         )
 
     # --- Exception safety ----------------------------------------------
@@ -219,6 +225,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="hi",
             final_response="hey",
             interrupted=False,
+            turn_outcome="verified",
         )
         # sync_all was attempted.
         agent._memory_manager.sync_all.assert_called_once()
@@ -236,6 +243,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="hi",
             final_response="hey",
             interrupted=False,
+            turn_outcome="verified",
         )
         # sync_all still happened before the prefetch blew up.
         agent._memory_manager.sync_all.assert_called_once()
@@ -256,6 +264,7 @@ class TestSyncExternalMemoryForTurn:
             ],
             final_response="A terminal window showing a stack trace.",
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_called_once_with(
             "[1 image] what is in this screenshot?",
@@ -273,6 +282,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message="describe it",
             final_response=[{"type": "text", "text": "a cat"}],
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_called_once_with(
             "describe it", "a cat",
@@ -287,6 +297,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message=[{"type": "audio", "data": "..."}],
             final_response="noted",
             interrupted=False,
+            turn_outcome="verified",
         )
         agent._memory_manager.sync_all.assert_not_called()
         agent._memory_manager.queue_prefetch_all.assert_not_called()
@@ -309,6 +320,7 @@ class TestSyncExternalMemoryForTurn:
             original_user_message=user,
             final_response=final,
             interrupted=interrupted,
+            turn_outcome="verified" if expect_sync else "partial",
         )
         if expect_sync:
             agent._memory_manager.sync_all.assert_called_once()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2550,6 +2550,17 @@ class TestConcurrentToolExecution:
             lambda fs, timeout=None: (set(), set(fs)),
         )
         agent._flush_messages_to_session_db = MagicMock()
+        agent.session_id = "session-1"
+        agent._current_turn_id = "turn-1"
+        agent._current_api_request_id = "api-1"
+        hook_calls = []
+
+        def _capture_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _capture_hook)
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
         tc = _mock_tool_call(name="write_file", arguments='{"path":"x"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
@@ -2558,9 +2569,13 @@ class TestConcurrentToolExecution:
             agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
 
         result = messages[0]
+        assert result["content"] == "[Tool execution cancelled — write_file was skipped due to timeout]"
         assert result["effect_disposition"] == "none"
-        assert "cancelled" in result["content"].lower()
         assert "[UNRESOLVED]" not in result["content"]
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["status"] == "cancelled"
+        assert post_calls[0]["error_type"] == "tool_timeout_cancelled"
 
     def test_concurrent_late_real_result_wins_without_sleep(self, agent, monkeypatch):
         """A real result present after the deadline snapshot beats fabrication."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4357,7 +4357,8 @@ class TestRunConversation:
             result = agent.run_conversation("hello", conversation_history=prefill)
 
         mock_compress.assert_not_called()  # no compression triggered
-        assert result["completed"] is True
+        assert result["completed"] is False
+        assert result["outcome"] == "partial"
         # #34452: the bare "(empty)" sentinel is now replaced by a
         # user-visible end-of-turn explanation so the failure isn't silent.
         assert result["final_response"] != "(empty)"
@@ -4381,7 +4382,8 @@ class TestRunConversation:
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
+        assert result["outcome"] == "partial"
         # #34452: explanation replaces the bare "(empty)" sentinel.
         assert result["final_response"] != "(empty)"
         assert "No reply:" in result["final_response"]
@@ -4430,7 +4432,8 @@ class TestRunConversation:
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
+        assert result["outcome"] == "partial"
         # #34452: explanation replaces the bare "(empty)" sentinel.
         assert result["final_response"] != "(empty)"
         assert "No reply:" in result["final_response"]
@@ -4528,7 +4531,8 @@ class TestRunConversation:
             patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
+        assert result["outcome"] == "partial"
         # #34452: explanation replaces the bare "(empty)" sentinel.
         assert result["final_response"] != "(empty)"
         assert "No reply:" in result["final_response"]
@@ -4615,7 +4619,8 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("ask me")
         # Should recover partial streamed content, not fall through to (empty)
-        assert result["completed"] is True
+        assert result["completed"] is False
+        assert result["outcome"] == "partial"
         assert result["final_response"].startswith("The answer to your question is that")
         assert "No reply:" in result["final_response"]
         assert result["response_previewed"] is False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2532,6 +2532,36 @@ class TestConcurrentToolExecution:
         assert "do not retry blindly" in result["content"].lower()
         assert "cancelled" not in result["content"].lower()
 
+    def test_concurrent_timeout_prefers_confirmed_cancellation(self, agent, monkeypatch):
+        """A timeout-cancelled future must be classified as no-effect."""
+        from agent import tool_executor
+
+        monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.1")
+        future = MagicMock()
+        future.cancel.return_value = True
+        future.cancelled.return_value = True
+        executor = MagicMock()
+        executor.submit.return_value = future
+        ticks = iter((0.0, 0.0, 1.0))
+        monkeypatch.setattr(tool_executor.time, "monotonic", lambda: next(ticks))
+        monkeypatch.setattr(
+            tool_executor.concurrent.futures,
+            "wait",
+            lambda fs, timeout=None: (set(), set(fs)),
+        )
+        agent._flush_messages_to_session_db = MagicMock()
+        tc = _mock_tool_call(name="write_file", arguments='{"path":"x"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("tools.daemon_pool.DaemonThreadPoolExecutor", return_value=executor):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        result = messages[0]
+        assert result["effect_disposition"] == "none"
+        assert "cancelled" in result["content"].lower()
+        assert "[UNRESOLVED]" not in result["content"]
+
     def test_concurrent_late_real_result_wins_without_sleep(self, agent, monkeypatch):
         """A real result present after the deadline snapshot beats fabrication."""
         from agent import tool_executor

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2501,6 +2501,105 @@ class TestRetryAfterCap:
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""
 
+    def test_concurrent_timeout_marks_missing_result_unresolved(self, agent, monkeypatch):
+        """A deadline with no worker result must warn against blind retry."""
+        from agent import tool_executor
+
+        monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.1")
+        future = MagicMock()
+        future.cancel.return_value = False
+        future.cancelled.return_value = False
+        executor = MagicMock()
+        executor.submit.return_value = future
+        ticks = iter((0.0, 0.0, 1.0))
+        monkeypatch.setattr(tool_executor.time, "monotonic", lambda: next(ticks))
+        monkeypatch.setattr(
+            tool_executor.concurrent.futures,
+            "wait",
+            lambda fs, timeout=None: (set(), set(fs)),
+        )
+        agent._flush_messages_to_session_db = MagicMock()
+        tc = _mock_tool_call(name="write_file", arguments='{"path":"x"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("tools.daemon_pool.DaemonThreadPoolExecutor", return_value=executor):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        result = messages[0]
+        assert result["effect_disposition"] == "unknown"
+        assert "[UNRESOLVED]" in result["content"]
+        assert "do not retry blindly" in result["content"].lower()
+        assert "cancelled" not in result["content"].lower()
+
+    def test_concurrent_late_real_result_wins_without_sleep(self, agent, monkeypatch):
+        """A real result present after the deadline snapshot beats fabrication."""
+        from agent import tool_executor
+
+        monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.1")
+        future = MagicMock()
+        future.cancel.return_value = False
+        future.cancelled.return_value = False
+        executor = MagicMock()
+
+        def submit_and_complete(target, *args, **kwargs):
+            target(*args, **kwargs)
+            return future
+
+        executor.submit.side_effect = submit_and_complete
+        ticks = iter((0.0, 0.0, 1.0))
+        monkeypatch.setattr(tool_executor.time, "monotonic", lambda: next(ticks))
+        monkeypatch.setattr(
+            tool_executor.concurrent.futures,
+            "wait",
+            lambda fs, timeout=None: (set(), set(fs)),
+        )
+        agent._flush_messages_to_session_db = MagicMock()
+        tc = _mock_tool_call(name="write_file", arguments='{"path":"x"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("tools.daemon_pool.DaemonThreadPoolExecutor", return_value=executor), \
+             patch("run_agent.handle_function_call", return_value="real-result"):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert messages[0]["content"] == "real-result"
+        assert "timed out" not in messages[0]["content"]
+
+    @pytest.mark.parametrize("cancel_result", [False, True])
+    def test_concurrent_interrupt_is_cancelled_only_when_future_cancelled(
+        self, agent, monkeypatch, cancel_result
+    ):
+        """An interrupted worker without confirmed cancellation stays unresolved."""
+        from agent import tool_executor
+
+        monkeypatch.delenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", raising=False)
+        future = MagicMock()
+        future.cancel.return_value = cancel_result
+        future.cancelled.return_value = cancel_result
+        executor = MagicMock()
+        executor.submit.return_value = future
+        agent._flush_messages_to_session_db = MagicMock()
+        tc = _mock_tool_call(name="write_file", arguments='{"path":"x"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        def interrupt_on_wait(fs, timeout=None):
+            agent._interrupt_requested = True
+            return set(), set(fs)
+
+        monkeypatch.setattr(tool_executor.concurrent.futures, "wait", interrupt_on_wait)
+        with patch("tools.daemon_pool.DaemonThreadPoolExecutor", return_value=executor):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        result = messages[0]
+        if cancel_result:
+            assert "cancelled" in result["content"].lower()
+        else:
+            assert result["effect_disposition"] == "unknown"
+            assert "[UNRESOLVED]" in result["content"]
+            assert "cancelled" not in result["content"].lower()
+
     def test_single_tool_uses_sequential_path(self, agent):
         """Single tool call should use sequential path, not concurrent."""
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")

--- a/tests/tools/test_approval_fallback_execution.py
+++ b/tests/tools/test_approval_fallback_execution.py
@@ -1,5 +1,7 @@
 """Real guard-path coverage for no-callback approval retries."""
 
+import json
+
 import tools.approval as approval
 
 
@@ -38,6 +40,8 @@ def test_terminal_fallback_retry_consumes_exact_approval(monkeypatch):
         command = "rm -rf /tmp/fallback-a"
         pending = approval.check_all_command_guards(command, "local")
         assert pending["status"] == "pending_approval"
+        for key in ("request_id", "argument_hash", "operation", "tool_name"):
+            assert key in pending
 
         assert approval.resolve_gateway_approval(
             SESSION, "once", request_id=pending["request_id"]
@@ -65,6 +69,8 @@ def test_execute_code_fallback_retry_consumes_exact_approval(monkeypatch):
         code = "import os\nprint(1)"
         pending = approval.check_execute_code_guard(code, "local")
         assert pending["status"] == "pending_approval"
+        for key in ("request_id", "argument_hash", "operation", "tool_name"):
+            assert key in pending
 
         assert approval.resolve_gateway_approval(
             SESSION, "once", request_id=pending["request_id"]
@@ -84,6 +90,102 @@ def test_execute_code_fallback_retry_consumes_exact_approval(monkeypatch):
         assert SESSION not in approval._pending_by_session
     finally:
         _finish_session(token)
+
+
+def test_terminal_fallback_deny_retry_is_blocked_with_reason(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        command = "rm -rf /tmp/fallback-denied"
+        pending = approval.check_all_command_guards(command, "local")
+        reason = "wrong directory"
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "deny",
+            request_id=pending["request_id"],
+            reason=reason,
+        ) == 1
+
+        retried = approval.check_all_command_guards(command, "local")
+        assert retried["approved"] is False
+        assert retried["status"] == "blocked"
+        assert retried["outcome"] == "denied"
+        assert retried["resolution_reason"] == reason
+        assert retried["deny_reason"] == reason
+        assert reason in retried["message"]
+        assert pending["request_id"] not in approval._pending
+    finally:
+        _finish_session(token)
+
+
+def test_execute_code_fallback_deny_retry_is_blocked_with_reason(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        code = "import os\nprint('denied')"
+        pending = approval.check_execute_code_guard(code, "local")
+        reason = "use the terminal tool"
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "deny",
+            request_id=pending["request_id"],
+            reason=reason,
+        ) == 1
+
+        retried = approval.check_execute_code_guard(code, "local")
+        assert retried["approved"] is False
+        assert retried["status"] == "blocked"
+        assert retried["outcome"] == "denied"
+        assert retried["resolution_reason"] == reason
+        assert retried["deny_reason"] == reason
+        assert reason in retried["message"]
+        assert pending["request_id"] not in approval._pending
+    finally:
+        _finish_session(token)
+
+
+def _pending_identity_payload(operation):
+    return {
+        "approved": False,
+        "status": "pending_approval",
+        "approval_pending": True,
+        "request_id": f"{operation}-request",
+        "argument_hash": f"{operation}-hash",
+        "operation": operation,
+        "tool_name": operation,
+        "created_at": 1.0,
+        "expires_at": 2.0,
+        "command": "redacted",
+        "description": "approval required",
+        "pattern_key": operation,
+    }
+
+
+def test_terminal_public_tool_preserves_pending_identity(monkeypatch):
+    from tools import terminal_tool
+
+    pending = _pending_identity_payload("terminal")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {
+        "env_type": "local", "cwd": ".", "timeout": 30,
+    })
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _: "default")
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *args, **kwargs: pending)
+    monkeypatch.setitem(terminal_tool._active_environments, "default", object())
+
+    result = json.loads(terminal_tool.terminal_tool("rm -rf /tmp/a"))
+    for key in ("request_id", "argument_hash", "operation", "tool_name"):
+        assert result[key] == pending[key]
+
+
+def test_execute_code_public_tool_preserves_pending_identity(monkeypatch):
+    from tools import code_execution_tool, terminal_tool
+
+    pending = _pending_identity_payload("execute_code")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"env_type": "local"})
+    monkeypatch.setattr(approval, "check_execute_code_guard", lambda *args, **kwargs: pending)
+
+    result = json.loads(code_execution_tool.execute_code("print(1)", task_id="identity-test"))
+    for key in ("request_id", "argument_hash", "operation", "tool_name"):
+        assert result[key] == pending[key]
 
 
 def test_pending_metadata_is_deep_copied_and_hash_is_required():

--- a/tests/tools/test_approval_fallback_execution.py
+++ b/tests/tools/test_approval_fallback_execution.py
@@ -52,12 +52,9 @@ def test_terminal_fallback_retry_consumes_exact_approval(monkeypatch):
         assert changed.get("status") != "pending_approval"
 
         pending = approval.check_all_command_guards(command, "local")
-        assert approval.resolve_gateway_approval(
-            SESSION, "once", request_id=pending["request_id"]
-        ) == 1
-        retried = approval.check_all_command_guards(command, "local")
-        assert retried["approved"] is True
-        assert pending["request_id"] not in approval._pending
+        assert pending["approved"] is True
+        assert pending.get("status") != "pending_approval"
+        assert pending["user_approved"] is True
         assert SESSION not in approval._pending_by_session
     finally:
         _finish_session(token)
@@ -81,13 +78,53 @@ def test_execute_code_fallback_retry_consumes_exact_approval(monkeypatch):
         assert changed.get("status") != "pending_approval"
 
         pending = approval.check_execute_code_guard(code, "local")
-        assert approval.resolve_gateway_approval(
-            SESSION, "once", request_id=pending["request_id"]
-        ) == 1
-        retried = approval.check_execute_code_guard(code, "local")
-        assert retried["approved"] is True
-        assert pending["request_id"] not in approval._pending
+        assert pending["approved"] is True
+        assert pending.get("status") != "pending_approval"
+        assert pending["user_approved"] is True
         assert SESSION not in approval._pending_by_session
+    finally:
+        _finish_session(token)
+
+
+def test_changed_terminal_retry_does_not_invalidate_other_resolved_approvals(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        requests = [
+            approval.submit_pending(
+                SESSION,
+                {
+                    "operation": "terminal",
+                    "tool_name": "terminal",
+                    "arguments": {"command": command},
+                    "command": command,
+                    "pattern_key": "recursive delete",
+                },
+            )
+            for command in (
+                "rm -rf /tmp/fallback-first",
+                "rm -rf /tmp/fallback-second",
+            )
+        ]
+        for request in requests:
+            assert approval.resolve_gateway_approval(
+                SESSION,
+                "once",
+                request_id=request["request_id"],
+                request_hash=request["argument_hash"],
+            ) == 1
+
+        changed = approval.check_all_command_guards(
+            "rm -rf /tmp/fallback-third", "local"
+        )
+        assert changed["status"] == "stale"
+        for request in requests:
+            assert approval._pending[request["request_id"]]["status"] == "resolved"
+
+        for request in requests:
+            retried = approval.check_all_command_guards(
+                request["arguments"]["command"], "local"
+            )
+            assert retried["approved"] is True
     finally:
         _finish_session(token)
 
@@ -172,7 +209,7 @@ def test_terminal_public_tool_preserves_pending_identity(monkeypatch):
     monkeypatch.setitem(terminal_tool._active_environments, "default", object())
 
     result = json.loads(terminal_tool.terminal_tool("rm -rf /tmp/a"))
-    for key in ("request_id", "argument_hash", "operation", "tool_name"):
+    for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at"):
         assert result[key] == pending[key]
 
 
@@ -184,7 +221,7 @@ def test_execute_code_public_tool_preserves_pending_identity(monkeypatch):
     monkeypatch.setattr(approval, "check_execute_code_guard", lambda *args, **kwargs: pending)
 
     result = json.loads(code_execution_tool.execute_code("print(1)", task_id="identity-test"))
-    for key in ("request_id", "argument_hash", "operation", "tool_name"):
+    for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at"):
         assert result[key] == pending[key]
 
 

--- a/tests/tools/test_approval_fallback_execution.py
+++ b/tests/tools/test_approval_fallback_execution.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 import tools.approval as approval
 
 
@@ -86,6 +88,113 @@ def test_execute_code_fallback_retry_consumes_exact_approval(monkeypatch):
         _finish_session(token)
 
 
+def test_terminal_fallback_does_not_consume_a_different_tool_identity(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        command = "rm -rf /tmp/tool-identity"
+        request = approval.submit_pending(
+            SESSION,
+            {
+                "operation": "terminal",
+                "tool_name": "execute_code",
+                "arguments": {"command": command},
+                "command": command,
+                "pattern_key": "recursive delete",
+            },
+        )
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash=request["argument_hash"],
+        ) == 1
+
+        result = approval.check_all_command_guards(command, "local")
+
+        assert result["approved"] is False
+        assert approval.get_pending_approval(request["request_id"])["status"] == "resolved"
+    finally:
+        _finish_session(token)
+
+
+def test_execute_code_fallback_does_not_consume_a_terminal_identity(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        code = "import os\nprint(1)"
+        command = f"execute_code <<'PY'\n{code}\nPY"
+        request = approval.submit_pending(
+            SESSION,
+            {
+                "operation": "execute_code",
+                "tool_name": "terminal",
+                "arguments": {"command": command, "code": code},
+                "pattern_key": "execute_code",
+            },
+        )
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash=request["argument_hash"],
+        ) == 1
+
+        result = approval.check_execute_code_guard(code, "local")
+
+        assert result["approved"] is False
+        assert approval.get_pending_approval(request["request_id"])["status"] == "resolved"
+    finally:
+        _finish_session(token)
+
+
+@pytest.mark.parametrize(
+    "identity_field, stored_value, expected_value",
+    [
+        ("policy_key", "plugin_rule:other", "plugin_rule:expected"),
+        ("requester", "user-one", "user-two"),
+        ("channel", "channel-one", "channel-two"),
+    ],
+)
+def test_plugin_fallback_requires_complete_execution_identity(
+    monkeypatch, identity_field, stored_value, expected_value
+):
+    token = _gateway_session(monkeypatch)
+    try:
+        arguments = {"path": "one"}
+        request = approval.submit_pending(
+            SESSION,
+            {
+                "operation": "write_file",
+                "tool_name": "write_file",
+                "arguments": arguments,
+                "pattern_key": stored_value if identity_field == "policy_key" else "plugin_rule:expected",
+                "requester": stored_value if identity_field == "requester" else "user-one",
+                "channel": stored_value if identity_field == "channel" else "channel-one",
+            },
+        )
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash=request["argument_hash"],
+        ) == 1
+
+        from tools.approval import request_tool_approval
+
+        result = request_tool_approval(
+            "write_file",
+            "why",
+            rule_key="expected",
+            arguments=arguments,
+            requester=expected_value if identity_field == "requester" else "user-one",
+            channel=expected_value if identity_field == "channel" else "channel-one",
+        )
+
+        assert result["approved"] is False
+        assert approval.get_pending_approval(request["request_id"])["status"] == "resolved"
+    finally:
+        _finish_session(token)
+
+
 def test_changed_terminal_retry_does_not_invalidate_other_resolved_approvals(monkeypatch):
     token = _gateway_session(monkeypatch)
     try:
@@ -97,7 +206,7 @@ def test_changed_terminal_retry_does_not_invalidate_other_resolved_approvals(mon
                     "tool_name": "terminal",
                     "arguments": {"command": command},
                     "command": command,
-                    "pattern_key": "recursive delete",
+                    "pattern_key": "delete in root path",
                 },
             )
             for command in (

--- a/tests/tools/test_approval_fallback_execution.py
+++ b/tests/tools/test_approval_fallback_execution.py
@@ -1,0 +1,114 @@
+"""Real guard-path coverage for no-callback approval retries."""
+
+import tools.approval as approval
+
+
+SESSION = "fallback-execution-session"
+
+
+def _reset_state():
+    with approval._lock:
+        approval._gateway_queues.clear()
+        approval._gateway_notify_cbs.clear()
+        approval._session_approved.clear()
+        approval._permanent_approved.clear()
+        approval._pending.clear()
+        approval._pending_by_session.clear()
+
+
+def _gateway_session(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "manual")
+    token = approval.set_current_session_key(SESSION)
+    _reset_state()
+    return token
+
+
+def _finish_session(token):
+    approval.reset_current_session_key(token)
+    _reset_state()
+
+
+def test_terminal_fallback_retry_consumes_exact_approval(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        command = "rm -rf /tmp/fallback-a"
+        pending = approval.check_all_command_guards(command, "local")
+        assert pending["status"] == "pending_approval"
+
+        assert approval.resolve_gateway_approval(
+            SESSION, "once", request_id=pending["request_id"]
+        ) == 1
+
+        changed = approval.check_all_command_guards("rm -rf /tmp/fallback-b", "local")
+        assert changed["approved"] is False
+        assert changed.get("status") != "pending_approval"
+
+        pending = approval.check_all_command_guards(command, "local")
+        assert approval.resolve_gateway_approval(
+            SESSION, "once", request_id=pending["request_id"]
+        ) == 1
+        retried = approval.check_all_command_guards(command, "local")
+        assert retried["approved"] is True
+        assert pending["request_id"] not in approval._pending
+        assert SESSION not in approval._pending_by_session
+    finally:
+        _finish_session(token)
+
+
+def test_execute_code_fallback_retry_consumes_exact_approval(monkeypatch):
+    token = _gateway_session(monkeypatch)
+    try:
+        code = "import os\nprint(1)"
+        pending = approval.check_execute_code_guard(code, "local")
+        assert pending["status"] == "pending_approval"
+
+        assert approval.resolve_gateway_approval(
+            SESSION, "once", request_id=pending["request_id"]
+        ) == 1
+
+        changed = approval.check_execute_code_guard("import os\nprint(2)", "local")
+        assert changed["approved"] is False
+        assert changed.get("status") != "pending_approval"
+
+        pending = approval.check_execute_code_guard(code, "local")
+        assert approval.resolve_gateway_approval(
+            SESSION, "once", request_id=pending["request_id"]
+        ) == 1
+        retried = approval.check_execute_code_guard(code, "local")
+        assert retried["approved"] is True
+        assert pending["request_id"] not in approval._pending
+        assert SESSION not in approval._pending_by_session
+    finally:
+        _finish_session(token)
+
+
+def test_pending_metadata_is_deep_copied_and_hash_is_required():
+    _reset_state()
+    arguments = {"nested": {"value": 1}}
+    request = approval.submit_pending(
+        SESSION,
+        {
+            "operation": "execute_code",
+            "tool_name": "execute_code",
+            "arguments": arguments,
+        },
+    )
+    arguments["nested"]["value"] = 2
+    request["arguments"]["nested"]["value"] = 3
+
+    stored = approval.get_pending_approval(request["request_id"])
+    assert stored is not None
+    assert stored["arguments"] == {"nested": {"value": 1}}
+    assert approval.resolve_gateway_approval(
+        SESSION, "once", request_id=request["request_id"]
+    ) == 1
+    assert approval.consume_pending_approval(SESSION, request["request_id"]) is None
+    assert approval.consume_pending_approval(
+        SESSION,
+        request["request_id"],
+        request_hash=stored["argument_hash"],
+    ) is None

--- a/tests/tools/test_approval_fallback_identity.py
+++ b/tests/tools/test_approval_fallback_identity.py
@@ -1,0 +1,115 @@
+"""Regression tests for identity and fail-closed fallback approvals."""
+
+import time
+
+import tools.approval as approval
+
+
+SESSION = "fallback-identity-session"
+
+
+def _clear_state():
+    with approval._lock:
+        approval._pending.clear()
+        getattr(approval, "_pending_by_session", {}).clear()
+
+
+def _submit(command="rm -rf /tmp/a", **extra):
+    data = {
+        "operation": "terminal",
+        "tool_name": "terminal",
+        "arguments": {"command": command},
+        "pattern_key": "recursive delete",
+        "requester": "user-1",
+        "channel": "api",
+    }
+    data.update(extra)
+    return approval.submit_pending(SESSION, data)
+
+
+class TestFallbackApprovalIdentity:
+    def setup_method(self):
+        _clear_state()
+
+    def teardown_method(self):
+        _clear_state()
+
+    def test_two_pending_approvals_are_independently_addressable(self):
+        first = _submit(command="rm -rf /tmp/a")
+        second = _submit(command="rm -rf /tmp/b")
+
+        assert first["request_id"] != second["request_id"]
+        assert first["argument_hash"] != second["argument_hash"]
+        assert first["operation"] == "terminal"
+        assert first["tool_name"] == "terminal"
+        assert first["policy_key"] == "recursive delete"
+        assert first["requester"] == "user-1"
+        assert first["session_key"] == SESSION
+        assert first["channel"] == "api"
+        assert first["created_at"] <= first["expires_at"]
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=second["request_id"],
+            request_hash=second["argument_hash"],
+        ) == 1
+        assert approval._pending[second["request_id"]]["resolution"] == "once"
+        assert approval._pending[first["request_id"]]["resolution"] is None
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=second["request_id"],
+            request_hash=second["argument_hash"],
+        ) == 0
+
+    def test_changed_arguments_fail_closed(self):
+        request = _submit(command="rm -rf /tmp/a")
+
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash="changed-arguments",
+        ) == 0
+        assert approval._pending[request["request_id"]]["resolution"] is None
+
+    def test_expired_request_fails_closed(self):
+        request = _submit(expires_at=time.time() - 1)
+
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash=request["argument_hash"],
+        ) == 0
+        assert approval._pending[request["request_id"]]["status"] == "expired"
+        assert approval._pending[request["request_id"]]["resolution"] is None
+
+    def test_post_restart_in_memory_request_fails_closed(self):
+        request = _submit()
+        with approval._lock:
+            approval._pending.clear()
+            getattr(approval, "_pending_by_session", {}).clear()
+
+        assert approval.resolve_gateway_approval(
+            SESSION,
+            "once",
+            request_id=request["request_id"],
+            request_hash=request["argument_hash"],
+        ) == 0
+
+    def test_legacy_session_resolution_is_fifo_and_resolve_all_is_preserved(self, caplog):
+        caplog.set_level("INFO")
+        first = _submit(command="rm -rf /tmp/a")
+        second = _submit(command="rm -rf /tmp/b")
+        third = _submit(command="rm -rf /tmp/c")
+
+        assert approval.resolve_gateway_approval(SESSION, "once") == 1
+        assert approval._pending[first["request_id"]]["resolution"] == "once"
+        assert approval._pending[second["request_id"]]["resolution"] is None
+        assert "session_fifo" in caplog.text
+        assert first["request_id"] in caplog.text
+
+        assert approval.resolve_gateway_approval(SESSION, "deny", resolve_all=True) == 2
+        assert approval._pending[second["request_id"]]["resolution"] == "deny"
+        assert approval._pending[third["request_id"]]["resolution"] == "deny"

--- a/tests/tools/test_approval_fallback_identity.py
+++ b/tests/tools/test_approval_fallback_identity.py
@@ -73,6 +73,32 @@ class TestFallbackApprovalIdentity:
         ) == 0
         assert approval._pending[request["request_id"]]["resolution"] is None
 
+    def test_request_id_collision_is_session_bound_and_does_not_mutate_original(self):
+        request = _submit(request_id="shared-request")
+        original = approval.get_pending_approval(request["request_id"])
+
+        collision = approval.submit_pending(
+            "other-session",
+            {
+                "request_id": request["request_id"],
+                "operation": "terminal",
+                "tool_name": "terminal",
+                "arguments": {"command": "rm -rf /tmp/other"},
+                "pattern_key": "recursive delete",
+                "requester": "other-user",
+                "channel": "other-api",
+            },
+        )
+
+        assert collision is None
+        assert approval.get_pending_approval(request["request_id"]) == original
+
+    def test_same_request_id_and_identity_is_idempotent(self):
+        first = _submit(request_id="same-request")
+        second = _submit(request_id=first["request_id"])
+
+        assert second == first
+
     def test_expired_request_fails_closed(self):
         request = _submit(expires_at=time.time() - 1)
 

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import subprocess
+import threading
 import time
 import pytest
 from pathlib import Path
@@ -189,6 +190,68 @@ class TestTakeCheckpoint:
         r2 = mgr.ensure_checkpoint(str(work_dir), "second")
         assert r1 is True
         assert r2 is False  # dedup'd
+
+    def test_concurrent_same_turn_only_takes_once(self, mgr, work_dir, monkeypatch):
+        mgr._git_available = True
+        callers_ready = threading.Barrier(2)
+        take_started = threading.Event()
+        release_take = threading.Event()
+        calls = []
+        results = []
+
+        def fake_take(directory, reason):
+            calls.append((directory, reason))
+            take_started.set()
+            release_take.wait(timeout=5)
+            return True
+
+        monkeypatch.setattr(mgr, "_take", fake_take)
+
+        def ensure(reason):
+            callers_ready.wait(timeout=5)
+            results.append(mgr.ensure_checkpoint(str(work_dir), reason))
+
+        threads = [
+            threading.Thread(target=ensure, args=("first",)),
+            threading.Thread(target=ensure, args=("second",)),
+        ]
+        for thread in threads:
+            thread.start()
+        assert take_started.wait(timeout=5)
+        release_take.set()
+        for thread in threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+        assert len(calls) == 1
+        assert sorted(results) == [False, True]
+
+    def test_failed_checkpoint_can_retry_same_turn(self, mgr, work_dir, monkeypatch):
+        mgr._git_available = True
+        calls = []
+
+        def fake_take(directory, reason):
+            calls.append((directory, reason))
+            return len(calls) == 2
+
+        monkeypatch.setattr(mgr, "_take", fake_take)
+
+        assert mgr.ensure_checkpoint(str(work_dir), "first") is False
+        assert mgr.ensure_checkpoint(str(work_dir), "retry") is True
+        assert len(calls) == 2
+
+    def test_successful_checkpoint_deduplicates_same_turn(self, mgr, work_dir, monkeypatch):
+        mgr._git_available = True
+        calls = []
+        monkeypatch.setattr(
+            mgr,
+            "_take",
+            lambda directory, reason: calls.append((directory, reason)) or True,
+        )
+
+        assert mgr.ensure_checkpoint(str(work_dir), "first") is True
+        assert mgr.ensure_checkpoint(str(work_dir), "duplicate") is False
+        assert len(calls) == 1
 
     def test_new_turn_resets_dedup(self, mgr, work_dir):
         assert mgr.ensure_checkpoint(str(work_dir), "turn 1") is True

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -226,6 +226,40 @@ class TestTakeCheckpoint:
         assert len(calls) == 1
         assert sorted(results) == [False, True]
 
+    def test_inflight_checkpoint_survives_new_turn(self, mgr, work_dir, monkeypatch):
+        mgr._git_available = True
+        take_started = threading.Event()
+        release_take = threading.Event()
+        calls = []
+        first_result = []
+
+        def fake_take(directory, reason):
+            calls.append((directory, reason))
+            take_started.set()
+            release_take.wait(timeout=5)
+            return True
+
+        monkeypatch.setattr(mgr, "_take", fake_take)
+
+        first = threading.Thread(
+            target=lambda: first_result.append(
+                mgr.ensure_checkpoint(str(work_dir), "first")
+            )
+        )
+        first.start()
+        assert take_started.wait(timeout=5)
+
+        mgr.new_turn()
+        second_result = mgr.ensure_checkpoint(str(work_dir), "second")
+
+        release_take.set()
+        first.join(timeout=5)
+        assert not first.is_alive()
+
+        assert second_result is False
+        assert first_result == [True]
+        assert len(calls) == 1
+
     def test_failed_checkpoint_can_retry_same_turn(self, mgr, work_dir, monkeypatch):
         mgr._git_available = True
         calls = []

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -119,6 +119,8 @@ def gw_session(monkeypatch):
     with A._lock:
         A._gateway_queues.pop(session_key, None)
         A._gateway_notify_cbs.pop(session_key, None)
+        A._session_approved.pop(session_key, None)
+        A._permanent_approved.discard("execute_code")
     try:
         yield session_key
     finally:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import fnmatch
 import functools
 import hashlib
+import json
 import logging
 import os
 import re
@@ -20,6 +21,7 @@ import sys
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -1403,7 +1405,10 @@ def detect_dangerous_command(command: str) -> tuple:
 # =========================================================================
 
 _lock = threading.Lock()
+# Fallback approvals are indexed by their request id; the per-session list is
+# only the compatibility ordering used by session-only /approve and /deny.
 _pending: dict[str, dict] = {}
+_pending_by_session: dict[str, list[str]] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
@@ -1460,22 +1465,140 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+def _approval_arguments(approval: dict):
+    """Return the stable, non-display argument payload used for revalidation."""
+    if "arguments" in approval:
+        return approval["arguments"]
+    if "args" in approval:
+        return approval["args"]
+    if "argument_hash" in approval:
+        return None
+    return approval.get("command", approval.get("code", approval.get("description", "")))
+
+
+def _approval_argument_hash(approval: dict) -> str:
+    """Hash normalized approval arguments without persisting their raw value."""
+    supplied = approval.get("argument_hash") or approval.get("args_hash")
+    if supplied:
+        return str(supplied)
+    normalized = json.dumps(
+        _approval_arguments(approval),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _mark_expired(request: dict) -> bool:
+    """Mark a fallback request expired and return whether it is still valid."""
+    if request.get("status") != "pending":
+        return False
+    try:
+        expired = time.time() >= float(request["expires_at"])
+    except (KeyError, TypeError, ValueError):
+        expired = True
+    if expired:
+        request["status"] = "expired"
+        return False
+    return True
+
+
+def _resolve_fallback_approval(
+    session_key: str,
+    choice: str,
+    *,
+    request_id: Optional[str],
+    resolve_all: bool,
+    reason: Optional[str],
+    request_hash: Optional[str],
+) -> int:
+    """Resolve an in-memory fallback request, preserving the legacy int API."""
+    with _lock:
+        if request_id:
+            request = _pending.get(request_id)
+            if not request or request.get("session_key") != session_key:
+                logger.warning(
+                    "approval_resolution outcome=missing resolution_mode=exact "
+                    "request_id=%s session_key=%s",
+                    request_id, session_key,
+                )
+                return 0
+            if request.get("resolution") is not None:
+                logger.warning(
+                    "approval_resolution outcome=already_resolved resolution_mode=exact "
+                    "request_id=%s session_key=%s",
+                    request_id, session_key,
+                )
+                return 0
+            if not _mark_expired(request):
+                logger.warning(
+                    "approval_resolution outcome=stale resolution_mode=exact "
+                    "request_id=%s session_key=%s",
+                    request_id, session_key,
+                )
+                return 0
+            if request_hash and request_hash != request.get("argument_hash"):
+                request["status"] = "stale"
+                logger.warning(
+                    "approval_resolution outcome=changed resolution_mode=exact "
+                    "request_id=%s session_key=%s",
+                    request_id, session_key,
+                )
+                return 0
+            targets = [request]
+            resolution_mode = "exact"
+        else:
+            ids = _pending_by_session.get(session_key, [])
+            valid = []
+            for current_id in ids:
+                request = _pending.get(current_id)
+                if request and _mark_expired(request):
+                    valid.append(request)
+            if not valid:
+                return 0
+            targets = valid if resolve_all else valid[:1]
+            resolution_mode = "session_all" if resolve_all else "session_fifo"
+
+        resolved_at = time.time()
+        for request in targets:
+            request["resolution"] = choice
+            request["resolution_reason"] = reason
+            request["resolved_at"] = resolved_at
+            request["resolution_mode"] = resolution_mode
+            request["status"] = "resolved"
+            logger.info(
+                "approval_resolution outcome=resolved resolution_mode=%s "
+                "request_id=%s session_key=%s choice=%s",
+                resolution_mode, request["request_id"], session_key, choice,
+            )
+        return len(targets)
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
-    """Called by the gateway's /approve or /deny handler to unblock
-    waiting agent thread(s).
+                             reason: Optional[str] = None,
+                             request_id: Optional[str] = None,
+                             request_hash: Optional[str] = None) -> int:
+    """Resolve a gateway approval by exact request id or legacy session FIFO.
 
-    When *resolve_all* is True every pending approval in the session is
-    resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
-
-    *reason* is an optional free-text explanation attached to an explicit
-    deny (``/deny <reason>``).  It is relayed back to the agent in the
-    BLOCKED message so it can adapt instead of only hearing "denied".
-
-    Returns the number of approvals resolved (0 means nothing was pending).
+    Callback-backed approvals retain their existing event queue behavior. The
+    no-callback fallback is keyed by request id and remains in memory until a
+    later tool retry consumes the resolved decision.
     """
+    if request_id or not _gateway_queues.get(session_key):
+        fallback_count = _resolve_fallback_approval(
+            session_key,
+            choice,
+            request_id=request_id,
+            resolve_all=resolve_all,
+            reason=reason,
+            request_hash=request_hash,
+        )
+        if fallback_count or request_id:
+            return fallback_count
+
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
@@ -1502,10 +1625,93 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
-def submit_pending(session_key: str, approval: dict):
-    """Store a pending approval request for a session."""
+def has_pending_approval(session_key: str) -> bool:
+    """Return whether a valid no-callback approval remains for *session_key*."""
     with _lock:
-        _pending[session_key] = approval
+        return any(
+            request is not None and _mark_expired(request)
+            for request_id in _pending_by_session.get(session_key, [])
+            for request in [_pending.get(request_id)]
+        )
+
+
+def get_pending_approval(request_id: str) -> Optional[dict]:
+    """Return a copy of an in-memory approval request, if it still exists."""
+    with _lock:
+        request = _pending.get(request_id)
+        return dict(request) if request is not None else None
+
+
+def consume_pending_approval(
+    session_key: str,
+    request_id: str,
+    *,
+    request_hash: Optional[str] = None,
+) -> Optional[dict]:
+    """Consume one resolved fallback approval after revalidating its identity."""
+    with _lock:
+        request = _pending.get(request_id)
+        if not request or request.get("session_key") != session_key:
+            return None
+        if request.get("status") != "resolved" or request.get("resolution") in {None, "deny"}:
+            return None
+        try:
+            if time.time() >= float(request["expires_at"]):
+                request["status"] = "expired"
+                return None
+        except (KeyError, TypeError, ValueError):
+            request["status"] = "stale"
+            return None
+        if request_hash and request_hash != request.get("argument_hash"):
+            request["status"] = "stale"
+            logger.warning(
+                "approval_resolution outcome=changed resolution_mode=consume "
+                "request_id=%s session_key=%s",
+                request_id, session_key,
+            )
+            return None
+        request["status"] = "consumed"
+        return dict(request)
+
+
+def submit_pending(session_key: str, approval: dict) -> dict:
+    """Store and return an identity-bound, in-memory fallback approval request."""
+    request = dict(approval)
+    request_id = str(request.get("request_id") or uuid.uuid4().hex)
+    with _lock:
+        existing = _pending.get(request_id)
+        if existing is not None:
+            if _approval_argument_hash(request) != existing.get("argument_hash"):
+                existing["status"] = "stale"
+                logger.warning(
+                    "approval_resolution outcome=changed resolution_mode=submit "
+                    "request_id=%s session_key=%s",
+                    request_id, session_key,
+                )
+            return dict(existing)
+        created_at = float(request.get("created_at") or time.time())
+        expires_at = request.get("expires_at")
+        if expires_at is None:
+            expires_at = created_at + max(_get_approval_timeout(), 0)
+        request.update({
+            "request_id": request_id,
+            "session_key": session_key,
+            "created_at": created_at,
+            "expires_at": float(expires_at),
+            "argument_hash": _approval_argument_hash(request),
+            "operation": request.get("operation") or request.get("tool_name") or "",
+            "tool_name": request.get("tool_name") or request.get("operation") or "",
+            "policy_key": request.get("policy_key") or request.get("pattern_key"),
+            "requester": request.get("requester") or request.get("user_id") or "",
+            "channel": request.get("channel") or request.get("platform") or "",
+            "status": "pending",
+            "resolution": None,
+            "resolution_reason": None,
+            "resolved_at": None,
+        })
+        _pending[request_id] = request
+        _pending_by_session.setdefault(session_key, []).append(request_id)
+        return dict(request)
 
 
 def approve_session(session_key: str, pattern_key: str):
@@ -1537,7 +1743,8 @@ def clear_session(session_key: str) -> None:
     with _lock:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
-        _pending.pop(session_key, None)
+        for request_id in _pending_by_session.pop(session_key, []):
+            _pending.pop(request_id, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
@@ -2006,6 +2213,7 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    approval_metadata: Optional[dict] = None,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -2172,17 +2380,25 @@ def _run_approval_gate(
 
         # No notify callback (e.g. API server without an attached chat):
         # queue for /approve /deny review, agent sees approval_required.
-        submit_pending(session_key, {
+        pending = dict(approval_metadata or {})
+        pending.update({
             "command": display_target,
             "pattern_key": pattern_key,
             "description": description,
         })
+        pending_request = submit_pending(session_key, pending)
+        pending_fields = {
+            key: pending_request[key]
+            for key in ("request_id", "created_at", "expires_at")
+            if key in pending_request
+        } if isinstance(pending_request, dict) else {}
         return {
             "approved": False,
             "pattern_key": pattern_key,
             "status": "approval_required",
             "command": display_target,
             "description": description,
+            **pending_fields,
             "message": (
                 f"⚠️ This action is potentially dangerous ({description}). "
                 f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -2304,6 +2520,10 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    arguments=None,
+    requester: str = "",
+    channel: str = "",
+    request_id: str = "",
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -2382,6 +2602,14 @@ def request_tool_approval(
             "but no interactive user or gateway is present to approve it. "
             "A plugin flagged this action for human confirmation."
         ),
+        approval_metadata={
+            "operation": tool_name,
+            "tool_name": tool_name,
+            "arguments": arguments if arguments is not None else {"reason": description},
+            "requester": requester,
+            "channel": channel,
+            "request_id": request_id,
+        },
     )
 
 
@@ -2875,17 +3103,26 @@ def check_all_command_guards(command: str, env_type: str,
         from agent.redact import redact_sensitive_text
         _disp_command = redact_sensitive_text(command)
         _disp_combined_desc = redact_sensitive_text(combined_desc)
-        submit_pending(session_key, {
+        pending_request = submit_pending(session_key, {
+            "operation": "terminal",
+            "tool_name": "terminal",
+            "argument_hash": _approval_argument_hash({"arguments": {"command": command}}),
             "command": _disp_command,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
         })
+        pending_fields = {
+            key: pending_request[key]
+            for key in ("request_id", "created_at", "expires_at")
+            if key in pending_request
+        }
         return {
             "approved": False,
             "pattern_key": primary_key,
             "status": "pending_approval",
             "approval_pending": True,
+            **pending_fields,
             "command": _disp_command,
             "description": _disp_combined_desc,
             "message": (
@@ -3074,17 +3311,26 @@ def check_execute_code_guard(code: str, env_type: str,
     if notify_cb is None:
         # No gateway callback registered (e.g. ask-mode without a notifier):
         # surface a pending approval for backward compatibility.
-        submit_pending(session_key, {
+        pending_request = submit_pending(session_key, {
+            "operation": "execute_code",
+            "tool_name": "execute_code",
+            "argument_hash": _approval_argument_hash({"arguments": {"command": command, "code": code}}),
             "command": display_command,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
             "description": display_description,
         })
+        pending_fields = {
+            key: pending_request[key]
+            for key in ("request_id", "created_at", "expires_at")
+            if key in pending_request
+        }
         return {
             "approved": False,
             "pattern_key": pattern_key,
             "status": "pending_approval",
             "approval_pending": True,
+            **pending_fields,
             "command": display_command,
             "description": display_description,
             "message": (

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1682,7 +1682,7 @@ def consume_pending_approval(
         request = _pending.get(request_id)
         if not request or request.get("session_key") != session_key:
             return None
-        if request.get("status") != "resolved" or request.get("resolution") in {None, "deny"}:
+        if request.get("status") != "resolved" or request.get("resolution") is None:
             return None
         try:
             if time.time() >= float(request["expires_at"]):
@@ -1819,6 +1819,36 @@ def _stale_pending_approval_result(operation: str, description: str) -> dict:
             f"the current arguments ({description}). Do NOT retry with changed "
             "arguments; request a new approval."
         ),
+    }
+
+
+def _consumed_pending_approval_result(
+    operation: str, description: str, request: dict,
+) -> dict:
+    """Return the result for an exact resolved fallback retry."""
+    reason = request.get("resolution_reason")
+    if request.get("resolution") == "deny":
+        reason_addendum = f' Reason given by the user: "{reason}".' if reason else ""
+        return {
+            "approved": False,
+            "status": "blocked",
+            "outcome": "denied",
+            "user_consent": False,
+            "deny_reason": reason,
+            "resolution_reason": reason,
+            "description": description,
+            "message": (
+                f"BLOCKED: {operation} approval was denied by the user."
+                f"{reason_addendum} The user has NOT consented to this action."
+                " Do NOT retry it, rephrase it, or attempt the same outcome via"
+                " a different path."
+            ),
+        }
+    return {
+        "approved": True,
+        "message": None,
+        "user_approved": True,
+        "description": description,
     }
 
 
@@ -2384,12 +2414,9 @@ def _run_approval_gate(
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
-        return {
-            "approved": True,
-            "message": None,
-            "user_approved": True,
-            "description": description,
-        }
+        return _consumed_pending_approval_result(
+            pending_operation, description, consumed,
+        )
     if stale:
         return _stale_pending_approval_result(pending_operation, description)
 
@@ -2523,7 +2550,7 @@ def _run_approval_gate(
         pending_request = submit_pending(session_key, pending)
         pending_fields = {
             key: pending_request[key]
-            for key in ("request_id", "created_at", "expires_at")
+            for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")
             if key in pending_request
         } if isinstance(pending_request, dict) else {}
         return {
@@ -3104,12 +3131,9 @@ def check_all_command_guards(command: str, env_type: str,
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
-        return {
-            "approved": True,
-            "message": None,
-            "user_approved": True,
-            "description": "; ".join(desc for _, desc, _ in warnings),
-        }
+        return _consumed_pending_approval_result(
+            "terminal", "; ".join(desc for _, desc, _ in warnings), consumed,
+        )
     if stale:
         return _stale_pending_approval_result("terminal", "; ".join(
             desc for _, desc, _ in warnings
@@ -3257,7 +3281,6 @@ def check_all_command_guards(command: str, env_type: str,
             "operation": "terminal",
             "tool_name": "terminal",
             "arguments": {"command": command},
-            "argument_hash": _approval_argument_hash({"arguments": {"command": command}}),
             "command": _disp_command,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
@@ -3266,7 +3289,7 @@ def check_all_command_guards(command: str, env_type: str,
         })
         pending_fields = {
             key: pending_request[key]
-            for key in ("request_id", "created_at", "expires_at")
+            for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")
             if key in pending_request
         }
         return {
@@ -3436,12 +3459,9 @@ def check_execute_code_guard(code: str, env_type: str,
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
-        return {
-            "approved": True,
-            "message": None,
-            "user_approved": True,
-            "description": description,
-        }
+        return _consumed_pending_approval_result(
+            "execute_code", description, consumed,
+        )
     if stale:
         return _stale_pending_approval_result("execute_code", description)
     if is_approved(session_key, pattern_key):
@@ -3482,7 +3502,6 @@ def check_execute_code_guard(code: str, env_type: str,
             "operation": "execute_code",
             "tool_name": "execute_code",
             "arguments": {"command": command, "code": code},
-            "argument_hash": _approval_argument_hash({"arguments": {"command": command, "code": code}}),
             "command": display_command,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
@@ -3491,7 +3510,7 @@ def check_execute_code_guard(code: str, env_type: str,
         })
         pending_fields = {
             key: pending_request[key]
-            for key in ("request_id", "created_at", "expires_at")
+            for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")
             if key in pending_request
         }
         return {

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1776,8 +1776,6 @@ def _consume_matching_pending_approval(
             None,
         )
         if matching is None:
-            for request in candidates:
-                request["status"] = "stale"
             return None, bool(candidates)
         request_id = matching["request_id"]
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,6 +9,7 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+import copy
 import fnmatch
 import functools
 import hashlib
@@ -1471,24 +1472,48 @@ def _approval_arguments(approval: dict):
         return approval["arguments"]
     if "args" in approval:
         return approval["args"]
-    if "argument_hash" in approval:
-        return None
     return approval.get("command", approval.get("code", approval.get("description", "")))
 
 
 def _approval_argument_hash(approval: dict) -> str:
-    """Hash normalized approval arguments without persisting their raw value."""
-    supplied = approval.get("argument_hash") or approval.get("args_hash")
-    if supplied:
-        return str(supplied)
+    """Hash normalized approval arguments; never trust a caller-supplied hash."""
     normalized = json.dumps(
-        _approval_arguments(approval),
+        copy.deepcopy(_approval_arguments(approval)),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
         default=str,
     )
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _prune_pending_locked() -> None:
+    """Drop terminal fallback records and repair the session index.
+
+    Callers hold ``_lock``. A just-expired record is left in place until the
+    next safe-point call so legacy inspection can still report its status.
+    """
+    for request_id, request in list(_pending.items()):
+        status = request.get("status")
+        if status in {"pending", "resolved"}:
+            try:
+                if time.time() >= float(request["expires_at"]):
+                    request["status"] = "expired"
+            except (KeyError, TypeError, ValueError):
+                request["status"] = "stale"
+            continue
+        if status in {"consumed", "expired", "stale"}:
+            _pending.pop(request_id, None)
+    for session_key, request_ids in list(_pending_by_session.items()):
+        kept = [
+            request_id for request_id in request_ids
+            if request_id in _pending
+            and _pending[request_id].get("session_key") == session_key
+        ]
+        if kept:
+            _pending_by_session[session_key] = kept
+        else:
+            _pending_by_session.pop(session_key, None)
 
 
 def _mark_expired(request: dict) -> bool:
@@ -1516,6 +1541,7 @@ def _resolve_fallback_approval(
 ) -> int:
     """Resolve an in-memory fallback request, preserving the legacy int API."""
     with _lock:
+        _prune_pending_locked()
         if request_id:
             request = _pending.get(request_id)
             if not request or request.get("session_key") != session_key:
@@ -1628,6 +1654,7 @@ def has_blocking_approval(session_key: str) -> bool:
 def has_pending_approval(session_key: str) -> bool:
     """Return whether a valid no-callback approval remains for *session_key*."""
     with _lock:
+        _prune_pending_locked()
         return any(
             request is not None and _mark_expired(request)
             for request_id in _pending_by_session.get(session_key, [])
@@ -1636,10 +1663,11 @@ def has_pending_approval(session_key: str) -> bool:
 
 
 def get_pending_approval(request_id: str) -> Optional[dict]:
-    """Return a copy of an in-memory approval request, if it still exists."""
+    """Return a deep copy of an in-memory approval request, if it exists."""
     with _lock:
+        _prune_pending_locked()
         request = _pending.get(request_id)
-        return dict(request) if request is not None else None
+        return copy.deepcopy(request) if request is not None else None
 
 
 def consume_pending_approval(
@@ -1650,6 +1678,7 @@ def consume_pending_approval(
 ) -> Optional[dict]:
     """Consume one resolved fallback approval after revalidating its identity."""
     with _lock:
+        _prune_pending_locked()
         request = _pending.get(request_id)
         if not request or request.get("session_key") != session_key:
             return None
@@ -1662,7 +1691,8 @@ def consume_pending_approval(
         except (KeyError, TypeError, ValueError):
             request["status"] = "stale"
             return None
-        if request_hash and request_hash != request.get("argument_hash"):
+        stored_hash = request.get("argument_hash")
+        if not request_hash or not stored_hash or request_hash != stored_hash:
             request["status"] = "stale"
             logger.warning(
                 "approval_resolution outcome=changed resolution_mode=consume "
@@ -1671,14 +1701,17 @@ def consume_pending_approval(
             )
             return None
         request["status"] = "consumed"
-        return dict(request)
+        consumed = copy.deepcopy(request)
+        _prune_pending_locked()
+        return consumed
 
 
 def submit_pending(session_key: str, approval: dict) -> dict:
     """Store and return an identity-bound, in-memory fallback approval request."""
-    request = dict(approval)
+    request = copy.deepcopy(approval)
     request_id = str(request.get("request_id") or uuid.uuid4().hex)
     with _lock:
+        _prune_pending_locked()
         existing = _pending.get(request_id)
         if existing is not None:
             if _approval_argument_hash(request) != existing.get("argument_hash"):
@@ -1688,7 +1721,7 @@ def submit_pending(session_key: str, approval: dict) -> dict:
                     "request_id=%s session_key=%s",
                     request_id, session_key,
                 )
-            return dict(existing)
+            return copy.deepcopy(existing)
         created_at = float(request.get("created_at") or time.time())
         expires_at = request.get("expires_at")
         if expires_at is None:
@@ -1711,7 +1744,82 @@ def submit_pending(session_key: str, approval: dict) -> dict:
         })
         _pending[request_id] = request
         _pending_by_session.setdefault(session_key, []).append(request_id)
-        return dict(request)
+        return copy.deepcopy(request)
+
+
+def _consume_matching_pending_approval(
+    session_key: str,
+    operation: str,
+    arguments,
+) -> tuple[Optional[dict], bool]:
+    """Consume the resolved request for this exact operation, if any.
+
+    The bool reports a resolved same-operation request whose hash did not
+    match. That is a stale retry and must fail closed instead of opening a new
+    approval request for changed arguments.
+    """
+    current_hash = _approval_argument_hash({"arguments": arguments})
+    with _lock:
+        _prune_pending_locked()
+        candidates = []
+        for request_id in _pending_by_session.get(session_key, []):
+            request = _pending.get(request_id)
+            if (
+                request is not None
+                and request.get("status") == "resolved"
+                and request.get("operation") == operation
+            ):
+                candidates.append(request)
+        matching = next(
+            (request for request in candidates
+             if request.get("argument_hash") == current_hash),
+            None,
+        )
+        if matching is None:
+            for request in candidates:
+                request["status"] = "stale"
+            return None, bool(candidates)
+        request_id = matching["request_id"]
+
+    consumed = consume_pending_approval(
+        session_key, request_id, request_hash=current_hash,
+    )
+    return consumed, consumed is None
+
+
+def _apply_consumed_approval_scope(session_key: str, request: dict) -> None:
+    """Apply the stored once/session/always choice after exact consumption."""
+    choice = request.get("resolution")
+    if choice not in {"session", "always"}:
+        return
+    keys = request.get("pattern_keys") or [
+        request.get("policy_key") or request.get("pattern_key")
+    ]
+    if isinstance(keys, str):
+        keys = [keys]
+    for key in keys:
+        if key:
+            approve_session(session_key, key)
+    if choice == "always" and request.get("allow_permanent", True):
+        for key in keys:
+            if key:
+                approve_permanent(key)
+        save_permanent_allowlist(_permanent_approved)
+
+
+def _stale_pending_approval_result(operation: str, description: str) -> dict:
+    """Build the fail-closed result for a changed resolved retry."""
+    return {
+        "approved": False,
+        "status": "stale",
+        "outcome": "stale",
+        "user_consent": False,
+        "message": (
+            f"BLOCKED: the resolved {operation} approval no longer matches "
+            f"the current arguments ({description}). Do NOT retry with changed "
+            "arguments; request a new approval."
+        ),
+    }
 
 
 def approve_session(session_key: str, pattern_key: str):
@@ -2262,6 +2370,29 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
+    pending_metadata = approval_metadata or {}
+    pending_operation = (
+        pending_metadata.get("operation")
+        or pending_metadata.get("tool_name")
+        or "terminal"
+    )
+    pending_arguments = pending_metadata.get("arguments")
+    if pending_arguments is None:
+        pending_arguments = {"command": display_target}
+    consumed, stale = _consume_matching_pending_approval(
+        session_key, pending_operation, pending_arguments,
+    )
+    if consumed is not None:
+        _apply_consumed_approval_scope(session_key, consumed)
+        return {
+            "approved": True,
+            "message": None,
+            "user_approved": True,
+            "description": description,
+        }
+    if stale:
+        return _stale_pending_approval_result(pending_operation, description)
+
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
@@ -2380,7 +2511,10 @@ def _run_approval_gate(
 
         # No notify callback (e.g. API server without an attached chat):
         # queue for /approve /deny review, agent sees approval_required.
-        pending = dict(approval_metadata or {})
+        pending = copy.deepcopy(approval_metadata or {})
+        pending.setdefault("operation", pending_operation)
+        pending.setdefault("tool_name", pending_operation)
+        pending.setdefault("arguments", copy.deepcopy(pending_arguments))
         pending.update({
             "command": display_target,
             "pattern_key": pattern_key,
@@ -2965,6 +3099,22 @@ def check_all_command_guards(command: str, env_type: str,
     if not warnings:
         return {"approved": True, "message": None}
 
+    consumed, stale = _consume_matching_pending_approval(
+        session_key, "terminal", {"command": command},
+    )
+    if consumed is not None:
+        _apply_consumed_approval_scope(session_key, consumed)
+        return {
+            "approved": True,
+            "message": None,
+            "user_approved": True,
+            "description": "; ".join(desc for _, desc, _ in warnings),
+        }
+    if stale:
+        return _stale_pending_approval_result("terminal", "; ".join(
+            desc for _, desc, _ in warnings
+        ))
+
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
@@ -3106,10 +3256,12 @@ def check_all_command_guards(command: str, env_type: str,
         pending_request = submit_pending(session_key, {
             "operation": "terminal",
             "tool_name": "terminal",
+            "arguments": {"command": command},
             "argument_hash": _approval_argument_hash({"arguments": {"command": command}}),
             "command": _disp_command,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
+            "allow_permanent": not has_tirith,
             "description": _disp_combined_desc,
         })
         pending_fields = {
@@ -3277,6 +3429,21 @@ def check_execute_code_guard(code: str, env_type: str,
     # Check session/permanent approval — same gate as check_all_command_guards.
     # Without this, "Approve session" / "Always" choices are stored but never
     # consulted, so every execute_code call re-prompts the user (#39275).
+    consumed, stale = _consume_matching_pending_approval(
+        session_key,
+        "execute_code",
+        {"command": command, "code": code},
+    )
+    if consumed is not None:
+        _apply_consumed_approval_scope(session_key, consumed)
+        return {
+            "approved": True,
+            "message": None,
+            "user_approved": True,
+            "description": description,
+        }
+    if stale:
+        return _stale_pending_approval_result("execute_code", description)
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
@@ -3314,10 +3481,12 @@ def check_execute_code_guard(code: str, env_type: str,
         pending_request = submit_pending(session_key, {
             "operation": "execute_code",
             "tool_name": "execute_code",
+            "arguments": {"command": command, "code": code},
             "argument_hash": _approval_argument_hash({"arguments": {"command": command, "code": code}}),
             "command": display_command,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
+            "allow_permanent": True,
             "description": display_description,
         })
         pending_fields = {

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1487,6 +1487,45 @@ def _approval_argument_hash(approval: dict) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+_APPROVAL_IDENTITY_FIELDS = (
+    "operation", "tool_name", "policy_key", "requester", "channel",
+)
+
+
+def _approval_identity(approval: dict) -> dict:
+    """Return the canonical immutable identity fields for a fallback request."""
+    return {
+        "operation": approval.get("operation") or approval.get("tool_name") or "",
+        "tool_name": approval.get("tool_name") or approval.get("operation") or "",
+        "policy_key": approval.get("policy_key") or approval.get("pattern_key") or "",
+        "requester": approval.get("requester") or approval.get("user_id") or "",
+        "channel": approval.get("channel") or approval.get("platform") or "",
+    }
+
+
+def _approval_identity_matches(request: dict, expected_identity: Optional[dict]) -> bool:
+    """Match every identity field supplied by the current execution path."""
+    if expected_identity is None:
+        return True
+    actual = _approval_identity(request)
+    for field in _APPROVAL_IDENTITY_FIELDS:
+        if field not in expected_identity:
+            if actual[field]:
+                return False
+            continue
+        expected = expected_identity[field]
+        if expected is None:
+            if actual[field]:
+                return False
+            continue
+        if isinstance(expected, (list, tuple, set, frozenset)):
+            if actual[field] not in expected:
+                return False
+        elif actual[field] != (expected or ""):
+            return False
+    return True
+
+
 def _prune_pending_locked() -> None:
     """Drop terminal fallback records and repair the session index.
 
@@ -1706,7 +1745,7 @@ def consume_pending_approval(
         return consumed
 
 
-def submit_pending(session_key: str, approval: dict) -> dict:
+def submit_pending(session_key: str, approval: dict) -> Optional[dict]:
     """Store and return an identity-bound, in-memory fallback approval request."""
     request = copy.deepcopy(approval)
     request_id = str(request.get("request_id") or uuid.uuid4().hex)
@@ -1714,13 +1753,18 @@ def submit_pending(session_key: str, approval: dict) -> dict:
         _prune_pending_locked()
         existing = _pending.get(request_id)
         if existing is not None:
-            if _approval_argument_hash(request) != existing.get("argument_hash"):
-                existing["status"] = "stale"
+            same_identity = (
+                existing.get("session_key") == session_key
+                and _approval_identity(existing) == _approval_identity(request)
+                and existing.get("argument_hash") == _approval_argument_hash(request)
+            )
+            if not same_identity:
                 logger.warning(
                     "approval_resolution outcome=changed resolution_mode=submit "
                     "request_id=%s session_key=%s",
                     request_id, session_key,
                 )
+                return None
             return copy.deepcopy(existing)
         created_at = float(request.get("created_at") or time.time())
         expires_at = request.get("expires_at")
@@ -1751,12 +1795,13 @@ def _consume_matching_pending_approval(
     session_key: str,
     operation: str,
     arguments,
+    *,
+    expected_identity: Optional[dict] = None,
 ) -> tuple[Optional[dict], bool]:
-    """Consume the resolved request for this exact operation, if any.
+    """Consume the resolved request for this exact execution identity, if any.
 
-    The bool reports a resolved same-operation request whose hash did not
-    match. That is a stale retry and must fail closed instead of opening a new
-    approval request for changed arguments.
+    The bool reports a resolved same-identity request whose hash did not
+    match. Identity-mismatched requests remain pending for their own retry.
     """
     current_hash = _approval_argument_hash({"arguments": arguments})
     with _lock:
@@ -1768,6 +1813,7 @@ def _consume_matching_pending_approval(
                 request is not None
                 and request.get("status") == "resolved"
                 and request.get("operation") == operation
+                and _approval_identity_matches(request, expected_identity)
             ):
                 candidates.append(request)
         matching = next(
@@ -2407,8 +2453,19 @@ def _run_approval_gate(
     pending_arguments = pending_metadata.get("arguments")
     if pending_arguments is None:
         pending_arguments = {"command": display_target}
+    expected_identity = {
+        "operation": pending_operation,
+        "tool_name": pending_metadata.get("tool_name") or pending_operation,
+        "policy_key": pending_metadata.get("policy_key")
+        or pending_metadata.get("pattern_key")
+        or pattern_key,
+    }
+    for field in ("requester", "channel"):
+        if field in pending_metadata:
+            expected_identity[field] = pending_metadata[field]
     consumed, stale = _consume_matching_pending_approval(
         session_key, pending_operation, pending_arguments,
+        expected_identity=expected_identity,
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
@@ -2546,6 +2603,10 @@ def _run_approval_gate(
             "description": description,
         })
         pending_request = submit_pending(session_key, pending)
+        if pending_request is None:
+            if pending.get("request_id"):
+                return _stale_pending_approval_result(pending_operation, description)
+            pending_request = pending
         pending_fields = {
             key: pending_request[key]
             for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")
@@ -3125,7 +3186,14 @@ def check_all_command_guards(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     consumed, stale = _consume_matching_pending_approval(
-        session_key, "terminal", {"command": command},
+        session_key,
+        "terminal",
+        {"command": command},
+        expected_identity={
+            "operation": "terminal",
+            "tool_name": "terminal",
+            "policy_key": [key for key, _, _ in warnings],
+        },
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
@@ -3285,6 +3353,8 @@ def check_all_command_guards(command: str, env_type: str,
             "allow_permanent": not has_tirith,
             "description": _disp_combined_desc,
         })
+        if pending_request is None:
+            return _stale_pending_approval_result("terminal", _disp_combined_desc)
         pending_fields = {
             key: pending_request[key]
             for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")
@@ -3454,6 +3524,11 @@ def check_execute_code_guard(code: str, env_type: str,
         session_key,
         "execute_code",
         {"command": command, "code": code},
+        expected_identity={
+            "operation": "execute_code",
+            "tool_name": "execute_code",
+            "policy_key": pattern_key,
+        },
     )
     if consumed is not None:
         _apply_consumed_approval_scope(session_key, consumed)
@@ -3506,6 +3581,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "allow_permanent": True,
             "description": display_description,
         })
+        if pending_request is None:
+            return _stale_pending_approval_result("execute_code", description)
         pending_fields = {
             key: pending_request[key]
             for key in ("request_id", "argument_hash", "operation", "tool_name", "created_at", "expires_at")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -55,6 +55,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -639,6 +640,8 @@ class CheckpointManager:
         self.max_total_size_mb = max(0, int(max_total_size_mb))
         self.max_file_size_mb = max(0, int(max_file_size_mb))
         self._checkpointed_dirs: Set[str] = set()
+        self._checkpointing_dirs: Set[str] = set()
+        self._checkpoint_state_lock = threading.Lock()
         self._git_available: Optional[bool] = None  # lazy probe
 
     # ------------------------------------------------------------------
@@ -647,7 +650,9 @@ class CheckpointManager:
 
     def new_turn(self) -> None:
         """Reset per-turn dedup.  Call at the start of each agent iteration."""
-        self._checkpointed_dirs.clear()
+        with self._checkpoint_state_lock:
+            self._checkpointed_dirs.clear()
+            self._checkpointing_dirs.clear()
 
     # ------------------------------------------------------------------
     # Public API
@@ -676,16 +681,26 @@ class CheckpointManager:
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 
-        if abs_dir in self._checkpointed_dirs:
-            return False
+        with self._checkpoint_state_lock:
+            if (
+                abs_dir in self._checkpointed_dirs
+                or abs_dir in self._checkpointing_dirs
+            ):
+                return False
+            self._checkpointing_dirs.add(abs_dir)
 
-        self._checkpointed_dirs.add(abs_dir)
-
+        success = False
         try:
-            return self._take(abs_dir, reason)
+            success = self._take(abs_dir, reason)
         except Exception as e:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
-            return False
+        finally:
+            with self._checkpoint_state_lock:
+                self._checkpointing_dirs.discard(abs_dir)
+                if success:
+                    self._checkpointed_dirs.add(abs_dir)
+
+        return success
 
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
         """List available checkpoints for a directory (most recent first)."""

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -652,7 +652,6 @@ class CheckpointManager:
         """Reset per-turn dedup.  Call at the start of each agent iteration."""
         with self._checkpoint_state_lock:
             self._checkpointed_dirs.clear()
-            self._checkpointing_dirs.clear()
 
     # ------------------------------------------------------------------
     # Public API

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1166,7 +1166,10 @@ def execute_code(
             "duration_seconds": 0,
             **{
                 key: _guard[key]
-                for key in ("request_id", "argument_hash", "operation", "tool_name")
+                for key in (
+                    "request_id", "argument_hash", "operation", "tool_name",
+                    "created_at", "expires_at",
+                )
                 if key in _guard
             },
         }, ensure_ascii=False)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1164,6 +1164,11 @@ def execute_code(
             "error": _guard.get("message") or "execute_code blocked by approval guard.",
             "tool_calls_made": 0,
             "duration_seconds": 0,
+            **{
+                key: _guard[key]
+                for key in ("request_id", "argument_hash", "operation", "tool_name")
+                if key in _guard
+            },
         }, ensure_ascii=False)
 
     # Clean interrupt slate for a user-approved script before EITHER dispatch

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2297,7 +2297,10 @@ def terminal_tool(
                         "pattern_key": approval.get("pattern_key", ""),
                         **{
                             key: approval[key]
-                            for key in ("request_id", "argument_hash", "operation", "tool_name")
+                            for key in (
+                                "request_id", "argument_hash", "operation", "tool_name",
+                                "created_at", "expires_at",
+                            )
                             if key in approval
                         },
                     }, ensure_ascii=False)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2295,6 +2295,11 @@ def terminal_tool(
                         "command": approval.get("command", command),
                         "description": approval.get("description", "command flagged"),
                         "pattern_key": approval.get("pattern_key", ""),
+                        **{
+                            key: approval[key]
+                            for key in ("request_id", "argument_hash", "operation", "tool_name")
+                            if key in approval
+                        },
                     }, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")


### PR DESCRIPTION
## Summary

Adds the first reliability spine for Hermes turns and tool execution.

### Phase 1 changes

- Defines one canonical terminal-outcome contract across finalization, persistence, memory, gateway delivery, and tests.
- Prevents false-success completion for partial, blocked, failed, interrupted, unresolved, and cancelled turns.
- Gates durable memory sync and background review on verified outcomes; permits only safe no-tool conversational `completed_unverified` sync.
- Makes checkpoint deduplication concurrency-safe, retryable, and correct across turn boundaries with detached work.
- Makes fallback approvals request-, session-, operation-, tool-, policy-, requester-, channel-, and argument-hash-bound; preserves legacy FIFO/all UX and fails closed on identity mismatch or collision.
- Makes timeout outcomes explicitly unresolved unless cancellation is confirmed, preserves late-result precedence, and persists timeout cancellation effect disposition.
- Adds regression coverage for the reliability races and boundary contracts.

## Verification

- Full Phase 1 matrix: **6,970 passed, 3 failed**.
- The 3 failures are pre-existing Anthropic OAuth/keychain `MagicMock` fixture failures, reproduced independently.
- Async gate enabled with `pytest-asyncio==1.3.0`; previously blocked async tests: **156/156 passed**.
- Post-rebase focused gate: **925/925 passed**.
- Ruff and `git diff --check`: passed.

The branch was rebased onto current `origin/main` before publishing.
