### PR TITLE
fix(cli): keep logs --follow attached across rotation

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -19,6 +19,7 @@ Usage examples::
     hermes logs --since 30m -f     # follow, starting 30 min ago
 """
 
+import os
 import re
 import sys
 import time
@@ -338,6 +339,19 @@ def _read_last_n_lines(path: Path, n: int) -> list:
         return all_lines[-n:]
 
 
+def _follow_file_identity(stat_result: os.stat_result) -> tuple[int, int]:
+    """Return a stable identity for a followed file across replacements."""
+    return stat_result.st_dev, stat_result.st_ino
+
+
+def _decode_follow_line(raw_line: bytes) -> str:
+    """Decode one followed line while preserving text-mode newline behavior."""
+    line = raw_line.decode("utf-8", errors="replace")
+    if line.endswith("\r\n"):
+        return line[:-2] + "\n"
+    return line
+
+
 def _follow_log(
     path: Path,
     *,
@@ -346,20 +360,80 @@ def _follow_log(
     since: Optional[datetime] = None,
     component_prefixes: Optional[Sequence[str]] = None,
 ) -> None:
-    """Poll a log file for new content and print matching lines."""
-    with open(path, "r", encoding="utf-8", errors="replace") as f:
-        # Seek to end
-        f.seek(0, 2)
-        while True:
-            line = f.readline()
-            if line:
-                if _matches_filters(line, min_level=min_level,
-                                    session_filter=session_filter, since=since,
-                                    component_prefixes=component_prefixes):
-                    print(line, end="")
-                    sys.stdout.flush()
-            else:
-                time.sleep(0.3)
+    """Poll a log file for new content and print matching lines.
+
+    Follow Hermes' ``<name>.log`` to ``<name>.log.1`` rollover, draining any
+    unread lines from the rotated generation before reading its replacement.
+    Source handles are closed before output and between polls so follow mode
+    does not block rotation on Windows.
+    """
+    identity: Optional[tuple[int, int]] = None
+    offset = 0
+    missed_before_first_open = False
+
+    while True:
+        try:
+            with open(path, "rb") as stream:
+                open_stat = os.fstat(stream.fileno())
+                current_identity = _follow_file_identity(open_stat)
+                if identity is None:
+                    if missed_before_first_open:
+                        stream.seek(0)
+                        raw_lines = stream.readlines()
+                        offset = stream.tell()
+                    else:
+                        offset = stream.seek(0, os.SEEK_END)
+                        raw_lines = []
+                    identity = current_identity
+                    rotated = False
+                elif current_identity == identity:
+                    stream.seek(offset)
+                    raw_lines = stream.readlines()
+                    offset = stream.tell()
+                    rotated = False
+                else:
+                    raw_lines = []
+                    rotated = True
+        except FileNotFoundError:
+            if identity is None:
+                missed_before_first_open = True
+            time.sleep(0.3)
+            continue
+
+        if rotated:
+            rotated_lines = []
+            rotated_path = path.with_name(f"{path.name}.1")
+            try:
+                with open(rotated_path, "rb") as rotated_stream:
+                    rotated_stat = os.fstat(rotated_stream.fileno())
+                    if _follow_file_identity(rotated_stat) == identity:
+                        rotated_stream.seek(offset)
+                        rotated_lines = rotated_stream.readlines()
+            except FileNotFoundError:
+                # If the previous generation is already gone, continue with
+                # the live file rather than stalling follow mode forever.
+                pass
+
+            identity = current_identity
+            offset = 0
+            raw_lines = rotated_lines
+
+        wrote_output = False
+        for raw_line in raw_lines:
+            line = _decode_follow_line(raw_line)
+            if _matches_filters(line, min_level=min_level,
+                                session_filter=session_filter, since=since,
+                                component_prefixes=component_prefixes):
+                print(line, end="")
+                wrote_output = True
+        if wrote_output:
+            sys.stdout.flush()
+
+        if rotated:
+            # Re-open the replacement immediately and read it from byte zero.
+            continue
+
+        time.sleep(0.3)
 
 
 def list_logs() -> None:

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -1,12 +1,16 @@
 """Tests for hermes_cli.logs — log viewing and filtering."""
 
+import builtins
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta
 
+import pytest
 
 from hermes_cli.logs import (
     LOG_FILES,
     _extract_level,
     _extract_logger_name,
+    _follow_log,
     _line_matches_component,
     _matches_filters,
     _parse_line_timestamp,
@@ -250,6 +254,166 @@ class TestReadTail:
         result = _read_last_n_lines(log_file, 10)
         assert result == []
 
+
+class _StopFollow(Exception):
+    pass
+
+
+_STOP_FOLLOW = object()
+
+
+def _install_follow_steps(monkeypatch, *steps):
+    remaining = iter(steps)
+
+    def fake_sleep(_seconds):
+        try:
+            step = next(remaining)
+        except StopIteration:
+            pytest.fail("follower performed an unexpected extra poll")
+        if step is _STOP_FOLLOW:
+            raise _StopFollow
+        step()
+
+    monkeypatch.setattr("hermes_cli.logs.time.sleep", fake_sleep)
+
+
+class TestFollowLog:
+    def test_emits_append_once_with_closed_streams(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        log_file = tmp_path / "agent.log"
+        log_file.write_text("historical\n", encoding="utf-8")
+        opened_streams = []
+        real_open = builtins.open
+
+        def tracked_open(*args, **kwargs):
+            stream = real_open(*args, **kwargs)
+            opened_streams.append(stream)
+            return stream
+
+        def append_line():
+            assert opened_streams
+            assert all(stream.closed for stream in opened_streams)
+            with log_file.open("a", encoding="utf-8") as stream:
+                stream.write("new\n")
+
+        def check_streams_closed():
+            assert all(stream.closed for stream in opened_streams)
+
+        monkeypatch.setattr("hermes_cli.logs.open", tracked_open, raising=False)
+        _install_follow_steps(
+            monkeypatch,
+            append_line,
+            check_streams_closed,
+            _STOP_FOLLOW,
+        )
+
+        with pytest.raises(_StopFollow):
+            _follow_log(log_file)
+
+        assert capsys.readouterr().out == "new\n"
+
+    def test_drains_old_generation_before_replacement(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        log_file = tmp_path / "agent.log"
+        rotated_file = tmp_path / "agent.log.1"
+        log_file.write_text("historical\n", encoding="utf-8")
+
+        def rotate_with_unread_line():
+            with log_file.open("a", encoding="utf-8") as stream:
+                stream.write("unread old generation\n")
+            log_file.rename(rotated_file)
+            log_file.write_text("first new generation\n", encoding="utf-8")
+
+        _install_follow_steps(monkeypatch, rotate_with_unread_line, _STOP_FOLLOW)
+
+        with pytest.raises(_StopFollow):
+            _follow_log(log_file)
+
+        assert capsys.readouterr().out == (
+            "unread old generation\n"
+            "first new generation\n"
+        )
+
+    def test_recovers_after_complete_missing_path_poll(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        log_file = tmp_path / "agent.log"
+        rotated_file = tmp_path / "agent.log.1"
+        log_file.write_text("historical\n", encoding="utf-8")
+
+        def remove_active_path():
+            log_file.rename(rotated_file)
+
+        def create_replacement():
+            log_file.write_text("after gap\n", encoding="utf-8")
+
+        _install_follow_steps(
+            monkeypatch,
+            remove_active_path,
+            create_replacement,
+            _STOP_FOLLOW,
+        )
+
+        with pytest.raises(_StopFollow):
+            _follow_log(log_file)
+
+        assert capsys.readouterr().out == "after gap\n"
+
+    def test_reads_from_start_after_initial_missing_path(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        log_file = tmp_path / "agent.log"
+
+        def create_log():
+            log_file.write_text("created during gap\n", encoding="utf-8")
+
+        _install_follow_steps(monkeypatch, create_log, _STOP_FOLLOW)
+
+        with pytest.raises(_StopFollow):
+            _follow_log(log_file)
+
+        assert capsys.readouterr().out == "created during gap\n"
+
+    def test_normalizes_crlf_before_output(self, tmp_path, monkeypatch, capsys):
+        log_file = tmp_path / "agent.log"
+        log_file.write_bytes(b"historical\r\n")
+
+        def append_crlf_line():
+            with log_file.open("ab") as stream:
+                stream.write(b"windows line\r\n")
+
+        _install_follow_steps(monkeypatch, append_crlf_line, _STOP_FOLLOW)
+
+        with pytest.raises(_StopFollow):
+            _follow_log(log_file)
+
+        assert capsys.readouterr().out == "windows line\n"
+
+    def test_broken_pipe_propagates(self, tmp_path, monkeypatch):
+        log_file = tmp_path / "agent.log"
+        log_file.write_text("historical\n", encoding="utf-8")
+
+        def append_line():
+            with log_file.open("a", encoding="utf-8") as stream:
+                stream.write("new\n")
+
+        def unexpected_poll():
+            pytest.fail("BrokenPipeError was swallowed")
+
+        class BrokenStdout:
+            def write(self, _text):
+                raise BrokenPipeError("consumer closed")
+
+            def flush(self):
+                pass
+
+        _install_follow_steps(monkeypatch, append_line, unexpected_poll)
+
+        with redirect_stdout(BrokenStdout()):
+            with pytest.raises(BrokenPipeError, match="consumer closed"):
+                _follow_log(log_file)
 
 # ---------------------------------------------------------------------------
 # LOG_FILES registry


### PR DESCRIPTION
## What does this PR do?

`hermes logs --follow` keeps reading the same open file. When Hermes renames `agent.log` to `agent.log.1` and creates a replacement, the open handle still points to the old file. New log entries then stop appearing without any error.

This patch follows Hermes' normal `.log` to `.log.1` rollover:

- identify generations by `(st_dev, st_ino)` and retain a byte offset
- use short-lived binary handles so polling does not hold a file open across sleeps or output
- drain unread records from the matching `.1` generation before reading the replacement from byte zero
- retry a transiently missing active pathname, including before the first successful open
- preserve text-mode CRLF normalization and UTF-8 replacement decoding
- allow output failures such as `BrokenPipeError` to propagate instead of treating them as filesystem retries

This only handles Hermes' normal rename-and-recreate rollover. Other rotation schemes are unchanged.

## Related Issue

No issue was found for this exact bug. #27649 and #34349 cover the writer side of log rotation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/logs.py`: make follow mode generation-aware while keeping handles closed between polls
- `tests/hermes_cli/test_logs.py`: add deterministic coverage for appends, rollover ordering, missing-path recovery, initial creation, CRLF output, handle lifetime, and broken pipes

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_logs.py tests/test_hermes_logging.py -q`.
2. Run `ruff check hermes_cli/logs.py tests/hermes_cli/test_logs.py`.
3. Run `python scripts/check-windows-footguns.py --all`.
4. Start `hermes logs --follow`, append to the active log, rename it to `<name>.log.1`, create a replacement, and verify unread old-generation records appear once before replacement records.

Validation performed:

- focused test suites: `112 passed`
- targeted Ruff check: passed
- targeted `ty` check: passed
- Windows-footgun scan: passed (`757 files scanned`)
- `git diff --check`: passed
- a real `hermes logs --follow` smoke test emitted the unread old generation before the replacement, once each

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): N/A; user-facing syntax and configuration are unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

Manual rollover output after the fix:

```text
unread-old-generation
first-new-generation
```

Both records were emitted once and in generation order; the follower produced no stderr output.
