### PR TITLE
feat(gateway): negotiate scoped WebSocket grants

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,6 +15,7 @@ The routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -621,7 +622,9 @@ async def api_auth_ws_ticket(request: Request):
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the
-    expected pattern.
+    expected pattern. A bodyless request intentionally retains the dashboard's
+    full legacy authority. A mobile audience requests a narrower grant for one
+    WebSocket connection; it is not a persistent device credential.
     """
     sess = getattr(request.state, "session", None)
     if sess is None:
@@ -632,11 +635,58 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    body = await request.body()
+    requested = {}
+    if body:
+        try:
+            requested = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+        if not isinstance(requested, dict):
+            raise HTTPException(status_code=400, detail="Expected a JSON object")
+
+    audience = str(requested.get("audience") or "").strip()
+    if "scopes" in requested and not audience:
+        raise HTTPException(
+            status_code=400,
+            detail="audience is required when scopes are requested",
+        )
+    if audience:
+        from tui_gateway.mobile_contract import (
+            MOBILE_AUDIENCE,
+            normalize_mobile_scopes,
+        )
+
+        if audience != MOBILE_AUDIENCE:
+            raise HTTPException(status_code=400, detail="Unsupported WebSocket audience")
+        raw_scopes = requested.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise HTTPException(status_code=400, detail="scopes must be an array")
+        try:
+            granted_scopes = normalize_mobile_scopes(raw_scopes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        ticket = mint_ticket(
+            user_id=sess.user_id,
+            provider=sess.provider,
+            audience=audience,
+            scopes=granted_scopes,
+        )
+    else:
+        # Preserve the existing dashboard contract exactly for bodyless calls.
+        ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,
         user_id=sess.user_id,
         ip=_client_ip(request),
     )
-    return {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    response = {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    if audience:
+        response.update(
+            {
+                "audience": audience,
+                "granted_scopes": list(granted_scopes),
+            }
+        )
+    return response

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -646,11 +646,13 @@ async def api_auth_ws_ticket(request: Request):
             raise HTTPException(status_code=400, detail="Expected a JSON object")
 
     audience = str(requested.get("audience") or "").strip()
-    if "scopes" in requested and not audience:
-        raise HTTPException(
-            status_code=400,
-            detail="audience is required when scopes are requested",
+    if body and not audience:
+        detail = (
+            "audience is required when scopes are requested"
+            if "scopes" in requested
+            else "audience is required for a non-empty ticket request"
         )
+        raise HTTPException(status_code=400, detail=detail)
     if audience:
         from tui_gateway.mobile_contract import (
             MOBILE_AUDIENCE,

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -5,10 +5,13 @@ mode the legacy ``?token=<_SESSION_TOKEN>`` query param works because the
 token is injected into the SPA bundle. In gated mode there is no injected
 token — so this module provides two credential shapes:
 
-1. **Single-use browser tickets** (``mint_ticket`` / ``consume_ticket``).
-   The SPA gets a fresh ticket via the authenticated REST endpoint
-   ``POST /api/auth/ws-ticket`` and passes it as ``?ticket=`` on the WS
-   upgrade. Single-use, TTL = 30 seconds — a leaked ticket is uninteresting.
+1. **Single-use client tickets** (``mint_ticket`` / ``consume_ticket``).
+   The SPA gets a full-authority legacy ticket from a bodyless authenticated
+   ``POST /api/auth/ws-ticket``. A native client can request a mobile audience
+   and explicit scopes instead. Both pass ``?ticket=`` on the WS upgrade and
+   are single-use with TTL = 30 seconds. The scoped ticket narrows one socket;
+   it is not a persistent device credential or a replacement for the legacy
+   compatibility path.
 
 2. **A process-lifetime internal credential** (``internal_ws_credential`` /
    ``consume_internal_credential``). This authenticates *server-spawned*
@@ -53,13 +56,21 @@ _internal_credential: Optional[str] = None
 #: credential, so audit logs distinguish them from browser-initiated tickets.
 INTERNAL_USER_ID = "server-internal"
 INTERNAL_PROVIDER = "server-internal"
+LEGACY_AUDIENCE = "dashboard"
+LEGACY_SCOPES = ("*",)
 
 
 class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(
+    *,
+    user_id: str,
+    provider: str,
+    audience: str = LEGACY_AUDIENCE,
+    scopes: tuple[str, ...] = LEGACY_SCOPES,
+) -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -70,6 +81,8 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     info = {
         "user_id": user_id,
         "provider": provider,
+        "audience": audience,
+        "scopes": tuple(scopes),
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -132,10 +145,10 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     Unlike :func:`consume_ticket` this is **not** single-use — the value is
     not removed on success, so a server-spawned child can present it on every
     (re)connect. Returns the fixed server-internal identity ``info`` dict
-    (``{user_id, provider}``), mirroring the ``info`` shape ``consume_ticket``
-    returns, so a caller that wants to record the connecting identity can; the
-    current ``_ws_auth_ok`` caller validates for the boolean outcome only and
-    discards the dict.
+    (identity plus legacy audience/scopes), mirroring the ``info`` shape
+    ``consume_ticket`` returns so the gateway can carry one effective grant
+    shape through its transport. Non-gateway callers may validate only the
+    boolean outcome and discard the dict.
 
     A constant-time compare against the (lazily-minted) credential avoids
     leaking length / prefix information on mismatch. If no internal
@@ -150,6 +163,8 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     return {
         "user_id": INTERNAL_USER_ID,
         "provider": INTERNAL_PROVIDER,
+        "audience": LEGACY_AUDIENCE,
+        "scopes": LEGACY_SCOPES,
     }
 
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -77,12 +77,20 @@ def mint_ticket(
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
     """
+    scope_tuple = tuple(scopes)
+    if audience == "hermes.mobile":
+        from tui_gateway.mobile_contract import normalize_mobile_scopes
+
+        scope_tuple = normalize_mobile_scopes(scope_tuple)
+    elif audience != LEGACY_AUDIENCE or scope_tuple != LEGACY_SCOPES:
+        raise ValueError(f"unsupported WebSocket audience or grant: {audience}")
+
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
         "audience": audience,
-        "scopes": tuple(scopes),
+        "scopes": scope_tuple,
         "minted_at": int(time.time()),
     }
     with _lock:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14442,8 +14442,10 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_result(
+    ws: "WebSocket",
+) -> tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Validate WS-upgrade auth and return its effective authorization grant.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -14451,15 +14453,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``authorization`` is the server-derived grant carried by an accepted
+    credential; it is ``None`` for every rejected request.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
 
     Gated (public bind, no ``--insecure``): one of two credentials —
 
-    * ``?ticket=<single-use>`` — a browser-minted, single-use, 30s-TTL ticket
-      consumed against the dashboard-auth ticket store. This is what the SPA
-      (and native clients) use.
+    * ``?ticket=<single-use>`` — a client-minted, single-use, 30s-TTL ticket
+      consumed against the dashboard-auth ticket store. The bodyless SPA flow
+      retains legacy dashboard authority. A native mobile ticket is restricted
+      to ``/api/ws`` and carries explicit scopes into its dispatcher.
     * ``?internal=<process-credential>`` — the process-lifetime internal
       credential, used only by WS clients the server spawns itself (the
       embedded-TUI PTY child attaching to ``/api/ws`` and ``/api/pub``). It
@@ -14491,8 +14496,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                grant = consume_internal_credential(internal)
+                return None, "internal", grant
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14500,15 +14505,26 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            grant = consume_ticket(ticket)
+            if (
+                grant.get("audience") == "hermes.mobile"
+                and ws.url.path != "/api/ws"
+            ):
+                audit_log(
+                    AuditEvent.WS_TICKET_REJECTED,
+                    reason="mobile ticket used outside /api/ws",
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return "ticket_audience_mismatch", "ticket", None
+            return None, "ticket", grant
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14516,14 +14532,29 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return (
+            None,
+            "token",
+            {
+                "user_id": "loopback",
+                "provider": "loopback",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            },
+        )
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Compatibility view of :func:`_ws_auth_result` for non-gateway sockets."""
+    reason, credential, _authorization = _ws_auth_result(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -15613,7 +15644,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, authorization = _ws_auth_result(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -15623,7 +15655,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, authorization=authorization)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -13,6 +13,8 @@ pre-existing regression unrelated to dashboard-auth.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -20,14 +22,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
+from hermes_cli import mcp_startup
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
+    consume_ticket,
     consume_internal_credential,
     internal_ws_credential,
     mint_ticket,
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tui_gateway import server as tui_server
+from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +122,13 @@ class TestWsTicketEndpoint:
         r = gated_app.post("/api/auth/ws-ticket")
         assert r.status_code == 200
         body = r.json()
-        assert "ticket" in body
+        assert set(body) == {"ticket", "ttl_seconds"}
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "dashboard"
+        assert grant["scopes"] == ("*",)
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -132,6 +141,58 @@ class TestWsTicketEndpoint:
         tickets = {gated_app.post("/api/auth/ws-ticket").json()["ticket"]
                    for _ in range(5)}
         assert len(tickets) == 5
+
+    def test_mobile_ticket_returns_and_preserves_the_granted_scopes(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.read", "conversation.write"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["audience"] == "hermes.mobile"
+        assert body["granted_scopes"] == [
+            "conversation.read",
+            "conversation.write",
+        ]
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "hermes.mobile"
+        assert grant["scopes"] == ("conversation.read", "conversation.write")
+
+    @pytest.mark.parametrize("scope", ["approval.respond", "shell.exec"])
+    def test_mobile_ticket_rejects_scopes_not_enforced_by_this_contract(
+        self,
+        gated_app,
+        scope,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"audience": "hermes.mobile", "scopes": [scope]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"unsupported mobile scope: {scope}"
+
+    def test_scopes_without_a_mobile_audience_do_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"scopes": ["conversation.read"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "audience is required when scopes are requested"
 
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
@@ -150,6 +211,54 @@ class TestWsTicketEndpoint:
             f"GET /api/auth/ws-ticket leaked a ticket (status={r.status_code}, "
             f"body[:200]={body[:200]!r})"
         )
+
+
+def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
+    sent = []
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
+    ticket = mint_ticket(
+        user_id="mobile-user",
+        provider="stub",
+        audience="hermes.mobile",
+        scopes=("conversation.read",),
+    )
+
+    class QueryParams:
+        def get(self, key, default=""):
+            return {"ticket": ticket}.get(key, default)
+
+    class FakeWS:
+        query_params = QueryParams()
+        client = SimpleNamespace(host="203.0.113.10")
+        url = SimpleNamespace(path="/api/ws")
+        headers = {
+            "host": "fly-app.fly.dev",
+            "origin": "https://fly-app.fly.dev",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise tui_ws._WebSocketDisconnect()
+
+        async def close(self, code=None):
+            pass
+
+    asyncio.run(web_server.gateway_ws(FakeWS()))
+
+    authorization = sent[0]["params"]["payload"]["authorization"]
+    assert authorization == {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ["conversation.read"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +337,26 @@ class TestWsAuthOkGated:
         ticket = mint_ticket(user_id="u1", provider="stub")
         ws = _fake_ws(query={"ticket": ticket})
         assert web_server._ws_auth_ok(ws) is True
+
+    @pytest.mark.parametrize("path", ["/api/pty", "/api/console", "/api/pub", "/api/events"])
+    def test_mobile_ticket_cannot_authenticate_non_gateway_websockets(
+        self,
+        gated_app,
+        path,
+    ):
+        ticket = mint_ticket(
+            user_id="mobile-user",
+            provider="stub",
+            audience="hermes.mobile",
+            scopes=("conversation.read",),
+        )
+        ws = _fake_ws(query={"ticket": ticket}, path=path)
+
+        reason, credential, authorization = web_server._ws_auth_result(ws)
+
+        assert reason == "ticket_audience_mismatch"
+        assert credential == "ticket"
+        assert authorization is None
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -5,16 +5,14 @@ The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
-These tests exercise the helper at the unit level (no actual WS upgrade)
-plus the ticket-mint endpoint under realistic gated-mode setup. We don't
-test the full WS upgrade because the starlette TestClient WS path has a
-pre-existing regression unrelated to dashboard-auth.
+These tests exercise the helper at the unit level, the ticket-mint endpoint
+under realistic gated-mode setup, and one public mint-to-upgrade-to-dispatch
+round trip. The full upgrade supplies explicit Host/Origin headers because
+Starlette's WebSocket TestClient does not inherit the HTTP ``base_url`` host.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -33,7 +31,6 @@ from hermes_cli.dashboard_auth.ws_tickets import (
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 from tui_gateway import server as tui_server
-from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +191,35 @@ class TestWsTicketEndpoint:
         assert response.status_code == 400
         assert response.json()["detail"] == "audience is required when scopes are requested"
 
+    def test_nonempty_request_without_an_audience_does_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post("/api/auth/ws-ticket", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "audience is required for a non-empty ticket request"
+        )
+
+    def test_mobile_write_grant_requires_read_scope(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.write"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "conversation.read is required for every mobile WebSocket grant"
+        )
+
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
         r = gated_app.get("/api/auth/ws-ticket", follow_redirects=False)
@@ -213,52 +239,47 @@ class TestWsTicketEndpoint:
         )
 
 
-def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
-    sent = []
+def test_scoped_ticket_grant_reaches_gateway_ready_and_dispatch(gated_app, monkeypatch):
     monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
     monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
-    ticket = mint_ticket(
-        user_id="mobile-user",
-        provider="stub",
-        audience="hermes.mobile",
-        scopes=("conversation.read",),
+
+    _logged_in(gated_app)
+    minted = gated_app.post(
+        "/api/auth/ws-ticket",
+        json={
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
+        },
     )
+    assert minted.status_code == 200
 
-    class QueryParams:
-        def get(self, key, default=""):
-            return {"ticket": ticket}.get(key, default)
-
-    class FakeWS:
-        query_params = QueryParams()
-        client = SimpleNamespace(host="203.0.113.10")
-        url = SimpleNamespace(path="/api/ws")
-        headers = {
-            "host": "fly-app.fly.dev",
-            "origin": "https://fly-app.fly.dev",
+    with gated_app.websocket_connect(
+        f"/api/ws?ticket={minted.json()['ticket']}",
+        headers={
+            "Host": "fly-app.fly.dev",
+            "Origin": "https://fly-app.fly.dev",
+        },
+    ) as socket:
+        ready = socket.receive_json()
+        authorization = ready["params"]["payload"]["authorization"]
+        assert authorization == {
+            "subject": "stub-user-1",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
         }
 
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            sent.append(json.loads(line))
-
-        async def receive_text(self):
-            raise tui_ws._WebSocketDisconnect()
-
-        async def close(self, code=None):
-            pass
-
-    asyncio.run(web_server.gateway_ws(FakeWS()))
-
-    authorization = sent[0]["params"]["payload"]["authorization"]
-    assert authorization == {
-        "subject": "mobile-user",
-        "provider": "stub",
-        "audience": "hermes.mobile",
-        "scopes": ["conversation.read"],
-    }
+        socket.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": "denied-write",
+                "method": "prompt.submit",
+                "params": {},
+            }
+        )
+        denied = socket.receive_json()
+        assert denied["error"]["data"]["required_scope"] == "conversation.write"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,27 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_ticket_store_rejects_unknown_audiences(self):
+        with pytest.raises(ValueError, match="unsupported WebSocket audience"):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.future",
+                scopes=("*",),
+            )
+
+    def test_ticket_store_rejects_mobile_grants_without_read_scope(self):
+        with pytest.raises(
+            ValueError,
+            match="conversation.read is required for every mobile WebSocket grant",
+        ):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.mobile",
+                scopes=("conversation.write",),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -51,6 +51,19 @@ class TestMintAndConsume:
         seen = {mint_ticket(user_id="u1", provider="x") for _ in range(50)}
         assert len(seen) == 50
 
+    def test_scoped_ticket_preserves_its_authorization_grant(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.write"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["audience"] == "hermes.mobile"
+        assert info["scopes"] == ("conversation.read", "conversation.write")
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -121,8 +121,11 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "not.a.mobile.method",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read"],
+            "grantable": False,
         },
     }
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,10 +1,130 @@
 import asyncio
+import json
 import threading
 import time
 
 from hermes_cli import mcp_startup
+from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+
+
+def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
+    monkeypatch,
+):
+    sent = []
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(mobile_contract, "SERVER_VERSION", "test-version")
+    monkeypatch.setattr(mobile_contract, "SERVER_RELEASE_DATE", "test-release")
+    monkeypatch.setattr(mobile_contract, "SERVER_INSTANCE_ID", "test-instance")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "user-1",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ("conversation.read", "conversation.write"),
+    }
+
+    asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+
+    assert sent[0] == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": "test-skin",
+                "server": {
+                    "version": "test-version",
+                    "release_date": "test-release",
+                    "instance_id": "test-instance",
+                },
+                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
+                "contract": {"name": "hermes.mobile", "major": 1},
+                "schemas": {
+                    "gateway.ready": 1,
+                    "authorization.grant": 1,
+                    "authorization.error": 1,
+                },
+                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "authorization": {
+                    "subject": "user-1",
+                    "provider": "stub",
+                    "audience": "hermes.mobile",
+                    "scopes": ["conversation.read", "conversation.write"],
+                },
+            },
+        },
+    }
+
+
+def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
+    monkeypatch,
+):
+    sent = []
+    received = False
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "mobile-request",
+                        "method": "not.a.mobile.method",
+                        "params": {},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(
+        ws_mod.handle_ws(
+            FakeWS(),
+            authorization={
+                "subject": "user-1",
+                "provider": "stub",
+                "audience": "hermes.mobile",
+                "scopes": ("conversation.read",),
+            },
+        )
+    )
+
+    assert sent[1]["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "not.a.mobile.method",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read"],
+        },
+    }
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,0 +1,217 @@
+"""Public JSON-RPC conformance tests for the mobile authorization contract."""
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self, authorization=None):
+        self.authorization = authorization
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "prompt.submit",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-1",
+        "error": {
+            "code": 4030,
+            "message": "insufficient authorization scope",
+            "data": {
+                "reason": "missing_scope",
+                "method": "prompt.submit",
+                "required_scope": "conversation.write",
+                "granted_scopes": ["conversation.read"],
+            },
+        },
+    }
+
+
+def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-2",
+            "method": "shell.exec",
+            "params": {"command": "true"},
+        },
+        transport,
+    )
+
+    assert response["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "shell.exec",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read", "conversation.write"],
+        },
+    }
+
+
+def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-request",
+            "method": "approval.respond",
+            "params": {"choice": "once"},
+        },
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "method_not_available_to_mobile",
+        "method": "approval.respond",
+        "required_scope": None,
+        "granted_scopes": ["conversation.read", "conversation.write"],
+    }
+
+
+def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+    server._sessions.clear()
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-3",
+            "method": "session.active_list",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-3",
+        "result": {"sessions": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "required_scope"),
+    [
+        ("session.list", "conversation.read"),
+        ("session.active_list", "conversation.read"),
+        ("session.activate", "conversation.read"),
+        ("session.history", "conversation.read"),
+        ("session.status", "conversation.read"),
+        ("session.usage", "conversation.read"),
+        ("session.create", "conversation.write"),
+        ("session.resume", "conversation.write"),
+        ("prompt.submit", "conversation.write"),
+        ("session.interrupt", "conversation.control"),
+        ("session.steer", "conversation.control"),
+    ],
+)
+def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
+    method,
+    required_scope,
+):
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (),
+        }
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": method,
+        "required_scope": required_scope,
+        "granted_scopes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        {
+            "subject": "server-internal",
+            "provider": "server-internal",
+            "audience": "dashboard",
+            "scopes": ("*",),
+        },
+    ],
+)
+def test_legacy_and_internal_dispatch_keep_the_existing_behavior(authorization):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-request",
+            "method": "not.a.real.method",
+            "params": {},
+        },
+        RecordingTransport(authorization),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "legacy-request",
+        "error": {
+            "code": -32601,
+            "message": "unknown method: not.a.real.method",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -220,25 +220,28 @@ def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(metho
     assert response["error"]["data"]["grantable"] is False
 
 
-def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
-    authorization = _mobile_authorization(
-        "conversation.read",
-        "conversation.write",
-        "conversation.control",
+def test_mobile_dispatch_rejects_hidden_history_deletion():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "hidden-delete",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "known",
+                "text": "replace",
+                "truncate_before_user_ordinal": 1,
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
     )
 
-    delete_denial = mobile_contract.mobile_method_denial(
-        "prompt.submit",
-        authorization,
-        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
-    )
-    profile_denial = mobile_contract.mobile_method_denial(
-        "session.create",
-        authorization,
-        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
-    )
-
-    assert delete_denial == {
+    assert response["error"]["data"] == {
         "reason": "parameter_not_available_to_mobile",
         "method": "prompt.submit",
         "parameter": "truncate_before_user_ordinal",
@@ -252,10 +255,55 @@ def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters(
         ],
         "grantable": False,
     }
-    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
-    assert profile_denial["parameter"] == "messages"
-    assert profile_denial["required_scope"] == "mobile.unavailable"
-    assert profile_denial["grantable"] is False
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("close_on_disconnect", True),
+        ("cwd", "/tmp/outside"),
+        ("fast", True),
+        ("messages", [{"role": "system", "content": "override"}]),
+        ("model", "provider/model"),
+        ("parent_session_id", "parent"),
+        ("profile", "../../outside"),
+        ("provider", "custom"),
+        ("reasoning_effort", "high"),
+        ("source", "spoofed-platform"),
+    ],
+)
+def test_mobile_dispatch_rejects_each_privileged_create_parameter(
+    monkeypatch,
+    parameter,
+    value,
+):
+    def fail_if_handler_runs(_profile):
+        raise AssertionError("session.create handler ran before mobile authorization")
+
+    monkeypatch.setattr(server, "_profile_home", fail_if_handler_runs)
+    server._sessions.clear()
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "privileged-create",
+            "method": "session.create",
+            "params": {parameter: value},
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == parameter
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
+    assert server._sessions == {}
 
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
@@ -268,12 +316,13 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             self.interrupted = True
 
     agent = Agent()
+    original_transport = RecordingTransport()
     session = {
         "agent": agent,
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
-        "transport": None,
+        "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
@@ -294,7 +343,9 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     assert response["result"] == {"status": "queued"}
     assert agent.interrupted is False
+    assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
+    assert session["queued_prompt"]["transport"] is transport
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,7 +1,10 @@
 """Public JSON-RPC conformance tests for the mobile authorization contract."""
 
+import threading
+
 import pytest
 
+from tui_gateway import mobile_contract
 from tui_gateway import server
 
 
@@ -18,15 +21,17 @@ class RecordingTransport:
         pass
 
 
+def _mobile_authorization(*scopes):
+    return {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": scopes,
+    }
+
+
 def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
 
     response = server.dispatch(
         {
@@ -48,7 +53,10 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
                 "reason": "missing_scope",
                 "method": "prompt.submit",
                 "required_scope": "conversation.write",
+                "required_scopes": ["conversation.write"],
+                "missing_scopes": ["conversation.write"],
                 "granted_scopes": ["conversation.read"],
+                "grantable": True,
             },
         },
     }
@@ -56,12 +64,7 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
 
 def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -80,20 +83,18 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "shell.exec",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read", "conversation.write"],
+            "grantable": False,
         },
     }
 
 
 def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -109,20 +110,16 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     assert response["error"]["data"] == {
         "reason": "method_not_available_to_mobile",
         "method": "approval.respond",
-        "required_scope": None,
+        "required_scope": "mobile.unavailable",
+        "required_scopes": ["mobile.unavailable"],
+        "missing_scopes": ["mobile.unavailable"],
         "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": False,
     }
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
     server._sessions.clear()
 
     response = server.dispatch(
@@ -147,29 +144,19 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
     [
         ("session.list", "conversation.read"),
         ("session.active_list", "conversation.read"),
-        ("session.activate", "conversation.read"),
+        ("session.activate", "conversation.control"),
         ("session.history", "conversation.read"),
-        ("session.status", "conversation.read"),
-        ("session.usage", "conversation.read"),
         ("session.create", "conversation.write"),
-        ("session.resume", "conversation.write"),
+        ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
-        ("session.steer", "conversation.control"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
     method,
     required_scope,
 ):
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": (),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization())
 
     response = server.dispatch(
         {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
@@ -180,8 +167,142 @@ def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
         "reason": "missing_scope",
         "method": method,
         "required_scope": required_scope,
+        "required_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
+        "missing_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
         "granted_scopes": [],
+        "grantable": True,
     }
+
+
+def test_mobile_create_requires_write_and_control():
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": "session.create",
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.write", "conversation.control"],
+        "missing_scopes": ["conversation.control"],
+        "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": True,
+    }
+
+
+@pytest.mark.parametrize("method", ["session.status", "session.usage", "session.steer"])
+def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(method):
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "unavailable", "method": method, "params": {}},
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    assert response["error"]["data"]["required_scope"] == "mobile.unavailable"
+    assert response["error"]["data"]["grantable"] is False
+
+
+def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
+    authorization = _mobile_authorization(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+
+    delete_denial = mobile_contract.mobile_method_denial(
+        "prompt.submit",
+        authorization,
+        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
+    )
+    profile_denial = mobile_contract.mobile_method_denial(
+        "session.create",
+        authorization,
+        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
+    )
+
+    assert delete_denial == {
+        "reason": "parameter_not_available_to_mobile",
+        "method": "prompt.submit",
+        "parameter": "truncate_before_user_ordinal",
+        "required_scope": "conversation.delete",
+        "required_scopes": ["conversation.delete"],
+        "missing_scopes": ["conversation.delete"],
+        "granted_scopes": [
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ],
+        "grantable": False,
+    }
+    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
+    assert profile_denial["parameter"] == "messages"
+    assert profile_denial["required_scope"] == "mobile.unavailable"
+    assert profile_denial["grantable"] is False
+
+
+def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
+    monkeypatch,
+):
+    class Agent:
+        interrupted = False
+
+        def interrupt(self):
+            self.interrupted = True
+
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["busy"] = session
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "busy-write",
+            "method": "prompt.submit",
+            "params": {"session_id": "busy", "text": "next"},
+        },
+        transport,
+    )
+
+    assert response["result"] == {"status": "queued"}
+    assert agent.interrupted is False
+    assert session["queued_prompt"]["text"] == "next"
+
+
+def test_mobile_scope_grants_require_read_access():
+    with pytest.raises(
+        ValueError,
+        match="conversation.read is required for every mobile WebSocket grant",
+    ):
+        mobile_contract.normalize_mobile_scopes(["conversation.write"])
 
 
 @pytest.mark.parametrize(

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
 
@@ -41,6 +42,11 @@ CONVERSATION_WRITE_SCOPE = "conversation.write"
 # mutation idempotency; clients must wait for that separately advertised
 # capability before treating retries as safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
+CONVERSATION_DELETE_SCOPE = "conversation.delete"
+# Error-only marker for a method or parameter that has no grantable mobile
+# scope in this contract version.  It is deliberately absent from
+# SUPPORTED_MOBILE_SCOPES; clients must also inspect ``grantable``.
+MOBILE_UNAVAILABLE_SCOPE = "mobile.unavailable"
 
 SUPPORTED_MOBILE_SCOPES = frozenset(
     {
@@ -50,18 +56,52 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
-MOBILE_METHOD_SCOPES = {
-    "session.list": CONVERSATION_READ_SCOPE,
-    "prompt.submit": CONVERSATION_WRITE_SCOPE,
-    "session.active_list": CONVERSATION_READ_SCOPE,
-    "session.activate": CONVERSATION_READ_SCOPE,
-    "session.history": CONVERSATION_READ_SCOPE,
-    "session.status": CONVERSATION_READ_SCOPE,
-    "session.usage": CONVERSATION_READ_SCOPE,
-    "session.create": CONVERSATION_WRITE_SCOPE,
-    "session.resume": CONVERSATION_WRITE_SCOPE,
-    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
-    "session.steer": CONVERSATION_CONTROL_SCOPE,
+@dataclass(frozen=True)
+class MobileMethodPolicy:
+    """Scopes and parameters that make one existing gateway method mobile-safe."""
+
+    required_scopes: tuple[str, ...]
+    allowed_parameters: frozenset[str]
+
+
+MOBILE_METHOD_POLICIES = {
+    "session.list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset(),
+    ),
+    "session.active_list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"current_session_id"}),
+    ),
+    # Activating or resuming rebinds the live transport, so read access alone
+    # is intentionally insufficient even though both responses contain history.
+    "session.activate": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    "session.history": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    # Creating a live session starts Hermes-owned workers and hooks.  It is both
+    # a conversation write and a runtime-control action, with server-derived
+    # profile/source/model/cwd rather than client-selected privileged knobs.
+    "session.create": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE, CONVERSATION_CONTROL_SCOPE),
+        frozenset({"cols", "title"}),
+    ),
+    "session.resume": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"cols", "session_id"}),
+    ),
+    "prompt.submit": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE,),
+        frozenset({"session_id", "text"}),
+    ),
+    "session.interrupt": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
 }
 
 
@@ -76,6 +116,10 @@ def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
             granted.append(scope)
     if not granted:
         raise ValueError("at least one mobile scope is required")
+    if CONVERSATION_READ_SCOPE not in granted:
+        raise ValueError(
+            "conversation.read is required for every mobile WebSocket grant"
+        )
     return tuple(granted)
 
 
@@ -113,25 +157,85 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
     }
 
 
-def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+def authorization_allows_scope(authorization: dict | None, scope: str) -> bool:
+    """Return whether a connection may perform a scope-gated side effect."""
+    grant = effective_authorization(authorization)
+    return grant["audience"] != MOBILE_AUDIENCE or scope in grant["scopes"]
+
+
+def _denial(
+    *,
+    reason: str,
+    method: str,
+    grant: dict,
+    required_scopes: tuple[str, ...],
+    grantable: bool,
+    parameter: str | None = None,
+) -> dict:
+    missing = (
+        list(required_scopes)
+        if not grantable
+        else [scope for scope in required_scopes if scope not in grant["scopes"]]
+    )
+    data = {
+        "reason": reason,
+        "method": method,
+        "required_scope": missing[0] if missing else required_scopes[0],
+        "required_scopes": list(required_scopes),
+        "missing_scopes": missing,
+        "granted_scopes": grant["scopes"],
+        "grantable": grantable,
+    }
+    if parameter is not None:
+        data["parameter"] = parameter
+    return data
+
+
+def mobile_method_denial(
+    method: str,
+    authorization: dict | None,
+    params: dict | None = None,
+) -> dict | None:
     """Describe why a mobile grant cannot call *method*, or return ``None``."""
     grant = effective_authorization(authorization)
     if grant["audience"] != MOBILE_AUDIENCE:
         return None
 
-    required_scope = MOBILE_METHOD_SCOPES.get(method)
-    if required_scope is None:
-        return {
-            "reason": "method_not_available_to_mobile",
-            "method": method,
-            "required_scope": None,
-            "granted_scopes": grant["scopes"],
-        }
-    if required_scope not in grant["scopes"]:
-        return {
-            "reason": "missing_scope",
-            "method": method,
-            "required_scope": required_scope,
-            "granted_scopes": grant["scopes"],
-        }
+    policy = MOBILE_METHOD_POLICIES.get(method)
+    if policy is None:
+        return _denial(
+            reason="method_not_available_to_mobile",
+            method=method,
+            grant=grant,
+            required_scopes=(MOBILE_UNAVAILABLE_SCOPE,),
+            grantable=False,
+        )
+
+    params = params or {}
+    unsupported_parameters = sorted(set(params) - policy.allowed_parameters)
+    if unsupported_parameters:
+        parameter = unsupported_parameters[0]
+        required_scope = (
+            CONVERSATION_DELETE_SCOPE
+            if method == "prompt.submit"
+            and parameter == "truncate_before_user_ordinal"
+            else MOBILE_UNAVAILABLE_SCOPE
+        )
+        return _denial(
+            reason="parameter_not_available_to_mobile",
+            method=method,
+            parameter=parameter,
+            grant=grant,
+            required_scopes=(required_scope,),
+            grantable=False,
+        )
+
+    if any(scope not in grant["scopes"] for scope in policy.required_scopes):
+        return _denial(
+            reason="missing_scope",
+            method=method,
+            grant=grant,
+            required_scopes=policy.required_scopes,
+            grantable=True,
+        )
     return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -1,0 +1,137 @@
+"""Versioned authorization contract for native/mobile gateway clients.
+
+This module is deliberately transport-only: it defines what a scoped client
+may ask the existing TUI JSON-RPC gateway to do. It does not introduce a new
+runtime or duplicate any Hermes-owned session state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from hermes_cli import __release_date__, __version__
+
+MOBILE_AUDIENCE = "hermes.mobile"
+LEGACY_AUDIENCE = "dashboard"
+PROTOCOL_NAME = "hermes.tui.jsonrpc"
+PROTOCOL_MAJOR = 1
+MOBILE_CONTRACT_NAME = "hermes.mobile"
+MOBILE_CONTRACT_MAJOR = 1
+
+SERVER_VERSION = __version__
+SERVER_RELEASE_DATE = __release_date__
+# A new server process is a new event-stream authority.  This identity is
+# intentionally stable across connections but changes after process restart;
+# durable deployment identity remains outside this first contract slice.
+SERVER_INSTANCE_ID = str(uuid.uuid4())
+
+# Advertise only schemas this slice actually defines.  Conversation snapshots,
+# replay, mutation idempotency, and recoverable approvals land in later slices
+# and must not be inferred from Mobile Client Contract v1 alone.
+CLIENT_SCHEMA_MAJORS = {
+    "gateway.ready": 1,
+    "authorization.grant": 1,
+    "authorization.error": 1,
+}
+
+CONVERSATION_READ_SCOPE = "conversation.read"
+CONVERSATION_WRITE_SCOPE = "conversation.write"
+# This scope is an authorization boundary only.  It does not claim durable
+# mutation idempotency; clients must wait for that separately advertised
+# capability before treating retries as safe.
+CONVERSATION_CONTROL_SCOPE = "conversation.control"
+
+SUPPORTED_MOBILE_SCOPES = frozenset(
+    {
+        CONVERSATION_READ_SCOPE,
+        CONVERSATION_WRITE_SCOPE,
+        CONVERSATION_CONTROL_SCOPE,
+    }
+)
+
+MOBILE_METHOD_SCOPES = {
+    "session.list": CONVERSATION_READ_SCOPE,
+    "prompt.submit": CONVERSATION_WRITE_SCOPE,
+    "session.active_list": CONVERSATION_READ_SCOPE,
+    "session.activate": CONVERSATION_READ_SCOPE,
+    "session.history": CONVERSATION_READ_SCOPE,
+    "session.status": CONVERSATION_READ_SCOPE,
+    "session.usage": CONVERSATION_READ_SCOPE,
+    "session.create": CONVERSATION_WRITE_SCOPE,
+    "session.resume": CONVERSATION_WRITE_SCOPE,
+    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
+    "session.steer": CONVERSATION_CONTROL_SCOPE,
+}
+
+
+def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested mobile authorization grant."""
+    granted: list[str] = []
+    for raw in scopes:
+        scope = str(raw or "").strip()
+        if not scope or scope not in SUPPORTED_MOBILE_SCOPES:
+            raise ValueError(f"unsupported mobile scope: {scope or '<empty>'}")
+        if scope not in granted:
+            granted.append(scope)
+    if not granted:
+        raise ValueError("at least one mobile scope is required")
+    return tuple(granted)
+
+
+def effective_authorization(raw: dict | None = None) -> dict:
+    """Return the stable, JSON-safe authorization grant exposed to a client."""
+    raw = raw or {}
+    scopes = raw.get("scopes", ("*",))
+    if not isinstance(scopes, (list, tuple)):
+        scopes = (str(scopes),)
+    return {
+        "subject": str(raw.get("subject") or raw.get("user_id") or "legacy"),
+        "provider": str(raw.get("provider") or "legacy"),
+        "audience": str(raw.get("audience") or LEGACY_AUDIENCE),
+        "scopes": [str(scope) for scope in scopes],
+    }
+
+
+def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> dict:
+    """Build the additive first-frame contract for every WebSocket client."""
+    return {
+        "skin": skin,
+        "server": {
+            "version": SERVER_VERSION,
+            "release_date": SERVER_RELEASE_DATE,
+            "instance_id": SERVER_INSTANCE_ID,
+        },
+        "protocol": {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR},
+        "contract": {
+            "name": MOBILE_CONTRACT_NAME,
+            "major": MOBILE_CONTRACT_MAJOR,
+        },
+        "schemas": dict(CLIENT_SCHEMA_MAJORS),
+        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "authorization": effective_authorization(authorization),
+    }
+
+
+def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+    """Describe why a mobile grant cannot call *method*, or return ``None``."""
+    grant = effective_authorization(authorization)
+    if grant["audience"] != MOBILE_AUDIENCE:
+        return None
+
+    required_scope = MOBILE_METHOD_SCOPES.get(method)
+    if required_scope is None:
+        return {
+            "reason": "method_not_available_to_mobile",
+            "method": method,
+            "required_scope": None,
+            "granted_scopes": grant["scopes"],
+        }
+    if required_scope not in grant["scopes"]:
+        return {
+            "reason": "missing_scope",
+            "method": method,
+            "required_scope": required_scope,
+            "granted_scopes": grant["scopes"],
+        }
+    return None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1205,8 +1205,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, *, data: dict | None = None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):
@@ -1268,6 +1271,16 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        from tui_gateway.mobile_contract import mobile_method_denial
+
+        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        if denial is not None:
+            return _err(
+                _rid,
+                4030,
+                "insufficient authorization scope",
+                data=denial,
+            )
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1273,7 +1273,11 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
         _rid, method, _params = normalized
         from tui_gateway.mobile_contract import mobile_method_denial
 
-        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        denial = mobile_method_denial(
+            method,
+            getattr(t, "authorization", None),
+            _params,
+        )
         if denial is not None:
             return _err(
                 _rid,
@@ -5101,7 +5105,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     session["queued_prompt"] = {"text": text, "transport": transport}
 
 
-def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any) -> dict:
+def _handle_busy_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    allow_control: bool = True,
+) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
 
@@ -5116,6 +5128,14 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
     without interrupting; ``steer`` → inject into the live turn if accepted,
     else queue.
     """
+    # A scoped writer may enqueue the next user turn, but must not inherit the
+    # dashboard's interrupt/steer preference unless its connection also holds
+    # conversation.control.
+    if not allow_control:
+        _enqueue_prompt(session, text, transport)
+        session["last_active"] = time.time()
+        return _ok(rid, {"status": "queued"})
+
     mode = _load_busy_input_mode()
     agent = session.get("agent")
     if mode == "steer" and agent is not None and hasattr(agent, "steer"):
@@ -8137,7 +8157,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.interrupt")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Interrupting a deferred/lazy session must not build the very agent the
+    # caller is trying to stop. Operate on live state only.
+    session, err = _sess_nowait(params, rid)
     if err:
         return err
     # Safety net: if the turn's run thread is already gone but `running` stayed
@@ -8459,7 +8481,23 @@ def _(rid, params: dict) -> dict:
             # interrupt the live turn) so it runs as the next turn. See
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
-            return _handle_busy_submit(rid, sid, session, text, t or session.get("transport"))
+            active_transport = t or session.get("transport")
+            from tui_gateway.mobile_contract import (
+                CONVERSATION_CONTROL_SCOPE,
+                authorization_allows_scope,
+            )
+
+            return _handle_busy_submit(
+                rid,
+                sid,
+                session,
+                text,
+                active_transport,
+                allow_control=authorization_allows_scope(
+                    getattr(active_transport, "authorization", None),
+                    CONVERSATION_CONTROL_SCOPE,
+                ),
+            )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8470,11 +8470,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    # Re-bind accepted idle work to the current client. A busy scoped writer
+    # without conversation.control queues its next turn on this transport but
+    # must not seize the in-flight turn from the currently attached client.
+    t = current_transport()
     with session["history_lock"]:
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
@@ -8487,16 +8486,19 @@ def _(rid, params: dict) -> dict:
                 authorization_allows_scope,
             )
 
+            allow_control = authorization_allows_scope(
+                getattr(active_transport, "authorization", None),
+                CONVERSATION_CONTROL_SCOPE,
+            )
+            if t is not None and allow_control:
+                session["transport"] = t
             return _handle_busy_submit(
                 rid,
                 sid,
                 session,
                 text,
                 active_transport,
-                allow_control=authorization_allows_scope(
-                    getattr(active_transport, "authorization", None),
-                    CONVERSATION_CONTROL_SCOPE,
-                ),
+                allow_control=allow_control,
             )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -8505,6 +8507,8 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if t is not None:
+            session["transport"] = t
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,6 +81,10 @@ class WSTransport:
     the loop we're currently blocking. We detect that case and fire-and-
     forget instead. Callers that need to know when the bytes are on the wire
     should use :meth:`write_async` from the loop thread.
+
+    ``authorization`` is the server-derived grant for this connection. The
+    dispatcher reads it before resolving any method; clients cannot mutate it
+    through JSON-RPC input.
     """
 
     def __init__(
@@ -89,10 +93,12 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        authorization: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        self.authorization = authorization
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -280,7 +286,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, authorization: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -298,7 +304,12 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            authorization=authorization,
+        )
 
         # The desktop app and dashboard chat reach the agent through this WS
         # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
@@ -316,13 +327,18 @@ async def handle_ws(ws: Any) -> None:
             thread_name="tui-ws-mcp-discovery",
         )
 
+        from tui_gateway.mobile_contract import gateway_ready_payload
+
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    "payload": {"skin": server.resolve_skin()},
+                    "payload": gateway_ready_payload(
+                        skin=server.resolve_skin(),
+                        authorization=authorization,
+                    ),
                 },
             }
         )


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in, versioned authorization contract for native and other external clients on the existing `/api/ws` JSON-RPC transport.

An authenticated client can request a single-use `hermes.mobile` ticket with explicit conversation scopes. The resulting server-derived grant is carried through upgrade, reported in the additive `gateway.ready` payload, and enforced by a fail-closed method and parameter policy before handlers run.

Bodyless dashboard ticket minting, internal credentials, loopback tokens, stdio dispatch, and the existing `skin` ready field remain compatible.

This is a draft for maintainer feedback on contract naming, versioning, and the intentionally narrow v1 boundary.

## Related Issue

Fixes #62857

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Extend `POST /api/auth/ws-ticket` with an opt-in mobile audience and validated explicit scopes while preserving the bodyless legacy response.
- Carry the effective ticket grant through `/api/ws` and report server, protocol, contract, schema, capability, and authorization metadata in `gateway.ready`.
- Enforce a minimum mobile method and parameter allowlist with structured missing or non-grantable scope errors.
- Keep shell, configuration, credential, plugin, process, deletion, permanent-policy, approval, account, and unmapped methods unavailable.
- Require read access in every mobile grant; require write plus control to create live sessions.
- Prevent write-scoped busy submissions from interrupting, steering, or seizing another client in-flight transport.
- Add public cookie login to ticket mint to real WebSocket upgrade to ready and denied-dispatch coverage.

## Security Boundary

The mobile ticket is connection attenuation, not a persistent device credential or a replacement for the existing auth gate. It is accepted only on `/api/ws`, remains single-use with the existing TTL, and cannot authorize hidden parameters such as `profile`, `cwd`, seeded system history, model or provider overrides, transcript truncation, or future fields.

Replay cursors, mutation idempotency, and stable addressable approvals are intentionally not advertised by this slice.

## How to Test

1. Run the hermetic auth and gateway selection:

`scripts/run_tests.sh tests/tui_gateway tests/test_tui_gateway_loop_noise.py tests/test_tui_gateway_queue_on_busy.py tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py tests/hermes_cli/test_dashboard_auth_*.py -q`

2. Run Ruff on the ten changed Python files.
3. Run `git diff --check` and `scripts/check-windows-footguns.py --diff main`.

Refreshed onto current official main f67aae323010e32c592a185984d36b20e9fa474a; head d8bc3bc9b1277b54d72b097c7a5d0328ecb62348.

Local result: 44 files, 975 tests passed, 0 failed on macOS 27.0. Ruff, diff check, and Windows-footgun scan pass. The full repository suite was not run locally and is left to CI.

## Checklist

### Code

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`
- [x] Conventional commit messages
- [x] Searched open and merged issues and PRs for duplicates
- [x] Focused change with no unrelated dependency or config updates
- [ ] Full `pytest tests/ -q` suite run locally
- [x] Added behavior and public-boundary tests
- [x] Tested on macOS 27.0

### Documentation and Housekeeping

- [x] Relevant module and API docstrings updated; broader client docs deferred pending contract feedback
- [x] `cli-config.yaml.example` N/A
- [x] Contributor workflow docs N/A
- [x] Cross-platform impact considered and Windows-footgun scan passed
- [x] Tool descriptions and schemas N/A

## Screenshots / Logs

No UI change. Focused hermetic result: `975 passed, 0 failed`.