### PR TITLE
fix(memory): recall on cold start so first-turn hindsight auto-inject works

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -24,6 +24,12 @@ Config via environment variables:
   HINDSIGHT_RETAIN_USER_PREFIX     — label used before user turns in retained transcripts
   HINDSIGHT_RETAIN_ASSISTANT_PREFIX — label used before assistant turns in retained transcripts
 
+Recall on the first turn of a fresh session is served synchronously (the warm
+prefetch cache is only populated after a turn completes), bounded by a small
+latency budget. Configure via config.json:
+  first_turn_recall          — enable synchronous cold-start recall (default: true)
+  first_turn_recall_timeout  — latency budget in seconds for that recall (default: 3.0)
+
 Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 ~/.hindsight/config.json (legacy, shared) for backward compatibility.
 """
@@ -721,6 +727,14 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        # Cold-start recall: on the first turn of a fresh session the warm
+        # prefetch cache is empty (it is only populated post-turn by
+        # queue_prefetch), so auto-inject would silently return nothing.
+        # When True, prefetch() falls back to a synchronous, latency-bounded
+        # recall on that first turn so memory context is available from turn 1
+        # without depending on a prompt directive. Reset on every session
+        # switch. Subsequent turns keep the fast warm-prefetch path.
+        self._first_turn_pending = True
         # Single-writer model for retain. sync_turn() enqueues; the writer
         # thread drains sequentially. Avoids spawning ad-hoc threads that
         # can race the interpreter shutdown and emit "cannot schedule new
@@ -781,6 +795,11 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Recall controls
         self._auto_recall = True
+        # Reliable first-turn recall: when the warm prefetch cache is empty
+        # (cold start / turn 1), perform a synchronous recall bounded by
+        # _first_turn_recall_timeout seconds. Gated on auto_recall.
+        self._first_turn_recall = True
+        self._first_turn_recall_timeout = 3.0
         self._recall_max_tokens = 4096
         # Default to observation-only recall. Observations are Hindsight's
         # consolidated knowledge layer — deduplicated, evidence-grounded
@@ -1084,6 +1103,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
+            {"key": "first_turn_recall", "description": "On the first turn of a fresh session (when the warm prefetch cache is empty), do a synchronous recall so memory context is available from turn 1 instead of one turn late", "default": True},
+            {"key": "first_turn_recall_timeout", "description": "Latency budget in seconds for the synchronous first-turn recall; if the backend is slower the turn proceeds without memory context", "default": 3.0},
             {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
             {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
@@ -1151,9 +1172,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
-        """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+    def _run_sync(self, coro, timeout: float | None = None):
+        """Schedule *coro* on the shared loop using the configured timeout.
+
+        A caller may pass an explicit *timeout* (seconds) to bound a single
+        call more tightly than the default request timeout — used by the
+        synchronous first-turn recall so a slow backend can't stall the turn.
+        """
+        return _run_sync(coro, timeout=timeout if timeout is not None else self._timeout)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1400,11 +1426,17 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
-        """Run an async Hindsight client operation, retrying once after idle shutdown."""
+    def _run_hindsight_operation(self, operation, *, timeout: float | None = None):
+        """Run an async Hindsight client operation, retrying once after idle shutdown.
+
+        *timeout* (seconds) bounds each scheduled call; ``None`` uses the
+        configured request timeout. Callers on a latency-sensitive path
+        (e.g. synchronous first-turn recall) pass a small budget so a slow
+        backend degrades to "no memory context" instead of stalling.
+        """
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1415,7 +1447,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1583,6 +1615,12 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
+        self._first_turn_recall = self._config.get("first_turn_recall", True)
+        self._first_turn_recall_timeout = float(
+            self._config.get("first_turn_recall_timeout", 3.0)
+        )
+        # A fresh initialize() means a fresh session — arm the cold-start recall.
+        self._first_turn_pending = True
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
         # Default narrows recall to observation-only; pass an explicit
         # `recall_types` list in config.json to broaden (e.g. include
@@ -1713,6 +1751,53 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _execute_recall(self, query: str, *, timeout: float | None = None) -> str:
+        """Run a recall/reflect for *query* and return formatted result text.
+
+        Shared by the warm background prefetch (queue_prefetch) and the
+        synchronous cold-start recall (prefetch). Returns "" on no results
+        or failure. *timeout* bounds the call; None uses the configured
+        request timeout.
+        """
+        try:
+            if self._prefetch_method == "reflect":
+                logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
+                resp = self._run_hindsight_operation(
+                    lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget),
+                    timeout=timeout,
+                )
+                return resp.text or ""
+            recall_kwargs: dict = {
+                "bank_id": self._bank_id, "query": query,
+                "budget": self._budget, "max_tokens": self._recall_max_tokens,
+            }
+            if self._recall_tags:
+                recall_kwargs["tags"] = self._recall_tags
+                recall_kwargs["tags_match"] = self._recall_tags_match
+            if self._recall_types:
+                recall_kwargs["types"] = self._recall_types
+            logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
+                         self._bank_id, len(query), self._budget)
+            resp = self._run_hindsight_operation(
+                lambda client: client.arecall(**recall_kwargs),
+                timeout=timeout,
+            )
+            num_results = len(resp.results) if resp.results else 0
+            logger.debug("Recall: returned %d results", num_results)
+            return "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+        except Exception as e:
+            logger.debug("Hindsight recall failed: %s", e, exc_info=True)
+            return ""
+
+    def _format_prefetch(self, result: str) -> str:
+        """Wrap recall text with the memory-context header for injection."""
+        header = self._recall_prompt_preamble or (
+            "# Hindsight Memory (persistent cross-session context)\n"
+            "Use this to answer questions about the user and prior sessions. "
+            "Do not call tools to look up information that is already present here."
+        )
+        return f"{header}\n\n{result}"
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1720,16 +1805,47 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""
-        if not result:
-            logger.debug("Prefetch: no results available")
+        if result:
+            logger.debug("Prefetch: returning %d chars of warm context", len(result))
+            self._first_turn_pending = False
+            return self._format_prefetch(result)
+
+        # Cold start (turn 1 of a fresh session): the warm cache is empty
+        # because queue_prefetch only populates it AFTER a turn completes.
+        # Do a synchronous, latency-bounded recall so memory context is
+        # available from the first message, rather than one turn late. Only
+        # fires once per session (first_turn_pending), respects auto_recall,
+        # skips tools-only mode, and never runs during shutdown.
+        if (
+            self._first_turn_pending
+            and self._first_turn_recall
+            and self._auto_recall
+            and self._memory_mode != "tools"
+            and not self._shutting_down.is_set()
+            and query
+            and query.strip()
+        ):
+            self._first_turn_pending = False
+            recall_query = query
+            if self._recall_max_input_chars and len(recall_query) > self._recall_max_input_chars:
+                recall_query = recall_query[:self._recall_max_input_chars]
+            logger.debug("Prefetch: cold-start synchronous recall (budget=%.1fs)",
+                         self._first_turn_recall_timeout)
+            try:
+                text = self._execute_recall(
+                    recall_query, timeout=self._first_turn_recall_timeout
+                )
+            except Exception as e:
+                logger.debug("Prefetch: cold-start recall failed: %s", e, exc_info=True)
+                text = ""
+            if text:
+                logger.debug("Prefetch: cold-start recall returned %d chars", len(text))
+                return self._format_prefetch(text)
+            logger.debug("Prefetch: cold-start recall returned nothing")
             return ""
-        logger.debug("Prefetch: returning %d chars of context", len(result))
-        header = self._recall_prompt_preamble or (
-            "# Hindsight Memory (persistent cross-session context)\n"
-            "Use this to answer questions about the user and prior sessions. "
-            "Do not call tools to look up information that is already present here."
-        )
-        return f"{header}\n\n{result}"
+
+        logger.debug("Prefetch: no results available")
+        return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._memory_mode == "tools":
@@ -1755,32 +1871,13 @@ class HindsightMemoryProvider(MemoryProvider):
             # thread, never the reply path, so it adds no response latency.
             if self._prefetch_waits_for_retain:
                 self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            try:
-                if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
-                else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
-                if text:
-                    with self._prefetch_lock:
-                        self._prefetch_result = text
-            except Exception as e:
-                logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
+            text = self._execute_recall(query)
+            if text:
+                with self._prefetch_lock:
+                    self._prefetch_result = text
+                # A warm result is now cached — the next prefetch() will use the
+                # fast path, so the synchronous cold-start recall isn't needed.
+                self._first_turn_pending = False
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
@@ -2161,6 +2258,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_counter = 0
         self._turn_index = 0
         self._last_retained_turn_count = 0
+        # New session -> re-arm the synchronous cold-start recall so the first
+        # turn after a /new, /reset, /resume, /branch, or compression rotation
+        # gets memory context immediately instead of one turn late.
+        self._first_turn_pending = True
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -65,6 +65,11 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.6.1"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+# If less than this much of the end-to-end budget remains after a first
+# cold-start attempt fails, skip the single idle-daemon retry instead of
+# handing it a near-zero (guaranteed-timeout) budget or overshooting the
+# caller's deadline.
+_COLD_START_RETRY_FLOOR_SECONDS = 0.5
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
 # Without it, reusing a stable session-scoped document_id silently
@@ -1429,25 +1434,47 @@ class HindsightMemoryProvider(MemoryProvider):
     def _run_hindsight_operation(self, operation, *, timeout: float | None = None):
         """Run an async Hindsight client operation, retrying once after idle shutdown.
 
-        *timeout* (seconds) bounds each scheduled call; ``None`` uses the
-        configured request timeout. Callers on a latency-sensitive path
-        (e.g. synchronous first-turn recall) pass a small budget so a slow
-        backend degrades to "no memory context" instead of stalling.
+        *timeout* (seconds) is an end-to-end budget, not a per-attempt one.
+        ``None`` uses the configured request timeout. Callers on a
+        latency-sensitive path (e.g. synchronous first-turn recall) pass a
+        small budget so a slow backend degrades to "no memory context"
+        instead of stalling. When the first attempt hits a retriable
+        embedded-daemon failure, the retry only gets whatever time is left
+        in the budget, so a slow/flaky cold start can never exceed *timeout*
+        (minus a small floor to keep the retry from being a no-op).
         """
         client = self._get_client()
+        started = time.monotonic()
         try:
             return self._run_sync(operation(client), timeout=timeout)
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
+            retry_timeout = timeout
+            if timeout is not None:
+                remaining = timeout - (time.monotonic() - started)
+                # The retry only gets the leftover budget so the end-to-end
+                # cost never exceeds *timeout*. If too little is left to make a
+                # meaningful attempt, skip the retry on this bounded cold path
+                # rather than overshoot the deadline.
+                if remaining < _COLD_START_RETRY_FLOOR_SECONDS:
+                    logger.info(
+                        "Hindsight embedded daemon unreachable and cold-start budget "
+                        "(%.2fs) nearly exhausted (%.2fs left); skipping retry: %s",
+                        timeout, remaining, exc,
+                    )
+                    raise
+                retry_timeout = remaining
             logger.info(
-                "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
+                "Hindsight embedded daemon appears unreachable; recreating client and "
+                "retrying once (retry budget=%.2fs): %s",
+                retry_timeout if retry_timeout is not None else -1.0,
                 exc,
             )
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client), timeout=timeout)
+            return self._run_sync(operation(client), timeout=retry_timeout)
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -487,6 +487,124 @@ class TestToolHandlers:
 
 
 # ---------------------------------------------------------------------------
+# Cold-start retry budget (PR #62870 review follow-up)
+# ---------------------------------------------------------------------------
+
+
+async def _dummy_coro():
+    return None
+
+
+class TestColdStartRetryBudget:
+    """`first_turn_recall_timeout` must bound the cold-start recall end-to-end.
+
+    Regression for the review on PR #62870: the single idle-daemon retry used
+    to receive a *fresh* full timeout, so a slow-then-retriable cold start
+    could take up to ~2x the advertised latency budget. The retry must only
+    get the remaining budget, and must be skipped once the budget is spent.
+    """
+
+    def _operation(self, client):
+        return _dummy_coro()
+
+    def test_retry_gets_only_remaining_budget(self, provider, monkeypatch):
+        provider._mode = "local_embedded"
+        monkeypatch.setattr(provider, "_get_client", lambda: MagicMock())
+
+        budget = 3.0
+        seen_timeouts: list = []
+        calls = {"n": 0}
+
+        def fake_run_sync(coro, timeout=None):
+            coro.close()  # never awaited on this synthetic path
+            seen_timeouts.append(timeout)
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Slow first attempt consumes part of the budget, then the
+                # embedded daemon appears unreachable (retriable).
+                time.sleep(0.2)
+                raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+            return "recovered"
+
+        monkeypatch.setattr(provider, "_run_sync", fake_run_sync)
+
+        result = provider._run_hindsight_operation(self._operation, timeout=budget)
+
+        assert result == "recovered"
+        assert len(seen_timeouts) == 2
+        assert seen_timeouts[0] == budget
+        # Retry got only the leftover budget: strictly less than the original
+        # full timeout and still positive.
+        assert 0 < seen_timeouts[1] < budget
+        # And it never exceeds the elapsed-adjusted remaining time.
+        assert seen_timeouts[1] <= budget - 0.2 + 0.05
+
+    def test_retry_skipped_when_budget_exhausted(self, provider, monkeypatch):
+        provider._mode = "local_embedded"
+        monkeypatch.setattr(provider, "_get_client", lambda: MagicMock())
+
+        budget = 1.0
+        seen_timeouts: list = []
+
+        def fake_run_sync(coro, timeout=None):
+            coro.close()
+            seen_timeouts.append(timeout)
+            # Burn past the point where a meaningful retry budget remains.
+            time.sleep(0.7)
+            raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+
+        monkeypatch.setattr(provider, "_run_sync", fake_run_sync)
+
+        with pytest.raises(RuntimeError, match="Cannot connect to host"):
+            provider._run_hindsight_operation(self._operation, timeout=budget)
+
+        # Only the first attempt ran; the retry was skipped because <0.5s left.
+        assert len(seen_timeouts) == 1
+
+    def test_non_retriable_error_is_not_retried(self, provider, monkeypatch):
+        provider._mode = "local_embedded"
+        monkeypatch.setattr(provider, "_get_client", lambda: MagicMock())
+
+        calls = {"n": 0}
+
+        def fake_run_sync(coro, timeout=None):
+            coro.close()
+            calls["n"] += 1
+            raise ValueError("bad request")
+
+        monkeypatch.setattr(provider, "_run_sync", fake_run_sync)
+
+        with pytest.raises(ValueError, match="bad request"):
+            provider._run_hindsight_operation(self._operation, timeout=3.0)
+
+        assert calls["n"] == 1
+
+    def test_no_timeout_passes_through_without_budget_math(self, provider, monkeypatch):
+        """With timeout=None (default request timeout), the retry still fires
+        and simply reuses None — no deadline is imposed."""
+        provider._mode = "local_embedded"
+        monkeypatch.setattr(provider, "_get_client", lambda: MagicMock())
+
+        seen_timeouts: list = []
+        calls = {"n": 0}
+
+        def fake_run_sync(coro, timeout=None):
+            coro.close()
+            seen_timeouts.append(timeout)
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+            return "ok"
+
+        monkeypatch.setattr(provider, "_run_sync", fake_run_sync)
+
+        result = provider._run_hindsight_operation(self._operation, timeout=None)
+
+        assert result == "ok"
+        assert seen_timeouts == [None, None]
+
+
+# ---------------------------------------------------------------------------
 # Prefetch tests
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -493,8 +493,57 @@ class TestToolHandlers:
 
 class TestPrefetch:
     def test_prefetch_returns_empty_when_no_result(self, provider):
+        # Non-first turn (warm-path): an empty warm cache yields no context.
+        provider._first_turn_pending = False
         assert provider.prefetch("test") == ""
 
+    def test_prefetch_cold_start_synchronous_recall(self, provider):
+        """Turn 1 of a fresh session: warm cache is empty, so prefetch does a
+        synchronous recall so memory context is available immediately."""
+        assert provider._first_turn_pending is True
+        result = provider.prefetch("when is my birthday?")
+        assert "Memory 1" in result and "Memory 2" in result
+        provider._client.arecall.assert_awaited()
+        # One-shot: the flag is consumed so subsequent turns use the warm path.
+        assert provider._first_turn_pending is False
+
+    def test_prefetch_cold_start_disabled_returns_empty(self, provider_with_config):
+        p = provider_with_config(first_turn_recall=False)
+        p._client = _make_mock_client()
+        assert p.prefetch("when is my birthday?") == ""
+        p._client.arecall.assert_not_awaited()
+
+    def test_prefetch_cold_start_respects_auto_recall_off(self, provider_with_config):
+        p = provider_with_config(auto_recall=False)
+        p._client = _make_mock_client()
+        assert p.prefetch("when is my birthday?") == ""
+        p._client.arecall.assert_not_awaited()
+
+    def test_prefetch_cold_start_only_fires_once(self, provider):
+        provider.prefetch("first question")
+        provider._client.arecall.reset_mock()
+        # Second call with empty warm cache must NOT re-run synchronous recall.
+        assert provider.prefetch("second question") == ""
+        provider._client.arecall.assert_not_awaited()
+
+    def test_prefetch_warm_result_takes_precedence_over_cold_start(self, provider):
+        provider._prefetch_result = "- warm memory"
+        result = provider.prefetch("test")
+        assert "- warm memory" in result
+        provider._client.arecall.assert_not_awaited()
+
+    def test_prefetch_default_preamble(self, provider):
+        provider._prefetch_result = "- some memory"
+        result = provider.prefetch("test")
+        assert "Hindsight Memory" in result
+        assert "- some memory" in result
+
+    def test_prefetch_custom_preamble(self, provider_with_config):
+        p = provider_with_config(recall_prompt_preamble="Custom header:")
+        p._prefetch_result = "- memory line"
+        result = p.prefetch("test")
+        assert result.startswith("Custom header:")
+        assert "- memory line" in result
 
     def test_queue_prefetch_skipped_in_tools_mode(self, provider_with_config):
         p = provider_with_config(memory_mode="tools")
@@ -872,6 +921,31 @@ class TestSessionSwitchBufferFlush:
         assert p._document_id != old_doc
         assert p._document_id.startswith("new-sid-")
 
+    def test_no_flush_when_buffer_empty(self, provider):
+        """Switch with no buffered turns must not fire a spurious retain."""
+        provider.on_session_switch("new-sid")
+        # Nothing enqueued — join is immediate.
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+        assert provider._session_id == "new-sid"
+
+    def test_prefetch_result_cleared_on_switch(self, provider):
+        """Stale recall text from the old session must not leak into the
+        next session's first prefetch read."""
+        provider._prefetch_result = "old-session recall: User likes Rust"
+        provider.on_session_switch("new-sid")
+        assert provider._prefetch_result == ""
+        # And subsequent prefetch() (warm path) should now report empty, not
+        # the leftover. Disable cold-start recall to isolate the warm cache.
+        provider._first_turn_recall = False
+        assert provider.prefetch("anything") == ""
+
+    def test_session_switch_rearms_cold_start_recall(self, provider):
+        """A session switch must re-arm the synchronous first-turn recall so
+        the new session gets memory context on its first message."""
+        provider._first_turn_pending = False
+        provider.on_session_switch("new-sid")
+        assert provider._first_turn_pending is True
 
     def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
         """on_session_switch must wait for an in-flight prefetch from the


### PR DESCRIPTION
## Problem

With the hindsight memory provider, the first message of a fresh session receives an empty memory context. Auto-injected memory only starts working from the second turn onward, so relevant recalled context is missing exactly when a conversation begins.

## Root cause

The auto-inject prefetch is one turn lagged. `prefetch()` returns the warm cache that `queue_prefetch` populates *after* the previous turn completes. On the first turn of a session that warm cache is empty, so there is nothing to inject.

## Change

- `prefetch()` now falls back to a synchronous, latency-bounded recall when the warm cache is empty on the first turn of a session (cold start), so memory context is available from turn 1.
- Gated on `auto_recall` and bounded by `first_turn_recall_timeout` (default `3.0s`), so a slow backend degrades to "no context" instead of stalling the turn.
- One-shot per session: `_first_turn_pending` is consumed on the first prefetch and re-armed on session switch; subsequent turns keep the fast warm path with no added latency.
- Recall/reflect execution is refactored into a shared `_execute_recall` helper used by both the warm and cold paths.
- New config keys: `first_turn_recall` (default `true`) and `first_turn_recall_timeout` (default `3.0`).

## Testing

Adds tests in `tests/plugins/memory/test_hindsight_provider.py` covering:
- Cold-start synchronous recall populating first-turn context.
- One-shot behavior (warm path used on subsequent turns).
- Timeout fallback to empty context when the backend is slow.
- Gating on `auto_recall` / `first_turn_recall`.