### PR TITLE
fix(gateway): show channel override model/provider in session info banner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12319,10 +12319,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional["SessionSource"] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
@@ -12332,6 +12332,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
         model = _resolve_gateway_model()
+        # Channel overrides win over the global default — otherwise the /new
+        # banner advertises config.model while the session runs the override.
+        override_provider = None
+        cfg = getattr(self, "config", None)
+        if source is not None and cfg is not None:
+            try:
+                ch = _get_channel_override(
+                    cfg,
+                    source.platform,
+                    str(source.chat_id) if source.chat_id else "",
+                    thread_id=str(source.thread_id) if getattr(source, "thread_id", None) else None,
+                    parent_id=str(source.parent_chat_id) if getattr(source, "parent_chat_id", None) else None,
+                )
+                if ch:
+                    if ch.model:
+                        model = ch.model
+                    if ch.provider:
+                        override_provider = ch.provider
+            except Exception:
+                pass
         config_context_length = None
         provider = None
         base_url = None
@@ -12398,11 +12418,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Resolve runtime credentials for probing
         try:
             runtime = _resolve_runtime_agent_kwargs()
-            provider = provider or runtime.get("provider")
+            provider = override_provider or provider or runtime.get("provider")
             base_url = base_url or runtime.get("base_url")
             api_key = runtime.get("api_key")
         except Exception:
-            pass
+            provider = override_provider or provider
 
         context_length = get_model_context_length(
             model,

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -109,6 +109,70 @@ class TestFormatSessionInfo:
         assert "config" in info
 
 
+class TestChannelOverrideSessionInfo:
+    """The /new banner must advertise the channel override's model/provider,
+    not the global config default the session won't actually use."""
+
+    _RUNTIME = {"provider": "openrouter", "base_url": "", "api_key": ""}
+
+    def _runner_with_override(self, runner, chat_id="123", **override_kwargs):
+        from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+        runner.config = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                channel_overrides={chat_id: ChannelOverride(**override_kwargs)},
+            ),
+        })
+        return runner
+
+    def _source(self, chat_id="123", thread_id=None):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+        return SessionSource(
+            platform=Platform.TELEGRAM, chat_id=chat_id, user_id="u1",
+            thread_id=thread_id,
+        )
+
+    def test_override_model_and_provider_shown(self, runner, tmp_path):
+        self._runner_with_override(runner, model="override-model", provider="anthropic")
+        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: base-model\n  provider: openrouter\n",
+                                  "base-model", self._RUNTIME)
+        with p1, p2, p3:
+            info = runner._format_session_info(self._source())
+        assert "override-model" in info
+        assert "anthropic" in info
+        assert "base-model" not in info
+
+    def test_no_source_uses_base_model(self, runner, tmp_path):
+        self._runner_with_override(runner, model="override-model")
+        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: base-model\n",
+                                  "base-model", self._RUNTIME)
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "base-model" in info
+        assert "override-model" not in info
+
+    def test_unmatched_chat_uses_base_model(self, runner, tmp_path):
+        self._runner_with_override(runner, chat_id="999", model="override-model")
+        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: base-model\n",
+                                  "base-model", self._RUNTIME)
+        with p1, p2, p3:
+            info = runner._format_session_info(self._source(chat_id="123"))
+        assert "base-model" in info
+        assert "override-model" not in info
+
+    def test_override_provider_survives_runtime_failure(self, runner, tmp_path):
+        self._runner_with_override(runner, model="override-model", provider="anthropic")
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("model:\n  default: base-model\n  context_length: 4096\n")
+        with patch("gateway.run._hermes_home", tmp_path), \
+             patch("gateway.run._resolve_gateway_model", return_value="base-model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", side_effect=RuntimeError("no creds")):
+            info = runner._format_session_info(self._source())
+        assert "override-model" in info
+        assert "anthropic" in info
+
+
 class TestResetNoticeSessionInfo:
     """#59003: the auto-reset banner must report the serving profile's config,
     not the multiplexer's base config."""


### PR DESCRIPTION
## What

The `/new` reset banner and the auto-reset notice build their session info block from the global `config.yaml` model only. Chats configured with a `channel_overrides` entry (per-channel model/provider) get a banner advertising a model the session never uses.

## Why

`_format_session_info()` had no access to the message source, so it could only resolve the global default. The caller (`_reset_notice_session_info`) already receives the `SessionSource` — this change passes it down and applies the same `_get_channel_override` lookup the message path uses (chat_id → thread_id → parent_id), so the banner reports what the session actually runs.

Also: when runtime credential resolution raises, the override provider was silently dropped — now kept.

## How to test

1. Configure a channel override in `config.yaml`:
   ```yaml
   platforms:
     telegram:
       channel_overrides:
         "<chat_id>":
           model: some/other-model
           provider: anthropic
   ```
2. Send `/new` in that chat.
3. Before: banner shows `model.default` from config. After: banner shows the override model/provider.

Unit tests: `tests/gateway/test_session_info.py::TestChannelOverrideSessionInfo` (override shown, no-source fallback, unmatched chat fallback, runtime-failure keeps override provider). Ran the full gateway session-info/override test files — 104 passed.

## Platforms tested

Linux (Ubuntu, gateway + Photon/iMessage adapter with a live channel override).