### PR TITLE
fix(agent): guard fallback notice finalization

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -79,6 +79,25 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _finalize_retry_status_on_success(agent: Any) -> None:
+    """Surface fallback status without breaking a successfully recovered turn."""
+    for method_name in (
+        "_emit_pending_fallback_notice",
+        "_clear_status_buffer",
+    ):
+        method = getattr(agent, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            method()
+        except Exception:
+            logger.debug(
+                "Retry status finalizer %s failed",
+                method_name,
+                exc_info=True,
+            )
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -5093,8 +5112,7 @@ def run_conversation(
                 # switch notice (if a fallback activated this turn) before
                 # dropping the noisy retry buffer, so a provider/model switch
                 # stays visible even when the fallback succeeds.
-                agent._emit_pending_fallback_notice()
-                agent._clear_status_buffer()
+                _finalize_retry_status_on_success(agent)
 
                 from agent.agent_runtime_helpers import (
                     intent_ack_continuation_mode,

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -9,6 +9,7 @@ silently dropped.
 from __future__ import annotations
 
 
+from agent.conversation_loop import _finalize_retry_status_on_success
 from run_agent import AIAgent
 
 
@@ -148,8 +149,7 @@ def test_pending_fallback_notice_emitted_once_on_success():
     agent._pending_fallback_notice = "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
 
     # Success path order: emit pending notice, then drop the buffer.
-    agent._emit_pending_fallback_notice()
-    agent._clear_status_buffer()
+    _finalize_retry_status_on_success(agent)
 
     # The durable notice was shown exactly once; the buffered retry noise was
     # silently dropped.
@@ -172,6 +172,19 @@ def test_pending_fallback_notice_noop_when_unset():
     # No _pending_fallback_notice attribute set at all.
     agent._emit_pending_fallback_notice()
     assert emitted == []
+
+
+def test_success_status_finalization_tolerates_pre_notice_agent():
+    """A pre-notice AIAgent can meet a lazily imported newer loop."""
+    cleared = []
+
+    class LegacyAgent:
+        def _clear_status_buffer(self):
+            cleared.append(True)
+
+    _finalize_retry_status_on_success(LegacyAgent())
+
+    assert cleared == [True]
 
 
 def test_flush_discards_pending_fallback_notice():


### PR DESCRIPTION
## Summary

- make successful fallback status finalization tolerant of older agent instances
- preserve the fallback notice-before-buffer-clear ordering for current agents
- add regression coverage for a pre-notice agent meeting a lazily imported newer conversation loop

## Root Cause

`AIAgent.run_conversation()` imports `agent.conversation_loop` lazily. A process that loaded an older `AIAgent` class before an on-disk update can therefore load a newer conversation loop later. The successful fallback path called the newly added `_emit_pending_fallback_notice()` method unconditionally, so an otherwise recovered turn failed with `AttributeError` when the older instance did not have that cosmetic helper.

The success path now treats notice emission and retry-buffer cleanup as best-effort status finalization. Missing methods and callback failures cannot abort recovered content, while current agents retain the same emission order.

## Tests

- `scripts/run_tests.sh tests/run_agent/test_retry_status_buffer.py -q` (12 passed)
- `python3 -m py_compile agent/conversation_loop.py tests/run_agent/test_retry_status_buffer.py`
- `git diff --check`

Fixes #62914
