### PR TITLE
fix(wecom): release inbound dedup claims when the handler fails, without re-running completed turns

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2061,6 +2061,21 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+def _merge_dedup_claim_ids(target: MessageEvent, source: MessageEvent) -> None:
+    """Carry inbound-dedup claim ids across event merges.
+
+    Adapters that release dedup claims on handler failure (see
+    ``on_handler_failure``) track each inbound message's claim ids in
+    ``event.metadata["dedup_msg_ids"]``. When base merges or replaces
+    buffered events it must preserve the union, or the dropped event's ids
+    stay claimed for the dedup TTL after a failure and the platform's
+    redelivery is silently discarded.
+    """
+    ids = source.metadata.get("dedup_msg_ids")
+    if ids:
+        target.metadata.setdefault("dedup_msg_ids", []).extend(ids)
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -2091,6 +2106,7 @@ def merge_pending_message_event(
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+            _merge_dedup_claim_ids(existing, event)
             return
 
         if existing_has_media or incoming_has_media:
@@ -2109,6 +2125,7 @@ def merge_pending_message_event(
                 and event.message_type != MessageType.TEXT
             ):
                 existing.message_type = event.message_type
+            _merge_dedup_claim_ids(existing, event)
             return
 
         if (
@@ -2118,8 +2135,14 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            _merge_dedup_claim_ids(existing, event)
             return
 
+    if existing is not None:
+        # The replaced event's content is discarded by policy, but its claim
+        # ids must ride the replacement so a later handler failure releases
+        # them too.
+        _merge_dedup_claim_ids(event, existing)
     pending_messages[session_key] = event
 
 
@@ -4018,6 +4041,19 @@ class BasePlatformAdapter(ABC):
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
+    async def on_handler_failure(self, event: MessageEvent) -> None:
+        """Hook called when the message handler failed before completing.
+
+        Fires only when ``self._message_handler(event)`` raised or was
+        unexpectedly cancelled before returning — i.e. the event was NOT
+        processed. Delivery failures after a completed handler do NOT fire
+        this hook (the turn already ran; re-processing it would duplicate
+        side effects), and neither do expected cancellations (/stop, session
+        reset). Adapters use this to release per-message claims — e.g. an
+        inbound dedup entry — so a platform redelivery can retry the message
+        instead of being dropped as a duplicate.
+        """
+
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""
         hook = getattr(self, hook_name, None)
@@ -4269,6 +4305,7 @@ class BasePlatformAdapter(ABC):
                     if state.event.text
                     else event.text
                 )
+            _merge_dedup_claim_ids(state.event, event)
             latest_message_id = getattr(event, "message_id", None)
             latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
             if latest_message_id is not None:
@@ -4644,6 +4681,7 @@ class BasePlatformAdapter(ABC):
                             "[%s] Command '/%s' dispatch failed: %s",
                             self.name, cmd, e, exc_info=True,
                         )
+                        await self._run_processing_hook("on_handler_failure", event)
                     return
 
                 # Other bypass commands (/approve, /deny, /status,
@@ -4653,9 +4691,11 @@ class BasePlatformAdapter(ABC):
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,
                 )
+                _inline_handler_done = False
                 try:
                     _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                     response = await self._message_handler(event)
+                    _inline_handler_done = True
                     _text, _eph_ttl = self._unwrap_ephemeral(response)
                     if _text:
                         _r = await self._send_with_retry(
@@ -4672,6 +4712,8 @@ class BasePlatformAdapter(ABC):
                             )
                 except Exception as e:
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
+                    if not _inline_handler_done:
+                        await self._run_processing_hook("on_handler_failure", event)
                 return
 
             # Clarify reply bypass: if the agent is blocked on a
@@ -4704,11 +4746,13 @@ class BasePlatformAdapter(ABC):
                         "[%s] Routing message to clarify text-intercept for %s",
                         self.name, session_key,
                     )
+                    _inline_handler_done = False
                     try:
                         _thread_meta = _thread_metadata_for_source(
                             event.source, _reply_anchor_for_event(event)
                         )
                         response = await self._message_handler(event)
+                        _inline_handler_done = True
                         _text, _eph_ttl = self._unwrap_ephemeral(response)
                         if _text:
                             _r = await self._send_with_retry(
@@ -4728,6 +4772,8 @@ class BasePlatformAdapter(ABC):
                             "[%s] Clarify text-intercept dispatch failed: %s",
                             self.name, e, exc_info=True,
                         )
+                        if not _inline_handler_done:
+                            await self._run_processing_hook("on_handler_failure", event)
                     return
 
             if self._busy_session_handler is not None:
@@ -4852,11 +4898,17 @@ class BasePlatformAdapter(ABC):
                 typing_task,
             )
         
+        # Distinguishes handler failures (event not processed — adapters may
+        # release per-message claims via on_handler_failure) from failures
+        # after the handler returned (delivery problems; re-processing would
+        # duplicate side effects).
+        handler_completed = False
         try:
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            handler_completed = True
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -5206,9 +5258,13 @@ class BasePlatformAdapter(ABC):
             if current_task is None or current_task not in self._expected_cancelled_tasks:
                 outcome = ProcessingOutcome.FAILURE
             await self._run_processing_hook("on_processing_complete", event, outcome)
+            if not handler_completed and outcome is ProcessingOutcome.FAILURE:
+                await self._run_processing_hook("on_handler_failure", event)
             raise
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
+            if not handler_completed:
+                await self._run_processing_hook("on_handler_failure", event)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -38,6 +38,13 @@ class MessageDeduplicator:
         # In message handler:
         if self._dedup.is_duplicate(msg_id):
             return
+        try:
+            ...  # process the message
+        except BaseException:
+            # Release the claim so the platform's redelivery is retried
+            # instead of being dropped as a duplicate.
+            self._dedup.remove(msg_id)
+            raise
     """
 
     def __init__(self, max_size: int = 2000, ttl_seconds: float = 300):
@@ -69,6 +76,17 @@ class MessageDeduplicator:
                 )[-self._max_size:]
                 self._seen = dict(newest)
         return False
+
+    def remove(self, msg_id: str) -> None:
+        """Evict *msg_id* so a later delivery of it is treated as new.
+
+        ``is_duplicate()`` marks a message seen at check time, before the
+        adapter has finished processing it.  Adapters call this to release
+        that claim when processing fails, so the platform's redelivery of
+        the same message is retried instead of silently dropped for the
+        remainder of the TTL window.
+        """
+        self._seen.pop(msg_id, None)
 
     def clear(self):
         """Clear all tracked messages."""

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -516,7 +516,8 @@ class WeComAdapter(BasePlatformAdapter):
         """Parse a deduplicated callback and dispatch it to the gateway."""
         self._remember_reply_req_id(msg_id, self._payload_req_id(payload))
 
-        sender = body.get("from") if isinstance(body.get("from"), dict) else {}
+        raw_from = body.get("from")
+        sender = raw_from if isinstance(raw_from, dict) else {}
         sender_id = str(sender.get("userid") or "").strip()
         chat_id = str(body.get("chatid") or sender_id).strip()
         if not chat_id:
@@ -572,6 +573,9 @@ class WeComAdapter(BasePlatformAdapter):
             reply_to_message_id=f"quote:{msg_id}" if has_reply_context else None,
             reply_to_text=reply_text if has_reply_context else None,
             timestamp=datetime.now(tz=timezone.utc),
+            # Carried so every later failure point — the batch flush and the
+            # background processing hook — can release this claim.
+            metadata={"dedup_msg_ids": [msg_id]},
         )
 
         # Only batch plain text messages — commands, media, etc. dispatch
@@ -580,6 +584,27 @@ class WeComAdapter(BasePlatformAdapter):
             self._enqueue_text_event(event)
         else:
             await self.handle_message(event)
+
+    async def on_handler_failure(self, event: MessageEvent) -> None:
+        """Release dedup claims when the message handler fails before completing.
+
+        THE claim contract, in one place: `_on_message` marks each msgid as a
+        claim before processing; whichever site owns the failure window
+        releases it so WeCom's redelivery (sent when no reply frame acks the
+        callback) is retried instead of dropped as a duplicate for the TTL.
+        The sites are disjoint: the `_on_message` except owns synchronous
+        intake failures, the `_flush_text_batch` except owns batched dispatch
+        failures, and this hook owns the background pipeline — base fires it
+        only when the handler raised or was unexpectedly cancelled BEFORE
+        completing.  Completed turns (including delivery failures after them)
+        and expected cancellations (/stop, session reset) keep their claims:
+        re-processing those would duplicate side effects or resurrect an
+        aborted message.
+        """
+        # .get(): events synthesized outside _process_message (gateway
+        # command replays) may not carry claim ids.
+        for stale_id in event.metadata.get("dedup_msg_ids", ()):
+            self._dedup.remove(stale_id)
 
     # ------------------------------------------------------------------
     # Text message aggregation (handles WeCom client-side splits)
@@ -606,7 +631,13 @@ class WeComAdapter(BasePlatformAdapter):
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            event._dedup_msg_ids = [event.message_id]  # type: ignore[attr-defined]
+            # Enforce the claim-tracking invariant at the storage boundary:
+            # every event in the registry carries its claim ids, even if it
+            # did not come through _process_message (tests build raw events).
+            event.metadata.setdefault(
+                "dedup_msg_ids",
+                [event.message_id] if event.message_id else [],
+            )
             self._pending_text_batches[key] = event
         else:
             if event.text:
@@ -614,9 +645,7 @@ class WeComAdapter(BasePlatformAdapter):
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             # Track every merged msgid so a failed flush can release all of
             # their dedup claims, not just the first chunk's.
-            merged_ids = getattr(existing, "_dedup_msg_ids", [existing.message_id])
-            merged_ids.append(event.message_id)
-            existing._dedup_msg_ids = merged_ids  # type: ignore[attr-defined]
+            existing.metadata["dedup_msg_ids"].append(event.message_id)
             # Merge any media that might be attached
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
@@ -664,16 +693,31 @@ class WeComAdapter(BasePlatformAdapter):
                 "[WeCom] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
+            dispatch = asyncio.ensure_future(self.handle_message(event))
             try:
-                await self.handle_message(event)
+                # Shielded: a supersede-cancel (new chunk cancels this flush)
+                # must not kill an in-flight dispatch — before gateway
+                # acceptance that would lose the popped batch, after it a
+                # release would double-process on redelivery.  The dispatch
+                # runs to completion either way; claims stay held.
+                await asyncio.shield(dispatch)
+            except asyncio.CancelledError:
+                if not dispatch.done():
+                    # If the surviving dispatch still fails before the
+                    # background pipeline takes over (which reports through
+                    # on_handler_failure), release its claims then.
+                    def _release_if_dispatch_failed(task: "asyncio.Task[None]") -> None:
+                        if not task.cancelled() and task.exception() is not None:
+                            for stale_id in event.metadata.get("dedup_msg_ids", ()):
+                                self._dedup.remove(stale_id)
+
+                    dispatch.add_done_callback(_release_if_dispatch_failed)
+                raise
             except BaseException:
-                # Dispatch failed after the dedup mark(s).  Release the claims
-                # for every merged chunk so WeCom's redelivery is retried
-                # instead of dropped as a duplicate (same contract as
-                # _on_message for the non-batched path).
-                for stale_id in getattr(event, "_dedup_msg_ids", None) or (
-                    [event.message_id] if event.message_id else []
-                ):
+                # Synchronous dispatch failure (before the background
+                # pipeline): release so the redelivery retries (contract:
+                # on_handler_failure).
+                for stale_id in event.metadata.get("dedup_msg_ids", ()):
                     self._dedup.remove(stale_id)
                 raise
         finally:

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -500,6 +500,20 @@ class WeComAdapter(BasePlatformAdapter):
         if self._dedup.is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s ignored", self.name, msg_id)
             return
+        try:
+            await self._process_message(payload, body, msg_id)
+        except BaseException:
+            # Processing failed after the dedup mark.  Release the claim so
+            # WeCom's redelivery of this callback (sent when our ACK is lost,
+            # e.g. after the websocket reconnects) is retried instead of being
+            # dropped as a duplicate for the rest of the TTL window.
+            self._dedup.remove(msg_id)
+            raise
+
+    async def _process_message(
+        self, payload: Dict[str, Any], body: Dict[str, Any], msg_id: str
+    ) -> None:
+        """Parse a deduplicated callback and dispatch it to the gateway."""
         self._remember_reply_req_id(msg_id, self._payload_req_id(payload))
 
         sender = body.get("from") if isinstance(body.get("from"), dict) else {}
@@ -592,11 +606,17 @@ class WeComAdapter(BasePlatformAdapter):
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event._dedup_msg_ids = [event.message_id]  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
         else:
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # Track every merged msgid so a failed flush can release all of
+            # their dedup claims, not just the first chunk's.
+            merged_ids = getattr(existing, "_dedup_msg_ids", [existing.message_id])
+            merged_ids.append(event.message_id)
+            existing._dedup_msg_ids = merged_ids  # type: ignore[attr-defined]
             # Merge any media that might be attached
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
@@ -644,7 +664,18 @@ class WeComAdapter(BasePlatformAdapter):
                 "[WeCom] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
-            await self.handle_message(event)
+            try:
+                await self.handle_message(event)
+            except BaseException:
+                # Dispatch failed after the dedup mark(s).  Release the claims
+                # for every merged chunk so WeCom's redelivery is retried
+                # instead of dropped as a duplicate (same contract as
+                # _on_message for the non-batched path).
+                for stale_id in getattr(event, "_dedup_msg_ids", None) or (
+                    [event.message_id] if event.message_id else []
+                ):
+                    self._dedup.remove(stale_id)
+                raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/tests/gateway/test_message_deduplicator.py
+++ b/tests/gateway/test_message_deduplicator.py
@@ -99,3 +99,18 @@ class TestMessageDeduplicatorTTL:
         # the check is `now - ts < ttl` which is `0 < 0` = False
         # This means TTL=0 effectively disables dedup
         assert dedup.is_duplicate("msg-1") is False
+
+    def test_remove_releases_claim(self):
+        """remove() lets a redelivery of a failed message through."""
+        dedup = MessageDeduplicator(ttl_seconds=60)
+        assert dedup.is_duplicate("msg-1") is False
+        dedup.remove("msg-1")
+        assert dedup.is_duplicate("msg-1") is False, \
+            "Released claim should not suppress the redelivery"
+        assert dedup.is_duplicate("msg-1") is True
+
+    def test_remove_unknown_id_is_noop(self):
+        """remove() on an untracked ID must not raise."""
+        dedup = MessageDeduplicator(ttl_seconds=60)
+        dedup.remove("never-seen")
+        assert dedup.is_duplicate("never-seen") is False

--- a/tests/gateway/test_wecom_dedup_redelivery.py
+++ b/tests/gateway/test_wecom_dedup_redelivery.py
@@ -1,17 +1,13 @@
-"""Regression: a transient failure after the dedup mark must not drop the
-platform redelivery.
+"""Regression: a failure after the dedup mark must not drop the platform
+redelivery — and a completed turn must never be re-executed by one.
 
 ``MessageDeduplicator.is_duplicate()`` marks a message seen at check time,
 before the adapter has handed it to the gateway.  WeCom redelivers a callback
-when our ACK is lost (#47573), and an exception escaping ``_on_message`` tears
-down the websocket via ``_listen_loop`` — same process, same adapter instance,
-same dedup cache — so the redelivery arrives right after reconnect.  Without
-releasing the dedup claim on failure, that redelivery is classified as a
-duplicate and the user's message is silently lost for the dedup TTL (300s).
-
-The failure is injected at ``handle_message`` — the dispatch boundary, where
-exceptions really do propagate (unlike media downloads, which ``_cache_media``
-degrades to "no media" by design).
+when no reply frame acks it (#47573), so the claim lifecycle has three
+disjoint owners (see ``WeComAdapter.on_handler_failure`` for the contract):
+the ``_on_message`` except (synchronous intake), the ``_flush_text_batch``
+except (batched dispatch), and the ``on_handler_failure`` lifecycle hook
+(background pipeline, fired by base only when the handler did not complete).
 """
 
 import asyncio
@@ -20,9 +16,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 
 
-def _payload(msgid: str) -> dict:
+def _payload(msgid: str, text: str = "hello") -> dict:
     return {
         "cmd": "aibot_msg_callback",
         "headers": {"req_id": f"req-{msgid}"},
@@ -32,25 +29,34 @@ def _payload(msgid: str) -> dict:
             "chatid": "",
             "chattype": "single",
             "msgtype": "text",
-            "text": {"content": "hello"},
+            "text": {"content": text},
         },
     }
 
 
-def _adapter():
+def _adapter(batch_delay: float = 0.0):
+    """Build a WeCom adapter; batching is off unless a delay is given."""
     from plugins.platforms.wecom.adapter import WeComAdapter
 
     adapter = WeComAdapter(PlatformConfig(enabled=True, extra={"dm_policy": "pairing"}))
-    # Disable text-batch aggregation so dispatch is synchronous and the
-    # assertions below observe handle_message directly.
-    adapter._text_batch_delay_seconds = 0
+    adapter._text_batch_delay_seconds = batch_delay
     return adapter
+
+
+async def _drain_background(adapter):
+    """Await the real background processing tasks (and their follow-ups)."""
+    for _ in range(10):
+        tasks = list(adapter._background_tasks)
+        if not tasks:
+            return
+        await asyncio.gather(*tasks, return_exceptions=True)
+    raise AssertionError("background processing did not settle")
 
 
 @pytest.mark.asyncio
 async def test_redelivery_processed_after_transient_failure():
     adapter = _adapter()
-    # First attempt: dispatch fails transiently after the dedup mark.
+    # First attempt: dispatch fails synchronously after the dedup mark.
     # Redelivery: succeeds.
     adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
 
@@ -78,46 +84,6 @@ async def test_successful_message_still_deduplicated():
 
 
 @pytest.mark.asyncio
-async def test_batched_text_flush_failure_releases_claim():
-    """TEXT messages dispatch from the background batch-flush task; a failure
-    there must release the claim too, not just the synchronous path."""
-    adapter = _adapter()
-    adapter._text_batch_delay_seconds = 0.1  # keep batching enabled
-    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
-
-    await adapter._on_message(_payload("m-4"))
-    key = next(iter(adapter._pending_text_batch_tasks))
-    with pytest.raises(RuntimeError):
-        await adapter._pending_text_batch_tasks[key]
-    assert adapter.handle_message.call_count == 1
-
-    # Redelivery must be re-enqueued and reprocessed.
-    await adapter._on_message(_payload("m-4"))
-    await adapter._pending_text_batch_tasks[key]
-    assert adapter.handle_message.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_flush_failure_releases_all_merged_chunk_claims():
-    """A failed flush of a merged batch must release every chunk's claim,
-    not just the batch head's."""
-    adapter = _adapter()
-    adapter._text_batch_delay_seconds = 0.1
-    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
-
-    await adapter._on_message(_payload("m-5a"))
-    await adapter._on_message(_payload("m-5b"))  # merged into the same batch
-    key = next(iter(adapter._pending_text_batch_tasks))
-    with pytest.raises(RuntimeError):
-        await adapter._pending_text_batch_tasks[key]
-
-    # Redelivery of the SECOND chunk (not the batch head) must be reprocessed.
-    await adapter._on_message(_payload("m-5b"))
-    await adapter._pending_text_batch_tasks[key]
-    assert adapter.handle_message.call_count == 2
-
-
-@pytest.mark.asyncio
 async def test_cancellation_releases_claim():
     adapter = _adapter()
     adapter.handle_message = AsyncMock(side_effect=[asyncio.CancelledError(), None])
@@ -125,7 +91,157 @@ async def test_cancellation_releases_claim():
     with pytest.raises(asyncio.CancelledError):
         await adapter._on_message(_payload("m-3"))
 
-    # A message cancelled mid-processing never reached the gateway; its
+    # A message cancelled mid-intake never reached the gateway; its
     # redelivery must be reprocessed.
     await adapter._on_message(_payload("m-3"))
     assert adapter.handle_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_releases_all_merged_chunk_claims():
+    """A failed flush of a merged batch must release every chunk's claim —
+    the head's and the appended one's."""
+    adapter = _adapter(batch_delay=0.1)
+    adapter.handle_message = AsyncMock(
+        side_effect=[RuntimeError("dispatch failed"), None, None]
+    )
+
+    await adapter._on_message(_payload("m-5a"))
+    await adapter._on_message(_payload("m-5b"))  # merged into the same batch
+    key = next(iter(adapter._pending_text_batch_tasks))
+    with pytest.raises(RuntimeError):
+        await adapter._pending_text_batch_tasks[key]
+
+    # Redelivery of the batch HEAD must be reprocessed...
+    await adapter._on_message(_payload("m-5a"))
+    await adapter._pending_text_batch_tasks[key]
+    assert adapter.handle_message.call_count == 2
+
+    # ...and so must the redelivery of the SECOND (appended) chunk.
+    await adapter._on_message(_payload("m-5b"))
+    await adapter._pending_text_batch_tasks[key]
+    assert adapter.handle_message.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_supersede_cancel_neither_loses_nor_duplicates():
+    """A flush cancelled because a newer chunk superseded it must let the
+    in-flight dispatch run to completion (shielded): the popped batch is
+    neither lost nor double-processed, and its claims stay held."""
+    adapter = _adapter(batch_delay=0.05)
+    dispatch_started = asyncio.Event()
+    dispatch_blocker = asyncio.Event()
+    dispatched = []
+
+    async def slow_handle(event):
+        dispatched.append(event.text)
+        if len(dispatched) == 1:
+            dispatch_started.set()
+            await dispatch_blocker.wait()  # supersede-cancel lands on the flush here
+
+    adapter.handle_message = slow_handle
+
+    await adapter._on_message(_payload("m-6", text="first"))
+    await asyncio.wait_for(dispatch_started.wait(), timeout=2)
+
+    # A newer message supersedes the in-flight flush; the shielded dispatch
+    # of m-6 must survive the cancel and complete.
+    await adapter._on_message(_payload("m-7", text="second"))
+    key = next(iter(adapter._pending_text_batch_tasks))
+    dispatch_blocker.set()
+    await adapter._pending_text_batch_tasks[key]
+    for _ in range(10):
+        if len(dispatched) == 2:
+            break
+        await asyncio.sleep(0)
+    assert dispatched == ["first", "second"]
+
+    # m-6 was processed exactly once: its claim is held, so a redelivery is
+    # suppressed instead of double-processed.
+    await adapter._on_message(_payload("m-6", text="first"))
+    assert key not in adapter._pending_text_batches
+    assert dispatched == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_background_processing_failure_releases_claim():
+    """Failures of the real message handler surface in the background task
+    (handle_message returns after scheduling it) — base fires
+    on_handler_failure and the claim must be released there."""
+    adapter = _adapter()
+    adapter.send = AsyncMock()  # error-notification send; no websocket in tests
+    handler = AsyncMock(side_effect=[RuntimeError("agent failed"), None])
+    adapter.set_message_handler(handler)
+
+    await adapter._on_message(_payload("m-8"))
+    await _drain_background(adapter)
+    assert handler.await_count == 1
+
+    # WeCom redelivers (no reply frame was sent) — must be reprocessed.
+    await adapter._on_message(_payload("m-8"))
+    await _drain_background(adapter)
+    assert handler.await_count == 2
+
+    # Successful processing keeps the claim: a true duplicate stays dropped.
+    await adapter._on_message(_payload("m-8"))
+    await _drain_background(adapter)
+    assert handler.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_after_completed_handler_keeps_claim():
+    """A completed turn whose reply SEND fails is a delivery problem, not a
+    handler failure: re-processing it would duplicate tool side effects, so
+    the claim must stay held and the redelivery must stay suppressed."""
+    adapter = _adapter()
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="boom"))
+    handler = AsyncMock(return_value="reply text")
+    adapter.set_message_handler(handler)
+
+    await adapter._on_message(_payload("m-9"))
+    await _drain_background(adapter)
+    assert handler.await_count == 1
+
+    # base classifies this run FAILURE (delivery heuristic), but the handler
+    # completed — the redelivery must NOT re-run the turn.
+    await adapter._on_message(_payload("m-9"))
+    await _drain_background(adapter)
+    assert handler.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_busy_inline_dispatch_failure_releases_claim():
+    """On a busy session, bypass commands dispatch inline inside base's
+    handle_message where failures are swallowed — base must still report
+    them via on_handler_failure so the claim is released."""
+    adapter = _adapter()
+    adapter.send = AsyncMock()
+    started = asyncio.Event()
+    blocker = asyncio.Event()
+    calls = []
+
+    async def handler(event):
+        calls.append(event.text)
+        if len(calls) == 1:
+            started.set()
+            await blocker.wait()
+            return None
+        raise RuntimeError("inline dispatch failed")
+
+    adapter.set_message_handler(handler)
+
+    # Occupy the session with a long-running turn.
+    await adapter._on_message(_payload("m-10", text="long task"))
+    await asyncio.wait_for(started.wait(), timeout=2)
+
+    # /status bypasses the active-session guard and dispatches inline; the
+    # handler raises and base swallows it — but the claim must be released.
+    await adapter._on_message(_payload("m-11", text="/status"))
+    assert calls[-1] == "/status"
+
+    # WeCom redelivers the failed command — it must be reprocessed.
+    await adapter._on_message(_payload("m-11", text="/status"))
+    assert calls.count("/status") == 2
+
+    blocker.set()
+    await _drain_background(adapter)

--- a/tests/gateway/test_wecom_dedup_redelivery.py
+++ b/tests/gateway/test_wecom_dedup_redelivery.py
@@ -1,0 +1,131 @@
+"""Regression: a transient failure after the dedup mark must not drop the
+platform redelivery.
+
+``MessageDeduplicator.is_duplicate()`` marks a message seen at check time,
+before the adapter has handed it to the gateway.  WeCom redelivers a callback
+when our ACK is lost (#47573), and an exception escaping ``_on_message`` tears
+down the websocket via ``_listen_loop`` — same process, same adapter instance,
+same dedup cache — so the redelivery arrives right after reconnect.  Without
+releasing the dedup claim on failure, that redelivery is classified as a
+duplicate and the user's message is silently lost for the dedup TTL (300s).
+
+The failure is injected at ``handle_message`` — the dispatch boundary, where
+exceptions really do propagate (unlike media downloads, which ``_cache_media``
+degrades to "no media" by design).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _payload(msgid: str) -> dict:
+    return {
+        "cmd": "aibot_msg_callback",
+        "headers": {"req_id": f"req-{msgid}"},
+        "body": {
+            "msgid": msgid,
+            "from": {"userid": "user-1"},
+            "chatid": "",
+            "chattype": "single",
+            "msgtype": "text",
+            "text": {"content": "hello"},
+        },
+    }
+
+
+def _adapter():
+    from plugins.platforms.wecom.adapter import WeComAdapter
+
+    adapter = WeComAdapter(PlatformConfig(enabled=True, extra={"dm_policy": "pairing"}))
+    # Disable text-batch aggregation so dispatch is synchronous and the
+    # assertions below observe handle_message directly.
+    adapter._text_batch_delay_seconds = 0
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_redelivery_processed_after_transient_failure():
+    adapter = _adapter()
+    # First attempt: dispatch fails transiently after the dedup mark.
+    # Redelivery: succeeds.
+    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
+
+    with pytest.raises(RuntimeError):
+        await adapter._on_message(_payload("m-1"))
+    assert adapter.handle_message.call_count == 1
+
+    # WeCom redelivers the same msgid after the lost ACK — it must be
+    # reprocessed, not swallowed as a duplicate.
+    await adapter._on_message(_payload("m-1"))
+    assert adapter.handle_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_successful_message_still_deduplicated():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_message(_payload("m-2"))
+    adapter.handle_message.assert_called_once()
+
+    # A true duplicate of a successfully processed message stays suppressed.
+    await adapter._on_message(_payload("m-2"))
+    adapter.handle_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batched_text_flush_failure_releases_claim():
+    """TEXT messages dispatch from the background batch-flush task; a failure
+    there must release the claim too, not just the synchronous path."""
+    adapter = _adapter()
+    adapter._text_batch_delay_seconds = 0.1  # keep batching enabled
+    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
+
+    await adapter._on_message(_payload("m-4"))
+    key = next(iter(adapter._pending_text_batch_tasks))
+    with pytest.raises(RuntimeError):
+        await adapter._pending_text_batch_tasks[key]
+    assert adapter.handle_message.call_count == 1
+
+    # Redelivery must be re-enqueued and reprocessed.
+    await adapter._on_message(_payload("m-4"))
+    await adapter._pending_text_batch_tasks[key]
+    assert adapter.handle_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_releases_all_merged_chunk_claims():
+    """A failed flush of a merged batch must release every chunk's claim,
+    not just the batch head's."""
+    adapter = _adapter()
+    adapter._text_batch_delay_seconds = 0.1
+    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("dispatch failed"), None])
+
+    await adapter._on_message(_payload("m-5a"))
+    await adapter._on_message(_payload("m-5b"))  # merged into the same batch
+    key = next(iter(adapter._pending_text_batch_tasks))
+    with pytest.raises(RuntimeError):
+        await adapter._pending_text_batch_tasks[key]
+
+    # Redelivery of the SECOND chunk (not the batch head) must be reprocessed.
+    await adapter._on_message(_payload("m-5b"))
+    await adapter._pending_text_batch_tasks[key]
+    assert adapter.handle_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cancellation_releases_claim():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock(side_effect=[asyncio.CancelledError(), None])
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._on_message(_payload("m-3"))
+
+    # A message cancelled mid-processing never reached the gateway; its
+    # redelivery must be reprocessed.
+    await adapter._on_message(_payload("m-3"))
+    assert adapter.handle_message.call_count == 2


### PR DESCRIPTION
## What this fixes

`MessageDeduplicator.is_duplicate()` marks a message seen at check time, before processing finishes. WeCom acks a callback only via the reply frame and redelivers the same msgid on silence (#47573), so any failure between the mark and a completed run left a stale claim that swallowed every redelivery for the dedup TTL (300s) — silent message loss with only a DEBUG trace.

Fixes #62860.

## How the claim lifecycle works now

A claim is released exactly when the message was NOT processed, and kept when it was:

- **Synchronous intake failures** (`_on_message`): release and re-raise.
- **Batched dispatch** (`_flush_text_batch`): the dispatch is wrapped in `asyncio.shield` — a supersede-cancel from a newer chunk can land before gateway acceptance (dropping the popped batch) or after it (double-processing on redelivery if released); letting the in-flight dispatch complete removes both cases. A shielded dispatch that still fails synchronously releases its claims via a done-callback.
- **Background pipeline** (the normal path — `handle_message` returns after scheduling `_process_message_background`): a new additive `on_handler_failure` lifecycle hook in base fires only when the message handler raised or was unexpectedly cancelled **before completing**, gated by a `handler_completed` flag. `ProcessingOutcome.FAILURE` alone is a delivery heuristic (a failed reply send, or an image-only reply that never records delivery, both classify FAILURE after a fully completed run) — releasing on it would re-run completed turns and duplicate tool side effects. The busy-session inline dispatch paths (bypass commands, clarify text-intercept) swallow handler exceptions by design; they now report through the same hook, so a failed `/approve` or clarify answer no longer keeps its claim while the agent stays blocked.
- **Kept deliberately**: completed turns with failed delivery, expected cancellations (`/stop`, session reset), and policy-blocked messages.

Claim ids ride `MessageEvent.metadata["dedup_msg_ids"]`; base's event merges (`merge_pending_message_event`, `_queue_text_debounce`) now preserve their union, since a dropped id stayed claimed forever after a failure. The key is unprefixed because base owns its merge semantics (`_merge_dedup_claim_ids`) — it is shared claim infrastructure, not adapter-private state.

## Scope boundary

WeCom-only adoption by design. DingTalk's stream handler acks `STATUS_OK` before processing, so it never redelivers on later failure — a release there would be dead code. Other adapters sharing the helper (google_chat is at-least-once Pub/Sub, slack redelivers on Socket-Mode reconnects per its own comments) have the same mark-before-success shape and can adopt `remove()` + `on_handler_failure` in follow-ups; the base hook and merge preservation shipped here are what make that adoption one method per adapter.

## Tests

`tests/gateway/test_wecom_dedup_redelivery.py` exercises the real dispatch lifecycle (`set_message_handler` + background tasks, no `handle_message` mock where the contract depends on base):

- synchronous intake failure → redelivery reprocessed; success → duplicate suppressed
- background handler failure → released via the hook; **delivery failure after a completed handler → claim kept** (redelivery must not re-run the turn)
- busy-session inline bypass failure (real `/status` on an occupied session) → released
- supersede-cancel → shielded dispatch completes; neither loss nor duplicate
- failed merged flush → head and appended chunk claims released independently (mutation-tested: a head-only release regression fails the suite)

`pytest` across the wecom/batching/dedup/base-session neighborhood: 157 passed, 1 pre-existing environmental failure (`TestWeComZombieSessionFix`, reproduces identically without these commits — missing optional aiohttp in the minimal dev env). `ruff` clean; `ty` diagnostics net −1 vs the previous head (macOS 15, Python 3.12; behavior is platform-independent).
