### PR TITLE
fix(kanban): don't crash completing a task with a whitespace-only summary

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4032,7 +4032,7 @@ def complete_task(
                         "phantom_cards": phantom_cards,
                         "verified_cards": verified_cards,
                         "summary_preview": (
-                            (summary or result or "").strip().splitlines()[0][:200]
+                            ((summary or result or "").strip().splitlines() or [""])[0][:200]
                             if (summary or result)
                             else None
                         ),
@@ -4102,7 +4102,7 @@ def complete_task(
         # second SQL round-trip. First line only, 400 char cap — the
         # full summary stays on the run row.
         ev_summary = (summary if summary is not None else result) or ""
-        ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
+        ev_summary = (ev_summary.strip().splitlines() or [""])[0][:400]
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
@@ -4519,10 +4519,7 @@ def edit_completed_task_result(
                     "UPDATE task_runs SET metadata = ? WHERE id = ?",
                     (json.dumps(metadata, ensure_ascii=False), run_id),
                 )
-        ev_summary = (
-            handoff_summary.strip().splitlines()[0][:400]
-            if handoff_summary else ""
-        )
+        ev_summary = (handoff_summary.strip().splitlines() or [""])[0][:400]
         _append_event(
             conn, task_id, "edited",
             {

--- a/tests/hermes_cli/test_kanban_whitespace_summary.py
+++ b/tests/hermes_cli/test_kanban_whitespace_summary.py
@@ -1,0 +1,50 @@
+"""Regression: completing/editing a task with a whitespace-only summary or
+result must not crash.
+
+``complete_task`` and ``edit_completed_task_result`` build a one-line event
+preview via ``text.strip().splitlines()[0]`` guarded only by the *truthiness*
+of the raw text. A non-empty but whitespace-only string (``"   "``, a bare
+newline) is truthy, so the guard passes, but ``.strip().splitlines()`` is
+``[]`` and ``[0]`` raises ``IndexError`` inside the write transaction. LLM
+workers and ``hermes kanban complete <id> --summary "\\n"`` reach this on the
+normal success path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_task(conn, title="t"):
+    tid = kb.create_task(conn, title=title, assignee="worker")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.claim_task(conn, tid, claimer="worker") is not None
+    return tid
+
+
+@pytest.mark.parametrize("summary", ["   ", "\n\n", "\t"])
+def test_complete_task_whitespace_summary_does_not_crash(kanban_home, summary):
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        assert kb.complete_task(conn, tid, summary=summary) is True
+
+
+@pytest.mark.parametrize("result", ["   ", "\n"])
+def test_edit_completed_result_whitespace_does_not_crash(kanban_home, result):
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        assert kb.complete_task(conn, tid, result="real") is True
+        assert kb.edit_completed_task_result(conn, tid, result=result) is True


### PR DESCRIPTION
## What does this PR do?

Completing (or backfilling) a kanban task with a **non-empty but whitespace-only** summary/result raises `IndexError` inside the write transaction and aborts a completion that should succeed.

`complete_task` and `edit_completed_task_result` build a one-line event preview like this:

```python
ev_summary = (summary if summary is not None else result) or ""
ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
```

The guard `if ev_summary` tests the **truthiness of the raw text**. A string like `"   "` or a bare newline is truthy, so the guard passes — but `"   ".strip().splitlines()` is `[]`, so `[0]` raises:

```
IndexError: list index out of range
  hermes_cli/kanban_db.py:4105  (complete_task)
```

An LLM worker emitting a blank/newline-only handoff, or `hermes kanban complete <id> --summary "\n"`, hits this on the normal success path (neither the CLI nor `redact_sensitive_text` strips the value first).

## Related Issue

Fixes #

(No existing issue — glad to open one first if you'd prefer.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — guard on the split result instead of the raw text: `(....strip().splitlines() or [""])[0]`. Applied at the three sites that share the idiom:
  - `complete_task` — the `completed` event `summary` (line ~4105)
  - `complete_task` — the hallucination-blocked `summary_preview` (line ~4035)
  - `edit_completed_task_result` — the `edited` event summary (line ~4523)

## How to Test

1. `uv run pytest tests/hermes_cli/test_kanban_whitespace_summary.py -q` — 5 passed (all fail on `main` with `IndexError`).
2. Regression: `uv run pytest tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py -q` — 404 passed.

New test file `tests/hermes_cli/test_kanban_whitespace_summary.py` asserts `complete_task(..., summary="   ")` and `edit_completed_task_result(..., result="  ")` return `True` instead of raising.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the touched suites and they pass
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu (WSL2), Python 3.12