### PR TITLE
fix(langfuse): repair silent trace-loss chain in observability plugin

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -12,9 +12,23 @@ Pick one:
 hermes tools  # → Langfuse Observability
 
 # Manual
-pip install langfuse
+pip install 'langfuse>=3.0'
 hermes plugins enable observability/langfuse
 ```
+
+**The `>=3.0` pin is mandatory, not a suggestion.** This plugin uses the
+OTEL-based v3+ Python SDK (`start_observation`, `create_trace_id`). If an
+unpinned `pip install langfuse` (or an environment rebuild) resolves to a
+2.x SDK, the plugin's import fails silently — caught by a fail-open
+try/except — and every hook becomes a permanent no-op. No error, no log
+line, no trace, ever. See Troubleshooting below.
+
+**If you self-host Langfuse, the server must also be v3+.** SDK v3+ ships
+traces via OTLP (`/api/public/otel/v1/traces`), which does not exist on
+Langfuse server 2.x — every export 404s regardless of how correctly the
+SDK is configured. `docker-compose.selfhost-v3-example.yml` in this
+directory is a known-working v3 stack (web + worker + Postgres +
+ClickHouse + Redis + MinIO).
 
 ## Required credentials
 
@@ -51,3 +65,43 @@ HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
 ```bash
 hermes plugins disable observability/langfuse
 ```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| No traces ever appear, no errors anywhere | `langfuse` SDK is <3.0 (silent import failure, fail-open by design) | `pip install --upgrade 'langfuse>=3.0'`, restart the gateway |
+| `agent.log` shows `ValueError: <Token ...> was created in a different Context` | Older versions of this plugin entered `start_as_current_observation()`'s context manager in one hook call and ended the span in another — Hermes hooks fire pre/post a turn on different worker threads, and OTEL's contextvars Token can't be popped cross-thread. Fixed in `_start_root_trace` by switching to the detached `client.start_observation()` (no "current span" contextvar involved). If you see this, your plugin copy predates that fix. | Pull the latest `plugins/observability/langfuse/__init__.py` |
+| Self-hosted: every trace export gets `404` in the exporter logs | Langfuse *server* is still on major version 2; SDK v3+ only speaks OTLP, which 2.x servers don't implement | Upgrade the server to `langfuse/langfuse:3` — see `docker-compose.selfhost-v3-example.yml` |
+| Self-hosted: `langfuse-web`/`langfuse-worker` crash-loop with `CLICKHOUSE_URL is not configured` | v3 requires ClickHouse (+ Redis + S3-compatible storage); v2's Postgres-only compose isn't enough | Add `clickhouse`, `redis`, `minio` services per the example compose file |
+| Self-hosted: ClickHouse migration fails with `There is no Zookeeper configuration ... ReplicatedMergeTree` | The stock `clickhouse-server` image ships a demo `default` cluster; Langfuse's migrator tries `ON CLUSTER default` against it, which needs Zookeeper | Set `CLICKHOUSE_CLUSTER_ENABLED: "false"` explicitly on `langfuse-web`/`langfuse-worker` |
+| Self-hosted: API calls return `Invalid authorization header. Confirm that you've configured the correct host.` after a v2→v3 upgrade | v3 added an organization layer above projects; API keys created under v2 have `organization_id = NULL` in Postgres and fail auth with this misleading message | Simplest fix: generate a fresh key pair for the project rather than repairing the old one (see script below) |
+
+### Recreating an API key by hand (self-hosted, post v2→v3 migration)
+
+If old keys are stuck with a null `organization_id`, generate a new pair
+with correctly computed hashes and insert it directly rather than trying
+to repair the old row (an in-place `UPDATE ... organization_id` backfill
+was observed to be immediately followed by the row disappearing — likely
+an app-side cleanup of org-less keys, not confirmed as reproducible):
+
+```python
+import uuid, hashlib, bcrypt
+
+SALT = "<your SALT env var value>"
+pk = f"pk-lf-{uuid.uuid4()}"
+sk = f"sk-lf-{uuid.uuid4()}"
+hashed_secret_key = bcrypt.hashpw(sk.encode(), bcrypt.gensalt(11)).decode()
+
+def fast_hash(secret: str, salt: str) -> str:
+    salt_hash = hashlib.sha256(salt.encode()).hexdigest()
+    return hashlib.sha256((secret + salt_hash).encode()).hexdigest()
+
+fast_hashed_secret_key = fast_hash(sk, SALT)
+display_secret_key = sk[:6] + "..." + sk[-4:]
+```
+
+Then `INSERT INTO api_keys (id, note, public_key, hashed_secret_key,
+display_secret_key, project_id, organization_id, fast_hashed_secret_key,
+scope) VALUES (...)` — get `project_id`/`organization_id` via `SELECT id,
+org_id FROM projects WHERE name = '<your project>'`.

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -34,16 +34,14 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 try:
-    from langfuse import Langfuse, propagate_attributes
+    from langfuse import Langfuse
 except Exception:  # pragma: no cover - fail-open when optional dep is missing
     Langfuse = None
-    propagate_attributes = None
 
 
 @dataclass
 class TraceState:
     trace_id: str
-    root_ctx: Any
     root_span: Any
     generations: Dict[str, Any] = field(default_factory=dict)
     tools: Dict[str, Any] = field(default_factory=dict)
@@ -621,42 +619,23 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     if session_id:
         trace_ctx["session_id"] = session_id
 
-    if propagate_attributes is not None:
-        try:
-            with propagate_attributes(
-                session_id=session_id or task_key,
-                trace_name="Hermes turn",
-                tags=["hermes", "langfuse"],
-            ):
-                root_ctx = client.start_as_current_observation(
-                    trace_context=trace_ctx,
-                    name="Hermes turn",
-                    as_type="chain",
-                    input=trace_input,
-                    metadata=metadata,
-                    end_on_exit=False,
-                )
-                root_span = root_ctx.__enter__()
-        except Exception:
-            root_ctx = client.start_as_current_observation(
-                trace_context=trace_ctx,
-                name="Hermes turn",
-                as_type="chain",
-                input=trace_input,
-                metadata=metadata,
-                end_on_exit=False,
-            )
-            root_span = root_ctx.__enter__()
-    else:
-        root_ctx = client.start_as_current_observation(
-            trace_context=trace_ctx,
-            name="Hermes turn",
-            as_type="chain",
-            input=trace_input,
-            metadata=metadata,
-            end_on_exit=False,
-        )
-        root_span = root_ctx.__enter__()
+    # Use the detached start_observation() (not start_as_current_observation())
+    # deliberately: the "current" variant pushes an OTEL contextvars Token when
+    # entered and expects it popped from the *same* thread/async context it was
+    # created in. Hermes hooks fire pre/post across the agent's worker threads,
+    # so entering here and ending the span later (in _finish_trace, possibly on
+    # a different thread) trips OTEL's cross-context Token check —
+    # ``ValueError: <Token ...> was created in a different Context`` — and the
+    # trace silently never reaches Langfuse. start_observation() returns the
+    # same span object without touching the "current span" contextvar, so
+    # start/end can safely happen on different threads.
+    root_span = client.start_observation(
+        trace_context=trace_ctx,
+        name="Hermes turn",
+        as_type="chain",
+        input=trace_input,
+        metadata=metadata,
+    )
 
     try:
         root_span.set_trace_io(input=trace_input)
@@ -664,7 +643,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         pass
 
     _debug(f"started trace {trace_id} for {task_key}")
-    return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
+    return TraceState(trace_id=trace_id, root_span=root_span)
 
 
 def _start_child_observation(state: TraceState, *, client: Langfuse, name: str, as_type: str,

--- a/plugins/observability/langfuse/docker-compose.selfhost-v3-example.yml
+++ b/plugins/observability/langfuse/docker-compose.selfhost-v3-example.yml
@@ -1,0 +1,159 @@
+# Known-working self-hosted Langfuse v3 stack for use with this plugin.
+#
+# This is a reference/example, not meant to be used verbatim — replace every
+# CHANGEME below with your own secret before running `docker compose up -d`.
+# Generate random values with `openssl rand -hex 16` (or -hex 32 for
+# ENCRYPTION_KEY).
+#
+# Why this file exists: this plugin requires Langfuse Python SDK v3+, which
+# only ships traces via OTLP. OTLP ingestion does not exist on Langfuse
+# server 2.x — every export silently 404s regardless of how correctly the
+# SDK is configured. If you're self-hosting, the server must be v3+, and v3's
+# architecture needs more than Postgres: ClickHouse (trace/observation
+# storage), Redis (queue/cache), and S3-compatible object storage (MinIO
+# here), plus a separate worker process that drains the ingestion queue into
+# ClickHouse. See README.md's Troubleshooting section for the specific
+# failure modes this stack avoids (Zookeeper/cluster errors, crash-looping
+# on missing CLICKHOUSE_URL, post-migration auth failures).
+#
+# If you're upgrading an existing v2 instance in place: keep your existing
+# Postgres service/volume (Postgres schema migrates automatically on first
+# v3 boot) and add the clickhouse/redis/minio/langfuse-worker services below
+# — do not start from a blank volume or you'll lose your v2 data.
+services:
+  langfuse-web:
+    image: docker.io/langfuse/langfuse:3
+    ports:
+      - "3000:3000"
+    environment: &langfuse-env
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/langfuse # CHANGEME
+      DIRECT_URL: postgresql://postgres:postgres@db:5432/langfuse # CHANGEME
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: CHANGEME-min-32-chars
+      SALT: CHANGEME-min-length-ok
+      ENCRYPTION_KEY: CHANGEME # generate via `openssl rand -hex 32`
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: CHANGEME
+      # Prevents Langfuse's ClickHouse migrator from issuing `ON CLUSTER
+      # default` against the demo cluster the stock clickhouse-server image
+      # ships out of the box — that path needs Zookeeper and fails without it.
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: CHANGEME
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: CHANGEME
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://localhost:9090
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_AUTH: CHANGEME
+    depends_on: &langfuse-depends-on
+      db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Required, not optional: without the worker, the web service queues
+  # ingested traces into Redis but nothing ever drains the queue into
+  # ClickHouse, so the UI stays at zero traces even though ingestion
+  # "succeeds" (200 OK) on every request.
+  langfuse-worker:
+    image: docker.io/langfuse/langfuse-worker:3
+    environment: *langfuse-env
+    depends_on: *langfuse-depends-on
+    restart: unless-stopped
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres # CHANGEME
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  clickhouse:
+    image: docker.io/clickhouse/clickhouse-server
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: CHANGEME # must match CLICKHOUSE_PASSWORD above
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      - langfuse_clickhouse_logs:/var/log/clickhouse-server
+    ports:
+      - "127.0.0.1:8123:8123"
+      - "127.0.0.1:9000:9000"
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 1s
+    restart: unless-stopped
+
+  minio:
+    image: cgr.dev/chainguard/minio
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: CHANGEME # must match the LANGFUSE_S3_*_SECRET_ACCESS_KEY values above
+    ports:
+      - "9090:9000"
+      - "127.0.0.1:9091:9001"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+    restart: unless-stopped
+
+  redis:
+    image: docker.io/redis:7
+    command: >
+      --requirepass CHANGEME
+      --maxmemory-policy noeviction
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 10s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  langfuse_postgres:
+  langfuse_clickhouse_data:
+  langfuse_clickhouse_logs:
+  langfuse_minio_data:
+  langfuse_redis_data:


### PR DESCRIPTION
## Summary

Traces silently never reach Langfuse in the bundled `observability/langfuse` plugin. Root cause: `_start_root_trace` enters `client.start_as_current_observation(...)` via a manual `.__enter__()` call, then ends the span later via `.end()` from `_finish_trace` — but Hermes fires its pre/post hooks across different worker threads. OTEL's `contextvars.Token` (pushed on enter) can only be popped in the same thread/context it was created in, so the mismatched enter/exit raises `ValueError: <Token ...> was created in a different Context` on essentially every turn. The exception is swallowed with no user-facing error or log line pointing at the real cause — the trace just never shows up.

- Switches to the detached `client.start_observation(...)` API, which returns the same span type without mutating OTEL's "current span" contextvar, so start and end can safely happen on different threads.
- Documents (README) that the `langfuse>=3.0` SDK pin is load-bearing — an unpinned install can silently resolve to a 2.x SDK, which lacks `propagate_attributes`/OTEL support this plugin needs, making every hook a no-op with zero errors.
- Documents that self-hosted Langfuse servers must also be v3+ (v3 SDKs speak OTLP exclusively; v2 servers don't implement that endpoint and 404 on every export).
- Adds a known-working v3 self-hosted `docker-compose` reference plus a troubleshooting table for the failure modes hit while debugging this end to end.

## Test plan

- [x] Verified locally: real Hermes turns (`tui`, `cron`, `discord` platforms) now produce complete traces in a self-hosted Langfuse v3 instance — nested LLM-call spans, token usage, cost fields, tool-call counts all present, confirmed via `GET /api/public/traces/<id>`.
- [x] `python -c "import ast; ast.parse(...)"` syntax check on the modified plugin file.
- [ ] Would appreciate a maintainer sanity-check against Langfuse Cloud (only tested against self-hosted v3 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)