### PR TITLE
fix(tui): dispatch custom skill bundles as agent turns

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1266,6 +1266,58 @@ def test_slash_exec_rejects_skill_commands(server):
     assert "skill command" in resp["error"]["message"]
 
 
+def test_slash_exec_routes_custom_skill_bundle_away_from_worker(server):
+    """slash.exec expands any custom bundle through command.dispatch."""
+    sid = "test-session"
+
+    class Worker:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, cmd):
+            self.calls.append(cmd)
+            return f"worker:{cmd}"
+
+    worker = Worker()
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "slash_worker": worker,
+    }
+    fake_bundles = {
+        "/analysis-pack": {
+            "name": "analysis-pack",
+            "skills": ["source-check", "claim-audit"],
+        }
+    }
+    fake_msg = (
+        '[IMPORTANT: The user has invoked the "analysis-pack" skill bundle.]\n\n'
+        "User instruction: compare vector databases"
+    )
+
+    with patch("agent.skill_bundles.get_skill_bundles", return_value=fake_bundles), \
+         patch(
+             "agent.skill_bundles.build_bundle_invocation_message",
+             return_value=(fake_msg, ["source-check", "claim-audit"], []),
+         ):
+        resp = server.handle_request({
+            "id": "r-bundle-slash",
+            "method": "slash.exec",
+            "params": {
+                "command": "analysis-pack compare vector databases",
+                "session_id": sid,
+            },
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {
+        "type": "send",
+        "message": fake_msg,
+        "notice": "⚡ Loading bundle: analysis-pack (2 skills)",
+    }
+    assert worker.calls == []
+
+
 def test_slash_exec_handles_plugin_commands_in_live_gateway(server):
     """Plugin slash commands return normal slash.exec output without using the worker."""
     sid = "test-session"
@@ -1416,6 +1468,37 @@ def test_command_dispatch_queue_sends_message(server):
     result = resp["result"]
     assert result["type"] == "send"
     assert result["message"] == "tell me about quantum computing"
+
+
+def test_command_dispatch_builtin_queue_wins_over_colliding_bundle(server):
+    """A custom /queue bundle must not shadow the built-in /queue command."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+    fake_bundles = {
+        "/queue": {
+            "name": "queue",
+            "skills": ["source-check", "claim-audit"],
+        }
+    }
+
+    with patch("agent.skill_bundles.get_skill_bundles", return_value=fake_bundles), \
+         patch("agent.skill_bundles.build_bundle_invocation_message") as build_bundle:
+        resp = server.handle_request({
+            "id": "r-queue-collision",
+            "method": "command.dispatch",
+            "params": {
+                "name": "queue",
+                "arg": "tell me about quantum computing",
+                "session_id": sid,
+            },
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {
+        "type": "send",
+        "message": "tell me about quantum computing",
+    }
+    build_bundle.assert_not_called()
 
 
 def test_command_dispatch_queue_requires_arg(server):
@@ -1617,6 +1700,54 @@ def test_command_dispatch_returns_skill_payload(server):
     assert result["type"] == "skill"
     assert result["message"] == fake_msg
     assert result["name"] == "hermes-agent-dev"
+
+
+def test_command_dispatch_returns_custom_bundle_payload(server):
+    """command.dispatch preserves bundle arguments in a sendable agent turn."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+    fake_bundles = {
+        "/review-suite": {
+            "name": "review-suite",
+            "skills": ["source-check", "claim-audit", "enough-research"],
+        }
+    }
+    arg = "audit the migration plan"
+    fake_msg = (
+        '[IMPORTANT: The user has invoked the "review-suite" skill bundle.]\n\n'
+        f"User instruction: {arg}"
+    )
+
+    with patch("agent.skill_bundles.get_skill_bundles", return_value=fake_bundles), \
+         patch(
+             "agent.skill_bundles.build_bundle_invocation_message",
+             return_value=(
+                 fake_msg,
+                 ["source-check", "claim-audit", "enough-research"],
+                 [],
+             ),
+         ) as build_bundle, \
+         patch("agent.skill_commands.build_skill_invocation_message") as build_skill, \
+         patch.object(server, "_resolve_session_platform", return_value="tui"):
+        resp = server.handle_request({
+            "id": "r-bundle-dispatch",
+            "method": "command.dispatch",
+            "params": {"name": "review-suite", "arg": arg, "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {
+        "type": "send",
+        "message": fake_msg,
+        "notice": "⚡ Loading bundle: review-suite (3 skills)",
+    }
+    build_bundle.assert_called_once_with(
+        "/review-suite",
+        arg,
+        task_id=sid,
+        platform="tui",
+    )
+    build_skill.assert_not_called()
 
 
 def test_command_dispatch_awaits_async_plugin_handler(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11867,6 +11867,52 @@ def _(rid, params: dict) -> dict:
         pass
 
     try:
+        from agent.skill_bundles import (
+            build_bundle_invocation_message,
+            get_skill_bundles,
+            resolve_bundle_command_key,
+        )
+
+        from hermes_cli.commands import resolve_command
+
+        bundle_key = (
+            resolve_bundle_command_key(name)
+            if resolve_command(name) is None
+            else None
+        )
+    except Exception:
+        bundle_key = None
+
+    if bundle_key is not None:
+        try:
+            bundle_result = build_bundle_invocation_message(
+                bundle_key,
+                arg,
+                task_id=session.get("session_key", "") if session else "",
+                platform=_resolve_session_platform(),
+            )
+        except Exception as exc:
+            return _err(rid, 4018, f"bundle dispatch failed: {exc}")
+
+        if not bundle_result:
+            return _err(rid, 4018, f"failed to load bundle: {bundle_key}")
+
+        msg, loaded_names, missing = bundle_result
+        bundle_info = get_skill_bundles().get(bundle_key, {})
+        bundle_name = bundle_info.get("name", bundle_key.lstrip("/"))
+        notice = f"⚡ Loading bundle: {bundle_name} ({len(loaded_names)} skills)"
+        if missing:
+            notice += f"\nSkipped missing skills: {', '.join(missing)}"
+        return _ok(
+            rid,
+            {
+                "type": "send",
+                "message": msg,
+                "notice": notice,
+            },
+        )
+
+    try:
         from agent.skill_commands import (
             scan_skill_commands,
             build_skill_invocation_message,
@@ -12277,7 +12323,7 @@ def _(rid, params: dict) -> dict:
         except Exception as exc:
             return _err(rid, 5009, f"compress failed: {exc}")
 
-    return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
+    return _err(rid, 4018, f"not a quick/plugin/bundle/skill command: {name}")
 
 
 # ── Methods: paste ────────────────────────────────────────────────────
@@ -13069,10 +13115,11 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
-    # Skill slash commands and _pending_input commands must NOT go through the
-    # slash worker — see _PENDING_INPUT_COMMANDS definition above. Plugin
-    # commands must also avoid the worker, but unlike skills/pending-input they
-    # still return normal slash.exec output so the TUI keeps the pager path.
+    # Skill and bundle slash commands plus _pending_input commands must NOT go
+    # through the slash worker — see _PENDING_INPUT_COMMANDS definition above.
+    # Plugin commands must also avoid the worker, but unlike skills and
+    # pending-input commands they still return normal slash.exec output so the
+    # TUI keeps the pager path.
     _cmd_text = cmd.lstrip("/") if cmd.startswith("/") else cmd
     _cmd_parts = _cmd_text.split(maxsplit=1)
     _cmd_base = (_cmd_parts[0] if _cmd_parts else "").lower()
@@ -13099,6 +13146,27 @@ def _(rid, params: dict) -> dict:
                 4018,
                 "snapshot restore mutates live config/state; use command.dispatch for /snapshot restore",
             )
+
+    try:
+        from agent.skill_bundles import resolve_bundle_command_key
+        from hermes_cli.commands import resolve_command
+
+        _bundle_key = (
+            resolve_bundle_command_key(_cmd_base)
+            if resolve_command(_cmd_base) is None
+            else None
+        )
+        if _bundle_key is not None:
+            return _methods["command.dispatch"](
+                rid,
+                {
+                    "name": _bundle_key.lstrip("/"),
+                    "arg": _cmd_arg,
+                    "session_id": params.get("session_id", ""),
+                },
+            )
+    except Exception:
+        pass
 
     try:
         from agent.skill_commands import get_skill_commands


### PR DESCRIPTION
## What does this PR do?

Fixes custom skill-bundle slash commands hanging under `hermes --tui`.

The normal CLI recognizes bundles in `cli.py:8988`, expands them, prints the loading banner, and places the expanded agent message on `_pending_input` at `cli.py:9005`. The normal CLI process loop consumes that queue at `cli.py:15170`.

The TUI followed a different path. `slash.exec` intercepted individual skill commands and a fixed set of other `_pending_input` commands, but it did not recognize custom bundles. The bundle therefore reached the persistent slash worker. `tui_gateway/slash_worker.py:101-133` calls `HermesCLI.process_command()` and returns only captured stdout. It never runs the normal CLI process loop, so the loading banner came back while the expanded agent message stayed on the worker's private queue.

The fix detects any installed custom bundle in `slash.exec` and routes it directly through `command.dispatch`. That handler now expands bundles through the shared `agent.skill_bundles` implementation and returns the existing structured `send` response with both the expanded message and a loading notice. The TUI already handles that response by displaying `notice` and submitting `message` as an agent turn.

Dispatch precedence stays aligned with the CLI and gateway paths: quick commands and plugins are checked first, bundles beat individual skills, and built-in commands continue through their existing routes. The shared builder receives the resolved TUI or desktop platform so global and platform-disabled skills keep using the existing filtering behavior.

## Related Issue

Fixes #62863

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Recognize generic custom bundles in `slash.exec` before the slash worker.
  - Expand bundles in `command.dispatch` through `build_bundle_invocation_message`.
  - Return `{type: "send", message, notice}` so the TUI starts a normal agent turn.
  - Preserve bundle-over-skill precedence and pass the resolved surface to disabled-skill filtering.
  - Include skipped missing skills in the loading notice.
- `tests/tui_gateway/test_protocol.py`
  - Prove `slash.exec` routes a generically named bundle away from the worker.
  - Prove `command.dispatch` preserves the user arguments, returns a sendable payload, and checks the bundle before the individual-skill builder.
  - Verify the platform is passed into the shared bundle builder.

## How to Test

1. Focused gateway regression and existing individual-skill dispatch checks:
   ```
   scripts/run_tests.sh tests/tui_gateway/test_protocol.py -k 'slash_exec_rejects_skill_commands or command_dispatch_returns_skill_payload or custom_skill_bundle or custom_bundle_payload' -q
   ```
   Result: 4 passed, 0 failed.
2. Complete relevant protocol file:
   ```
   scripts/run_tests.sh tests/tui_gateway/test_protocol.py -q
   ```
   Result: 77 passed, 0 failed.
3. Shared bundle behavior:
   ```
   scripts/run_tests.sh tests/agent/test_skill_bundles.py -q
   ```
   Result: 35 passed, 0 failed.
4. Existing gateway bundle dispatch tests:
   ```
   python -m pytest tests/gateway/test_bundles_command.py -q
   ```
   Result: 4 passed, 0 failed. The canonical wrapper could not collect this file on native Windows because its clean environment converted `HOME` to a POSIX path before launching Windows Python, so this adjacent file used the project venv directly.
5. Direct integration check against an isolated real `HERMES_HOME` containing a generic `integration-pack` YAML and one real local skill. Both `slash.exec` and `command.dispatch` returned `type=send`, a bundle loading notice, the bundle header, and `User instruction: compare self-hosted vector databases`. The worker stub was configured to fail if called, and was not called.
6. Lint:
   ```
   ruff check tui_gateway/server.py tests/tui_gateway/test_protocol.py
   ```
   Result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Before the fix, the real slash-worker seam returned only:

```text
⚡ Loading bundle: tui-bundle-probe (2 skills)
```

The worker's private `_pending_input` queue contained one unconsumed expanded message.

After the fix, both RPC routes return a structured agent turn:

```text
slash.exec: type=send, bundle_header=True, instruction=True
command.dispatch: type=send, bundle_header=True, instruction=True
```

Remaining limitation: the TUI reports an explicit bundle-load error when every referenced skill is missing or disabled. It does not start an empty agent turn.

