### PR TITLE
fix(plugins): stop loading chronos via general PluginContext

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1345,17 +1345,18 @@ class PluginManager:
         #   - flat: ``plugins/disk-cleanup/plugin.yaml`` (standalone)
         #   - category: ``plugins/image_gen/openai/plugin.yaml`` (backend)
         #
-        # ``memory/``, ``context_engine/``, and ``model-providers/`` are
-        # skipped at the top level — they have their own discovery systems
-        # (plugins/memory/__init__.py, providers/__init__.py). ``platforms/``
-        # is a category holding platform adapters (scanned one level deeper
-        # below).
+        # ``memory/``, ``context_engine/``, ``model-providers/``, and
+        # ``cron_providers/`` are skipped at the top level — they have their
+        # own discovery systems (plugins/memory/__init__.py,
+        # providers/__init__.py, plugins/cron_providers/__init__.py).
+        # ``platforms/`` is a category holding platform adapters (scanned one
+        # level deeper below).
         repo_plugins = get_bundled_plugins_dir()
         logger.debug("Scanning bundled plugins: %s", repo_plugins)
         bundled = self._scan_directory(
             repo_plugins,
             source="bundled",
-            skip_names={"memory", "context_engine", "platforms", "model-providers"},
+            skip_names={"memory", "context_engine", "platforms", "model-providers", "cron_providers"},
         )
         logger.debug("  bundled (top-level): %d manifest(s)", len(bundled))
         manifests.extend(bundled)
@@ -1413,8 +1414,8 @@ class PluginManager:
                 logger.debug("Skipping disabled plugin '%s'", lookup_key)
                 continue
 
-            # Exclusive plugins (memory providers) have their own
-            # discovery/activation path. The general loader records the
+            # Exclusive plugins (memory / cron scheduler providers) have their
+            # own discovery/activation path. The general loader records the
             # manifest for introspection but does not load the module.
             if manifest.kind == "exclusive":
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
@@ -1628,6 +1629,20 @@ class PluginManager:
                             kind = "exclusive"
                             logger.debug(
                                 "Plugin %s: detected memory provider, "
+                                "treating as kind='exclusive'",
+                                key,
+                            )
+                        elif (
+                            "register_cron_scheduler" in source_text
+                            or "CronScheduler" in source_text
+                        ):
+                            # Cron scheduler provider (e.g. bundled Chronos).
+                            # Route to plugins/cron_providers discovery via
+                            # cron.provider — PluginContext has no
+                            # register_cron_scheduler (#62951).
+                            kind = "exclusive"
+                            logger.debug(
+                                "Plugin %s: detected cron scheduler provider, "
                                 "treating as kind='exclusive'",
                                 key,
                             )

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1063,7 +1063,7 @@ def _discover_all_plugins() -> list:
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
-        (repo_plugins, "bundled", {"memory", "context_engine"}),
+        (repo_plugins, "bundled", {"memory", "context_engine", "cron_providers"}),
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)

--- a/plugins/cron_providers/chronos/plugin.yaml
+++ b/plugins/cron_providers/chronos/plugin.yaml
@@ -1,4 +1,5 @@
 name: chronos
+kind: exclusive
 description: >-
   Chronos — NAS-mediated managed cron provider for scale-to-zero hosted agents.
   Delegates the "wake me at time T" trigger to Nous infrastructure so an idle

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -300,6 +300,60 @@ class TestPluginLoading:
         assert "exclusive" in (entry.error or "").lower()
 
 
+    def test_user_cron_scheduler_plugin_auto_coerced_to_exclusive(self, tmp_path, monkeypatch):
+        """User-installed cron scheduler plugins must NOT be loaded by the
+        general PluginManager — they belong to plugins/cron_providers.
+
+        Regression for #62951:
+            'PluginContext' object has no attribute 'register_cron_scheduler'
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "chronos-user"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "chronos-user"}))
+        (plugin_dir / "__init__.py").write_text(
+            "class FakeCron:\n"
+            "    pass\n"
+            "def register(ctx):\n"
+            "    ctx.register_cron_scheduler(FakeCron())\n"
+        )
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos-user"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "chronos-user" in mgr._plugins
+        entry = mgr._plugins["chronos-user"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "exclusive" in (entry.error or "").lower()
+
+    def test_bundled_cron_providers_skipped_by_general_loader(self, tmp_path, monkeypatch):
+        """Bundled plugins/cron_providers/* must not enter the general loader.
+
+        Chronos ships under that category and uses register_cron_scheduler,
+        which PluginContext does not expose (#62951).
+        """
+        hermes_home = tmp_path / "hermes_home_bundled"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos", "cron_providers/chronos"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "chronos" not in mgr._plugins
+        assert "cron_providers/chronos" not in mgr._plugins
+
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
﻿## Summary

Bundled Chronos fails to load on current main when it is present in `plugins.enabled`:

```text
Failed to load plugin 'chronos': 'PluginContext' object has no attribute 'register_cron_scheduler'
```

Chronos is a **cron scheduler provider**. It already has its own discovery path under `plugins/cron_providers/` and is activated via `cron.provider: chronos`. The general plugin loader was still scanning that category and calling `register()` with a `PluginContext` that never grew `register_cron_scheduler` — the same class of bug memory providers already fixed with `kind: exclusive` + skip_names.

## Changes

- Skip `cron_providers/` in general bundled discovery (alongside `memory/`, etc.).
- Auto-coerce plugins that call `register_cron_scheduler` / define `CronScheduler` to `kind: exclusive`.
- Mark bundled Chronos `plugin.yaml` as `kind: exclusive`.
- Keep `hermes plugins list` scanner in sync.

Activation remains: set `cron.provider: chronos` (built-in ticker stays the default fallback).

## Test plan

```bash
python -m pytest tests/hermes_cli/test_plugins.py::TestPluginLoading::test_user_cron_scheduler_plugin_auto_coerced_to_exclusive tests/hermes_cli/test_plugins.py::TestPluginLoading::test_bundled_cron_providers_skipped_by_general_loader tests/hermes_cli/test_plugins.py::TestPluginLoading::test_user_memory_plugin_auto_coerced_to_exclusive tests/plugins/test_chronos_cron.py -q
```

Result: **16 passed**.

Fixes #62951
