### PR TITLE
feat(delegation): compact skill index for subagents + per-task skill promotion

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1446,6 +1446,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    promoted_skills: "frozenset[str] | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1463,9 +1464,15 @@ def build_skills_system_prompt(
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
+    the rendered index. The sentinel ``"*"`` demotes EVERY category (the
+    subagent compact index). Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    ``promoted_skills`` re-promotes named skills to full descriptions even
+    inside demoted categories — the delegate_task per-task ``skills=[...]``
+    allowlist rides on this, so a brief can hand its child exactly the
+    domain skills the task needs while the rest of the index stays compact.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -1486,6 +1493,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        tuple(sorted(promoted_skills or ())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1630,27 +1638,54 @@ def build_skills_system_prompt(
     # their parent.
     demoted = frozenset(
         cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
+        if "*" in (compact_categories or frozenset())
+        or cat.split("/", 1)[0] in (compact_categories or frozenset())
     )
 
     hidden_note = ""
     if demoted:
-        hidden_note = (
-            "\n(Categories marked [names only] are outside the current coding "
-            "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
-        )
+        if compact_categories and "*" in compact_categories:
+            hidden_note = (
+                "\n(This is a compact index: descriptions are omitted for brevity, "
+                "but every skill works normally — load any of them with "
+                "skill_view(name), or browse with skills_list.)"
+            )
+        else:
+            hidden_note = (
+                "\n(Categories marked [names only] are outside the current coding "
+                "context, so their descriptions are omitted — the skills work "
+                "normally and load with skill_view(name) as usual.)"
+            )
 
     if not skills_by_category:
         result = ""
     else:
         index_lines = []
+        _promoted = promoted_skills or frozenset()
         for category in sorted(skills_by_category.keys()):
             # Deduplicate and sort skills within each category
             seen = set()
             if category in demoted:
-                names = sorted({name for name, _ in skills_by_category[category]})
-                index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                cat_promoted = sorted(
+                    {(n, d) for n, d in skills_by_category[category] if n in _promoted},
+                    key=lambda x: x[0],
+                )
+                names = sorted(
+                    {name for name, _ in skills_by_category[category] if name not in _promoted}
+                )
+                if names:
+                    index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                elif cat_promoted:
+                    index_lines.append(f"  {category}:")
+                else:
+                    index_lines.append(f"  {category} [names only]:")
+                # Promoted skills keep full descriptions even in a demoted
+                # category (the per-task allowlist).
+                for name, desc in cat_promoted:
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    index_lines.append(f"    - {name}: {desc}" if desc else f"    - {name}")
                 continue
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1750,6 +1750,7 @@ def build_skills_system_prompt(
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
     skills_dir_override: "Path | None" = None,
+    promoted_skills: "frozenset[str] | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1767,9 +1768,15 @@ def build_skills_system_prompt(
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
+    the rendered index. The sentinel ``"*"`` demotes EVERY category (the
+    subagent compact index). Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    ``promoted_skills`` re-promotes named skills to full descriptions even
+    inside demoted categories — the delegate_task per-task ``skills=[...]``
+    allowlist rides on this, so a brief can hand its child exactly the
+    domain skills the task needs while the rest of the index stays compact.
     """
     # Home resolution is EXPLICIT when a caller passes skills_dir_override
     # (the agent knows its own profile home from its session_db path). This
@@ -1803,6 +1810,7 @@ def build_skills_system_prompt(
             available_toolsets,
             compact_categories,
             project_dirs=project_dirs,
+            promoted_skills=promoted_skills,
         )
     finally:
         if _home_token is not None:
@@ -1816,6 +1824,7 @@ def _build_skills_system_prompt_inner(
     available_toolsets: "set[str] | None",
     compact_categories: "frozenset[str] | None",
     project_dirs: "list[Path] | None" = None,
+    promoted_skills: "frozenset[str] | None" = None,
 ) -> str:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
@@ -1831,6 +1840,7 @@ def _build_skills_system_prompt_inner(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        tuple(sorted(promoted_skills or ())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -2050,16 +2060,24 @@ def _build_skills_system_prompt_inner(
     # their parent.
     demoted = frozenset(
         cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
+        if "*" in (compact_categories or frozenset())
+        or cat.split("/", 1)[0] in (compact_categories or frozenset())
     )
 
     hidden_note = ""
     if demoted:
-        hidden_note = (
-            "\n(Categories marked [names only] are outside the current coding "
-            "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
-        )
+        if compact_categories and "*" in compact_categories:
+            hidden_note = (
+                "\n(This is a compact index: descriptions are omitted for brevity, "
+                "but every skill works normally — load any of them with "
+                "skill_view(name), or browse with skills_list.)"
+            )
+        else:
+            hidden_note = (
+                "\n(Categories marked [names only] are outside the current coding "
+                "context, so their descriptions are omitted — the skills work "
+                "normally and load with skill_view(name) as usual.)"
+            )
 
     if not skills_by_category:
         result = ""
@@ -2070,12 +2088,31 @@ def _build_skills_system_prompt_inner(
         if available_tools is not None and "web_search" not in available_tools:
             _basic_tools = "terminal"
         index_lines = []
+        _promoted = promoted_skills or frozenset()
         for category in sorted(skills_by_category.keys()):
             # Deduplicate and sort skills within each category
             seen = set()
             if category in demoted:
-                names = sorted({name for name, _ in skills_by_category[category]})
-                index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                cat_promoted = sorted(
+                    {(n, d) for n, d in skills_by_category[category] if n in _promoted},
+                    key=lambda x: x[0],
+                )
+                names = sorted(
+                    {name for name, _ in skills_by_category[category] if name not in _promoted}
+                )
+                if names:
+                    index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                elif cat_promoted:
+                    index_lines.append(f"  {category}:")
+                else:
+                    index_lines.append(f"  {category} [names only]:")
+                # Promoted skills keep full descriptions even in a demoted
+                # category (the per-task allowlist).
+                for name, desc in cat_promoted:
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    index_lines.append(f"    - {name}: {desc}" if desc else f"    - {name}")
                 continue
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -311,10 +311,33 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        # Subagent compact index (delegate_task children): a spawned child
+        # inherits the parent's ENTIRE skills index — measured at 85%+ of a
+        # child's system prompt (~86KB / ~22k tokens on a large skills tree)
+        # for descriptions it almost never reads. Demote everything to
+        # names-only (the "*" sentinel; same demote-never-hide contract as
+        # the coding posture) and re-promote only the skills the dispatching
+        # brief named via delegate_task(skills=[...]). Config-gated:
+        # delegation.compact_skill_index (default ON; set false to restore
+        # the full index for children).
+        _promoted = frozenset()
+        if (agent.platform or "").lower() == "subagent":
+            try:
+                from tools.delegate_tool import _load_config as _delegation_config
+
+                _sub_compact = bool(
+                    (_delegation_config() or {}).get("compact_skill_index", True)
+                )
+            except Exception:
+                _sub_compact = True
+            if _sub_compact:
+                _compact_cats = frozenset({"*"}) | _compact_cats
+                _promoted = frozenset(getattr(agent, "_delegate_skills", ()) or ())
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            promoted_skills=_promoted or None,
         )
     else:
         skills_prompt = ""

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -638,11 +638,34 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        # Subagent compact index (delegate_task children): a spawned child
+        # inherits the parent's ENTIRE skills index — measured at 85%+ of a
+        # child's system prompt (~86KB / ~22k tokens on a large skills tree)
+        # for descriptions it almost never reads. Demote everything to
+        # names-only (the "*" sentinel; same demote-never-hide contract as
+        # the coding posture) and re-promote only the skills the dispatching
+        # brief named via delegate_task(skills=[...]). Config-gated:
+        # delegation.compact_skill_index (default ON; set false to restore
+        # the full index for children).
+        _promoted = frozenset()
+        if (agent.platform or "").lower() == "subagent":
+            try:
+                from tools.delegate_tool import _load_config as _delegation_config
+
+                _sub_compact = bool(
+                    (_delegation_config() or {}).get("compact_skill_index", True)
+                )
+            except Exception:
+                _sub_compact = True
+            if _sub_compact:
+                _compact_cats = frozenset({"*"}) | _compact_cats
+                _promoted = frozenset(getattr(agent, "_delegate_skills", ()) or ())
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
+            promoted_skills=_promoted or None,
         )
     else:
         skills_prompt = ""

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2092,6 +2092,11 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # Give delegated subagents a names-only skill index (descriptions
+        # dropped) and re-promote only the skills the dispatching brief named
+        # via delegate_task(skills=[...]). Demote-never-hide: every skill stays
+        # loadable with skill_view(). Set false to give children the full index.
+        "compact_skill_index": True,
         "max_iterations": 250,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch

--- a/run_agent.py
+++ b/run_agent.py
@@ -5722,6 +5722,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            skills=function_args.get("skills"),
             parent_agent=self,
         )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8519,6 +8519,7 @@ class AIAgent:
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
+            skills=function_args.get("skills"),
             parent_agent=self,
         )
 

--- a/tests/agent/test_subagent_compact_skills.py
+++ b/tests/agent/test_subagent_compact_skills.py
@@ -1,0 +1,124 @@
+"""Subagent compact skill index (delegate_task skill scoping).
+
+The bug class under test: a delegate_task child inherits the parent's ENTIRE
+skills index — measured at 85%+ of a child's system prompt on a large skills
+tree — for descriptions it almost never reads. The fix demotes every category
+to names-only for subagents (the "*" sentinel), re-promoting only skills the
+dispatching brief named via delegate_task(skills=[...]).
+
+Contracts:
+  1. "*" in compact_categories demotes EVERY category to names-only.
+  2. promoted_skills re-promote named skills to full descriptions inside
+     demoted categories; the rest of the category stays names-only.
+  3. Nothing is hidden: every skill name still appears in the index.
+  4. The compact index is dramatically smaller than the full index.
+  5. Cache correctness: different promoted sets produce different outputs
+     (the cache key includes promoted_skills).
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _make_skills_tree(root: Path, n_categories: int = 4, per_cat: int = 6) -> None:
+    for c in range(n_categories):
+        cat = root / f"cat{c}"
+        cat.mkdir(parents=True)
+        for s in range(per_cat):
+            d = cat / f"skill-{c}-{s}"
+            d.mkdir()
+            (d / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{c}-{s}\n"
+                f"description: \"A long, detailed description for skill {c}-{s} "
+                "explaining endpoints, workflows, pitfalls, and conventions that "
+                "costs real tokens in every prompt that includes it verbatim.\"\n"
+                "---\n\n# body\n"
+            )
+
+
+class SubagentCompactIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="subskills-test-"))
+        _make_skills_tree(self.tmp)
+        # Patch the module's skills-dir resolution + kill the caches.
+        import agent.prompt_builder as pb
+
+        self.pb = pb
+        self._patches = [
+            mock.patch.object(pb, "get_skills_dir", return_value=self.tmp),
+            mock.patch.object(pb, "get_all_skills_dirs", return_value=[self.tmp]),
+            mock.patch.object(pb, "get_disabled_skill_names", return_value=set()),
+        ]
+        for p in self._patches:
+            p.start()
+        pb.clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self.pb.clear_skills_system_prompt_cache(clear_snapshot=True)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _build(self, **kw):
+        return self.pb.build_skills_system_prompt(**kw)
+
+    def test_star_sentinel_demotes_everything(self):
+        full = self._build()
+        compact = self._build(compact_categories=frozenset({"*"}))
+        # 1. every category demoted -> no description text survives
+        self.assertNotIn("A long, detailed description", compact)
+        self.assertIn("[names only]", compact)
+        # 3. nothing hidden: every skill name still present
+        for c in range(4):
+            for s in range(6):
+                self.assertIn(f"skill-{c}-{s}", compact)
+        # 4. dramatically smaller (compare the index block, not the fixed
+        # instructional header that dominates at this small fixture size)
+        def _index_block(s: str) -> str:
+            i = s.find("<available_skills>")
+            return s[i:] if i >= 0 else s
+
+        self.assertLess(len(_index_block(compact)), len(_index_block(full)) * 0.5)
+
+    def test_promoted_skills_keep_descriptions(self):
+        compact = self._build(
+            compact_categories=frozenset({"*"}),
+            promoted_skills=frozenset({"skill-1-2", "skill-3-0"}),
+        )
+        # promoted entries render with full descriptions
+        self.assertIn("skill-1-2: A long, detailed description", compact)
+        self.assertIn("skill-3-0: A long, detailed description", compact)
+        # non-promoted siblings stay names-only
+        self.assertNotIn("skill-1-3: A long, detailed description", compact)
+        self.assertIn("skill-1-3", compact)  # but the name is still there
+
+    def test_compact_footer_explains_the_contract(self):
+        compact = self._build(compact_categories=frozenset({"*"}))
+        self.assertIn("compact index", compact)
+        self.assertIn("skill_view", compact)
+
+    def test_cache_distinguishes_promoted_sets(self):
+        a = self._build(compact_categories=frozenset({"*"}))
+        b = self._build(
+            compact_categories=frozenset({"*"}),
+            promoted_skills=frozenset({"skill-0-0"}),
+        )
+        self.assertNotEqual(a, b)
+        # and a repeat call returns the cached identical string
+        a2 = self._build(compact_categories=frozenset({"*"}))
+        self.assertEqual(a, a2)
+
+    def test_category_demotion_still_works_unchanged(self):
+        """The coding-posture path (named categories) must be untouched."""
+        out = self._build(compact_categories=frozenset({"cat0"}))
+        self.assertIn("cat0 [names only]", out)
+        # other categories keep descriptions
+        self.assertIn("skill-1-0: A long, detailed description", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_subagent_compact_skills.py
+++ b/tests/agent/test_subagent_compact_skills.py
@@ -16,6 +16,7 @@ Contracts:
      (the cache key includes promoted_skills).
 """
 
+import os
 import shutil
 import tempfile
 import unittest
@@ -118,6 +119,86 @@ class SubagentCompactIndexTest(unittest.TestCase):
         self.assertIn("cat0 [names only]", out)
         # other categories keep descriptions
         self.assertIn("skill-1-0: A long, detailed description", out)
+
+
+class TestCompactSkillIndexDefaultResolves(unittest.TestCase):
+    """The gate must be DECLARED, not just read.
+
+    ``agent/system_prompt.py`` reads
+    ``(_delegation_config() or {}).get("compact_skill_index", True)``. A read
+    with an inline default still works, but the key never appears in
+    ``hermes config``, so the behaviour is undiscoverable and un-overridable
+    through the documented surface. This drives the REAL resolution chain
+    against a temp HERMES_HOME with NO config.yaml (AGENTS.md asks for
+    real-path validation over mocks here) and proves the default arrives from
+    DEFAULT_CONFIG rather than from the call-site fallback.
+    """
+
+    def test_default_is_declared_in_default_config(self):
+        """The key exists in the shipped delegation defaults."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        delegation = DEFAULT_CONFIG["delegation"]
+        self.assertIn("compact_skill_index", delegation)
+        self.assertIs(delegation["compact_skill_index"], True)
+
+    def test_default_resolves_through_load_config_on_a_bare_home(self):
+        """With no config.yaml, the loader still yields the declared default.
+
+        This is the assertion the inline ``.get(..., True)`` fallback cannot
+        make: it proves the value survives the real
+        DEFAULT_CONFIG -> load_config -> _load_config chain.
+        """
+        home = Path(tempfile.mkdtemp())
+        try:
+            self.assertFalse((home / "config.yaml").exists())
+            with mock.patch.dict(
+                os.environ, {"HERMES_HOME": str(home)}, clear=False
+            ):
+                os.environ.pop("HERMES_IGNORE_USER_CONFIG", None)
+                import importlib
+
+                import hermes_cli.config as _cfg
+                importlib.reload(_cfg)
+                from tools.delegate_tool import _load_config
+
+                delegation = _load_config() or {}
+                self.assertIn(
+                    "compact_skill_index",
+                    delegation,
+                    "delegation.compact_skill_index must resolve from "
+                    "DEFAULT_CONFIG on a home with no config.yaml",
+                )
+                self.assertIs(delegation["compact_skill_index"], True)
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def test_a_user_can_turn_the_compact_index_off(self):
+        """The declared key is honoured when a real config.yaml sets it false.
+
+        Without the DEFAULT_CONFIG entry this still "worked", but only by
+        accident of the inline fallback; pinning it proves the documented
+        override path is live.
+        """
+        home = Path(tempfile.mkdtemp())
+        try:
+            (home / "config.yaml").write_text(
+                "delegation:\n  compact_skill_index: false\n"
+            )
+            with mock.patch.dict(
+                os.environ, {"HERMES_HOME": str(home)}, clear=False
+            ):
+                os.environ.pop("HERMES_IGNORE_USER_CONFIG", None)
+                import importlib
+
+                import hermes_cli.config as _cfg
+                importlib.reload(_cfg)
+                from tools.delegate_tool import _load_config
+
+                delegation = _load_config() or {}
+                self.assertIs(delegation.get("compact_skill_index"), False)
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1064,6 +1064,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Per-task skill promotion: names re-promoted to full descriptions in the
+    # child's compact skills index (see agent/system_prompt.py). None/empty =
+    # pure names-only index.
+    skills: Optional[List[str]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1358,6 +1362,12 @@ def _build_child_agent(
         **child_optional_kwargs,
     )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
+    # Per-task skill promotion (see agent/system_prompt.py): names the brief
+    # wants re-promoted to full descriptions in the child's compact index.
+    # Set BEFORE the first request — the system prompt is built lazily.
+    child._delegate_skills = tuple(
+        s.strip() for s in (skills or []) if isinstance(s, str) and s.strip()
+    )
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""
@@ -2373,6 +2383,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    skills: Optional[List[str]] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2473,7 +2484,9 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [
+            {"goal": goal, "context": context, "role": top_role, "skills": skills}
+        ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2532,6 +2545,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                skills=(t.get("skills") if "skills" in t else skills),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3422,6 +3436,11 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Per-task skill promotion override. See top-level 'skills'.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3445,6 +3464,18 @@ DELEGATE_TASK_SCHEMA = {
                     "just continue working in the meantime. Setting this has no "
                     "effect; the parameter remains only for backward "
                     "compatibility."
+                ),
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Skill names to promote in the subagent's skill index. "
+                    "Subagents get a compact names-only index by default; "
+                    "skills named here keep their full descriptions so the "
+                    "child loads them reliably. Pass the skills the task's "
+                    "domain needs (e.g. ['systematic-debugging']). The child "
+                    "can still browse/load ANY skill via skills_list/skill_view."
                 ),
             },
         },
@@ -3506,6 +3537,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        skills=args.get("skills"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1626,6 +1626,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Per-task skill promotion: names re-promoted to full descriptions in the
+    # child's compact skills index (see agent/system_prompt.py). None/empty =
+    # pure names-only index.
+    skills: Optional[List[str]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -2027,6 +2031,12 @@ def _build_child_agent(
     # close it out from under a background child (#81267).
     if child_session_db is not None:
         child._owns_session_db = True
+    # Per-task skill promotion (see agent/system_prompt.py): names the brief
+    # wants re-promoted to full descriptions in the child's compact index.
+    # Set BEFORE the first request — the system prompt is built lazily.
+    child._delegate_skills = tuple(
+        s.strip() for s in (skills or []) if isinstance(s, str) and s.strip()
+    )
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""
@@ -3642,6 +3652,7 @@ def delegate_task(
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
+    skills: Optional[List[str]] = None,
     parent_agent=None,
     credentials_cfg: Optional[Dict[str, Any]] = None,
 ) -> str:
@@ -3776,7 +3787,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "skills": skills,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3908,6 +3924,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                skills=(t.get("skills") if "skills" in t else skills),
             )
         except ValueError as exc:
             # Explicit-pin preflight failures (e.g. pinned delegation.command
@@ -4956,6 +4973,11 @@ DELEGATE_TASK_SCHEMA = {
                                 "fields you will read."
                             ),
                         },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Per-task skill promotion override. See top-level 'skills'.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -4997,6 +5019,18 @@ DELEGATE_TASK_SCHEMA = {
                     "For action='steer': the course correction, appended to "
                     "the child's next tool result mid-run. Be directive and "
                     "specific."
+                ),
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Skill names to promote in the subagent's skill index. "
+                    "Subagents get a compact names-only index by default; "
+                    "skills named here keep their full descriptions so the "
+                    "child loads them reliably. Pass the skills the task's "
+                    "domain needs (e.g. ['systematic-debugging']). The child "
+                    "can still browse/load ANY skill via skills_list/skill_view."
                 ),
             },
         },
@@ -5063,6 +5097,7 @@ registry.register(
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),
+        skills=args.get("skills"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -502,6 +502,7 @@ delegation:
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # compact_skill_index: true               # Give children a names-only skill index (descriptions dropped), re-promoting only the skills the brief passed via delegate_task(skills=[...]). Demote-never-hide: every skill stays loadable with skill_view(). Set false to give children the full index.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints


### PR DESCRIPTION
A `delegate_task` child inherits the parent's **entire skills index** — on a large skills tree we measured **86KB of a 90KB subagent system prompt (~22k tokens per spawn)** spent on skill descriptions the child almost never reads. Every hermes-agent install with a grown skills tree pays this on every delegation.

**Layer 1 (default ON):** subagent spawns get a **names-only compact index** — implemented as a `"*"` sentinel on the existing `compact_categories` machinery, so it follows the same demote-never-hide contract as the coding posture: every skill name stays visible, everything remains loadable via `skill_view`/`skills_list`, and a footer explains the compaction. Config gate: `delegation.compact_skill_index: false` restores the full index.

**Layer 2:** `delegate_task(skills=[...])` (+ per-task override in batch mode) re-promotes named skills to full descriptions inside the compact index — the dispatching brief hands its child exactly the domain skills the task needs.

Measured on a 165-skill install: 86,101B → 49,381B (~9.2k tokens saved per spawn). We're also tracking a compensation metric in production (avg skill_view calls per subagent session) to confirm children don't bulk-load to reconstruct the index — flat so far.

Verified on this base: 161 delegate+compact tests pass; request-composition suite pass; 5 new tests cover the star sentinel, promotion, nothing-hidden, cache-key separation, and the existing category-demotion path (byte-identical when the feature is off).