### PR TITLE
fix(62256): ci: typecheck workflow lacks a concurrency group and job timeouts

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,10 @@
 # .github/workflows/typecheck.yml
 name: Typecheck
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 
@@ -8,6 +12,7 @@ jobs:
   typecheck:
     name: Check TypeScript
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         package:
@@ -37,6 +42,7 @@ jobs:
   desktop-build:
     name: Build desktop app
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
Fixes #62256

## Changes

```
.github/workflows/typecheck.yml | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```

Auto-generated by Hermes Harness — reviewed by AI gate before submission.