### PR TITLE
fix(gateway): use code-point budget for fallback chunk split boundary

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -974,8 +974,8 @@ class GatewayStreamConsumer:
         while len_fn(remaining) > limit:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
             split_at = remaining.rfind("\n", 0, _cp_budget)
-            if split_at < limit // 2:
-                split_at = limit
+            if split_at < _cp_budget // 2:
+                split_at = _cp_budget
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -2363,3 +2363,35 @@ class TestStripOrphanCloseTags:
             assert tag not in consumer._accumulated
         assert "trailing prose" in consumer._accumulated
         assert "more" in consumer._accumulated
+
+
+# ── UTF-16 chunk-split regression ────────────────────────────────────────
+
+
+class TestSplitTextChunksUtf16:
+    """Regression: _split_text_chunks must respect a UTF-16 code-unit limit.
+
+    Emoji (U+1F600 and similar) encode as two UTF-16 code units (surrogate
+    pairs) but count as a single Python character.  A naive ``len()``-based
+    split therefore underestimates the encoded size and can produce chunks
+    that exceed the platform limit.  The fix (071ba19) passes a ``len_fn``
+    that counts UTF-16 code units, and this test pins that contract.
+    """
+
+    def test_emoji_chunks_respect_utf16_limit(self):
+        from gateway.platforms.base import utf16_len
+
+        text = "😀" * 100  # 100 emoji × 2 UTF-16 units = 200 UTF-16 code units
+        limit = 50  # UTF-16 code-unit budget per chunk
+
+        chunks = GatewayStreamConsumer._split_text_chunks(text, limit, len_fn=utf16_len)
+
+        for chunk in chunks:
+            assert utf16_len(chunk) <= limit, (
+                f"Chunk exceeds UTF-16 limit ({limit}): "
+                f"utf16_len={utf16_len(chunk)!r}, chunk={chunk!r}"
+            )
+
+        assert "".join(chunks) == text, (
+            "Reassembled chunks do not equal the original input"
+        )


### PR DESCRIPTION
## What does this PR do?
`_split_text_chunks()` correctly calculates `_cp_budget` (code-point boundary) via `_custom_unit_to_cp()` for adapters using custom length functions (e.g. UTF-16 unit counters). However, the fallback path when no suitable newline is found was using `limit` (raw platform units) instead of `_cp_budget` (code points) as the split boundary.

For adapters measuring UTF-16 units, emoji and other astral-plane characters count as 2 units each, so slicing at `limit` instead of `_cp_budget` can produce chunks that substantially exceed `MAX_MESSAGE_LENGTH` and fail delivery.

This PR fixes both the split boundary and the too-short newline guard to consistently use `_cp_budget`.

## Related Issue
None

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/stream_consumer.py` L977-978: changed `split_at < limit // 2` → `split_at < _cp_budget // 2` and `split_at = limit` → `split_at = _cp_budget` in `_split_text_chunks()`

## How to Test
1. Configure a UTF-16 length adapter (e.g. Telegram)
2. Send a message containing emoji-heavy text that exceeds the platform limit
3. Confirm all returned chunks satisfy `len_fn(chunk) <= limit`

## Checklist
- [x] I have read the Contributing Guide
- [x] Commit messages follow Conventional Commits format
- [x] I have checked for duplicate PRs
- [x] This PR is scoped to a single fix
- [x] `pytest tests/ -q` passed
- [x] Platform: Windows 11 + WSL2 Ubuntu

### Documentation & Housekeeping
- README/docs update: N/A
- cli-config.yaml.example: N/A
- CONTRIBUTING.md/AGENTS.md: N/A
- Cross-platform impact: N/A
- Tool description/schema: N/A

## Screenshots / Logs
N/A