### PR TITLE
fix(kanban): count wedged-worker reclaims as failures + measure crash grace from the active run

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3740,6 +3740,31 @@ def release_stale_claims(
                 run_id=run_id,
             )
             reclaimed += 1
+        if heartbeat_stale:
+            # H1 (Audit 2026-07-11): a wedged-but-alive worker (PID up,
+            # heartbeat stale >1h) used to be reclaimed WITHOUT failure
+            # accounting — the same structural wedge respawned forever and
+            # the circuit breaker never tripped (livelock without backoff).
+            # Count it like a crash/timeout so consecutive_failures reaches
+            # failure_limit and the card auto-blocks for a human.
+            _record_task_failure(
+                conn, row["id"],
+                "wedged worker reclaimed: pid alive but heartbeat stale "
+                f">{DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS}s "
+                f"(lock={row['claim_lock']})",
+                outcome="reclaimed",
+                event_payload_extra={
+                    "wedged": True,
+                    "worker_pid": (
+                        int(row["worker_pid"])
+                        if row["worker_pid"] is not None else None
+                    ),
+                    "last_heartbeat_at": (
+                        int(row["last_heartbeat_at"])
+                        if row["last_heartbeat_at"] is not None else None
+                    ),
+                },
+            )
     return reclaimed
 
 
@@ -6382,8 +6407,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+            "SELECT t.id, t.worker_pid, t.claim_lock, t.started_at, "
+            "       r.started_at AS active_started_at "
+            "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+            "WHERE t.status = 'running' AND t.worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
@@ -6393,8 +6420,16 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 continue
             # Skip liveness check inside the launch-window grace period
             # so a freshly-spawned worker isn't reclaimed before its PID
-            # is visible on /proc.
-            started_at = row["started_at"] if "started_at" in row.keys() else None
+            # is visible on /proc. H2 (Audit 2026-07-11): measure from the
+            # ACTIVE run, not ``tasks.started_at`` — that column freezes at
+            # the first-ever claim, so from the first respawn on the grace
+            # was a no-op (exactly the respawn case it exists for).
+            # ``enforce_max_runtime`` does the same for the same reason.
+            started_at = (
+                row["active_started_at"]
+                if row["active_started_at"] is not None
+                else (row["started_at"] if "started_at" in row.keys() else None)
+            )
             if started_at is not None:
                 grace = _resolve_crash_grace_seconds()
                 if time.time() - started_at < grace:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3631,10 +3631,15 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
-        "FROM tasks "
-        "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
+        "SELECT t.id, t.claim_lock, t.worker_pid, t.claim_expires, "
+        "       t.last_heartbeat_at, t.current_run_id, "
+        "       r.task_id AS run_task_id, r.status AS run_status, "
+        "       r.ended_at AS run_ended_at, r.claim_lock AS run_claim_lock, "
+        "       r.worker_pid AS run_worker_pid "
+        "FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' AND t.claim_expires IS NOT NULL "
+        "  AND t.claim_expires < ?",
         (now,),
     ).fetchall()
     for row in stale:
@@ -3649,10 +3654,31 @@ def release_stale_claims(
             hb is not None
             and (now - int(hb)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
         )
+        raw_pid = row["worker_pid"]
+        pid = raw_pid if type(raw_pid) is int and raw_pid > 0 else None
+        pid_alive = False
+        if pid is not None:
+            try:
+                pid_alive = bool(_pid_alive(pid))
+            except (OSError, TypeError, ValueError):
+                # Process-table lookup failures are unknown, never proof that
+                # this claim represents a live wedged worker.
+                pid_alive = False
+        active_run_owned = (
+            row["current_run_id"] is not None
+            and row["run_task_id"] == row["id"]
+            and row["run_status"] == "running"
+            and row["run_ended_at"] is None
+            and row["run_claim_lock"] == row["claim_lock"]
+            and row["run_worker_pid"] == pid
+        )
+        confirmed_live_wedge = (
+            heartbeat_stale and host_local and active_run_owned and pid_alive
+        )
         if (
             host_local
-            and row["worker_pid"]
-            and _pid_alive(row["worker_pid"])
+            and pid is not None
+            and pid_alive
             and not heartbeat_stale
         ):
             new_expires = now + _resolve_claim_ttl_seconds()
@@ -3677,7 +3703,7 @@ def release_stale_claims(
                     conn, row["id"], "claim_extended",
                     {
                         "reason": "pid_alive",
-                        "worker_pid": int(row["worker_pid"]),
+                        "worker_pid": pid,
                         "claim_lock": row["claim_lock"],
                         "claim_expires_was": int(row["claim_expires"]),
                         "claim_expires_now": new_expires,
@@ -3692,7 +3718,7 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            pid, row["claim_lock"], signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -3703,12 +3729,42 @@ def release_stale_claims(
             )
             continue
         with write_txn(conn):
+            if confirmed_live_wedge:
+                # Revalidate the active-run binding after termination and
+                # under the write lock. A respawn or ownership change in the
+                # classification/termination window must not inherit this
+                # wedge failure.
+                owner = conn.execute(
+                    "SELECT t.status, t.claim_lock, t.worker_pid, "
+                    "       t.current_run_id, r.task_id, r.status AS run_status, "
+                    "       r.ended_at, r.claim_lock AS run_claim_lock, "
+                    "       r.worker_pid AS run_worker_pid "
+                    "FROM tasks t LEFT JOIN task_runs r "
+                    "  ON r.id = t.current_run_id WHERE t.id = ?",
+                    (row["id"],),
+                ).fetchone()
+                confirmed_live_wedge = bool(
+                    owner is not None
+                    and owner["status"] == "running"
+                    and owner["claim_lock"] == row["claim_lock"]
+                    and owner["worker_pid"] == raw_pid
+                    and owner["current_run_id"] == row["current_run_id"]
+                    and owner["task_id"] == row["id"]
+                    and owner["run_status"] == "running"
+                    and owner["ended_at"] is None
+                    and owner["run_claim_lock"] == row["claim_lock"]
+                    and owner["run_worker_pid"] == pid
+                )
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
-                "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                "AND claim_expires IS NOT NULL AND claim_expires < ? "
+                "AND current_run_id IS ? AND worker_pid IS ?",
+                (
+                    row["id"], row["claim_lock"], now,
+                    row["current_run_id"], raw_pid,
+                ),
             )
             if cur.rowcount != 1:
                 continue
@@ -3721,8 +3777,7 @@ def release_stale_claims(
             payload = {
                 "stale_lock": row["claim_lock"],
                 "worker_pid": (
-                    int(row["worker_pid"])
-                    if row["worker_pid"] is not None else None
+                    pid
                 ),
                 "claim_expires": int(row["claim_expires"]),
                 "last_heartbeat_at": (
@@ -3739,32 +3794,28 @@ def release_stale_claims(
                 payload,
                 run_id=run_id,
             )
+            if confirmed_live_wedge:
+                # This call joins the surrounding reclaim transaction so a
+                # persistence failure cannot release the claim without also
+                # recording the confirmed wedge (or vice versa).
+                _record_task_failure(
+                    conn, row["id"],
+                    "wedged worker reclaimed: live host-local active-run PID "
+                    "with heartbeat stale "
+                    f">{DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS}s "
+                    f"(lock={row['claim_lock']})",
+                    outcome="reclaimed",
+                    event_payload_extra={
+                        "wedged": True,
+                        "worker_pid": pid,
+                        "last_heartbeat_at": (
+                            int(row["last_heartbeat_at"])
+                            if row["last_heartbeat_at"] is not None else None
+                        ),
+                    },
+                    _in_transaction=True,
+                )
             reclaimed += 1
-        if heartbeat_stale:
-            # H1 (Audit 2026-07-11): a wedged-but-alive worker (PID up,
-            # heartbeat stale >1h) used to be reclaimed WITHOUT failure
-            # accounting — the same structural wedge respawned forever and
-            # the circuit breaker never tripped (livelock without backoff).
-            # Count it like a crash/timeout so consecutive_failures reaches
-            # failure_limit and the card auto-blocks for a human.
-            _record_task_failure(
-                conn, row["id"],
-                "wedged worker reclaimed: pid alive but heartbeat stale "
-                f">{DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS}s "
-                f"(lock={row['claim_lock']})",
-                outcome="reclaimed",
-                event_payload_extra={
-                    "wedged": True,
-                    "worker_pid": (
-                        int(row["worker_pid"])
-                        if row["worker_pid"] is not None else None
-                    ),
-                    "last_heartbeat_at": (
-                        int(row["last_heartbeat_at"])
-                        if row["last_heartbeat_at"] is not None else None
-                    ),
-                },
-            )
     return reclaimed
 
 
@@ -6585,6 +6636,7 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    _in_transaction: bool = False,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -6610,6 +6662,9 @@ def _record_task_failure(
       counter; if the breaker trips, the task is re-transitioned
       ``ready → blocked`` and a ``gave_up`` event is emitted.
 
+    ``_in_transaction=True`` is for reclaim paths that already hold a
+    ``write_txn`` and need release plus accounting to commit atomically.
+
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
     context (e.g. pid on crash, elapsed on timeout).
@@ -6623,7 +6678,8 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
-    with write_txn(conn):
+    transaction = contextlib.nullcontext(conn) if _in_transaction else write_txn(conn)
+    with transaction:
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries "
             "FROM tasks WHERE id = ?", (task_id,),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4790,3 +4790,119 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Audit 2026-07-11 H1/H2: wedged-worker respawn brake + per-run crash grace
+# ---------------------------------------------------------------------------
+
+def _wedge_and_reclaim(conn, monkeypatch, t):
+    """Make task t look wedged (pid alive, heartbeat stale >1h, TTL expired)
+    and run release_stale_claims with a successful termination stub."""
+    import hermes_cli.kanban_db as _kb
+    kb._set_worker_pid(conn, t, 12345)
+    conn.execute(
+        "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
+        (int(time.time()) - 60, int(time.time()) - 7200, t),
+    )
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        _kb, "_terminate_reclaimed_worker",
+        lambda *a, **k: {
+            "termination_attempted": True,
+            "host_local": True,
+            "terminated": True,
+        },
+    )
+    return kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+
+
+def test_wedged_reclaim_counts_as_failure(kanban_home, monkeypatch):
+    """H1: a wedged-but-alive worker (pid up, heartbeat stale >1h) that gets
+    reclaimed must increment the failure counter — before the fix the same
+    structural wedge respawned forever and the circuit breaker never tripped."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="wedges forever", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        reclaimed = _wedge_and_reclaim(conn, monkeypatch, t)
+        assert reclaimed == 1
+        row = conn.execute(
+            "SELECT status, consecutive_failures FROM tasks WHERE id = ?", (t,),
+        ).fetchone()
+        assert row["consecutive_failures"] == 1
+        assert row["status"] == "ready"  # first wedge: retry allowed
+
+
+def test_wedged_reclaim_trips_circuit_breaker(kanban_home, monkeypatch):
+    """H1: repeated wedge-reclaims must eventually auto-block (gave_up),
+    not respawn unboundedly."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="wedges forever", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        for _ in range(kb.DEFAULT_FAILURE_LIMIT):
+            claimed = kb.claim_task(conn, t, claimer=f"{host}:worker")
+            assert claimed is not None
+            assert _wedge_and_reclaim(conn, monkeypatch, t) == 1
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked"
+        kinds = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            ).fetchall()
+        ]
+        assert "gave_up" in kinds
+
+
+def test_ttl_reclaim_of_dead_pid_does_not_count_failure(kanban_home, monkeypatch):
+    """Scope guard for H1: an ordinary TTL reclaim of a DEAD worker keeps its
+    existing semantics (no failure accounting here — the crash path owns that)."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="died quietly", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 60, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        assert kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None) == 1
+        row = conn.execute(
+            "SELECT status, consecutive_failures FROM tasks WHERE id = ?", (t,),
+        ).fetchone()
+        assert row["status"] == "ready"
+        assert (row["consecutive_failures"] or 0) == 0
+
+
+def test_crash_grace_measured_from_active_run(kanban_home, monkeypatch):
+    """H2: the launch-window crash grace must be measured from the ACTIVE
+    run, not tasks.started_at (frozen at the first-ever claim) — otherwise
+    the grace is a no-op from the first respawn on, exactly the case it
+    exists for."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "3600")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="respawned", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        # First claim happened long ago (tasks.started_at is frozen there) …
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        conn.execute(
+            "UPDATE tasks SET started_at = ? WHERE id = ?",
+            (int(time.time()) - 7200, t),
+        )
+        # … the ACTIVE run however started just now (fresh respawn).
+        kb._set_worker_pid(conn, t, 999999)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        crashed = kb.detect_crashed_workers(conn)
+        # Fresh respawn is inside the grace window → NOT reclaimed as crashed.
+        assert crashed == []
+        assert kb.get_task(conn, t).status == "running"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4797,16 +4797,15 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
 # Audit 2026-07-11 H1/H2: wedged-worker respawn brake + per-run crash grace
 # ---------------------------------------------------------------------------
 
-def _wedge_and_reclaim(conn, monkeypatch, t):
-    """Make task t look wedged (pid alive, heartbeat stale >1h, TTL expired)
-    and run release_stale_claims with a successful termination stub."""
+def _wedge_and_reclaim(conn, monkeypatch, t, *, pid_alive=True):
+    """Expire a stale-heartbeat claim and run a successful reclaim."""
     import hermes_cli.kanban_db as _kb
     kb._set_worker_pid(conn, t, 12345)
     conn.execute(
         "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
         (int(time.time()) - 60, int(time.time()) - 7200, t),
     )
-    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: pid_alive)
     monkeypatch.setattr(
         _kb, "_terminate_reclaimed_worker",
         lambda *a, **k: {
@@ -4868,18 +4867,235 @@ def test_ttl_reclaim_of_dead_pid_does_not_count_failure(kanban_home, monkeypatch
         t = kb.create_task(conn, title="died quietly", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
         kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kb._set_worker_pid(conn, t, 12345)
-        conn.execute(
-            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
-            (int(time.time()) - 60, t),
-        )
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
-        assert kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None) == 1
+        assert _wedge_and_reclaim(
+            conn, monkeypatch, t, pid_alive=False,
+        ) == 1
         row = conn.execute(
             "SELECT status, consecutive_failures FROM tasks WHERE id = ?", (t,),
         ).fetchone()
         assert row["status"] == "ready"
         assert (row["consecutive_failures"] or 0) == 0
+
+
+@pytest.mark.parametrize("pid", [None, "not-a-pid"])
+def test_wedged_reclaim_without_valid_pid_does_not_count_failure(
+    kanban_home, monkeypatch, pid,
+):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="unconfirmed wedge", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET worker_pid = ?, claim_expires = ?, "
+            "last_heartbeat_at = ? WHERE id = ?",
+            (pid, now - 60, now - 7200, t),
+        )
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ? WHERE id = "
+            "(SELECT current_run_id FROM tasks WHERE id = ?)",
+            (pid, t),
+        )
+        monkeypatch.setattr(
+            _kb, "_terminate_reclaimed_worker",
+            lambda *a, **k: {
+                "termination_attempted": False,
+                "host_local": True,
+                "terminated": False,
+            },
+        )
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 1
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+
+
+def test_wedged_reclaim_of_non_local_pid_does_not_count_failure(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="foreign claim", assignee="a")
+        kb.claim_task(conn, t, claimer="other-host:worker")
+        assert _wedge_and_reclaim(conn, monkeypatch, t) == 1
+        assert kb.get_task(conn, t).consecutive_failures == 0
+
+
+def test_wedged_reclaim_with_pid_lookup_error_does_not_count_failure(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="unknown pid state", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, t),
+        )
+
+        def _lookup_failed(_pid):
+            raise OSError("process table unavailable")
+
+        monkeypatch.setattr(_kb, "_pid_alive", _lookup_failed)
+        monkeypatch.setattr(
+            _kb, "_terminate_reclaimed_worker",
+            lambda *a, **k: {
+                "termination_attempted": False,
+                "host_local": True,
+                "terminated": False,
+            },
+        )
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 1
+        assert kb.get_task(conn, t).consecutive_failures == 0
+
+
+def test_wedged_reclaim_requires_active_run_pid_ownership(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="mismatched run", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, t),
+        )
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = 54321 WHERE id = "
+            "(SELECT current_run_id FROM tasks WHERE id = ?)",
+            (t,),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_terminate_reclaimed_worker",
+            lambda *a, **k: {
+                "termination_attempted": True,
+                "host_local": True,
+                "terminated": True,
+            },
+        )
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 1
+        assert kb.get_task(conn, t).consecutive_failures == 0
+
+
+def test_wedged_reclaim_revalidates_run_ownership_after_termination(
+    kanban_home, monkeypatch,
+):
+    """A PID/run change in the termination window cannot inherit the wedge."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="ownership race", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        def _ownership_changed(*_args, **_kwargs):
+            conn.execute(
+                "UPDATE task_runs SET worker_pid = 54321 WHERE id = "
+                "(SELECT current_run_id FROM tasks WHERE id = ?)",
+                (t,),
+            )
+            return {
+                "termination_attempted": True,
+                "host_local": True,
+                "terminated": True,
+            }
+
+        monkeypatch.setattr(_kb, "_terminate_reclaimed_worker", _ownership_changed)
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 1
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+
+
+def test_wedged_reclaim_is_idempotent(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="one wedge", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        assert _wedge_and_reclaim(conn, monkeypatch, t) == 1
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 0
+        assert kb.get_task(conn, t).consecutive_failures == 1
+
+
+def test_wedged_reclaim_accounting_failure_rolls_back_release(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="atomic wedge", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, t),
+        )
+        before = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "consecutive_failures, current_run_id FROM tasks WHERE id = ?",
+            (t,),
+        ).fetchone()
+        event_count_before = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ?", (t,),
+        ).fetchone()[0]
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_terminate_reclaimed_worker",
+            lambda *a, **k: {
+                "termination_attempted": True,
+                "host_local": True,
+                "terminated": True,
+            },
+        )
+        monkeypatch.setattr(
+            _kb, "_record_task_failure",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("injected")),
+        )
+        with pytest.raises(RuntimeError, match="injected"):
+            kb.release_stale_claims(conn, signal_fn=lambda *_: None)
+        after = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "consecutive_failures, current_run_id FROM tasks WHERE id = ?",
+            (t,),
+        ).fetchone()
+        assert tuple(after) == tuple(before)
+        run = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (before["current_run_id"],),
+        ).fetchone()
+        assert tuple(run) == ("running", None, None)
+        event_count_after = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ?", (t,),
+        ).fetchone()[0]
+        assert event_count_after == event_count_before
 
 
 def test_crash_grace_measured_from_active_run(kanban_home, monkeypatch):


### PR DESCRIPTION
## Summary
Two related dispatcher-liveness fixes:

1. **Wedged-worker livelock:** `release_stale_claims` reclaims a wedged-but-alive worker (PID up, heartbeat stale beyond `DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS`) without recording a task failure. The same structural wedge therefore respawns unboundedly and the `consecutive_failures` circuit breaker never trips — a livelock with no backoff. The heartbeat-stale reclaim now funnels through `_record_task_failure(outcome="reclaimed")`; after `failure_limit` consecutive wedges the card auto-blocks (`gave_up`). Ordinary TTL reclaims of dead PIDs keep their existing semantics (the crash path owns their accounting).

2. **Launch grace frozen at first claim:** `detect_crashed_workers` measured its launch-window crash grace from `tasks.started_at`, which freezes at the FIRST-ever claim — so from the first respawn on, the grace was a no-op, which is exactly the respawn case it exists for. It now measures from the active run's `started_at` (the same approach `enforce_max_runtime` already uses, for the same reason).

## Why
Both found in a production audit: a worker wedged in a logic loop was reclaimed and respawned every hour for an unbounded number of rounds without ever tripping the breaker; and freshly respawned workers could be misclassified as crashed inside their launch window because their grace had expired days earlier.

## Validation
```
python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
# 397 passed (upstream main + this patch)

python -m pytest tests/hermes_cli/test_kanban_db.py -k "wedged or crash_grace or dead_pid"
# 5 new regression tests
```

## Notes
The reclaim-side failure accounting only fires on the heartbeat-stale branch; a scope-guard test (`test_ttl_reclaim_of_dead_pid_does_not_count_failure`) pins that ordinary TTL reclaims of dead workers stay failure-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)