### PR TITLE
chore: ignore stale virtualenv artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /venv/
 /venv.old/
+/venv.stale.*/
 /_pycache/
 *.pyc*
 __pycache__/


### PR DESCRIPTION
## Summary
- Ignore launch/update-created stale virtualenv directories named `venv.stale.*`
- Keeps `git status` clean when a recovered stale venv artifact remains in the checkout

## Verification
- `git diff --check`
- `git check-ignore -v venv.stale.20260712035437`
- Static diff scan for secrets/injection patterns
- `.venv/Scripts/python -m pytest tests/hermes_cli/test_update_interrupted_recovery.py -v --tb=short` (12 passed)

## Notes
- `scripts/run_tests.sh ...` is POSIX-venv-only on this Windows checkout and looks for `bin/activate`; direct pytest through the uv-created Windows `.venv\Scripts\python.exe` was used instead.