### PR TITLE
fix(pricing): update DeepSeek Jul 2026 rates + add v4-flash

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -452,9 +452,21 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.14"),
         output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07-10",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-07-10",
     ),
     (
         "deepseek",
@@ -470,12 +482,12 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07-10",
     ),
     # Google Gemini
     (

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -233,9 +233,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -248,8 +248,37 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Ensure deepseek-v4-flash (newly added) has pricing data."""
+    entry = lookup_pricing_for_model(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_deepseek_v4_flash_estimate_usage_cost():
+    """Ensure deepseek-v4-flash sessions get a dollar estimate, not unknown."""
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():


### PR DESCRIPTION
## Summary

DeepSeek published pricing updates effective July 2026 (confirmed via [official pricing page](https://api-docs.deepseek.com/quick_start/pricing)). This PR updates the pricing table and test coverage:

**Pricing updates:**
- `deepseek-chat`: add missing `cache_read_cost_per_million` ($0.0028/M tokens) — previously billed cache reads at input rate
- `deepseek-v4-flash`: new model, add missing pricing entry (same rates as deepseek-chat)
- `deepseek-v4-pro`: reflect ~75% price cut effective Jul 2026:
  - Input: $1.74 → $0.435/M
  - Output: $3.48 → $0.87/M
  - Cache reads: $0.0145 → $0.003625/M

**Test updates:**
- Fix assertions in `test_deepseek_v4_pro_pricing_entry_exists()` and `test_deepseek_v4_pro_estimate_usage_cost()` to match new pricing
- Add regression tests for new v4-flash entry: `test_deepseek_v4_flash_pricing_entry_exists()` and `test_deepseek_v4_flash_estimate_usage_cost()`

## Relationship to #61878

This PR is orthogonal to #61878 (cache extraction fix). #61878 patches `extract_cache_stats()` to read DeepSeek's top-level `prompt_cache_hit_tokens` field; this PR ensures the pricing table is accurate once that extraction reaches the accounting path. Both are needed for correct direct-DeepSeek cost estimation.

## Test plan

- [ ] Run pricing tests: `pytest tests/agent/test_usage_pricing.py -k deepseek -v`
- [ ] Verify v4-pro pricing is no longer the highest-cost DeepSeek model
- [ ] Confirm v4-flash can be requested and priced