### PR TITLE
fix(mcp): strip credential headers on cross-origin redirects

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -88,6 +88,106 @@ class TestFilterMCPChildren:
 
 
 # ---------------------------------------------------------------------------
+# HTTP redirect credential stripping
+# ---------------------------------------------------------------------------
+
+class TestMCPRedirectCredentialStripping:
+    def test_cross_origin_redirect_strips_configured_credential_headers(self):
+        """httpx only strips Authorization by default; MCP config headers such
+        as X-Api-Key must also be removed before a cross-origin redirect.
+        """
+        import httpx
+
+        from tools.mcp_tool import _make_mcp_cross_origin_request_sanitizer
+
+        seen: list[tuple[str, dict[str, str]]] = []
+
+        def handler(request):
+            seen.append((str(request.url), dict(request.headers)))
+            if len(seen) == 1:
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://evil.example/mcp"},
+                    request=request,
+                )
+            return httpx.Response(200, text="ok", request=request)
+
+        async def drive():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler),
+                follow_redirects=True,
+                event_hooks={
+                    "request": [_make_mcp_cross_origin_request_sanitizer("https://mcp.example/mcp")],
+                },
+            ) as client:
+                await client.get(
+                    "https://mcp.example/mcp",
+                    headers={
+                        "Authorization": "Bearer auth-secret",
+                        "X-Api-Key": "api-secret",
+                        "X-Auth-Token": "token-secret",
+                        "MCP-Protocol-Version": "2025-03-26",
+                    },
+                )
+
+        asyncio.run(drive())
+
+        assert len(seen) == 2
+        first_headers = seen[0][1]
+        redirect_headers = seen[1][1]
+        assert first_headers["authorization"] == "Bearer auth-secret"
+        assert first_headers["x-api-key"] == "api-secret"
+        assert first_headers["x-auth-token"] == "token-secret"
+        assert "authorization" not in redirect_headers
+        assert "x-api-key" not in redirect_headers
+        assert "x-auth-token" not in redirect_headers
+        assert redirect_headers["mcp-protocol-version"] == "2025-03-26"
+
+    def test_same_origin_redirect_preserves_configured_headers(self):
+        """Same-origin MCP redirects keep configured headers for canonical
+        /mcp -> /mcp/ style endpoint normalization.
+        """
+        import httpx
+
+        from tools.mcp_tool import _make_mcp_cross_origin_request_sanitizer
+
+        seen: list[tuple[str, dict[str, str]]] = []
+
+        def handler(request):
+            seen.append((str(request.url), dict(request.headers)))
+            if len(seen) == 1:
+                return httpx.Response(
+                    307,
+                    headers={"Location": "https://mcp.example/mcp/"},
+                    request=request,
+                )
+            return httpx.Response(200, text="ok", request=request)
+
+        async def drive():
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler),
+                follow_redirects=True,
+                event_hooks={
+                    "request": [_make_mcp_cross_origin_request_sanitizer("https://mcp.example/mcp")],
+                },
+            ) as client:
+                await client.get(
+                    "https://mcp.example/mcp",
+                    headers={
+                        "Authorization": "Bearer auth-secret",
+                        "X-Api-Key": "api-secret",
+                    },
+                )
+
+        asyncio.run(drive())
+
+        assert len(seen) == 2
+        redirect_headers = seen[1][1]
+        assert redirect_headers["authorization"] == "Bearer auth-secret"
+        assert redirect_headers["x-api-key"] == "api-secret"
+
+
+# ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -120,6 +120,84 @@ logger = logging.getLogger(__name__)
 _OSV_MALWARE_CHECK_TIMEOUT_S = 12.0
 
 
+_MCP_REDIRECT_SENSITIVE_EXACT_HEADERS = {
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+}
+_MCP_REDIRECT_SENSITIVE_HEADER_MARKERS = (
+    "apikey",
+    "auth",
+    "credential",
+    "secret",
+    "token",
+)
+
+
+def _url_origin_tuple(url: Any) -> tuple[str, str, int | None]:
+    """Return scheme/host/effective-port for redirect comparisons."""
+    if isinstance(url, str):
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+        if port is None:
+            if scheme == "https":
+                port = 443
+            elif scheme == "http":
+                port = 80
+        return scheme, host, port
+    scheme = str(getattr(url, "scheme", "") or "").lower()
+    host = str(getattr(url, "host", "") or "").lower()
+    port = getattr(url, "port", None)
+    if port is None:
+        if scheme == "https":
+            port = 443
+        elif scheme == "http":
+            port = 80
+    return scheme, host, port
+
+
+def _is_mcp_redirect_sensitive_header(name: str) -> bool:
+    """Whether a configured MCP header should not survive a cross-origin redirect."""
+    normalized = name.lower()
+    if normalized in _MCP_REDIRECT_SENSITIVE_EXACT_HEADERS:
+        return True
+    compact = re.sub(r"[^a-z0-9]", "", normalized)
+    return any(marker in compact for marker in _MCP_REDIRECT_SENSITIVE_HEADER_MARKERS)
+
+
+async def _strip_mcp_credentials_on_cross_origin_redirect(response: Any) -> None:
+    """Strip credential-like MCP headers from a redirected cross-origin request.
+
+    httpx removes ``Authorization`` across origins, but user-configured MCP
+    headers commonly carry credentials under names such as ``X-Api-Key`` or
+    ``X-Auth-Token``. Those must not be replayed to a different redirect host.
+    """
+    next_request = getattr(response, "next_request", None)
+    if not getattr(response, "is_redirect", False) or next_request is None:
+        return
+    if _url_origin_tuple(response.request.url) == _url_origin_tuple(next_request.url):
+        return
+    for header_name in list(next_request.headers):
+        if _is_mcp_redirect_sensitive_header(header_name):
+            next_request.headers.pop(header_name, None)
+
+
+def _make_mcp_cross_origin_request_sanitizer(origin_url: Any) -> Callable[[Any], Coroutine[Any, Any, None]]:
+    """Build an httpx request hook that strips MCP credentials off-origin."""
+    origin = _url_origin_tuple(origin_url)
+
+    async def _sanitize_request(request: Any) -> None:
+        if _url_origin_tuple(request.url) == origin:
+            return
+        for header_name in list(request.headers):
+            if _is_mcp_redirect_sensitive_header(header_name):
+                request.headers.pop(header_name, None)
+
+    return _sanitize_request
+
+
 # ---------------------------------------------------------------------------
 # Stdio subprocess stderr redirection
 # ---------------------------------------------------------------------------
@@ -2423,6 +2501,10 @@ class MCPServerTask:
                     kwargs: dict = {
                         "follow_redirects": True,
                         "verify": _verify_for_factory,
+                        "event_hooks": {
+                            "request": [_make_mcp_cross_origin_request_sanitizer(url)],
+                            "response": [_strip_mcp_credentials_on_cross_origin_redirect],
+                        },
                     }
                     if timeout is not None:
                         kwargs["timeout"] = timeout
@@ -2469,23 +2551,14 @@ class MCPServerTask:
             # matching the SDK's own create_mcp_http_client defaults.
             import httpx
 
-            _original_url = httpx.URL(url)
-
-            async def _strip_auth_on_cross_origin_redirect(response):
-                """Strip Authorization headers when redirected to a different origin."""
-                if response.is_redirect and response.next_request:
-                    target = response.next_request.url
-                    if (target.scheme, target.host, target.port) != (
-                        _original_url.scheme, _original_url.host, _original_url.port,
-                    ):
-                        response.next_request.headers.pop("authorization", None)
-                        response.next_request.headers.pop("Authorization", None)
-
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
-                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                "event_hooks": {
+                    "request": [_make_mcp_cross_origin_request_sanitizer(url)],
+                    "response": [_strip_mcp_credentials_on_cross_origin_redirect],
+                },
             }
             if headers:
                 client_kwargs["headers"] = headers


### PR DESCRIPTION
## Summary

MCP HTTP transports now strip credential-like configured headers before following cross-origin redirects.

## Problem

The Streamable HTTP MCP path already attempted to strip `Authorization` on cross-origin redirects, but MCP server config supports arbitrary headers. Those headers commonly carry credentials under names like `X-Api-Key`, `X-Auth-Token`, `api-key`, or `X-Secret`.

HTTPX removes `Authorization` across origins by default, but it preserves custom headers such as `X-Api-Key` on redirected requests. That means a remote MCP endpoint that redirects to another origin can receive configured MCP credentials that were intended only for the original server.

## Changes

- Add a shared MCP redirect header sanitizer.
- Strip credential-like headers on cross-origin redirected requests:
  - `Authorization`
  - `Proxy-Authorization`
  - `Cookie`
  - names containing `api-key`, `auth`, `credential`, `secret`, or `token`
- Preserve same-origin redirects for normal endpoint canonicalization.
- Preserve non-secret protocol headers such as `MCP-Protocol-Version`.
- Apply the sanitizer to the Streamable HTTP path.
- Apply the sanitizer to the SSE custom HTTP client factory path.
- Add regression coverage for cross-origin stripping and same-origin preservation.

## Tests

```text
python -m pytest tests/tools/test_mcp_tool.py -k "MCPRedirectCredentialStripping" -q --timeout-method=thread
2 passed, 212 deselected

python -m pytest tests/tools/test_mcp_sse_transport.py -q --timeout-method=thread
4 passed

python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py