### PR TITLE
feat(whatsapp-cloud): migrate built-in adapter to plugin registry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8707,19 +8707,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Platform registry lookup for '%s' failed: %s", platform.value, e)
         # Fall through to built-in adapters below
 
-        if platform == Platform.WHATSAPP_CLOUD:
-            from gateway.platforms.whatsapp_cloud import (
-                WhatsAppCloudAdapter,
-                check_whatsapp_cloud_requirements,
-            )
-            if not check_whatsapp_cloud_requirements():
-                logger.warning(
-                    "WhatsApp Cloud: aiohttp/httpx missing — reinstall hermes-agent"
-                )
-                return None
-            return WhatsAppCloudAdapter(config)
-        
-        elif platform == Platform.SIGNAL:
+        if platform == Platform.SIGNAL:
             from gateway.platforms.signal import SignalAdapter, check_signal_requirements
             if not check_signal_requirements():
                 logger.warning("Signal: SIGNAL_HTTP_URL or SIGNAL_ACCOUNT not configured")

--- a/plugins/platforms/whatsapp_cloud/__init__.py
+++ b/plugins/platforms/whatsapp_cloud/__init__.py
@@ -1,0 +1,39 @@
+"""WhatsApp Cloud platform plugin — registers the adapter via the plugin registry."""
+from __future__ import annotations
+import os
+from gateway.platforms.whatsapp_cloud import (
+    WhatsAppCloudAdapter,
+    check_whatsapp_cloud_requirements,
+)
+
+
+def _is_connected(config) -> bool:
+    return bool(
+        (
+            os.getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
+            and os.getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
+        )
+        or (
+            config.extra.get("phone_number_id")
+            and config.extra.get("access_token")
+        )
+    )
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="whatsapp_cloud",
+        label="WhatsApp Cloud",
+        adapter_factory=lambda cfg: WhatsAppCloudAdapter(cfg),
+        check_fn=check_whatsapp_cloud_requirements,
+        validate_config=_is_connected,
+        is_connected=_is_connected,
+        required_env=["WHATSAPP_CLOUD_PHONE_NUMBER_ID", "WHATSAPP_CLOUD_ACCESS_TOKEN"],
+        install_hint="pip install aiohttp httpx",
+        allowed_users_env="WHATSAPP_CLOUD_ALLOWED_USERS",
+        allow_all_env="WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+        cron_deliver_env_var="WHATSAPP_CLOUD_HOME_CHANNEL",
+        emoji="📱",
+        platform_hint="You are on WhatsApp. Keep responses concise. Avoid heavy markdown.",
+    )

--- a/plugins/platforms/whatsapp_cloud/plugin.yaml
+++ b/plugins/platforms/whatsapp_cloud/plugin.yaml
@@ -1,0 +1,54 @@
+name: whatsapp-cloud-platform
+label: WhatsApp Cloud
+kind: platform
+version: 1.0.0
+description: >
+  WhatsApp Business Cloud API adapter for Hermes Agent.
+  Connects to WhatsApp via the official Meta Cloud API (Business account
+  required, public webhook URL required, token-based auth).
+  Supports text, media (image/video/audio/document), voice notes,
+  24-hour conversation window with template fallback, and HMAC webhook
+  verification.
+author: NousResearch
+requires_env:
+  - name: WHATSAPP_CLOUD_PHONE_NUMBER_ID
+    description: "WhatsApp phone number ID from Meta Developer Console"
+    prompt: "WhatsApp Cloud phone number ID"
+    password: false
+  - name: WHATSAPP_CLOUD_ACCESS_TOKEN
+    description: "System User permanent access token"
+    prompt: "WhatsApp Cloud access token"
+    password: true
+optional_env:
+  - name: WHATSAPP_CLOUD_APP_SECRET
+    description: "App secret for X-Hub-Signature-256 HMAC verification"
+    prompt: "WhatsApp Cloud app secret (or empty)"
+    password: true
+  - name: WHATSAPP_CLOUD_VERIFY_TOKEN
+    description: "Shared secret for webhook verification handshake"
+    prompt: "WhatsApp Cloud verify token (or empty)"
+    password: true
+  - name: WHATSAPP_CLOUD_WEBHOOK_HOST
+    description: "Webhook server host (default: 0.0.0.0)"
+    prompt: "Webhook host"
+    password: false
+  - name: WHATSAPP_CLOUD_WEBHOOK_PORT
+    description: "Webhook server port (default: 8090)"
+    prompt: "Webhook port"
+    password: false
+  - name: WHATSAPP_CLOUD_ALLOWED_USERS
+    description: "Comma-separated WhatsApp phone numbers allowed to talk to the bot"
+    prompt: "Allowed phone numbers (comma-separated)"
+    password: false
+  - name: WHATSAPP_CLOUD_ALLOW_ALL_USERS
+    description: "Allow any WhatsApp user to trigger the bot (dev only)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: WHATSAPP_CLOUD_HOME_CHANNEL
+    description: "Default phone number for cron / notification delivery"
+    prompt: "Home channel phone number (or empty)"
+    password: false
+  - name: WHATSAPP_CLOUD_HOME_CHANNEL_NAME
+    description: "Display name for the WhatsApp Cloud home channel"
+    prompt: "Home channel display name (or empty)"
+    password: false


### PR DESCRIPTION
## What does this PR do?
Migrates the WhatsApp Cloud adapter from the legacy `if/elif` chain in `_create_adapter()` to the self-registering plugin registry (`platform_registry`).

The `plugins/platforms/whatsapp_cloud/` directory existed but was empty. This PR completes it by adding:
- `__init__.py` — registers a `PlatformEntry` with the platform registry (factory, check_fn, validate_config, auth env vars, cron delivery, platform hint)
- `plugin.yaml` — manifest with all required/optional env vars for `hermes setup` / config UI

The legacy `if platform == Platform.WHATSAPP_CLOUD` block is removed from `gateway/run.py`; the registry lookup that already runs before the fallback chain now handles it.

## Related Issue
None

## Type of Change
- [x] ♻️ Refactor
- [x] ✨ New feature

## Changes Made
- `plugins/platforms/whatsapp_cloud/__init__.py`: new file — platform_registry registration
- `plugins/platforms/whatsapp_cloud/plugin.yaml`: new file — plugin manifest
- `gateway/run.py`: removed legacy `if platform == Platform.WHATSAPP_CLOUD` block from `_create_adapter()`

## How to Test
1. Configure `WHATSAPP_CLOUD_PHONE_NUMBER_ID` and `WHATSAPP_CLOUD_ACCESS_TOKEN`
2. Start the gateway — WhatsApp Cloud adapter should load via plugin registry
3. Confirm `hermes gateway status` shows WhatsApp Cloud as connected
4. `python3 -c "from plugins.platforms.whatsapp_cloud import *; print('ok')"` should print `ok`

## Checklist
- [x] I have read the Contributing Guide
- [x] Commit messages follow Conventional Commits format
- [x] I have checked for duplicate PRs
- [x] This PR is scoped to a single migration
- [x] `pytest tests/ -q` passed
- [x] Platform: Windows 11 + WSL2 Ubuntu

### Documentation & Housekeeping
- README/docs update: N/A
- cli-config.yaml.example: N/A
- CONTRIBUTING.md/AGENTS.md: N/A
- Cross-platform impact: N/A
- Tool description/schema: N/A

## Screenshots / Logs
```
$ python3 -c "from plugins.platforms.whatsapp_cloud import *; print('ok')"
ok
```