### PR TITLE
fix: plug per-task and per-turn memory leaks in long-running processes

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -86,6 +86,12 @@ SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
 MAX_CONTENT_MODIFIED_RETRIES = 3
 RETRY_BASE_DELAY = 0.5  # 0.5, 1.0, 2.0 — exponential
 
+# Most files a client keeps open (didOpen'd) at once. Each tracked file
+# pins its full text here AND a mirror copy in the server; the LRU cap
+# bounds both. 64 comfortably covers the working set of an active edit
+# loop while keeping worst-case pinned text in the low MBs.
+MAX_TRACKED_FILES = 64
+
 
 def file_uri(path: str) -> str:
     """Return ``file://`` URI for an absolute filesystem path.
@@ -232,6 +238,14 @@ class LSPClient:
         # Per-document state (version, text, diagnostic stores, and
         # their freshness tags), keyed by absolute file path (NOT URI).
         # See _DocState for the version-based freshness model.
+        #
+        # Insertion-ordered LRU capped at MAX_TRACKED_FILES: each entry
+        # holds the file's full text (for incremental-sync ranges), and the
+        # server mirrors every open document in its own memory, so an
+        # uncapped dict pins the contents of every file a long coding run
+        # ever touches — on both sides of the pipe — until the whole client
+        # is reaped. Evicted files are didClose'd and transparently
+        # re-didOpen'ed on their next touch.
         self._docs: Dict[str, _DocState] = {}
         # Capability registrations — only diagnostic ones are tracked.
         self._diagnostic_registrations: Dict[str, Dict[str, Any]] = {}
@@ -771,6 +785,9 @@ class LSPClient:
             # stale by definition (see _DocState).
             doc.version = new_version
             doc.text = text
+            # pop+reinsert refreshes LRU recency (dicts are insertion-ordered).
+            self._docs.pop(abs_path, None)
+            self._docs[abs_path] = doc
             return new_version
 
         # First open: didChangeWatchedFiles CREATED + didOpen.
@@ -792,7 +809,28 @@ class LSPClient:
                 }
             },
         )
+        await self._evict_lru_files()
         return 0
+
+    async def _evict_lru_files(self) -> None:
+        """didClose + drop least-recently-opened files beyond MAX_TRACKED_FILES.
+
+        Frees the cached text on our side and lets the server release its
+        mirror of the document. Per-path diagnostic state goes with it —
+        the fresh-open path rebuilds it on the file's next touch.
+        """
+        while len(self._docs) > MAX_TRACKED_FILES:
+            old_path = next(iter(self._docs))
+            # One _DocState carries text, both diagnostic stores, and their
+            # freshness tags, so dropping the entry releases all of it.
+            self._docs.pop(old_path, None)
+            try:
+                await self._send_notification(
+                    "textDocument/didClose",
+                    {"textDocument": {"uri": file_uri(old_path)}},
+                )
+            except Exception as e:
+                logger.debug("didClose during LRU eviction failed for %s: %s", old_path, e)
 
     async def save_file(self, path: str) -> None:
         """Send didSave for ``path``.  Some linters re-scan only on save."""

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -61,6 +61,11 @@ logger = logging.getLogger("agent.lsp.manager")
 DEFAULT_IDLE_TIMEOUT = 600  # seconds; servers idle for >10min get reaped
 MIN_IDLE_TIMEOUT = 30  # floor for config values; must exceed any per-op wait budget
 
+# Most per-file diagnostic baselines kept for delta filtering. Insertion-
+# ordered eviction; matches the working-set thinking behind the client's
+# MAX_TRACKED_FILES cap.
+_DELTA_BASELINE_CAP = 256
+
 
 class _BackgroundLoop:
     """A daemon thread that owns one asyncio event loop.
@@ -182,11 +187,32 @@ class LSPService:
         # Delta baseline: file path → snapshot of diagnostics taken
         # immediately before a write.  ``get_diagnostics_sync`` filters
         # out anything in the baseline so the agent only sees errors
-        # introduced by the current edit.
+        # introduced by the current edit.  Bounded via _cap_delta_baseline:
+        # only the most recent write to a path matters, but entries for
+        # paths never written again would otherwise live for the service's
+        # lifetime.
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
 
         if self._enabled and self._idle_timeout > 0:
             self._loop.run(self._start_idle_reaper(), timeout=2.0)
+
+    def _cap_delta_baseline(self) -> None:
+        """Evict oldest baseline entries beyond _DELTA_BASELINE_CAP."""
+        while len(self._delta_baseline) > _DELTA_BASELINE_CAP:
+            self._delta_baseline.pop(next(iter(self._delta_baseline)), None)
+
+    def _set_delta_baseline(self, abs_path: str, diags: List[Dict[str, Any]]) -> None:
+        """Store a baseline for ``abs_path``, refreshing its recency.
+
+        The dict is insertion-ordered and evicted oldest-first, but a plain
+        reassignment keeps an existing key in its original slot — so a path
+        rewritten every edit would still age out ahead of paths never touched
+        again.  Pop-then-set moves the just-written path to the most-recent
+        end, so eviction reflects actual write recency.
+        """
+        self._delta_baseline.pop(abs_path, None)
+        self._delta_baseline[abs_path] = diags
+        self._cap_delta_baseline()
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -312,11 +338,11 @@ class LSPService:
             # slow-but-alive server gets falsely marked broken.
             t = max(8.0, self._wait_timeout + 3.0)
             diags = self._loop.run(self._snapshot_async(file_path), timeout=t)
-            self._delta_baseline[os.path.abspath(file_path)] = diags or []
+            self._set_delta_baseline(os.path.abspath(file_path), diags or [])
         except Exception as e:  # noqa: BLE001
             logger.debug("baseline snapshot failed for %s: %s", file_path, e)
             self._mark_broken_for_file(file_path, e)
-            self._delta_baseline[os.path.abspath(file_path)] = []
+            self._set_delta_baseline(os.path.abspath(file_path), [])
 
     def get_diagnostics_sync(
         self,
@@ -405,7 +431,7 @@ class LSPService:
             except Exception:  # noqa: BLE001
                 fresh = []
             if fresh:
-                self._delta_baseline[abs_path] = fresh
+                self._set_delta_baseline(abs_path, fresh)
 
         if diags:
             eventlog.log_diagnostics(server_id, file_path, len(diags))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2247,6 +2247,42 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+# Singleton for the tool-call audit log (display.tool_progress: log).
+# One fixed-name Logger + one RotatingFileHandler for the process lifetime:
+# named Loggers are never garbage-collected (they live in
+# logging.Logger.manager.loggerDict forever), so a per-turn name would add
+# one permanent Logger per logged turn; and a single shared handler keeps
+# concurrent turns from double-writing lines, which per-turn handlers on a
+# shared logger would do.
+_tool_call_logger: Optional[logging.Logger] = None
+_tool_call_logger_lock = threading.Lock()
+
+
+def _get_tool_call_logger() -> logging.Logger:
+    global _tool_call_logger
+    with _tool_call_logger_lock:
+        if _tool_call_logger is None:
+            from logging.handlers import RotatingFileHandler
+
+            from agent.redact import RedactingFormatter
+
+            log_dir = _hermes_home / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            file_handler = RotatingFileHandler(
+                log_dir / "tool_calls.log",
+                maxBytes=5 * 1024 * 1024,
+                backupCount=3,
+                encoding="utf-8",
+            )
+            file_handler.setFormatter(RedactingFormatter("%(message)s"))
+            tool_logger = logging.getLogger("hermes.tool_calls")
+            tool_logger.setLevel(logging.INFO)
+            tool_logger.propagate = False
+            tool_logger.addHandler(file_handler)
+            _tool_call_logger = tool_logger
+        return _tool_call_logger
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -23537,23 +23573,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             """
             if log_queue is None:
                 return
-            from logging.handlers import RotatingFileHandler
-
-            from agent.redact import RedactingFormatter
-
-            log_dir = _hermes_home / "logs"
-            log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = RotatingFileHandler(
-                log_dir / "tool_calls.log",
-                maxBytes=5 * 1024 * 1024,
-                backupCount=3,
-                encoding="utf-8",
-            )
-            file_handler.setFormatter(RedactingFormatter("%(message)s"))
-            tool_logger = logging.getLogger(f"hermes.tool_calls.{id(log_queue)}")
-            tool_logger.setLevel(logging.INFO)
-            tool_logger.propagate = False
-            tool_logger.addHandler(file_handler)
+            tool_logger = _get_tool_call_logger()
             try:
                 while True:
                     try:
@@ -23566,8 +23586,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except asyncio.CancelledError:
                 pass
             finally:
-                # Drain remaining entries before closing so late tool calls
-                # from the final iteration aren't lost.
+                # Drain remaining entries before exiting so late tool calls
+                # from the final iteration aren't lost. The logger and its
+                # handler are process-wide singletons — nothing to close.
                 while True:
                     try:
                         tool_logger.info("%s", log_queue.get_nowait())
@@ -23575,12 +23596,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         break
                     except Exception:
                         break
-                tool_logger.removeHandler(file_handler)
-                try:
-                    file_handler.flush()
-                    file_handler.close()
-                except Exception:
-                    pass
 
         # Extracted to TurnRunner.send_progress_messages. The threading
         # metadata computed above is published onto the shared TurnContext

--- a/run_agent.py
+++ b/run_agent.py
@@ -3991,6 +3991,20 @@ class AIAgent:
         except Exception:
             pass
 
+        # 3b. Drop per-task file-tool trackers (read/dedup history,
+        # patch-failure counts, cwd anchors, cached file-ops handles).
+        # Nothing else pops a finished task's entries, and tool calls may
+        # have keyed them on the conversation task_id rather than the
+        # session_id, so clear both.
+        try:
+            from tools.file_tools import clear_task_trackers
+
+            for _tid in {task_id, getattr(self, "_current_task_id", None)}:
+                if _tid:
+                    clear_task_trackers(_tid)
+        except Exception:
+            pass
+
         # 4. Release the session-owned computer-use backend.  This ends the
         # exact cua-driver session, drops typed-browser refs/grants, and stops
         # a private embedded daemon when Hermes YOLO selected unrestricted

--- a/tests/agent/lsp/test_file_lru.py
+++ b/tests/agent/lsp/test_file_lru.py
@@ -1,0 +1,152 @@
+"""LRU cap on the client's tracked-file text cache.
+
+``LSPClient._docs`` holds every opened file's full text (and the server
+mirrors each open document in its own memory) with no per-file eviction —
+a marathon coding run pinned the contents of every file it ever touched
+until the whole client was idle-reaped. The cap evicts the least recently
+opened files with a proper ``didClose``; evicted files transparently
+re-``didOpen`` on their next touch.
+
+Runs against the in-process mock LSP server, same harness as
+test_client_e2e.py.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import agent.lsp.client as client_mod
+from agent.lsp.client import LSPClient
+
+MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+
+
+def _client(workspace: Path, script: str = "clean") -> LSPClient:
+    env = {"MOCK_LSP_SCRIPT": script, "PYTHONPATH": os.environ.get("PYTHONPATH", "")}
+    return LSPClient(
+        server_id=f"mock-{script}",
+        workspace_root=str(workspace),
+        command=[sys.executable, MOCK_SERVER],
+        env=env,
+        cwd=str(workspace),
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_files_evicted_beyond_cap(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_mod, "MAX_TRACKED_FILES", 3)
+
+    files = []
+    for i in range(5):
+        f = tmp_path / f"f{i}.py"
+        f.write_text(f"print({i})\n")
+        files.append(os.path.abspath(str(f)))
+
+    client = _client(tmp_path)
+    await client.start()
+    try:
+        for path in files:
+            await client.open_file(path, language_id="python")
+
+        # Cap holds; the two least-recently-opened files were evicted.
+        assert len(client._docs) == 3
+        assert files[0] not in client._docs
+        assert files[1] not in client._docs
+        assert set(files[2:]).issubset(client._docs)
+
+        # An evicted file re-opens transparently as a fresh didOpen.
+        version = await client.open_file(files[0], language_id="python")
+        assert version == 0
+        assert files[0] in client._docs
+        assert len(client._docs) == 3
+
+        # A still-tracked file keeps taking the didChange path.
+        version = await client.open_file(files[4], language_id="python")
+        assert version == 1
+    finally:
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_reopen_refreshes_lru_recency(tmp_path: Path, monkeypatch):
+    """Touching a tracked file must move it to the back of the eviction
+    queue — LRU, not FIFO-by-first-open."""
+    monkeypatch.setattr(client_mod, "MAX_TRACKED_FILES", 2)
+
+    a, b, c = (tmp_path / n for n in ("a.py", "b.py", "c.py"))
+    for f in (a, b, c):
+        f.write_text("print()\n")
+    a_p, b_p, c_p = (os.path.abspath(str(f)) for f in (a, b, c))
+
+    client = _client(tmp_path)
+    await client.start()
+    try:
+        await client.open_file(a_p, language_id="python")
+        await client.open_file(b_p, language_id="python")
+        # Touch a again: b becomes least recently used.
+        await client.open_file(a_p, language_id="python")
+        await client.open_file(c_p, language_id="python")
+
+        assert b_p not in client._docs
+        assert {a_p, c_p} == set(client._docs)
+    finally:
+        await client.shutdown()
+
+
+def test_delta_baseline_capped(monkeypatch):
+    """The manager's per-path diagnostic baselines are bounded too — same
+    grow-per-path-forever shape, smaller entries."""
+    import agent.lsp.manager as manager_mod
+    from agent.lsp.manager import LSPService
+
+    monkeypatch.setattr(manager_mod, "_DELTA_BASELINE_CAP", 4)
+    svc = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="auto",
+    )
+    try:
+        for i in range(10):
+            svc._delta_baseline[f"/tmp/file{i}.py"] = [{"message": f"d{i}"}]
+            svc._cap_delta_baseline()
+        assert len(svc._delta_baseline) == 4
+        assert "/tmp/file9.py" in svc._delta_baseline
+        assert "/tmp/file0.py" not in svc._delta_baseline
+    finally:
+        svc.shutdown()
+
+
+def test_delta_baseline_refreshes_recency_on_rewrite(monkeypatch):
+    """A path rewritten every edit must not age out ahead of paths never
+    touched again — _set_delta_baseline moves the rewritten path to the recent
+    end so eviction reflects actual write recency (PR #62934 review follow-up)."""
+    import agent.lsp.manager as manager_mod
+    from agent.lsp.manager import LSPService
+
+    monkeypatch.setattr(manager_mod, "_DELTA_BASELINE_CAP", 3)
+    svc = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="auto",
+    )
+    try:
+        svc._set_delta_baseline("/tmp/a.py", [{"m": "a"}])
+        svc._set_delta_baseline("/tmp/b.py", [{"m": "b"}])
+        svc._set_delta_baseline("/tmp/c.py", [{"m": "c"}])
+        # Re-write the oldest path: it should jump to the most-recent end and
+        # carry the new value.
+        svc._set_delta_baseline("/tmp/a.py", [{"m": "a2"}])
+        assert list(svc._delta_baseline) == ["/tmp/b.py", "/tmp/c.py", "/tmp/a.py"]
+        assert svc._delta_baseline["/tmp/a.py"] == [{"m": "a2"}]
+        # The next insert evicts b (now genuinely oldest), NOT the rewritten a.
+        svc._set_delta_baseline("/tmp/d.py", [{"m": "d"}])
+        assert "/tmp/b.py" not in svc._delta_baseline
+        assert "/tmp/a.py" in svc._delta_baseline
+        assert set(svc._delta_baseline) == {"/tmp/c.py", "/tmp/a.py", "/tmp/d.py"}
+    finally:
+        svc.shutdown()

--- a/tests/gateway/test_tool_log_mode.py
+++ b/tests/gateway/test_tool_log_mode.py
@@ -86,3 +86,44 @@ async def test_write_tool_log_writes_and_rotates_handler(tmp_path, monkeypatch):
     await asyncio.sleep(0)  # keep the asyncio marker honest
 
 
+def test_tool_call_logger_is_a_fixed_name_singleton(tmp_path, monkeypatch):
+    """One process-wide Logger, not one per turn.
+
+    Named Loggers live in logging.Logger.manager.loggerDict forever; the
+    old per-turn name (``hermes.tool_calls.<id(log_queue)>``) permanently
+    added one Logger per logged turn. The singleton must hand back the
+    same fixed-name Logger on every call and never grow loggerDict.
+    """
+    import logging
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_tool_call_logger", None)
+    # The named Logger object itself is process-global: shed handlers from
+    # any earlier creation so this test builds (and later removes) its own.
+    logging.getLogger("hermes.tool_calls").handlers.clear()
+
+    try:
+        first = gateway_run._get_tool_call_logger()
+        dict_size = len(logging.Logger.manager.loggerDict)
+        for _ in range(50):
+            assert gateway_run._get_tool_call_logger() is first
+        assert first.name == "hermes.tool_calls"
+        assert len(logging.Logger.manager.loggerDict) == dict_size
+        assert len(first.handlers) == 1
+
+        first.info("%s", '2026-07-11 10:00:00  terminal: "echo hi"')
+        content = (tmp_path / "logs" / "tool_calls.log").read_text(encoding="utf-8")
+        assert "terminal" in content
+    finally:
+        for h in list(first.handlers):
+            first.removeHandler(h)
+            h.close()
+
+
+def test_log_mode_disables_chat_progress():
+    """tool_progress_enabled must be False in log mode (silent in chat)."""
+    for mode, expected in [("all", True), ("log", False), ("off", False)]:
+        enabled = mode not in {"off", "log"}
+        assert enabled is expected

--- a/tests/tools/test_task_tracker_cleanup.py
+++ b/tests/tools/test_task_tracker_cleanup.py
@@ -1,0 +1,112 @@
+"""clear_task_trackers: per-task file-tool state must die with its task.
+
+The four module-level registries in tools.file_tools are keyed by task_id
+and had no removal path for finished tasks. Subagent task ids are unique
+per delegation (``subagent-<n>-<uuid>``), so a long-running gateway process
+accreted one dead entry set per delegation for its whole lifetime. These
+tests cover the new clear_task_trackers() helper and its AIAgent.close()
+wiring.
+"""
+
+import types
+
+import tools.file_tools as ft
+import tools.terminal_tool as tt
+from tools.file_tools import clear_task_trackers
+
+
+def _seed(task_id: str) -> None:
+    with ft._read_tracker_lock:
+        ft._read_tracker[task_id] = {"last_key": None, "read_history": set()}
+    with ft._patch_failure_lock:
+        ft._patch_failure_tracker[task_id] = {"/tmp/a.py": 2}
+    with ft._file_ops_lock:
+        tt._session_cwd[task_id] = "/tmp"
+        ft._file_ops_cache[task_id] = object()
+
+
+def _purge(*task_ids: str) -> None:
+    for tid in task_ids:
+        clear_task_trackers(tid)
+
+
+class TestClearTaskTrackers:
+    def test_pops_all_four_registries(self):
+        tid = "subagent-1-deadbeef"
+        _seed(tid)
+        try:
+            clear_task_trackers(tid)
+            with ft._read_tracker_lock:
+                assert tid not in ft._read_tracker
+            with ft._patch_failure_lock:
+                assert tid not in ft._patch_failure_tracker
+            with ft._file_ops_lock:
+                assert tid not in tt._session_cwd
+                assert tid not in ft._file_ops_cache
+        finally:
+            _purge(tid)
+
+    def test_other_tasks_untouched(self):
+        dead, alive = "subagent-2-11111111", "subagent-3-22222222"
+        _seed(dead)
+        _seed(alive)
+        try:
+            clear_task_trackers(dead)
+            with ft._read_tracker_lock:
+                assert alive in ft._read_tracker
+            with ft._file_ops_lock:
+                assert tt._session_cwd.get(alive) == "/tmp"
+        finally:
+            _purge(dead, alive)
+
+    def test_shared_container_alias_survives_child_clear(self):
+        """Subagents collapse to the parent's "default" container key
+        (terminal_tool._resolve_container_task_id); clearing a child must
+        pop only the child's exact key, never the shared alias."""
+        child = "subagent-4-33333333"
+        _seed(child)
+        with ft._file_ops_lock:
+            tt._session_cwd["default"] = "/parent/cwd"
+        try:
+            clear_task_trackers(child)
+            with ft._file_ops_lock:
+                assert tt._session_cwd.get("default") == "/parent/cwd"
+        finally:
+            _purge(child)
+            with ft._file_ops_lock:
+                tt._session_cwd.pop("default", None)
+
+    def test_empty_and_missing_ids_are_noops(self):
+        clear_task_trackers("")
+        clear_task_trackers("never-seeded-task-id")
+
+
+class TestAgentCloseWiring:
+    def test_close_clears_session_and_conversation_task_ids(self):
+        """AIAgent.close() must clear trackers for both id keyings: tool
+        calls key on the conversation task_id while close() historically
+        only knew session_id."""
+        from run_agent import AIAgent
+
+        session_tid = "close-test-session"
+        convo_tid = "subagent-5-44444444"
+        _seed(session_tid)
+        _seed(convo_tid)
+
+        fake = types.SimpleNamespace(
+            session_id=session_tid,
+            _current_task_id=convo_tid,
+            client=None,
+            _session_messages=[],
+            _end_session_on_close=False,
+        )
+        try:
+            AIAgent.close(fake)
+            with ft._read_tracker_lock:
+                assert session_tid not in ft._read_tracker
+                assert convo_tid not in ft._read_tracker
+            with ft._file_ops_lock:
+                assert session_tid not in ft._file_ops_cache
+                assert convo_tid not in ft._file_ops_cache
+        finally:
+            _purge(session_tid, convo_tid)

--- a/tests/tui_gateway/test_ephemeral_agent_tracker_cleanup.py
+++ b/tests/tui_gateway/test_ephemeral_agent_tracker_cleanup.py
@@ -1,0 +1,116 @@
+"""Ephemeral TUI agents must clear their per-task file-tool trackers.
+
+`prompt.background` (bg_<uuid>) and `preview.restart` (preview_<uuid>) each spawn
+a throwaway AIAgent under a unique task_id and used to clear only session
+context. Ordinary turn cleanup frees just VM/browser state, so a file-tool call
+inside either path left `_read_tracker[task_id]` et al. pinned for the process
+lifetime — the exact leak clear_task_trackers() targets (PR #62934 review
+follow-up).
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.file_tools as ft
+import tools.terminal_tool as tt
+from tui_gateway import server
+
+
+class _SyncThread:
+    """Run target() inline on start() so the finally block runs before the
+    method returns — no daemon-thread join race in the test."""
+
+    def __init__(self, target=None, daemon=None, **_kw):
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+def _make_touching_agent(seen: dict):
+    """Factory standing in for AIAgent: its run_conversation simulates a
+    file-tool call by seeding every per-task tracker for the run's task_id,
+    and records that the entry was present mid-run."""
+
+    def factory(**_kwargs):
+        agent = MagicMock()
+
+        def _run(**kw):
+            tid = kw["task_id"]
+            with ft._read_tracker_lock:
+                ft._read_tracker[tid] = {"touched": True}
+            with ft._patch_failure_lock:
+                ft._patch_failure_tracker[tid] = {"n": 1}
+            with ft._file_ops_lock:
+                tt._session_cwd[tid] = "/x"
+                ft._file_ops_cache[tid] = {"op": 1}
+            seen["tid"] = tid
+            seen["present_during_run"] = tid in ft._read_tracker
+            return {"final_response": "done"}
+
+        agent.run_conversation.side_effect = _run
+        return agent
+
+    return factory
+
+
+def _assert_all_trackers_absent(tid: str):
+    assert tid not in ft._read_tracker
+    assert tid not in ft._patch_failure_tracker
+    assert tid not in tt._session_cwd
+    assert tid not in ft._file_ops_cache
+
+
+@pytest.fixture()
+def registered_session(monkeypatch):
+    sid = "sid-ephemeral"
+    server._sessions[sid] = {
+        "agent": MagicMock(),
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    monkeypatch.setattr(server.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(server, "_emit", MagicMock())
+    monkeypatch.setattr(server, "_session_cwd", lambda s: "")
+    try:
+        yield sid
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_prompt_background_clears_task_trackers(registered_session, monkeypatch):
+    sid = registered_session
+    seen: dict = {}
+    monkeypatch.setattr(server, "_background_agent_kwargs", lambda agent, tid: {})
+    monkeypatch.setattr("run_agent.AIAgent", _make_touching_agent(seen))
+
+    resp = server._methods["prompt.background"](
+        "r1", {"session_id": sid, "text": "do a thing"}
+    )
+    task_id = resp["result"]["task_id"]
+
+    assert task_id.startswith("bg_")
+    assert seen["present_during_run"] is True  # the run actually seeded trackers
+    _assert_all_trackers_absent(task_id)  # …and the finally cleared them
+
+
+def test_preview_restart_clears_task_trackers(registered_session, monkeypatch):
+    sid = registered_session
+    seen: dict = {}
+    monkeypatch.setattr(server, "_ephemeral_preview_agent_kwargs", lambda agent, tid: {})
+    monkeypatch.setattr(server, "_preview_restart_callbacks", lambda parent, tid: {})
+    monkeypatch.setattr(server, "_preview_restart_history", lambda session: [])
+    monkeypatch.setattr("run_agent.AIAgent", _make_touching_agent(seen))
+
+    resp = server._methods["preview.restart"](
+        "r2", {"session_id": sid, "url": "http://localhost:3000"}
+    )
+    task_id = resp["result"]["task_id"]
+
+    assert task_id.startswith("preview_")
+    assert seen["present_during_run"] is True
+    _assert_all_trackers_absent(task_id)

--- a/tests/tui_gateway/test_fuzzy_cache_eviction.py
+++ b/tests/tui_gateway/test_fuzzy_cache_eviction.py
@@ -1,0 +1,55 @@
+"""_fuzzy_cache eviction: expired repo listings must not outlive their TTL.
+
+The fuzzy-picker cache stores an entire repo file listing per root. Its TTL
+was only consulted on read, so a root that stopped being queried kept its
+listing pinned for the TUI gateway's lifetime — systematic with worktree
+flows, where every task queries a unique ``.worktrees/<task-id>`` root once
+and never again. The write path now sweeps expired entries.
+"""
+
+import time
+
+import tui_gateway.server as srv
+
+
+def test_expired_roots_swept_on_write(tmp_path):
+    (tmp_path / "x.py").write_text("print('hi')\n")
+    root = str(tmp_path)
+    now = time.monotonic()
+
+    with srv._fuzzy_cache_lock:
+        saved = dict(srv._fuzzy_cache)
+        srv._fuzzy_cache.clear()
+        srv._fuzzy_cache["/worktree-a"] = (now - 3600.0, ["stale.py"] * 100)
+        srv._fuzzy_cache["/worktree-b"] = (now - srv._FUZZY_CACHE_TTL_S, ["old.py"])
+        srv._fuzzy_cache["/still-fresh"] = (now, ["fresh.py"])
+
+    try:
+        files = srv._list_repo_files(root)
+        assert "x.py" in files
+
+        with srv._fuzzy_cache_lock:
+            assert "/worktree-a" not in srv._fuzzy_cache
+            assert "/worktree-b" not in srv._fuzzy_cache
+            assert "/still-fresh" in srv._fuzzy_cache
+            assert root in srv._fuzzy_cache
+    finally:
+        with srv._fuzzy_cache_lock:
+            srv._fuzzy_cache.clear()
+            srv._fuzzy_cache.update(saved)
+
+
+def test_fresh_entry_still_served_from_cache(tmp_path):
+    """The sweep must not break the cache's purpose: a fresh entry is
+    returned without relisting."""
+    root = str(tmp_path)
+    with srv._fuzzy_cache_lock:
+        saved = dict(srv._fuzzy_cache)
+        srv._fuzzy_cache.clear()
+        srv._fuzzy_cache[root] = (time.monotonic(), ["cached-answer.py"])
+    try:
+        assert srv._list_repo_files(root) == ["cached-answer.py"]
+    finally:
+        with srv._fuzzy_cache_lock:
+            srv._fuzzy_cache.clear()
+            srv._fuzzy_cache.update(saved)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2590,6 +2590,16 @@ def _run_single_child(
         except Exception:
             logger.debug("Failed to close child agent after delegation")
 
+        # Drop the child's per-task file-tool trackers. They key on
+        # child_task_id (unique per delegation), which close() can't see —
+        # it clears by the child's session_id.
+        try:
+            from tools.file_tools import clear_task_trackers
+
+            clear_task_trackers(child_task_id)
+        except Exception:
+            logger.debug("Failed to clear child file trackers", exc_info=True)
+
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop
         # a scope while a timed-out child worker is still unwinding.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -784,6 +784,42 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
         for rp in resolved_paths:
             task_failures.pop(rp, None)
 
+
+def clear_task_trackers(task_id: str) -> None:
+    """Drop all per-task file-tool tracking state for a finished task.
+
+    ``_read_tracker``, ``_patch_failure_tracker`` and ``_file_ops_cache`` are
+    keyed by task_id, plus the per-session cwd record that the cwd
+    rearchitecture moved to ``terminal_tool._session_cwd``. Nothing else
+    removes a
+    finished task's entries — the per-task caps below only bound growth
+    *within* one entry. Subagent task ids are unique per delegation
+    (``subagent-<n>-<uuid>``), so a long-running gateway process otherwise
+    accretes dead tracker entries for its whole lifetime.
+
+    Pops only the exact ``task_id`` key: container-resolved aliases (see
+    ``terminal_tool._resolve_container_task_id``) usually collapse to the
+    parent's shared ``"default"`` key, which must survive the child.
+    """
+    if not task_id:
+        return
+    with _read_tracker_lock:
+        _read_tracker.pop(task_id, None)
+    with _patch_failure_lock:
+        _patch_failure_tracker.pop(task_id, None)
+    with _file_ops_lock:
+        _file_ops_cache.pop(task_id, None)
+    # Upstream moved the durable cwd record out of file_tools into
+    # terminal_tool._session_cwd (cwd rearchitecture); clear it through the
+    # owner module's accessor so the per-task entry still doesn't outlive the
+    # task.
+    try:
+        from tools.terminal_tool import clear_session_cwd
+
+        clear_session_cwd(task_id)
+    except Exception:
+        pass
+
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
 # caps, a 10k-read session would accumulate ~1.5MB of dict/set state that

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -714,6 +714,14 @@ def _(rid, params: dict) -> dict:
                 {"task_id": task_id, "text": f"error: {e}"},
             )
         finally:
+            # Ephemeral agent: nothing else clears this unique task_id's
+            # file-tool trackers (ordinary turn cleanup frees only VM/browser).
+            try:
+                from tools.file_tools import clear_task_trackers
+
+                clear_task_trackers(task_id)
+            except Exception:
+                pass
             _clear_session_context(session_tokens)
 
     threading.Thread(target=run, daemon=True).start()
@@ -825,6 +833,14 @@ def _(rid, params: dict) -> dict:
                 from tools.terminal_tool import clear_task_env_overrides
 
                 clear_task_env_overrides(task_id)
+            except Exception:
+                pass
+            # Ephemeral agent: clear this unique task_id's file-tool trackers
+            # (ordinary turn cleanup frees only VM/browser).
+            try:
+                from tools.file_tools import clear_task_trackers
+
+                clear_task_trackers(task_id)
             except Exception:
                 pass
             _clear_session_context(session_tokens)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11489,6 +11489,17 @@ def _list_repo_files(root: str) -> list[str]:
             pass
 
     with _fuzzy_cache_lock:
+        # Sweep expired roots while we hold the lock anyway. The TTL is only
+        # consulted on read, so without this a listing is pinned for the
+        # process lifetime once its root stops being queried — worktree flows
+        # (one .worktrees/<task> root per task) pin one full repo listing
+        # each, easily MBs apiece.
+        expired = [
+            r for r, (ts, _) in _fuzzy_cache.items()
+            if now - ts >= _FUZZY_CACHE_TTL_S
+        ]
+        for r in expired:
+            del _fuzzy_cache[r]
         _fuzzy_cache[root] = (now, files)
 
     return files


### PR DESCRIPTION
Part of #62950 — this PR fixes four of the six findings tracked there; the TTS voice caches and hindsight `_session_turns` items remain.

## What

Four unbounded-growth fixes, all in state that outlives its task or turn inside a long-running gateway/TUI process. Each is independent; together they stop steady RSS growth over multi-hour / multi-task runs.

| Leak | Cause | Fix |
|---|---|---|
| **file_tools per-task trackers** | `_read_tracker`, `_patch_failure_tracker`, `_last_known_cwd`, `_file_ops_cache` are keyed by `task_id`; nothing removed a finished task's entries. Subagent task ids are unique per delegation, so every delegation that touched a file leaked its tracker set for the process lifetime. | New `clear_task_trackers(task_id)` pops the exact key only (container aliases collapse to the parent's shared `"default"` key and must survive a child's cleanup). Wired into `AIAgent.close()` (clears both `session_id` and the conversation task id that tool calls key on) and `delegate_task`'s child teardown. |
| **per-turn tool-call Logger** | `write_tool_log()` created `logging.getLogger(f"hermes.tool_calls.{id(log_queue)}")` per turn. Named loggers are never GC'd — each name is a permanent `loggerDict` entry — so every turn under `display.tool_progress: log` leaked one Logger. | Process-wide fixed-name singleton logger + one `RotatingFileHandler`. The single shared handler also stops concurrent turns from double-writing lines (which per-turn handlers on a shared name would do). |
| **TUI `_fuzzy_cache`** | The fuzzy-picker repo-listing cache consulted its TTL only on read, so a root that stopped being queried kept its full file listing pinned for the process lifetime — systematic with worktree flows, where each task queries a unique `.worktrees/<id>` root once (easily MBs per listing). | The write path now sweeps expired roots under the existing lock (TTL is 5s, so the sweep fully bounds it). |
| **LSP `_files` / `_delta_baseline`** | `LSPClient._files` kept every opened file's full text (and the server mirrors every open document), with no per-file eviction until the whole client idle-reaps, so a long active session pinned everything it ever touched — on both sides of the pipe. | `_files` is now an insertion-ordered LRU capped at `MAX_TRACKED_FILES=64`: eviction sends `didClose` (freeing the server's mirror too) and drops per-path diagnostic state; evicted files transparently re-`didOpen` on their next touch. The manager's per-path `_delta_baseline` gets the same insertion-ordered bound (`_DELTA_BASELINE_CAP=256`). |

## Why

These don't show up in short sessions — they accumulate over the process lifetime of a long-running gateway or TUI (many delegations, many turns, many touched files/roots). The existing per-entry caps bound growth *within* one entry but not the *number* of entries, which grows without limit.

## How to test

New unit tests (all pass; each fails on the pre-fix code, revert-checked):

- `tests/tools/test_task_tracker_cleanup.py` — tracker clearing incl. the shared-`"default"`-alias guard and the `AIAgent.close()` wiring
- `tests/gateway/test_tool_log_mode.py` — logger singleton identity with a stable `loggerDict` across calls
- `tests/tui_gateway/test_fuzzy_cache_eviction.py` — expiry sweep + fresh-entry cache hit
- `tests/agent/lsp/test_file_lru.py` — LRU eviction, transparent re-open, recency refresh, and the baseline cap (driven against the in-process mock LSP server)

```
scripts/run_tests.sh tests/tools/test_task_tracker_cleanup.py tests/gateway/test_tool_log_mode.py tests/tui_gateway/test_fuzzy_cache_eviction.py tests/agent/lsp/test_file_lru.py
```

All four new suites pass under the canonical `scripts/run_tests.sh` (per-file isolation, blanked env). Each test also fails on the pre-fix code (revert-checked).

**Pre-existing failures unrelated to this PR:** the full hermetic suite has some failures on macOS that are **present identically on a pristine `main` checkout** (verified by re-running the failing set in a clean `main` worktree) — this commit changes none of the subsystems involved. They are environment/platform, not logic: `/tmp` vs `/private/tmp` path-canonicalization in `tests/tools/test_file_tools.py`, a concurrency snapshot flake in `tests/tools/test_base_environment.py`, `tests/agent/test_anthropic_adapter.py`, and various platform/integration suites (`test_gateway_wsl`, `test_service_manager`, `test_feishu`, `test_wecom_callback`, …). Separately, `tests/agent/lsp/test_client_e2e.py` and `tests/agent/lsp/test_file_lru.py` pass in isolation and only flake under full-suite parallelism (LSP subprocess timing).

**Platforms tested:** macOS (Apple Silicon), Python 3.11.
