### PR TITLE
feat: accept non-image file drops and pastes in dashboard chat

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1856,6 +1856,56 @@ async def upload_chat_image(payload: ChatImageUpload, profile: Optional[str] = N
     }
 
 
+_CHAT_FILE_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+
+
+@app.post("/api/chat/file-upload")
+async def upload_chat_file(payload: ChatImageUpload, profile: Optional[str] = None):
+    """Persist a browser-provided chat file (PDF, docs, any type) for the TUI.
+
+    Same mechanism as ``/api/chat/image-upload`` but without the image-only
+    constraint. Non-image drops/pastes in the dashboard chat upload here, then
+    the page types the gateway-visible path into the TUI input so the agent
+    can read the file with its file tools. Files land under
+    ``HERMES_HOME/uploads/``.
+    """
+    data, mime_type = _decode_data_url(payload.data_url)
+    if not data:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+    if len(data) > _CHAT_FILE_UPLOAD_MAX_BYTES:
+        mb = _CHAT_FILE_UPLOAD_MAX_BYTES // (1024 * 1024)
+        raise HTTPException(status_code=413, detail=f"File is too large; cap is {mb} MB")
+
+    name = _sanitize_chat_image_filename(payload.filename)
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._-") or "upload"
+    with _profile_scope(profile) as scoped_home:
+        home = scoped_home or get_hermes_home()
+        up_dir = Path(home) / "uploads"
+        try:
+            up_dir.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Upload directory is not writable")
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"Could not create upload directory: {exc}")
+
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        target = up_dir / f"dashboard_{ts}_{secrets.token_hex(4)}_{name}"
+        try:
+            target.write_bytes(data)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Upload directory is not writable")
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"Could not write file: {exc}")
+
+    return {
+        "ok": True,
+        "path": str(target),
+        "name": target.name,
+        "bytes": len(data),
+        "mime_type": mime_type,
+    }
+
+
 @app.get("/api/files")
 async def list_managed_files(request: Request, path: Optional[str] = None):
     policy, target, display_path = _resolve_managed_path(path, request)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1860,48 +1860,90 @@ _CHAT_FILE_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
 
 
 @app.post("/api/chat/file-upload")
-async def upload_chat_file(payload: ChatImageUpload, profile: Optional[str] = None):
+async def upload_chat_file(
+    file: UploadFile = File(...),
+    profile: Optional[str] = None,
+):
     """Persist a browser-provided chat file (PDF, docs, any type) for the TUI.
 
-    Same mechanism as ``/api/chat/image-upload`` but without the image-only
-    constraint. Non-image drops/pastes in the dashboard chat upload here, then
-    the page types the gateway-visible path into the TUI input so the agent
-    can read the file with its file tools. Files land under
-    ``HERMES_HOME/uploads/``.
-    """
-    data, mime_type = _decode_data_url(payload.data_url)
-    if not data:
-        raise HTTPException(status_code=400, detail="Uploaded file is empty")
-    if len(data) > _CHAT_FILE_UPLOAD_MAX_BYTES:
-        mb = _CHAT_FILE_UPLOAD_MAX_BYTES // (1024 * 1024)
-        raise HTTPException(status_code=413, detail=f"File is too large; cap is {mb} MB")
+    Non-image drops/pastes in the dashboard chat upload here, then the page
+    types the gateway-visible path into the TUI input so the agent can read
+    the file with its file tools. Files land under ``HERMES_HOME/uploads/``.
 
-    name = _sanitize_chat_image_filename(payload.filename)
+    Streams the multipart body to disk in fixed-size chunks like
+    ``/api/files/upload-stream`` — the base64-data-URL-in-JSON pattern is
+    banned here for the same reasons documented on that endpoint (NS-501):
+    ~33% payload inflation, whole file buffered in memory twice, proxy
+    body-size/timeout 502s on large uploads.
+    """
+    name = _sanitize_chat_image_filename(file.filename)
     name = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._-") or "upload"
+
+    # Resolve the profile home up front and exit the scope before any await:
+    # _profile_scope swaps process-global skill-module state under a lock, so
+    # it must never be held across the streaming reads below.
     with _profile_scope(profile) as scoped_home:
         home = scoped_home or get_hermes_home()
-        up_dir = Path(home) / "uploads"
-        try:
-            up_dir.mkdir(parents=True, exist_ok=True)
-        except PermissionError:
-            raise HTTPException(status_code=403, detail="Upload directory is not writable")
-        except OSError as exc:
-            raise HTTPException(status_code=500, detail=f"Could not create upload directory: {exc}")
 
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        target = up_dir / f"dashboard_{ts}_{secrets.token_hex(4)}_{name}"
-        try:
-            target.write_bytes(data)
-        except PermissionError:
-            raise HTTPException(status_code=403, detail="Upload directory is not writable")
-        except OSError as exc:
-            raise HTTPException(status_code=500, detail=f"Could not write file: {exc}")
+    up_dir = Path(home) / "uploads"
+    try:
+        up_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Upload directory is not writable")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not create upload directory: {exc}")
 
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    target = up_dir / f"dashboard_{ts}_{secrets.token_hex(4)}_{name}"
+
+    # Write to a sibling temp file, then atomically rename into place so a
+    # partial/aborted upload never leaves a half-written file at the final path.
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".upload", dir=str(up_dir)
+    )
+    tmp_path = Path(tmp_name)
+    total = 0
+    renamed = False
+    try:
+        with os.fdopen(tmp_fd, "wb") as out:
+            while True:
+                chunk = await file.read(_UPLOAD_CHUNK_BYTES)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _CHAT_FILE_UPLOAD_MAX_BYTES:
+                    mb = _CHAT_FILE_UPLOAD_MAX_BYTES // (1024 * 1024)
+                    raise HTTPException(
+                        status_code=413, detail=f"File is too large; cap is {mb} MB"
+                    )
+                out.write(chunk)
+        if total == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+        os.replace(tmp_path, target)
+        renamed = True
+    except HTTPException:
+        raise
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Upload directory is not writable")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not write file: {exc}")
+    finally:
+        # Covers every non-success exit, including asyncio.CancelledError when
+        # the browser aborts mid-stream. os.replace clears tmp_path on success.
+        if not renamed:
+            tmp_path.unlink(missing_ok=True)
+        await file.close()
+
+    mime_type = (
+        file.content_type
+        or mimetypes.guess_type(name)[0]
+        or "application/octet-stream"
+    )
     return {
         "ok": True,
         "path": str(target),
         "name": target.name,
-        "bytes": len(data),
+        "bytes": total,
         "mime_type": mime_type,
     }
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -964,6 +964,95 @@ class TestWebServerEndpoints:
 
         assert resp.status_code == 401
 
+    # ── POST /api/chat/file-upload (browser drop/paste, any file type) ──
+
+    def test_chat_file_upload_writes_to_default_profile_uploads(self):
+        from hermes_constants import get_hermes_home
+
+        resp = self.client.post(
+            "/api/chat/file-upload",
+            json={
+                "data_url": "data:application/pdf;base64,JVBERi0xLjQK",
+                "filename": "../../report.pdf",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        target = Path(data["path"])
+        assert data["ok"] is True
+        assert data["mime_type"] == "application/pdf"
+        assert target.parent == get_hermes_home() / "uploads"
+        assert target.name.startswith("dashboard_")
+        assert target.name.endswith("_report.pdf")
+        assert target.is_file()
+        assert target.read_bytes().startswith(b"%PDF-1.4")
+
+    def test_chat_file_upload_writes_to_requested_profile_uploads(self):
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+
+        resp = self.client.post(
+            "/api/chat/file-upload?profile=worker",
+            json={
+                "data_url": "data:text/csv;base64,YSxiLGMK",
+                "filename": "leads.csv",
+            },
+        )
+
+        assert resp.status_code == 200
+        target = Path(resp.json()["path"])
+        assert target.parent == worker_home / "uploads"
+        assert target.is_file()
+        assert target.read_bytes() == b"a,b,c\n"
+
+    def test_chat_file_upload_accepts_non_image_mime(self):
+        resp = self.client.post(
+            "/api/chat/file-upload",
+            json={"data_url": "data:text/plain;base64,aGVsbG8=", "filename": "note.txt"},
+        )
+
+        assert resp.status_code == 200
+        assert Path(resp.json()["path"]).read_bytes() == b"hello"
+
+    def test_chat_file_upload_rejects_empty_payload(self):
+        resp = self.client.post(
+            "/api/chat/file-upload",
+            json={"data_url": "data:application/pdf;base64,", "filename": "empty.pdf"},
+        )
+
+        assert resp.status_code == 400
+        assert "empty" in resp.json()["detail"].lower()
+
+    def test_chat_file_upload_enforces_size_cap(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_CHAT_FILE_UPLOAD_MAX_BYTES", 4)
+
+        resp = self.client.post(
+            "/api/chat/file-upload",
+            json={
+                "data_url": "data:application/pdf;base64,JVBERi0xLjQK",
+                "filename": "large.pdf",
+            },
+        )
+
+        assert resp.status_code == 413
+        assert "too large" in resp.json()["detail"].lower()
+
+    def test_chat_file_upload_requires_auth(self):
+        from hermes_cli.web_server import _SESSION_HEADER_NAME
+
+        resp = self.client.post(
+            "/api/chat/file-upload",
+            json={"data_url": "data:text/plain;base64,aGVsbG8="},
+            headers={_SESSION_HEADER_NAME: "wrong-token"},
+        )
+
+        assert resp.status_code == 401
+
     # ── Dashboard font override ─────────────────────────────────────────
 
     def test_get_dashboard_font_defaults_to_theme(self):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -971,10 +971,7 @@ class TestWebServerEndpoints:
 
         resp = self.client.post(
             "/api/chat/file-upload",
-            json={
-                "data_url": "data:application/pdf;base64,JVBERi0xLjQK",
-                "filename": "../../report.pdf",
-            },
+            files={"file": ("../../report.pdf", b"%PDF-1.4\n", "application/pdf")},
         )
 
         assert resp.status_code == 200
@@ -982,6 +979,7 @@ class TestWebServerEndpoints:
         target = Path(data["path"])
         assert data["ok"] is True
         assert data["mime_type"] == "application/pdf"
+        assert data["bytes"] == len(b"%PDF-1.4\n")
         assert target.parent == get_hermes_home() / "uploads"
         assert target.name.startswith("dashboard_")
         assert target.name.endswith("_report.pdf")
@@ -996,10 +994,7 @@ class TestWebServerEndpoints:
 
         resp = self.client.post(
             "/api/chat/file-upload?profile=worker",
-            json={
-                "data_url": "data:text/csv;base64,YSxiLGMK",
-                "filename": "leads.csv",
-            },
+            files={"file": ("leads.csv", b"a,b,c\n", "text/csv")},
         )
 
         assert resp.status_code == 200
@@ -1011,7 +1006,7 @@ class TestWebServerEndpoints:
     def test_chat_file_upload_accepts_non_image_mime(self):
         resp = self.client.post(
             "/api/chat/file-upload",
-            json={"data_url": "data:text/plain;base64,aGVsbG8=", "filename": "note.txt"},
+            files={"file": ("note.txt", b"hello", "text/plain")},
         )
 
         assert resp.status_code == 200
@@ -1020,34 +1015,37 @@ class TestWebServerEndpoints:
     def test_chat_file_upload_rejects_empty_payload(self):
         resp = self.client.post(
             "/api/chat/file-upload",
-            json={"data_url": "data:application/pdf;base64,", "filename": "empty.pdf"},
+            files={"file": ("empty.pdf", b"", "application/pdf")},
         )
 
         assert resp.status_code == 400
         assert "empty" in resp.json()["detail"].lower()
 
     def test_chat_file_upload_enforces_size_cap(self, monkeypatch):
+        from hermes_constants import get_hermes_home
+
         import hermes_cli.web_server as web_server
 
         monkeypatch.setattr(web_server, "_CHAT_FILE_UPLOAD_MAX_BYTES", 4)
 
         resp = self.client.post(
             "/api/chat/file-upload",
-            json={
-                "data_url": "data:application/pdf;base64,JVBERi0xLjQK",
-                "filename": "large.pdf",
-            },
+            files={"file": ("large.pdf", b"%PDF-1.4\n", "application/pdf")},
         )
 
         assert resp.status_code == 413
         assert "too large" in resp.json()["detail"].lower()
+        # The streaming path must not leave a partial temp file behind.
+        up_dir = get_hermes_home() / "uploads"
+        leftovers = [p for p in up_dir.iterdir() if "large" in p.name]
+        assert leftovers == []
 
     def test_chat_file_upload_requires_auth(self):
         from hermes_cli.web_server import _SESSION_HEADER_NAME
 
         resp = self.client.post(
             "/api/chat/file-upload",
-            json={"data_url": "data:text/plain;base64,aGVsbG8="},
+            files={"file": ("note.txt", b"hello", "text/plain")},
             headers={_SESSION_HEADER_NAME: "wrong-token"},
         )
 

--- a/web/src/lib/chatImagePaste.test.ts
+++ b/web/src/lib/chatImagePaste.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   firstImageFromClipboard,
   imageFilesFromTransfer,
+  runOrderedUploads,
   transferMayContainImage,
 } from "./chatImagePaste";
 
@@ -95,5 +96,47 @@ describe("transferMayContainImage", () => {
       items: [makeItem("string", "text/plain", null)],
     });
     expect(transferMayContainImage(data)).toBe(false);
+  });
+});
+
+describe("runOrderedUploads", () => {
+  it("holds non-image insertion until the image attach resolves, even when the non-image upload would finish first", async () => {
+    const order: string[] = [];
+    let resolveAttach!: () => void;
+    let attachArg: File[] | null = null;
+    let insertArg: File[] | null = null;
+
+    // attachImages stays pending until we resolve it by hand; insertFiles would
+    // complete synchronously — the reversed-completion order the review asked
+    // to cover. Serialization must still run attach fully first.
+    const attachImages = (files: File[]): Promise<void> => {
+      attachArg = files;
+      return new Promise<void>((resolve) => {
+        resolveAttach = () => {
+          order.push("attach-done");
+          resolve();
+        };
+      });
+    };
+    const insertFiles = async (files: File[]): Promise<void> => {
+      insertArg = files;
+      order.push("insert-start");
+    };
+
+    const img = new File(["x"], "a.png", { type: "image/png" });
+    const pdf = new File(["y"], "b.pdf", { type: "application/pdf" });
+    const done = runOrderedUploads([img], [pdf], { attachImages, insertFiles });
+
+    // Flush microtasks: insert must not have started while attach is pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(insertArg).toBeNull();
+
+    resolveAttach();
+    await done;
+
+    expect(order).toEqual(["attach-done", "insert-start"]);
+    expect(attachArg).toEqual([img]);
+    expect(insertArg).toEqual([pdf]);
   });
 });

--- a/web/src/lib/chatImagePaste.test.ts
+++ b/web/src/lib/chatImagePaste.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   firstImageFromClipboard,
   imageFilesFromTransfer,
   runOrderedUploads,
   transferMayContainImage,
+  uploadChatFile,
 } from "./chatImagePaste";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 // Minimal DataTransfer stand-ins. jsdom's DataTransfer doesn't let us seed
 // items/files, so we hand-roll the shape the helpers read.
@@ -96,6 +102,54 @@ describe("transferMayContainImage", () => {
       items: [makeItem("string", "text/plain", null)],
     });
     expect(transferMayContainImage(data)).toBe(false);
+  });
+});
+
+describe("uploadChatFile", () => {
+  it("streams the file as multipart form data, not base64 JSON", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            path: "/home/user/.hermes/uploads/dashboard_x_report.pdf",
+            name: "dashboard_x_report.pdf",
+            bytes: 4,
+            mime_type: "application/pdf",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        ),
+    );
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pdf = new File(["%PDF"], "report.pdf", { type: "application/pdf" });
+    const uploaded = await uploadChatFile(pdf, "worker");
+
+    expect(uploaded.path).toBe(
+      "/home/user/.hermes/uploads/dashboard_x_report.pdf",
+    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/api/chat/file-upload?profile=worker");
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBeInstanceOf(FormData);
+    const sent = (init?.body as FormData).get("file");
+    expect(sent).toBeInstanceOf(File);
+    expect((sent as File).name).toBe("report.pdf");
+    // The browser must set the multipart boundary itself — an explicit
+    // Content-Type header would break the request.
+    expect(new Headers(init?.headers).has("Content-Type")).toBe(false);
+  });
+
+  it("rejects empty files client-side", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      uploadChatFile(new File([], "empty.pdf", { type: "application/pdf" })),
+    ).rejects.toThrow(/empty/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/lib/chatImagePaste.ts
+++ b/web/src/lib/chatImagePaste.ts
@@ -69,6 +69,94 @@ export function firstImageFromClipboard(
   return imageFilesFromTransfer(data)[0] ?? null;
 }
 
+// Non-image chat uploads (PDFs, docs, archives) — server cap mirrored in
+// /api/chat/file-upload.
+const MAX_FILE_BYTES = 50 * 1024 * 1024;
+
+/** Pull every non-image file out of a DataTransfer (clipboard or drop). */
+export function nonImageFilesFromTransfer(
+  data: DataTransfer | null,
+): File[] {
+  if (!data) return [];
+  const files: File[] = [];
+  const seen = new Set<string>();
+  const add = (file: File | null) => {
+    if (!file || file.type.startsWith("image/")) return;
+    const key = imageFileKey(file);
+    if (seen.has(key)) return;
+    seen.add(key);
+    files.push(file);
+  };
+
+  if (data.items?.length) {
+    for (let i = 0; i < data.items.length; i++) {
+      const item = data.items[i];
+      if (item.kind === "file" && !item.type.startsWith("image/")) {
+        add(item.getAsFile());
+      }
+    }
+  }
+
+  if (data.files?.length) {
+    for (let i = 0; i < data.files.length; i++) {
+      add(data.files[i]);
+    }
+  }
+
+  return files;
+}
+
+/** True when a drag payload may contain any file (for dragover preventDefault). */
+export function transferMayContainFile(data: DataTransfer | null): boolean {
+  if (!data) return false;
+  if (data.items?.length) {
+    for (let i = 0; i < data.items.length; i++) {
+      if (data.items[i].kind === "file") return true;
+    }
+    return false;
+  }
+  return (data.files?.length ?? 0) > 0;
+}
+
+/**
+ * Upload a non-image chat file to ``HERMES_HOME/uploads`` via the generic
+ * chat upload endpoint and return the absolute gateway path. The caller
+ * types the path into the TUI input so the agent can read the file with
+ * its file tools.
+ */
+export async function uploadChatFile(
+  file: File,
+  profile = "",
+): Promise<ChatImageUploadResult> {
+  if (file.size === 0) throw new Error("file is empty");
+  if (file.size > MAX_FILE_BYTES) {
+    const mb = Math.round(MAX_FILE_BYTES / (1024 * 1024));
+    throw new Error(`file too large (max ${mb} MB)`);
+  }
+
+  const dataUrl = await fileToDataUrl(file);
+  const qs = profile ? `?profile=${encodeURIComponent(profile)}` : "";
+  const res = await authedFetch(`/api/chat/file-upload${qs}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      data_url: dataUrl,
+      filename: file.name,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(text || `HTTP ${res.status}`);
+  }
+
+  const uploaded = (await res.json()) as ChatImageUploadResult;
+  if (!uploaded?.path) {
+    throw new Error("file upload did not return a path");
+  }
+  return uploaded;
+}
+
 /** True when a drag payload may contain an image (for dragover preventDefault). */
 export function transferMayContainImage(data: DataTransfer | null): boolean {
   if (!data) return false;

--- a/web/src/lib/chatImagePaste.ts
+++ b/web/src/lib/chatImagePaste.ts
@@ -250,3 +250,27 @@ export async function uploadChatImage(
   }
   return uploaded;
 }
+
+export interface OrderedUploadHandlers {
+  /** Attach images: writes `/image … \r` into the PTY draft (submits). */
+  attachImages: (files: File[]) => Promise<void>;
+  /** Insert non-image paths: types them into the PTY draft (no Return). */
+  insertFiles: (files: File[]) => Promise<void>;
+}
+
+/**
+ * Serialize a mixed drop/paste. The image flow and the non-image flow both
+ * write to the same PTY WebSocket, so running them concurrently lets a faster
+ * non-image upload type its path into the draft mid-way through the image
+ * command — corrupting or prematurely submitting it. Completing the image
+ * attach before inserting non-image paths keeps the two writers ordered
+ * regardless of which upload resolves first. See PR #62869 review.
+ */
+export async function runOrderedUploads(
+  images: File[],
+  others: File[],
+  handlers: OrderedUploadHandlers,
+): Promise<void> {
+  await handlers.attachImages(images);
+  await handlers.insertFiles(others);
+}

--- a/web/src/lib/chatImagePaste.ts
+++ b/web/src/lib/chatImagePaste.ts
@@ -123,6 +123,11 @@ export function transferMayContainFile(data: DataTransfer | null): boolean {
  * chat upload endpoint and return the absolute gateway path. The caller
  * types the path into the TUI input so the agent can read the file with
  * its file tools.
+ *
+ * Streams the raw bytes as multipart/form-data (same rationale as the
+ * managed-files upload-stream path, NS-501): base64 JSON inflates the body
+ * ~33%, buffers the whole file in memory, and trips proxy limits on large
+ * files. Do NOT set Content-Type — the browser adds the multipart boundary.
  */
 export async function uploadChatFile(
   file: File,
@@ -134,15 +139,12 @@ export async function uploadChatFile(
     throw new Error(`file too large (max ${mb} MB)`);
   }
 
-  const dataUrl = await fileToDataUrl(file);
+  const form = new FormData();
+  form.append("file", file, file.name);
   const qs = profile ? `?profile=${encodeURIComponent(profile)}` : "";
   const res = await authedFetch(`/api/chat/file-upload${qs}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      data_url: dataUrl,
-      filename: file.name,
-    }),
+    body: form,
   });
 
   if (!res.ok) {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -51,7 +51,9 @@ import {
 } from "@/lib/pty-mobile-input";
 import {
   imageFilesFromTransfer,
-  transferMayContainImage,
+  nonImageFilesFromTransfer,
+  transferMayContainFile,
+  uploadChatFile,
   uploadChatImage,
 } from "@/lib/chatImagePaste";
 import { PluginSlot } from "@/plugins";
@@ -587,24 +589,49 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         await driveImageAttach(paths);
       })().catch(reportImageUploadError);
     };
-    const handleBrowserPaste = (ev: ClipboardEvent) => {
-      const files = imageFilesFromTransfer(ev.clipboardData);
+    // Non-image files (PDFs, docs, …): upload to HERMES_HOME/uploads, then
+    // type the gateway-visible paths into the TUI input (no Return) so the
+    // user can add instructions before sending.
+    const uploadAndInsertFiles = (files: File[]) => {
       if (!files.length) return;
+      void (async () => {
+        const paths: string[] = [];
+        for (const file of files) {
+          const uploaded = await uploadChatFile(file, scopedProfile);
+          if (imageUploadDisposed) return;
+          paths.push(uploaded.path);
+        }
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          setBanner("File uploaded, but chat is not connected — try again.");
+          return;
+        }
+        ws.send(paths.join(" ") + " ");
+        term.focus();
+      })().catch(reportImageUploadError);
+    };
+    const handleBrowserPaste = (ev: ClipboardEvent) => {
+      const images = imageFilesFromTransfer(ev.clipboardData);
+      const others = nonImageFilesFromTransfer(ev.clipboardData);
+      if (!images.length && !others.length) return;
       ev.preventDefault();
       ev.stopPropagation();
-      uploadAndAttachImages(files);
+      uploadAndAttachImages(images);
+      uploadAndInsertFiles(others);
     };
     const handleBrowserDragOver = (ev: DragEvent) => {
-      if (!transferMayContainImage(ev.dataTransfer)) return;
+      if (!transferMayContainFile(ev.dataTransfer)) return;
       ev.preventDefault();
       if (ev.dataTransfer) ev.dataTransfer.dropEffect = "copy";
     };
     const handleBrowserDrop = (ev: DragEvent) => {
-      const files = imageFilesFromTransfer(ev.dataTransfer);
-      if (!files.length) return;
+      const images = imageFilesFromTransfer(ev.dataTransfer);
+      const others = nonImageFilesFromTransfer(ev.dataTransfer);
+      if (!images.length && !others.length) return;
       ev.preventDefault();
       ev.stopPropagation();
-      uploadAndAttachImages(files);
+      uploadAndAttachImages(images);
+      uploadAndInsertFiles(others);
     };
     host.addEventListener("paste", handleBrowserPaste, { capture: true });
     host.addEventListener("dragover", handleBrowserDragOver, { capture: true });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -52,6 +52,7 @@ import {
 import {
   imageFilesFromTransfer,
   nonImageFilesFromTransfer,
+  runOrderedUploads,
   transferMayContainFile,
   uploadChatFile,
   uploadChatImage,
@@ -577,38 +578,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
       term.focus();
     };
-    const uploadAndAttachImages = (files: File[]) => {
+    const uploadAndAttachImages = async (files: File[]) => {
       if (!files.length) return;
-      void (async () => {
-        const paths: string[] = [];
-        for (const file of files) {
-          const uploaded = await uploadChatImage(file, scopedProfile);
-          if (imageUploadDisposed) return;
-          paths.push(uploaded.path);
-        }
-        await driveImageAttach(paths);
-      })().catch(reportImageUploadError);
+      const paths: string[] = [];
+      for (const file of files) {
+        const uploaded = await uploadChatImage(file, scopedProfile);
+        if (imageUploadDisposed) return;
+        paths.push(uploaded.path);
+      }
+      await driveImageAttach(paths);
     };
     // Non-image files (PDFs, docs, …): upload to HERMES_HOME/uploads, then
     // type the gateway-visible paths into the TUI input (no Return) so the
     // user can add instructions before sending.
-    const uploadAndInsertFiles = (files: File[]) => {
+    const uploadAndInsertFiles = async (files: File[]) => {
       if (!files.length) return;
-      void (async () => {
-        const paths: string[] = [];
-        for (const file of files) {
-          const uploaded = await uploadChatFile(file, scopedProfile);
-          if (imageUploadDisposed) return;
-          paths.push(uploaded.path);
-        }
-        const ws = wsRef.current;
-        if (!ws || ws.readyState !== WebSocket.OPEN) {
-          setBanner("File uploaded, but chat is not connected — try again.");
-          return;
-        }
-        ws.send(paths.join(" ") + " ");
-        term.focus();
-      })().catch(reportImageUploadError);
+      const paths: string[] = [];
+      for (const file of files) {
+        const uploaded = await uploadChatFile(file, scopedProfile);
+        if (imageUploadDisposed) return;
+        paths.push(uploaded.path);
+      }
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        setBanner("File uploaded, but chat is not connected — try again.");
+        return;
+      }
+      ws.send(paths.join(" ") + " ");
+      term.focus();
+    };
+    // Serialize image + non-image writes so a mixed drop/paste can't interleave
+    // a file path into the image command draft (PR #62869 review).
+    const dispatchTransfer = (images: File[], others: File[]) => {
+      void runOrderedUploads(images, others, {
+        attachImages: uploadAndAttachImages,
+        insertFiles: uploadAndInsertFiles,
+      }).catch(reportImageUploadError);
     };
     const handleBrowserPaste = (ev: ClipboardEvent) => {
       const images = imageFilesFromTransfer(ev.clipboardData);
@@ -616,8 +621,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (!images.length && !others.length) return;
       ev.preventDefault();
       ev.stopPropagation();
-      uploadAndAttachImages(images);
-      uploadAndInsertFiles(others);
+      dispatchTransfer(images, others);
     };
     const handleBrowserDragOver = (ev: DragEvent) => {
       if (!transferMayContainFile(ev.dataTransfer)) return;
@@ -630,8 +634,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (!images.length && !others.length) return;
       ev.preventDefault();
       ev.stopPropagation();
-      uploadAndAttachImages(images);
-      uploadAndInsertFiles(others);
+      dispatchTransfer(images, others);
     };
     host.addEventListener("paste", handleBrowserPaste, { capture: true });
     host.addEventListener("dragover", handleBrowserDragOver, { capture: true });
@@ -688,7 +691,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
                 );
               }
               if (files.length) {
-                uploadAndAttachImages(files);
+                void uploadAndAttachImages(files).catch(reportImageUploadError);
                 return;
               }
             }


### PR DESCRIPTION
## Problem

The dashboard chat page only intercepts **image** files on drag-drop and paste (`transferMayContainImage` gates the `dragover` preventDefault). Dropping any other file type (PDF, CSV, docs, ...) falls through to the browser default action, which navigates to the file — the browser opens the PDF instead of attaching it to the chat.

## Solution

- New endpoint `POST /api/chat/file-upload`: same data-URL mechanism as `/api/chat/image-upload`, but without the image-only constraint. Any mime type, 50 MB cap, sanitized filename, written under `HERMES_HOME/uploads/` (profile-scoped, same pattern as the images dir).
- Chat page now intercepts **any** file on drop/paste:
  - images keep the existing flow (upload to `HERMES_HOME/images` + drive `/image` for vision);
  - non-image files upload to the new endpoint, then the gateway-visible path is typed into the TUI input (no Return), so the user can add instructions before sending and the agent reads the file with its file tools.

## Tests

6 new tests in `tests/hermes_cli/test_web_server.py` mirroring the image-upload suite: default/profile-scoped writes, path-traversal-safe filenames, non-image mime accepted, empty payload rejected, size cap (413), auth required (401). 13/13 upload tests pass via `scripts/run_tests.sh`.

## Notes

Motivation: on WSLg the desktop app cannot receive OS-level drag-drop from Windows Explorer (RDP limitation), so the browser dashboard is the natural surface for file-based workflows — and non-image files were a hole there.

## Related work

Closes #50913 (drag & drop file attachments in the dashboard chat — this PR implements exactly that flow for the existing xterm chat surface).

Overlap note: #49231 also adds file uploads, but as part of a new native React chat panel (beta) with its own endpoint. This PR is intentionally minimal — it fixes the file-drop hole in the *current* xterm-based chat without introducing a new surface, so it can land (and help #50913) independently of the panel rework.