### PR TITLE
fix(installer): verify SSH clone produced a valid .git directory

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1273,7 +1273,8 @@ clone_repo() {
         # so SSH fails fast instead of hanging when no key is configured.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null && \
+           [ -d "$INSTALL_DIR/.git" ]; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone


### PR DESCRIPTION
**Fixes #62132**

On some platforms (Lightning.ai Ubuntu VMs, and potentially others), `git clone` via SSH exits with code 0 even when it fails to produce a valid clone. The script then skips the HTTPS fallback and the install breaks at a later step.

**Fix:** After the SSH clone succeeds (exit code 0), also verify that `$INSTALL_DIR/.git` actually exists. If it is missing, treat the clone as failed and fall through to the HTTPS fallback path.