### PR TITLE
fix(google_meet): forward mode to pm.start on the node start_bot path

### DIFF
--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -125,7 +125,7 @@ class NodeServer:
                 kwargs = {
                     k: payload[k]
                     for k in ("url", "guest_name", "duration", "headed",
-                              "auth_state", "session_id", "out_dir")
+                              "auth_state", "session_id", "out_dir", "mode")
                     if k in payload
                 }
                 if "url" not in kwargs:

--- a/tests/plugins/test_google_meet_node.py
+++ b/tests/plugins/test_google_meet_node.py
@@ -325,6 +325,33 @@ def test_server_handle_request_start_bot_dispatches(tmp_path, monkeypatch):
     assert captured["duration"] == "30m"
 
 
+def test_server_handle_request_start_bot_forwards_mode(tmp_path, monkeypatch):
+    # The node client sends mode="realtime" so a remote join can run the
+    # realtime pipeline; the server must forward it to pm.start rather than
+    # dropping it (which would pin every node join to the "transcribe" default).
+    from plugins.google_meet.node.server import NodeServer
+    from plugins.google_meet.node import protocol
+    from plugins.google_meet import process_manager as pm
+
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "pid": 1, "meeting_id": "abc-defg-hij"}
+
+    monkeypatch.setattr(pm, "start", fake_start)
+
+    s = NodeServer(token_path=tmp_path / "t.json")
+    tok = s.ensure_token()
+    req = protocol.make_request("start_bot", tok, {
+        "url": "https://meet.google.com/abc-defg-hij",
+        "mode": "realtime",
+    })
+    resp = asyncio.run(s._handle_request(req))
+    assert resp["type"] == "response"
+    assert captured.get("mode") == "realtime"
+
+
 def test_server_handle_request_start_bot_missing_url(tmp_path):
     from plugins.google_meet.node.server import NodeServer
     from plugins.google_meet.node import protocol


### PR DESCRIPTION
## What does this PR do?

Joining a Meet through a **node** with `mode="realtime"` silently runs in transcribe mode, because the node server drops the `mode` key.

`NodeServer._handle_request` builds the `pm.start(**kwargs)` call from a fixed key whitelist:

```python
kwargs = {
    k: payload[k]
    for k in ("url", "guest_name", "duration", "headed",
              "auth_state", "session_id", "out_dir")
    if k in payload
}
```

`"mode"` isn't in that tuple. But the node client sends it (`node/client.py`):

```python
payload = {"url": url, "guest_name": guest_name, "headed": bool(headed), "mode": mode}
```

and `pm.start` accepts it (`mode: str = "transcribe"`). So over a node hop, `meet_join(url=..., mode="realtime")` loses the mode and falls back to `"transcribe"` — the realtime pipeline never starts.

## Related Issue

Fixes #

(No existing issue — happy to open one first if you'd prefer.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/node/server.py` — add `"mode"` to the `start_bot` kwargs whitelist. (Only `mode` is added: it's the one key the client sends that `pm.start` accepts and the server was dropping; the client does not send the `realtime_*`/`auth_state`/`session_id`/`out_dir` keys, so those are left as-is.)

## How to Test

1. `uv run pytest tests/plugins/test_google_meet_node.py -q` — 43 passed.

New test `test_server_handle_request_start_bot_forwards_mode` sends `mode="realtime"` in a `start_bot` request and asserts `pm.start` receives `mode="realtime"` (fails on `main` — `mode` is absent from the captured kwargs).

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the touched suite and it passes
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu (WSL2), Python 3.12