### PR TITLE
fix(cron): avoid live adapter reuse across event loops

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1536,9 +1536,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
-        # Prefer the live adapter when the gateway is running — this supports E2EE
-        # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
-        runtime_adapter = (adapters or {}).get(platform)
+        # Cron delivery runs outside the gateway adapter's ownership context.
+        # Use the standalone sender here; otherwise the DeliveryRouter can reuse
+        # a live aiohttp-backed adapter across event loops.
+        runtime_adapter = (
+            None
+            if os.getenv("HERMES_CRON_SESSION")
+            else (adapters or {}).get(platform)
+        )
         delivered = False
         target_errors = []
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -933,6 +933,78 @@ class TestSendToPlatformChunking:
         finally:
             doc_path.unlink(missing_ok=True)
 
+
+    def test_matrix_send_to_platform_cron_skips_live_adapter(self, monkeypatch):
+        live_adapter = SimpleNamespace(
+            _client=SimpleNamespace(api=SimpleNamespace(session=SimpleNamespace(_loop=asyncio.get_event_loop())))
+        )
+        ephemeral = SimpleNamespace(connect=AsyncMock(return_value=True), disconnect=AsyncMock())
+        core = AsyncMock(return_value={"success": True, "platform": "matrix", "message_id": "$cron"})
+        runner = SimpleNamespace(adapters={Platform.MATRIX: live_adapter})
+        pconfig = SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com"})
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+        with (
+            patch("gateway.run._gateway_runner_ref", return_value=runner),
+            patch("plugins.platforms.matrix.adapter.MatrixAdapter", return_value=ephemeral),
+            patch("tools.send_message_tool._matrix_send_core", core),
+        ):
+            result = asyncio.run(
+                _send_to_platform(Platform.MATRIX, pconfig, "!room:example.com", "cron text")
+            )
+
+        assert result == {"success": True, "platform": "matrix", "message_id": "$cron"}
+        core.assert_awaited_once_with(ephemeral, "!room:example.com", "cron text", [], None)
+        ephemeral.connect.assert_awaited_once()
+        ephemeral.disconnect.assert_awaited_once()
+
+    def test_matrix_send_to_platform_falls_back_for_foreign_loop(self):
+        foreign_loop = asyncio.new_event_loop()
+        try:
+            live_adapter = SimpleNamespace(
+                _client=SimpleNamespace(api=SimpleNamespace(session=SimpleNamespace(_loop=foreign_loop)))
+            )
+            ephemeral = SimpleNamespace(connect=AsyncMock(return_value=True), disconnect=AsyncMock())
+            core = AsyncMock(return_value={"success": True, "platform": "matrix", "message_id": "$fallback"})
+            runner = SimpleNamespace(adapters={Platform.MATRIX: live_adapter})
+            pconfig = SimpleNamespace(enabled=True, token="tok", extra={})
+            with (
+                patch("gateway.run._gateway_runner_ref", return_value=runner),
+                patch("plugins.platforms.matrix.adapter.MatrixAdapter", return_value=ephemeral),
+                patch("tools.send_message_tool._matrix_send_core", core),
+            ):
+                result = asyncio.run(
+                    _send_to_platform(
+                        Platform.MATRIX, pconfig, "!room:example.com", "fallback text"
+                    )
+                )
+            assert result == {"success": True, "platform": "matrix", "message_id": "$fallback"}
+            core.assert_awaited_once_with(ephemeral, "!room:example.com", "fallback text", [], None)
+            ephemeral.connect.assert_awaited_once()
+            ephemeral.disconnect.assert_awaited_once()
+        finally:
+            foreign_loop.close()
+
+    def test_matrix_send_to_platform_reuses_same_loop_live_adapter(self):
+        async def run():
+            live_adapter = SimpleNamespace(
+                _client=SimpleNamespace(api=SimpleNamespace(session=SimpleNamespace(_loop=asyncio.get_running_loop())))
+            )
+            core = AsyncMock(return_value={"success": True, "platform": "matrix", "message_id": "$live"})
+            runner = SimpleNamespace(adapters={Platform.MATRIX: live_adapter})
+            pconfig = SimpleNamespace(enabled=True, token="tok", extra={})
+            with (
+                patch("gateway.run._gateway_runner_ref", return_value=runner),
+                patch("tools.send_message_tool._matrix_send_core", core),
+            ):
+                result = await _send_to_platform(
+                    Platform.MATRIX, pconfig, "!room:example.com", "live text"
+                )
+            assert result == {"success": True, "platform": "matrix", "message_id": "$live"}
+            core.assert_awaited_once_with(live_adapter, "!room:example.com", "live text", [], None)
+
+        asyncio.run(run())
+
     def test_matrix_text_only_uses_adapter_path(self):
         """Text-only Matrix sends must go through the E2EE-capable adapter.
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1678,7 +1678,7 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         runner = _gateway_runner_ref()
     except Exception:
         runner = None
-    if runner is not None:
+    if runner is not None and not os.getenv("HERMES_CRON_SESSION"):
         try:
             from gateway.config import Platform
             live_adapter = runner.adapters.get(Platform.MATRIX)
@@ -1688,6 +1688,18 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
                 "ephemeral connect (may re-init E2EE per send, see #46310)",
                 exc_info=True,
             )
+            live_adapter = None
+
+    if live_adapter is not None:
+        # aiohttp sessions are bound to the loop that created them. Cron and
+        # tool execution can run on a different loop from the gateway, so do
+        # not reuse a live Matrix adapter across loop ownership boundaries.
+        try:
+            adapter_loop = live_adapter._client.api.session._loop
+        except AttributeError:
+            adapter_loop = None
+        if adapter_loop is not None and adapter_loop is not asyncio.get_running_loop():
+            logger.debug("Matrix: live adapter belongs to another event loop; using ephemeral adapter")
             live_adapter = None
 
     if live_adapter is not None:


### PR DESCRIPTION
## Summary

Cron delivery can reuse the live Matrix adapter from a different asyncio event loop. Because the adapter owns an `aiohttp` session, this can fail with:

```text
Timeout context manager should be used inside a task
```

The failure was reproduced in a live Hermes gateway during manual execution of a Matrix-delivered cron job.

## Root cause

There are two cron delivery paths involved:

- `cron/scheduler.py` routes gateway cron delivery through `DeliveryRouter` and selects the live adapter by default.
- Tool-driven Matrix delivery enters `_send_to_platform(Platform.MATRIX, ...)` and then `_send_matrix_via_adapter()`.

Both paths could reuse a gateway-owned Matrix adapter from cron execution without establishing that the adapter’s HTTP session belonged to the current event loop.

The original revision of this PR changed the generic `_send_via_adapter()` helper, but review and live tracing showed that this was not the Matrix path. That change has been removed from this revision.

## Fix

- In `cron/scheduler.py`, cron execution no longer selects a live `runtime_adapter`; it uses the standalone/ephemeral delivery path instead.
- In `_send_matrix_via_adapter()`:
  - cron context skips live-adapter reuse;
  - foreign-loop Matrix sessions fall back to an ephemeral adapter;
  - same-loop non-cron calls continue to reuse the live adapter.

The reconnect/liveness problem for an already-connected Matrix gateway remains outside this PR.

## Testing

The focused Matrix/send-message suite passes:

```text
155 passed, 0 failed
```

Coverage includes the real `_send_to_platform(Platform.MATRIX, ...)` route for:

- cron-context fallback;
- foreign-loop fallback;
- same-loop live-adapter reuse.

Also verified:

- Python compilation for all changed modules;
- `git diff --check`;
- live delivery through the running Matrix gateway after reloading commit `47d1511`;
- `theo-daily-curiosity` recorded `last_status: ok` with `last_delivery_error: null`;
- no new timeout or Matrix delivery error appeared in the gateway journal.

Tested on Linux with the repository's Hermes virtual environment.

## Related work

This is the Matrix/generic cron counterpart of the event-loop mismatch documented in [#18014](https://github.com/NousResearch/hermes-agent/issues/18014), although that issue is WeChat-specific and already resolved on current main.

The Matrix cron delivery architecture is related to [#3767](https://github.com/NousResearch/hermes-agent/pull/3767) and [#5271](https://github.com/NousResearch/hermes-agent/pull/5271).

## Scope

This PR fixes cross-event-loop reuse during cron delivery. It does not implement Matrix reconnect supervision after a dead sync/session; that is a separate failure mode and should be reviewed independently.
