### PR TITLE
fix(agent): split concatenated parallel tool call arguments from Gemini OpenAI-compat endpoint (#62937)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2474,33 +2474,72 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 tc = tool_calls_acc[idx]
                 arguments = tc["function"]["arguments"]
                 tool_name = tc["function"]["name"] or "?"
+                _split_handled = False
                 if arguments and arguments.strip():
                     try:
                         json.loads(arguments)
-                    except json.JSONDecodeError:
-                        # Attempt repair before flagging as truncated.
-                        # Models like GLM-5.1 via Ollama produce trailing
-                        # commas, unclosed brackets, Python None, etc.
-                        # Without repair, these hit the truncation handler
-                        # and kill the session.  _repair_tool_call_arguments
-                        # returns "{}" for unrepairable args, which is far
-                        # better than a crashed session.
-                        repaired = _repair_tool_call_arguments(arguments, tool_name)
-                        if repaired != "{}":
-                            # Successfully repaired — use the fixed args
-                            arguments = repaired
-                        else:
-                            # Unrepairable — flag for truncation handling
-                            has_truncated_tool_args = True
-                mock_tool_calls.append(SimpleNamespace(
-                    id=tc["id"],
-                    type=tc["type"],
-                    extra_content=tc.get("extra_content"),
-                    function=SimpleNamespace(
-                        name=tc["function"]["name"],
-                        arguments=arguments,
-                    ),
-                ))
+                    except json.JSONDecodeError as e:
+                        # Gemini OpenAI-compat endpoint concatenates multiple
+                        # parallel tool call arguments into one entry (no
+                        # incremental index).  Detect "Extra data" and split
+                        # them apart with raw_decode, emitting one
+                        # mock_tool_call per object with distinct ids.
+                        if "Extra data" in str(e):
+                            decoder = json.JSONDecoder()
+                            remaining = arguments.strip()
+                            split_objects: list[str] = []
+                            while remaining:
+                                try:
+                                    obj, end = decoder.raw_decode(remaining)
+                                    split_objects.append(
+                                        json.dumps(obj, separators=(",", ":"))
+                                    )
+                                    remaining = remaining[end:].strip()
+                                except json.JSONDecodeError:
+                                    break
+                            if len(split_objects) >= 2:
+                                for i, split_args in enumerate(split_objects):
+                                    split_id = (
+                                        f"{tc['id']}_split_{i}"
+                                        if tc.get("id")
+                                        else f"call_split_{idx}_{i}"
+                                    )
+                                    mock_tool_calls.append(SimpleNamespace(
+                                        id=split_id,
+                                        type=tc["type"],
+                                        extra_content=tc.get("extra_content"),
+                                        function=SimpleNamespace(
+                                            name=tc["function"]["name"],
+                                            arguments=split_args,
+                                        ),
+                                    ))
+                                _split_handled = True
+
+                        if not _split_handled:
+                            # Attempt repair before flagging as truncated.
+                            # Models like GLM-5.1 via Ollama produce trailing
+                            # commas, unclosed brackets, Python None, etc.
+                            # Without repair, these hit the truncation handler
+                            # and kill the session.  _repair_tool_call_arguments
+                            # returns "{}" for unrepairable args, which is far
+                            # better than a crashed session.
+                            repaired = _repair_tool_call_arguments(arguments, tool_name)
+                            if repaired != "{}":
+                                # Successfully repaired — use the fixed args
+                                arguments = repaired
+                            else:
+                                # Unrepairable — flag for truncation handling
+                                has_truncated_tool_args = True
+                if not _split_handled:
+                    mock_tool_calls.append(SimpleNamespace(
+                        id=tc["id"],
+                        type=tc["type"],
+                        extra_content=tc.get("extra_content"),
+                        function=SimpleNamespace(
+                            name=tc["function"]["name"],
+                            arguments=arguments,
+                        ),
+                    ))
 
         # Zero-chunk guard: stream yielded nothing usable — a provider/upstream
         # error or malformed SSE, not a legitimate empty completion. Raise so the

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -269,6 +269,27 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
+    # Repair pass 5: concatenated JSON objects (Gemini OpenAI-compat).
+    # When the payload is ≥2 complete objects glued together, return the
+    # first one rather than giving up entirely.
+    try:
+        decoder = json.JSONDecoder()
+        first_obj, end = decoder.raw_decode(raw_stripped)
+        tail = raw_stripped[end:].strip()
+        if tail:
+            # At least one more complete object follows — try to decode
+            # it to confirm; if it works we have ≥2 objects.
+            decoder.raw_decode(tail)
+            result = json.dumps(first_obj, separators=(",", ":"))
+            logger.warning(
+                "Repaired concatenated tool_call arguments for %s — "
+                "split ≥2 objects, returning first (was: %s)",
+                tool_name, raw_stripped[:80],
+            )
+            return result
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
     # Last resort: replace with empty object so the API request doesn't
     # crash the entire session.
     logger.warning(


### PR DESCRIPTION
## Summary
When the configured provider is Gemini via its OpenAI-compatible endpoint, the model frequently emits multiple parallel function calls concatenated into a single `tool_calls` entry. Google's OpenAI-compat layer does not increment `tool_calls[].index` for parallel calls, so the streaming assembler concatenates all argument fragments into one string. `json.loads()` rejects with "Extra data", and `_repair_tool_call_arguments` replaces everything with `{}`. Tools execute with empty arguments — silently doing nothing.

## Changes
1. **`agent/chat_completion_helpers.py`**: When `json.loads` fails with "Extra data" on tool call arguments, uses `json.JSONDecoder().raw_decode` to peel off each complete object and emit one `mock_tool_call` per object (with distinct `_split_N` ids)
2. **`agent/message_sanitization.py`**: Added Repair pass 5 — when payload contains ≥2 concatenated JSON objects, returns the first decoded object instead of `{}`

## Verification
99 tool_call/streaming/repair tests pass.