### PR TITLE
fix(gateway): release dedup claim when message processing fails to prevent silent message loss (#62860)

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -70,6 +70,15 @@ class MessageDeduplicator:
                 self._seen = dict(newest)
         return False
 
+    def remove(self, msg_id: str) -> None:
+        """Remove a message id from the dedup cache so it can be re-processed.
+
+        Call this when message processing fails after is_duplicate() has
+        already marked the id as seen — otherwise the platform's redelivery
+        will be silently dropped for the duration of the TTL window.
+        """
+        self._seen.pop(msg_id, None)
+
     def clear(self):
         """Clear all tracked messages."""
         self._seen.clear()

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -562,10 +562,17 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the WeCom client.
-        if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
-            self._enqueue_text_event(event)
-        else:
-            await self.handle_message(event)
+        try:
+            if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
+                self._enqueue_text_event(event)
+            else:
+                await self.handle_message(event)
+        except Exception:
+            logger.exception(
+                "[%s] Failed to process message %s, releasing dedup claim",
+                self.name, msg_id,
+            )
+            self._dedup.remove(msg_id)
 
     # ------------------------------------------------------------------
     # Text message aggregation (handles WeCom client-side splits)
@@ -645,6 +652,13 @@ class WeComAdapter(BasePlatformAdapter):
                 key, len(event.text or ""),
             )
             await self.handle_message(event)
+        except Exception:
+            logger.exception(
+                "[%s] Failed processing text batch %s, releasing dedup claim",
+                self.name, key,
+            )
+            if event and event.message_id:
+                self._dedup.remove(event.message_id)
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)


### PR DESCRIPTION
## Summary
`MessageDeduplicator.is_duplicate()` marks a message id as seen at check time, BEFORE the adapter has successfully processed the message. If processing raises after that mark, the platform's redelivery of the same message is classified as a duplicate and silently dropped for the full dedup TTL (300s). The user's message never reaches the agent; the only trace is a DEBUG-level "Duplicate message ignored" line.

## Changes
1. **`gateway/platforms/helpers.py`** — Added `remove(msg_id)` method to `MessageDeduplicator` that pops a previously-marked id from the cache, allowing re-processing
2. **`plugins/platforms/wecom/adapter.py`** — Added try/except wrappers in `_on_message()` and `_flush_text_batch()` that call `self._dedup.remove(msg_id)` on failure, releasing the claim so the platform's redelivery is accepted

## Verification
304 gateway tests pass (8 dedup tests + full suite).