### PR TITLE
fix(config): clear stale model.api_key from config.yaml when env var is updated

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6088,11 +6088,76 @@ async def get_env_vars(profile: Optional[str] = None):
     return result
 
 
+def _is_provider_api_key_env(key: str) -> bool:
+    """Return True when *key* looks like a provider credential env var.
+
+    Covers canonical ``*_API_KEY`` names plus legacy/ad-hoc names such as
+    ``ANTHROPIC_TOKEN`` and ``AZURE_ANTHROPIC_KEY``.  When the user
+    explicitly updates one of these env vars via the Settings UI the stale
+    inline ``model.api_key`` in config.yaml must be evicted — otherwise an
+    old key left behind by an earlier ``POST /api/model/set`` call still
+    takes priority over the fresh env-var value at resolution time.
+    """
+    if not isinstance(key, str) or not key.strip():
+        return False
+    k = key.strip()
+    # The canonical pattern: <VENDOR>_API_KEY
+    if k.endswith("_API_KEY"):
+        return True
+    # Legacy / ad-hoc names that do not follow the **_**API_KEY convention.
+    _ADDITIONAL_CREDENTIAL_KEYS = frozenset({
+        "ANTHROPIC_TOKEN",
+        "AZURE_ANTHROPIC_KEY",
+        "HF_TOKEN",
+    })
+    return k in _ADDITIONAL_CREDENTIAL_KEYS
+
+
+def _clear_stale_model_api_key() -> None:
+    """Remove inline ``model.api_key`` from config.yaml if present.
+
+    An inline key left behind by ``POST /api/model/set`` takes priority
+    over env vars in the runtime resolver (see ``runtime_provider.py``,
+    ``_resolve_api_key_for_endpoint``).  When the user explicitly updates a
+    provider credential via the Settings / Env UI we must evict the stale
+    inline copy so the new env-var value is actually used.
+    """
+    try:
+        config_path = get_config_path()
+        if not config_path.exists():
+            return
+        config = read_raw_config()
+        if not isinstance(config, dict):
+            return
+        model_cfg = config.get("model")
+        if not isinstance(model_cfg, dict):
+            return
+        if not model_cfg.get("api_key"):
+            return  # nothing to clear
+        clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
+        config["model"] = model_cfg
+        save_config(config)
+        _log.debug(
+            "Cleared stale model.api_key from config.yaml after env-var update"
+        )
+    except Exception:
+        _log.warning(
+            "Failed to clear stale model.api_key from config.yaml",
+            exc_info=True,
+        )
+
+
 @app.put("/api/env")
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
             save_env_value(body.key, body.value)
+        # When the user updates a provider API key env var, evict any stale
+        # inline model.api_key from config.yaml that an earlier model-setup
+        # step may have left behind.  This ensures the new env-var value is
+        # actually resolved at runtime.
+        if _is_provider_api_key_env(body.key):
+            _clear_stale_model_api_key()
         return {"ok": True, "key": body.key}
     except ValueError as exc:
         # save_env_value raises ValueError for invalid names and for keys
@@ -13748,6 +13813,12 @@ async def save_toolset_env(name: str, body: ToolsetEnvUpdate, profile: Optional[
                 saved.append(key)
             else:
                 skipped.append(key)
+
+        # If any of the saved keys is a provider credential, also evict the
+        # stale inline model.api_key from config.yaml (see _clear_stale_model_api_key
+        # for rationale).
+        if any(_is_provider_api_key_env(k) for k in saved):
+            _clear_stale_model_api_key()
 
         status = {k: bool(get_env_value(k)) for k in allowed}
     return {"ok": True, "name": name, "saved": saved, "skipped": skipped, "is_set": status}


### PR DESCRIPTION
## Description

When a user updates a provider API key via the Settings/Env UI (`PUT /api/env` or `PUT /api/tools/toolsets/{name}/env`), only `~/.hermes/.env` was being updated. Any stale inline `model.api_key` left behind in `config.yaml` by an earlier `POST /api/model/set` call was **not cleared**, and the runtime resolver (`runtime_provider.py`) gives the inline key priority over env vars. This meant the old key continued to be used, causing **silent HTTP 401 authentication failures** even though the UI showed the new key.

## Changes

1. **`_is_provider_api_key_env(key)`** — identifies env-var names that look like provider credentials (all `*_API_KEY` vars plus legacy names such as `ANTHROPIC_TOKEN`, `AZURE_ANTHROPIC_KEY`, `HF_TOKEN`).

2. **`_clear_stale_model_api_key()`** — loads `config.yaml`, removes `model.api_key` if present, and saves. Best-effort: logs a warning on failure but never crashes the request.

3. **Both `PUT /api/env` and `PUT /api/tools/toolsets/{name}/env`** now call these helpers after successfully saving any provider credential env var.

## Why this approach

- **Minimal**: no changes to the runtime resolution order, no breaking changes to multi-profile inline-key storage.
- **Conservative**: only evicts `model.api_key` when the user *explicitly* updates a provider credential via the UI — normal model config via `POST /api/model/set` continues to work as before.
- **Safe**: the helper is best-effort with a try/except wrapper; a failure to read/write config.yaml just logs a warning and never breaks the env-var save.

Fixes #62269