### PR TITLE
fix: align MoA diagnostics with virtual provider state

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -744,16 +744,22 @@ def run_doctor(args):
             provider = provider_raw.lower()
             default_model = (model_section.get("default") or model_section.get("model") or "").strip()
 
+            # Runtime-only providers intentionally do not have an auth/catalog
+            # entry because they do not speak to an inference endpoint directly.
+            virtual_provider_ids = {"moa"}
             known_providers: set = set()
             try:
                 from hermes_cli.auth import (
                     PROVIDER_REGISTRY,
                     resolve_provider as _resolve_auth_provider,
                 )
-                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {
+                    "openrouter", "custom", "auto"
+                }
             except Exception:
                 _resolve_auth_provider = None
                 pass
+            known_providers.update(virtual_provider_ids)
             try:
                 from hermes_cli.config import get_compatible_custom_providers as _compatible_custom_providers
                 from hermes_cli.providers import (
@@ -795,7 +801,7 @@ def run_doctor(args):
             if (
                 provider
                 and _resolve_auth_provider is not None
-                and provider not in {"auto", "custom"}
+                and provider not in ({"auto", "custom"} | virtual_provider_ids)
             ):
                 try:
                     runtime_provider = _resolve_auth_provider(provider)
@@ -803,16 +809,18 @@ def run_doctor(args):
                 except Exception:
                     runtime_provider = provider
 
-            catalog_provider = provider
+            catalog_provider = provider if provider in virtual_provider_ids else None
             if (
                 provider
                 and _resolve_provider_full is not None
-                and provider not in {"auto", "custom"}
+                and provider not in ({"auto", "custom"} | virtual_provider_ids)
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
+            elif provider in {"auto", "custom"}:
+                catalog_provider = provider
 
             if provider and provider != "auto":
                 if catalog_provider is None or (

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -64,7 +64,19 @@ def _print_config(config: dict[str, Any]) -> None:
     cfg = normalize_moa_config(config.get("moa") if isinstance(config, dict) else {})
     print("Mixture of Agents presets")
     print(f"Default: {cfg['default_preset']}")
-    active = cfg.get("active_preset") or "(off)"
+    model_cfg = config.get("model") if isinstance(config, dict) else {}
+    if (
+        isinstance(model_cfg, dict)
+        and str(model_cfg.get("provider") or "").strip().lower() == "moa"
+    ):
+        active = str(
+            model_cfg.get("default")
+            or model_cfg.get("model")
+            or cfg["default_preset"]
+        ).strip()
+    else:
+        legacy_active = str(cfg.get("active_preset") or "").strip()
+        active = f"{legacy_active} (legacy)" if legacy_active else "(off)"
     print(f"Active in config: {active}")
     for name, preset in cfg["presets"].items():
         marker = "*" if name == cfg["default_preset"] else " "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -469,6 +469,54 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_moa_virtual_provider(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: moa\n"
+        "  default: review\n"
+        "moa:\n"
+        "  default_preset: review\n"
+        "  presets:\n"
+        "    review:\n"
+        "      reference_models:\n"
+        "        - provider: zai\n"
+        "          model: glm-5.2\n"
+        "      aggregator:\n"
+        "        provider: zai\n"
+        "        model: glm-5.2\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'moa' is not a recognised provider" not in out
+    assert "model.provider 'moa' is unknown" not in out
+
+
 def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_moa_cmd.py
+++ b/tests/hermes_cli/test_moa_cmd.py
@@ -1,0 +1,35 @@
+from hermes_cli.moa_cmd import _print_config
+
+
+def _config(*, provider="moa", model="full", legacy_active=""):
+    return {
+        "model": {"provider": provider, "default": model},
+        "moa": {
+            "default_preset": "full",
+            "active_preset": legacy_active,
+            "presets": {
+                "full": {
+                    "reference_models": [{"provider": "zai", "model": "glm-5.2"}],
+                    "aggregator": {"provider": "zai", "model": "glm-5.2"},
+                }
+            },
+        },
+    }
+
+
+def test_print_config_reports_main_model_moa_preset_as_active(capsys):
+    _print_config(_config())
+
+    assert "Active in config: full" in capsys.readouterr().out
+
+
+def test_print_config_reports_off_when_main_provider_is_not_moa(capsys):
+    _print_config(_config(provider="zai", model="glm-5.2"))
+
+    assert "Active in config: (off)" in capsys.readouterr().out
+
+
+def test_print_config_keeps_legacy_active_preset_compatibility(capsys):
+    _print_config(_config(provider="zai", model="glm-5.2", legacy_active="full"))
+
+    assert "Active in config: full (legacy)" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- treat `moa` as a valid runtime-only virtual provider in `hermes doctor`
- derive `hermes moa list` active state from the top-level model selection
- preserve the legacy `moa.active_preset` display path with an explicit legacy label
- add regression coverage for both diagnostics

## Root cause
MoA is implemented as a virtual model provider, but Doctor only accepted auth/catalog providers. The MoA list command still read the legacy `active_preset` field instead of the current `model.provider: moa` + selected preset state.

## Test plan
- `pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_moa_cmd.py tests/hermes_cli/test_moa_config.py tests/cli/test_moa_command.py -q --tb=short -n 0` (96 passed)
- `ruff check hermes_cli/doctor.py hermes_cli/moa_cmd.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_moa_cmd.py`
- live `hermes doctor` reports all checks passed
- live `hermes moa list` reports the selected `full` preset as active
