### PR TITLE
fix(gateway): honor streaming.mode alias so nested streaming config isn't silently disabled

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -74,6 +74,23 @@ def _env_multiplex_profiles_override() -> "bool | None":
     return None
 
 
+def _normalize_transport_token(value: Any) -> str:
+    """Normalize a streaming transport/mode value to a canonical token.
+
+    Handles the YAML 1.1 boolean quirk where bare ``on`` / ``off`` parse to
+    Python ``True`` / ``False`` (see ``gateway/display_config.py`` ``_normalise``).
+    Without this, ``mode: off`` arrives as boolean ``False`` and stringifying it
+    yields ``"false"`` instead of the advertised ``"off"``, so streaming would be
+    enabled instead of disabled. Booleans map to ``"auto"`` (True) / ``"off"``
+    (False); anything else is lower-cased, defaulting to ``"auto"``.
+    """
+    if value is None:
+        return "auto"
+    if isinstance(value, bool):
+        return "auto" if value else "off"
+    return str(value).strip().lower() or "auto"
+
+
 def _coerce_float(value: Any, default: float) -> float:
     """Coerce numeric config values, falling back on malformed input."""
     if value is None:
@@ -598,19 +615,25 @@ class StreamingConfig:
         # a surprising footgun: the whole reply buffers and sends at once.
         # ``mode: off`` disables streaming; an explicit ``enabled`` key always
         # wins so callers can force either state.
+        #
+        # ``transport`` alone does NOT imply ``enabled``: ``streaming.enabled``
+        # is the documented master switch (see website/docs/user-guide/
+        # configuration.md), so a bare ``transport`` only selects HOW to stream
+        # once streaming is on. Only the ``mode`` alias flips ``enabled``.
         raw_transport = data.get("transport")
         raw_mode = data.get("mode")
-        transport = raw_transport if raw_transport is not None else raw_mode
-        if transport is None:
-            transport = "auto"
-        transport = str(transport).strip().lower() or "auto"
+        # Normalize both through the same helper so YAML's bare ``off``/``on``
+        # (parsed as bool False/True) become canonical tokens rather than
+        # ``"false"``/``"true"``.
+        picked = raw_transport if raw_transport is not None else raw_mode
+        transport = _normalize_transport_token(picked)
 
         if "enabled" in data:
             enabled = _coerce_bool(data.get("enabled"), False)
-        elif raw_mode is not None or raw_transport is not None:
-            # A mode/transport was given without an explicit enabled flag:
-            # infer enabled from the transport ("off" = disabled, else on).
-            enabled = transport != "off"
+        elif raw_mode is not None:
+            # The ``mode`` alias (and only ``mode``) infers enabled:
+            # ``off`` disables, anything else enables.
+            enabled = _normalize_transport_token(raw_mode) != "off"
         else:
             enabled = False
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -588,9 +588,35 @@ class StreamingConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
         if not data:
             return cls()
+
+        # ``mode`` is an ergonomic alias for the transport that ALSO implies
+        # ``enabled``.  A config like ``streaming: {mode: auto}`` reads as
+        # "turn streaming on, transport=auto" — matching the natural intent
+        # of someone enabling streaming without also spelling out
+        # ``enabled: true``.  Without this, ``mode`` was silently ignored and
+        # streaming stayed disabled (``enabled`` defaults to False), which is
+        # a surprising footgun: the whole reply buffers and sends at once.
+        # ``mode: off`` disables streaming; an explicit ``enabled`` key always
+        # wins so callers can force either state.
+        raw_transport = data.get("transport")
+        raw_mode = data.get("mode")
+        transport = raw_transport if raw_transport is not None else raw_mode
+        if transport is None:
+            transport = "auto"
+        transport = str(transport).strip().lower() or "auto"
+
+        if "enabled" in data:
+            enabled = _coerce_bool(data.get("enabled"), False)
+        elif raw_mode is not None or raw_transport is not None:
+            # A mode/transport was given without an explicit enabled flag:
+            # infer enabled from the transport ("off" = disabled, else on).
+            enabled = transport != "off"
+        else:
+            enabled = False
+
         return cls(
-            enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "auto"),
+            enabled=enabled,
+            transport=transport,
             edit_interval=_coerce_float(
                 data.get("edit_interval"), DEFAULT_STREAMING_EDIT_INTERVAL,
             ),

--- a/tests/test_gateway_streaming_nested_config.py
+++ b/tests/test_gateway_streaming_nested_config.py
@@ -90,12 +90,17 @@ class TestStreamingModeAlias:
         # transport still resolves from mode
         assert sc.transport == "auto"
 
-    def test_transport_takes_precedence_over_mode(self):
+    def test_transport_selects_transport_but_mode_controls_enabled(self):
+        """``transport`` picks HOW to stream; ``mode`` is the enable alias.
+
+        With ``mode: off`` the master switch is off even though ``transport``
+        selects the draft path — ``enabled`` is inferred from ``mode`` only.
+        """
         from gateway.config import StreamingConfig
 
         sc = StreamingConfig.from_dict({"mode": "off", "transport": "draft"})
         assert sc.transport == "draft"
-        assert sc.enabled is True
+        assert sc.enabled is False
 
     def test_empty_block_stays_disabled(self):
         from gateway.config import StreamingConfig
@@ -103,9 +108,59 @@ class TestStreamingModeAlias:
         sc = StreamingConfig.from_dict({})
         assert sc.enabled is False
 
-    def test_transport_only_enables(self):
+    def test_transport_only_does_not_enable(self):
+        """``streaming.enabled`` is the documented master switch, so a bare
+        ``transport`` must not flip streaming on by itself."""
         from gateway.config import StreamingConfig
 
         sc = StreamingConfig.from_dict({"transport": "edit"})
-        assert sc.enabled is True
+        assert sc.enabled is False
+        # transport is still recorded so it takes effect once streaming is on.
         assert sc.transport == "edit"
+
+
+class TestStreamingYamlBooleanQuirk:
+    """YAML 1.1 parses bare ``off``/``on`` as booleans; ``mode``/``transport``
+    must normalize those back to canonical string tokens.
+
+    Regression for the review on PR #62873: bare ``mode: off`` arrived as
+    Python ``False`` and stringified to ``"false"``, which is not ``"off"``,
+    so streaming was enabled instead of honoring the advertised disable.
+    """
+
+    def test_mode_bare_off_boolean_disables(self):
+        from gateway.config import StreamingConfig
+
+        # yaml.safe_load("off") -> False
+        sc = StreamingConfig.from_dict({"mode": False})
+        assert sc.enabled is False
+        assert sc.transport == "off"
+
+    def test_mode_bare_on_boolean_enables(self):
+        from gateway.config import StreamingConfig
+
+        # yaml.safe_load("on") -> True
+        sc = StreamingConfig.from_dict({"mode": True})
+        assert sc.enabled is True
+        assert sc.transport == "auto"
+
+    def test_transport_bare_off_boolean_normalizes(self):
+        from gateway.config import StreamingConfig
+
+        # transport alone never enables, but the token must still normalize.
+        sc = StreamingConfig.from_dict({"transport": False})
+        assert sc.enabled is False
+        assert sc.transport == "off"
+
+    def test_loader_normalizes_bare_yaml_off(self):
+        """End-to-end through load_gateway_config(): unquoted ``mode: off``
+        (a YAML boolean) must keep streaming disabled."""
+        cfg = _load_with_yaml_dict({"streaming": {"mode": False}})
+        assert cfg.streaming.enabled is False
+        assert cfg.streaming.transport == "off"
+
+    def test_loader_nested_mode_enables(self):
+        """Nested gateway.streaming.mode alias enables through the loader."""
+        cfg = _load_with_yaml_dict({"gateway": {"streaming": {"mode": "edit"}}})
+        assert cfg.streaming.enabled is True
+        assert cfg.streaming.transport == "edit"

--- a/tests/test_gateway_streaming_nested_config.py
+++ b/tests/test_gateway_streaming_nested_config.py
@@ -41,3 +41,71 @@ class TestStreamingConfigNested:
         })
         assert cfg.streaming.enabled is True
         assert cfg.streaming.transport == "edit"
+
+
+class TestStreamingModeAlias:
+    """``streaming: {mode: ...}`` is an alias that also implies ``enabled``.
+
+    Regression for a live config footgun: ``streaming: {mode: auto}`` was
+    silently ignored (mode was never read), so streaming stayed disabled and
+    the whole reply buffered before the first Telegram send.
+    """
+
+    def test_mode_auto_enables_streaming(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"mode": "auto"})
+        assert sc.enabled is True
+        assert sc.transport == "auto"
+
+    def test_mode_edit_enables_streaming(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"mode": "edit"})
+        assert sc.enabled is True
+        assert sc.transport == "edit"
+
+    def test_mode_off_disables_streaming(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"mode": "off"})
+        assert sc.enabled is False
+        assert sc.transport == "off"
+
+    def test_mode_with_extra_keys_still_enables(self):
+        """Real-world block: mode plus unrelated preloader_frames."""
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict(
+            {"mode": "auto", "preloader_frames": ["a", "b"]}
+        )
+        assert sc.enabled is True
+        assert sc.transport == "auto"
+
+    def test_explicit_enabled_overrides_mode(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"mode": "auto", "enabled": False})
+        assert sc.enabled is False
+        # transport still resolves from mode
+        assert sc.transport == "auto"
+
+    def test_transport_takes_precedence_over_mode(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"mode": "off", "transport": "draft"})
+        assert sc.transport == "draft"
+        assert sc.enabled is True
+
+    def test_empty_block_stays_disabled(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({})
+        assert sc.enabled is False
+
+    def test_transport_only_enables(self):
+        from gateway.config import StreamingConfig
+
+        sc = StreamingConfig.from_dict({"transport": "edit"})
+        assert sc.enabled is True
+        assert sc.transport == "edit"


### PR DESCRIPTION
## Problem

A nested streaming config that sets only `streaming.mode` (e.g. `streaming: {mode: auto}`) silently does nothing. Streaming stays off, the whole reply is buffered, and it is sent as a single message - with no error or warning to signal that the config was ignored.

## Root cause

`StreamingConfig.from_dict` keyed streaming on `enabled`, which defaults to `False`, and treated `mode` as unrelated. A config that specified `mode` but not `enabled` therefore parsed as disabled, so `mode` was effectively a no-op.

## Change

- `StreamingConfig.from_dict` now treats `mode` as an alias for `transport` that also implies `enabled`, so `streaming: {mode: auto}` turns streaming on instead of being silently ignored.
- `mode: off` disables streaming.
- Precedence is explicit: an explicit `enabled` key still wins, and an explicit `transport` takes precedence over `mode`.

## Testing

Adds `tests/test_gateway_streaming_nested_config.py` covering:
- `mode` alone enables streaming and maps to `transport`.
- `mode: off` disables streaming.
- Precedence: explicit `enabled` and explicit `transport` over `mode`.
- The real-world `mode + preloader_frames` nested block.