### PR TITLE
docs(cli): remove phantom slash commands

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -312,7 +312,6 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
@@ -359,7 +358,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit)        Exit CLI
 ```
 
 ---
@@ -917,7 +916,7 @@ and logs — avoids shell-escaping backslashes in bash.
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement
-3. Load explicitly: `/skill name` or `hermes -s name`
+3. Load explicitly: `/<skill-name>` or `hermes -s name`
 
 ### Gateway issues
 Check logs first:


### PR DESCRIPTION
## What does this PR do?

The bundled `hermes-agent` skill documented `/skill <name>` even though Hermes registers installed skills directly as `/<skill-name>`. It also listed `/q` as a quit alias even though the command registry assigns `/q` to `/queue`.

This removes the phantom `/skill` command from the command table, corrects the quit aliases, and updates the troubleshooting section to use the real `/<skill-name>` syntax.

## Related Issue

Fixes #50605

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove `/skill <name>` from the bundled slash-command table.
- Change `/quit (/exit, /q)` to `/quit (/exit)`.
- Replace the second phantom `/skill name` example with `/<skill-name>`.

## How to Test

1. Open `skills/autonomous-ai-agents/hermes-agent/SKILL.md`.
2. Confirm the command table contains `/skills` but does not advertise `/skill <name>`.
3. Confirm the exit section lists only `/quit` and `/exit`.
4. Confirm the troubleshooting section recommends `/<skill-name>` or `hermes -s name`.

Relevant contract tests:

- `/q` queue alias test passed: 1 passed.
- `/quit` and `/exit` behavior tests passed: 6 passed.
- Installed skill slash-command resolution tests passed: 2 passed.
- A broader Windows run of `tests/agent/test_skill_commands.py` produced 48 passed, 2 skipped, and 4 unrelated fixture/cache failures in supporting-file and inline-shell tests.
- `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features), or N/A for this documentation-only correction
- [x] I've tested on my platform: Windows 11

The full Python suite was not run because this changes only bundled Markdown documentation. Existing command and skill-resolution tests were used to verify the documented behavior.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Not applicable. This corrects bundled command documentation only.
