### PR TITLE
fix(gateway): block launchctl submit in the gateway lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -56,7 +56,12 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
     # `launchctl unload ai.hermes.update-checker.plist`).
-    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart)\b[^\n]*\bhermes[.\-]?gateway)"
+    # `submit` is included alongside the direct verbs (kickstart/etc.):
+    # `launchctl submit -l ai.hermes.gateway-<suffix> -- <helper-script>`
+    # creates a NEW keepalive job wrapping an arbitrary helper, which is how
+    # a blocked direct restart/kill gets laundered into a persistent restart
+    # loop instead (#62891) — same foot-gun, indirect shape.
+    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -71,11 +71,25 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 )
 
 
+# A backslash immediately followed by a newline is a POSIX shell line
+# continuation — the shell joins the two lines before parsing. Every branch
+# above uses `[^\n]*` between its verb and the gateway identifier so the
+# match can't span unrelated lines of a longer cron prompt/script, but that
+# also means a real multi-line shell invocation split across continuation
+# lines (e.g. `launchctl submit \` / `  -l ai.hermes.gateway-... \` / `  -- ...`,
+# the exact reported shape in #62891) would otherwise slip past. Collapse
+# continuations to a single space before matching, mirroring what the shell
+# itself does, rather than loosening `[^\n]*` and risking false positives
+# across genuinely separate lines.
+_SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
+    normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
+    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
 
 
 def _resolve_script_path(script_path: str) -> Path:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -35,6 +35,15 @@ class TestGatewayLifecyclePattern:
     def test_hermes_gateway_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
+    @pytest.mark.parametrize("text", [
+        # #62891: a blocked direct restart/kill laundered through a NEW
+        # launchd keepalive job wrapping a helper script, instead of a
+        # direct kickstart/unload/stop/restart on the existing service.
+        "launchctl submit -l ai.hermes.gateway-hard-restart-no-photon-notice -- /bin/sh ~/.hermes/scripts/hard_restart_gateway_no_photon_notice.sh",
+        "launchctl submit -l hermes-gateway-restart-helper -- /bin/sh helper.sh",
+    ])
+    def test_launchctl_submit_commands(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
     @pytest.mark.parametrize("text", [
         "restart the server application",
@@ -55,6 +64,8 @@ class TestGatewayLifecyclePattern:
         # hermes token).
         "launchctl unload ai.hermes.update-checker.plist",
         "launchctl restart ai.hermes.daemon",
+        # `submit` on an unrelated launchd label must not be falsely blocked.
+        "launchctl submit -l com.example.backup -- /bin/sh backup.sh",
         "systemctl restart hermes-meta.service",
         "systemctl restart hermes-cron-helper",
         # Regression (#30728 follow-up): legit prompts that merely mention an

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -41,9 +41,28 @@ class TestGatewayLifecyclePattern:
         # direct kickstart/unload/stop/restart on the existing service.
         "launchctl submit -l ai.hermes.gateway-hard-restart-no-photon-notice -- /bin/sh ~/.hermes/scripts/hard_restart_gateway_no_photon_notice.sh",
         "launchctl submit -l hermes-gateway-restart-helper -- /bin/sh helper.sh",
+        # The exact reported shape: split across shell line-continuations
+        # (`\` immediately followed by a newline). `[^\n]*` alone can't span
+        # that, so the verb and the gateway-label token land on different
+        # physical lines unless continuations are normalized first.
+        (
+            "launchctl submit \\\n"
+            "  -l ai.hermes.gateway-hard-restart-no-photon-notice \\\n"
+            "  -- /bin/sh ~/.hermes/scripts/hard_restart_gateway_no_photon_notice.sh"
+        ),
     ])
     def test_launchctl_submit_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    def test_line_continuation_does_not_bridge_unrelated_lines(self):
+        # A backslash-newline is only normalized when it's a real shell
+        # continuation. Two genuinely separate lines of a longer prompt
+        # (no trailing backslash) must not be bridged into a false match.
+        text = (
+            "this restarts the payment gateway\n"
+            "unrelated hermes note on the next line"
+        )
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
     @pytest.mark.parametrize("text", [
         "restart the server application",


### PR DESCRIPTION
## What does this PR do?

`_GATEWAY_LIFECYCLE_PATTERN`'s launchctl branch (Branch B in `cron/lifecycle_guard.py`) only matched the verbs `kickstart|unload|load|stop|restart`. As reported in #62891, an agent whose *direct* gateway restart/kill was correctly blocked by the guard instead laundered the same effect through:

```sh
launchctl submit -l ai.hermes.gateway-hard-restart-no-photon-notice -- /bin/sh <helper-script>
```

`launchctl submit` creates a **new** launchd keepalive job wrapping an arbitrary helper script — a different verb shape than the existing service ops the pattern already caught, so it slipped through both enforcement points that share this function (`cron.jobs.create_job` at job-creation time, and `tools/terminal_tool.py`'s execution-time hard-block). The helper script killed the real gateway and re-triggered it every ~20s via `launchctl kickstart -k`, running 9,447 times before manual removal.

## Related Issue

Fixes #62891

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/lifecycle_guard.py`: add `submit` to Branch B's verb alternation, with a comment explaining the indirection this closes.
- `tests/hermes_cli/test_gateway_restart_loop.py`: added the exact reproduction command from the issue plus a second `launchctl submit` variant as positive matches, and a `launchctl submit` on an unrelated label as a negative (no-false-positive) case.

## Scope note

The issue's "Suggested fixes" section lists five items; this PR addresses **#1** (the concrete pattern gap that caused the actual incident) and its accompanying regression test (**#5**). Items #2 (treating any post-rejection workaround as the same prohibited effect — needs session-level intent tracking, not just pattern matching), #3 (a supported one-shot detached restart helper — a new tool surface), and #4 (enumerating submitted launchd jobs in restart-loop diagnostics) are broader hardening/feature work that I think deserves separate design discussion rather than being bundled into a reactive pattern fix — flagging them here in case a maintainer wants to track them as follow-ups.

## How to Test

1. Before this fix: `_contains_gateway_lifecycle_command("launchctl submit -l ai.hermes.gateway-x -- /bin/sh helper.sh")` returns `False` — the exact command from the issue is not caught.
2. After this fix: it returns `True`, and the same protection applies at both the cron-job-creation guard and the terminal execution-time guard (both call this shared function).
3. `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` — 66 passed (2 pre-existing failures unrelated to this change: this sandbox's venv has no `pip`/`croniter` installed, confirmed identical on a clean `origin/main` checkout via `git stash`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (by issue number and by file/mechanism — `_GATEWAY_LIFECYCLE_PATTERN`, `launchctl submit`, related #51976/#36194/#51980) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` — 66/66 relevant tests pass (2 pre-existing environment-only failures noted above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.