### PR TITLE
fix(api_server): load SessionDB history in /v1/runs when session_id is provided

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4279,6 +4279,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
+        # When a session_id was explicitly provided (or resolved via
+        # previous_response_id) but conversation_history is omitted, auto-load
+        # the existing history from SessionDB — consistent with
+        # POST /api/sessions/{session_id}/chat/stream behavior.
+        if not conversation_history and session_id != run_id:
+            conversation_history = self._conversation_history_for_session(session_id)
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple


### PR DESCRIPTION
Fixes #62732

When a `session_id` is provided to `POST /v1/runs` (either explicitly or via `previous_response_id`) but no `conversation_history` is supplied, the run now auto-loads the existing conversation history from SessionDB — consistent with `POST /api/sessions/{session_id}/chat/stream`.

Previously the run received an empty history even when the session existed in SessionDB, breaking context-dependent conversations.