### PR TITLE
fix(discord): restore bot-owned thread follow-ups

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6138,6 +6138,16 @@ class DiscordAdapter(BasePlatformAdapter):
         if is_thread:
             thread_id = str(message.channel.id)
             parent_channel_id = self._get_parent_channel_id(message.channel)
+            bot_user = getattr(self._client, "user", None)
+            bot_user_id = getattr(bot_user, "id", None)
+            thread_owner_id = getattr(message.channel, "owner_id", None)
+            bot_owns_thread = (
+                bot_user_id is not None
+                and thread_owner_id is not None
+                and str(thread_owner_id) == str(bot_user_id)
+            )
+            if bot_owns_thread and not self._discord_thread_require_mention():
+                self._threads.mark(thread_id)
 
         is_voice_linked_channel = False
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -81,12 +81,20 @@ class FakeForumChannel:
 
 
 class FakeThread:
-    def __init__(self, channel_id: int = 1, name: str = "thread", parent=None, guild_name: str = "Hermes Server"):
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "thread",
+        parent=None,
+        guild_name: str = "Hermes Server",
+        owner_id: int | None = None,
+    ):
         self.id = channel_id
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
         self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.owner_id = owner_id
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -598,6 +606,24 @@ async def test_discord_unknown_thread_still_requires_mention(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_owned_thread_allows_first_unmentioned_followup(adapter, monkeypatch):
+    """A bot-created thread remains mention-free after a gateway restart."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    thread = FakeThread(channel_id=790, name="daily plan", owner_id=999)
+    assert "790" not in adapter._threads
+    message = make_message(channel=thread, content="first follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    assert "790" in adapter._threads
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- recognize a Discord thread owned by the current bot as participated before mention gating
- preserve `thread_require_mention: true` as the explicit safety override
- add a regression test for the first unmentioned follow-up after a gateway restart

## Problem
Thread participation state can be absent after a gateway restart, especially for threads created by scheduled delivery. The first human follow-up is then dropped unless it explicitly mentions the bot, even though Discord durably identifies the thread owner.

## Verification
- `tests/gateway/test_discord_free_response.py`: 60 passed
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed