### PR TITLE
fix(whatsapp): allow group messages in self-chat mode for /sethome

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -546,10 +546,21 @@ async function startSocket() {
       // Handle fromMe messages based on mode
       let fromOwner = false;
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) {
+        // Status broadcasts are never useful regardless of mode
+        if (chatId.includes('status')) {
           emitDebugEvent({
             stage: 'ignored',
-            reason: isGroup ? 'from_me_group' : 'from_me_status',
+            reason: 'from_me_status',
+            chatId: redactWhatsAppId(chatId),
+          });
+          continue;
+        }
+        // In non-self-chat modes, skip group messages.
+        // In self-chat, allow them for /sethome.
+        if (isGroup && WHATSAPP_MODE !== 'self-chat') {
+          emitDebugEvent({
+            stage: 'ignored',
+            reason: 'from_me_group',
             chatId: redactWhatsAppId(chatId),
           });
           continue;
@@ -598,22 +609,8 @@ async function startSocket() {
           const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
           const chatNumber = chatId.replace(/@.*/, '');
           const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-          emitDebugEvent({
-            stage: 'self_chat_check',
-            matched: !!isSelfChat,
-            chatId: redactWhatsAppId(chatId),
-            accountId: redactWhatsAppId(sock.user?.id),
-            accountLid: redactWhatsAppId(sock.user?.lid),
-          });
-          if (!isSelfChat) {
-            emitDebugEvent({
-              stage: 'ignored',
-              reason: 'self_chat_mismatch',
-              chatId: redactWhatsAppId(chatId),
-              senderId: redactWhatsAppId(senderId),
-            });
-            continue;
-          }
+          // In self-chat mode, also allow group messages (e.g. for /sethome)
+          if (!isSelfChat && !isGroup) continue;
         }
       }
 


### PR DESCRIPTION
## Summary

In self-chat mode, the WhatsApp bridge was dropping all group messages because the self-chat gate only checked `isSelfChat` and did not account for group chat IDs. This prevented `/sethome` from working with WhatsApp groups — a common setup where users create a 1-person group as their home channel.

## Change

Changes the self-chat gate in `scripts/whatsapp-bridge/bridge.js` from:

```js
if (!isSelfChat) {
  emitDebugEvent(...);
  continue;
}
```

to:

```js
// In self-chat mode, also allow group messages (e.g. for /sethome)
if (!isSelfChat && !isGroup) continue;
```

This allows group messages through in self-chat mode while still blocking stranger DMs, preserving the security boundary from #8389.

## Test Plan

- [ ] In self-chat mode, group messages are received by the bridge
- [ ] /sethome works with a WhatsApp group chat ID
- [ ] Stranger DMs are still blocked in self-chat mode