### PR TITLE
fix(computer-use): block destructive key combos in hyphen notation

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -332,9 +332,35 @@ class TestSafetyGuards:
         assert "error" in parsed
         assert "blocked key combo" in parsed["error"]
 
+    @pytest.mark.parametrize("keys", [
+        "ctrl-alt-delete",          # hyphen notation (alt -> option)
+        "alt-f4",                   # force-quit window
+        "cmd-shift-q",              # log out, hyphenated
+        "cmd+shift-backspace",      # mixed + and - separators
+    ])
+    def test_blocked_key_combos_hyphen_notation(self, keys, noop_backend):
+        # The cua-driver backend splits key strings on both '+' and '-'
+        # (cua_backend._parse_key_combo), so "ctrl-alt-delete" executes as the
+        # real destructive combo. The block must canonicalize the same way or
+        # it is trivially bypassed with hyphen notation.
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "key", "keys": keys})
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert "blocked key combo" in parsed["error"]
+
     def test_safe_key_combos_pass(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "key", "keys": "cmd+s"})
+        parsed = json.loads(out)
+        assert "error" not in parsed
+
+    @pytest.mark.parametrize("keys", ["cmd-c", "ctrl-c", "cmd+-"])
+    def test_safe_hyphen_key_combos_pass(self, keys, noop_backend):
+        # Non-destructive combos written with hyphens (and the literal '-'
+        # zoom key) must not be caught by the widened separator.
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "key", "keys": keys})
         parsed = json.loads(out)
         assert "error" not in parsed
 

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -109,7 +109,11 @@ _KEY_ALIASES = {
 
 
 def _canon_key_combo(keys: str) -> frozenset:
-    parts = [p.strip().lower() for p in re.split(r"\s*\+\s*", keys) if p.strip()]
+    # Split on both "+" and "-": the cua-driver backend's _parse_key_combo
+    # accepts hyphen-separated combos too, so "ctrl-alt-delete" executes as
+    # the real destructive shortcut. Mirror its separators here, otherwise the
+    # _BLOCKED_KEY_COMBOS gate is trivially bypassed with hyphen notation.
+    parts = [p.strip().lower() for p in re.split(r"\s*[+\-]\s*", keys) if p.strip()]
     parts = [_KEY_ALIASES.get(p, p) for p in parts]
     return frozenset(parts)
 


### PR DESCRIPTION
## What does this PR do?

The `_BLOCKED_KEY_COMBOS` safety gate in `handle_computer_use` is bypassed when a destructive shortcut is written with hyphens instead of `+`.

`_canon_key_combo` (tools/computer_use/tool.py) canonicalizes the key string by splitting on `+` **only**:

```python
parts = [p.strip().lower() for p in re.split(r"\s*\+\s*", keys) if p.strip()]
```

But the cua-driver backend that actually executes the combo, `cua_backend._parse_key_combo`, splits on **both** `+` and `-`:

```python
parts = [p.strip().lower() for p in re.split(r'[+\-]', keys) if p.strip()]
```

So `{"action":"key","keys":"ctrl-alt-delete"}` canonicalizes to a single unknown token `frozenset({"ctrl-alt-delete"})` at the gate — matching no blocked combo, so it passes — while the backend faithfully parses it into `ctrl+option+delete` and presses the real destructive shortcut. The same bypass works for `alt-f4`, `cmd-shift-q`, `cmd-option-backspace`, etc. Hyphen notation (`Ctrl-Alt-Del`, `Alt-F4`) is one of the most common ways these combos are written, so this isn't an exotic input.

## Related Issue

Fixes #

(No existing issue — happy to open one first if preferred.)

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/tool.py` — `_canon_key_combo` now splits on both `+` and `-` (`re.split(r"\s*[+\-]\s*", keys)`), mirroring the backend's `_parse_key_combo`, so the gate canonicalizes combos the same way they will be executed.

## How to Test

1. Before the fix: `handle_computer_use({"action": "key", "keys": "ctrl-alt-delete"})` returns `{"action": "key", "ok": True}` (executed), while `"ctrl+alt+delete"` is correctly blocked.
2. After the fix: both notations return `{"error": "blocked key combo: ..."}`.
3. `uv run pytest tests/tools/test_computer_use.py -q` — 182 passed.

New tests in `TestSafetyGuards`:
- `test_blocked_key_combos_hyphen_notation` — `ctrl-alt-delete`, `alt-f4`, `cmd-shift-q`, and the mixed `cmd+shift-backspace` are now blocked (all four fail on `main`, pass with this change).
- `test_safe_hyphen_key_combos_pass` — non-destructive hyphen combos (`cmd-c`, `ctrl-c`) and the literal `-` zoom key (`cmd+-`) are **not** wrongly blocked.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and the touched suite passes
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu (WSL2), Python 3.12