### PR TITLE
fix(whatsapp): add --experimental-global-webcrypto flag to bridge launch

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -642,6 +642,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._bridge_process = subprocess.Popen(
                 [
                     find_node_executable("node") or "node",
+                    "--experimental-global-webcrypto",
                     str(bridge_path),
                     "--port", str(self._bridge_port),
                     "--session", str(self._session_path),


### PR DESCRIPTION
## Summary

Baileys 7.x requires the Node.js `--experimental-global-webcrypto` flag to provide the Web Crypto API. Without this flag, the WhatsApp bridge crashes with a `crypto.subtle is undefined` error on Node 18+.

## Change

Adds `"--experimental-global-webcrypto"` to the `subprocess.Popen` argument list in `plugins/platforms/whatsapp/adapter.py` when launching the WhatsApp bridge process, immediately after the Node executable path.

## Test Plan

- [ ] WhatsApp bridge launches successfully on Node 18+
- [ ] Bridge connects and processes messages normally
- [ ] No `crypto.subtle` related errors in bridge logs