### PR TITLE
fix: fail closed when write approval gate is unavailable

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2822,7 +2822,11 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(event.source)
         config_path = _hermes_home / "config.yaml"
 
-        gate_on = wa.write_approval_enabled(wa.SKILLS)
+        try:
+            gate_on = wa.write_approval_enabled(wa.SKILLS)
+        except wa.WriteApprovalConfigError:
+            # Fail closed: keep the review surface available while writes are blocked.
+            gate_on = True
         wants_toggle = bool(args) and args[0].lower() in {"approval", "mode"}
         if not gate_on and not wants_toggle and wa.pending_count(wa.SKILLS) == 0:
             return ("Skill write approval is off (skills.write_approval). "

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -22,7 +22,10 @@ from tools import write_approval as wa
 
 
 def _fmt_state(subsystem: str) -> str:
-    on = wa.write_approval_enabled(subsystem)
+    try:
+        on = wa.write_approval_enabled(subsystem)
+    except wa.WriteApprovalConfigError:
+        return f"{subsystem}.write_approval = unavailable (writes blocked)"
     return f"{subsystem}.write_approval = {'on' if on else 'off'}"
 
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -11,6 +11,7 @@ import json
 import os
 import tempfile
 import shutil
+from unittest.mock import patch
 
 import pytest
 
@@ -63,6 +64,27 @@ def test_normalize_enabled_coerces_values():
     assert wa._normalize_enabled(None) is False
 
 
+def test_config_read_failure_blocks_instead_of_allowing(hermes_home):
+    from tools import write_approval as wa
+
+    with patch("hermes_cli.config.load_config", side_effect=RuntimeError("config unreadable")):
+        decision = wa.evaluate_gate(wa.MEMORY)
+
+    assert decision.blocked is True
+    assert decision.allow is False
+    assert "configuration" in decision.message.lower()
+
+
+def test_status_command_reports_config_failure_as_blocked(hermes_home):
+    from hermes_cli.write_approval_commands import _fmt_state
+
+    with patch("hermes_cli.config.load_config", side_effect=RuntimeError("config unreadable")):
+        state = _fmt_state("memory")
+
+    assert "unavailable" in state.lower()
+    assert "blocked" in state.lower()
+
+
 # ---------------------------------------------------------------------------
 # Memory gate
 # ---------------------------------------------------------------------------
@@ -76,6 +98,26 @@ def test_memory_gate_off_allows_write(hermes_home):
     assert r["success"] is True
     assert r["entry_count"] == 1
     assert wa.pending_count("memory") == 0
+
+
+def test_memory_gate_module_import_failure_blocks_write(hermes_home):
+    import builtins
+    import tools.memory_tool as mt
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in (fromlist or ()):
+            raise ImportError("gate unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=guarded_import):
+        raw = mt._apply_write_gate("add", "memory", "must not write", None)
+
+    assert raw is not None
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "gate" in result["error"].lower()
 
 
 def test_memory_gate_on_no_interactive_stages(hermes_home):
@@ -183,6 +225,26 @@ def test_skill_gate_off_allows_create(hermes_home):
     r = json.loads(smt.skill_manage("create", "free-skill", content=_SKILL))
     assert r.get("success") is True
     assert wa.pending_count("skills") == 0
+
+
+def test_skill_gate_module_import_failure_blocks_write(hermes_home):
+    import builtins
+    import tools.skill_manager_tool as smt
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in (fromlist or ()):
+            raise ImportError("gate unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=guarded_import):
+        raw = smt._apply_skill_write_gate("create", "must-not-write", content=_SKILL)
+
+    assert raw is not None
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "gate" in result["error"].lower()
 
 
 def test_skill_gate_on_always_stages(hermes_home):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -834,9 +834,10 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     try:
         from tools import write_approval as wa
     except Exception:
-        # If the gate module can't load, fail open (current behaviour) rather
-        # than blocking all memory writes.
-        return None
+        return tool_error(
+            "Memory write blocked: approval gate is unavailable; nothing was saved.",
+            success=False,
+        )
 
     # Build a small inline summary/detail for the foreground approval prompt.
     label = "user profile" if target == "user" else "memory"
@@ -887,7 +888,10 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
     try:
         from tools import write_approval as wa
     except Exception:
-        return None
+        return tool_error(
+            "Memory batch blocked: approval gate is unavailable; nothing was saved.",
+            success=False,
+        )
 
     label = "user profile" if target == "user" else "memory"
     summary = f"apply {len(operations)} op(s) to {label}"

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1269,7 +1269,10 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     try:
         from tools import write_approval as wa
     except Exception:
-        return None  # fail open
+        return tool_error(
+            "Skill write blocked: approval gate is unavailable; nothing was saved.",
+            success=False,
+        )
 
     decision = wa.evaluate_gate(wa.SKILLS)
     if decision.allow:

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -67,6 +67,10 @@ _SUBSYSTEMS = (MEMORY, SKILLS)
 CONFIG_KEY = "write_approval"
 
 
+class WriteApprovalConfigError(RuntimeError):
+    """Raised when the write gate cannot determine its configured posture."""
+
+
 # ---------------------------------------------------------------------------
 # Config resolution
 # ---------------------------------------------------------------------------
@@ -84,8 +88,10 @@ def write_approval_enabled(subsystem: str) -> bool:
         from hermes_cli.config import load_config, cfg_get
         cfg = load_config()
         raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
-    except Exception:
-        return False
+    except Exception as exc:
+        raise WriteApprovalConfigError(
+            f"Unable to read {subsystem}.{CONFIG_KEY} from configuration"
+        ) from exc
     return _normalize_enabled(raw)
 
 
@@ -271,7 +277,19 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
     delays a write for approval, never silently refuses it. ``blocked`` is
     still produced when the user *actively denies* an inline prompt.
     """
-    if not write_approval_enabled(subsystem):
+    try:
+        enabled = write_approval_enabled(subsystem)
+    except WriteApprovalConfigError as exc:
+        logger.error("Write approval configuration unavailable: %s", exc)
+        return GateDecision(
+            blocked=True,
+            message=(
+                "Write blocked: approval-gate configuration is unavailable. "
+                "No persistent memory or skill change was saved."
+            ),
+        )
+
+    if not enabled:
         return GateDecision(allow=True)
 
     background = is_background()


### PR DESCRIPTION
## Summary

- fail closed when the memory/skill write-approval configuration cannot be read
- block memory and skill mutations when the approval gate module is unavailable
- keep CLI and gateway review/status surfaces available while writes are blocked
- add regression coverage for configuration and gate-import failures

## Security invariant

If write validation is unavailable, persistent memory and skill mutations must be blocked rather than silently allowed. Read/review surfaces remain available so the operator can diagnose and recover.

## Tests

- `uv run --extra dev pytest -q tests/tools/test_write_approval.py tests/tools/test_memory_tool.py tests/tools/test_skill_manager_tool.py` — 230 passed
- `uv run --extra dev ruff check gateway/slash_commands.py hermes_cli/write_approval_commands.py tests/tools/test_write_approval.py tools/memory_tool.py tools/skill_manager_tool.py tools/write_approval.py`
- `git diff --check`
