### PR TITLE
fix(tools): downgrade check_fn 'returned False' log from WARNING to DEBUG

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -188,7 +188,10 @@ def _check_fn_cached(fn: Callable) -> bool:
 
         # No recent success (or grace expired) — honor the failure. Log it so
         # silent tool loss in quiet mode (subagents) is diagnosable.
-        logger.warning(
+        # Use DEBUG for steady-state "returned False" (tool simply not configured)
+        # to avoid spamming errors.log; keep WARNING for raised (unexpected).
+        _log = logger.warning if raised else logger.debug
+        _log(
             "check_fn %s %s; dependent tools will be unavailable this turn",
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",


### PR DESCRIPTION
When a tool's `check_fn` returns `False` (tool simply not configured — e.g. browser CDP, X/Twitter search), the registry logs a WARNING every turn. These end up in `errors.log` and create noise for users who haven't configured those optional tools.

**Before** (repeats every turn, fills `errors.log`):
```
WARNING tools.registry: check_fn check_x_search_requirements returned False; dependent tools will be unavailable this turn
WARNING tools.registry: check_fn _browser_cdp_check returned False; dependent tools will be unavailable this turn
```

**After:**
- `returned False` → logged at **DEBUG** (still visible in `agent.log` with `logging.level: DEBUG`, invisible in `errors.log`)
- `raised` → stays at **WARNING** (genuine unexpected failure, belongs in `errors.log`)

One file changed, 2 lines modified in `tools/registry.py`.