### PR TITLE
fix(tools): preserve Kanban lifecycle tools for task workers

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -395,9 +395,13 @@ def _compute_tool_definitions(
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
-    # stripped out. See issue #17309.
+    # stripped out. See issue #17309. Task-scoped Kanban workers are the one
+    # exception: their check_fns still constrain them to the scoped worker
+    # lifecycle surface (including child-task creation/dependency linking).
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
+            if os.environ.get("HERMES_KANBAN_TASK") and toolset_name == "kanban":
+                continue
             if validate_toolset(toolset_name):
                 from toolsets import bundle_non_core_tools, get_toolset
                 if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1434,6 +1434,87 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     assert "Do not shell out" in prompt or "tools — they work" in prompt
 
 
+def test_worker_kanban_guidance_survives_disabled_kanban_toolset(monkeypatch, tmp_path):
+    """Task scope overrides a profile's ordinary-chat Kanban restriction."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    defs = get_tool_definitions(
+        enabled_toolsets=["file"],
+        disabled_toolsets=["kanban"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    expected_worker_surface = {
+        "kanban_show",
+        "kanban_complete",
+        "kanban_block",
+        "kanban_heartbeat",
+        "kanban_comment",
+        "kanban_create",
+        "kanban_link",
+    }
+    direct_names = {tool["function"]["name"] for tool in defs}
+    assert {name for name in direct_names if name.startswith("kanban_")} == (
+        expected_worker_surface
+    )
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        enabled_toolsets=["file"],
+        disabled_toolsets=["kanban"],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent_names = {tool["function"]["name"] for tool in getattr(agent, "tools")}
+    assert {name for name in agent_names if name.startswith("kanban_")} == (
+        expected_worker_surface
+    )
+
+    prompt = agent._build_system_prompt()
+    assert "Kanban task execution protocol" in prompt
+    assert "kanban_show()" in prompt
+    assert "kanban_complete" in prompt
+
+
+def test_normal_chat_still_honors_disabled_kanban_toolset(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    defs = get_tool_definitions(
+        enabled_toolsets=["kanban"],
+        disabled_toolsets=["kanban"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    names = {tool["function"]["name"] for tool in defs}
+    assert not any(name.startswith("kanban_") for name in names)
+
+
 def test_kanban_guidance_prompt_size_bounded(monkeypatch, tmp_path):
     """Sanity: the guidance block stays lean so it doesn't blow up the
     cached prompt.


### PR DESCRIPTION
## What changed

- Preserve the Kanban lifecycle toolset for dispatcher-scoped workers identified by `HERMES_KANBAN_TASK`, even when the assignee profile disables the ordinary-chat `kanban` toolset.
- Keep the existing disabled-toolset behavior unchanged for normal chat sessions.
- Add regression coverage across direct schema resolution, `AIAgent` tool assembly, and worker prompt guidance.

## Why

Assignee profiles may intentionally disable Kanban tools during ordinary chat. That same profile restriction was also applied after the dispatcher scoped a process as a Kanban worker, stripping the lifecycle tools the worker needs to inspect, heartbeat, comment, create/link child tasks, block, and complete its assigned task.

The worker environment is already constrained by Kanban task-scoped `check_fn` guards. This change makes that task scope the narrow exception while preserving the profile restriction everywhere else.

## How to test

```bash
python -m pytest -q \
  tests/tools/test_kanban_tools.py \
  tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
python -m ruff check model_tools.py tests/tools/test_kanban_tools.py
git diff --check upstream/main...HEAD
```

Verified locally:

- 103 tests passed
- Ruff check passed
- clean merge-tree against current `upstream/main`
- changed paths are limited to `model_tools.py` and `tests/tools/test_kanban_tools.py`

## Platform tested

- macOS 26.5.1
