### PR TITLE
feat(mcp): add AgentWeb to approved catalog

### DIFF
--- a/optional-mcps/agentweb/manifest.yaml
+++ b/optional-mcps/agentweb/manifest.yaml
@@ -12,7 +12,7 @@ transport:
 install:
   type: git
   url: https://github.com/thanhan-a17/agentweb.git
-  ref: v2.0.0
+  ref: v2.0.1
   bootstrap:
     - "python3 -m venv .venv"
     - ".venv/bin/pip install '.[mcp]'"

--- a/optional-mcps/agentweb/manifest.yaml
+++ b/optional-mcps/agentweb/manifest.yaml
@@ -1,0 +1,31 @@
+manifest_version: 1
+
+name: agentweb
+description: Zero-API-key web search, page extraction, and exact evidence for AI agents.
+source: https://github.com/thanhan-a17/agentweb
+
+transport:
+  type: stdio
+  command: "${INSTALL_DIR}/.venv/bin/agentweb-mcp"
+  args: []
+
+install:
+  type: git
+  url: https://github.com/thanhan-a17/agentweb.git
+  ref: v2.0.0
+  bootstrap:
+    - "python3 -m venv .venv"
+    - ".venv/bin/pip install '.[mcp]'"
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - agentweb_search
+    - agentweb_fetch
+    - agentweb_evidence
+
+post_install: |
+  AgentWeb requires no API key or mandatory account. It exposes search, fetch,
+  and exact evidence tools. Start a new Hermes session after installation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/agentweb" = ["optional-mcps/agentweb/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 


### PR DESCRIPTION
## Summary

Adds AgentWeb v2.0.0 to Hermes's optional MCP catalog.

AgentWeb provides three read-only, zero-API-key tools:
- `agentweb_search`
- `agentweb_fetch`
- `agentweb_evidence`

## Installation

The manifest pins `v2.0.0`, creates an isolated venv, installs the MCP extra, and launches the local stdio server from that venv.

## Verification

- Catalog parser loads the manifest successfully
- Transport resolves to `${INSTALL_DIR}/.venv/bin/agentweb-mcp`
- All three tools are selected by default
- Local Hermes MCP connection tested: 3/3 tools discovered, 250 ms startup

Source: https://github.com/thanhan-a17/agentweb
Release: https://github.com/thanhan-a17/agentweb/releases/tag/v2.0.0
