### PR TITLE
fix(moa): add timeout to future.result() in _run_references_parallel

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 # references; this cap just protects against a pathologically large preset
 # opening dozens of sockets at once.
 _MAX_REFERENCE_WORKERS = 8
+
+# Timeout for each reference-model call in _run_references_parallel.
+# Without this, a hung model provider freezes the entire MoA turn.
+_REFERENCE_RESULT_TIMEOUT = 120
 
 
 class _RefAccounting:
@@ -380,7 +384,19 @@ def _run_references_parallel(
         # Collect every reference before returning — the aggregator needs the
         # complete set, so there is no early-exit / first-completed path here.
         for future, idx in futures.items():
-            results[idx] = future.result()
+            try:
+                results[idx] = future.result(timeout=_REFERENCE_RESULT_TIMEOUT)
+            except FuturesTimeoutError:
+                label = _slot_label(reference_models[idx])
+                logger.warning(
+                    "Reference model %s timed out after %ds — skipping",
+                    label, _REFERENCE_RESULT_TIMEOUT,
+                )
+                results[idx] = (
+                    label,
+                    f"[skipped: reference model timed out after {_REFERENCE_RESULT_TIMEOUT}s]",
+                    _RefAccounting(CanonicalUsage()),
+                )
 
     return [r for r in results if r is not None]
 


### PR DESCRIPTION
## Summary

Add a 120s timeout to `future.result()` in the MoA reference model fan-out, preventing indefinite blocking when a reference model provider hangs.

## Problem

`_run_references_parallel` in `agent/moa_loop.py` calls `future.result()` without any timeout parameter. If a reference model's API call hangs (network issue, rate limiting, provider outage), the entire MoA turn blocks forever — the agent conversation freezes with no error or recovery path.

This is the same class of bug as the `subprocess.run` timeout fixes and the `asyncio.run future.result()` timeout fix (PR #62264), but in the MoA reference parallel execution path.

## Fix

- Added `_REFERENCE_RESULT_TIMEOUT = 120` constant
- Imported `TimeoutError` from `concurrent.futures`\n- Wrapped `future.result()` with `timeout=_REFERENCE_RESULT_TIMEOUT`
- On timeout, log a warning and return a graceful skip placeholder instead of blocking indefinitely
- The existing `[r for r in results if r is not None]` filter already handles None-like results, and the new skip tuple follows the same pattern as the existing MoA recursion guard

## Testing
- Syntax check passed (py_compile)
- Behavior verified