### PR TITLE
fix(agent): preserve xAI fallback responses routing

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1464,6 +1464,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
+        elif fb_provider in {"xai", "xai-oauth"} or base_url_host_matches(
+            fb_base_url, "api.x.ai"
+        ):
+            fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"
             or fb_base_url.rstrip("/").lower().endswith("/anthropic")

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -371,6 +371,19 @@ _GROK_EFFORT_CAPABLE_PREFIXES = (
     "grok-4.5",
 )
 
+_GROK_HIGH_CAPPED_EFFORT_PREFIXES = (
+    "grok-4.5",
+)
+
+
+def _normalize_grok_model_name(model: str) -> str:
+    name = (model or "").strip().lower()
+    if not name:
+        return ""
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return name
+
 
 def grok_supports_reasoning_effort(model: str) -> bool:
     """Return True when an xAI Grok model accepts ``reasoning.effort``.
@@ -380,14 +393,20 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     if a future Grok model isn't listed, we send no effort dial rather
     than 400.
     """
-    name = (model or "").strip().lower()
+    name = _normalize_grok_model_name(model)
     if not name:
         return False
-    # Strip common aggregator prefixes (x-ai/, openrouter/x-ai/, xai/, ...)
-    for sep in ("/",):
-        if sep in name:
-            name = name.rsplit(sep, 1)[-1]
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
+
+
+def normalize_grok_reasoning_effort(model: str, effort: str) -> str:
+    """Clamp Grok reasoning effort to the strongest value the model accepts."""
+    normalized_effort = str(effort or "medium").strip().lower() or "medium"
+    name = _normalize_grok_model_name(model)
+    if any(name.startswith(prefix) for prefix in _GROK_HIGH_CAPPED_EFFORT_PREFIXES):
+        if normalized_effort in {"max", "xhigh"}:
+            return "high"
+    return normalized_effort
 
 
 _CONTEXT_LENGTH_KEYS = (

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -265,7 +265,10 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["prompt_cache_key"] = cache_key
 
         if reasoning_enabled and is_xai_responses:
-            from agent.model_metadata import grok_supports_reasoning_effort
+            from agent.model_metadata import (
+                grok_supports_reasoning_effort,
+                normalize_grok_reasoning_effort,
+            )
 
             # Ask xAI to echo back encrypted reasoning items so we can
             # replay them on subsequent turns for cross-turn coherence.
@@ -280,6 +283,9 @@ class ResponsesApiTransport(ProviderTransport):
             # the target model is on the allowlist; otherwise send no
             # `reasoning` key at all and let the model reason on its own.
             if grok_supports_reasoning_effort(model):
+                reasoning_effort = normalize_grok_reasoning_effort(
+                    model, reasoning_effort
+                )
                 kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
             if is_github_responses:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -604,6 +604,27 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("reasoning") == {"effort": "low"}
 
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("max", "high"),
+            ("xhigh", "high"),
+        ],
+    )
+    def test_xai_grok_4_5_normalizes_reasoning_effort(self, transport, effort, expected):
+        """grok-4.5 caps stronger inherited effort values at high."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.5", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": effort},
+        )
+        assert kw.get("reasoning") == {"effort": expected}
+        assert "reasoning.encrypted_content" in kw.get("include", [])
+
     def test_xai_grok_code_fast_omits_reasoning_effort(self, transport):
         """grok-code-fast-1 rejects reasoning.effort."""
         messages = [{"role": "user", "content": "Hi"}]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6432,6 +6432,30 @@ class TestFallbackAnthropicProvider:
         assert agent.client is mock_client
 
 
+class TestFallbackXaiProvider:
+    """Fallback xAI providers must preserve normal Responses API routing."""
+
+    def test_fallback_to_xai_oauth_sets_codex_responses(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "xai-oauth", "model": "grok-4.5"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.x.ai/v1"
+        mock_client.api_key = "xai-oauth-token"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+        assert agent.client is mock_client
+
+
 def test_aiagent_uses_copilot_acp_client():
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),


### PR DESCRIPTION
## What does this PR do?

Fixes the two xAI fallback regressions tracked in #62881.

When Hermes activates an `xai` / `xai-oauth` fallback today, the fallback routing logic can leave the agent on `chat_completions` even though the normal xAI path uses the Responses API. That makes a configured `grok-4.5` fallback unusable for an OpenAI/Codex primary.

This change makes fallback activation preserve the normal xAI `codex_responses` routing and clamps inherited `max` / `xhigh` reasoning effort to `high` for `grok-4.5`, which is the strongest value that model accepts.

## Related Issue

Fixes #62881

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/chat_completion_helpers.py` so `xai` and `xai-oauth` fallbacks select `codex_responses`, matching the normal xAI runtime path.
- Added a small Grok model helper in `agent/model_metadata.py` to normalize model names and cap `grok-4.5` reasoning effort at `high` when the inherited value is `max` or `xhigh`.
- Updated `agent/transports/codex.py` to apply the Grok 4.5 effort normalization before sending `reasoning.effort` to xAI.
- Added regression tests in `tests/run_agent/test_run_agent.py` and `tests/agent/transports/test_codex_transport.py` covering xAI fallback API-mode selection and Grok 4.5 effort normalization.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py -k 'grok_4_5 or xai_reasoning_effort_passed or xai_grok_4_20_multi_agent_keeps_reasoning_effort'`.
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -k 'fallback_to_xai_oauth_sets_codex_responses or fallback_to_anthropic_sets_api_mode'`.
3. Confirm `git diff --check` passes and that an `xai-oauth/grok-4.5` fallback now uses `codex_responses` with `reasoning.effort=high` when the primary inherits `max`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused proof is recorded locally at `/tmp/hermes-62881-proof.txt`.
