### PR TITLE
feat(api-server): honor per-request reasoning effort

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -135,6 +135,28 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _parse_request_reasoning_config(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return a normalized request-scoped reasoning override.
+
+    Omission means "use the gateway default." Explicit values are validated
+    here so a malformed client cannot silently run at an unintended effort.
+    """
+    if "reasoning_effort" not in body:
+        return None
+
+    raw_effort = body["reasoning_effort"]
+    if not isinstance(raw_effort, str):
+        raise ValueError("'reasoning_effort' must be a string")
+
+    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+
+    reasoning_config = parse_reasoning_effort(raw_effort)
+    if reasoning_config is None:
+        choices = ", ".join(("none", *VALID_REASONING_EFFORTS))
+        raise ValueError(f"'reasoning_effort' must be one of: {choices}")
+    return reasoning_config
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -1270,6 +1292,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        reasoning_config_override: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1290,6 +1313,10 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``reasoning_config_override`` is normalized at the HTTP boundary and
+        applies only to this agent instance. It never mutates process-global
+        state or the persisted gateway configuration.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1302,7 +1329,13 @@ class APIServerAdapter(BasePlatformAdapter):
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
-        reasoning_config = GatewayRunner._load_reasoning_config()
+        # Copy the override because an AIAgent may update its own config
+        # in-place; concurrent requests must never share mutable state.
+        reasoning_config = (
+            dict(reasoning_config_override)
+            if reasoning_config_override is not None
+            else GatewayRunner._load_reasoning_config()
+        )
         model = _resolve_gateway_model()
 
         # When the primary provider's auth fails (expired token / 429 quota
@@ -2115,6 +2148,14 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
+        try:
+            reasoning_config_override = _parse_request_reasoning_config(body)
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), param="reasoning_effort"),
+                status=400,
+            )
+
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
@@ -2319,6 +2360,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                reasoning_config_override=reasoning_config_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2339,11 +2381,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                reasoning_config_override=reasoning_config_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            # Effort changes observable behavior, so it belongs in the
+            # idempotency identity just like model and messages.
+            fp = _make_request_fingerprint(
+                body,
+                keys=["model", "messages", "tools", "tool_choice", "stream", "reasoning_effort"],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -3259,6 +3307,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        try:
+            reasoning_config_override = _parse_request_reasoning_config(body)
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), param="reasoning_effort"),
+                status=400,
+            )
+
         raw_input = body.get("input")
         if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -3406,6 +3462,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                reasoning_config_override=reasoning_config_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -3440,13 +3497,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                reasoning_config_override=reasoning_config_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "model",
+                    "tools",
+                    "reasoning_effort",
+                ],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -4075,6 +4141,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        reasoning_config_override: Optional[Dict[str, Any]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4085,6 +4152,9 @@ class APIServerAdapter(BasePlatformAdapter):
         *route* is an optional ``model_routes`` entry (resolved from the
         request's ``model`` field) that overrides the global model/provider
         for this specific request.
+
+        ``reasoning_config_override`` carries the normalized request setting
+        to the agent factory without consulting or changing shared state.
 
         If *agent_ref* is a one-element list, the AIAgent instance is stored
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
@@ -4111,6 +4181,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    reasoning_config_override=reasoning_config_override,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
@@ -4230,6 +4301,14 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        try:
+            reasoning_config_override = _parse_request_reasoning_config(body)
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), param="reasoning_effort"),
+                status=400,
+            )
 
         raw_input = body.get("input")
         if not raw_input:
@@ -4358,6 +4437,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    reasoning_config_override=reasoning_config_override,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -148,13 +148,17 @@ def _parse_request_reasoning_config(body: Dict[str, Any]) -> Optional[Dict[str, 
     if not isinstance(raw_effort, str):
         raise ValueError("'reasoning_effort' must be a string")
 
-    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+    from hermes_constants import VALID_REASONING_EFFORTS
 
-    reasoning_config = parse_reasoning_effort(raw_effort)
-    if reasoning_config is None:
+    # The config-file parser also accepts human-friendly YAML aliases such as
+    # "false" and "disabled". Keep this external request contract canonical.
+    normalized_effort = raw_effort.strip().lower()
+    if normalized_effort == "none":
+        return {"enabled": False}
+    if normalized_effort not in VALID_REASONING_EFFORTS:
         choices = ", ".join(("none", *VALID_REASONING_EFFORTS))
         raise ValueError(f"'reasoning_effort' must be one of: {choices}")
-    return reasoning_config
+    return {"enabled": True, "effort": normalized_effort}
 
 
 def _normalize_chat_content(

--- a/tests/gateway/test_api_server_reasoning_effort.py
+++ b/tests/gateway/test_api_server_reasoning_effort.py
@@ -1,0 +1,208 @@
+"""Contract tests for request-scoped API server reasoning effort."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _parse_request_reasoning_config,
+)
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    return app
+
+
+def _completed_agent() -> MagicMock:
+    agent = MagicMock()
+    agent.run_conversation.return_value = {"final_response": "done"}
+    agent.session_prompt_tokens = 1
+    agent.session_completion_tokens = 1
+    agent.session_total_tokens = 2
+    return agent
+
+
+async def _wait_for_calls(mock: MagicMock, expected: int) -> None:
+    for _ in range(50):
+        if mock.call_count >= expected:
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"expected {expected} calls, observed {mock.call_count}")
+
+
+@pytest.mark.parametrize(
+    ("effort", "expected"),
+    [
+        ("none", {"enabled": False}),
+        ("low", {"enabled": True, "effort": "low"}),
+        ("xhigh", {"enabled": True, "effort": "xhigh"}),
+        ("max", {"enabled": True, "effort": "max"}),
+    ],
+)
+def test_parse_request_reasoning_config(effort, expected):
+    assert _parse_request_reasoning_config({"reasoning_effort": effort}) == expected
+
+
+def test_parse_request_reasoning_config_uses_default_when_omitted():
+    assert _parse_request_reasoning_config({}) is None
+
+
+@pytest.mark.parametrize("effort", [None, False, 3, "", "extreme"])
+def test_parse_request_reasoning_config_rejects_invalid_values(effort):
+    with pytest.raises(ValueError, match="reasoning_effort"):
+        _parse_request_reasoning_config({"reasoning_effort": effort})
+
+
+def test_create_agent_prefers_isolated_request_override(monkeypatch):
+    captured = {}
+    persisted = {"enabled": True, "effort": "medium"}
+    request_override = {"enabled": True, "effort": "xhigh"}
+    global_loader = MagicMock(return_value=persisted)
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("run_agent.AIAgent", CapturingAgent)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "base_url": "https://example.test/v1",
+            "api_mode": "responses",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-test")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 10)
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(global_loader),
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+    adapter._create_agent(
+        session_id="request-session",
+        reasoning_config_override=request_override,
+    )
+
+    assert captured["reasoning_config"] == request_override
+    assert captured["reasoning_config"] is not request_override
+    assert request_override == {"enabled": True, "effort": "xhigh"}
+    assert persisted == {"enabled": True, "effort": "medium"}
+    global_loader.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "reasoning_effort": "low",
+            },
+        ),
+        (
+            "/v1/responses",
+            {"input": "hello", "reasoning_effort": "low"},
+        ),
+    ],
+)
+async def test_synchronous_endpoints_forward_reasoning_override(endpoint, payload):
+    adapter = _make_adapter()
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "done"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    )
+
+    with patch.object(adapter, "_run_agent", run_agent):
+        async with TestClient(TestServer(_create_app(adapter))) as client:
+            response = await client.post(endpoint, json=payload)
+
+    assert response.status == 200
+    assert run_agent.await_args.kwargs["reasoning_config_override"] == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "reasoning_effort": 3,
+            },
+        ),
+        ("/v1/responses", {"input": "hello", "reasoning_effort": "extreme"}),
+        ("/v1/runs", {"input": "hello", "reasoning_effort": None}),
+    ],
+)
+async def test_endpoints_reject_invalid_reasoning_before_starting_work(
+    endpoint, payload
+):
+    adapter = _make_adapter()
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        response = await client.post(endpoint, json=payload)
+        data = await response.json()
+
+    assert response.status == 400
+    assert data["error"]["param"] == "reasoning_effort"
+    assert adapter._run_streams == {}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_keep_reasoning_overrides_isolated():
+    adapter = _make_adapter()
+    create_agent = MagicMock(side_effect=lambda **_: _completed_agent())
+
+    with patch.object(adapter, "_create_agent", create_agent):
+        async with TestClient(TestServer(_create_app(adapter))) as client:
+            low_response, xhigh_response = await asyncio.gather(
+                client.post(
+                    "/v1/runs",
+                    json={"input": "low task", "reasoning_effort": "low"},
+                ),
+                client.post(
+                    "/v1/runs",
+                    json={"input": "deep task", "reasoning_effort": "xhigh"},
+                ),
+            )
+            assert low_response.status == 202
+            assert xhigh_response.status == 202
+            await _wait_for_calls(create_agent, 2)
+
+    observed = {
+        tuple(sorted(call.kwargs["reasoning_config_override"].items()))
+        for call in create_agent.call_args_list
+    }
+    assert observed == {
+        (("effort", "low"), ("enabled", True)),
+        (("effort", "xhigh"), ("enabled", True)),
+    }

--- a/tests/gateway/test_api_server_reasoning_effort.py
+++ b/tests/gateway/test_api_server_reasoning_effort.py
@@ -48,6 +48,7 @@ async def _wait_for_calls(mock: MagicMock, expected: int) -> None:
     [
         ("none", {"enabled": False}),
         ("low", {"enabled": True, "effort": "low"}),
+        (" HIGH ", {"enabled": True, "effort": "high"}),
         ("xhigh", {"enabled": True, "effort": "xhigh"}),
         ("max", {"enabled": True, "effort": "max"}),
     ],
@@ -60,7 +61,10 @@ def test_parse_request_reasoning_config_uses_default_when_omitted():
     assert _parse_request_reasoning_config({}) is None
 
 
-@pytest.mark.parametrize("effort", [None, False, 3, "", "extreme"])
+@pytest.mark.parametrize(
+    "effort",
+    [None, False, 3, "", "extreme", "false", "disabled"],
+)
 def test_parse_request_reasoning_config_rejects_invalid_values(effort):
     with pytest.raises(ValueError, match="reasoning_effort"):
         _parse_request_reasoning_config({"reasoning_effort": effort})
@@ -150,6 +154,129 @@ async def test_synchronous_endpoints_forward_reasoning_override(endpoint, payloa
 
 
 @pytest.mark.asyncio
+async def test_streaming_chat_completion_forwards_reasoning_override():
+    adapter = _make_adapter()
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "done"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    )
+
+    async def finish_stream(
+        _request,
+        _completion_id,
+        _model,
+        _created,
+        _stream_q,
+        agent_task,
+        *_args,
+        **_kwargs,
+    ):
+        await agent_task
+        return web.json_response({"ok": True})
+
+    payload = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "reasoning_effort": "low",
+        "stream": True,
+    }
+    with (
+        patch.object(adapter, "_run_agent", run_agent),
+        patch.object(
+            adapter,
+            "_write_sse_chat_completion",
+            side_effect=finish_stream,
+        ),
+    ):
+        async with TestClient(TestServer(_create_app(adapter))) as client:
+            response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status == 200
+    assert run_agent.await_args.kwargs["reasoning_config_override"] == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+
+@pytest.mark.asyncio
+async def test_streaming_responses_forwards_reasoning_override():
+    adapter = _make_adapter()
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "done"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    )
+
+    async def finish_stream(*_args, **kwargs):
+        await kwargs["agent_task"]
+        return web.json_response({"ok": True})
+
+    payload = {
+        "input": "hello",
+        "reasoning_effort": "xhigh",
+        "stream": True,
+    }
+    with (
+        patch.object(adapter, "_run_agent", run_agent),
+        patch.object(
+            adapter,
+            "_write_sse_responses",
+            side_effect=finish_stream,
+        ),
+    ):
+        async with TestClient(TestServer(_create_app(adapter))) as client:
+            response = await client.post("/v1/responses", json=payload)
+
+    assert response.status == 200
+    assert run_agent.await_args.kwargs["reasoning_config_override"] == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "base_payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {"messages": [{"role": "user", "content": "hello"}]},
+        ),
+        ("/v1/responses", {"input": "hello"}),
+    ],
+)
+async def test_idempotency_distinguishes_reasoning_effort(endpoint, base_payload):
+    adapter = _make_adapter()
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "done"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    )
+    headers = {"Idempotency-Key": f"reasoning-effort:{endpoint}"}
+
+    with patch.object(adapter, "_run_agent", run_agent):
+        async with TestClient(TestServer(_create_app(adapter))) as client:
+            for effort in ("low", "xhigh"):
+                response = await client.post(
+                    endpoint,
+                    json={**base_payload, "reasoning_effort": effort},
+                    headers=headers,
+                )
+                assert response.status == 200
+
+    assert run_agent.await_count == 2
+    assert [
+        call.kwargs["reasoning_config_override"] for call in run_agent.await_args_list
+    ] == [
+        {"enabled": True, "effort": "low"},
+        {"enabled": True, "effort": "xhigh"},
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("endpoint", "payload"),
     [
@@ -161,6 +288,14 @@ async def test_synchronous_endpoints_forward_reasoning_override(endpoint, payloa
             },
         ),
         ("/v1/responses", {"input": "hello", "reasoning_effort": "extreme"}),
+        (
+            "/v1/chat/completions",
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "reasoning_effort": "false",
+            },
+        ),
+        ("/v1/responses", {"input": "hello", "reasoning_effort": "disabled"}),
         ("/v1/runs", {"input": "hello", "reasoning_effort": None}),
     ],
 )

--- a/tests/gateway/test_api_server_reasoning_effort.py
+++ b/tests/gateway/test_api_server_reasoning_effort.py
@@ -51,6 +51,7 @@ async def _wait_for_calls(mock: MagicMock, expected: int) -> None:
         (" HIGH ", {"enabled": True, "effort": "high"}),
         ("xhigh", {"enabled": True, "effort": "xhigh"}),
         ("max", {"enabled": True, "effort": "max"}),
+        ("ultra", {"enabled": True, "effort": "ultra"}),
     ],
 )
 def test_parse_request_reasoning_config(effort, expected):
@@ -319,7 +320,7 @@ async def test_concurrent_runs_keep_reasoning_overrides_isolated():
 
     with patch.object(adapter, "_create_agent", create_agent):
         async with TestClient(TestServer(_create_app(adapter))) as client:
-            low_response, xhigh_response = await asyncio.gather(
+            low_response, xhigh_response, ultra_response = await asyncio.gather(
                 client.post(
                     "/v1/runs",
                     json={"input": "low task", "reasoning_effort": "low"},
@@ -328,10 +329,15 @@ async def test_concurrent_runs_keep_reasoning_overrides_isolated():
                     "/v1/runs",
                     json={"input": "deep task", "reasoning_effort": "xhigh"},
                 ),
+                client.post(
+                    "/v1/runs",
+                    json={"input": "deepest task", "reasoning_effort": "ultra"},
+                ),
             )
             assert low_response.status == 202
             assert xhigh_response.status == 202
-            await _wait_for_calls(create_agent, 2)
+            assert ultra_response.status == 202
+            await _wait_for_calls(create_agent, 3)
 
     observed = {
         tuple(sorted(call.kwargs["reasoning_config_override"].items()))
@@ -340,4 +346,5 @@ async def test_concurrent_runs_keep_reasoning_overrides_isolated():
     assert observed == {
         (("effort", "low"), ("enabled", True)),
         (("effort", "xhigh"), ("enabled", True)),
+        (("effort", "ultra"), ("enabled", True)),
     }


### PR DESCRIPTION
## What Does This PR Do?

Hermes' OpenAI-compatible API accepted `reasoning_effort` in client payloads,
but Chat Completions, Responses, and Runs did not apply it to the request's
agent. Concurrent clients therefore fell back to one persisted Gateway
reasoning configuration.

This PR adds a strictly request-scoped override. The API validates the value at
the HTTP boundary, copies the normalized reasoning configuration into that
request's `AIAgent`, and never writes it to `config.yaml`, session state, or
process-global configuration.

## Functionality Delta

| Before | After |
| --- | --- |
| `reasoning_effort` was silently ignored | All three endpoint families consume it in streaming and non-streaming paths |
| Every request used the Gateway default | Omission preserves that default; an explicit value applies to one request |
| Invalid input was indistinguishable from ignored input | Invalid type/value returns HTTP 400 with `param: reasoning_effort` |
| Concurrent clients effectively shared one effort | Each request receives an isolated copied reasoning configuration |
| Idempotency ignored effort | Otherwise-identical requests with different efforts have distinct fingerprints |

The public request vocabulary follows Agent's canonical
`VALID_REASONING_EFFORTS`, currently `minimal`, `low`, `medium`, `high`,
`xhigh`, `max`, and `ultra`, plus explicit `none`. Configuration-only aliases
such as `false` and `disabled` remain valid in human-written configuration but
are rejected by the HTTP contract. Provider/model adapters remain responsible
for translating or clamping canonical values to actual model capabilities.

## Scope And Related Work

This is the Agent half of nesquena/hermes-webui#5972. The WebUI PR binds its
existing selector to each submitted turn, including queued and concurrent
turns and immediate model/provider switches; this PR makes the Agent API
consume and isolate that value.

It is a focused alternative to #24422. This branch excludes `fast_mode`, keeps
strict invalid-input behavior, includes effort in idempotency identity, and
covers Chat Completions, Responses, and Runs.

The review cycle is pinned to upstream `7b5ba2054721` and feature head
`5df045e491d5`.

## Changes Made

- Add a strict request parser separate from permissive configuration parsing.
- Pass a copied reasoning override through all three endpoint families,
  including streaming execution.
- Preserve the persisted Gateway default when the field is omitted and support
  explicit `none` without mutating shared state.
- Include reasoning effort in endpoint idempotency fingerprints.
- Cover invalid aliases, endpoint forwarding, streaming, defaults,
  idempotency, mutable-state isolation, and concurrent `low`/`xhigh`/`ultra`
  runs.

## How To Test

```bash
scripts/run_tests.sh -j 1 tests/gateway/test_api_server_reasoning_effort.py -q

.venv/bin/ruff check \
  gateway/platforms/api_server.py \
  tests/gateway/test_api_server_reasoning_effort.py
```

## Verification

- Locked-head request-effort gate: **27 passed**.
- Complete suite at `5df045e491d5`: **40,466 passed and 20 failed**. A serial
  rerun of all seven residual files produced 19 failures at both feature
  `5df045e491d5` and exact upstream `7b5ba2054721`; the remaining mtime/cache
  identities varied across byte-identical files. Changed-file Ruff and
  `git diff --check` passed.
- Paired WebUI focused gate: **649 passed; JavaScript syntax and changed-line
  Ruff checks passed**.
- Real browser/Gateway acceptance: simultaneous MiMo/low, DeepSeek/ultra, and
  MiMo/minimal turns retained distinct downstream tuples; one session retained
  its ID across MiMo/low -> DeepSeek/max -> MiMo/medium turns.

## Model Used

OpenAI Codex, GPT-5.6 sol with xhigh reasoning.