### PR TITLE
[Experimental] feat(cron): Dream weekly blueprint + Langfuse self-observation

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -97,6 +97,11 @@ class AutomationBlueprint:
     deliver_default: str = "origin"
     skills: tuple = ()        # skills the job loads before running
     tags: tuple = ()
+    # Extra toolsets to grant beyond the account's default set (e.g. a
+    # maintenance job that needs `memory`/`skills` toolsets it wouldn't
+    # otherwise have). Empty tuple = no override, matches create_job()'s
+    # existing default behavior.
+    enabled_toolsets: tuple = ()
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +481,50 @@ CATALOG: List[AutomationBlueprint] = [
         ],
         tags=("daily", "curiosity"),
     ),
+    AutomationBlueprint(
+        key="dream",
+        title="Dream — weekly memory hygiene, learning & self-observation",
+        description="A weekly maintenance pass: compresses and consolidates "
+        "memory, learns new behavioral patterns from the week's sessions, "
+        "reviews recent Langfuse traces for repeated tool-call failures, and "
+        "writes a report of what changed. EXPERIMENTAL — see PR description "
+        "for known limitations before enabling.",
+        category="weekly",
+        schedule_template="{minute} {hour} * * 0",
+        prompt_template=(
+            "Weekly Dream pass. Do not write any plan or explanation. Your "
+            "very first output must be a tool call — call "
+            "session_search(sort=\"newest\", limit=10) right now, before "
+            "writing anything else.\n\n"
+            "After that, in order: read 3-5 sessions via "
+            "session_search(session_id=...) — merge/remove/shorten memory "
+            "entries via memory(operations=[...]) (limits: MEMORY.md 2200 "
+            "chars, USER.md 1375 chars; if either store >80%, compress under "
+            "60%) — if under 80% after that, add up to 3 new entries "
+            "(patterns seen 2+ times, under 80 chars each) — call "
+            "langfuse_query(action=\"list_errors\", since=\"<7 days ago "
+            "ISO8601>\", until=\"<now>\") and note any real findings, skip "
+            "silently on error — only patch a skill via "
+            "skill_manage(action=\"patch\", ...) if you found direct "
+            "evidence one is wrong, zero fixes is normal — finish by "
+            "calling dream_report(...) with everything you did, then reply "
+            "with exactly its summary text and nothing else."
+        ),
+        slots=[
+            _TIME("03:00"),
+            BlueprintSlot(
+                name="deliver", type="enum", label="Where to deliver the summary?",
+                default="local", options=("local", "origin", "telegram", "discord", "email"),
+                optional=False, strict=False,
+                help="local = save the report only, no message (default — this "
+                "is a maintenance job with no natural originating chat); or "
+                "any connected platform name for a short weekly summary",
+            ),
+        ],
+        deliver_default="local",
+        enabled_toolsets=("session_search", "memory", "skills", "langfuse", "dream"),
+        tags=("weekly", "maintenance", "memory", "experimental"),
+    ),
 ]
 
 _CATALOG_BY_KEY = {r.key: r for r in CATALOG}
@@ -708,6 +757,8 @@ def fill_blueprint(
     }
     if blueprint.skills:
         spec["skills"] = list(blueprint.skills)
+    if blueprint.enabled_toolsets:
+        spec["enabled_toolsets"] = list(blueprint.enabled_toolsets)
     if origin is not None:
         spec["origin"] = origin
     return spec

--- a/tools/dream_report_tool.py
+++ b/tools/dream_report_tool.py
@@ -1,0 +1,352 @@
+"""Dream weekly report — deterministic REPORT.md/run.json writer.
+
+Dream (the weekly memory-hygiene/learning/self-observation cron job) is a
+plain prompt-driven cron job, not a bespoke Python orchestrator like
+``agent/curator.py``. This tool is the reliability lever for its report: the
+LLM supplies *structured* fields describing what it did, and this module
+owns rendering — formatting is guaranteed consistent even though the
+*content* (what actually changed) still comes from the model's own turn.
+
+Mirrors ``agent/curator.py``'s report-directory shape
+(``{stamp}/REPORT.md`` + ``run.json`` under ``logs/<name>/``) without
+sharing its diffing code, which is tightly coupled to skill-archival
+semantics and not a fit here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+DREAM_REPORT_SCHEMA = {
+    "name": "dream_report",
+    "description": (
+        "Write this week's Dream report (REPORT.md + run.json under "
+        "~/.hermes/logs/dream/). Call this exactly once, as the LAST tool "
+        "call of a Dream run, after hygiene, learning, the Langfuse review, "
+        "and any skill fixes are done. All fields are optional — omit or "
+        "pass an empty list for anything that didn't happen this run (e.g. "
+        "no skill fixes most weeks is expected and correct)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_usage_before": {
+                "type": "string",
+                "description": (
+                    "MEMORY.md usage before this run, transcribed from the "
+                    "'MEMORY (your personal notes)' header in your system "
+                    "prompt, e.g. '62% — 1,364/2,200 chars'."
+                ),
+            },
+            "memory_usage_after": {
+                "type": "string",
+                "description": (
+                    "MEMORY.md usage after hygiene/learning, transcribed "
+                    "from the memory() tool's own 'usage' response field."
+                ),
+            },
+            "user_usage_before": {
+                "type": "string",
+                "description": "USER.md usage before this run, same source as memory_usage_before.",
+            },
+            "user_usage_after": {
+                "type": "string",
+                "description": "USER.md usage after this run, same source as memory_usage_after.",
+            },
+            "memory_changes": {
+                "type": "array",
+                "description": "Changes made to MEMORY.md this run.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "op": {"type": "string", "enum": ["add", "remove", "merge"]},
+                        "text": {"type": "string"},
+                        "merged_from": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["op", "text"],
+                },
+            },
+            "user_changes": {
+                "type": "array",
+                "description": "Changes made to USER.md this run. Same shape as memory_changes.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "op": {"type": "string", "enum": ["add", "remove", "merge"]},
+                        "text": {"type": "string"},
+                        "merged_from": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["op", "text"],
+                },
+            },
+            "skill_changes": {
+                "type": "array",
+                "description": (
+                    "Targeted skill fixes made this run via skill_manage. "
+                    "Evidence-gated — most weeks this is empty."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "action": {"type": "string", "enum": ["patch", "create", "edit"]},
+                        "reason": {"type": "string"},
+                        "evidence": {"type": "string"},
+                    },
+                    "required": ["name", "action", "reason"],
+                },
+            },
+            "langfuse_findings": {
+                "type": "array",
+                "description": "Anomalies found via langfuse_query this run, kept for the record even if not acted on.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {"type": "string"},
+                        "timestamp": {"type": "string"},
+                        "symptom": {"type": "string"},
+                    },
+                    "required": ["trace_id", "symptom"],
+                },
+            },
+            "flagged_for_code_fix": {
+                "type": "array",
+                "description": (
+                    "Issues found that need an actual code change, not a memory/skill edit. "
+                    "Not acted on automatically — this is a record for a human (or a future "
+                    "automated pass) to pick up."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "issue": {"type": "string"},
+                        "evidence": {"type": "array", "items": {"type": "string"}},
+                        "suspected_area": {"type": "string"},
+                    },
+                    "required": ["issue"],
+                },
+            },
+            "summary": {
+                "type": "string",
+                "description": (
+                    "3-5 plain-text lines summarizing the run. If Dream's delivery is "
+                    "not 'local', this is sent to the user verbatim as the delivered message "
+                    "— write it for a human reading a notification, not a log."
+                ),
+            },
+        },
+    },
+}
+
+
+def _dream_reports_root() -> Path:
+    """Directory where Dream run reports are written.
+
+    Lives under ``~/.hermes/logs/dream/`` alongside ``agent.log`` and the
+    sibling ``logs/curator/`` reports dir — operational telemetry, not
+    mixed into ``~/.hermes/skills/`` or the memory stores it's reporting on.
+    """
+    root = get_hermes_home() / "logs" / "dream"
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.debug("Dream reports dir create failed: %s", e)
+    return root
+
+
+def _bullet_changes(lines: List[str], heading: str, changes: List[Dict[str, Any]], empty_text: str) -> None:
+    lines.append(f"## {heading}\n")
+    if not changes:
+        lines.append(f"_{empty_text}_\n")
+        return
+    for c in changes:
+        if not isinstance(c, dict):
+            continue
+        op = c.get("op") or c.get("action") or "?"
+        text = c.get("text") or c.get("reason") or ""
+        line = f"- **{op}**: {text}"
+        merged_from = c.get("merged_from")
+        if merged_from:
+            line += f" _(merged from: {', '.join(merged_from)})_"
+        evidence = c.get("evidence")
+        if evidence:
+            line += f" — evidence: {evidence}"
+        name = c.get("name")
+        if name:
+            line = f"- **{op}** `{name}`: {text}" + (f" — evidence: {evidence}" if evidence else "")
+        lines.append(line)
+    lines.append("")
+
+
+def _render_dream_report_markdown(payload: Dict[str, Any]) -> str:
+    """Render the human-readable Dream report."""
+    lines: List[str] = []
+    generated_at = payload.get("generated_at", "")
+    lines.append(f"# Dream run — {generated_at}\n")
+
+    lines.append("## Memory\n")
+    lines.append(f"- MEMORY.md: {payload.get('memory_usage_before') or '(not recorded)'} → "
+                 f"{payload.get('memory_usage_after') or '(not recorded)'}")
+    lines.append(f"- USER.md: {payload.get('user_usage_before') or '(not recorded)'} → "
+                 f"{payload.get('user_usage_after') or '(not recorded)'}")
+    lines.append("")
+    _bullet_changes(lines, "Memory changes", payload.get("memory_changes") or [], "No memory changes this run.")
+    _bullet_changes(lines, "User-profile changes", payload.get("user_changes") or [], "No user-profile changes this run.")
+
+    lines.append("## Skills\n")
+    skill_changes = payload.get("skill_changes") or []
+    if not skill_changes:
+        lines.append("_No skill changes this run._\n")
+    else:
+        for c in skill_changes:
+            if not isinstance(c, dict):
+                continue
+            name = c.get("name", "?")
+            action = c.get("action", "?")
+            reason = c.get("reason", "")
+            evidence = c.get("evidence", "")
+            line = f"- **{action}** `{name}`: {reason}"
+            if evidence:
+                line += f" — evidence: {evidence}"
+            lines.append(line)
+        lines.append("")
+
+    lines.append("## Langfuse findings\n")
+    findings = payload.get("langfuse_findings") or []
+    if not findings:
+        lines.append("_No anomalies found in the past week._\n")
+    else:
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            trace_id = f.get("trace_id", "?")
+            ts = f.get("timestamp", "")
+            symptom = f.get("symptom", "")
+            lines.append(f"- `{trace_id}` ({ts}): {symptom}")
+        lines.append("")
+
+    # Stable header — a future automated pass over these reports would grep
+    # for this exact section, so don't rename it casually.
+    lines.append("## Flagged for code-level fix\n")
+    flagged = payload.get("flagged_for_code_fix") or []
+    if not flagged:
+        lines.append("_None this run._\n")
+    else:
+        for item in flagged:
+            if not isinstance(item, dict):
+                continue
+            issue = item.get("issue", "?")
+            area = item.get("suspected_area", "")
+            evidence = item.get("evidence") or []
+            lines.append(f"- {issue}" + (f" _(suspected: {area})_" if area else ""))
+            for e in evidence:
+                lines.append(f"  - evidence: {e}")
+        lines.append("")
+
+    lines.append("## Summary\n")
+    lines.append(payload.get("summary") or "_(no summary provided)_")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def dream_report(
+    memory_usage_before: Optional[str] = None,
+    memory_usage_after: Optional[str] = None,
+    user_usage_before: Optional[str] = None,
+    user_usage_after: Optional[str] = None,
+    memory_changes: Optional[List[Dict[str, Any]]] = None,
+    user_changes: Optional[List[Dict[str, Any]]] = None,
+    skill_changes: Optional[List[Dict[str, Any]]] = None,
+    langfuse_findings: Optional[List[Dict[str, Any]]] = None,
+    flagged_for_code_fix: Optional[List[Dict[str, Any]]] = None,
+    summary: Optional[str] = None,
+) -> str:
+    """Write this week's Dream report. See DREAM_REPORT_SCHEMA for field docs."""
+    root = _dream_reports_root()
+    started_at = datetime.now(timezone.utc)
+    stamp = started_at.strftime("%Y%m%d-%H%M%S")
+    run_dir = root / stamp
+    suffix = 1
+    while run_dir.exists():
+        suffix += 1
+        run_dir = root / f"{stamp}-{suffix}"
+    try:
+        run_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as e:
+        logger.warning("Dream report dir create failed: %s", e)
+        return json.dumps({"success": False, "error": f"could not create report dir: {e}"}, ensure_ascii=False)
+
+    payload = {
+        "generated_at": started_at.isoformat(),
+        "memory_usage_before": memory_usage_before,
+        "memory_usage_after": memory_usage_after,
+        "user_usage_before": user_usage_before,
+        "user_usage_after": user_usage_after,
+        "memory_changes": memory_changes or [],
+        "user_changes": user_changes or [],
+        "skill_changes": skill_changes or [],
+        "langfuse_findings": langfuse_findings or [],
+        "flagged_for_code_fix": flagged_for_code_fix or [],
+        "summary": summary or "",
+    }
+
+    try:
+        (run_dir / "run.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    except OSError as e:
+        logger.warning("Dream run.json write failed: %s", e)
+
+    try:
+        md = _render_dream_report_markdown(payload)
+        (run_dir / "REPORT.md").write_text(md, encoding="utf-8")
+    except OSError as e:
+        logger.warning("Dream REPORT.md write failed: %s", e)
+
+    return json.dumps(
+        {
+            "success": True,
+            "report_dir": str(run_dir),
+            "message": "Report written. This is the last step of a Dream run — do not call any more tools.",
+        },
+        ensure_ascii=False,
+    )
+
+
+def check_dream_report_requirements() -> bool:
+    """Dream report tool has no external requirements -- always available."""
+    return True
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="dream_report",
+    toolset="dream",
+    schema=DREAM_REPORT_SCHEMA,
+    handler=lambda args, **kw: dream_report(
+        memory_usage_before=args.get("memory_usage_before"),
+        memory_usage_after=args.get("memory_usage_after"),
+        user_usage_before=args.get("user_usage_before"),
+        user_usage_after=args.get("user_usage_after"),
+        memory_changes=args.get("memory_changes"),
+        user_changes=args.get("user_changes"),
+        skill_changes=args.get("skill_changes"),
+        langfuse_findings=args.get("langfuse_findings"),
+        flagged_for_code_fix=args.get("flagged_for_code_fix"),
+        summary=args.get("summary"),
+    ),
+    check_fn=check_dream_report_requirements,
+    emoji="🌙",
+)

--- a/tools/langfuse_query_tool.py
+++ b/tools/langfuse_query_tool.py
@@ -1,0 +1,300 @@
+"""Langfuse query tool — read back traces/observations for self-observation.
+
+The bundled ``plugins/observability/langfuse`` plugin is write-only: it
+opens traces and ends them, but nothing in this codebase reads them back.
+This tool is the first reader, built for the Dream cron job's weekly
+self-observation pass but generically usable from any agent turn.
+
+Query design verified live against a self-hosted Langfuse v3 instance:
+
+- ``GET /api/public/traces`` accepts ``fields=core,io`` for a compact
+  payload (name/timestamps/input/output, no scores/metrics/observations).
+  On this deployment, ``fields`` values that include ``metrics``,
+  ``scores``, or ``observations`` return HTTP 500 (a ClickHouse
+  column-resolution bug) — never request those field groups here.
+- The ``filter`` query param takes a JSON array of filter objects, ANDed
+  together. A ``level`` column filter must use
+  ``{"type": "stringOptions", "column": "level", "operator": "any of",
+  "value": [...]}`` — ``categoryOptions`` 400s on this column (it expects
+  a ``key`` field that doesn't apply here).
+- Server-side ``level`` filtering only catches genuine SDK/OTEL-flagged
+  errors (``ERROR``/``WARNING``). The narration-only tool-call failure
+  this tool was built to help catch (a local model emitting
+  ``{"content": "[Calling tool", "tool_calls": []}`` instead of a real
+  tool call) is logged at ``level: DEFAULT`` — it is invisible to a level
+  filter and requires a client-side heuristic pass over trace bodies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from plugins.observability.langfuse import _validate_langfuse_key
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL_DEFAULT = "https://cloud.langfuse.com"
+_MAX_FIELD_CHARS = 4000
+_MAX_PAGES = 3
+_PAGE_LIMIT = 100
+
+# Heuristic markers for the narration-only tool-call failure: the model
+# describes an intended tool call in plain text instead of emitting a real
+# structured tool_call. Expect to tune this list as real Dream runs surface
+# false positives/negatives -- not a documented Langfuse feature, just a
+# pattern match over trace output bodies.
+_NARRATION_MARKERS = (
+    re.compile(r"^\[?calling\b", re.IGNORECASE),
+    re.compile(r"\bi(?:'ll| will)\s+(?:now\s+)?call\b.*\btool\b", re.IGNORECASE),
+    re.compile(r"\binvoking\b.*\btool\b", re.IGNORECASE),
+)
+
+
+def _env(name: str, default: str = "") -> str:
+    import os
+
+    return os.environ.get(name, default).strip()
+
+
+def _lf_creds() -> Optional[tuple]:
+    """Return (public_key, secret_key, base_url) from env, or None if unset/placeholder.
+
+    Server-side only -- never exposed to the LLM/prompt as a tool argument
+    or echoed back in a tool result.
+    """
+    public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+    secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+    if not (public_key and secret_key):
+        return None
+    issues = [
+        msg
+        for msg in (
+            _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+            _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+        )
+        if msg
+    ]
+    if issues:
+        logger.warning("langfuse_query: credentials look like placeholders (%s)", "; ".join(issues))
+        return None
+    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or _BASE_URL_DEFAULT
+    return public_key, secret_key, base_url.rstrip("/")
+
+
+def check_langfuse_query_requirements() -> bool:
+    return _lf_creds() is not None
+
+
+def _truncate(value: Any, limit: int = _MAX_FIELD_CHARS) -> Any:
+    if isinstance(value, str) and len(value) > limit:
+        return value[:limit] + f"...[truncated, {len(value)} chars total]"
+    return value
+
+
+def _looks_like_narration_failure(output: Any) -> Optional[str]:
+    """Return a one-line symptom string if `output` matches the narration-only pattern, else None."""
+    if not isinstance(output, dict):
+        return None
+    tool_calls = output.get("tool_calls")
+    content = output.get("content")
+    if tool_calls not in (None, []):
+        return None
+    if not isinstance(content, str):
+        return None
+    stripped = content.strip()
+    if not stripped:
+        return "empty response, no tool_calls (dead turn)"
+    for pattern in _NARRATION_MARKERS:
+        if pattern.search(stripped):
+            return f"narrated instead of calling: {stripped[:120]!r}"
+    return None
+
+
+def _get(base_url: str, auth: tuple, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    resp = httpx.get(f"{base_url}{path}", auth=auth, params=params, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _list_errors(since: Optional[str], until: Optional[str], limit: int) -> str:
+    creds = _lf_creds()
+    if creds is None:
+        return json.dumps(
+            {"error": "Langfuse credentials not configured or look like placeholders"}, ensure_ascii=False
+        )
+    public_key, secret_key, base_url = creds
+    auth = (public_key, secret_key)
+    limit = max(1, min(int(limit or 20), _PAGE_LIMIT))
+
+    time_filter: List[Dict[str, Any]] = []
+    if since:
+        time_filter.append({"type": "datetime", "column": "timestamp", "operator": ">=", "value": since})
+    if until:
+        time_filter.append({"type": "datetime", "column": "timestamp", "operator": "<=", "value": until})
+
+    findings_by_id: Dict[str, Dict[str, Any]] = {}
+
+    # Pass 1: server-side level filter -- catches genuine SDK/OTEL errors cheaply.
+    level_filter = time_filter + [
+        {"type": "stringOptions", "column": "level", "operator": "any of", "value": ["ERROR", "WARNING"]}
+    ]
+    try:
+        for page in range(1, _MAX_PAGES + 1):
+            data = _get(
+                base_url,
+                auth,
+                "/api/public/traces",
+                {
+                    "fields": "core,io",
+                    "filter": json.dumps(level_filter),
+                    "limit": limit,
+                    "page": page,
+                },
+            )
+            items = data.get("data") or []
+            for t in items:
+                findings_by_id[t["id"]] = {
+                    "trace_id": t.get("id"),
+                    "timestamp": t.get("timestamp"),
+                    "name": t.get("name"),
+                    "symptom": "flagged ERROR/WARNING level by Langfuse",
+                }
+            if len(items) < limit:
+                break
+    except httpx.HTTPError as e:
+        logger.warning("langfuse_query list_errors (level pass) failed: %s", e)
+
+    # Pass 2: client-side heuristic over the same time window (no level
+    # filter) for the narration-only-tool-call pattern the level filter
+    # cannot see (logged at level=DEFAULT).
+    try:
+        for page in range(1, _MAX_PAGES + 1):
+            data = _get(
+                base_url,
+                auth,
+                "/api/public/traces",
+                {
+                    "fields": "core,io",
+                    "filter": json.dumps(time_filter) if time_filter else None,
+                    "limit": limit,
+                    "page": page,
+                },
+            )
+            items = data.get("data") or []
+            for t in items:
+                symptom = _looks_like_narration_failure(t.get("output"))
+                if symptom:
+                    tid = t.get("id")
+                    if tid not in findings_by_id:
+                        findings_by_id[tid] = {
+                            "trace_id": tid,
+                            "timestamp": t.get("timestamp"),
+                            "name": t.get("name"),
+                            "symptom": symptom,
+                        }
+            if len(items) < limit:
+                break
+    except httpx.HTTPError as e:
+        logger.warning("langfuse_query list_errors (heuristic pass) failed: %s", e)
+
+    return json.dumps({"count": len(findings_by_id), "findings": list(findings_by_id.values())}, ensure_ascii=False)
+
+
+def _get_trace(trace_id: str) -> str:
+    if not trace_id:
+        return json.dumps({"error": "trace_id is required"}, ensure_ascii=False)
+    creds = _lf_creds()
+    if creds is None:
+        return json.dumps(
+            {"error": "Langfuse credentials not configured or look like placeholders"}, ensure_ascii=False
+        )
+    public_key, secret_key, base_url = creds
+    auth = (public_key, secret_key)
+    try:
+        data = _get(base_url, auth, f"/api/public/traces/{trace_id}", {})
+    except httpx.HTTPStatusError as e:
+        return json.dumps({"error": f"Langfuse returned {e.response.status_code}"}, ensure_ascii=False)
+    except httpx.HTTPError as e:
+        return json.dumps({"error": f"Langfuse request failed: {e}"}, ensure_ascii=False)
+
+    truncated = {k: _truncate(v) for k, v in data.items()}
+    return json.dumps(truncated, ensure_ascii=False)
+
+
+def langfuse_query(
+    action: str,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    limit: int = 20,
+) -> str:
+    action = (action or "").strip().lower()
+    if action == "list_errors":
+        return _list_errors(since, until, limit)
+    if action == "get_trace":
+        return _get_trace(trace_id)
+    return json.dumps({"error": f"unknown action {action!r}, expected 'list_errors' or 'get_trace'"}, ensure_ascii=False)
+
+
+LANGFUSE_QUERY_SCHEMA = {
+    "name": "langfuse_query",
+    "description": (
+        "Read back traces from the self-hosted Langfuse observability instance for "
+        "self-observation -- find recent tool-call failures, narration-only responses, "
+        "and other anomalies Hermes had no other way to notice. Read-only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list_errors", "get_trace"],
+                "description": (
+                    "'list_errors': time-boxed digest of anomalous traces (not full bodies). "
+                    "'get_trace': full detail for one trace_id."
+                ),
+            },
+            "since": {
+                "type": "string",
+                "description": "ISO8601 start of the time window. list_errors only.",
+            },
+            "until": {
+                "type": "string",
+                "description": "ISO8601 end of the time window, default now. list_errors only.",
+            },
+            "trace_id": {
+                "type": "string",
+                "description": "Trace id to fetch full detail for. get_trace only.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results per page for list_errors, default 20, capped at 100.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="langfuse_query",
+    toolset="langfuse",
+    schema=LANGFUSE_QUERY_SCHEMA,
+    handler=lambda args, **kw: langfuse_query(
+        action=args.get("action", ""),
+        since=args.get("since"),
+        until=args.get("until"),
+        trace_id=args.get("trace_id"),
+        limit=args.get("limit", 20),
+    ),
+    check_fn=check_langfuse_query_requirements,
+    emoji="🔭",
+)


### PR DESCRIPTION
**Experimental — replaces #55084, which had drifted too far from `main` to rebase cleanly (314 commits) and mixed in unrelated commits. Closing that one in favor of this clean version.**

## Summary

- Adds a `dream` blueprint (`cron/blueprint_catalog.py`): a weekly cron that reviews the past week's sessions, does memory hygiene + learning (compress/consolidate MEMORY.md and USER.md, then add new behavioral-pattern entries in the freed headroom), reviews recent Langfuse traces for repeated tool-call failures, and writes a report of what changed.
- Adds `dream_report` (`tools/dream_report_tool.py`): a deterministic report writer. The LLM supplies structured fields describing what it did; Python owns rendering `REPORT.md`/`run.json` under `~/.hermes/logs/dream/{stamp}/`, mirroring `agent/curator.py`'s existing report-dir pattern.
- Adds `langfuse_query` (`tools/langfuse_query_tool.py`): the first tool that reads back from Langfuse — today's bundled `plugins/observability/langfuse` plugin is write-only. `list_errors` does a two-pass query: a server-side `level` filter for genuine SDK-flagged errors, plus a client-side heuristic pass for narration-only tool-call failures (a model describing an intended tool call as text instead of emitting a real `tool_calls` entry) — that failure mode logs at `level: DEFAULT` and is invisible to server-side filtering alone. `get_trace` pulls full detail for one trace on demand.
- Extends `AutomationBlueprint` with an `enabled_toolsets: tuple = ()` field, threaded through `fill_blueprint()` into `create_job()`'s existing `enabled_toolsets` kwarg — Dream needs toolsets beyond a job's defaults and there was no way to express that from a blueprint before.

## Why "experimental"

Building and testing this against a local model (`gemma-4-e4b-it-4bit` via rapid-mlx) surfaced two things worth flagging honestly rather than shipping quietly:

1. **`cron/scheduler.py`'s `run_job()` sets `skip_memory=True` for every cron job** (comment: "Cron system prompts would corrupt user representations"). Side effect: `agent._memory_store` stays `None` for any cron-triggered turn, and `agent/tool_executor.py` dispatches `memory()` calls with `store=agent._memory_store` — so **the `memory` tool silently fails for every cron job**, not just this one. This blueprint's hygiene/learning steps can't actually write to memory as a cron job until that's addressed. I don't fully understand the original rationale for the blanket guard, so I didn't attempt a fix here — flagging for maintainer input on the right scope (an explicit opt-in override for trusted jobs? re-scoping the guard to whatever it was actually protecting against?).
2. Separately, in my own testing, cron-triggered turns against this local model failed to emit real tool calls far more often than interactive sessions with a comparable or smaller local model+prompt — even a single-line, single-tool diagnostic prompt failed 4/4 times. Not root-caused; flagging as a possible interaction between `skip_memory`/`quiet_mode`/`platform="cron"` and provider-specific tool-calling behavior, worth someone with more cross-model visibility taking a look.

Neither issue is specific to Dream's own logic — they're pre-existing cron-execution-path issues this blueprint happened to surface. The two tools themselves (`dream_report`, `langfuse_query`) are verified working correctly in isolation and against a live self-hosted Langfuse instance; it's the cron *invocation* of the whole blueprint end-to-end that's unproven pending the above.

## Test plan

- [x] `fill_blueprint(get_blueprint("dream"), {})` produces a valid `create_job()` spec with correct schedule/deliver/enabled_toolsets defaults.
- [x] `dream_report` verified in isolation: populated and empty-fields payloads both render correct `REPORT.md`/`run.json`, including "no changes this run" fallback text.
- [x] `langfuse_query(action="list_errors", ...)` verified against a live self-hosted Langfuse v3 instance — correctly found a real narration-only-tool-call trace via the client-side heuristic pass (not visible to the server-side level filter, as expected); `get_trace` pulled full detail correctly; graceful failure confirmed for missing/placeholder credentials.
- [ ] End-to-end blueprint → live cron run, blocked on the `skip_memory` issue above — not yet demonstrated working start-to-finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)