### PR TITLE
fix(61964): Bug: pet CLI animation floods stdout, causing Docker log to grow ~4GB/

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -213,6 +213,11 @@ export function writeDiffToTerminal(
   skipSyncMarkers = false,
   onDrain?: () => void
 ): { bytes: number; backpressure: boolean } {
+  // Suppress output when stdout is not a terminal (e.g., inside a Docker container)
+  if (!terminal.stdout.isTTY) {
+    return { bytes: 0, backpressure: false }
+  }
+
   // No output if there are no patches
   if (diff.length === 0) {
     return { bytes: 0, backpressure: false }


### PR DESCRIPTION
Fixes #61964

## Changes

```
ui-tui/packages/hermes-ink/src/ink/terminal.ts | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```

Auto-generated by Hermes Harness — reviewed by AI gate before submission.