### PR TITLE
fix(auth): _auth_lock_path follows symlinks so shared auth.json serializes across processes

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -981,7 +981,23 @@ def _load_global_auth_store() -> Dict[str, Any]:
 
 
 def _auth_lock_path() -> Path:
-    return _auth_file_path().with_suffix(".lock")
+    # Resolve symlinks so shared-auth setups (profiled workers, delegated
+    # agents, or multi-agent hosts symlinking ~/.hermes/auth.json to a
+    # single canonical file — cf. #19436 / #29530 / #38176) all lock the
+    # SAME file. Without this resolution each process locks its own local
+    # auth.lock while writing to the shared target, and cross-process
+    # load-modify-save races can persist a partial store that purges
+    # providers a peer just added (see #8040).
+    #
+    # Non-symlink setups: realpath returns the original path, behavior
+    # unchanged. Broken symlinks: realpath returns the (non-existent)
+    # target path; the caller's flock still coordinates on that path.
+    auth = _auth_file_path()
+    try:
+        target = Path(os.path.realpath(str(auth)))
+    except OSError:
+        target = auth
+    return target.with_suffix(".lock")
 
 
 _auth_lock_holder = threading.local()

--- a/tests/hermes_cli/test_auth_lock_path_symlink.py
+++ b/tests/hermes_cli/test_auth_lock_path_symlink.py
@@ -1,0 +1,74 @@
+"""Regression: _auth_lock_path() must follow symlinks so shared-auth setups
+serialize correctly across processes.
+
+Motivating incident: 3 Hermes agent processes on one host each symlinked
+their ~/.hermes/auth.json to a single canonical file (a shared Codex OAuth
+setup). Because the flock lived at the CALLER's local ~/.hermes/auth.lock,
+each process held a different lock while writing to the same file — and a
+cross-process load-modify-save race purged 3 of 5 providers from
+credential_pool in one refresh cycle. See #8040 (comment) for the trace.
+"""
+
+from pathlib import Path
+
+import hermes_cli.auth as auth
+from hermes_cli.auth import _auth_lock_path
+
+
+def _make_home(base: Path, name: str, shared_auth: Path) -> Path:
+    home = base / name / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").symlink_to(shared_auth)
+    return home
+
+
+def test_lock_path_follows_symlink_to_shared_target(tmp_path, monkeypatch):
+    """Two profiles sharing an auth.json via symlink must resolve to the SAME lock."""
+    shared = tmp_path / "shared" / "auth.json"
+    shared.parent.mkdir(parents=True, exist_ok=True)
+    shared.write_text('{"version": 1, "providers": {}}')
+
+    home_a = _make_home(tmp_path, "agent_a", shared)
+    home_b = _make_home(tmp_path, "agent_b", shared)
+
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    lock_a = _auth_lock_path()
+
+    monkeypatch.setenv("HERMES_HOME", str(home_b))
+    lock_b = _auth_lock_path()
+
+    expected = shared.parent / "auth.lock"
+    assert lock_a == expected
+    assert lock_b == expected
+    assert lock_a == lock_b
+
+
+def test_lock_path_for_regular_file_unchanged(tmp_path, monkeypatch):
+    """Non-symlinked auth.json: lock sits next to it (behavior unchanged)."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").write_text('{"version": 1, "providers": {}}')
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    assert _auth_lock_path() == home / "auth.lock"
+
+
+def test_lock_path_when_auth_json_missing(tmp_path, monkeypatch):
+    """No auth.json yet: lock path derives from _auth_file_path() unchanged."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    assert _auth_lock_path() == home / "auth.lock"
+
+
+def test_lock_path_with_broken_symlink(tmp_path, monkeypatch):
+    """Dangling symlink: realpath returns the (non-existent) target;
+    lock still lives next to it so a future creator picks up the same lock."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    missing_target = tmp_path / "shared" / "auth.json"
+    (home / "auth.json").symlink_to(missing_target)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    assert _auth_lock_path() == missing_target.parent / "auth.lock"


### PR DESCRIPTION
## Summary

- `_auth_lock_path()` returned the caller's LOCAL `~/.hermes/auth.lock` — silently broke shared-auth via symlink (the pattern the community is already DIY-ing per #19436 / #29530 / #38176).
- In a shared-auth setup, each process held a different flock while writing to the SAME real file. Load-modify-save races across processes could persist a partial store that PURGED providers a peer just added.
- Fix resolves the symlink target so all sharers lock the same file. Non-symlink setups are unchanged (`realpath` returns the original path).

## Motivation

I hit this on a 3-agent host sharing one Codex OAuth via `~/.hermes/auth.json` → `/var/lib/hermes-oauth/auth.json` symlinks. After the first refresh cycle, the shared `auth.json` went from 5 providers (`gemini`, `openai-codex`, `openrouter`, `xai`, `copilot`) to 2 (`gemini`, `openrouter`). `openai-codex`, `xai`, `copilot` all wiped from `credential_pool`. `active_provider` cleared. `providers` map emptied. Required a full OAuth re-auth to recover.

Traced to `_auth_lock_path()` — the `fcntl.flock` was on `~/agent-x/.hermes/auth.lock`, not on the target of the symlink, so cross-process serialization silently didn't work.

## Related

- #8040 — same class of bug, but for `agent/credential_pool.py`'s process-local `threading.Lock`. That issue suggests using the `fcntl.flock` pattern from `hermes_cli/auth.py` as a fix template — which is exactly the code path this PR corrects. So if #8040 gets that fix without this PR, the shared-auth case is still broken. Left a comment there flagging it: NousResearch/hermes-agent#8040 (comment)
- #19436 / #29530 / #38176 — feature requests for native shared-auth. This PR makes the DIY-symlink workaround people are already using actually safe.

## Fix

`hermes_cli/auth.py::_auth_lock_path` now resolves the auth.json symlink and places the lock next to the REAL file:

```python
def _auth_lock_path() -> Path:
    auth = _auth_file_path()
    try:
        target = Path(os.path.realpath(str(auth)))
    except OSError:
        target = auth
    return target.with_suffix(".lock")
```

- **Symlink setup:** all processes lock the SAME `<target-dir>/auth.lock` — cross-process load-modify-save is properly serialized.
- **Non-symlink setup:** `realpath` returns the original path; lock stays at `~/.hermes/auth.lock` — identical to today.
- **Broken symlink (dangling):** `realpath` returns the (non-existent) target path; the flock is created next to it, and a future creator of the shared file picks up the same lock.

## Tests

Added `tests/hermes_cli/test_auth_lock_path_symlink.py` with 4 cases:

- Two profiles sharing an `auth.json` via symlink resolve to the SAME lock (the regression this fixes).
- Non-symlinked `auth.json`: lock sits next to it (behavior unchanged).
- No `auth.json` yet: lock path derives from `_auth_file_path()` unchanged.
- Dangling symlink: lock is placed next to the (non-existent) target.

All 4 pass locally.

## Test plan

- [x] New regression tests pass
- [x] Verified on my 3-agent host: after applying, `_auth_lock_path()` returns the shared target `/var/lib/hermes-oauth/auth.lock` for all agents; the shared lock file gets created group-writable on first acquisition; no observed provider-purge in subsequent refresh cycles.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmDNdF6D8TVXRohg17tqNU