### PR TITLE
fix(mcp): use /proc/stat starttime instead of psutil create_time() to avoid false-orphan on WSL2

### DIFF
--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -1,3 +1,5 @@
+import os
+
 import psutil
 
 from tui_gateway import slash_worker
@@ -9,13 +11,71 @@ def test_is_orphaned_true_when_ppid_changes():
 
 
 def test_is_orphaned_true_when_parent_create_time_mismatch():
-    # Same ppid but a different create_time means the PID was reused.
+    # Same ppid but a different starttime means the PID was reused by an
+    # unrelated process. On Linux the /proc starttime won't be 0.0, so this
+    # exercises the mismatch branch directly.
     me = psutil.Process()
     assert slash_worker._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
 
 
 def test_is_orphaned_false_when_parent_alive_and_matches():
+    # Snapshot the starttime with the SAME helper the implementation compares
+    # against, so the units match (ticks on Linux, epoch via psutil otherwise).
     me = psutil.Process()
+    starttime = slash_worker._read_proc_starttime(me.pid)
+    if starttime is not None:
+        snapshot = float(starttime)
+    else:
+        snapshot = me.create_time()
     assert (
-        slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
+        slash_worker._is_orphaned(me.pid, snapshot, getppid=lambda: me.pid) is False
+    )
+
+
+def test_read_proc_starttime_handles_comm_with_spaces_and_parens():
+    # /proc/<pid>/stat field 2 (comm) can contain spaces and parens — e.g.
+    # "chrome (helper)". A naive split() over the whole record corrupts every
+    # field index after it; the helper must split on the LAST ')'.
+    me = psutil.Process()
+    # comm is our own process name; force a synthetic record with a tricky
+    # comm to prove the index is correct regardless of content.
+    fake_pid = me.pid
+    real_stat = open(f"/proc/{fake_pid}/stat").read()
+    # Replace comm with something containing spaces+parens.
+    real_tail = real_stat.rsplit(")", 1)[1]
+    fake_stat = f"{fake_pid} (my proc (with) parens){real_tail}"
+    import tui_gateway.slash_worker as sw
+    import unittest.mock as mock
+
+    m = mock.mock_open(read_data=fake_stat)
+    with mock.patch("builtins.open", m):
+        result = sw._read_proc_starttime(fake_pid)
+    # The real starttime from the tail must parse correctly despite the
+    # spaces/parens in the synthetic comm.
+    expected = int(real_tail.split()[19])
+    assert result == expected
+
+
+def test_is_orphaned_fallback_preserves_pid_reuse_guard(monkeypatch):
+    # On non-Linux (or when /proc is unavailable) the fallback must NOT
+    # degrade to a bare pid_exists() — it must compare the psutil
+    # create_time() fingerprint so a recycled PID is detected as different.
+    me = psutil.Process()
+    real_create_time = me.create_time()
+
+    # Force the /proc fast path off so the fallback runs.
+    monkeypatch.setattr(slash_worker, "_read_proc_starttime", lambda pid: None)
+    # Mismatched create_time snapshot → must report orphaned (PID reuse).
+    assert (
+        slash_worker._is_orphaned(
+            me.pid, real_create_time + 9999, getppid=lambda: me.pid
+        )
+        is True
+    )
+    # Matching snapshot → must report NOT orphaned (parent alive, same proc).
+    assert (
+        slash_worker._is_orphaned(
+            me.pid, real_create_time, getppid=lambda: me.pid
+        )
+        is False
     )

--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,0 +1,70 @@
+import unittest.mock as mock
+
+import psutil
+
+from tools import mcp_stdio_watchdog
+
+
+def test_is_orphaned_true_when_ppid_changes():
+    # The original parent went away and the watchdog was reparented.
+    assert mcp_stdio_watchdog._is_orphaned(1234, 1.0, getppid=lambda: 999999) is True
+
+
+def test_is_orphaned_true_when_parent_starttime_mismatch():
+    # Same ppid but a different starttime means the PID was reused by an
+    # unrelated process. On Linux the /proc starttime won't be 0.0, so this
+    # exercises the mismatch branch directly.
+    me = psutil.Process()
+    assert mcp_stdio_watchdog._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
+
+
+def test_is_orphaned_false_when_parent_alive_and_matches():
+    # Snapshot the fingerprint with the same helper the implementation compares
+    # against, so units match (ticks on Linux, epoch via psutil otherwise).
+    me = psutil.Process()
+    starttime = mcp_stdio_watchdog._read_proc_starttime(me.pid)
+    if starttime is not None:
+        snapshot = float(starttime)
+    else:
+        snapshot = me.create_time()
+    assert mcp_stdio_watchdog._is_orphaned(me.pid, snapshot, getppid=lambda: me.pid) is False
+
+
+def test_read_proc_starttime_handles_comm_with_spaces_and_parens():
+    # /proc/<pid>/stat field 2 (comm) can contain spaces and parens. A naive
+    # split() over the whole record corrupts every field index after it; the
+    # helper must split on the last ')'.
+    me = psutil.Process()
+    fake_pid = me.pid
+    real_stat = open(f'/proc/{fake_pid}/stat').read()
+    real_tail = real_stat.rsplit(')', 1)[1]
+    fake_stat = f'{fake_pid} (my proc (with) parens){real_tail}'
+
+    m = mock.mock_open(read_data=fake_stat)
+    with mock.patch('builtins.open', m):
+        result = mcp_stdio_watchdog._read_proc_starttime(fake_pid)
+
+    expected = int(real_tail.split()[19])
+    assert result == expected
+
+
+def test_is_orphaned_fallback_preserves_pid_reuse_guard(monkeypatch):
+    # On non-Linux (or when /proc is unavailable) the fallback must compare the
+    # psutil create_time() fingerprint rather than degrading to bare pid_exists().
+    me = psutil.Process()
+    real_create_time = me.create_time()
+
+    monkeypatch.setattr(mcp_stdio_watchdog, '_read_proc_starttime', lambda pid: None)
+
+    assert (
+        mcp_stdio_watchdog._is_orphaned(
+            me.pid, real_create_time + 9999, getppid=lambda: me.pid
+        )
+        is True
+    )
+    assert (
+        mcp_stdio_watchdog._is_orphaned(
+            me.pid, real_create_time, getppid=lambda: me.pid
+        )
+        is False
+    )

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -63,6 +63,27 @@ _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
 
 
+def _read_proc_starttime(pid: int):
+    """Read the starttime field (field 22, clock ticks since boot) from
+    ``/proc/<pid>/stat``. Returns ``None`` if ``/proc`` is unavailable
+    (non-Linux) or the entry is malformed/unreadable.
+
+    ``comm`` (field 2) can contain spaces and parens — e.g.
+    ``chrome (helper)`` — so a naive ``split()`` over the whole record
+    corrupts every field index after it. We split on the *last* ``)`` and
+    index into the whitespace-delimited tail, the same approach used by
+    ``gateway/drain_control.py``. After ``comm`` the tail starts at field 3,
+    so starttime (field 22, 1-indexed) is the tail's index 19.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            stat = f.read()
+        tail = stat.rsplit(")", 1)[1].split()
+        return int(tail[19])
+    except (FileNotFoundError, IndexError, ValueError, OSError):
+        return None
+
+
 def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getppid) -> bool:
     """True once the process that spawned us is gone.
 
@@ -70,53 +91,32 @@ def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getpp
     subreaper, not always PID 1), and guards against PID reuse via the recorded
     starttime of the original parent.
 
-    NOTE: we deliberately avoid psutil.Process(pid).create_time(). On WSL2,
-    psutil derives create_time() from a (boot_time, /proc/pid/stat starttime)
-    pair where boot_time = time.time() - /proc/uptime. WSL2's /proc/uptime
-    jitters by ~1-2s, so boot_time (and thus create_time()) drifts over the
-    life of a process. The watchdog snapshots create_time at spawn and
-    compares later — a ~10-18s drift flips the comparison and makes
-    is_orphaned() return True for a LIVING parent, killing every stdio MCP
-    child on a ~10-30s reconnect loop. Reading the raw starttime field
-    (field 22, in clock ticks) from /proc/<pid>/stat is stable across reads
-    and immune to the boot_time drift, so we use that on Linux. ``psutil`` is
-    only used for pid_exists() and as a non-Linux fallback.
+    On Linux we read the raw starttime field (field 22, clock ticks since boot)
+    from ``/proc/<ppid>/stat``. This is stable across reads — unlike
+    ``psutil.Process(pid).create_time()``, which drifts ~1-2s on WSL2 because
+    psutil derives it from ``(boot_time, /proc/pid/stat starttime)`` where
+    ``boot_time = time.time() - /proc/uptime`` and WSL2's ``/proc/uptime``
+    jitters. The watchdog snapshots create_time at spawn and compares later —
+    a drift flips the comparison and makes ``is_orphaned()`` return True for a
+    LIVING parent, killing every stdio MCP child on a ~10-30s reconnect loop.
+
+    The non-Linux fallback (``/proc`` unavailable) preserves the PID-reuse
+    guard by comparing ``psutil.Process(pid).create_time()`` against the
+    snapshot rather than degrading to a bare ``pid_exists()`` check, which
+    would miss the case where the PID was recycled by an unrelated process.
     """
     if getppid() != original_ppid:
         return True
-    # Fast path: read /proc/<ppid>/stat directly (Linux). Stable across reads.
-    try:
-        with open(f"/proc/{original_ppid}/stat") as f:
-            stat_fields = f.read().split()
-        if len(stat_fields) >= 22:
-            # Field 22 (1-indexed) = starttime in clock ticks since boot.
-            return int(stat_fields[21]) != parent_create_time
-        # Malformed stat — fall back to existence check.
-        if psutil is not None:
-            return not psutil.pid_exists(original_ppid)
+    # Linux fast path: /proc ticks (stable, immune to WSL2 boot_time drift).
+    starttime = _read_proc_starttime(original_ppid)
+    if starttime is not None:
+        return starttime != parent_create_time
+    # Fallback (non-Linux or /proc unreadable): compare the psutil create_time
+    # fingerprint so a PID-reuse (same pid, different process) is still caught.
+    if psutil is None:
         return False
-    except FileNotFoundError:
-        # /proc unavailable (non-Linux) or process gone.
-        if psutil is None:
-            return False
-        try:
-            return not psutil.pid_exists(original_ppid)
-        except psutil.Error:
-            return True
-    except (ProcessLookupError, OSError):
-        if psutil is None:
-            return False
-        try:
-            return not psutil.pid_exists(original_ppid)
-        except psutil.Error:
-            return True
-    except ValueError:
-        if psutil is None:
-            return False
-        try:
-            return not psutil.pid_exists(original_ppid)
-        except psutil.Error:
-            return True
+    try:
+        return psutil.Process(original_ppid).create_time() != parent_create_time
     except psutil.Error:
         return True
 

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -64,23 +64,59 @@ _TERM_GRACE_S = 3.0
 
 
 def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getppid) -> bool:
-    """Mirrors ``tui_gateway.slash_worker._is_orphaned`` exactly.
+    """True once the process that spawned us is gone.
 
-    True once the process that spawned us is gone. Never trusts a bare
-    ``getppid() == 1`` check (Linux reparents orphans to a subreaper, not
-    always PID 1), and guards against PID reuse via the recorded creation
-    time of the original parent.
+    Never trusts a bare ``getppid() == 1`` check (Linux reparents orphans to a
+    subreaper, not always PID 1), and guards against PID reuse via the recorded
+    starttime of the original parent.
+
+    NOTE: we deliberately avoid psutil.Process(pid).create_time(). On WSL2,
+    psutil derives create_time() from a (boot_time, /proc/pid/stat starttime)
+    pair where boot_time = time.time() - /proc/uptime. WSL2's /proc/uptime
+    jitters by ~1-2s, so boot_time (and thus create_time()) drifts over the
+    life of a process. The watchdog snapshots create_time at spawn and
+    compares later — a ~10-18s drift flips the comparison and makes
+    is_orphaned() return True for a LIVING parent, killing every stdio MCP
+    child on a ~10-30s reconnect loop. Reading the raw starttime field
+    (field 22, in clock ticks) from /proc/<pid>/stat is stable across reads
+    and immune to the boot_time drift, so we use that on Linux. ``psutil`` is
+    only used for pid_exists() and as a non-Linux fallback.
     """
     if getppid() != original_ppid:
         return True
-    if psutil is None:
-        # No reliable staleness check available; fall back to the ppid
-        # comparison alone (still catches the common case).
-        return False
+    # Fast path: read /proc/<ppid>/stat directly (Linux). Stable across reads.
     try:
-        if not psutil.pid_exists(original_ppid):
+        with open(f"/proc/{original_ppid}/stat") as f:
+            stat_fields = f.read().split()
+        if len(stat_fields) >= 22:
+            # Field 22 (1-indexed) = starttime in clock ticks since boot.
+            return int(stat_fields[21]) != parent_create_time
+        # Malformed stat — fall back to existence check.
+        if psutil is not None:
+            return not psutil.pid_exists(original_ppid)
+        return False
+    except FileNotFoundError:
+        # /proc unavailable (non-Linux) or process gone.
+        if psutil is None:
+            return False
+        try:
+            return not psutil.pid_exists(original_ppid)
+        except psutil.Error:
             return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
+    except (ProcessLookupError, OSError):
+        if psutil is None:
+            return False
+        try:
+            return not psutil.pid_exists(original_ppid)
+        except psutil.Error:
+            return True
+    except ValueError:
+        if psutil is None:
+            return False
+        try:
+            return not psutil.pid_exists(original_ppid)
+        except psutil.Error:
+            return True
     except psutil.Error:
         return True
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -639,25 +639,20 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         my_pid = os.getpid()
         # Read the raw starttime field (clock ticks since boot) from
         # /proc/<pid>/stat. This is stable across reads — unlike
-        # psutil.Process.create_time(), which drifts on WSL2 because
+        # psutil.Process(pid).create_time(), which drifts on WSL2 because
         # psutil derives it from time.time() - /proc/uptime and the latter
         # jitters by ~1-2s. The watchdog's _is_orphaned() compares against
         # this value, so it MUST be in the same unit (ticks). Falls back to
         # psutil create_time() only on non-Linux where /proc is absent.
-        parent_start_time = None
-        try:
-            with open(f"/proc/{my_pid}/stat") as f:
-                stat_fields = f.read().split()
-            if len(stat_fields) >= 22:
-                parent_start_time = float(stat_fields[21])
-        except (OSError, ValueError):
-            pass
-        if parent_start_time is None:
-            try:
-                import psutil
-                parent_start_time = psutil.Process(my_pid).create_time()
-            except ImportError:
-                parent_start_time = time.time()
+        # Lazy import avoids a circular load (watchdog imports nothing from
+        # here, but keeping it local makes the dependency obvious).
+        from tools.mcp_stdio_watchdog import _read_proc_starttime
+        starttime = _read_proc_starttime(my_pid)
+        if starttime is not None:
+            parent_start_time = float(starttime)
+        else:
+            import psutil
+            parent_start_time = psutil.Process(my_pid).create_time()
     except Exception:
         # Never let watchdog bookkeeping failure block a real MCP connection.
         return command, args

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -637,18 +637,34 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         return command, args
     try:
         my_pid = os.getpid()
+        # Read the raw starttime field (clock ticks since boot) from
+        # /proc/<pid>/stat. This is stable across reads — unlike
+        # psutil.Process.create_time(), which drifts on WSL2 because
+        # psutil derives it from time.time() - /proc/uptime and the latter
+        # jitters by ~1-2s. The watchdog's _is_orphaned() compares against
+        # this value, so it MUST be in the same unit (ticks). Falls back to
+        # psutil create_time() only on non-Linux where /proc is absent.
+        parent_start_time = None
         try:
-            import psutil
-            create_time = psutil.Process(my_pid).create_time()
-        except ImportError:
-            create_time = time.time()
+            with open(f"/proc/{my_pid}/stat") as f:
+                stat_fields = f.read().split()
+            if len(stat_fields) >= 22:
+                parent_start_time = float(stat_fields[21])
+        except (OSError, ValueError):
+            pass
+        if parent_start_time is None:
+            try:
+                import psutil
+                parent_start_time = psutil.Process(my_pid).create_time()
+            except ImportError:
+                parent_start_time = time.time()
     except Exception:
         # Never let watchdog bookkeeping failure block a real MCP connection.
         return command, args
     watchdog_args = [
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_stdio_watchdog.py"),
         "--ppid", str(my_pid),
-        "--create-time", repr(create_time),
+        "--create-time", repr(parent_start_time),
         "--",
         command,
         *args,

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -51,37 +51,45 @@ _ORPHAN_GRACE_S = max(0.0, _env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
 _in_flight = threading.Event()  # set while a command is executing
 
 
+def _read_proc_starttime(pid: int):
+    """Read the starttime field (field 22, clock ticks since boot) from
+    ``/proc/<pid>/stat``. Returns ``None`` if ``/proc`` is unavailable
+    (non-Linux) or the entry is malformed/unreadable.
+
+    ``comm`` (field 2) can contain spaces and parens, so a naive ``split()``
+    over the whole record corrupts every field index after it. Split on the
+    last ``)`` and index into the tail (starttime is tail index 19), matching
+    ``gateway/drain_control.py`` and ``tools/mcp_stdio_watchdog.py``.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            stat = f.read()
+        tail = stat.rsplit(")", 1)[1].split()
+        return int(tail[19])
+    except (FileNotFoundError, IndexError, ValueError, OSError):
+        return None
+
+
 def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
     """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
     (never ==1: Linux reparents to a subreaper) and guard PID reuse via the
     /proc/<pid>/stat starttime (stable) instead of psutil create_time()
-    (which drifts ~1-2s on WSL2 via the jittery /proc/uptime boot_time)."""
+    (which drifts ~1-2s on WSL2 via the jittery /proc/uptime boot_time).
+
+    Non-Linux fallback compares psutil create_time() (not a bare pid_exists)
+    so a recycled PID is still detected as a different process.
+    """
     if getppid() != original_ppid:
         return True
-    # Fast path: read /proc/<ppid>/stat directly (Linux). Stable across reads.
-    try:
-        with open(f"/proc/{original_ppid}/stat") as f:
-            stat_fields = f.read().split()
-        if len(stat_fields) >= 22:
-            # Field 22 (1-indexed) = starttime in clock ticks since boot.
-            return int(stat_fields[21]) != parent_create_time
-        if psutil is not None:
-            return not psutil.pid_exists(original_ppid)
+    # Linux fast path: /proc ticks (stable, immune to WSL2 boot_time drift).
+    starttime = _read_proc_starttime(original_ppid)
+    if starttime is not None:
+        return starttime != parent_create_time
+    # Fallback: compare the psutil create_time fingerprint (PID-reuse guard).
+    if psutil is None:
         return False
-    except FileNotFoundError:
-        if psutil is None:
-            return False
-        try:
-            return not psutil.pid_exists(original_ppid)
-        except psutil.Error:
-            return True
-    except (ProcessLookupError, OSError, ValueError):
-        if psutil is None:
-            return False
-        try:
-            return not psutil.pid_exists(original_ppid)
-        except psutil.Error:
-            return True
+    try:
+        return psutil.Process(original_ppid).create_time() != parent_create_time
     except psutil.Error:
         return True
 
@@ -168,17 +176,15 @@ def main():
     orig_ppid = os.getppid()
     # Read raw starttime (clock ticks) from /proc/stat — stable, unlike
     # psutil.create_time() which drifts on WSL2 (see _is_orphaned docstring).
-    parent_create_time = 0.0
-    try:
-        with open(f"/proc/{orig_ppid}/stat") as f:
-            stat_fields = f.read().split()
-        if len(stat_fields) >= 22:
-            parent_create_time = float(stat_fields[21])
-    except (OSError, ValueError):
+    # Falls back to psutil create_time() on non-Linux where /proc is absent.
+    parent_create_time = _read_proc_starttime(orig_ppid)
+    if parent_create_time is None:
         try:
             parent_create_time = psutil.Process(orig_ppid).create_time()
         except psutil.Error:
             parent_create_time = 0.0
+    else:
+        parent_create_time = float(parent_create_time)
     _start_parent_death_watchdog(orig_ppid, parent_create_time)
     _prepare_slash_worker_runtime()
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -53,14 +53,35 @@ _in_flight = threading.Event()  # set while a command is executing
 
 def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
     """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
-    (never ==1: Linux reparents to a subreaper) and guard PID reuse via
-    create_time."""
+    (never ==1: Linux reparents to a subreaper) and guard PID reuse via the
+    /proc/<pid>/stat starttime (stable) instead of psutil create_time()
+    (which drifts ~1-2s on WSL2 via the jittery /proc/uptime boot_time)."""
     if getppid() != original_ppid:
         return True
+    # Fast path: read /proc/<ppid>/stat directly (Linux). Stable across reads.
     try:
-        if not psutil.pid_exists(original_ppid):
+        with open(f"/proc/{original_ppid}/stat") as f:
+            stat_fields = f.read().split()
+        if len(stat_fields) >= 22:
+            # Field 22 (1-indexed) = starttime in clock ticks since boot.
+            return int(stat_fields[21]) != parent_create_time
+        if psutil is not None:
+            return not psutil.pid_exists(original_ppid)
+        return False
+    except FileNotFoundError:
+        if psutil is None:
+            return False
+        try:
+            return not psutil.pid_exists(original_ppid)
+        except psutil.Error:
             return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
+    except (ProcessLookupError, OSError, ValueError):
+        if psutil is None:
+            return False
+        try:
+            return not psutil.pid_exists(original_ppid)
+        except psutil.Error:
+            return True
     except psutil.Error:
         return True
 
@@ -145,10 +166,19 @@ def main():
     # Start before the (hundreds-of-ms) HermesCLI build — that window is itself
     # an orphan risk if the gateway dies mid-spawn.
     orig_ppid = os.getppid()
+    # Read raw starttime (clock ticks) from /proc/stat — stable, unlike
+    # psutil.create_time() which drifts on WSL2 (see _is_orphaned docstring).
+    parent_create_time = 0.0
     try:
-        parent_create_time = psutil.Process(orig_ppid).create_time()
-    except psutil.Error:
-        parent_create_time = 0.0
+        with open(f"/proc/{orig_ppid}/stat") as f:
+            stat_fields = f.read().split()
+        if len(stat_fields) >= 22:
+            parent_create_time = float(stat_fields[21])
+    except (OSError, ValueError):
+        try:
+            parent_create_time = psutil.Process(orig_ppid).create_time()
+        except psutil.Error:
+            parent_create_time = 0.0
     _start_parent_death_watchdog(orig_ppid, parent_create_time)
     _prepare_slash_worker_runtime()
 


### PR DESCRIPTION
## Problem

On WSL2, every stdio MCP server (and every TUI slash-worker background command) gets SIGTERMed on a ~10-30s reconnect loop, producing endless `keepalive failed, triggering reconnect` warnings. From the user's perspective it looks like "the gateway keeps restarting." Root cause is a **false-orphan detection** in the parent-death watchdogs.

## Root cause

`psutil.Process(pid).create_time()` **drifts ~1-2s over the life of a process on WSL2**. psutil derives it as:

```
create_time = boot_time + starttime_ticks / CLK_TCK
boot_time   = time.time() - uptime       # uptime from /proc/uptime
```

WSL2's `/proc/uptime` jitters by ~1-2s, so `boot_time` (and therefore `create_time()`) drifts. The orphan watchdogs snapshot `create_time()` at spawn and compare it later to detect PID reuse. The drift flips the comparison after ~10-18s, making `is_orphaned()` return `True` for a **living parent** — which then SIGTERMs the child.

The raw `starttime` field (clock ticks since boot, field 22 of `/proc/<pid>/stat`) is **stable across reads** and immune to the boot_time drift.

### Reproduction (isolated, no gateway)

Monitoring `psutil.Process(os.getpid()).create_time()` for a living process:

```
t=0s  ct=1783813304.0
...
t=16s ct=1783813304.0
t=18s ct=1783813306.0   ← +2.0s drift, same PID, same /proc/<pid>/stat starttime
```

The same probe reading `/proc/<pid>/stat` field 22 returns `22271900` ticks at every sample.

### Impact in production

Gateway logs (Hermes v0.18.2, WSL2, psutil 7.2.2) before the fix:

```
20:08  12 keepalive failed
20:09   5
20:10   4
20:11  10
...  ~5-13/min sustained
```

After the fix: **0 keepalive-failed events** over 16+ min; all 4 stdio MCPs stay connected.

## Fix

Read the raw `starttime` (clock ticks) directly from `/proc/<pid>/stat` field 22 instead of `psutil.Process(pid).create_time()`. psutil is retained only for `pid_exists()` and as a non-Linux fallback (where `/proc` is absent). Same fix in all three affected call sites that share the `_is_orphaned` pattern:

- `tools/mcp_stdio_watchdog.py` — MCP stdio server subprocess watchdog
- `tui_gateway/slash_worker.py` — TUI slash-command background workers (had the identical bug)
- `tools/mcp_tool.py` — `_wrap_command_with_watchdog` now passes starttime in **ticks** (unit-consistent with the new `_is_orphaned`)

The semantic of orphan detection (getppid check + starttime/PID-reuse guard) is preserved; on native Linux and macOS where psutil's `create_time()` does not drift, behavior is identical to before.

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/tools/test_mcp_stability.py tests/tui_gateway/test_slash_worker_*.py` → **245 passed, 0 failed**
- 24s / 12-sample isolated test of `_is_orphaned()` for a living parent: `False` at every sample (pre-patch: flipped to `True` after ~12s)
- Live gateway: 0 keepalive-failed events in 16+ min post-restart vs 5-13/min pre-patch; 4/4 stdio MCPs connected and stable

## Notes

- Non-Linux platforms fall back to `psutil.pid_exists()` (orphan detection by PID existence only), matching the pre-existing `psutil is None` fallback.
- No new dependencies; `/proc/<pid>/stat` is read with a 2-line `open().read().split()`.