### PR TITLE
fix(gateway): preserve notices for confirmed restart handoffs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8636,16 +8636,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
             # Persist the home-startup notification before releasing the shutdown
-            # event.  start_gateway() waits on that event and may otherwise exit
-            # before a supervisor-triggered SIGTERM leaves any durable handoff.
-            is_external_signal_restart = (
-                getattr(self, "_signal_initiated_shutdown", False)
-                and not self._restart_requested
-            )
+            # event. start_gateway() waits on that event and may otherwise exit
+            # before a confirmed non-chat restart handoff is durable.
+            #
+            # An unexpected SIGTERM is deliberately not enough evidence: the same
+            # signal path covers OOM recovery and a bare `kill`, after which a
+            # later manual cold start must not emit a stale recovery notice.
             is_non_chat_restart = (
                 self._restart_requested and self._restart_command_source is None
             )
-            if is_non_chat_restart or is_external_signal_restart:
+            if is_non_chat_restart:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8554,7 +8554,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):
                 self._busy_ack_ts.clear()
-            self._shutdown_event.set()
 
             # Global cleanup: kill any remaining tool subprocesses not tied
             # to a specific agent (catch-all for zombie prevention). On the
@@ -8636,7 +8635,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            # Persist the home-startup notification before releasing the shutdown
+            # event.  start_gateway() waits on that event and may otherwise exit
+            # before a supervisor-triggered SIGTERM leaves any durable handoff.
+            is_external_signal_restart = (
+                getattr(self, "_signal_initiated_shutdown", False)
+                and not self._restart_requested
+            )
+            is_non_chat_restart = (
+                self._restart_requested and self._restart_command_source is None
+            )
+            if is_non_chat_restart or is_external_signal_restart:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
@@ -8705,6 +8714,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 self._update_runtime_status("stopped", self._exit_reason)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
+            # Release wait_for_shutdown() only after lifecycle markers and
+            # terminal status are durable; this prevents the replacement path
+            # from racing past a supervisor-restart notification.
+            self._shutdown_event.set()
 
         self._stop_task = asyncio.create_task(_stop_impl())
         await self._stop_task

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,8 +41,6 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # ──────────────────────────────────────────────────────────────────────
 # Git email → GitHub username mapping
-# ──────────────────────────────────────────────────────────────────────
-
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "agungsubastian1963@gmail.com": "aguung",  # PR #64461 salvage (gateway: multiplex secret_scope for authz/Slack/webhooks)
@@ -58,6 +56,7 @@ AUTHOR_MAP = {
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)
     "jdjiayou@163.com": "JiaDe-Wu",  # PR #34742 salvage (bedrock: bearer routing + streaming fallback + image decode; #28156)
+    "carlosmcejas@users.noreply.github.com": "cmcejas",
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -398,6 +398,31 @@ def _stopped_state_persisted(runner) -> bool:
 
 
 @pytest.mark.asyncio
+async def test_external_signal_persists_home_marker_before_releasing_shutdown(tmp_path, monkeypatch):
+    """Supervisor restarts must retain the startup notice before process exit."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._signal_initiated_shutdown = True
+    writes = []
+
+    def record_marker(path, payload, **kwargs):
+        writes.append((path.name, payload, runner._shutdown_event.is_set()))
+
+    monkeypatch.setattr(gateway_run, "atomic_json_write", record_marker)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert len(writes) == 1
+    marker_name, payload, shutdown_released = writes[0]
+    assert marker_name == ".restart_pending.json"
+    assert isinstance(payload["requested_at"], float)
+    assert shutdown_released is False
+    assert runner._shutdown_event.is_set() is True
+
+
+@pytest.mark.asyncio
 async def test_signal_initiated_shutdown_persists_running_not_stopped(tmp_path, monkeypatch):
     """Unexpected SIGTERM (container restart / OOM / kill) must persist
     gateway_state=running — NOT stopped, and NOT leave the mid-shutdown

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -398,12 +398,34 @@ def _stopped_state_persisted(runner) -> bool:
 
 
 @pytest.mark.asyncio
-async def test_external_signal_persists_home_marker_before_releasing_shutdown(tmp_path, monkeypatch):
-    """Supervisor restarts must retain the startup notice before process exit."""
+async def test_unexpected_signal_does_not_persist_home_startup_marker(tmp_path, monkeypatch):
+    """An OOM or bare kill must not notify a later manual cold start."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
     runner._signal_initiated_shutdown = True
+    writes = []
+
+    def record_marker(path, payload, **kwargs):
+        writes.append((path.name, payload, runner._shutdown_event.is_set()))
+
+    monkeypatch.setattr(gateway_run, "atomic_json_write", record_marker)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert writes == []
+    assert runner._shutdown_event.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_non_chat_restart_persists_home_marker_before_releasing_shutdown(tmp_path, monkeypatch):
+    """A confirmed restart handoff must retain its notice before process exit."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_requested = True
+    runner._restart_command_source = None
     writes = []
 
     def record_marker(path, payload, **kwargs):


### PR DESCRIPTION
## Summary

Keep home-channel restart notices tied to a confirmed, non-chat restart handoff.

- Persist `.restart_pending.json` only when `_restart_requested` is true and there is no chat command source.
- Persist the marker before `_shutdown_event` is released, so `start_gateway()` cannot exit before the handoff is durable.
- Do not treat the broad `_signal_initiated_shutdown` flag as notification evidence. It also covers OOM recovery and bare `kill`; a later manual cold start must not receive a stale recovery notice.
- Preserve unexpected-signal runtime state handling, which keeps container auto-start behavior intact.

## Regression coverage

- An unexpected terminal signal writes no home-channel startup marker.
- A confirmed non-chat restart writes the marker before shutdown release.
- Existing in-chat restart coverage remains unchanged.

## Why this is narrower than related lifecycle-notification PRs

Related proposals (#62523, #62546, #62742) broaden startup notifications to markerless or cold starts. This change keeps the existing explicit-handoff model and only fixes the durability ordering for that model. It avoids both cold-start noise and duplicate chat `/restart` notices. #59501 is Windows-specific and complementary.

## Attribution

Maps `carlosmcejas@users.noreply.github.com` to `@cmcejas` in `AUTHOR_MAP`, as required by the contributor check.

## Validation

- `python -m pytest -o 'addopts=' tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py -q`
  - `49 passed`
- GitHub CI: green on `305f2119602b4a574fe56c02f139f7963f12303e`.
