### PR TITLE
fix: isolate Codex app-server model selection

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -391,6 +391,8 @@ def run_codex_app_server_turn(
 
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            model=getattr(agent, "model", None),
+            reasoning_config=getattr(agent, "reasoning_config", None),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -151,7 +151,6 @@ _OAUTH_REFRESH_FAILURE_HINTS = (
     "please login",
     "auth profile",
     "no auth profile",
-    "oauth",
 )
 
 
@@ -176,6 +175,31 @@ def _classify_oauth_failure(*parts: str) -> Optional[str]:
                 "`/codex-runtime auto` if the issue persists.)"
             )
     return None
+
+
+def _clean_optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _codex_reasoning_effort(reasoning_config: Any) -> str:
+    """Return the Codex app-server reasoning effort for a turn.
+
+    Match the direct Codex Responses transport: default to ``medium`` and
+    clamp ``minimal`` to ``low`` because the backend rejects ``minimal``.
+    Sending an explicit effort also prevents app-server from inheriting a
+    stale global ``model_reasoning_effort`` from another Codex consumer.
+    """
+    effort = "medium"
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            return "medium"
+        configured = reasoning_config.get("effort")
+        if configured:
+            effort = str(configured).strip().lower() or effort
+    return {"minimal": "low"}.get(effort, effort)
 
 
 @dataclass
@@ -205,6 +229,8 @@ class CodexAppServerSession:
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
+        model: Optional[str] = None,
+        reasoning_config: Optional[dict[str, Any]] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
@@ -219,6 +245,8 @@ class CodexAppServerSession:
                 "workspace-write",
             )
         )
+        self._model = _clean_optional_string(model)
+        self._reasoning_effort = _codex_reasoning_effort(reasoning_config)
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
@@ -268,6 +296,8 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._model:
+            params["model"] = self._model
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
@@ -408,14 +438,14 @@ class CodexAppServerSession:
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
         try:
-            ts = self._client.request(
-                "turn/start",
-                {
-                    "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": user_input_text}],
-                },
-                timeout=10,
-            )
+            params = {
+                "threadId": self._thread_id,
+                "input": [{"type": "text", "text": user_input_text}],
+                "effort": self._reasoning_effort,
+            }
+            if self._model:
+                params["model"] = self._model
+            ts = self._client.request("turn/start", params, timeout=10)
         except CodexAppServerError as exc:
             # Classify auth/refresh failures so the user gets a clear
             # `codex login` pointer instead of a raw RPC error string.

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -149,17 +149,30 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
-        """thread/start carries cwd. We intentionally do NOT pass `permissions`
-        on this codex version (experimentalApi-gated + requires matching
-        config.toml [permissions] table). Letting codex use its default
-        (read-only unless user configures otherwise) is the documented path."""
+    def test_thread_start_passes_cwd_and_model(self):
+        """thread/start carries cwd and Hermes' selected model so Codex does
+        not fall back to a global ~/.codex/config.toml model from another
+        consumer. We still intentionally do NOT pass `permissions` on this
+        codex version (experimentalApi-gated + requires matching config.toml
+        [permissions] table)."""
         client = FakeClient()
-        s = make_session(client, permission_profile="workspace-write")
+        s = make_session(
+            client,
+            permission_profile="workspace-write",
+            model="gpt-5.5",
+        )
         s.ensure_started()
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
+        assert params["model"] == "gpt-5.5"
         assert "permissions" not in params  # see session.ensure_started() comment
+
+    def test_thread_start_omits_blank_model(self):
+        client = FakeClient()
+        s = make_session(client, model="  ")
+        s.ensure_started()
+        method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params == {"cwd": "/tmp"}
 
     def test_close_idempotent(self):
         client = FakeClient()
@@ -173,6 +186,32 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    def test_turn_start_passes_model_and_reasoning_effort(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed"},
+        )
+        s = make_session(
+            client,
+            model="gpt-5.5",
+            reasoning_config={"effort": "minimal"},
+        )
+
+        result = s.run_turn(
+            "hello",
+            turn_timeout=1.0,
+            notification_poll_timeout=0.001,
+        )
+
+        assert result.error is None
+        method, params = next(r for r in client.requests if r[0] == "turn/start")
+        assert params["threadId"] == "thread-fake-001"
+        assert params["input"] == [{"type": "text", "text": "hello"}]
+        assert params["model"] == "gpt-5.5"
+        assert params["effort"] == "low"
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
@@ -1220,6 +1259,15 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure("connection reset") is None
         assert _classify_oauth_failure("model returned bad json") is None
         assert _classify_oauth_failure("rate limit exceeded") is None
+
+    def test_oauth_word_alone_does_not_override_primary_model_error(self):
+        from agent.transports.codex_app_server_session import (
+            _classify_oauth_failure,
+        )
+        assert _classify_oauth_failure(
+            "400 Bad Request: gpt-5.6-sol requires a newer version of Codex",
+            "MCP stderr: Auth: Not logged in. OAuth realm unavailable.",
+        ) is None
 
     def test_empty_inputs(self):
         from agent.transports.codex_app_server_session import (

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -377,6 +377,21 @@ class TestRunConversationCodexPath:
 
         assert captured["cwd"] == str(tmp_path)
 
+    def test_agent_passes_model_and_reasoning_to_codex_session(self, monkeypatch):
+        """The app-server session must use the model selected in Hermes, not a
+        global ~/.codex/config.toml model that another Codex consumer left
+        behind."""
+        captured = self._capture_routing_agent(monkeypatch)
+        agent = _make_codex_agent(
+            model="gpt-5.5",
+            reasoning_config={"effort": "high"},
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("use the selected model")
+
+        assert captured["model"] == "gpt-5.5"
+        assert captured["reasoning_config"] == {"effort": "high"}
+
     def _capture_routing_agent(self, monkeypatch):
         """Build a codex agent with a CodexAppServerSession stub that captures
         the request_routing passed at construction time, so we can assert how
@@ -769,4 +784,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-


### PR DESCRIPTION
## Summary

- pass the Hermes-selected model into Codex app-server thread and turn start calls
- pass explicit reasoning effort to avoid inheriting stale global Codex CLI config
- keep OAuth failure classification conservative so unrelated model/version errors are not rewritten as login failures

## Root cause

Hermes codex_app_server sessions could inherit global ~/.codex/config.toml defaults from other Codex consumers. On Smith this surfaced as a misleading authentication failure even when ChatGPT/Codex login status was healthy.

## Validation

- scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py -q
- 97 tests passed, 0 failed
- git diff --check