### PR TITLE
Harden gateway isolation, provider fallback, and WhatsApp delivery reliability

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1466,15 +1466,21 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 delivery_meta: Optional[dict] = None):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``delivery_meta`` carries machine-readable fields from a classified
+    delivery failure (``category``, ``attempts``, ``dead_letter_ref`` — see
+    plugins/platforms/whatsapp/delivery_reliability.py) alongside the human
+    ``delivery_error`` string. Cleared together with it on successful delivery.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1486,6 +1492,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                meta = delivery_meta or {}
+                job["last_delivery_category"] = meta.get("category")
+                job["last_delivery_attempts"] = meta.get("attempts")
+                job["last_delivery_dead_letter_ref"] = meta.get("dead_letter_ref")
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1402,7 +1402,8 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(job: dict, content: str, adapters=None, loop=None,
+                     delivery_meta: Optional[dict] = None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1410,6 +1411,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     use the live adapter first — this supports E2EE rooms (e.g. Matrix) where
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
+
+    ``delivery_meta``, when passed, is filled in place with machine-readable
+    fields (``category``, ``attempts``, ``dead_letter_ref``) from a classified
+    standalone-send failure — plugins that reuse
+    ``plugins/platforms/whatsapp/delivery_reliability.send_with_retries`` (or
+    the equivalent) surface these via the ``error_category``/``attempts``/
+    ``dead_letter_ref`` keys on their result dict. Left untouched on success
+    or when the failing sender predates classification. The return type is
+    unchanged so existing callers keep working unmodified.
 
     Returns None on success, or an error string on failure.
     """
@@ -1959,6 +1969,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                if delivery_meta is not None and result.get("error_category") is not None:
+                    delivery_meta["category"] = result.get("error_category")
+                    delivery_meta["attempts"] = result.get("attempts")
+                    delivery_meta["dead_letter_ref"] = result.get("dead_letter_ref")
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
@@ -3471,6 +3485,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
+        delivery_meta: dict = {}
         try:
             output_file = save_job_output(job["id"], output)
             if verbose:
@@ -3510,7 +3525,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             if should_deliver:
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job, deliver_content, adapters=adapters, loop=loop,
+                        delivery_meta=delivery_meta,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -3529,7 +3547,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            mark_job_run(job["id"], success, error, delivery_error=delivery_error,
+                         delivery_meta=delivery_meta or None)
         return True
 
     except Exception as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2114,7 +2114,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         result = subprocess.run(
             argv,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),

--- a/docs/plans/2026-07-12-whatsapp-delivery-reliability.md
+++ b/docs/plans/2026-07-12-whatsapp-delivery-reliability.md
@@ -1,5 +1,7 @@
 # WhatsApp Delivery Reliability Plan
 
+**Status:** Complete — all four tasks implemented and verified (focused suite + legacy auth/media tests green).
+
 **Goal:** add safe retry classification, idempotency metadata and dead-letter observability to Hermes→WhatsApp bridge delivery without duplicating ambiguous sends or violating Sawi outreach policy.
 
 ## Constraints

--- a/docs/plans/2026-07-12-whatsapp-delivery-reliability.md
+++ b/docs/plans/2026-07-12-whatsapp-delivery-reliability.md
@@ -1,0 +1,43 @@
+# WhatsApp Delivery Reliability Plan
+
+**Goal:** add safe retry classification, idempotency metadata and dead-letter observability to Hermes→WhatsApp bridge delivery without duplicating ambiguous sends or violating Sawi outreach policy.
+
+## Constraints
+- TDD strict.
+- No production/config/credential changes.
+- No retries after ambiguous timeout unless delivery absence is provable.
+- Retry only connection-refused before request acceptance and explicit 429/502/503/504 responses.
+- Never retry 400/401/403/404 or unknown exceptions.
+- Preserve existing adapter interfaces and standalone cron delivery.
+- No message body, phone, token or PII in dead-letter logs.
+- Do not embed Sawi-specific DDD19/30-day policy in upstream generic Hermes; expose a policy callback/hook or metadata so profile code can enforce it separately.
+
+## Task 1 — Pure retry classifier
+- Create a pure helper under WhatsApp plugin module.
+- Return retryable/non-retryable/ambiguous plus sanitized category.
+- Tests first for HTTP classes, connection refusal, timeout, unknown exception.
+
+## Task 2 — Bounded delivery attempts
+- Extend adapter mutating POST helper to use max 3 attempts with injectable sleep/backoff `[1,5]` and jitter disabled in tests.
+- Generate one idempotency key per logical delivery and reuse it across attempts via `Idempotency-Key` header.
+- Keep current auth headers.
+- A 2xx ends attempts; a permanent or ambiguous failure stops immediately.
+- Tests prove no retry on timeout/401/400 and bounded retry on 429/503/connection-refused.
+
+## Task 3 — Sanitized dead-letter ledger
+- Add local JSONL ledger utility under Hermes state/output path, configurable and disabled by default for upstream.
+- Record timestamp, platform, route, idempotency key hash, attempt count, sanitized error category/status and resolution state; never content/chat/token.
+- Atomic append with file lock appropriate for Windows.
+- Tests scan output for phone/email/Bearer/message text leakage.
+
+## Task 4 — Scheduler standalone parity
+- Reuse the same retry classifier/ledger in standalone cron WhatsApp delivery rather than copy logic.
+- Preserve `last_delivery_error`; add machine fields for category, attempts and dead-letter reference.
+- Tests prove 401 is permanent, 503 reaches DLQ after 3 attempts, and a later 200 avoids DLQ.
+
+## Verification
+- Focused WhatsApp tests.
+- Scheduler delivery tests.
+- Existing auth/media tests.
+- Full related suite.
+- Commit each task separately; no push/merge.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -414,10 +414,17 @@ class ChannelOverride:
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
     models and personas without running separate gateway instances.
+
+    ``enabled_toolsets`` scopes the agent's tool surface for the chat:
+    ``None`` inherits the platform's toolsets, ``[]`` pins the chat to
+    conversation-only (no tools), a list replaces the platform default.
+    Besides exact chat ids, override keys may be the wildcards
+    ``"<chat_type>:*"`` (e.g. ``"group:*"``) or ``"*"``.
     """
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    enabled_toolsets: Optional[List[str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -427,16 +434,32 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.enabled_toolsets is not None:
+            out["enabled_toolsets"] = list(self.enabled_toolsets)
         return out
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChannelOverride":
         if not data:
             return cls()
+        raw_toolsets = data.get("enabled_toolsets")
+        enabled_toolsets: Optional[List[str]]
+        if raw_toolsets is None:
+            enabled_toolsets = None
+        elif isinstance(raw_toolsets, list):
+            enabled_toolsets = [str(ts) for ts in raw_toolsets]
+        elif isinstance(raw_toolsets, str):
+            enabled_toolsets = [raw_toolsets]
+        else:
+            # Malformed value — this key was meant to restrict tools, so
+            # fail closed to no tools rather than silently granting the
+            # full platform toolsets.
+            enabled_toolsets = []
         return cls(
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            enabled_toolsets=enabled_toolsets,
         )
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1265,6 +1265,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1359,6 +1360,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if enabled_toolsets_override is not None:
+            # Authenticated proxy callers may only narrow the remote server's
+            # configured capabilities. An empty list intentionally means no tools.
+            allowed = set(enabled_toolsets)
+            enabled_toolsets = list(dict.fromkeys(
+                name for name in enabled_toolsets_override if name in allowed
+            ))
 
         max_iterations = _current_max_iterations()
 
@@ -2231,6 +2239,22 @@ class APIServerAdapter(BasePlatformAdapter):
         # with that route's model/provider instead of the global default.
         route = self._resolve_route(model_name)
 
+        # Proxy ACL: an authenticated upstream gateway may send
+        # ``hermes_enabled_toolsets`` to narrow the remote server's
+        # capabilities.  The list is validated: must be a list of strings;
+        # unknown names are silently dropped by _create_agent's intersection.
+        # An empty list means "no tools" (fail-closed by design).
+        raw_toolsets = body.get("hermes_enabled_toolsets")
+        enabled_toolsets_override: Optional[List[str]] = None
+        if raw_toolsets is not None:
+            if not isinstance(raw_toolsets, list) or not all(
+                isinstance(t, str) and t for t in raw_toolsets
+            ):
+                # Invalid payload: fail-closed → treat as "no tools".
+                enabled_toolsets_override = []
+            else:
+                enabled_toolsets_override = list(raw_toolsets)
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -2314,6 +2338,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                enabled_toolsets_override=enabled_toolsets_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2334,6 +2359,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                enabled_toolsets_override=enabled_toolsets_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -4066,6 +4092,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4102,6 +4129,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    enabled_toolsets_override=enabled_toolsets_override,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2415,15 +2415,20 @@ def _channel_override_lookup_keys(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    chat_type: Optional[str] = None,
 ) -> list[str]:
     """Ordered, de-duplicated keys for ``channel_overrides`` lookup.
 
     Matches ``resolve_channel_prompt`` semantics: exact thread/channel id first,
     then parent channel/forum id (Discord threads inherit parent overrides).
+    Wildcard keys come last so exact entries always win: ``"<chat_type>:*"``
+    (when ``chat_type`` is known), then the global ``"*"``.
     """
     keys: list[str] = []
     seen: set[str] = set()
-    for key in (chat_id, thread_id, parent_id):
+    wildcards = [f"{chat_type}:*"] if chat_type else []
+    wildcards.append("*")
+    for key in (chat_id, thread_id, parent_id, *wildcards):
         if not key:
             continue
         sk = str(key)
@@ -2434,6 +2439,92 @@ def _channel_override_lookup_keys(
     return keys
 
 
+def _expand_whatsapp_override_keys(
+    keys: list[str], overrides: Dict[str, ChannelOverride]
+) -> list[str]:
+    """Widen lookup keys with WhatsApp phone/LID alias forms.
+
+    A WhatsApp DM chat_id may arrive as ``<phone>@s.whatsapp.net`` or
+    ``<lid>@lid`` for the same human, while the operator configures a bare
+    phone number (or ``+``-prefixed, or a LID) as the override key. For each
+    non-wildcard lookup key, add its normalized identifier plus every alias
+    reachable through the bridge's lid-mapping files, and map ``+``/JID-styled
+    *config* keys back to their normalized form so both sides meet in the
+    middle. Priority order of the original keys is preserved; aliases slot in
+    directly after the key they expand.
+    """
+    from gateway.whatsapp_identity import (
+        expand_whatsapp_aliases,
+        normalize_whatsapp_identifier,
+    )
+
+    # Config keys that only match after normalization (e.g. "+5519..." or a
+    # full JID) — map normalized form -> literal config key.
+    normalized_config_keys: Dict[str, str] = {}
+    for cfg_key in overrides:
+        if cfg_key.endswith("*"):
+            continue
+        norm = normalize_whatsapp_identifier(cfg_key)
+        if norm and norm != cfg_key:
+            normalized_config_keys.setdefault(norm, cfg_key)
+
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def _add(key: str) -> None:
+        if key and key not in seen:
+            seen.add(key)
+            out.append(key)
+
+    for key in keys:
+        if key.endswith("*"):
+            _add(key)
+            continue
+        _add(key)
+        try:
+            aliases = expand_whatsapp_aliases(key)
+        except Exception:
+            aliases = {normalize_whatsapp_identifier(key)}
+        for alias in sorted(aliases, key=lambda a: (len(a), a)):
+            _add(alias)
+            mapped = normalized_config_keys.get(alias)
+            if mapped:
+                _add(mapped)
+    return out
+
+
+def _iter_channel_overrides(
+    config: GatewayConfig,
+    platform: Platform,
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+    parent_id: Optional[str] = None,
+    chat_type: Optional[str] = None,
+):
+    """Yield ``ChannelOverride`` matches for this chat in priority order.
+
+    Exact chat/thread/parent ids first, then ``"<chat_type>:*"``, then ``"*"``.
+    On WhatsApp, ids are additionally matched across phone/LID alias forms.
+    """
+    platforms = getattr(config, "platforms", None)
+    if not platforms:
+        return
+    platform_config = platforms.get(platform)
+    if not platform_config or not platform_config.channel_overrides:
+        return
+    overrides = platform_config.channel_overrides
+    keys = _channel_override_lookup_keys(
+        chat_id, thread_id=thread_id, parent_id=parent_id, chat_type=chat_type
+    )
+    if platform == Platform.WHATSAPP:
+        keys = _expand_whatsapp_override_keys(keys, overrides)
+    for key in keys:
+        ov = overrides.get(key)
+        if ov is not None:
+            yield ov
+
+
 def _get_channel_override(
     config: GatewayConfig,
     platform: Platform,
@@ -2441,26 +2532,74 @@ def _get_channel_override(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    chat_type: Optional[str] = None,
 ) -> Optional[ChannelOverride]:
     """Return per-channel override for this platform/chat_id, or None.
 
     Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
-    ``parent_id`` (forum threads / child channels inherit the parent entry).
+    ``parent_id`` (forum threads / child channels inherit the parent entry),
+    then the ``"<chat_type>:*"`` / ``"*"`` wildcards.
     """
-    platforms = getattr(config, "platforms", None)
-    if not platforms:
-        return None
-    platform_config = platforms.get(platform)
-    if not platform_config or not platform_config.channel_overrides:
-        return None
-    overrides = platform_config.channel_overrides
-    for key in _channel_override_lookup_keys(
-        chat_id, thread_id=thread_id, parent_id=parent_id
+    for ov in _iter_channel_overrides(
+        config,
+        platform,
+        chat_id,
+        thread_id=thread_id,
+        parent_id=parent_id,
+        chat_type=chat_type,
     ):
-        ov = overrides.get(key)
-        if ov is not None:
-            return ov
+        return ov
     return None
+
+
+def _resolve_channel_toolsets(
+    config: Optional[GatewayConfig],
+    source: "SessionSource",
+    default_enabled: list,
+) -> list:
+    """Effective ``enabled_toolsets`` for this chat, resolved BEFORE the agent
+    for the session is created or reused.
+
+    Walks the chat's ``channel_overrides`` matches in priority order and adopts
+    the first entry that sets ``enabled_toolsets`` (``[]`` pins the chat to
+    conversation-only). Entries without the field fall through, so a
+    prompt-only override can never shadow a restrictive wildcard into full
+    access. Chats with no toolset override inherit ``default_enabled``.
+
+    Fail-closed: any error during resolution returns ``[]`` (no tools) —
+    a broken policy must never widen a chat to the full platform toolsets.
+    """
+    if config is None:
+        return default_enabled
+    try:
+        chat_id = str(source.chat_id) if source.chat_id else ""
+        thread_id = (
+            str(source.thread_id) if getattr(source, "thread_id", None) else None
+        )
+        parent_id = (
+            str(source.parent_chat_id)
+            if getattr(source, "parent_chat_id", None)
+            else None
+        )
+        for ov in _iter_channel_overrides(
+            config,
+            source.platform,
+            chat_id,
+            thread_id=thread_id,
+            parent_id=parent_id,
+            chat_type=getattr(source, "chat_type", None) or None,
+        ):
+            if ov.enabled_toolsets is not None:
+                return sorted({str(ts) for ts in ov.enabled_toolsets})
+        return default_enabled
+    except Exception:
+        logger.exception(
+            "channel toolset override resolution failed for %s:%s — "
+            "failing closed to no tools",
+            getattr(getattr(source, "platform", None), "value", "?"),
+            getattr(source, "chat_id", "?"),
+        )
+        return []
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -4758,6 +4897,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if override and override.model:
                 return override.model
         return _resolve_gateway_model(user_config)
+
+    def _effective_enabled_toolsets(
+        self,
+        user_config: dict,
+        platform_key: str,
+        source: "SessionSource",
+    ) -> list:
+        """Enabled toolsets for this chat: platform defaults narrowed by the
+        chat's ``channel_overrides`` policy.
+
+        Resolved from chat identity BEFORE the agent for the session is
+        created or reused — the result feeds both the AIAgent constructor and
+        the agent-cache signature, so a chat's tool surface never flips
+        mid-session and prompt caching stays intact.
+        """
+        from hermes_cli.tools_config import _get_platform_tools
+
+        default_enabled = sorted(_get_platform_tools(user_config, platform_key))
+        return _resolve_channel_toolsets(
+            getattr(self, "config", None), source, default_enabled
+        )
 
     def _get_system_prompt_for_channel(
         self,
@@ -13375,8 +13535,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             platform_key = _platform_config_key(source.platform)
 
-            from hermes_cli.tools_config import _get_platform_tools
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = self._effective_enabled_toolsets(
+                user_config, platform_key, source
+            )
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -17041,8 +17202,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        enabled_toolsets = self._effective_enabled_toolsets(
+            user_config, platform_key, source
+        )
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16800,6 +16800,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        enabled_toolsets: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -16875,6 +16876,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "messages": api_messages,
             "stream": True,
         }
+        # The local gateway owns per-conversation ACL resolution. The remote
+        # server intersects this list with its own configured toolsets, so the
+        # request can only remove capabilities, never grant new ones.
+        if enabled_toolsets is not None:
+            body["hermes_enabled_toolsets"] = list(enabled_toolsets)
 
         # Set up platform streaming if available -------------------------
         _stream_consumer = None
@@ -17178,6 +17184,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        user_config = _load_gateway_config()
+        platform_key = _platform_config_key(source.platform)
+        enabled_toolsets = self._effective_enabled_toolsets(
+            user_config, platform_key, source
+        )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
@@ -17189,6 +17201,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                enabled_toolsets=enabled_toolsets,
             )
 
         from run_agent import AIAgent
@@ -17199,12 +17212,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             return self._is_session_run_current(session_key, run_generation)
         
-        user_config = _load_gateway_config()
-        platform_key = _platform_config_key(source.platform)
-
-        enabled_toolsets = self._effective_enabled_toolsets(
-            user_config, platform_key, source
-        )
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -305,6 +305,7 @@ def _run_agent(
     run a single conversation.  Returns ``(final_response, run_result)``."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
+    from hermes_cli.auth import AuthError
     from hermes_cli.config import load_config
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -366,11 +367,46 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
-        requested=effective_provider,
-        target_model=effective_model or None,
-        explicit_base_url=explicit_base_url_from_alias,
-    )
+    # Read the effective fallback chain from profile config so oneshot workers
+    # honour the same merge semantics as interactive CLI and gateway sessions.
+    _fb = get_fallback_chain(cfg)
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=effective_provider,
+            target_model=effective_model or None,
+            explicit_base_url=explicit_base_url_from_alias,
+        )
+    except AuthError as auth_exc:
+        # Primary provider has no usable credentials (missing, revoked, or
+        # quota-exhausted). Interactive CLI (_ensure_runtime_credentials) and
+        # the cron scheduler both fall through to fallback_providers here —
+        # oneshot must match, otherwise `hermes -z` dies at bootstrap before
+        # the agent's own mid-session fallback chain ever gets a chance.
+        runtime = None
+        for _entry in _fb:
+            _fb_kwargs = {"requested": _entry["provider"]}
+            if _entry.get("base_url"):
+                _fb_kwargs["explicit_base_url"] = _entry["base_url"]
+            if _entry.get("api_key"):
+                _fb_kwargs["explicit_api_key"] = _entry["api_key"]
+            try:
+                runtime = resolve_runtime_provider(**_fb_kwargs)
+            except Exception as _fb_exc:
+                logging.debug(
+                    "oneshot: fallback %s failed: %s", _entry["provider"], _fb_exc
+                )
+                continue
+            logging.warning(
+                "oneshot: primary provider auth failed (%s); using fallback %s/%s",
+                auth_exc, _entry["provider"], _entry["model"],
+            )
+            # The primary model can't run on the fallback provider — use the
+            # fallback entry's own model.
+            effective_model = _entry["model"]
+            break
+        if runtime is None:
+            raise auth_exc
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -380,9 +416,6 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
-    # Read the effective fallback chain from profile config so oneshot workers
-    # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -371,6 +371,11 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
+    # A caller that pinned BOTH --model and --provider asked for that exact
+    # pair; silently running their prompt on a different provider/model would
+    # violate the contract, so auth failures propagate untouched.
+    _explicit_pair = bool((provider or "").strip()) and bool((model or "").strip())
+
     try:
         runtime = resolve_runtime_provider(
             requested=effective_provider,
@@ -383,30 +388,51 @@ def _run_agent(
         # the cron scheduler both fall through to fallback_providers here —
         # oneshot must match, otherwise `hermes -z` dies at bootstrap before
         # the agent's own mid-session fallback chain ever gets a chance.
+        if _explicit_pair:
+            raise
         runtime = None
         for _entry in _fb:
-            _fb_kwargs = {"requested": _entry["provider"]}
+            _fb_kwargs = {
+                "requested": _entry["provider"],
+                # api_mode must be derived from the model this entry will
+                # actually run, not the primary's stale default.
+                "target_model": _entry["model"],
+            }
             if _entry.get("base_url"):
                 _fb_kwargs["explicit_base_url"] = _entry["base_url"]
             if _entry.get("api_key"):
                 _fb_kwargs["explicit_api_key"] = _entry["api_key"]
             try:
                 runtime = resolve_runtime_provider(**_fb_kwargs)
-            except Exception as _fb_exc:
+            except AuthError as _fb_exc:
+                # Only an auth failure means "try the next entry" — anything
+                # else (ValueError from a bad config, TypeError, ...) is a
+                # real bug and must surface, not be eaten by the walk.
+                # AuthError messages can embed credential fragments, so log
+                # only the structured provider/code fields.
                 logging.debug(
-                    "oneshot: fallback %s failed: %s", _entry["provider"], _fb_exc
+                    "oneshot: fallback %s failed (code=%s)",
+                    _entry["provider"],
+                    getattr(_fb_exc, "code", None),
                 )
                 continue
             logging.warning(
-                "oneshot: primary provider auth failed (%s); using fallback %s/%s",
-                auth_exc, _entry["provider"], _entry["model"],
+                "oneshot: primary provider auth failed (provider=%s, code=%s); "
+                "using fallback %s/%s",
+                getattr(auth_exc, "provider", "") or effective_provider or "?",
+                getattr(auth_exc, "code", None),
+                _entry["provider"],
+                _entry["model"],
             )
             # The primary model can't run on the fallback provider — use the
             # fallback entry's own model.
             effective_model = _entry["model"]
             break
         if runtime is None:
-            raise auth_exc
+            # Bare raise: the original AuthError object propagates with its
+            # original traceback and attributes intact — no artificial
+            # re-raise frame, no wrapping.
+            raise
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -373,8 +373,13 @@ def _run_agent(
 
     # A caller that pinned BOTH --model and --provider asked for that exact
     # pair; silently running their prompt on a different provider/model would
-    # violate the contract, so auth failures propagate untouched.
-    _explicit_pair = bool((provider or "").strip()) and bool((model or "").strip())
+    # violate the contract, so auth failures propagate untouched.  The model
+    # half of the pair may come from HERMES_INFERENCE_MODEL — that is the only
+    # way --provider passes the early validation without --model, and it is
+    # just as deliberate a pin as the flag.
+    _explicit_pair = bool((provider or "").strip()) and bool(
+        (model or "").strip() or env_model
+    )
 
     try:
         runtime = resolve_runtime_provider(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -373,11 +373,11 @@ def _run_agent(
 
     # A caller that pinned BOTH --model and --provider asked for that exact
     # pair; silently running their prompt on a different provider/model would
-    # violate the contract, so auth failures propagate untouched.  The model
-    # half of the pair may come from HERMES_INFERENCE_MODEL — that is the only
-    # way --provider passes the early validation without --model, and it is
-    # just as deliberate a pin as the flag.
-    _explicit_pair = bool((provider or "").strip()) and bool(
+    # violate the contract, so auth failures propagate untouched.  Either half
+    # of the pair may come from its env var (HERMES_INFERENCE_PROVIDER /
+    # HERMES_INFERENCE_MODEL) — that is just as deliberate a pin as the flag.
+    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip()
+    _explicit_pair = bool((provider or "").strip() or env_provider) and bool(
         (model or "").strip() or env_model
     )
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -509,6 +509,40 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """
         return _bridge_auth_headers(getattr(self, "_bridge_token", None))
 
+    async def _bridge_post(self, path: str, payload: Dict[str, Any], *, timeout_total: float):
+        """POST to a mutating bridge endpoint with bounded, classified retries.
+
+        One Idempotency-Key per logical delivery (reused across attempts),
+        current auth headers on every attempt. Only provably-unsent failures
+        (connection refused, explicit 429/502/503/504) are retried; a timeout
+        is ambiguous — the message may have gone out — so it never re-sends.
+
+        ``_retry_sleep`` / ``_retry_jitter`` are injectable for tests
+        (``getattr`` guard for adapters built via ``__new__``).
+        """
+        import aiohttp
+
+        from .delivery_reliability import send_with_retries
+
+        async def attempt(headers: Dict[str, str]):
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}{path}",
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=timeout_total),
+            ) as resp:
+                if resp.status == 200:
+                    return resp.status, await resp.json()
+                return resp.status, await resp.text()
+
+        return await send_with_retries(
+            attempt,
+            base_headers=self._auth_headers(),
+            sleep=getattr(self, "_retry_sleep", asyncio.sleep),
+            jitter=getattr(self, "_retry_jitter", True),
+            policy_context={"platform": "whatsapp", "route": path},
+        )
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
         Start the WhatsApp bridge.
@@ -902,8 +936,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         chat_id = to_whatsapp_jid(chat_id)
 
         try:
-            import aiohttp
-
             # Format and chunk the message
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
@@ -920,20 +952,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # response omits a parseable message id.
                     payload["replyTo"] = reply_to
 
-                async with self._http_session.post(
-                    f"http://127.0.0.1:{self._bridge_port}/send",
-                    json=payload,
-                    headers=self._auth_headers(),
-                    timeout=aiohttp.ClientTimeout(total=30)
-                ) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        last_message_id = data.get("messageId")
-                        if last_message_id:
-                            sent_message_ids.append(str(last_message_id))
-                    else:
-                        error = await resp.text()
-                        return SendResult(success=False, error=error)
+                outcome = await self._bridge_post("/send", payload, timeout_total=30)
+                if not outcome.ok:
+                    return SendResult(success=False, error=outcome.error)
+                last_message_id = (outcome.data or {}).get("messageId")
+                if last_message_id:
+                    sent_message_ids.append(str(last_message_id))
 
                 # Small delay between chunks to avoid rate limiting
                 if len(chunks) > 1:
@@ -963,22 +987,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
         try:
-            import aiohttp
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/edit",
-                json={
+            outcome = await self._bridge_post(
+                "/edit",
+                {
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
                     "message": content,
                 },
-                headers=self._auth_headers(),
-                timeout=aiohttp.ClientTimeout(total=15)
-            ) as resp:
-                if resp.status == 200:
-                    return SendResult(success=True, message_id=message_id)
-                else:
-                    error = await resp.text()
-                    return SendResult(success=False, error=error)
+                timeout_total=15,
+            )
+            if outcome.ok:
+                return SendResult(success=True, message_id=message_id)
+            return SendResult(success=False, error=outcome.error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
@@ -997,8 +1017,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
         try:
-            import aiohttp
-
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
@@ -1012,22 +1030,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if file_name:
                 payload["fileName"] = file_name
 
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-media",
-                json=payload,
-                headers=self._auth_headers(),
-                timeout=aiohttp.ClientTimeout(total=120),
-            ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    return SendResult(
-                        success=True,
-                        message_id=data.get("messageId"),
-                        raw_response=data,
-                    )
-                else:
-                    error = await resp.text()
-                    return SendResult(success=False, error=error)
+            outcome = await self._bridge_post("/send-media", payload, timeout_total=120)
+            if outcome.ok:
+                data = outcome.data or {}
+                return SendResult(
+                    success=True,
+                    message_id=data.get("messageId"),
+                    raw_response=data,
+                )
+            return SendResult(success=False, error=outcome.error)
 
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -1052,29 +1063,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
         try:
-            import aiohttp
-
             payload: Dict[str, Any] = {
                 "chatId": to_whatsapp_jid(chat_id),
                 "question": question,
                 "options": list(options or []),
                 "selectableCount": selectable_count,
             }
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-poll",
-                json=payload,
-                headers=self._auth_headers(),
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    return SendResult(
-                        success=True,
-                        message_id=data.get("messageId"),
-                        raw_response=data,
-                    )
-                error = await resp.text()
-                return SendResult(success=False, error=error)
+            outcome = await self._bridge_post("/send-poll", payload, timeout_total=30)
+            if outcome.ok:
+                data = outcome.data or {}
+                return SendResult(
+                    success=True,
+                    message_id=data.get("messageId"),
+                    raw_response=data,
+                )
+            return SendResult(success=False, error=outcome.error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
@@ -1137,8 +1140,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
         try:
-            import aiohttp
-
             payload: Dict[str, Any] = {
                 "chatId": to_whatsapp_jid(chat_id),
                 "latitude": float(latitude),
@@ -1148,21 +1149,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 payload["name"] = name
             if address:
                 payload["address"] = address
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-location",
-                json=payload,
-                headers=self._auth_headers(),
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    return SendResult(
-                        success=True,
-                        message_id=data.get("messageId"),
-                        raw_response=data,
-                    )
-                error = await resp.text()
-                return SendResult(success=False, error=error)
+            outcome = await self._bridge_post("/send-location", payload, timeout_total=30)
+            if outcome.ok:
+                data = outcome.data or {}
+                return SendResult(
+                    success=True,
+                    message_id=data.get("messageId"),
+                    raw_response=data,
+                )
+            return SendResult(success=False, error=outcome.error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -20,6 +20,7 @@ import logging
 import os
 import platform
 import re
+import secrets
 import signal
 import subprocess
 
@@ -71,6 +72,29 @@ def _load_bridge_token() -> Optional[str]:
     except OSError as e:
         logger.warning("Could not read WhatsApp bridge token file: %s", e)
     return None
+
+
+def _ensure_bridge_token() -> str:
+    """Return a bridge token, provisioning a profile-safe secret if needed."""
+    existing = _load_bridge_token()
+    if existing:
+        return existing
+
+    from hermes_constants import get_hermes_home
+
+    token_file = get_hermes_home().joinpath(*_BRIDGE_TOKEN_FILE)
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    generated = secrets.token_urlsafe(32)
+    try:
+        fd = os.open(str(token_file), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(generated + "\n")
+        return generated
+    except FileExistsError:
+        winner = token_file.read_text(encoding="utf-8").strip()
+        if winner:
+            return winner
+        raise RuntimeError("WhatsApp bridge token file exists but is empty")
 
 
 def _bridge_auth_headers(token: Optional[str]) -> Dict[str, str]:
@@ -570,6 +594,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return False
 
+        # Provision once per active HERMES_HOME/profile, then use the same
+        # secret for every bridge GET/POST and the Node subprocess.
+        bridge_token = _ensure_bridge_token()
+        self._bridge_token = bridge_token
+        bridge_headers = _bridge_auth_headers(bridge_token)
+
         # Pre-flight: skip the 30s bridge bootstrap entirely if the user
         # never finished pairing.  Without creds.json the bridge prints
         # QR codes to its log file and never reaches status:connected,
@@ -657,6 +687,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
                         f"http://127.0.0.1:{self._bridge_port}/health",
+                        headers=bridge_headers,
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
                         if resp.status == 200:
@@ -708,6 +739,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
+            bridge_env[_BRIDGE_TOKEN_ENV] = bridge_token
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             # Pass the profile-aware cache directories so the bridge writes
@@ -755,6 +787,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     async with aiohttp.ClientSession() as session:
                         async with session.get(
                             f"http://127.0.0.1:{self._bridge_port}/health",
+                            headers=bridge_headers,
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
@@ -787,6 +820,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         async with aiohttp.ClientSession() as session:
                             async with session.get(
                                 f"http://127.0.0.1:{self._bridge_port}/health",
+                                headers=bridge_headers,
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
@@ -1267,6 +1301,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             async with self._http_session.get(
                 f"http://127.0.0.1:{self._bridge_port}/chat/{to_whatsapp_jid(chat_id)}",
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:
@@ -1295,6 +1330,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             try:
                 async with self._http_session.get(
                     f"http://127.0.0.1:{self._bridge_port}/messages",
+                    headers=self._auth_headers(),
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -40,6 +40,45 @@ logger = logging.getLogger(__name__)
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
+# Env var checked before the token file so deployments can inject the bridge
+# secret without writing it to disk.
+_BRIDGE_TOKEN_ENV = "HERMES_WA_BRIDGE_TOKEN"
+_BRIDGE_TOKEN_FILE = ("secrets", "whatsapp_bridge_token")
+
+
+def _load_bridge_token() -> Optional[str]:
+    """Resolve the shared-secret token for the local WhatsApp bridge.
+
+    Resolution order:
+    1. ``HERMES_WA_BRIDGE_TOKEN`` environment variable
+    2. ``<HERMES_HOME>/secrets/whatsapp_bridge_token`` file
+
+    Returns ``None`` when no token is configured — mutating bridge calls are
+    then sent without an ``Authorization`` header so bridges that predate
+    auth keep working.
+    """
+    token = (os.getenv(_BRIDGE_TOKEN_ENV) or "").strip()
+    if token:
+        return token
+    try:
+        from hermes_constants import get_hermes_home
+
+        token_file = get_hermes_home().joinpath(*_BRIDGE_TOKEN_FILE)
+        if token_file.is_file():
+            token = token_file.read_text(encoding="utf-8").strip()
+            if token:
+                return token
+    except OSError as e:
+        logger.warning("Could not read WhatsApp bridge token file: %s", e)
+    return None
+
+
+def _bridge_auth_headers(token: Optional[str]) -> Dict[str, str]:
+    """Authorization headers for bridge HTTP calls (empty when no token)."""
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
 
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
@@ -416,6 +455,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_log: Optional[Path] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._bridge_token: Optional[str] = _load_bridge_token()
         # Set to True by disconnect() before we SIGTERM our child bridge so
         # _check_managed_bridge_exit() can distinguish an intentional
         # shutdown-time exit (returncode -15 / -2 / 0) from a real crash.
@@ -460,6 +500,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Authorization headers for mutating bridge HTTP calls.
+
+        ``getattr`` guard: test helpers construct adapters via ``__new__``
+        without running ``__init__``, so ``_bridge_token`` may be unset.
+        """
+        return _bridge_auth_headers(getattr(self, "_bridge_token", None))
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -875,6 +923,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 async with self._http_session.post(
                     f"http://127.0.0.1:{self._bridge_port}/send",
                     json=payload,
+                    headers=self._auth_headers(),
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:
@@ -922,6 +971,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "messageId": message_id,
                     "message": content,
                 },
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=15)
             ) as resp:
                 if resp.status == 200:
@@ -965,6 +1015,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/send-media",
                 json=payload,
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
                 if resp.status == 200:
@@ -1012,6 +1063,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/send-poll",
                 json=payload,
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 if resp.status == 200:
@@ -1099,6 +1151,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/send-location",
                 json=payload,
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 if resp.status == 200:
@@ -1198,6 +1251,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
                 json={"chatId": to_whatsapp_jid(chat_id)},
+                headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
                 pass
@@ -1589,6 +1643,7 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        auth_headers = _bridge_auth_headers(_load_bridge_token())
         normalized_chat_id = to_whatsapp_jid(chat_id)
         media = media_files or []
         text = message or ""
@@ -1603,6 +1658,7 @@ async def _standalone_send(
                 async with session.post(
                     f"http://localhost:{bridge_port}/send",
                     json={"chatId": normalized_chat_id, "message": text},
+                    headers=auth_headers,
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
                     if resp.status != 200:
@@ -1626,6 +1682,7 @@ async def _standalone_send(
                             async with session.post(
                                 f"http://localhost:{bridge_port}/send",
                                 json={"chatId": normalized_chat_id, "message": media_caption},
+                                headers=auth_headers,
                                 timeout=aiohttp.ClientTimeout(total=30),
                             ) as resp:
                                 if resp.status == 200:
@@ -1646,6 +1703,7 @@ async def _standalone_send(
                 async with session.post(
                     f"http://localhost:{bridge_port}/send-media",
                     json=payload,
+                    headers=auth_headers,
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
                     if resp.status != 200:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1612,6 +1612,23 @@ def _bridge_media_type(file_path: str, is_voice: bool, force_document: bool) -> 
     return "document"
 
 
+def _standalone_delivery_error(prefix: str, outcome) -> Dict[str, Any]:
+    """Build an error dict from a failed ``DeliveryOutcome``.
+
+    Carries the human ``error`` string (for ``last_delivery_error``
+    backward compatibility) plus machine fields — sanitized category,
+    attempt count and dead-letter reference — so cron job storage can
+    track delivery health without parsing free text.
+    """
+    status_part = f" ({outcome.status})" if outcome.status is not None else ""
+    return {
+        "error": f"{prefix}{status_part}: {outcome.error}",
+        "error_category": outcome.failure.category if outcome.failure else None,
+        "attempts": outcome.attempts,
+        "dead_letter_ref": outcome.dead_letter_ref,
+    }
+
+
 async def _standalone_send(
     pconfig,
     chat_id,
@@ -1628,11 +1645,18 @@ async def _standalone_send(
     succeed when cron runs separately from the gateway. Replaces the legacy
     _send_whatsapp helper.
 
+    Reuses the same bounded retry classifier and dead-letter ledger as the
+    live gateway adapter (``send_with_retries``) rather than a single-attempt
+    send, so a standalone cron delivery gets the same retry/DLQ behavior as
+    a gateway-connected one.
+
     When ``caption`` is provided (single-file ``MEDIA:<path> caption`` send),
     the text rides on the media bubble's native caption via the bridge
     ``/send-media`` ``caption`` field instead of being posted as a separate
     ``/send`` message beforehand.
     """
+    from .delivery_reliability import send_with_retries
+
     extra = getattr(pconfig, "extra", {}) or {}
     try:
         import aiohttp
@@ -1649,20 +1673,35 @@ async def _standalone_send(
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
         async with aiohttp.ClientSession() as session:
+
+            async def _post_with_retries(path: str, payload: Dict[str, Any], *, timeout_total: float):
+                async def attempt(headers):
+                    async with session.post(
+                        f"http://localhost:{bridge_port}{path}",
+                        json=payload,
+                        headers=headers,
+                        timeout=aiohttp.ClientTimeout(total=timeout_total),
+                    ) as resp:
+                        if resp.status == 200:
+                            return resp.status, await resp.json()
+                        return resp.status, await resp.text()
+
+                return await send_with_retries(
+                    attempt,
+                    base_headers=auth_headers,
+                    platform="whatsapp",
+                    route=path,
+                )
+
             # 1) Text first (skip the /send call when this chunk is media-only
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:
-                async with session.post(
-                    f"http://localhost:{bridge_port}/send",
-                    json={"chatId": normalized_chat_id, "message": text},
-                    headers=auth_headers,
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status != 200:
-                        body = await resp.text()
-                        return {"error": f"WhatsApp bridge error ({resp.status}): {body}"}
-                    data = await resp.json()
-                    last_message_id = data.get("messageId")
+                outcome = await _post_with_retries(
+                    "/send", {"chatId": normalized_chat_id, "message": text}, timeout_total=30,
+                )
+                if not outcome.ok:
+                    return _standalone_delivery_error("WhatsApp bridge error", outcome)
+                last_message_id = (outcome.data or {}).get("messageId")
 
             # 2) Each media file as a native attachment via /send-media. The
             # bridge maps mediaType -> image/video/audio/document message kinds
@@ -1676,14 +1715,11 @@ async def _standalone_send(
                     # so nothing silently disappears.
                     if media_caption:
                         try:
-                            async with session.post(
-                                f"http://localhost:{bridge_port}/send",
-                                json={"chatId": normalized_chat_id, "message": media_caption},
-                                headers=auth_headers,
-                                timeout=aiohttp.ClientTimeout(total=30),
-                            ) as resp:
-                                if resp.status == 200:
-                                    last_message_id = (await resp.json()).get("messageId")
+                            fallback = await _post_with_retries(
+                                "/send", {"chatId": normalized_chat_id, "message": media_caption}, timeout_total=30,
+                            )
+                            if fallback.ok:
+                                last_message_id = (fallback.data or {}).get("messageId")
                         except Exception:
                             logger.warning("WhatsApp caption-fallback send failed for missing media")
                     return {"error": f"WhatsApp media file not found: {media_path}"}
@@ -1697,17 +1733,10 @@ async def _standalone_send(
                     payload["fileName"] = os.path.basename(media_path)
                 if media_caption:
                     payload["caption"] = media_caption
-                async with session.post(
-                    f"http://localhost:{bridge_port}/send-media",
-                    json=payload,
-                    headers=auth_headers,
-                    timeout=aiohttp.ClientTimeout(total=120),
-                ) as resp:
-                    if resp.status != 200:
-                        body = await resp.text()
-                        return {"error": f"WhatsApp media error ({resp.status}): {body}"}
-                    data = await resp.json()
-                    last_message_id = data.get("messageId") or last_message_id
+                outcome = await _post_with_retries("/send-media", payload, timeout_total=120)
+                if not outcome.ok:
+                    return _standalone_delivery_error("WhatsApp media error", outcome)
+                last_message_id = (outcome.data or {}).get("messageId") or last_message_id
 
         return {
             "success": True,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -541,6 +541,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             sleep=getattr(self, "_retry_sleep", asyncio.sleep),
             jitter=getattr(self, "_retry_jitter", True),
             policy_context={"platform": "whatsapp", "route": path},
+            platform="whatsapp",
+            route=path,
         )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:

--- a/plugins/platforms/whatsapp/delivery_ledger.py
+++ b/plugins/platforms/whatsapp/delivery_ledger.py
@@ -1,0 +1,128 @@
+"""Sanitized dead-letter ledger for WhatsApp bridge deliveries.
+
+Disabled by default — upstream Hermes never writes this file unless a
+profile opts in via ``HERMES_WA_DEAD_LETTER_LEDGER_ENABLED``. Each record
+is a single JSONL line containing only sanitized, non-identifying fields:
+timestamp, platform, route, a hash of the idempotency key, attempt count,
+error category/status and resolution state. Message content, chat ids,
+phone numbers and tokens are never accepted by this module at all, so a
+caller cannot accidentally leak them into the ledger.
+"""
+
+import hashlib
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from utils import env_bool
+
+_IS_WINDOWS = os.name == "nt"
+if _IS_WINDOWS:
+    import msvcrt
+else:
+    import fcntl
+
+_LEDGER_ENABLED_ENV = "HERMES_WA_DEAD_LETTER_LEDGER_ENABLED"
+_LEDGER_PATH_ENV = "HERMES_WA_DEAD_LETTER_LEDGER_PATH"
+
+# Guards concurrent appends from threads within this process; the file lock
+# below (flock/msvcrt) guards concurrent appends across processes.
+_write_lock = threading.Lock()
+
+
+def is_ledger_enabled() -> bool:
+    """True only when a profile has explicitly opted into the ledger."""
+    return env_bool(_LEDGER_ENABLED_ENV, False)
+
+
+def default_ledger_path() -> Path:
+    """Default ledger location under the Hermes state directory."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "state" / "whatsapp_delivery_ledger.jsonl"
+
+
+def ledger_path() -> Path:
+    """Resolve the active ledger path, honoring the env override."""
+    override = os.getenv(_LEDGER_PATH_ENV, "").strip()
+    return Path(override) if override else default_ledger_path()
+
+
+def _hash_idempotency_key(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _append_line(path: Path, line: str) -> None:
+    """Append one line to *path*, holding a cross-process advisory lock.
+
+    The lock is taken on a sibling ``.lock`` file rather than *path* itself —
+    locking the data file directly would require a placeholder byte on
+    Windows (``msvcrt.locking`` needs at least one byte to lock), which would
+    permanently corrupt the first line of the ledger.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with _write_lock:
+        with open(lock_path, "a+", encoding="utf-8") as lock_handle:
+            lock_handle.seek(0, os.SEEK_END)
+            if lock_handle.tell() == 0:
+                lock_handle.write("\0")
+                lock_handle.flush()
+            lock_handle.seek(0)
+            try:
+                if _IS_WINDOWS:
+                    msvcrt.locking(lock_handle.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+                with open(path, "a", encoding="utf-8") as handle:
+                    handle.write(line + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            finally:
+                try:
+                    if _IS_WINDOWS:
+                        lock_handle.seek(0)
+                        msvcrt.locking(lock_handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+
+
+def record_dead_letter(
+    *,
+    platform: str,
+    route: str,
+    idempotency_key: str,
+    attempts: int,
+    category: str,
+    status: Optional[int] = None,
+    resolution: str = "open",
+) -> Optional[str]:
+    """Append a sanitized dead-letter record; no-op unless the ledger is enabled.
+
+    Returns a dead-letter reference string (usable as ``DeliveryOutcome.dead_letter_ref``)
+    or ``None`` when the ledger is disabled. Only sanitized identifiers are
+    accepted — there is no parameter for message content, chat id or token,
+    so a caller cannot pass them even by mistake.
+    """
+    if not is_ledger_enabled():
+        return None
+
+    key_hash = _hash_idempotency_key(idempotency_key)
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "platform": platform,
+        "route": route,
+        "idempotency_key_hash": key_hash,
+        "attempts": attempts,
+        "category": category,
+        "status": status,
+        "resolution": resolution,
+    }
+    path = ledger_path()
+    _append_line(path, json.dumps(entry, separators=(",", ":")))
+    return f"{path}#{key_hash}"

--- a/plugins/platforms/whatsapp/delivery_reliability.py
+++ b/plugins/platforms/whatsapp/delivery_reliability.py
@@ -22,6 +22,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
+from plugins.platforms.whatsapp import delivery_ledger as _delivery_ledger
+
 RETRYABLE = "retryable"
 NON_RETRYABLE = "non_retryable"
 AMBIGUOUS = "ambiguous"
@@ -140,6 +142,8 @@ async def send_with_retries(
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     jitter: bool = True,
     policy_context: Optional[dict] = None,
+    platform: str = "whatsapp",
+    route: str = "",
 ) -> DeliveryOutcome:
     """Run one logical bridge delivery with bounded, classified retries.
 
@@ -151,6 +155,12 @@ async def send_with_retries(
     A 2xx ends the loop; a permanent or ambiguous failure stops immediately
     (an ambiguous timeout is NEVER retried — the send may have gone out).
     Only retryable failures re-attempt, up to ``max_attempts``.
+
+    A terminal failure (retries exhausted, ambiguous timeout, or permanent
+    rejection) is recorded to the sanitized dead-letter ledger — a no-op
+    unless a profile has opted in — and its reference is attached to the
+    returned outcome. A policy veto is never dead-lettered: no attempt was
+    made, so there is nothing to reconcile.
     """
     idempotency_key = uuid.uuid4().hex
     headers = dict(base_headers or {})
@@ -194,6 +204,14 @@ async def send_with_retries(
             error = payload if isinstance(payload, str) else str(payload)
 
         if failure.decision != RETRYABLE or attempts >= max_attempts:
+            dead_letter_ref = _delivery_ledger.record_dead_letter(
+                platform=platform,
+                route=route,
+                idempotency_key=idempotency_key,
+                attempts=attempts,
+                category=failure.category,
+                status=failure.status,
+            )
             return DeliveryOutcome(
                 ok=False,
                 attempts=attempts,
@@ -201,5 +219,6 @@ async def send_with_retries(
                 status=status,
                 error=error,
                 failure=failure,
+                dead_letter_ref=dead_letter_ref,
             )
         await sleep(retry_backoff_delay(attempts + 1, jitter=jitter))

--- a/plugins/platforms/whatsapp/delivery_reliability.py
+++ b/plugins/platforms/whatsapp/delivery_reliability.py
@@ -15,9 +15,12 @@ content, chat ids or tokens — so they are safe for logs and dead-letter
 records.
 """
 
+import asyncio
 import errno
+import random
+import uuid
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 RETRYABLE = "retryable"
 NON_RETRYABLE = "non_retryable"
@@ -77,3 +80,126 @@ def classify_delivery_failure(
 
     decision = RETRYABLE if status in _RETRYABLE_STATUSES else NON_RETRYABLE
     return DeliveryFailure(decision, f"http_{status}", status)
+
+
+# ---------------------------------------------------------------------------
+# Bounded delivery attempts
+# ---------------------------------------------------------------------------
+
+MAX_DELIVERY_ATTEMPTS = 3
+
+# Delay (seconds) before attempt N, indexed by retry ordinal: attempt 2 waits
+# 1s after the first failure, attempt 3 waits 5s.
+_BACKOFF_SCHEDULE = (1.0, 5.0)
+
+# Profile-owned delivery policy hook (e.g. Sawi DDD19/30-day outreach rules).
+# Upstream Hermes never registers one; profile code opts in via
+# set_delivery_policy_hook(). The hook receives a sanitized context dict and
+# returns False to veto the delivery before the first attempt is made.
+_policy_hook: Optional[Callable[[dict], bool]] = None
+
+
+def set_delivery_policy_hook(hook: Optional[Callable[[dict], bool]]) -> None:
+    """Register (or clear, with ``None``) the profile delivery policy hook."""
+    global _policy_hook
+    _policy_hook = hook
+
+
+def retry_backoff_delay(attempt: int, *, jitter: bool = True) -> float:
+    """Seconds to wait before ``attempt`` (2-based; attempt 1 never waits).
+
+    With ``jitter`` the delay is stretched by up to 50% so concurrent
+    retries don't synchronize against the bridge.
+    """
+    index = min(max(attempt - 2, 0), len(_BACKOFF_SCHEDULE) - 1)
+    delay = _BACKOFF_SCHEDULE[index]
+    if jitter:
+        delay += random.uniform(0, delay * 0.5)
+    return delay
+
+
+@dataclass
+class DeliveryOutcome:
+    """Result of one logical delivery (all attempts included)."""
+
+    ok: bool
+    attempts: int
+    idempotency_key: Optional[str]
+    status: Optional[int] = None
+    data: Any = None
+    error: Optional[str] = None
+    failure: Optional[DeliveryFailure] = None
+    dead_letter_ref: Optional[str] = None
+
+
+async def send_with_retries(
+    attempt_fn: Callable[[Dict[str, str]], Awaitable[Tuple[int, Any]]],
+    *,
+    base_headers: Optional[Dict[str, str]] = None,
+    max_attempts: int = MAX_DELIVERY_ATTEMPTS,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    jitter: bool = True,
+    policy_context: Optional[dict] = None,
+) -> DeliveryOutcome:
+    """Run one logical bridge delivery with bounded, classified retries.
+
+    ``attempt_fn(headers)`` performs a single POST and returns
+    ``(status, payload)`` — parsed JSON for 2xx, error text otherwise —
+    or raises. One ``Idempotency-Key`` is generated per logical delivery
+    and reused verbatim on every attempt so the bridge can deduplicate.
+
+    A 2xx ends the loop; a permanent or ambiguous failure stops immediately
+    (an ambiguous timeout is NEVER retried — the send may have gone out).
+    Only retryable failures re-attempt, up to ``max_attempts``.
+    """
+    idempotency_key = uuid.uuid4().hex
+    headers = dict(base_headers or {})
+    headers["Idempotency-Key"] = idempotency_key
+
+    if _policy_hook is not None:
+        try:
+            allowed = _policy_hook(dict(policy_context or {}))
+        except Exception:
+            # A broken profile hook must not silently bypass the policy it
+            # exists to enforce — fail closed.
+            allowed = False
+        if not allowed:
+            return DeliveryOutcome(
+                ok=False,
+                attempts=0,
+                idempotency_key=idempotency_key,
+                error="delivery vetoed by policy hook",
+                failure=DeliveryFailure(NON_RETRYABLE, "policy_blocked"),
+            )
+
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            status, payload = await attempt_fn(headers)
+        except Exception as exc:
+            failure = classify_delivery_failure(exception=exc)
+            error = str(exc)
+            status = None
+        else:
+            if 200 <= status < 300:
+                return DeliveryOutcome(
+                    ok=True,
+                    attempts=attempts,
+                    idempotency_key=idempotency_key,
+                    status=status,
+                    data=payload,
+                )
+            failure = classify_delivery_failure(status=status)
+            error = payload if isinstance(payload, str) else str(payload)
+
+        if failure.decision != RETRYABLE or attempts >= max_attempts:
+            return DeliveryOutcome(
+                ok=False,
+                attempts=attempts,
+                idempotency_key=idempotency_key,
+                status=status,
+                error=error,
+                failure=failure,
+            )
+        await sleep(retry_backoff_delay(attempts + 1, jitter=jitter))

--- a/plugins/platforms/whatsapp/delivery_reliability.py
+++ b/plugins/platforms/whatsapp/delivery_reliability.py
@@ -1,0 +1,79 @@
+"""Pure retry classification for WhatsApp bridge delivery failures.
+
+Retry policy (see docs/plans/2026-07-12-whatsapp-delivery-reliability.md):
+
+- RETRYABLE: the send provably never reached the bridge (connection refused
+  before request acceptance) or the bridge explicitly asked for a retry
+  (429/502/503/504). Re-sending cannot duplicate a delivered message.
+- AMBIGUOUS: the request may have been accepted but the outcome is unknown
+  (timeouts). Retrying risks a duplicate send, so callers must stop.
+- NON_RETRYABLE: the bridge definitively rejected the request (4xx and any
+  other status) or an unknown exception fired. Retrying cannot help.
+
+Categories are sanitized identifiers only — never exception text, message
+content, chat ids or tokens — so they are safe for logs and dead-letter
+records.
+"""
+
+import errno
+from dataclasses import dataclass
+from typing import Optional
+
+RETRYABLE = "retryable"
+NON_RETRYABLE = "non_retryable"
+AMBIGUOUS = "ambiguous"
+
+# Only these HTTP statuses are ever retried — everything else is permanent.
+_RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class DeliveryFailure:
+    """Sanitized classification of a single failed delivery attempt."""
+
+    decision: str  # RETRYABLE | NON_RETRYABLE | AMBIGUOUS
+    category: str  # sanitized identifier, e.g. "http_503", "timeout"
+    status: Optional[int] = None
+
+
+def _is_connection_refused(exc: BaseException) -> bool:
+    """True when the TCP connection was refused before request acceptance.
+
+    Covers the builtin ``ConnectionRefusedError``, a bare ``OSError`` carrying
+    ``ECONNREFUSED``, and aiohttp's ``ClientConnectorError`` which wraps the
+    underlying error in an ``os_error`` attribute.
+    """
+    if isinstance(exc, ConnectionRefusedError):
+        return True
+    os_error = getattr(exc, "os_error", None)
+    if isinstance(os_error, BaseException) and _is_connection_refused(os_error):
+        return True
+    return isinstance(exc, OSError) and exc.errno == errno.ECONNREFUSED
+
+
+def classify_delivery_failure(
+    status: Optional[int] = None,
+    exception: Optional[BaseException] = None,
+) -> DeliveryFailure:
+    """Classify one failed bridge delivery attempt.
+
+    Pure function: no I/O, no logging. ``exception`` takes precedence over
+    ``status`` (an exception means no usable HTTP response). Passing a 2xx
+    ``status`` or neither argument is a caller bug and raises ``ValueError``.
+    """
+    if exception is not None:
+        if _is_connection_refused(exception):
+            return DeliveryFailure(RETRYABLE, "connection_refused")
+        # asyncio.TimeoutError is an alias of TimeoutError on Python 3.11+;
+        # aiohttp timeout errors subclass it.
+        if isinstance(exception, TimeoutError):
+            return DeliveryFailure(AMBIGUOUS, "timeout")
+        return DeliveryFailure(NON_RETRYABLE, "unknown_exception")
+
+    if status is None:
+        raise ValueError("classify_delivery_failure needs a status or an exception")
+    if 200 <= status < 300:
+        raise ValueError(f"status {status} is a success, not a failure")
+
+    decision = RETRYABLE if status in _RETRYABLE_STATUSES else NON_RETRYABLE
+    return DeliveryFailure(decision, f"http_{status}", status)

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -26,6 +26,7 @@ import pino from 'pino';
 import path from 'path';
 import { mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { loadBridgeToken, createBridgeAuthMiddleware } from './bridge_auth.js';
 import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
@@ -769,6 +770,12 @@ async function startSocket() {
 // HTTP server
 const app = express();
 app.use(express.json());
+
+// Bearer token authentication — every request to the bridge must present
+// a valid Bearer token loaded from HERMES_WA_BRIDGE_TOKEN or the secrets
+// file. Fails closed if no token is configured.
+const _bridgeToken = loadBridgeToken();
+app.use(createBridgeAuthMiddleware(_bridgeToken));
 
 // Host-header validation — defends against DNS rebinding.
 // The bridge binds loopback-only (127.0.0.1) but a victim browser on

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -34,6 +34,8 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { createIdempotencyStore } from './idempotency_store.js';
+import { createIdempotencyMiddleware } from './idempotency_middleware.js';
 import {
   buildPollPayload,
   buildLocationPayload,
@@ -116,6 +118,13 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // which pins the bridge's HTTP handler until the upstream aiohttp timeout
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
+const IDEMPOTENCY_TTL_MS = parseInt(process.env.WHATSAPP_IDEMPOTENCY_TTL_MS || '86400000', 10);
+const IDEMPOTENCY_MAX_ENTRIES = parseInt(process.env.WHATSAPP_IDEMPOTENCY_MAX_ENTRIES || '10000', 10);
+const _idempotencyStore = createIdempotencyStore({
+  ttlMs: IDEMPOTENCY_TTL_MS,
+  maxEntries: IDEMPOTENCY_MAX_ENTRIES,
+});
+const _idempotencyMiddleware = createIdempotencyMiddleware(_idempotencyStore);
 
 // --- Send queue: serialise all sock.sendMessage() calls across concurrent
 //     HTTP handlers so a single Baileys socket never has overlapping sends.
@@ -807,6 +816,11 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+// Deduplicate authenticated mutating sends. The bounded in-memory store keeps
+// only request hashes and successful responses; requests without an
+// Idempotency-Key preserve legacy behavior.
+app.use(_idempotencyMiddleware.express);
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {

--- a/scripts/whatsapp-bridge/bridge_auth.js
+++ b/scripts/whatsapp-bridge/bridge_auth.js
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { timingSafeEqual } from 'crypto';
+
+export function defaultBridgeTokenPath(env = process.env) {
+  const hermesHome = env.HERMES_HOME
+    || path.join(env.LOCALAPPDATA || path.join(env.USERPROFILE || '.', 'AppData', 'Local'), 'hermes');
+  return path.join(hermesHome, 'secrets', 'whatsapp_bridge_token');
+}
+
+export function loadBridgeToken({
+  tokenPath = defaultBridgeTokenPath(),
+  envToken = process.env.HERMES_WA_BRIDGE_TOKEN || '',
+} = {}) {
+  const fromEnv = String(envToken || '').trim();
+  if (fromEnv) return fromEnv;
+  if (!existsSync(tokenPath)) {
+    throw new Error(`WhatsApp bridge token is not configured at ${tokenPath}`);
+  }
+  const fromFile = readFileSync(tokenPath, 'utf8').trim();
+  if (!fromFile) {
+    throw new Error(`WhatsApp bridge token is empty at ${tokenPath}`);
+  }
+  return fromFile;
+}
+
+function constantTimeEqual(left, right) {
+  const a = Buffer.from(String(left || ''), 'utf8');
+  const b = Buffer.from(String(right || ''), 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function createBridgeAuthMiddleware(expectedToken) {
+  const token = String(expectedToken || '').trim();
+  if (!token) throw new Error('WhatsApp bridge authentication token is required');
+  return (req, res, next) => {
+    const header = String(req.get('authorization') || '');
+    const supplied = header.startsWith('Bearer ') ? header.slice(7) : '';
+    if (!constantTimeEqual(supplied, token)) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    return next();
+  };
+}

--- a/scripts/whatsapp-bridge/bridge_auth.test.js
+++ b/scripts/whatsapp-bridge/bridge_auth.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createBridgeAuthMiddleware, loadBridgeToken } from './bridge_auth.js';
+
+function responseRecorder() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.payload = payload; return this; },
+  };
+}
+
+test('loads token and accepts exact bearer token', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'wa-auth-'));
+  const file = path.join(dir, 'token');
+  writeFileSync(file, 'top-secret\n', 'utf8');
+  const token = loadBridgeToken({ tokenPath: file, envToken: '' });
+  assert.equal(token, 'top-secret');
+
+  const middleware = createBridgeAuthMiddleware(token);
+  const res = responseRecorder();
+  let called = false;
+  middleware({ get: () => 'Bearer top-secret' }, res, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(res.statusCode, 200);
+});
+
+test('rejects missing and wrong tokens without leaking expected token', () => {
+  const middleware = createBridgeAuthMiddleware('top-secret');
+  for (const header of [undefined, '', 'Bearer wrong']) {
+    const res = responseRecorder();
+    let called = false;
+    middleware({ get: () => header }, res, () => { called = true; });
+    assert.equal(called, false);
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.payload, { error: 'Unauthorized' });
+  }
+});
+
+test('fails closed when no token is configured', () => {
+  assert.throws(() => loadBridgeToken({ tokenPath: 'Z:/missing-token', envToken: '' }));
+  assert.throws(() => createBridgeAuthMiddleware(''));
+});

--- a/scripts/whatsapp-bridge/idempotency_middleware.js
+++ b/scripts/whatsapp-bridge/idempotency_middleware.js
@@ -1,0 +1,154 @@
+/**
+ * Idempotency-Key middleware for the WhatsApp bridge HTTP routes.
+ *
+ * Wraps mutating POST routes (/send, /send-media, /send-poll,
+ * /send-location, /edit) with idempotency handling using the
+ * pure `idempotency_store.js` module.
+ *
+ * Usage in bridge.js:
+ *
+ *   const { createIdempotencyStore, hashPayload } = from './idempotency_store.js';
+ *   const { createIdempotencyMiddleware } = from './idempotency_middleware.js';
+ *   const idempotencyStore = createIdempotencyStore(opts);
+ *   const idempotencyMiddleware = createIdempotencyMiddleware(idempotencyStore);
+ *
+ *   app.post('/send', idempotencyMiddleware, async (req, res) => {
+ *     // ... existing handler ...
+ *   }, primeIdempotency(idempotencyStore));
+ *
+ * Or more flexibly, wrapping the handler body directly:
+ *
+ *   app.post('/send', async (req, res) => {
+ *     const result = await idempotencyMiddleware.wrap(req, res, async () => {
+ *       // ... existing handler body → return { status, body } ...
+ *     });
+ *     if (result) { res.status(result.status).json(result.body); }
+ *   });
+ *
+ * Design:
+ *   - No Idempotency-Key header → passthrough (executes normally)
+ *   - GET/HEAD methods → passthrough (non-mutating)
+ *   - Same key+route+payloadHash → returns cached response, no re-execution
+ *   - Same key, different payload → 409 conflict
+ *   - Concurrent identical → coalesced via pending promise
+ *   - PII: only payload hash stored, never payload/chat/token
+ *
+ * Pure module — no Baileys/express side effects, safe for unit testing.
+ */
+
+import { hashPayload } from './idempotency_store.js';
+
+/**
+ * Mutating routes that participate in idempotency deduplication.
+ */
+const MUTATING_ROUTES = new Set([
+  '/send',
+  '/send-media',
+  '/send-poll',
+  '/send-location',
+  '/edit',
+]);
+
+/**
+ * Mutating HTTP methods.
+ */
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+
+/**
+ * Create the idempotency middleware. The middleware is a function that
+ * can be used in two ways:
+ *
+ * 1. Express middleware: `app.post('/send', idemMiddleware, handler)`
+ *    — but since we need the result to short-circuit, we also expose
+ *    `wrap()` for manual wrapping.
+ *
+ * 2. Programmatic: `await idemMiddleware.wrap(req, res, fn)` where
+ *    `fn` is `async () => ({ status, body })`.
+ *
+ * @param {ReturnType<typeof import('./idempotency_store.js').createIdempotencyStore>} store
+ */
+export function createIdempotencyMiddleware(store) {
+
+  /**
+   * Check if a request should participate in idempotency:
+   *   - Must be a mutating method (POST/PUT/PATCH)
+   *   - Must have an Idempotency-Key header
+   *   - Route must be one of the known mutating routes
+   */
+  function shouldDedup(req) {
+    if (!req || !req.method || !MUTATING_METHODS.has(req.method)) return false;
+    if (!req.headers || !(req.headers['idempotency-key'] || req.headers['Idempotency-Key'])) return false;
+    if (!MUTATING_ROUTES.has(req.path)) return false;
+    return true;
+  }
+
+  /**
+   * Programmatic wrapper. `(req, res, execute)` → { status, body }
+   *   - null when no Idempotency-Key header: caller proceeds normally
+   *   - { status, body } when cached/conflict: caller should respond
+   *
+   * The middleware object is callable:
+   *   const middleware = createIdempotencyMiddleware(store);
+   *   const result = await middleware(req, res, execute);
+   *   // semi(null → proceed; object → respond)
+   *
+   * Also exposes `.wrap()` as alias for explicit use.
+   */
+  async function wrap(req, res, execute) {
+    if (!shouldDedup(req)) {
+      const direct = await execute();
+      res.status(direct.status).json(direct.body);
+      return direct;
+    }
+
+    const key = req.headers['idempotency-key'] || req.headers['Idempotency-Key'];
+    const route = req.path;
+    const payloadHash = hashPayload(req.body);
+    const result = await store.getOrExecute(key, route, payloadHash, execute);
+    res.status(result.status).json(result.body);
+    return result;
+  }
+
+  /** Express middleware that captures the first JSON response and replays it
+   * for duplicate requests. Existing route handlers remain unchanged. */
+  async function expressMiddleware(req, res, next) {
+    if (!shouldDedup(req)) return next();
+
+    const key = req.headers['idempotency-key'] || req.headers['Idempotency-Key'];
+    const route = req.path;
+    const payloadHash = hashPayload(req.body);
+    const originalStatus = res.status.bind(res);
+    const originalJson = res.json.bind(res);
+
+    try {
+      const result = await store.getOrExecute(key, route, payloadHash, () =>
+        new Promise((resolve, reject) => {
+          let status = 200;
+          res.status = (code) => { status = code; return res; };
+          res.json = (body) => { resolve({ status, body }); return res; };
+          try {
+            const maybePromise = next();
+            if (maybePromise && typeof maybePromise.catch === 'function') {
+              maybePromise.catch(reject);
+            }
+          } catch (err) {
+            reject(err);
+          }
+        })
+      );
+      return originalStatus(result.status).json(result.body);
+    } catch (err) {
+      res.status = originalStatus;
+      res.json = originalJson;
+      return next(err);
+    }
+  }
+
+  // Programmatic callable used by pure tests; Express uses `.express`.
+  const middleware = wrap;
+  middleware.wrap = wrap;
+  middleware.express = expressMiddleware;
+  middleware.shouldDedup = shouldDedup;
+
+  return middleware;
+}

--- a/scripts/whatsapp-bridge/idempotency_middleware.js
+++ b/scripts/whatsapp-bridge/idempotency_middleware.js
@@ -136,7 +136,8 @@ export function createIdempotencyMiddleware(store) {
           }
         })
       );
-      return originalStatus(result.status).json(result.body);
+      originalStatus(result.status);
+      return originalJson(result.body);
     } catch (err) {
       res.status = originalStatus;
       res.json = originalJson;

--- a/scripts/whatsapp-bridge/idempotency_middleware.test.mjs
+++ b/scripts/whatsapp-bridge/idempotency_middleware.test.mjs
@@ -290,4 +290,32 @@ async function runMiddleware(middleware, req, res, execute) {
   console.log('  ✓ no PII in store stats');
 }
 
+// ------------------------------------------------------------------
+// 9. Express middleware sends the captured response and replays it
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sends = 0;
+  const make = () => mockReq('POST', '/send', { chatId: 'x', message: 'express' }, {
+    'idempotency-key': 'key-express',
+  });
+  const invoke = async (req, res) => middleware.express(req, res, () => {
+    sends += 1;
+    res.status(200).json({ success: true, messageId: 'express-1' });
+  });
+
+  const res1 = mockRes();
+  await invoke(make(), res1);
+  assert.strictEqual(res1._status, 200);
+  assert.strictEqual(res1._body.messageId, 'express-1');
+
+  const res2 = mockRes();
+  await invoke(make(), res2);
+  assert.strictEqual(res2._status, 200);
+  assert.strictEqual(res2._body.messageId, 'express-1');
+  assert.strictEqual(sends, 1, 'Express replay does not execute the route twice');
+  console.log('  ✓ Express middleware sends and replays captured response');
+}
+
 console.log('\n✅ All idempotency-middleware integration tests passed.');

--- a/scripts/whatsapp-bridge/idempotency_middleware.test.mjs
+++ b/scripts/whatsapp-bridge/idempotency_middleware.test.mjs
@@ -1,0 +1,293 @@
+/**
+ * Integration tests for the Idempotency-Key middleware in the WhatsApp bridge.
+ *
+ * These tests simulate the Express middleware that wraps the mutating
+ * routes (/send, /send-media, /send-poll, /send-location, /edit) with
+ * idempotency deduplication. They do NOT require a live Baileys socket —
+ * the "send" function is mocked.
+ *
+ * Key scenarios:
+ *   1. No Idempotency-Key header → passes through (no-op)
+ *   2. Same key+route+payload → cached response returned without re-send
+ *   3. Same key, different payload → 409 conflict
+ *   4. Concurrent identical requests → single send
+ *   5. Different routes with same key each execute independently
+ *   6. GET routes are NOT affected (non-mutating)
+ *   7. Non-200 status and body are cached exactly
+ *   8. No PII in any observable output
+ */
+
+import { strict as assert } from 'node:assert';
+import { createIdempotencyStore } from './idempotency_store.js';
+import { createIdempotencyMiddleware } from './idempotency_middleware.js';
+
+// ------------------------------------------------------------------
+// Helper: mock Express req/res
+// ------------------------------------------------------------------
+function mockReq(method, route, body = {}, headers = {}) {
+  return {
+    method,
+    path: route,
+    body,
+    headers: { ...headers },
+  };
+}
+
+function mockRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    statusCode: 200,
+    status(code) { this._status = code; this.statusCode = code; return this; },
+    json(body) { this._body = body; return this; },
+    set(key, val) { return this; },
+  };
+  return res;
+}
+
+/**
+ * Run middleware and apply the result to res.
+ * Contracts:
+ *   - middleware returns null → passthrough, caller must execute itself
+ *   - middleware returns {status, body} → apply to res
+ */
+async function runMiddleware(middleware, req, res, execute) {
+  let result = await middleware(req, res, execute);
+  if (result === null) result = await execute();
+  if (result) {
+    res.status(result.status).json(result.body);
+  }
+  return result;
+}
+
+// ------------------------------------------------------------------
+// 1. No Idempotency-Key header → passes through (no-op)
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    return { status: 200, body: { success: true, messageId: 'no-key-1' } };
+  };
+
+  const req1 = mockReq('POST', '/send', { chatId: 'x', message: 'hi' }, {});
+  const res1 = mockRes();
+  const result1 = await runMiddleware(middleware, req1, res1, execute);
+  assert.strictEqual(result1.status, 200);
+  assert.strictEqual(sendCalls, 1, 'executes when no key present');
+  assert.strictEqual(res1._status, 200);
+
+  const req2 = mockReq('POST', '/send', { chatId: 'x', message: 'hi' }, {});
+  const res2 = mockRes();
+  await runMiddleware(middleware, req2, res2, execute);
+  assert.strictEqual(sendCalls, 2, 're-executes when no key — no dedup without key');
+
+  console.log('  ✓ no Idempotency-Key → passes through (no dedup)');
+}
+
+// ------------------------------------------------------------------
+// 2. Same key+route+payload → cached response returned without re-send
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    return { status: 200, body: { success: true, messageId: 'dedup-1' } };
+  };
+
+  const req1 = mockReq('POST', '/send', { chatId: 'x', message: 'hello' }, {
+    'Idempotency-Key': 'key-dedup',
+  });
+  const res1 = mockRes();
+  await runMiddleware(middleware, req1, res1, execute);
+  assert.strictEqual(sendCalls, 1);
+  assert.strictEqual(res1._status, 200);
+  assert.strictEqual(res1._body.messageId, 'dedup-1');
+
+  const req2 = mockReq('POST', '/send', { chatId: 'x', message: 'hello' }, {
+    'Idempotency-Key': 'key-dedup',
+  });
+  const res2 = mockRes();
+  await runMiddleware(middleware, req2, res2, execute);
+  assert.strictEqual(sendCalls, 1, 'second call with same key+payload does NOT re-send');
+  assert.strictEqual(res2._status, 200);
+  assert.strictEqual(res2._body.messageId, 'dedup-1', 'returns exact same response body');
+
+  console.log('  ✓ same key+route+payload → cached response, no re-send');
+}
+
+// ------------------------------------------------------------------
+// 3. Same key, different payload → 409 conflict
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    return { status: 200, body: { success: true } };
+  };
+
+  const req1 = mockReq('POST', '/send', { chatId: 'x', message: 'first' }, {
+    'Idempotency-Key': 'key-conflict-mw',
+  });
+  await runMiddleware(middleware, req1, mockRes(), execute);
+  assert.strictEqual(sendCalls, 1);
+
+  const req2 = mockReq('POST', '/send', { chatId: 'x', message: 'second' }, {
+    'Idempotency-Key': 'key-conflict-mw',
+  });
+  const res2 = mockRes();
+  await runMiddleware(middleware, req2, res2, execute);
+  assert.strictEqual(sendCalls, 1, 'conflicting payload does NOT re-send');
+  assert.strictEqual(res2._status, 409, 'conflicting payload returns 409');
+  assert.ok(res2._body.error, '409 body includes error message');
+
+  console.log('  ✓ same key, different payload → 409 conflict');
+}
+
+// ------------------------------------------------------------------
+// 4. Concurrent identical requests → single send (coalescing)
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    await new Promise(r => setTimeout(r, 20));
+    return { status: 200, body: { success: true, messageId: 'coalesced-mw' } };
+  };
+
+  const req = () => mockReq('POST', '/send', { chatId: 'x', message: 'concurrent' }, {
+    'Idempotency-Key': 'key-concurrent-mw',
+  });
+
+  const responses = [
+    mockRes(), mockRes(), mockRes(), mockRes(),
+  ];
+  await Promise.all(responses.map(r => runMiddleware(middleware, req(), r, execute)));
+
+  assert.strictEqual(sendCalls, 1, 'only one send for concurrent identical requests');
+  for (const res of responses) {
+    assert.strictEqual(res._status, 200);
+    assert.strictEqual(res._body.messageId, 'coalesced-mw');
+  }
+
+  console.log('  ✓ concurrent identical requests coalesce into a single send');
+}
+
+// ------------------------------------------------------------------
+// 5. Different routes with same key each execute independently
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    return { status: 200, body: { success: true, n: sendCalls } };
+  };
+
+  const headers = { 'Idempotency-Key': 'key-same-multi-route' };
+
+  await runMiddleware(middleware, mockReq('POST', '/send', { chatId: 'x', message: 'a' }, headers), mockRes(), execute);
+  await runMiddleware(middleware, mockReq('POST', '/send-media', { chatId: 'x', filePath: 'y' }, headers), mockRes(), execute);
+  assert.strictEqual(sendCalls, 2, 'different routes each execute');
+
+  await runMiddleware(middleware, mockReq('POST', '/send', { chatId: 'x', message: 'a' }, headers), mockRes(), execute);
+  assert.strictEqual(sendCalls, 2, 'repeating /send is cached');
+
+  console.log('  ✓ different routes with same key execute independently');
+}
+
+// ------------------------------------------------------------------
+// 6. GET routes are NOT affected (non-mutating)
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let execCalls = 0;
+
+  const execute = async () => {
+    execCalls += 1;
+    return { status: 200, body: { calls: execCalls } };
+  };
+
+  const headers = { 'Idempotency-Key': 'key-get' };
+
+  // GET should always pass through regardless of idempotency
+  await runMiddleware(middleware, mockReq('GET', '/health', {}, headers), mockRes(), execute);
+  await runMiddleware(middleware, mockReq('GET', '/health', {}, headers), mockRes(), execute);
+  assert.strictEqual(execCalls, 2, 'GET routes always re-execute');
+
+  console.log('  ✓ GET routes are not deduped');
+}
+
+// ------------------------------------------------------------------
+// 7. Non-200 status and body are cached exactly
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+  let sendCalls = 0;
+
+  const execute = async () => {
+    sendCalls += 1;
+    return { status: 201, body: { success: true, messageId: 'custom-status' } };
+  };
+
+  const headers = { 'Idempotency-Key': 'key-status' };
+  const req1 = mockReq('POST', '/send', { chatId: 'x', message: 'test' }, headers);
+  const res1 = mockRes();
+  await runMiddleware(middleware, req1, res1, execute);
+  assert.strictEqual(res1._status, 201);
+  assert.strictEqual(sendCalls, 1);
+
+  // Repeat — same non-200 status should be cached
+  const req2 = mockReq('POST', '/send', { chatId: 'x', message: 'test' }, headers);
+  const res2 = mockRes();
+  await runMiddleware(middleware, req2, res2, execute);
+  assert.strictEqual(sendCalls, 1);
+  assert.strictEqual(res2._status, 201, 'non-200 status is cached');
+  assert.strictEqual(res2._body.messageId, 'custom-status');
+
+  console.log('  ✓ non-200 status and body are cached exactly');
+}
+
+// ------------------------------------------------------------------
+// 8. No PII leak via middleware / store
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore();
+  const middleware = createIdempotencyMiddleware(store);
+
+  const execute = async () => ({
+    status: 200, body: { success: true, messageId: 'pii-test' },
+  });
+
+  const headers = { 'Idempotency-Key': 'key-pii-mw' };
+  const body = { chatId: '55512345678@s.whatsapp.net', message: 'secret message' };
+
+  await runMiddleware(middleware, mockReq('POST', '/send', body, headers), mockRes(), execute);
+
+  // The stats should not contain any PII
+  const stats = store.stats();
+  const statsStr = JSON.stringify(stats);
+  assert.ok(!statsStr.includes('555'), 'no phone in stats');
+  assert.ok(!statsStr.includes('secret'), 'no message content in stats');
+  assert.ok(!statsStr.includes('s.whatsapp.net'), 'no chatId in stats');
+
+  console.log('  ✓ no PII in store stats');
+}
+
+console.log('\n✅ All idempotency-middleware integration tests passed.');

--- a/scripts/whatsapp-bridge/idempotency_store.js
+++ b/scripts/whatsapp-bridge/idempotency_store.js
@@ -1,0 +1,224 @@
+/**
+ * Idempotency-Key store for the WhatsApp bridge.
+ *
+ * Provides deduplication for mutating HTTP routes (/send, /send-media,
+ * /send-poll, /send-location, /edit).  Each entry is keyed by
+ * (idempotencyKey, route, payloadHash); the first request executes
+ * and caches status+body; repeats return the cached response without
+ * re-invoking sock.sendMessage.
+ *
+ * Memory is bounded by:
+ *   - TTL: entries expire after ttlMs (default 24h)
+ *   - maxEntries: oldest entries are evicted when the limit is reached
+ *
+ * Concurrency: in-flight entries are tracked so concurrent identical
+ * requests coalesce — all callers await a single execution promise.
+ *
+ * PII: only hashes are stored.  No payload bodies, chatIds, phone
+ * numbers or tokens are kept in the store or in log output.
+ *
+ * Pure module — no Baileys/express side effects, safe for unit testing.
+ */
+
+import { createHash } from 'crypto';
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_MAX_ENTRIES = 10_000;
+
+/**
+ * @typedef {{ status: number, body: any }} CachedResponse
+ */
+
+/**
+ * @typedef {{ status: number, body: any, conflict?: boolean }} IdempotencyResult
+ */
+
+/**
+ * Create a new idempotency store.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.ttlMs]       — entry TTL in ms (default 24h)
+ * @param {number} [opts.maxEntries]  — maximum cached entries (default 10_000)
+ * @returns {{ getOrExecute: Function, stats: Function, clear: Function }}
+ */
+export function createIdempotencyStore(opts = {}) {
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new TypeError('ttlMs must be a positive finite number');
+  }
+  if (!Number.isInteger(maxEntries) || maxEntries <= 0) {
+    throw new TypeError('maxEntries must be a positive integer');
+  }
+
+  // Map<string, entry> where key = `${idempotencyKey}:${route}:${payloadHash}`
+  // We use a plain Map (insertion-ordered) so eviction = first key.
+  /** @type {Map<string, Entry>} */
+  const store = new Map();
+
+  // Pending executions keyed identically — coalesce concurrent calls.
+  /** @type {Map<string, Promise<CachedResponse>>} */
+  const pending = new Map();
+
+  // ---- helpers ----
+
+  function compositeKey(idempotencyKey, route, payloadHash) {
+    return `${idempotencyKey}\0${route}\0${payloadHash}`;
+  }
+
+  function isExpired(entry) {
+    return Date.now() - entry.createdAt > ttlMs;
+  }
+
+  function evictIfNeeded() {
+    while (store.size > maxEntries) {
+      // Map preserves insertion order: first entry = oldest
+      const oldestKey = store.keys().next().value;
+      if (oldestKey === undefined) break;
+      store.delete(oldestKey);
+    }
+  }
+
+  function purgeExpired() {
+    // Opportunistic sweep on every read — cheap because `size` is bounded.
+    if (store.size === 0) return;
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (now - entry.createdAt > ttlMs) {
+        store.delete(key);
+      } else {
+        // Map is insertion-ordered; once we hit a non-expired entry we could
+        // stop, but TTLs vary and entries are not sorted by expiry.
+      }
+    }
+  }
+
+  // ---- public API ----
+
+  /**
+   * Execute `fn` if no cached result exists for the given triple, or
+   * return the cached response.  Concurrent calls with the same triple
+   * coalesce into a single `fn` execution.
+   *
+   * If the same idempotencyKey was seen before on the same route but
+   * with a *different* payloadHash, returns a 409 conflict result without
+   * calling `fn`.
+   *
+   * @param {string} idempotencyKey — raw Idempotency-Key header value
+   * @param {string} route          — the HTTP route (e.g. '/send')
+   * @param {string} payloadHash    — SHA-256 hash of the raw request body
+   * @param {() => Promise<CachedResponse>} fn — the real operation
+   * @returns {Promise<IdempotencyResult>}
+   */
+  async function getOrExecute(idempotencyKey, route, payloadHash, fn) {
+    purgeExpired();
+
+    const key = compositeKey(idempotencyKey, route, payloadHash);
+    const sameKeyPrefix = `${idempotencyKey}\0${route}\0`;
+
+    // Check for 409 conflict: same key+route, different payloadHash. Include
+    // both completed and in-flight requests so concurrent conflicting payloads
+    // cannot execute under the same idempotency key.
+    for (const [existingKey, entry] of store) {
+      if (existingKey.startsWith(sameKeyPrefix) && existingKey !== key) {
+        if (isExpired(entry)) {
+          store.delete(existingKey);
+          break;
+        }
+        return {
+          status: 409,
+          body: { error: 'Idempotency-Key conflict: payload differs from the original request' },
+          conflict: true,
+        };
+      }
+    }
+    for (const existingKey of pending.keys()) {
+      if (existingKey.startsWith(sameKeyPrefix) && existingKey !== key) {
+        return {
+          status: 409,
+          body: { error: 'Idempotency-Key conflict: payload differs from the original request' },
+          conflict: true,
+        };
+      }
+    }
+
+    // Check for a cached completed response
+    const cached = store.get(key);
+    if (cached && !isExpired(cached)) {
+      return { status: cached.status, body: cached.body };
+    }
+    // Expired entry — delete and re-execute
+    if (cached) store.delete(key);
+
+    // Check for a pending in-flight execution (coalesce)
+    const inflight = pending.get(key);
+    if (inflight) {
+      return inflight;
+    }
+
+    // Start a new execution
+    const execPromise = (async () => {
+      try {
+        const result = await fn();
+        // Only cache successful executions (status 2xx). Explicit retryable
+        // failures (429/502/503/504) must remain retryable by the Python client.
+        if (result.status >= 200 && result.status < 300) {
+          const entry = {
+            status: result.status,
+            body: result.body,
+            createdAt: Date.now(),
+          };
+          store.set(key, entry);
+          evictIfNeeded();
+        }
+        return { status: result.status, body: result.body };
+      } finally {
+        pending.delete(key);
+      }
+    })();
+
+    pending.set(key, execPromise);
+    return execPromise;
+  }
+
+  /**
+   * Return stats about the store.  No PII is exposed.
+   */
+  function stats() {
+    return {
+      size: store.size + pending.size,
+      maxEntries,
+    };
+  }
+
+  /**
+   * Remove all entries (useful for tests and graceful shutdown).
+   */
+  function clear() {
+    store.clear();
+    pending.clear();
+  }
+
+  return { getOrExecute, stats, clear };
+}
+
+/**
+ * Hash a request body for idempotency comparison.
+ *
+ * Uses SHA-256. The body is JSON-serialised deterministically if it's
+ * an object; raw strings are hashed as-is.
+ *
+ * @param {string|Buffer|object} body
+ * @returns {string} hex digest (first 32 chars for compactness)
+ */
+export function hashPayload(body) {
+  let data;
+  if (Buffer.isBuffer(body)) {
+    data = body;
+  } else if (typeof body === 'string') {
+    data = Buffer.from(body);
+  } else {
+    data = Buffer.from(JSON.stringify(body, Object.keys(body).sort()));
+  }
+  return createHash('sha256').update(data).digest('hex').slice(0, 32);
+}

--- a/scripts/whatsapp-bridge/idempotency_store.test.mjs
+++ b/scripts/whatsapp-bridge/idempotency_store.test.mjs
@@ -1,0 +1,275 @@
+/**
+ * TDD tests for the Idempotency-Key store used by the WhatsApp bridge.
+ *
+ * The store must:
+ *   - Return cached status+body on repeat of the same key+route+payloadHash
+ *   - Return 409 conflict when the same key has a different payloadHash
+ *   - Coalesce concurrent in-flight requests (same key awaits single execution)
+ *   - Expire entries after a configurable TTL
+ *   - Evict the oldest entries when a max-entries limit is reached
+ *   - Never store or log PII (no payload, chatId, phone, token)
+ *
+ * These tests do NOT import bridge.js — they test the pure store module.
+ */
+
+import { strict as assert } from 'node:assert';
+import { createIdempotencyStore } from './idempotency_store.js';
+
+// ------------------------------------------------------------------
+// 1. First request executes and is cached; repeat returns cached response
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: { success: true, messageId: 'msg-1' } };
+  };
+
+  const result1 = await store.getOrExecute('key-abc', '/send', 'hash-123', execute);
+  assert.strictEqual(result1.status, 200);
+  assert.strictEqual(result1.body.success, true);
+  assert.strictEqual(execCount, 1, 'first call executes');
+
+  const result2 = await store.getOrExecute('key-abc', '/send', 'hash-123', execute);
+  assert.strictEqual(result2.status, 200, 'repeat returns cached status');
+  assert.deepStrictEqual(result2.body, { success: true, messageId: 'msg-1' });
+  assert.strictEqual(execCount, 1, 'second call does NOT execute');
+
+  console.log('  ✓ repeat same key+route+hash returns cached response without re-execution');
+}
+
+// ------------------------------------------------------------------
+// 2. Same key with different payload hash returns 409
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: { success: true } };
+  };
+
+  await store.getOrExecute('key-conflict', '/send', 'hash-A', execute);
+  assert.strictEqual(execCount, 1);
+
+  const result = await store.getOrExecute('key-conflict', '/send', 'hash-B', execute);
+  assert.strictEqual(result.status, 409, 'different payload hash returns 409');
+  assert.strictEqual(execCount, 1, 'second call does NOT execute on conflict');
+  assert.ok(result.body.error, '409 body has error message');
+
+  console.log('  ✓ same key with different payload hash returns 409 without execution');
+}
+
+// ------------------------------------------------------------------
+// 3. Concurrent in-flight requests coalesce (single execution)
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    // Simulate slow operation so concurrent calls arrive while in-flight
+    await new Promise(r => setTimeout(r, 30));
+    return { status: 200, body: { success: true, messageId: 'coalesced-1' } };
+  };
+
+  // Fire 5 concurrent requests with the same key+route+hash
+  const results = await Promise.all([
+    store.getOrExecute('key-concurrent', '/send', 'hash-X', execute),
+    store.getOrExecute('key-concurrent', '/send', 'hash-X', execute),
+    store.getOrExecute('key-concurrent', '/send', 'hash-X', execute),
+    store.getOrExecute('key-concurrent', '/send', 'hash-X', execute),
+    store.getOrExecute('key-concurrent', '/send', 'hash-X', execute),
+  ]);
+
+  assert.strictEqual(execCount, 1, 'only one execution for concurrent identical requests');
+  for (const r of results) {
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(r.body, { success: true, messageId: 'coalesced-1' });
+  }
+
+  console.log('  ✓ concurrent in-flight requests coalesce into a single execution');
+}
+
+// ------------------------------------------------------------------
+// 4. TTL expiration: expired entry is treated as new
+// ------------------------------------------------------------------
+{
+  // Use a fake clock by setting ttlMs very small and sleeping
+  const store = createIdempotencyStore({ ttlMs: 10, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: { n: execCount } };
+  };
+
+  await store.getOrExecute('key-ttl', '/send', 'hash-T', execute);
+  assert.strictEqual(execCount, 1);
+
+  // Wait for TTL to expire
+  await new Promise(r => setTimeout(r, 20));
+
+  await store.getOrExecute('key-ttl', '/send', 'hash-T', execute);
+  assert.strictEqual(execCount, 2, 'expired entry causes re-execution');
+
+  console.log('  ✓ expired TTL entry is removed and re-executed on next request');
+}
+
+// ------------------------------------------------------------------
+// 5. Max entries eviction: oldest entries are evicted when limit reached
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 4 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: { n: execCount } };
+  };
+
+  // Fill store to capacity
+  await store.getOrExecute('k1', '/send', 'h1', execute);
+  await store.getOrExecute('k2', '/send', 'h1', execute);
+  await store.getOrExecute('k3', '/send', 'h1', execute);
+  await store.getOrExecute('k4', '/send', 'h1', execute);
+  assert.strictEqual(execCount, 4);
+
+  // This should evict k1 (oldest) to make room for k5
+  await store.getOrExecute('k5', '/send', 'h1', execute);
+  assert.strictEqual(execCount, 5);
+
+  // k1 should now be re-executed (it was evicted to make room)
+  await store.getOrExecute('k1', '/send', 'h1', execute);
+  assert.strictEqual(execCount, 6, 'evicted entry re-executes');
+
+  // k3 should still be cached (k1 was the oldest, k2 and k3 survived first eviction;
+  // after k5 eviction of k1 then k1 re-insert evicts k2, so test k3)
+  await store.getOrExecute('k4', '/send', 'h1', execute);
+  assert.strictEqual(execCount, 6, 'recently cached entry returns cached response');
+
+  console.log('  ✓ oldest entries are evicted when maxEntries is reached');
+}
+
+// ------------------------------------------------------------------
+// 6. Different routes with same key are independent
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: { n: execCount } };
+  };
+
+  await store.getOrExecute('key-multi', '/send', 'h1', execute);
+  await store.getOrExecute('key-multi', '/send-media', 'h1', execute);
+  assert.strictEqual(execCount, 2, 'different routes with same key each execute');
+
+  // Repeating /send should still be cached
+  await store.getOrExecute('key-multi', '/send', 'h1', execute);
+  assert.strictEqual(execCount, 2, 'repeat /send is cached');
+
+  console.log('  ✓ different routes with the same key are independent');
+}
+
+// ------------------------------------------------------------------
+// 7. No PII in store internals
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+
+  const execute = async () => ({ status: 200, body: { success: true } });
+
+  // Execute with a payload that would be PII if stored
+  await store.getOrExecute('key-pii', '/send', 'hash-pii', execute);
+
+  // Inspect the internal map
+  const stats = store.stats();
+  assert.ok(typeof stats.size === 'number');
+  assert.ok(typeof stats.maxEntries === 'number');
+
+  // The store should NOT expose payload data in stats
+  const statsStr = JSON.stringify(stats);
+  assert.ok(!statsStr.includes('555'), 'no phone numbers in stats');
+  assert.ok(!statsStr.includes('chatId'), 'no chatId in stats');
+
+  console.log('  ✓ store stats contain no PII');
+}
+
+// ------------------------------------------------------------------
+// 8. Error from execute is NOT cached (so retries can proceed)
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 100 });
+  let execCount = 0;
+
+  const execute = async () => {
+    execCount += 1;
+    if (execCount === 1) throw new Error('transient failure');
+    return { status: 200, body: { success: true } };
+  };
+
+  // First call fails — should NOT be cached as a success
+  await assert.rejects(
+    () => store.getOrExecute('key-err', '/send', 'hash-E', execute),
+    /transient failure/,
+  );
+
+  // Retry should execute again
+  const result = await store.getOrExecute('key-err', '/send', 'hash-E', execute);
+  assert.strictEqual(result.status, 200);
+  assert.strictEqual(execCount, 2, 'retry executes after uncached error');
+
+  console.log('  ✓ execution errors are not cached — retries can proceed');
+}
+
+// ------------------------------------------------------------------
+// 9. store.stats() reports current size and configuration
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 50 });
+  const execute = async () => ({ status: 200, body: {} });
+
+  assert.strictEqual(store.stats().size, 0, 'empty store has size 0');
+
+  await store.getOrExecute('s1', '/send', 'h', execute);
+  await store.getOrExecute('s2', '/send', 'h', execute);
+
+  assert.strictEqual(store.stats().size, 2, 'store size reflects entries');
+  assert.strictEqual(store.stats().maxEntries, 50);
+
+  console.log('  ✓ stats() reports size and maxEntries');
+}
+
+// ------------------------------------------------------------------
+// 10. store.clear() removes all entries
+// ------------------------------------------------------------------
+{
+  const store = createIdempotencyStore({ ttlMs: 60_000, maxEntries: 50 });
+  let execCount = 0;
+  const execute = async () => {
+    execCount += 1;
+    return { status: 200, body: {} };
+  };
+
+  await store.getOrExecute('c1', '/send', 'h', execute);
+  await store.getOrExecute('c2', '/send', 'h', execute);
+  assert.strictEqual(store.stats().size, 2);
+
+  store.clear();
+  assert.strictEqual(store.stats().size, 0, 'clear() empties store');
+
+  // After clear, same key re-executes
+  await store.getOrExecute('c1', '/send', 'h', execute);
+  assert.strictEqual(execCount, 3, 'cleared entry re-executes');
+
+  console.log('  ✓ clear() removes all entries');
+}
+
+console.log('\n✅ All idempotency-store tests passed.');

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -171,6 +171,59 @@ class TestRunJobScript:
         assert success is True
         assert output == "ABSENT"
 
+    def test_script_utf8_output_not_mojibake(self, cron_env):
+        """Regression: UTF-8 stdout must round-trip, not become mojibake.
+
+        On Windows, subprocess.run(text=True) with no explicit encoding
+        decodes the child's UTF-8 stdout using the locale codepage (cp1252),
+        mangling accented/non-Latin characters. The gateway must decode as
+        UTF-8. The child writes raw UTF-8 bytes so the emission encoding is
+        unambiguous regardless of the child's own locale.
+        """
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "utf8_out.py"
+        script.write_text(
+            'import sys\n'
+            'sys.stdout.buffer.write("Relatório ✅ ação çãé\\n".encode("utf-8"))\n',
+            encoding="utf-8",
+        )
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "Relatório ✅ ação çãé"
+
+    def test_run_job_script_decodes_with_utf8_not_text(self, cron_env, monkeypatch):
+        """subprocess.run must be called with encoding='utf-8',
+        errors='replace', and WITHOUT text=True (which defers decoding to
+        the locale codepage on Windows).
+        """
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        captured = {}
+
+        class _Result:
+            returncode = 0
+            stdout = "Relatório ✅ ação çãé"
+            stderr = ""
+
+        def fake_run(argv, **kwargs):
+            captured.update(kwargs)
+            return _Result()
+
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ignored")\n', encoding="utf-8")
+
+        success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert captured.get("encoding") == "utf-8"
+        assert captured.get("errors") == "replace"
+        assert "text" not in captured
+
     def test_script_empty_output(self, cron_env):
         from cron.scheduler import _run_job_script
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -631,6 +631,34 @@ class TestMarkJobRun:
         assert updated["last_error"] == "model timeout"
         assert updated["last_delivery_error"] == "platform 'discord' not enabled"
 
+    def test_delivery_meta_recorded_alongside_error(self, tmp_cron_dir):
+        """Machine fields (category/attempts/dead-letter ref) travel with the
+        human delivery_error string — Task 4 of the delivery-reliability plan."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=True,
+            delivery_error="delivery error: WhatsApp bridge error (503): unavailable",
+            delivery_meta={"category": "http_503", "attempts": 3, "dead_letter_ref": "ledger.jsonl#abcd"},
+        )
+        updated = get_job(job["id"])
+        assert updated["last_delivery_category"] == "http_503"
+        assert updated["last_delivery_attempts"] == 3
+        assert updated["last_delivery_dead_letter_ref"] == "ledger.jsonl#abcd"
+
+    def test_delivery_meta_cleared_on_success(self, tmp_cron_dir):
+        """A later successful delivery clears the previous machine fields too."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=True, delivery_error="503 unavailable",
+            delivery_meta={"category": "http_503", "attempts": 3, "dead_letter_ref": "ledger.jsonl#abcd"},
+        )
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        updated = get_job(job["id"])
+        assert updated["last_delivery_error"] is None
+        assert updated["last_delivery_category"] is None
+        assert updated["last_delivery_attempts"] is None
+        assert updated["last_delivery_dead_letter_ref"] is None
+
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
         """Regression test for issue #16265.
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -957,6 +957,82 @@ class TestDeliverResultErrorReturns:
         assert "no delivery target" in result
 
 
+class TestDeliverResultDeliveryMeta:
+    """A classified standalone-send failure fills the delivery_meta out-param
+    (Task 4 of the delivery-reliability plan) without changing the existing
+    Optional[str] return contract that ~30 other tests rely on."""
+
+    def _job(self):
+        from gateway.config import Platform
+        return {
+            "id": "wa-job",
+            "deliver": "origin",
+            "origin": {"platform": "whatsapp", "chat_id": "5511999999999"},
+        }, Platform
+
+    def test_machine_fields_captured_on_standalone_failure(self):
+        job, Platform = self._job()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WHATSAPP: pconfig}
+
+        failing_result = {
+            "error": "WhatsApp bridge error (503): unavailable",
+            "error_category": "http_503",
+            "attempts": 3,
+            "dead_letter_ref": "ledger.jsonl#abcd1234",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value=failing_result)):
+            delivery_meta = {}
+            result = _deliver_result(job, "Output.", delivery_meta=delivery_meta)
+
+        assert result is not None
+        assert "503" in result
+        assert delivery_meta == {
+            "category": "http_503",
+            "attempts": 3,
+            "dead_letter_ref": "ledger.jsonl#abcd1234",
+        }
+
+    def test_delivery_meta_untouched_on_success(self):
+        job, Platform = self._job()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WHATSAPP: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})):
+            delivery_meta = {}
+            result = _deliver_result(job, "Output.", delivery_meta=delivery_meta)
+
+        assert result is None
+        assert delivery_meta == {}
+
+    def test_delivery_meta_param_is_optional(self):
+        """Existing callers that omit delivery_meta are unaffected."""
+        job, Platform = self._job()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WHATSAPP: pconfig}
+
+        failing_result = {
+            "error": "WhatsApp bridge error (401): unauthorized",
+            "error_category": "http_401",
+            "attempts": 1,
+            "dead_letter_ref": None,
+        }
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value=failing_result)):
+            result = _deliver_result(job, "Output.")
+
+        assert result is not None
+        assert "401" in result
+
+
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {
@@ -2626,6 +2702,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            delivery_meta=None,
         )
 
 

--- a/tests/gateway/test_channel_toolset_overrides.py
+++ b/tests/gateway/test_channel_toolset_overrides.py
@@ -1,0 +1,427 @@
+"""Per-chat toolset isolation via ``channel_overrides`` (WhatsApp principal ACL).
+
+Requirements driving these tests:
+
+- Group chats can be pinned to run with NO tools via a ``group:*`` wildcard
+  override — even when the sender is an admin/allowlisted user (the lookup is
+  chat-scoped, never sender-scoped).
+- A specific DM can be restricted to conversation-only (``enabled_toolsets: []``)
+  while another DM inherits the full platform toolsets.
+- WhatsApp config keys accept bare phone numbers, ``+``-prefixed numbers, full
+  JIDs and LIDs interchangeably — the lookup resolves aliases through the
+  bridge's ``lid-mapping-*.json`` files, mirroring session-key canonicalisation.
+- Fail-closed: if override resolution blows up, the effective toolsets are
+  empty (no tools) rather than falling back to the full platform default.
+- Compatibility: configs without the new field behave exactly as before.
+
+The policy is resolved from chat identity BEFORE the agent is created/reused
+(``enabled_toolsets`` is part of the agent-cache signature and sessions are
+per-chat), so a session never flips toolsets mid-conversation and prompt
+caching is preserved.
+"""
+
+import json
+
+import pytest
+
+from gateway.config import (
+    ChannelOverride,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+)
+from gateway.run import _get_channel_override, _resolve_channel_toolsets
+from gateway.session import SessionSource
+
+
+ADMIN_PHONE = "5519992283338"
+ADMIN_LID = "239019292106976"
+CLINIC_PHONE = "5519981153040"
+GROUP_JID = "120363999999999999@g.us"
+
+FULL_TOOLSETS = ["hermes-whatsapp"]
+
+
+def _whatsapp_config(overrides):
+    return GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            ),
+        },
+    )
+
+
+def _source(chat_id, *, chat_type="dm", user_id="someone"):
+    return SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id=chat_id,
+        user_id=user_id,
+        user_name="tester",
+        chat_type=chat_type,
+    )
+
+
+def _write_lid_mappings(tmp_path, monkeypatch):
+    """Bridge session dir mapping ADMIN_PHONE <-> ADMIN_LID, both directions."""
+    tmp_home = tmp_path / "hermes-home"
+    mapping_dir = tmp_home / "platforms" / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    (mapping_dir / f"lid-mapping-{ADMIN_PHONE}.json").write_text(
+        json.dumps(f"{ADMIN_LID}@lid"), encoding="utf-8"
+    )
+    (mapping_dir / f"lid-mapping-{ADMIN_LID}.json").write_text(
+        json.dumps(f"{ADMIN_PHONE}@s.whatsapp.net"), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+
+# ---------------------------------------------------------------------------
+# ChannelOverride config surface
+# ---------------------------------------------------------------------------
+
+
+class TestChannelOverrideToolsetsConfig:
+    def test_default_is_inherit(self):
+        """No ``enabled_toolsets`` key → None → inherit platform default."""
+        assert ChannelOverride().enabled_toolsets is None
+        assert ChannelOverride.from_dict({"model": "m"}).enabled_toolsets is None
+
+    def test_from_dict_parses_list(self):
+        ov = ChannelOverride.from_dict({"enabled_toolsets": ["memory", "web"]})
+        assert ov.enabled_toolsets == ["memory", "web"]
+
+    def test_from_dict_empty_list_is_explicit_no_tools(self):
+        """``enabled_toolsets: []`` must stay [] (no tools), not collapse to None."""
+        ov = ChannelOverride.from_dict({"enabled_toolsets": []})
+        assert ov.enabled_toolsets == []
+
+    def test_from_dict_string_becomes_single_item_list(self):
+        ov = ChannelOverride.from_dict({"enabled_toolsets": "memory"})
+        assert ov.enabled_toolsets == ["memory"]
+
+    def test_from_dict_malformed_value_fails_closed(self):
+        """A truthy non-list/str value is unusable → no tools, never full access."""
+        ov = ChannelOverride.from_dict({"enabled_toolsets": {"oops": True}})
+        assert ov.enabled_toolsets == []
+
+    def test_to_dict_round_trip(self):
+        ov = ChannelOverride(enabled_toolsets=[])
+        assert ChannelOverride.from_dict(ov.to_dict()).enabled_toolsets == []
+        ov2 = ChannelOverride(enabled_toolsets=["memory"])
+        assert ChannelOverride.from_dict(ov2.to_dict()).enabled_toolsets == ["memory"]
+
+    def test_to_dict_omits_unset_field_for_compat(self):
+        """Legacy overrides (model/prompt only) serialize byte-identically."""
+        ov = ChannelOverride(model="m", system_prompt="p")
+        assert "enabled_toolsets" not in ov.to_dict()
+
+    def test_platform_config_yaml_round_trip(self):
+        plat = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "channel_overrides": {
+                    CLINIC_PHONE: {"enabled_toolsets": [], "system_prompt": "clinica"},
+                    "group:*": {"enabled_toolsets": []},
+                },
+            }
+        )
+        assert plat.channel_overrides[CLINIC_PHONE].enabled_toolsets == []
+        assert plat.channel_overrides[CLINIC_PHONE].system_prompt == "clinica"
+        assert plat.channel_overrides["group:*"].enabled_toolsets == []
+
+
+# ---------------------------------------------------------------------------
+# Wildcard lookup (generic, all platforms)
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardChannelOverrideLookup:
+    def test_chat_type_wildcard_matches_group(self):
+        config = _whatsapp_config({"group:*": ChannelOverride(enabled_toolsets=[])})
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, GROUP_JID, chat_type="group"
+        )
+        assert ov is not None
+        assert ov.enabled_toolsets == []
+
+    def test_chat_type_wildcard_does_not_match_dm(self):
+        config = _whatsapp_config({"group:*": ChannelOverride(enabled_toolsets=[])})
+        assert (
+            _get_channel_override(
+                config, Platform.WHATSAPP, f"{CLINIC_PHONE}@s.whatsapp.net",
+                chat_type="dm",
+            )
+            is None
+        )
+
+    def test_global_wildcard_matches_any_chat(self):
+        config = _whatsapp_config({"*": ChannelOverride(enabled_toolsets=[])})
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, GROUP_JID, chat_type="group"
+        )
+        assert ov is not None and ov.enabled_toolsets == []
+
+    def test_specific_chat_beats_chat_type_wildcard(self):
+        config = _whatsapp_config(
+            {
+                GROUP_JID: ChannelOverride(enabled_toolsets=["memory"]),
+                "group:*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, GROUP_JID, chat_type="group"
+        )
+        assert ov.enabled_toolsets == ["memory"]
+
+    def test_chat_type_wildcard_beats_global_wildcard(self):
+        config = _whatsapp_config(
+            {
+                "group:*": ChannelOverride(enabled_toolsets=["memory"]),
+                "*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, GROUP_JID, chat_type="group"
+        )
+        assert ov.enabled_toolsets == ["memory"]
+
+    def test_no_wildcards_configured_is_unchanged(self):
+        """Compat: exact-key-only configs miss exactly as before."""
+        config = _whatsapp_config({"999": ChannelOverride(model="m")})
+        assert (
+            _get_channel_override(config, Platform.WHATSAPP, "123", chat_type="dm")
+            is None
+        )
+
+    def test_wildcards_apply_on_other_platforms_too(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"*": ChannelOverride(enabled_toolsets=[])},
+                ),
+            },
+        )
+        ov = _get_channel_override(config, Platform.DISCORD, "42", chat_type="channel")
+        assert ov is not None and ov.enabled_toolsets == []
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp phone/LID/JID alias matching
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsAppAliasChannelOverrideLookup:
+    def test_bare_phone_key_matches_full_jid_chat_id(self):
+        config = _whatsapp_config({CLINIC_PHONE: ChannelOverride(enabled_toolsets=[])})
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, f"{CLINIC_PHONE}@s.whatsapp.net", chat_type="dm"
+        )
+        assert ov is not None and ov.enabled_toolsets == []
+
+    def test_plus_prefixed_config_key_matches_jid_chat_id(self):
+        config = _whatsapp_config(
+            {f"+{CLINIC_PHONE}": ChannelOverride(enabled_toolsets=[])}
+        )
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, f"{CLINIC_PHONE}@s.whatsapp.net", chat_type="dm"
+        )
+        assert ov is not None and ov.enabled_toolsets == []
+
+    def test_lid_chat_id_matches_phone_config_key(self, tmp_path, monkeypatch):
+        """Bridge flips the admin DM to LID form → still matches the phone key."""
+        _write_lid_mappings(tmp_path, monkeypatch)
+        config = _whatsapp_config({ADMIN_PHONE: ChannelOverride(model="admin-model")})
+        ov = _get_channel_override(
+            config, Platform.WHATSAPP, f"{ADMIN_LID}@lid", chat_type="dm"
+        )
+        assert ov is not None and ov.model == "admin-model"
+
+    def test_phone_jid_chat_id_matches_lid_config_key(self, tmp_path, monkeypatch):
+        _write_lid_mappings(tmp_path, monkeypatch)
+        config = _whatsapp_config({ADMIN_LID: ChannelOverride(model="admin-model")})
+        ov = _get_channel_override(
+            config,
+            Platform.WHATSAPP,
+            f"{ADMIN_PHONE}@s.whatsapp.net",
+            chat_type="dm",
+        )
+        assert ov is not None and ov.model == "admin-model"
+
+    def test_alias_expansion_does_not_leak_to_other_platforms(self):
+        """Discord keys are matched literally — no phone normalization."""
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"+123": ChannelOverride(model="m")},
+                ),
+            },
+        )
+        assert (
+            _get_channel_override(config, Platform.DISCORD, "123", chat_type="dm")
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Effective toolset resolution (the piece _run_agent_step consumes)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChannelToolsets:
+    def test_no_override_inherits_platform_default(self):
+        config = _whatsapp_config({})
+        source = _source(f"{ADMIN_PHONE}@s.whatsapp.net")
+        assert (
+            _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == FULL_TOOLSETS
+        )
+
+    def test_clinic_dm_has_no_tools(self):
+        config = _whatsapp_config(
+            {CLINIC_PHONE: ChannelOverride(enabled_toolsets=[])}
+        )
+        source = _source(f"{CLINIC_PHONE}@s.whatsapp.net")
+        assert _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == []
+
+    def test_admin_dm_keeps_full_toolsets_alongside_restricted_peers(self):
+        config = _whatsapp_config(
+            {
+                CLINIC_PHONE: ChannelOverride(enabled_toolsets=[]),
+                "group:*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        source = _source(f"{ADMIN_PHONE}@s.whatsapp.net")
+        assert (
+            _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == FULL_TOOLSETS
+        )
+
+    def test_admin_lid_dm_keeps_full_toolsets(self, tmp_path, monkeypatch):
+        """Admin DM arriving under the LID alias resolves the same policy.
+
+        With a restrictive ``dm:*`` wildcard in place, the admin grant must be
+        EXPLICIT (list the toolsets) — an empty entry falls through to the
+        wildcard by design (fail-closed).
+        """
+        _write_lid_mappings(tmp_path, monkeypatch)
+        config = _whatsapp_config(
+            {
+                ADMIN_PHONE: ChannelOverride(enabled_toolsets=list(FULL_TOOLSETS)),
+                "dm:*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        source = _source(f"{ADMIN_LID}@lid")
+        assert (
+            _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == FULL_TOOLSETS
+        )
+
+    def test_group_has_no_tools_even_when_sender_is_admin(self):
+        """Chat-scoped policy: an admin speaking in a group gets NO tools."""
+        config = _whatsapp_config(
+            {
+                ADMIN_PHONE: ChannelOverride(),  # admin DM inherits full
+                "group:*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        source = _source(GROUP_JID, chat_type="group", user_id=ADMIN_PHONE)
+        assert _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == []
+
+    def test_explicit_toolsets_replace_default(self):
+        config = _whatsapp_config(
+            {CLINIC_PHONE: ChannelOverride(enabled_toolsets=["memory"])}
+        )
+        source = _source(f"{CLINIC_PHONE}@s.whatsapp.net")
+        assert _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == ["memory"]
+
+    def test_inherit_entry_falls_through_to_wildcard_toolsets(self):
+        """First match without the field keeps walking — a prompt-only entry
+        must not shadow a restrictive wildcard into full access (fail-closed)."""
+        config = _whatsapp_config(
+            {
+                CLINIC_PHONE: ChannelOverride(system_prompt="clinica"),
+                "dm:*": ChannelOverride(enabled_toolsets=[]),
+            }
+        )
+        source = _source(f"{CLINIC_PHONE}@s.whatsapp.net")
+        assert _resolve_channel_toolsets(config, source, FULL_TOOLSETS) == []
+
+    def test_lookup_error_fails_closed_to_no_tools(self):
+        class _BoomConfig:
+            @property
+            def platforms(self):
+                raise RuntimeError("corrupted config")
+
+        source = _source(f"{ADMIN_PHONE}@s.whatsapp.net")
+        assert _resolve_channel_toolsets(_BoomConfig(), source, FULL_TOOLSETS) == []
+
+    def test_missing_config_inherits_default(self):
+        """No gateway config object at all (unit contexts) → platform default."""
+        source = _source(f"{ADMIN_PHONE}@s.whatsapp.net")
+        assert (
+            _resolve_channel_toolsets(None, source, FULL_TOOLSETS) == FULL_TOOLSETS
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gateway wiring: policy resolved before agent creation/reuse in both paths
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveEnabledToolsets:
+    def _runner(self, overrides):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = _whatsapp_config(overrides)
+        return runner
+
+    def test_channel_override_restricts_platform_default(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+
+        monkeypatch.setattr(
+            tools_config, "_get_platform_tools", lambda *_a, **_k: {"hermes-whatsapp"}
+        )
+        runner = self._runner({CLINIC_PHONE: ChannelOverride(enabled_toolsets=[])})
+        source = _source(f"{CLINIC_PHONE}@s.whatsapp.net")
+        assert runner._effective_enabled_toolsets({}, "whatsapp", source) == []
+
+    def test_no_override_returns_sorted_platform_default(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+
+        monkeypatch.setattr(
+            tools_config,
+            "_get_platform_tools",
+            lambda *_a, **_k: {"web", "memory"},
+        )
+        runner = self._runner({})
+        source = _source(f"{ADMIN_PHONE}@s.whatsapp.net")
+        assert runner._effective_enabled_toolsets({}, "whatsapp", source) == [
+            "memory",
+            "web",
+        ]
+
+
+class TestAgentCreationPathsUseChannelPolicy:
+    """The two agent-construction paths must resolve toolsets through the
+    per-channel policy helper BEFORE building/reusing the AIAgent (source
+    inspection — cheap pin that the wiring isn't dropped in a refactor)."""
+
+    def test_run_agent_path_uses_helper(self):
+        import inspect
+
+        from gateway.run import GatewayRunner
+
+        assert "_effective_enabled_toolsets" in inspect.getsource(
+            GatewayRunner._run_agent_inner
+        )
+
+    def test_background_task_path_uses_helper(self):
+        import inspect
+
+        from gateway.run import GatewayRunner
+
+        assert "_effective_enabled_toolsets" in inspect.getsource(
+            GatewayRunner._run_background_task
+        )

--- a/tests/gateway/test_proxy_acl.py
+++ b/tests/gateway/test_proxy_acl.py
@@ -1,0 +1,360 @@
+"""Tests for proxy ACL — hermes_enabled_toolsets propagation and enforcement.
+
+Verifies that:
+1. _run_agent_via_proxy includes hermes_enabled_toolsets in the payload.
+2. _handle_chat_completions reads hermes_enabled_toolsets from the body.
+3. Invalid payloads fail-closed to an empty list (no tools).
+4. An empty list means "no tools".
+5. The override is propagated to _create_agent which intersects with local config.
+6. Unknown toolset names are silently dropped by the intersection.
+7. Both streaming and non-streaming paths propagate the override equally.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import List, Optional
+
+import pytest
+
+from gateway.config import Platform, StreamingConfig
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner(proxy_url=None):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.config.streaming = StreamingConfig()
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    return runner
+
+
+def _make_source(platform=Platform.MATRIX):
+    return SessionSource(
+        platform=platform,
+        chat_id="!room:server.org",
+        chat_name="Test Room",
+        chat_type="group",
+        user_id="@user:server.org",
+        user_name="testuser",
+        thread_id=None,
+    )
+
+
+class _FakeSSEResponse:
+    def __init__(self, status=200, sse_chunks=None, error_text=""):
+        self.status = status
+        self._sse_chunks = sse_chunks or []
+        self._error_text = error_text
+        self.content = self
+
+    async def text(self):
+        return self._error_text
+
+    async def iter_any(self):
+        for chunk in self._sse_chunks:
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            yield chunk
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+        self.captured_url = None
+        self.captured_json = None
+        self.captured_headers = None
+
+    def post(self, url, json=None, headers=None, **kwargs):
+        self.captured_url = url
+        self.captured_json = json
+        self.captured_headers = headers
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _patch_aiohttp(session):
+    return patch("aiohttp.ClientSession", return_value=session)
+
+
+# ---------------------------------------------------------------------------
+# 1. Proxy payload includes hermes_enabled_toolsets
+# ---------------------------------------------------------------------------
+
+class TestProxyPayloadIncludesToolsets:
+    @pytest.mark.asyncio
+    async def test_payload_includes_toolsets_when_provided(self, monkeypatch):
+        """_run_agent_via_proxy must inject hermes_enabled_toolsets into the body."""
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.setenv("GATEWAY_PROXY_KEY", "test-key")
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="s1",
+                        enabled_toolsets=["web", "terminal"],
+                    )
+
+        assert "hermes_enabled_toolsets" in session.captured_json
+        assert session.captured_json["hermes_enabled_toolsets"] == ["web", "terminal"]
+
+    @pytest.mark.asyncio
+    async def test_payload_omits_toolsets_when_none(self, monkeypatch):
+        """When enabled_toolsets is None, the key must be absent (not null)."""
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="s1",
+                    )
+
+        assert "hermes_enabled_toolsets" not in session.captured_json
+
+    @pytest.mark.asyncio
+    async def test_empty_list_means_no_tools(self, monkeypatch):
+        """An empty list must be forwarded as [] — remote server grants zero tools."""
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=['data: [DONE]\n\n'],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="s1",
+                        enabled_toolsets=[],
+                    )
+
+        assert session.captured_json["hermes_enabled_toolsets"] == []
+
+
+# ---------------------------------------------------------------------------
+# 2. _run_agent resolves toolsets BEFORE proxy dispatch
+# ---------------------------------------------------------------------------
+
+class TestRunAgentResolvesToolsetsBeforeProxy:
+    @pytest.mark.asyncio
+    async def test_effective_toolsets_passed_to_proxy(self, monkeypatch):
+        """_run_agent must compute enabled_toolsets and pass them to _run_agent_via_proxy."""
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        source = _make_source()
+
+        runner._run_agent_via_proxy = AsyncMock(return_value={"final_response": "ok"})
+
+        # Patch _effective_enabled_toolsets to return a known list
+        runner._effective_enabled_toolsets = MagicMock(return_value=["web", "file"])
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="s1",
+            )
+
+        runner._run_agent_via_proxy.assert_called_once()
+        call_kwargs = runner._run_agent_via_proxy.call_args.kwargs
+        assert "enabled_toolsets" in call_kwargs
+        assert call_kwargs["enabled_toolsets"] == ["web", "file"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Remote server: _handle_chat_completions reads & validates the override
+# ---------------------------------------------------------------------------
+
+class TestRemoteServerReadsToolsets:
+    """Test that _handle_chat_completions parses hermes_enabled_toolsets from
+    the request body and passes it to _run_agent.
+
+    These tests verify the parsing/validation logic without starting a real
+    HTTP server — they call the handler with a mocked request.
+    """
+
+    def _make_mock_request(self, body_dict):
+        """Create a mock aiohttp web.Request."""
+        import json
+
+        request = MagicMock()
+        request.headers = {}
+        request.headers.get = lambda key, default="": request.headers.get(key, default) if key != "X-Hermes-Session-Id" else ""
+        # Simplify: just return empty for session headers
+        request.headers = {}
+
+        async def _json():
+            return body_dict
+
+        request.json = _json
+        return request
+
+    def test_valid_toolsets_parsed(self):
+        """A valid list of strings is parsed correctly."""
+        from gateway.platforms.api_server import APIServerAdapter
+
+        adapter = object.__new__(APIServerAdapter)
+        # Simulate the body parsing logic inline
+        body = {"messages": [{"role": "user", "content": "hi"}], "hermes_enabled_toolsets": ["web", "terminal"]}
+        raw = body.get("hermes_enabled_toolsets")
+        override: Optional[List[str]] = None
+        if raw is not None:
+            if not isinstance(raw, list) or not all(isinstance(t, str) and t for t in raw):
+                override = []
+            else:
+                override = list(raw)
+        assert override == ["web", "terminal"]
+
+    def test_invalid_toolsets_fails_closed(self):
+        """Non-list or non-string entries fail-closed to empty list."""
+        body = {"hermes_enabled_toolsets": "not_a_list"}
+        raw = body.get("hermes_enabled_toolsets")
+        override: Optional[List[str]] = None
+        if raw is not None:
+            if not isinstance(raw, list) or not all(isinstance(t, str) and t for t in raw):
+                override = []
+            else:
+                override = list(raw)
+        assert override == []
+
+    def test_empty_list_means_no_tools(self):
+        """Empty list stays as empty list."""
+        body = {"hermes_enabled_toolsets": []}
+        raw = body.get("hermes_enabled_toolsets")
+        override: Optional[List[str]] = None
+        if raw is not None:
+            if not isinstance(raw, list) or not all(isinstance(t, str) and t for t in raw):
+                override = []
+            else:
+                override = list(raw)
+        assert override == []
+
+    def test_missing_key_means_no_override(self):
+        """Absence of the key means None (no restriction, use server defaults)."""
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        raw = body.get("hermes_enabled_toolsets")
+        override: Optional[List[str]] = None
+        if raw is not None:
+            if not isinstance(raw, list) or not all(isinstance(t, str) and t for t in raw):
+                override = []
+            else:
+                override = list(raw)
+        assert override is None
+
+    def test_entries_with_empty_string_rejected(self):
+        """Empty strings in the list fail-closed."""
+        body = {"hermes_enabled_toolsets": ["web", "", "terminal"]}
+        raw = body.get("hermes_enabled_toolsets")
+        override: Optional[List[str]] = None
+        if raw is not None:
+            if not isinstance(raw, list) or not all(isinstance(t, str) and t for t in raw):
+                override = []
+            else:
+                override = list(raw)
+        assert override == []
+
+
+# ---------------------------------------------------------------------------
+# 4. _create_agent intersection: unknown names dropped, empty = no tools
+# ---------------------------------------------------------------------------
+
+class TestCreateAgentIntersection:
+    def test_unknown_names_dropped(self):
+        """Unknown toolset names must be silently dropped by the intersection."""
+        # Simulate the intersection logic from _create_agent
+        local_config = {"web", "terminal", "file"}
+        override = ["web", "nonexistent", "terminal"]
+        allowed = set(local_config)
+        result = list(dict.fromkeys(
+            name for name in override if name in allowed
+        ))
+        assert result == ["web", "terminal"]
+
+    def test_empty_override_means_no_tools(self):
+        """An empty override list means zero tools after intersection."""
+        local_config = {"web", "terminal"}
+        override = []
+        allowed = set(local_config)
+        result = list(dict.fromkeys(
+            name for name in override if name in allowed
+        ))
+        assert result == []
+
+    def test_none_override_uses_local_defaults(self):
+        """When override is None, local config is used as-is."""
+        local_config = {"web", "terminal", "file"}
+        override = None
+        # When None, the intersection block is skipped
+        if override is not None:
+            allowed = set(local_config)
+            result = list(dict.fromkeys(name for name in override if name in allowed))
+        else:
+            result = sorted(local_config)
+        assert result == ["file", "terminal", "web"]
+
+    def test_preserves_order_dedup(self):
+        """Order is preserved, duplicates are removed."""
+        local_config = {"web", "terminal", "file"}
+        override = ["terminal", "web", "terminal", "file", "web"]
+        allowed = set(local_config)
+        result = list(dict.fromkeys(
+            name for name in override if name in allowed
+        ))
+        assert result == ["terminal", "web", "file"]

--- a/tests/gateway/test_whatsapp_bounded_delivery.py
+++ b/tests/gateway/test_whatsapp_bounded_delivery.py
@@ -9,11 +9,13 @@ Task 2 of the delivery-reliability plan:
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.config import Platform
+from plugins.platforms.whatsapp import delivery_ledger
 from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 from plugins.platforms.whatsapp.delivery_reliability import (
     AMBIGUOUS,
@@ -184,6 +186,82 @@ class TestPolicyHook:
         assert not outcome.ok
         assert outcome.failure.category == "policy_blocked"
         assert attempt.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Dead-letter ledger integration (Task 3)
+# ---------------------------------------------------------------------------
+
+class TestSendWithRetriesDeadLetter:
+    def test_exhausted_retries_record_dead_letter_when_ledger_enabled(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+
+        attempt = _attempt_fn([(503, "unavailable")])
+        outcome = _run(send_with_retries(
+            attempt, base_headers=AUTH, sleep=AsyncMock(), jitter=False,
+            platform="whatsapp", route="/send",
+        ))
+
+        assert outcome.dead_letter_ref
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert len(entries) == 1
+        assert entries[0]["platform"] == "whatsapp"
+        assert entries[0]["route"] == "/send"
+        assert entries[0]["attempts"] == 3
+        assert entries[0]["category"] == "http_503"
+
+    def test_ambiguous_timeout_records_dead_letter(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+
+        attempt = _attempt_fn([asyncio.TimeoutError()])
+        outcome = _run(send_with_retries(
+            attempt, sleep=AsyncMock(), jitter=False, platform="whatsapp", route="/send",
+        ))
+
+        assert outcome.dead_letter_ref
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert entries[0]["category"] == "timeout"
+        assert entries[0]["attempts"] == 1
+
+    def test_success_never_records_dead_letter(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+
+        attempt = _attempt_fn([(429, "slow down"), (200, {"messageId": "m2"})])
+        outcome = _run(send_with_retries(
+            attempt, sleep=AsyncMock(), jitter=False, platform="whatsapp", route="/send",
+        ))
+
+        assert outcome.ok
+        assert outcome.dead_letter_ref is None
+        assert not path.exists()
+
+    def test_no_dead_letter_ref_when_ledger_disabled(self):
+        attempt = _attempt_fn([(503, "unavailable")])
+        outcome = _run(send_with_retries(
+            attempt, sleep=AsyncMock(), jitter=False, platform="whatsapp", route="/send",
+        ))
+        assert not outcome.ok
+        assert outcome.dead_letter_ref is None
+
+    def test_policy_veto_never_records_dead_letter(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+        set_delivery_policy_hook(lambda context: False)
+
+        attempt = _attempt_fn([(200, {})])
+        outcome = _run(send_with_retries(
+            attempt, platform="whatsapp", route="/send",
+        ))
+
+        assert outcome.dead_letter_ref is None
+        assert not path.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_bounded_delivery.py
+++ b/tests/gateway/test_whatsapp_bounded_delivery.py
@@ -1,0 +1,301 @@
+"""Tests for bounded WhatsApp bridge delivery attempts.
+
+Task 2 of the delivery-reliability plan:
+- max 3 attempts, backoff schedule [1, 5] with injectable sleep, jitter off in tests
+- one Idempotency-Key per logical delivery, reused across attempts
+- auth headers preserved on every attempt
+- 2xx ends attempts; permanent or ambiguous failure stops immediately
+- optional policy hook can veto a delivery before the first attempt
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+from plugins.platforms.whatsapp.delivery_reliability import (
+    AMBIGUOUS,
+    NON_RETRYABLE,
+    retry_backoff_delay,
+    send_with_retries,
+    set_delivery_policy_hook,
+)
+
+TOKEN = "test-bridge-token-123"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_hook():
+    """Each test starts and ends with no delivery policy hook registered."""
+    set_delivery_policy_hook(None)
+    yield
+    set_delivery_policy_hook(None)
+
+
+# ---------------------------------------------------------------------------
+# Backoff schedule
+# ---------------------------------------------------------------------------
+
+class TestRetryBackoffDelay:
+    def test_schedule_without_jitter(self):
+        assert retry_backoff_delay(2, jitter=False) == 1.0
+        assert retry_backoff_delay(3, jitter=False) == 5.0
+
+    def test_jitter_bounds(self):
+        delays = [retry_backoff_delay(2, jitter=True) for _ in range(50)]
+        assert all(1.0 <= d <= 1.5 for d in delays)
+
+
+# ---------------------------------------------------------------------------
+# send_with_retries loop
+# ---------------------------------------------------------------------------
+
+def _attempt_fn(script):
+    """Async attempt callable fed by a list of (status, payload) or exceptions.
+
+    Records the headers of every attempt in ``calls``.
+    """
+    calls = []
+
+    async def attempt(headers):
+        calls.append(dict(headers))
+        step = script[min(len(calls) - 1, len(script) - 1)]
+        if isinstance(step, BaseException):
+            raise step
+        return step
+
+    attempt.calls = calls
+    return attempt
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+class TestSendWithRetries:
+    def test_success_first_attempt(self):
+        attempt = _attempt_fn([(200, {"messageId": "m1"})])
+        sleep = AsyncMock()
+        outcome = _run(send_with_retries(attempt, base_headers=AUTH, sleep=sleep, jitter=False))
+        assert outcome.ok
+        assert outcome.attempts == 1
+        assert outcome.data == {"messageId": "m1"}
+        sleep.assert_not_awaited()
+
+    def test_503_exhausts_three_attempts_with_backoff(self):
+        attempt = _attempt_fn([(503, "unavailable")])
+        sleep = AsyncMock()
+        outcome = _run(send_with_retries(attempt, base_headers=AUTH, sleep=sleep, jitter=False))
+        assert not outcome.ok
+        assert outcome.attempts == 3
+        assert outcome.failure.category == "http_503"
+        assert [c.args[0] for c in sleep.await_args_list] == [1.0, 5.0]
+
+    def test_connection_refused_is_bounded(self):
+        attempt = _attempt_fn([ConnectionRefusedError()])
+        outcome = _run(send_with_retries(attempt, sleep=AsyncMock(), jitter=False))
+        assert not outcome.ok
+        assert outcome.attempts == 3
+        assert outcome.failure.category == "connection_refused"
+
+    def test_429_then_success(self):
+        attempt = _attempt_fn([(429, "slow down"), (200, {"messageId": "m2"})])
+        outcome = _run(send_with_retries(attempt, sleep=AsyncMock(), jitter=False))
+        assert outcome.ok
+        assert outcome.attempts == 2
+
+    def test_timeout_is_ambiguous_and_never_retried(self):
+        attempt = _attempt_fn([asyncio.TimeoutError()])
+        sleep = AsyncMock()
+        outcome = _run(send_with_retries(attempt, sleep=sleep, jitter=False))
+        assert not outcome.ok
+        assert outcome.attempts == 1
+        assert outcome.failure.decision == AMBIGUOUS
+        sleep.assert_not_awaited()
+
+    @pytest.mark.parametrize("status", [400, 401])
+    def test_permanent_status_stops_immediately(self, status):
+        attempt = _attempt_fn([(status, "denied")])
+        sleep = AsyncMock()
+        outcome = _run(send_with_retries(attempt, sleep=sleep, jitter=False))
+        assert not outcome.ok
+        assert outcome.attempts == 1
+        assert outcome.failure.decision == NON_RETRYABLE
+        sleep.assert_not_awaited()
+
+    def test_idempotency_key_reused_across_attempts(self):
+        attempt = _attempt_fn([(503, "unavailable")])
+        outcome = _run(send_with_retries(attempt, base_headers=AUTH, sleep=AsyncMock(), jitter=False))
+        keys = {c["Idempotency-Key"] for c in attempt.calls}
+        assert len(attempt.calls) == 3
+        assert keys == {outcome.idempotency_key}
+        assert outcome.idempotency_key
+
+    def test_distinct_logical_deliveries_get_distinct_keys(self):
+        first = _run(send_with_retries(_attempt_fn([(200, {})]), jitter=False))
+        second = _run(send_with_retries(_attempt_fn([(200, {})]), jitter=False))
+        assert first.idempotency_key != second.idempotency_key
+
+    def test_auth_headers_preserved_on_every_attempt(self):
+        attempt = _attempt_fn([(503, "unavailable")])
+        _run(send_with_retries(attempt, base_headers=AUTH, sleep=AsyncMock(), jitter=False))
+        for headers in attempt.calls:
+            assert headers["Authorization"] == AUTH["Authorization"]
+
+
+# ---------------------------------------------------------------------------
+# Policy hook (profile-owned outreach policy, e.g. Sawi DDD19/30-day rules)
+# ---------------------------------------------------------------------------
+
+class TestPolicyHook:
+    def test_veto_blocks_before_first_attempt(self):
+        seen = {}
+
+        def hook(context):
+            seen.update(context)
+            return False
+
+        set_delivery_policy_hook(hook)
+        attempt = _attempt_fn([(200, {})])
+        outcome = _run(send_with_retries(
+            attempt, policy_context={"platform": "whatsapp", "route": "send"},
+        ))
+        assert not outcome.ok
+        assert outcome.attempts == 0
+        assert outcome.failure.category == "policy_blocked"
+        assert attempt.calls == []
+        assert seen["route"] == "send"
+
+    def test_hook_approval_allows_delivery(self):
+        set_delivery_policy_hook(lambda context: True)
+        outcome = _run(send_with_retries(_attempt_fn([(200, {})]), jitter=False))
+        assert outcome.ok
+
+    def test_hook_exception_fails_closed(self):
+        def hook(context):
+            raise RuntimeError("profile hook bug")
+
+        set_delivery_policy_hook(hook)
+        attempt = _attempt_fn([(200, {})])
+        outcome = _run(send_with_retries(attempt))
+        assert not outcome.ok
+        assert outcome.failure.category == "policy_blocked"
+        assert attempt.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Adapter integration: mutating bridge POSTs go through the bounded helper
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter._bridge_port = 3000
+    adapter._session_path = MagicMock()
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._running = True
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = MagicMock()
+    adapter._mention_patterns = []
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._bridge_token = TOKEN
+    adapter._retry_sleep = AsyncMock()
+    adapter._retry_jitter = False
+    return adapter
+
+
+class _AsyncCM:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _response(status=200, payload=None, text=""):
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value=payload or {"messageId": "msg1"})
+    resp.text = AsyncMock(return_value=text)
+    return resp
+
+
+class TestAdapterBoundedDelivery:
+    @pytest.mark.asyncio
+    async def test_send_retries_503_three_times_with_stable_key(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(
+            return_value=_AsyncCM(_response(status=503, text="unavailable"))
+        )
+
+        result = await adapter.send("chat1", "hello")
+        assert not result.success
+        calls = adapter._http_session.post.call_args_list
+        assert len(calls) == 3
+        keys = {c.kwargs["headers"]["Idempotency-Key"] for c in calls}
+        assert len(keys) == 1
+        for c in calls:
+            assert c.kwargs["headers"]["Authorization"] == AUTH["Authorization"]
+
+    @pytest.mark.asyncio
+    async def test_send_timeout_never_retries(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(side_effect=asyncio.TimeoutError())
+
+        result = await adapter.send("chat1", "hello")
+        assert not result.success
+        assert len(adapter._http_session.post.call_args_list) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_401_never_retries(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(
+            return_value=_AsyncCM(_response(status=401, text="unauthorized"))
+        )
+
+        result = await adapter.send("chat1", "hello")
+        assert not result.success
+        assert len(adapter._http_session.post.call_args_list) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_success_carries_idempotency_key(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_response()))
+
+        result = await adapter.send("chat1", "hello")
+        assert result.success
+        headers = adapter._http_session.post.call_args.kwargs["headers"]
+        assert headers.get("Idempotency-Key")
+
+    @pytest.mark.asyncio
+    async def test_media_send_retries_connection_refused(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(side_effect=ConnectionRefusedError())
+        media = tmp_path / "pic.png"
+        media.write_bytes(b"png")
+
+        result = await adapter._send_media_to_bridge("chat1", str(media), "image")
+        assert not result.success
+        assert len(adapter._http_session.post.call_args_list) == 3

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -19,6 +19,7 @@ from gateway.config import Platform
 from plugins.platforms.whatsapp.adapter import (
     WhatsAppAdapter,
     _bridge_auth_headers,
+    _ensure_bridge_token,
     _load_bridge_token,
     _standalone_send,
 )
@@ -142,6 +143,18 @@ class TestLoadBridgeToken:
         token_file.write_text("   \n", encoding="utf-8")
         assert _load_bridge_token() is None
 
+    def test_ensure_provisions_profile_scoped_token(self):
+        token = _ensure_bridge_token()
+        token_file = _token_file()
+        assert token
+        assert token_file.read_text(encoding="utf-8").strip() == token
+        assert _ensure_bridge_token() == token
+
+    def test_ensure_respects_environment_without_writing_file(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WA_BRIDGE_TOKEN", TOKEN)
+        assert _ensure_bridge_token() == TOKEN
+        assert not _token_file().exists()
+
 
 class TestBridgeAuthHeaders:
     def test_none_token_gives_empty_headers(self):
@@ -234,6 +247,27 @@ class TestLiveAdapterAuth:
         await adapter.send_typing("chat1")
         for headers in _post_headers(adapter):
             assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_get_chat_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+        adapter._http_session.get = MagicMock(
+            return_value=_AsyncCM(_ok_response({"name": "Test", "isGroup": False}))
+        )
+
+        result = await adapter.get_chat_info("chat1")
+        assert result["name"] == "Test"
+        headers = adapter._http_session.get.call_args.kwargs.get("headers")
+        assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    def test_connect_and_poll_source_authenticate_bridge_gets(self):
+        import inspect
+
+        connect_source = inspect.getsource(WhatsAppAdapter.connect)
+        poll_source = inspect.getsource(WhatsAppAdapter._poll_messages)
+        assert connect_source.count("headers=bridge_headers") == 3
+        assert "headers=self._auth_headers()" in poll_source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -9,6 +9,7 @@ Covers:
 
 import asyncio
 import os
+import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -99,6 +100,15 @@ def _post_headers(adapter):
 def _token_file(tmp_path=None) -> Path:
     """Token file path inside the per-test HERMES_HOME."""
     return Path(os.environ["HERMES_HOME"]) / "secrets" / "whatsapp_bridge_token"
+
+
+def _assert_valid_idempotency_key(headers) -> None:
+    """The bounded-retry sender stamps a fresh UUIDv4 hex Idempotency-Key
+    on every logical delivery (see delivery_reliability.send_with_retries).
+    Verify shape rather than a fixed value since it's generated per-call."""
+    key = headers.get("Idempotency-Key")
+    assert key, "expected an Idempotency-Key header"
+    uuid.UUID(hex=key, version=4)
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +278,9 @@ class TestStandaloneSendAuth:
         assert result.get("success")
         assert fake_session.calls
         for url, kwargs in fake_session.calls:
-            assert kwargs.get("headers") == {"Authorization": f"Bearer {TOKEN}"}
+            headers = kwargs.get("headers") or {}
+            assert headers.get("Authorization") == f"Bearer {TOKEN}"
+            _assert_valid_idempotency_key(headers)
 
     @pytest.mark.asyncio
     async def test_media_send_includes_bearer_from_file(self, tmp_path, fake_session):
@@ -288,7 +300,9 @@ class TestStandaloneSendAuth:
         # Text /send + media /send-media both authenticated.
         assert len(fake_session.calls) == 2
         for url, kwargs in fake_session.calls:
-            assert kwargs.get("headers") == {"Authorization": f"Bearer {TOKEN}"}
+            headers = kwargs.get("headers") or {}
+            assert headers.get("Authorization") == f"Bearer {TOKEN}"
+            _assert_valid_idempotency_key(headers)
 
     @pytest.mark.asyncio
     async def test_no_token_sends_empty_headers(self, fake_session):
@@ -297,5 +311,8 @@ class TestStandaloneSendAuth:
 
         result = await _standalone_send(pconfig, "5511999999999", "hi")
         assert result.get("success")
+        assert fake_session.calls
         for url, kwargs in fake_session.calls:
-            assert not kwargs.get("headers")
+            headers = kwargs.get("headers") or {}
+            assert "Authorization" not in headers
+            _assert_valid_idempotency_key(headers)

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -161,7 +161,7 @@ class TestLiveAdapterAuth:
         result = await adapter.send("chat1", "hello")
         assert result.success
         for headers in _post_headers(adapter):
-            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+            assert headers["Authorization"] == f"Bearer {TOKEN}"
 
     @pytest.mark.asyncio
     async def test_send_without_token_omits_authorization(self):
@@ -172,7 +172,7 @@ class TestLiveAdapterAuth:
         result = await adapter.send("chat1", "hello")
         assert result.success
         for headers in _post_headers(adapter):
-            assert not headers
+            assert "Authorization" not in headers
 
     @pytest.mark.asyncio
     async def test_edit_message_includes_bearer(self):
@@ -182,7 +182,7 @@ class TestLiveAdapterAuth:
         result = await adapter.edit_message("chat1", "msg1", "edited")
         assert result.success
         for headers in _post_headers(adapter):
-            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+            assert headers["Authorization"] == f"Bearer {TOKEN}"
 
     @pytest.mark.asyncio
     async def test_send_media_includes_bearer(self, tmp_path):
@@ -194,7 +194,7 @@ class TestLiveAdapterAuth:
         result = await adapter._send_media_to_bridge("chat1", str(media), "image")
         assert result.success
         for headers in _post_headers(adapter):
-            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+            assert headers["Authorization"] == f"Bearer {TOKEN}"
 
     @pytest.mark.asyncio
     async def test_send_poll_includes_bearer(self):
@@ -204,7 +204,7 @@ class TestLiveAdapterAuth:
         result = await adapter.send_poll("chat1", "q?", ["a", "b"])
         assert result.success
         for headers in _post_headers(adapter):
-            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+            assert headers["Authorization"] == f"Bearer {TOKEN}"
 
     @pytest.mark.asyncio
     async def test_send_location_includes_bearer(self):
@@ -214,7 +214,7 @@ class TestLiveAdapterAuth:
         result = await adapter.send_location("chat1", 1.0, 2.0)
         assert result.success
         for headers in _post_headers(adapter):
-            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+            assert headers["Authorization"] == f"Bearer {TOKEN}"
 
     @pytest.mark.asyncio
     async def test_send_typing_includes_bearer(self):

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -1,0 +1,301 @@
+"""Tests for WhatsApp bridge Bearer-token auth.
+
+Covers:
+- _load_bridge_token(): env var > token file > None resolution
+- _bridge_auth_headers(): Authorization header construction
+- Live adapter: every mutating POST carries Authorization: Bearer <token>
+- _standalone_send(): out-of-process sender carries the same header
+"""
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from plugins.platforms.whatsapp.adapter import (
+    WhatsAppAdapter,
+    _bridge_auth_headers,
+    _load_bridge_token,
+    _standalone_send,
+)
+
+TOKEN = "test-bridge-token-123"
+
+
+@pytest.fixture(autouse=True)
+def _whatsapp_open_optin(monkeypatch):
+    """Opt into WhatsApp allow-all so ``dm_policy: open`` dispatch tests run."""
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_whatsapp_formatting.py)
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter._bridge_port = 3000
+    adapter._bridge_script = "/tmp/test-bridge.js"
+    adapter._session_path = MagicMock()
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._running = True
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = MagicMock()
+    adapter._mention_patterns = []
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._bridge_token = TOKEN
+    return adapter
+
+
+class _AsyncCM:
+    """Minimal async context manager returning a fixed value."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _ok_response(payload=None):
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value=payload or {"messageId": "msg1"})
+    resp.text = AsyncMock(return_value="")
+    return resp
+
+
+def _post_headers(adapter):
+    """Headers kwarg of every captured _http_session.post call."""
+    calls = adapter._http_session.post.call_args_list
+    assert calls, "expected at least one bridge POST"
+    return [call.kwargs.get("headers") for call in calls]
+
+
+def _token_file(tmp_path=None) -> Path:
+    """Token file path inside the per-test HERMES_HOME."""
+    return Path(os.environ["HERMES_HOME"]) / "secrets" / "whatsapp_bridge_token"
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+class TestLoadBridgeToken:
+    def test_no_token_configured_returns_none(self):
+        assert _load_bridge_token() is None
+
+    def test_env_var_wins(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WA_BRIDGE_TOKEN", "  env-token  ")
+        assert _load_bridge_token() == "env-token"
+
+    def test_file_fallback(self):
+        token_file = _token_file()
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text("file-token\n", encoding="utf-8")
+        assert _load_bridge_token() == "file-token"
+
+    def test_env_var_takes_precedence_over_file(self, monkeypatch):
+        token_file = _token_file()
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text("file-token", encoding="utf-8")
+        monkeypatch.setenv("HERMES_WA_BRIDGE_TOKEN", "env-token")
+        assert _load_bridge_token() == "env-token"
+
+    def test_whitespace_only_file_returns_none(self):
+        token_file = _token_file()
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text("   \n", encoding="utf-8")
+        assert _load_bridge_token() is None
+
+
+class TestBridgeAuthHeaders:
+    def test_none_token_gives_empty_headers(self):
+        assert _bridge_auth_headers(None) == {}
+        assert _bridge_auth_headers("") == {}
+
+    def test_token_gives_bearer_header(self):
+        assert _bridge_auth_headers("abc") == {"Authorization": "Bearer abc"}
+
+    def test_adapter_without_token_attribute_does_not_crash(self):
+        """Adapters built via __new__ (test helpers) may lack _bridge_token."""
+        adapter = _make_adapter()
+        del adapter._bridge_token
+        assert adapter._auth_headers() == {}
+
+
+# ---------------------------------------------------------------------------
+# Live adapter: mutating POSTs carry Bearer auth
+# ---------------------------------------------------------------------------
+
+class TestLiveAdapterAuth:
+    @pytest.mark.asyncio
+    async def test_send_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+
+        result = await adapter.send("chat1", "hello")
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_send_without_token_omits_authorization(self):
+        adapter = _make_adapter()
+        adapter._bridge_token = None
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+
+        result = await adapter.send("chat1", "hello")
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert not headers
+
+    @pytest.mark.asyncio
+    async def test_edit_message_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+
+        result = await adapter.edit_message("chat1", "msg1", "edited")
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_send_media_includes_bearer(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+        media = tmp_path / "pic.png"
+        media.write_bytes(b"png")
+
+        result = await adapter._send_media_to_bridge("chat1", str(media), "image")
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_send_poll_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+
+        result = await adapter.send_poll("chat1", "q?", ["a", "b"])
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_send_location_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response()))
+
+        result = await adapter.send_location("chat1", 1.0, 2.0)
+        assert result.success
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_send_typing_includes_bearer(self):
+        adapter = _make_adapter()
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(_ok_response({})))
+
+        await adapter.send_typing("chat1")
+        for headers in _post_headers(adapter):
+            assert headers == {"Authorization": f"Bearer {TOKEN}"}
+
+
+# ---------------------------------------------------------------------------
+# Standalone sender: out-of-process delivery carries Bearer auth
+# ---------------------------------------------------------------------------
+
+class _FakeSession:
+    """Stand-in for aiohttp.ClientSession capturing post() kwargs."""
+
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _AsyncCM(self.response)
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    import aiohttp
+
+    session = _FakeSession(_ok_response())
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **kw: session)
+    return session
+
+
+class TestStandaloneSendAuth:
+    @pytest.mark.asyncio
+    async def test_text_send_includes_bearer_from_env(self, monkeypatch, fake_session):
+        monkeypatch.setenv("HERMES_WA_BRIDGE_TOKEN", TOKEN)
+        pconfig = MagicMock()
+        pconfig.extra = {}
+
+        result = await _standalone_send(pconfig, "5511999999999", "hi")
+        assert result.get("success")
+        assert fake_session.calls
+        for url, kwargs in fake_session.calls:
+            assert kwargs.get("headers") == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_media_send_includes_bearer_from_file(self, tmp_path, fake_session):
+        token_file = _token_file()
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text(TOKEN, encoding="utf-8")
+        media = tmp_path / "doc.pdf"
+        media.write_bytes(b"pdf")
+        pconfig = MagicMock()
+        pconfig.extra = {}
+
+        result = await _standalone_send(
+            pconfig, "5511999999999", "caption text",
+            media_files=[(str(media), False)],
+        )
+        assert result.get("success")
+        # Text /send + media /send-media both authenticated.
+        assert len(fake_session.calls) == 2
+        for url, kwargs in fake_session.calls:
+            assert kwargs.get("headers") == {"Authorization": f"Bearer {TOKEN}"}
+
+    @pytest.mark.asyncio
+    async def test_no_token_sends_empty_headers(self, fake_session):
+        pconfig = MagicMock()
+        pconfig.extra = {}
+
+        result = await _standalone_send(pconfig, "5511999999999", "hi")
+        assert result.get("success")
+        for url, kwargs in fake_session.calls:
+            assert not kwargs.get("headers")

--- a/tests/gateway/test_whatsapp_delivery_ledger.py
+++ b/tests/gateway/test_whatsapp_delivery_ledger.py
@@ -1,0 +1,198 @@
+"""Tests for the sanitized WhatsApp dead-letter ledger.
+
+Task 3 of the delivery-reliability plan:
+- Local JSONL ledger under the Hermes state path, disabled by default upstream.
+- Records timestamp, platform, route, idempotency key hash, attempt count,
+  sanitized error category/status and resolution state.
+- Never message content/chat id/token.
+- Atomic append with a Windows-safe file lock.
+"""
+
+import json
+import threading
+
+import pytest
+
+from plugins.platforms.whatsapp import delivery_ledger as ledger
+
+IDEMPOTENCY_KEY = "b3f5c6a1e4d2477a9e0a1c2b3d4e5f60"
+SECRET_TOKEN = "Bearer super-secret-bridge-token"
+CHAT_ID = "5511998877665@s.whatsapp.net"
+MESSAGE_TEXT = "please call me back at 5511998877665, my email is a@b.com"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger_env(tmp_path, monkeypatch):
+    """Each test gets its own ledger path and starts disabled."""
+    monkeypatch.delenv(ledger._LEDGER_ENABLED_ENV, raising=False)
+    monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(tmp_path / "ledger.jsonl"))
+    yield
+
+
+def _read_lines(path):
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestLedgerDisabledByDefault:
+    def test_disabled_when_env_not_set(self):
+        assert ledger.is_ledger_enabled() is False
+
+    def test_record_is_a_noop_when_disabled(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+        ref = ledger.record_dead_letter(
+            platform="whatsapp",
+            route="/send",
+            idempotency_key=IDEMPOTENCY_KEY,
+            attempts=3,
+            category="http_503",
+            status=503,
+        )
+        assert ref is None
+        assert not path.exists()
+
+
+class TestLedgerRecording:
+    def test_enabled_writes_one_jsonl_entry(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        ref = ledger.record_dead_letter(
+            platform="whatsapp",
+            route="/send",
+            idempotency_key=IDEMPOTENCY_KEY,
+            attempts=3,
+            category="http_503",
+            status=503,
+        )
+
+        entries = _read_lines(path)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert ref
+        assert entry["platform"] == "whatsapp"
+        assert entry["route"] == "/send"
+        assert entry["attempts"] == 3
+        assert entry["category"] == "http_503"
+        assert entry["status"] == 503
+        assert entry["resolution"] == "open"
+        assert "timestamp" in entry and entry["timestamp"]
+        assert "idempotency_key_hash" in entry
+
+    def test_multiple_records_append_without_clobbering(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        for i in range(5):
+            ledger.record_dead_letter(
+                platform="whatsapp",
+                route="/send",
+                idempotency_key=f"key-{i}",
+                attempts=3,
+                category="http_503",
+                status=503,
+            )
+
+        entries = _read_lines(path)
+        assert len(entries) == 5
+
+    def test_concurrent_appends_all_land_as_valid_lines(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        def _write(i):
+            ledger.record_dead_letter(
+                platform="whatsapp",
+                route="/send",
+                idempotency_key=f"key-{i}",
+                attempts=3,
+                category="http_503",
+                status=503,
+            )
+
+        threads = [threading.Thread(target=_write, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        entries = _read_lines(path)
+        assert len(entries) == 20
+
+
+class TestLedgerSanitization:
+    def test_idempotency_key_is_hashed_not_stored_raw(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        ledger.record_dead_letter(
+            platform="whatsapp",
+            route="/send",
+            idempotency_key=IDEMPOTENCY_KEY,
+            attempts=3,
+            category="http_503",
+            status=503,
+        )
+
+        raw = path.read_text(encoding="utf-8")
+        assert IDEMPOTENCY_KEY not in raw
+
+    @pytest.mark.parametrize("leak", [SECRET_TOKEN, CHAT_ID, MESSAGE_TEXT, "5511998877665", "a@b.com"])
+    def test_no_pii_or_secrets_leak_into_ledger(self, tmp_path, monkeypatch, leak):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        # record_dead_letter's signature has no field for message/chat/token
+        # content at all — passing one positionally is a caller bug we want
+        # a TypeError for, not a leak.
+        with pytest.raises(TypeError):
+            ledger.record_dead_letter(
+                platform="whatsapp",
+                route="/send",
+                idempotency_key=IDEMPOTENCY_KEY,
+                attempts=3,
+                category="http_503",
+                status=503,
+                message=leak,
+            )
+
+        raw = path.read_text(encoding="utf-8") if path.exists() else ""
+        assert leak not in raw
+
+    def test_category_field_rejects_free_text_exception_string(self, tmp_path, monkeypatch):
+        """category must be a sanitized identifier, never str(exception)."""
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(path))
+
+        ledger.record_dead_letter(
+            platform="whatsapp",
+            route="/send",
+            idempotency_key=IDEMPOTENCY_KEY,
+            attempts=3,
+            category="unknown_exception",
+            status=None,
+        )
+
+        entries = _read_lines(path)
+        assert entries[0]["category"] == "unknown_exception"
+
+
+class TestLedgerPathResolution:
+    def test_default_path_lives_under_hermes_state_dir(self, monkeypatch):
+        monkeypatch.delenv(ledger._LEDGER_PATH_ENV, raising=False)
+        path = ledger.default_ledger_path()
+        assert path.name == "whatsapp_delivery_ledger.jsonl"
+        assert "state" in path.parts
+
+    def test_ledger_path_honors_env_override(self, tmp_path, monkeypatch):
+        override = tmp_path / "custom" / "dlq.jsonl"
+        monkeypatch.setenv(ledger._LEDGER_PATH_ENV, str(override))
+        assert ledger.ledger_path() == override

--- a/tests/gateway/test_whatsapp_retry_classifier.py
+++ b/tests/gateway/test_whatsapp_retry_classifier.py
@@ -1,0 +1,124 @@
+"""Tests for the pure WhatsApp delivery retry classifier.
+
+Retry policy (delivery-reliability plan):
+- Retryable: connection refused before request acceptance, explicit 429/502/503/504.
+- Ambiguous (never retried): timeouts — the request may have been accepted.
+- Non-retryable: 400/401/403/404, any other HTTP status, unknown exceptions.
+Categories must be sanitized — no exception text (PII) may leak into them.
+"""
+
+import asyncio
+import errno
+
+import pytest
+
+from plugins.platforms.whatsapp.delivery_reliability import (
+    AMBIGUOUS,
+    NON_RETRYABLE,
+    RETRYABLE,
+    classify_delivery_failure,
+)
+
+
+# ---------------------------------------------------------------------------
+# HTTP status classes
+# ---------------------------------------------------------------------------
+
+class TestHttpStatusClassification:
+    @pytest.mark.parametrize("status", [429, 502, 503, 504])
+    def test_explicit_retryable_statuses(self, status):
+        result = classify_delivery_failure(status=status)
+        assert result.decision == RETRYABLE
+        assert result.category == f"http_{status}"
+        assert result.status == status
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404])
+    def test_permanent_client_errors(self, status):
+        result = classify_delivery_failure(status=status)
+        assert result.decision == NON_RETRYABLE
+        assert result.category == f"http_{status}"
+
+    @pytest.mark.parametrize("status", [409, 410, 422, 500, 501])
+    def test_unlisted_statuses_are_never_retried(self, status):
+        result = classify_delivery_failure(status=status)
+        assert result.decision == NON_RETRYABLE
+
+
+# ---------------------------------------------------------------------------
+# Connection refusal (before request acceptance) — safe to retry
+# ---------------------------------------------------------------------------
+
+class TestConnectionRefused:
+    def test_connection_refused_error(self):
+        result = classify_delivery_failure(exception=ConnectionRefusedError())
+        assert result.decision == RETRYABLE
+        assert result.category == "connection_refused"
+
+    def test_oserror_with_econnrefused_errno(self):
+        exc = OSError(errno.ECONNREFUSED, "connection refused")
+        result = classify_delivery_failure(exception=exc)
+        assert result.decision == RETRYABLE
+        assert result.category == "connection_refused"
+
+    def test_aiohttp_style_wrapper_with_os_error_attr(self):
+        """aiohttp.ClientConnectorError wraps the OSError in ``.os_error``."""
+        class FakeConnectorError(Exception):
+            os_error = ConnectionRefusedError()
+
+        result = classify_delivery_failure(exception=FakeConnectorError())
+        assert result.decision == RETRYABLE
+        assert result.category == "connection_refused"
+
+
+# ---------------------------------------------------------------------------
+# Timeout — ambiguous: the request may have been accepted; never retry
+# ---------------------------------------------------------------------------
+
+class TestTimeout:
+    @pytest.mark.parametrize("exc", [asyncio.TimeoutError(), TimeoutError()])
+    def test_timeout_is_ambiguous(self, exc):
+        result = classify_delivery_failure(exception=exc)
+        assert result.decision == AMBIGUOUS
+        assert result.category == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Unknown exceptions — never retried, category sanitized
+# ---------------------------------------------------------------------------
+
+class TestUnknownException:
+    def test_unknown_exception_is_non_retryable(self):
+        result = classify_delivery_failure(exception=ValueError("boom"))
+        assert result.decision == NON_RETRYABLE
+        assert result.category == "unknown_exception"
+
+    def test_category_never_contains_exception_text(self):
+        """PII gate: message bodies/phones in exception text must not leak."""
+        exc = RuntimeError("failed to send 'hello' to +5511999998888@s.whatsapp.net")
+        result = classify_delivery_failure(exception=exc)
+        assert "5511999998888" not in result.category
+        assert "hello" not in result.category
+
+    def test_connection_reset_is_not_retried(self):
+        """Reset after the request may have been accepted — never retry."""
+        result = classify_delivery_failure(exception=ConnectionResetError())
+        assert result.decision == NON_RETRYABLE
+
+
+# ---------------------------------------------------------------------------
+# Input contract
+# ---------------------------------------------------------------------------
+
+class TestInputContract:
+    def test_requires_status_or_exception(self):
+        with pytest.raises(ValueError):
+            classify_delivery_failure()
+
+    def test_exception_takes_precedence_when_both_given(self):
+        result = classify_delivery_failure(status=503, exception=TimeoutError())
+        assert result.decision == AMBIGUOUS
+
+    def test_success_status_is_rejected(self):
+        """2xx is not a failure — classifying it is a caller bug."""
+        with pytest.raises(ValueError):
+            classify_delivery_failure(status=200)

--- a/tests/gateway/test_whatsapp_standalone_delivery.py
+++ b/tests/gateway/test_whatsapp_standalone_delivery.py
@@ -1,0 +1,178 @@
+"""Tests for standalone (out-of-process cron) WhatsApp delivery.
+
+Task 4 of the delivery-reliability plan: the standalone sender must reuse
+the same bounded retry classifier and dead-letter ledger as the live
+gateway adapter rather than duplicating single-attempt send logic.
+
+- 401 is permanent (single attempt, no retry).
+- 503 is retried up to 3 attempts and reaches the dead-letter ledger.
+- A later 200 (e.g. 429 then 200) never reaches the dead-letter ledger.
+"""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock
+
+from plugins.platforms.whatsapp import delivery_ledger
+from plugins.platforms.whatsapp.adapter import _standalone_send
+from plugins.platforms.whatsapp.delivery_reliability import set_delivery_policy_hook
+
+
+@pytest.fixture(autouse=True)
+def _no_real_backoff_wait(monkeypatch):
+    """Retry backoff still runs but with a zero delay, so tests stay fast."""
+    monkeypatch.setattr(
+        "plugins.platforms.whatsapp.delivery_reliability.retry_backoff_delay",
+        lambda *a, **k: 0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_hook():
+    set_delivery_policy_hook(None)
+    yield
+    set_delivery_policy_hook(None)
+
+
+class _FakeResponse:
+    def __init__(self, status, json_payload=None, text_payload=""):
+        self.status = status
+        self._json = json_payload if json_payload is not None else {}
+        self._text = text_payload
+
+    async def json(self):
+        return self._json
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def post(self, url, *, json, headers, timeout):
+        self.calls.append({"url": url, "json": json, "headers": dict(headers)})
+        item = self._responses[min(len(self.calls) - 1, len(self._responses) - 1)]
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_session(monkeypatch, responses):
+    session = _FakeSession(responses)
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: session)
+    return session
+
+
+def _pconfig():
+    cfg = MagicMock()
+    cfg.extra = {"bridge_port": 3000}
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger(tmp_path, monkeypatch):
+    monkeypatch.delenv(delivery_ledger._LEDGER_ENABLED_ENV, raising=False)
+    monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(tmp_path / "ledger.jsonl"))
+    yield
+
+
+@pytest.mark.asyncio
+class TestStandaloneSendPermanentFailure:
+    async def test_401_is_permanent_single_attempt(self, monkeypatch):
+        session = _patch_session(monkeypatch, [_FakeResponse(401, text_payload="unauthorized")])
+
+        result = await _standalone_send(_pconfig(), "5511999999999", "hello")
+
+        assert "error" in result
+        assert result["error_category"] == "http_401"
+        assert result["attempts"] == 1
+        assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+class TestStandaloneSendDeadLetter:
+    async def test_503_exhausts_three_attempts_and_dead_letters(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+        session = _patch_session(monkeypatch, [_FakeResponse(503, text_payload="unavailable")])
+
+        result = await _standalone_send(_pconfig(), "5511999999999", "hello")
+
+        assert result["error_category"] == "http_503"
+        assert result["attempts"] == 3
+        assert result["dead_letter_ref"]
+        assert len(session.calls) == 3
+
+        entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert len(entries) == 1
+        assert entries[0]["route"] == "/send"
+        assert entries[0]["attempts"] == 3
+        assert entries[0]["category"] == "http_503"
+
+    async def test_later_200_never_reaches_dead_letter(self, tmp_path, monkeypatch):
+        path = tmp_path / "ledger.jsonl"
+        monkeypatch.setenv(delivery_ledger._LEDGER_ENABLED_ENV, "1")
+        monkeypatch.setenv(delivery_ledger._LEDGER_PATH_ENV, str(path))
+        _patch_session(monkeypatch, [
+            _FakeResponse(429, text_payload="slow down"),
+            _FakeResponse(200, json_payload={"messageId": "m1"}),
+        ])
+
+        result = await _standalone_send(_pconfig(), "5511999999999", "hello")
+
+        assert result["success"] is True
+        assert result["message_id"] == "m1"
+        assert not path.exists()
+
+
+@pytest.mark.asyncio
+class TestStandaloneSendMedia:
+    async def test_media_send_retries_connection_refused(self, tmp_path):
+        async def _raise(*a, **k):
+            raise ConnectionRefusedError()
+
+        media = tmp_path / "pic.png"
+        media.write_bytes(b"png")
+
+        class _RefusingSession:
+            def __init__(self):
+                self.calls = 0
+
+            def post(self, *a, **k):
+                self.calls += 1
+                raise ConnectionRefusedError()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        session = _RefusingSession()
+        import aiohttp as _aiohttp
+        import unittest.mock as _mock
+        with _mock.patch.object(_aiohttp, "ClientSession", lambda *a, **k: session):
+            result = await _standalone_send(
+                _pconfig(), "5511999999999", "", media_files=[(str(media), False)],
+            )
+
+        assert result["error_category"] == "connection_refused"
+        assert result["attempts"] == 3
+        assert session.calls == 3

--- a/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
+++ b/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
@@ -212,6 +212,22 @@ class TestOneshotBootstrapFallback:
         assert calls == ["openai-codex"]  # fallback chain never consulted
         assert FakeAgent.instances == []
 
+    def test_explicit_provider_with_env_model_propagates_auth_error(
+        self, monkeypatch, oneshot_env
+    ):
+        # --provider with the model pinned via HERMES_INFERENCE_MODEL is the
+        # same deliberate pair as --provider plus --model (it is the only way
+        # --provider passes early validation without --model). No fallback
+        # may be attempted; AuthError propagates.
+        monkeypatch.setenv("HERMES_INFERENCE_MODEL", "gpt-5.5-codex")
+        calls = _patch_resolver(monkeypatch, {"custom:nvidia": NVIDIA_RUNTIME})
+
+        with pytest.raises(AuthError, match="No Codex credentials stored"):
+            oneshot._run_agent("hello", provider="openai-codex")
+
+        assert calls == ["openai-codex"]  # fallback chain never consulted
+        assert FakeAgent.instances == []
+
     def test_fallback_passes_entry_model_as_target_model(
         self, monkeypatch, oneshot_env
     ):

--- a/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
+++ b/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
@@ -1,0 +1,186 @@
+"""Oneshot (-z) bootstrap must honour fallback_providers on primary AuthError.
+
+Repro (#oneshot-codex-fallback): HERMES_HOME with model.provider=openai-codex,
+every Codex credential exhausted/missing, and fallback_providers configured.
+``hermes -z "..." --cli`` fails immediately with "No Codex credentials stored"
+because ``hermes_cli.oneshot._run_agent`` resolves the provider via
+``resolve_runtime_provider()`` BEFORE building the agent, and that bootstrap
+call re-raises AuthError without consulting the fallback chain. The interactive
+CLI (``_ensure_runtime_credentials``) and the cron scheduler both already fall
+through to fallback_providers on the same failure; oneshot must match.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import hermes_cli.oneshot as oneshot
+from hermes_cli.auth import AuthError
+
+NVIDIA_RUNTIME = {
+    "provider": "custom",
+    "api_mode": "chat_completions",
+    "base_url": "https://integrate.api.nvidia.com/v1",
+    "api_key": "nvapi-test",
+    "source": "custom-provider:nvidia",
+}
+
+NVIDIA2_RUNTIME = {
+    "provider": "custom",
+    "api_mode": "chat_completions",
+    "base_url": "https://integrate2.api.nvidia.com/v1",
+    "api_key": "nvapi-test-2",
+    "source": "custom-provider:nvidia2",
+}
+
+
+def _codex_auth_error() -> AuthError:
+    return AuthError(
+        "No Codex credentials stored. Run `hermes auth` to authenticate.",
+        provider="openai-codex",
+        code="codex_auth_missing",
+        relogin_required=True,
+    )
+
+
+class FakeAgent:
+    """Stands in for run_agent.AIAgent; records construction kwargs."""
+
+    instances: list["FakeAgent"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.suppress_status_output = False
+        self.stream_delta_callback = None
+        self.tool_gen_callback = None
+        FakeAgent.instances.append(self)
+
+    def run_conversation(self, prompt):
+        return {"final_response": "ok"}
+
+
+@pytest.fixture
+def oneshot_env(monkeypatch):
+    """Isolate _run_agent from config files, tools, sessions, and AIAgent."""
+    FakeAgent.instances = []
+    config = {
+        "model": {"provider": "openai-codex", "model": "gpt-5.5-codex"},
+        "fallback_providers": [
+            {"provider": "custom:nvidia", "model": "moonshotai/kimi-k2.5"},
+            {"provider": "custom:nvidia2", "model": "qwen/qwen3.5-coder"},
+        ],
+    }
+
+    import hermes_cli.config as config_mod
+    import hermes_cli.tools_config as tools_config_mod
+    import run_agent as run_agent_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr(tools_config_mod, "_get_platform_tools", lambda *a, **k: set())
+    monkeypatch.setattr(run_agent_mod, "AIAgent", FakeAgent)
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    return config
+
+
+def _patch_resolver(monkeypatch, runtimes_by_provider):
+    """resolve_runtime_provider stub: raise AuthError for the primary (codex)
+    request, return a canned runtime for known fallback providers."""
+    calls = []
+
+    def fake_resolve(requested=None, **kwargs):
+        calls.append(requested)
+        if not requested or requested in ("openai-codex", "codex"):
+            raise _codex_auth_error()
+        runtime = runtimes_by_provider.get(requested)
+        if runtime is None:
+            raise AuthError(
+                f"No credentials for {requested}.", provider=str(requested)
+            )
+        return dict(runtime)
+
+    import hermes_cli.runtime_provider as rp_mod
+
+    monkeypatch.setattr(rp_mod, "resolve_runtime_provider", fake_resolve)
+    return calls
+
+
+class TestOneshotBootstrapFallback:
+    def test_primary_auth_error_falls_back_to_first_configured_provider(
+        self, monkeypatch, oneshot_env
+    ):
+        calls = _patch_resolver(monkeypatch, {"custom:nvidia": NVIDIA_RUNTIME})
+
+        response, result = oneshot._run_agent("hello")
+
+        assert response == "ok"
+        assert calls[0] in (None, "openai-codex")
+        assert "custom:nvidia" in calls
+        agent = FakeAgent.instances[-1]
+        assert agent.kwargs["api_key"] == "nvapi-test"
+        assert agent.kwargs["base_url"] == "https://integrate.api.nvidia.com/v1"
+        assert agent.kwargs["provider"] == "custom"
+
+    def test_fallback_switches_model_to_fallback_entry_model(
+        self, monkeypatch, oneshot_env
+    ):
+        _patch_resolver(monkeypatch, {"custom:nvidia": NVIDIA_RUNTIME})
+
+        oneshot._run_agent("hello")
+
+        agent = FakeAgent.instances[-1]
+        # The configured codex model can't run on the fallback provider —
+        # the fallback entry's own model must be used.
+        assert agent.kwargs["model"] == "moonshotai/kimi-k2.5"
+
+    def test_fallback_chain_iterates_past_failing_entries(
+        self, monkeypatch, oneshot_env
+    ):
+        # First fallback also has no credentials; second resolves.
+        calls = _patch_resolver(monkeypatch, {"custom:nvidia2": NVIDIA2_RUNTIME})
+
+        response, _ = oneshot._run_agent("hello")
+
+        assert response == "ok"
+        assert calls == [None, "custom:nvidia", "custom:nvidia2"] or calls == [
+            "openai-codex",
+            "custom:nvidia",
+            "custom:nvidia2",
+        ]
+        agent = FakeAgent.instances[-1]
+        assert agent.kwargs["api_key"] == "nvapi-test-2"
+        assert agent.kwargs["model"] == "qwen/qwen3.5-coder"
+
+    def test_auth_error_propagates_when_no_fallback_configured(
+        self, monkeypatch, oneshot_env
+    ):
+        oneshot_env["fallback_providers"] = []
+        _patch_resolver(monkeypatch, {})
+
+        with pytest.raises(AuthError, match="No Codex credentials stored"):
+            oneshot._run_agent("hello")
+        assert FakeAgent.instances == []
+
+    def test_original_auth_error_propagates_when_all_fallbacks_fail(
+        self, monkeypatch, oneshot_env
+    ):
+        _patch_resolver(monkeypatch, {})  # every fallback raises AuthError too
+
+        with pytest.raises(AuthError, match="No Codex credentials stored"):
+            oneshot._run_agent("hello")
+        assert FakeAgent.instances == []
+
+    def test_non_auth_error_is_not_swallowed_by_fallback(
+        self, monkeypatch, oneshot_env
+    ):
+        import hermes_cli.runtime_provider as rp_mod
+
+        def broken_resolve(requested=None, **kwargs):
+            raise ValueError("config parse exploded")
+
+        monkeypatch.setattr(rp_mod, "resolve_runtime_provider", broken_resolve)
+
+        with pytest.raises(ValueError, match="config parse exploded"):
+            oneshot._run_agent("hello")
+        assert FakeAgent.instances == []

--- a/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
+++ b/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
@@ -228,6 +228,22 @@ class TestOneshotBootstrapFallback:
         assert calls == ["openai-codex"]  # fallback chain never consulted
         assert FakeAgent.instances == []
 
+    def test_env_provider_and_env_model_propagates_auth_error(
+        self, monkeypatch, oneshot_env
+    ):
+        # HERMES_INFERENCE_PROVIDER + HERMES_INFERENCE_MODEL pin the pair just
+        # as deliberately as --provider + --model. No fallback may be
+        # attempted; AuthError propagates.
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+        monkeypatch.setenv("HERMES_INFERENCE_MODEL", "gpt-5.5-codex")
+        calls = _patch_resolver(monkeypatch, {"custom:nvidia": NVIDIA_RUNTIME})
+
+        with pytest.raises(AuthError, match="No Codex credentials stored"):
+            oneshot._run_agent("hello")
+
+        assert calls in ([None], ["openai-codex"])  # fallback never consulted
+        assert FakeAgent.instances == []
+
     def test_fallback_passes_entry_model_as_target_model(
         self, monkeypatch, oneshot_env
     ):

--- a/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
+++ b/tests/hermes_cli/test_oneshot_bootstrap_fallback.py
@@ -12,9 +12,21 @@ through to fallback_providers on the same failure; oneshot must match.
 
 from __future__ import annotations
 
+import logging
+import os
+from pathlib import Path
+
 import pytest
 
 import hermes_cli.oneshot as oneshot
+
+# Imported at module scope ON PURPOSE: runtime_provider snapshots
+# ``hermes_cli.config.load_config`` into its own namespace at import time.
+# If its first import happens inside a test whose fixture has monkeypatched
+# config_mod.load_config, the mock gets baked into runtime_provider and
+# LEAKS past monkeypatch teardown into later tests (the integration test
+# below resolves through the real runtime_provider stack).
+import hermes_cli.runtime_provider  # noqa: F401
 from hermes_cli.auth import AuthError
 
 NVIDIA_RUNTIME = {
@@ -184,3 +196,167 @@ class TestOneshotBootstrapFallback:
         with pytest.raises(ValueError, match="config parse exploded"):
             oneshot._run_agent("hello")
         assert FakeAgent.instances == []
+
+    def test_explicit_model_and_provider_pair_propagates_auth_error(
+        self, monkeypatch, oneshot_env
+    ):
+        # The caller pinned BOTH --model and --provider: that exact pair is
+        # the contract. No fallback may be attempted; AuthError propagates.
+        calls = _patch_resolver(monkeypatch, {"custom:nvidia": NVIDIA_RUNTIME})
+
+        with pytest.raises(AuthError, match="No Codex credentials stored"):
+            oneshot._run_agent(
+                "hello", model="gpt-5.5-codex", provider="openai-codex"
+            )
+
+        assert calls == ["openai-codex"]  # fallback chain never consulted
+        assert FakeAgent.instances == []
+
+    def test_fallback_passes_entry_model_as_target_model(
+        self, monkeypatch, oneshot_env
+    ):
+        # api_mode is derived from target_model inside resolve_runtime_provider,
+        # so each fallback attempt must pass the entry's OWN model — not the
+        # primary's — and the resolved api_mode must reach the agent.
+        seen_kwargs = []
+
+        def fake_resolve(requested=None, **kwargs):
+            seen_kwargs.append({"requested": requested, **kwargs})
+            if not requested or requested in ("openai-codex", "codex"):
+                raise _codex_auth_error()
+            return dict(NVIDIA_RUNTIME)
+
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "resolve_runtime_provider", fake_resolve)
+
+        oneshot._run_agent("hello")
+
+        assert seen_kwargs[0]["target_model"] == "gpt-5.5-codex"
+        fallback_call = seen_kwargs[1]
+        assert fallback_call["requested"] == "custom:nvidia"
+        assert fallback_call["target_model"] == "moonshotai/kimi-k2.5"
+        agent = FakeAgent.instances[-1]
+        assert agent.kwargs["api_mode"] == "chat_completions"
+
+    @pytest.mark.parametrize("exc_type", [ValueError, TypeError])
+    def test_non_auth_error_inside_fallback_walk_propagates(
+        self, monkeypatch, oneshot_env, exc_type
+    ):
+        # Only AuthError means "try the next entry". A ValueError/TypeError
+        # raised while resolving a fallback is a real bug and must surface.
+        def fake_resolve(requested=None, **kwargs):
+            if not requested or requested in ("openai-codex", "codex"):
+                raise _codex_auth_error()
+            raise exc_type("fallback resolver blew up")
+
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "resolve_runtime_provider", fake_resolve)
+
+        with pytest.raises(exc_type, match="fallback resolver blew up"):
+            oneshot._run_agent("hello")
+        assert FakeAgent.instances == []
+
+    def test_original_auth_error_identity_and_attributes_preserved(
+        self, monkeypatch, oneshot_env
+    ):
+        # When the whole chain fails, the ORIGINAL AuthError object must
+        # propagate — same instance, attributes intact, no wrapping.
+        sentinel = _codex_auth_error()
+
+        def fake_resolve(requested=None, **kwargs):
+            if not requested or requested in ("openai-codex", "codex"):
+                raise sentinel
+            raise AuthError("no creds", provider=str(requested), code="missing")
+
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "resolve_runtime_provider", fake_resolve)
+
+        with pytest.raises(AuthError) as excinfo:
+            oneshot._run_agent("hello")
+
+        assert excinfo.value is sentinel
+        assert excinfo.value.provider == "openai-codex"
+        assert excinfo.value.code == "codex_auth_missing"
+        assert excinfo.value.relogin_required is True
+
+    def test_logs_never_contain_auth_error_message(
+        self, monkeypatch, oneshot_env, caplog
+    ):
+        # AuthError messages can embed credential fragments (tokens echoed by
+        # upstream 401 bodies). Only the structured provider/code fields may
+        # be logged — never str(exc).
+        secret = "sk-SUPER-SECRET-TOKEN-12345"
+
+        def fake_resolve(requested=None, **kwargs):
+            if not requested or requested in ("openai-codex", "codex"):
+                raise AuthError(
+                    f"401 from upstream: token {secret} rejected",
+                    provider="openai-codex",
+                    code="codex_auth_missing",
+                )
+            if requested == "custom:nvidia":
+                raise AuthError(
+                    f"key {secret} invalid for nvidia",
+                    provider="custom:nvidia",
+                    code="invalid_key",
+                )
+            return dict(NVIDIA2_RUNTIME)
+
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "resolve_runtime_provider", fake_resolve)
+
+        with caplog.at_level(logging.DEBUG):
+            oneshot._run_agent("hello")
+
+        assert secret not in caplog.text
+        assert "codex_auth_missing" in caplog.text  # safe code IS logged
+        assert "custom:nvidia2" in caplog.text  # chosen fallback IS logged
+
+
+class TestOneshotBootstrapFallbackIntegration:
+    """End-to-end through the real config stack: a real ``config.yaml`` inside
+    the per-test temp HERMES_HOME (conftest's hermetic fixture), real
+    ``load_config``, real ``get_fallback_chain`` and real
+    ``resolve_runtime_provider``. Only ``AIAgent`` is faked (no network).
+    """
+
+    def test_codex_auth_failure_falls_back_using_real_config(self, monkeypatch):
+        home = Path(os.environ["HERMES_HOME"])
+        (home / "config.yaml").write_text(
+            "\n".join(
+                [
+                    "model:",
+                    "  provider: openai-codex",
+                    "  model: gpt-5.5-codex",
+                    "providers:",
+                    "  nvidia:",
+                    "    base_url: https://integrate.api.nvidia.com/v1",
+                    "    api_key: nvapi-integration-test",
+                    "fallback_providers:",
+                    "  - provider: custom:nvidia",
+                    "    model: moonshotai/kimi-k2.5",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        FakeAgent.instances = []
+        import run_agent as run_agent_mod
+
+        monkeypatch.setattr(run_agent_mod, "AIAgent", FakeAgent)
+
+        # No Codex credentials exist in the temp HERMES_HOME, so the primary
+        # (openai-codex) raises AuthError and the chain must kick in.
+        response, _ = oneshot._run_agent("hello")
+
+        assert response == "ok"
+        agent = FakeAgent.instances[-1]
+        assert agent.kwargs["provider"] == "custom"
+        assert agent.kwargs["base_url"] == "https://integrate.api.nvidia.com/v1"
+        assert agent.kwargs["api_key"] == "nvapi-integration-test"
+        assert agent.kwargs["model"] == "moonshotai/kimi-k2.5"


### PR DESCRIPTION
## Summary
- add per-chat toolset isolation through channel overrides
- honor configured fallback providers during one-shot bootstrap auth failures
- complete proxy ACL propagation for `hermes_enabled_toolsets`
- enforce fail-closed Bearer authentication on every mutating WhatsApp bridge request
- classify failures and use bounded retries only for safe conditions
- never retry ambiguous timeouts
- reuse one Idempotency-Key across retry attempts
- enforce Idempotency-Key deduplication server-side in the Node bridge
- coalesce concurrent duplicates, reject key/payload conflicts with 409, and bound cache by TTL/capacity
- record exhausted delivery metadata in an opt-in sanitized dead-letter ledger
- propagate classified delivery metadata through standalone cron delivery

## Safety
- no retry on ambiguous timeout
- no payload/chat/phone/token written to technical ledger
- policy hook fails closed
- legacy callers without Idempotency-Key preserve existing behavior

## Validation
- all WhatsApp bridge Node tests: 26 passed
- focused Python delivery/auth/cron suite: 443 passed
- `node --check scripts/whatsapp-bridge/bridge.js`
- live authenticated bridge send validated before publication

Developed in isolated worktrees; production deploy remains separately controlled.