### PR TITLE
fix(gateway): prevent dual ownership during scoped lock creation

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1089,15 +1089,25 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except FileExistsError:
         return False, _read_json_file(lock_path)
+
+    created_stat = os.fstat(fd)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(record, handle)
     except Exception:
         try:
-            lock_path.unlink(missing_ok=True)
+            if os.path.samestat(created_stat, lock_path.stat()):
+                lock_path.unlink(missing_ok=True)
         except OSError:
             pass
         raise
+
+    try:
+        if not os.path.samestat(created_stat, lock_path.stat()):
+            return False, _read_json_file(lock_path)
+    except OSError:
+        return False, _read_json_file(lock_path)
+
     return True, None
 
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -929,6 +929,65 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "slack"
 
+    def test_acquire_scoped_lock_does_not_allow_dual_ownership_during_initial_write(self, tmp_path, monkeypatch):
+        """A contender must not unlink a lock file that is still being initialized."""
+        import threading
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+
+        original_dump = status.json.dump
+        first_writer_started = threading.Event()
+        allow_first_writer = threading.Event()
+        second_writer_finished = threading.Event()
+        call_count = 0
+        call_count_lock = threading.Lock()
+
+        def coordinated_dump(obj, handle, *args, **kwargs):
+            nonlocal call_count
+            with call_count_lock:
+                call_count += 1
+                call_number = call_count
+
+            if call_number == 1:
+                first_writer_started.set()
+                assert allow_first_writer.wait(timeout=5)
+            else:
+                original_dump(obj, handle, *args, **kwargs)
+                second_writer_finished.set()
+                return
+
+            original_dump(obj, handle, *args, **kwargs)
+
+        monkeypatch.setattr(status.json, "dump", coordinated_dump)
+
+        results = []
+
+        def acquire():
+            results.append(
+                status.acquire_scoped_lock(
+                    "slack-app-token",
+                    "secret",
+                    metadata={"platform": "slack"},
+                )
+            )
+
+        first = threading.Thread(target=acquire)
+        second = threading.Thread(target=acquire)
+
+        first.start()
+        assert first_writer_started.wait(timeout=5)
+
+        second.start()
+        assert second_writer_finished.wait(timeout=5)
+
+        allow_first_writer.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert sum(acquired for acquired, _ in results) == 1
+
     def test_acquire_scoped_lock_recovers_corrupt_lock_file(self, tmp_path, monkeypatch):
         """Lock file with invalid JSON should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))


### PR DESCRIPTION
## What does this PR do?

Fixes a TOCTOU race in `acquire_scoped_lock()` where two concurrent contenders can both report successful ownership of the same scoped lock.

The race occurs because the first process creates the lock file with `O_CREAT | O_EXCL` and then writes JSON in a separate step. During that window, a second contender can observe the still-empty file, treat it as stale, unlink it, and create its own lock. The first process then finishes writing through its still-open file descriptor and also returns success.

This breaks the scoped-lock invariant and can allow two local gateway processes to use the same external identity concurrently.

The fix records the identity of the file created by the winning `O_EXCL` open and verifies that the path still refers to the same file after writing. Cleanup also only removes the file when it is still the one created by the current contender.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Track the file identity returned by the successful `O_CREAT | O_EXCL` open.
- Prevent exception cleanup from unlinking a replacement lock owned by another contender.
- Verify after writing that the lock path still refers to the originally created file.
- Add a deterministic regression test that reproduces the dual-ownership race.

## How to Test

```bash
pytest tests/gateway/test_status.py::TestScopedLocks::test_acquire_scoped_lock_does_not_allow_dual_ownership_during_initial_write -q
pytest tests/gateway/test_status.py -q -k "acquire_scoped_lock"
```

Results:

- Regression test before fix: failed with `assert 2 == 1`
- Regression test after fix: `1 passed`
- Scoped-lock test group: `9 passed, 86 deselected`

The full `tests/gateway/test_status.py` run had 2 unrelated existing failures in `TestGetProcessStartTime` caused by the live-system guard blocking `p.kill()` under the local WSL environment.

## Checklist

- [x] Branched from `main`
- [x] Single commit
- [x] `git diff --check` passes
- [x] Duplicate PR/issue search completed
- [x] Regression test added

## Screenshots/Logs

```text
Before fix:
E       assert 2 == 1
1 failed

After fix:
1 passed in 0.34s

Scoped-lock tests:
9 passed, 86 deselected in 0.40s
```