### PR TITLE
fix(conversation): preserve strict output contracts at iteration limit (#62862)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1675,11 +1675,54 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
-    )
+    # Detect strict output contracts in the original user message (e.g., "Return ONLY")
+    # to preserve contract compliance even when iteration budget is exhausted.
+    # See #62862: one-shot output-contract violations.
+    original_user_message = ""
+    contract_detected = False
+    contract_pattern = None
+
+    # Walk back to find the original user message that started this turn
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            original_user_message = msg.get("content", "")
+            break
+
+    if original_user_message:
+        # Detect strict contract markers
+        contract_patterns = [
+            (r"return\s+only", "strict"),
+            (r"only\s+return", "strict"),
+            (r"strict\s+(output|contract|format)", "strict"),
+            (r"no\s+(extra|additional|meta)\s+text", "strict"),
+            (r"exactly\s+(this|the)", "strict"),
+            (r"no\s+preamble", "strict"),
+            (r"no\s+narration", "strict"),
+        ]
+
+        for pattern, contract_type in contract_patterns:
+            if re.search(pattern, original_user_message, re.IGNORECASE):
+                contract_detected = True
+                contract_pattern = pattern
+                break
+
+    # Build summary request with contract awareness
+    if contract_detected:
+        summary_request = (
+            "You've reached the maximum number of tool-calling iterations allowed. "
+            "Provide a final response that strictly follows the original output format request "
+            "from the user (e.g., table format, single line, specific structure). "
+            "Do NOT add any preamble, meta narration, or explanatory text. "
+            "If you have partial results, output them in the requested format. "
+            "If you cannot provide a complete response in the requested format, "
+            "return a structured failure that respects the format constraints."
+        )
+    else:
+        summary_request = (
+            "You've reached the maximum number of tool-calling iterations allowed. "
+            "Please provide a final response summarizing what you've found and accomplished so far, "
+            "without calling any more tools."
+        )
     messages.append({"role": "user", "content": summary_request})
 
     try:

--- a/tests/agent/test_handle_max_iterations_contract_preservation.py
+++ b/tests/agent/test_handle_max_iterations_contract_preservation.py
@@ -1,0 +1,225 @@
+"""Test strict output contract preservation in handle_max_iterations (#62862)."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent.chat_completion_helpers import handle_max_iterations
+
+
+class _MockAgent:
+    """Minimal agent mock for handle_max_iterations testing."""
+
+    def __init__(self):
+        self.max_iterations = 10
+        self._should_sanitize_tool_calls = lambda: False
+        self._copy_reasoning_content_for_api = lambda src, dst: None
+        self._sanitize_tool_calls_for_strict_api = lambda msg, model: None
+        self._sanitize_api_messages = lambda msgs: msgs
+        self._drop_thinking_only_and_merge_users = lambda msgs: msgs
+        self._cached_system_prompt = ""
+        self.ephemeral_system_prompt = None
+        self.prefill_messages = []
+        self.model = "gpt-4"
+        self.provider = "openai"
+        self.base_url = "https://api.openai.com/v1"
+        self.max_tokens = 4096
+        self.api_mode = "chat_completions"
+        self._base_url_lower = "https://api.openai.com/v1"
+        self.reasoning_config = None
+        self._supports_reasoning_extra_body = lambda: False
+        self._is_anthropic_oauth = False
+        self._anthropic_preserve_dots = lambda: False
+        self._get_transport = MagicMock()
+        self._get_transport.return_value.normalize_response.return_value.content = "test summary"
+        self._ensure_primary_openai_client = MagicMock()
+        self.openrouter_min_coding_score = None
+        self._is_openrouter_url = lambda: False
+        self._build_api_kwargs = lambda msgs: {"model": self.model, "messages": msgs, "tools": []}
+        self._run_codex_stream = MagicMock()
+        self._anthropic_messages_create = MagicMock()
+        self._resolve_lmstudio_summary_reasoning_effort = lambda: None
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock agent for testing."""
+    agent = _MockAgent()
+    # Mock OpenAI client
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "API response"
+    mock_client.chat.completions.create.return_value = mock_response
+    agent._ensure_primary_openai_client.return_value = mock_client
+    return agent
+
+
+def test_return_only_contract_preserved(mock_agent):
+    """When user message contains 'Return ONLY', summary request preserves contract."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Return ONLY the email address, no extra text."},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    # Check that the appended summary request enforces contract compliance
+    appended_request = messages[-1]["content"]
+    assert "strictly follows the original output format request" in appended_request
+    assert "Do NOT add any preamble" in appended_request
+    assert "meta narration" in appended_request
+
+
+def test_only_return_contract_preserved(mock_agent):
+    """When user message contains 'only return', summary request preserves contract."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "only return the table, nothing else"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows the original output format request" in appended_request
+
+
+def test_table_format_contract_preserved(mock_agent):
+    """When user requests table format with 'Return ONLY', summary preserves structure."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": (
+                "Return ONLY this table:\n"
+                "Profile | Auth | Live API | Mailbox | Scopes | Verdict\n"
+                "If any check fails, add one short \"Failure reason\" line."
+            ),
+        },
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "table format" in appended_request
+    assert "partial results" in appended_request.lower()
+    assert "structured failure" in appended_request.lower()
+
+
+def test_no_preamble_contract_preserved(mock_agent):
+    """When user explicitly requests no preamble, summary respects it."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "No preamble, just the results in CSV format"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "Do NOT add any preamble" in appended_request
+
+
+def test_no_contract_defaults_to_summary(mock_agent):
+    """When no strict contract is detected, use default summary request."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What's the weather like?"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "summarizing what you've found and accomplished" in appended_request
+    assert "strictly follows" not in appended_request
+
+
+def test_contract_detection_case_insensitive(mock_agent):
+    """Contract markers are detected case-insensitively."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "RETURN ONLY the results"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows" in appended_request
+
+
+def test_strict_output_contract_marker(mock_agent):
+    """'strict output' marker triggers contract preservation."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Use strict output format: JSON only"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows" in appended_request
+
+
+def test_no_narration_contract_marker(mock_agent):
+    """'no narration' marker triggers contract preservation."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Output the data with no narration"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "Do NOT add any preamble" in appended_request
+    assert "meta narration" in appended_request
+
+
+def test_exactly_this_contract_marker(mock_agent):
+    """'exactly this' marker triggers contract preservation."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Output exactly this format: YYYY-MM-DD"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows" in appended_request
+
+
+def test_multiple_user_messages_uses_latest(mock_agent):
+    """When there are multiple user messages, use the last one for contract detection."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "First message"},
+        {"role": "assistant", "content": "Response"},
+        {"role": "user", "content": "Return ONLY the final answer"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows" in appended_request
+
+
+def test_empty_user_message_defaults_to_summary(mock_agent):
+    """When user message is empty, default to regular summary."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": ""},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "summarizing what you've found and accomplished" in appended_request
+
+
+def test_no_extra_text_contract_marker(mock_agent):
+    """'no extra text' marker triggers contract preservation."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Return the data with no extra text"},
+    ]
+
+    handle_max_iterations(mock_agent, messages, 10)
+
+    appended_request = messages[-1]["content"]
+    assert "strictly follows" in appended_request


### PR DESCRIPTION
## What does this PR do?

Fixes a critical bug in Hermes one-shot and conversation flows where strict output contracts (e.g., "Return ONLY the table") are violated when the iteration budget is exhausted. Previously, `handle_max_iterations` would inject an open-ended summary prompt that causes the model to generate meta narration ("Let me summarize..."), repeat content, and break format constraints.

This fix detects strict contract markers in the original user message and preserves format compliance even at the iteration limit by injecting a contract-aware summary prompt instead of the default open-ended one.

## Related Issue

Fixes #62862

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Add contract detection logic in `handle_max_iterations`
  - Detect contract markers: "Return ONLY", "only return", "no preamble", "no narration", "exactly this", "strict output/format", "no extra/additional/meta text"
  - When contract detected, inject contract-aware prompt that enforces format compliance and disallows meta narration
  - When no contract detected, use original summary behavior (backward compatible)
- `tests/agent/test_handle_max_iterations_contract_preservation.py`: Add 12 regression tests
  - Test all contract marker variants
  - Test case-insensitive detection
  - Test table format preservation
  - Test fallback to summary when no contract present
  - Test edge cases (empty message, multiple user messages)

## How to Test

1. Unit tests: `pytest tests/agent/test_handle_max_iterations_contract_preservation.py -v` — all 12 tests pass
2. Regression tests: `pytest tests/agent/test_turn_finalizer_iteration_limit_exit.py -v` — all 15 tests pass
3. Integration scenario (one-shot):
   - Create a one-shot request with strict contract: `hermes -z "Return ONLY the email address, no extra text. Use gmail skill to call users/me/profile."`
   - Observed result: When iteration limit is reached, the response is either a valid email address or a structured failure, never "Let me summarize..." or other meta narration
4. Contract marker verification:
   - "Return ONLY this table:" → Table structure preserved even at limit
   - "no preamble" → No "Let me..." prefixes
   - "exactly this format: YYYY-MM-DD" → Date format preserved or structured failure

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/agent/test_handle_max_iterations_contract_preservation.py tests/agent/test_turn_finalizer_iteration_limit_exit.py -v` and all tests pass
- [x] I've added tests for my changes (12 new tests)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (inline code comments reference #62862)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — regex-based detection works cross-platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
