### PR TITLE
fix(gateway): snapshot and restore os.environ around plugin discovery to prevent third-party .env leaks (#62935)

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -29,10 +29,29 @@ Usage (gateway side):
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _restore_environ(snapshot: dict[str, str]) -> None:
+    """Restore os.environ to a previous snapshot.
+
+    Removes any keys that were added and reverts any keys that were changed
+    by code that ran between the snapshot and this call.  This prevents
+    third-party module-level code (e.g. ``microsoft_teams.apps`` calling
+    ``load_dotenv()`` at import time) from leaking .env values into the
+    current process.
+    """
+    # Remove keys that didn't exist before the snapshot.
+    for key in set(os.environ) - set(snapshot):
+        del os.environ[key]
+    # Revert keys that existed but were changed after the snapshot.
+    for key, val in snapshot.items():
+        if os.environ.get(key) != val:
+            os.environ[key] = val
 
 
 @dataclass
@@ -204,6 +223,11 @@ class PlatformRegistry:
         loader = self._deferred.pop(name, None)
         if loader is None:
             return
+        # Snapshot os.environ before the import to prevent third-party
+        # packages called during module loading (e.g. microsoft_teams.apps
+        # calling load_dotenv() at import time) from leaking .env values
+        # into the gateway process.
+        snapshot = os.environ.copy()
         try:
             loader()
         except Exception as e:
@@ -213,6 +237,8 @@ class PlatformRegistry:
                 e,
                 exc_info=True,
             )
+        finally:
+            _restore_environ(snapshot)
 
     def _resolve_all(self) -> None:
         """Run every pending deferred loader.


### PR DESCRIPTION
## Summary
`load_gateway_config()` triggers platform-plugin discovery which imports `microsoft_teams.apps`. That package executes `load_dotenv(find_dotenv(usecwd=True))` at module scope, walking up from cwd and loading the first `.env` into `os.environ` — in every gateway process, whether or not Teams is configured. This breaks profile secret isolation: profile gateways inherit the root profile's `.env` through a side channel that completely bypasses the secret scope design.

## Change
Added `os.environ` snapshot/restore around the deferred platform import in `platform_registry._resolve()`. A `_restore_environ(snapshot)` helper removes env vars that were added and reverts ones that were changed during the import, preventing any third-party module-level side effects from leaking into the gateway process.

## Verification
1440 gateway tests pass, including all 50 platform_registry tests.