### PR TITLE
fix(error_classifier): extract body.param and match backtick MiMo variant (#37469)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -219,8 +219,11 @@ _IMAGE_TOO_LARGE_PATTERNS = [
 #
 # See: https://github.com/NousResearch/hermes-agent/issues/27344
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
-    # Xiaomi MiMo: {"error":{"code":"400","message":"Param Incorrect","param":"text is not set"}}
+    # Xiaomi MiMo: {"error":{"code":"400","message":"Param Incorrect","param":"`text` is not set"}}
+    # The actual API wraps the param name in backticks; the plain variant
+    # without backticks never substring-matches when backticks are present.
     "text is not set",
+    "`text` is not set",
     # Generic "tool message must be string" shapes
     "tool message content must be a string",
     "tool content must be a string",
@@ -528,11 +531,18 @@ def classify_api_error(
     # "context length exceeded") is only in the inner JSON.
     _raw_msg = str(error).lower()
     _body_msg = ""
+    _body_param = ""
     _metadata_msg = ""
+    _metadata_param = ""
     if isinstance(body, dict):
         _err_obj = body.get("error", {})
         if isinstance(_err_obj, dict):
             _body_msg = str(_err_obj.get("message") or "").lower()
+            # Extract the ``param`` field — some providers (e.g. Xiaomi MiMo)
+            # put the diagnostic detail there, not in ``message``:
+            #   {"error":{"code":"400","message":"Param Incorrect",
+            #    "param":"`text` is not set"}}
+            _body_param = str(_err_obj.get("param") or "").lower()
             # Parse metadata.raw for wrapped provider errors
             _metadata = _err_obj.get("metadata", {})
             if isinstance(_metadata, dict):
@@ -545,16 +555,22 @@ def classify_api_error(
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
                                 _metadata_msg = str(_inner_err.get("message") or "").lower()
+                                _metadata_param = str(_inner_err.get("param") or "").lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
             _body_msg = str(body.get("message") or "").lower()
+            _body_param = str(body.get("param") or "").lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
         parts.append(_body_msg)
+    if _body_param and _body_param not in _raw_msg and _body_param not in _body_msg:
+        parts.append(_body_param)
     if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
         parts.append(_metadata_msg)
+    if _metadata_param and _metadata_param not in _raw_msg and _metadata_param not in _body_msg:
+        parts.append(_metadata_param)
     error_msg = " ".join(parts)
     provider_lower = (provider or "").strip().lower()
     model_lower = (model or "").strip().lower()

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1776,6 +1776,90 @@ class TestMultimodalToolContentUnsupported:
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
 
 
+class TestMultimodalParamExtraction:
+    """Issue #37469 — Xiaomi MiMo puts the diagnostic in ``body.error.param``,
+    not in ``message``.  The classifier must extract ``param`` into the
+    pattern-matching string so ``_MULTIMODAL_TOOL_CONTENT_PATTERNS`` can
+    match it.  These tests use body dicts where the error *string* does NOT
+    contain the param value — only the structured body does — so they prove
+    the body-param extraction is doing the work, not the string match.
+    """
+
+    def test_mimo_param_in_body_not_in_message(self):
+        """Raw MiMo 400 where ``str(error)`` says only ``Param Incorrect``
+        but ``body.error.param`` holds ```` `text` is not set ````.
+        """
+        e = MockAPIError(
+            "Error code: 400 - {'message': 'Param Incorrect'}",
+            status_code=400,
+            body={
+                "error": {
+                    "code": "400",
+                    "message": "Param Incorrect",
+                    "param": "`text` is not set",
+                    "type": "",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="xiaomi", model="mimo-v2.5")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+    def test_mimo_param_via_aggregator_metadata_raw(self):
+        """Same error but wrapped in aggregator ``metadata.raw``
+        (e.g. opencode-go → switchboard → MiMo).  The outer
+        ``message`` is ``Provider returned error``; the inner JSON's
+        ``param`` holds the diagnostic.
+        """
+        import json
+        inner = json.dumps({
+            "error": {
+                "code": "400",
+                "message": "Param Incorrect",
+                "param": "`text` is not set",
+                "type": "",
+            }
+        })
+        e = MockAPIError(
+            "Error code: 400 - {'message': 'Error from provider'}",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Error from provider: Provider returned error",
+                    "code": 400,
+                    "metadata": {
+                        "raw": inner,
+                        "provider_name": "Xiaomi",
+                        "is_byok": True,
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="opencode-go", model="mimo-v2.5")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+    def test_mimo_param_without_backticks_also_matches(self):
+        """If the API ever stops wrapping in backticks, the plain
+        pattern still catches it via body-param extraction.
+        """
+        e = MockAPIError(
+            "Error code: 400 - {'message': 'Param Incorrect'}",
+            status_code=400,
+            body={
+                "error": {
+                    "code": "400",
+                    "message": "Param Incorrect",
+                    "param": "text is not set",
+                    "type": "",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="xiaomi", model="mimo-v2.5")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+
 class TestOpenRouterUpstreamRateLimit:
     """Distinguish upstream-provider 429 from account-level 429 on OpenRouter.
 


### PR DESCRIPTION
## Summary

Fixes #37469
Follow-up to #46664 (closed as wrong-premise: bundled pricing changes with the param extraction).

Xiaomi MiMo returns 400 errors with the diagnostic detail in `body.error.param`, not in `message`:
```json
{"error":{"code":"400","message":"Param Incorrect","param":"`text` is not set","type":""}}
```

Two gaps in `agent/error_classifier.py` prevent the `multimodal_tool_content_unsupported` recovery path from firing, permanently poisoning the conversation:

1. **Param not extracted.** The classifier builds `error_msg` from `str(error)`, `body.error.message`, and `metadata.raw → error.message` — but never extracts `body.error.param`. When the error string omits the param value (common with aggregator relays), the pattern has nothing to match.

2. **Backtick mismatch.** The existing pattern `"text is not set"` (no backticks) does not substring-match the actual API value `` "`text` is not set" `` (with backticks) after `.lower()` — the backticks sit between `text` and ` is`, breaking the contiguous match.

### Concrete raw error body (from production)

Direct MiMo:
```json
{"error":{"code":"400","message":"Param Incorrect","param":"`text` is not set","type":""}}
```

Via aggregator relay (e.g. opencode-go → MiMo):
```json
{"error":{"message":"Error from provider: Provider returned error","code":400,
  "metadata":{"raw":"{\"error\":{\"code\":\"400\",\"message\":\"Param Incorrect\",\"param\":\"`text` is not set\",\"type\":\"\"}}",
  "provider_name":"Xiaomi","is_byok":True}}}
```

In the relay case, `str(error)` contains `"Error from provider"` — the actual param value is buried in `metadata.raw → error.param`. Without body.param extraction, the classifier never sees it.

## Changes

- `agent/error_classifier.py`:
  - Extract `body.error.param` and `metadata.raw → error.param` into the pattern-matching `error_msg` string, alongside existing `message` extractions
  - Add `` "`text` is not set" `` (backtick variant) to `_MULTIMODAL_TOOL_CONTENT_PATTERNS`
- `tests/agent/test_error_classifier.py`:
  - `TestMultimodalParamExtraction` — 3 new tests that use body dicts where the error *string* does NOT contain the param value, proving the body-param extraction does the work

No pricing, accounting, or usage-cost changes. Per @teknium1 on #46664: "If the `param` extraction for `text is not set` is still useful, it should come back as a tiny focused PR with a concrete raw error body and no pricing/accounting changes."

## Why both changes are needed

PR #37478 (approved) adds only the backtick pattern — works when `str(error)` contains the param verbatim, but fails through aggregator relays that strip the param from the outer message. PR #42244 extracts `body.param` but does NOT add the backtick pattern — so the extracted value `` "`text` is not set" `` still doesn't match the plain pattern `"text is not set"`. This PR does both.

## Credits

The backtick pattern idea was independently proposed in #37478 and #41614 by @liuhao1024. The body.param extraction concept originated in #35972 by @sujeet111 and was implemented in #42244 by @diogochubatsu. This PR combines both approaches — neither alone is sufficient for aggregator relays.

## Testing

```bash
PYTHONPATH=. python -m pytest tests/agent/test_error_classifier.py -x
# 182 passed

PYTHONPATH=. python -m pytest tests/agent/test_error_classifier.py::TestMultimodalParamExtraction -xvs
# 3 passed (all new)
```

Independently verified end-to-end on a live Hermes gateway (opencode-go → Xiaomi MiMo, mimo-v2.5): after patching, the classifier correctly classified the 400 as `multimodal_tool_content_unsupported`, the `_try_strip_image_parts_from_tool_messages` recovery path fired, and the session continued without abort.