### PR TITLE
fix(docker): remove --link flag from COPY to support Podman/Buildah builds (#62849)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,13 +193,12 @@ RUN cd web && npm run build && \
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.
-# --link decouples this layer from parents for cache purposes; --chmod bakes
-# the final read-only permissions at copy time so we skip the separate
+# `--chmod` bakes the final read-only permissions at copy time so we skip the separate
 # `chmod -R` pass that previously walked ~30k files across the venv +
 # node_modules + source (21s amd64 / 222s arm64 — #49113).  `a+rX,go-w`
 # gives the non-root hermes user read + traverse but no write; root retains
 # write so the build steps below don't need chmod u+w dances.
-COPY --link --chmod=a+rX,go-w . .
+COPY --chmod=a+rX,go-w . .
 
 # ---------- Permissions ----------
 # Link hermes-agent itself (editable). Deps are already installed in the

--- a/tests/tools/test_dockerfile_immutable_install.py
+++ b/tests/tools/test_dockerfile_immutable_install.py
@@ -17,7 +17,7 @@ def test_dockerfile_makes_opt_hermes_readonly_for_hermes_user() -> None:
 
     # --chmod on the source COPY bakes read-only perms at copy time instead
     # of a separate chmod -R pass (which walked ~30k files — #49113).
-    assert "COPY --link --chmod=a+rX,go-w . ." in text
+    assert "COPY --chmod=a+rX,go-w . ." in text
     # The old tree-walking passes must not be present.
     assert "chown -R root:root /opt/hermes" not in text
     assert "chmod -R a+rX /opt/hermes" not in text


### PR DESCRIPTION
## Summary
`COPY --link --chmod=...` uses the `--link` flag which is unsupported by Podman/Buildah. Linux users on Fedora, RHEL, NixOS, and rootless setups cannot build the Docker image.

## Change
Removed `--link` from the COPY command. The build works identically on Docker (BuildKit) and now also on Podman. Updated the stale comment that described `--link` behavior and the test assertion that matched the old line.

## Verification
All 6 dockerfile tests pass.