### PR TITLE
fix(agent): route Bedrock auxiliary Claude tasks through Converse

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5058,15 +5058,15 @@ def resolve_provider_client(
                 else (client, final_model))
 
     elif pconfig.auth_type == "aws_sdk":
-        # AWS SDK providers (Bedrock) — Claude models use the Anthropic Bedrock
-        # SDK (prompt caching, thinking); non-Claude models use Converse API.
+        # Auxiliary Bedrock requests deliberately mirror the main agent's
+        # Converse path, including Anthropic Claude/Fable models. This avoids
+        # AnthropicBedrock-SDK-only request fields on side tasks such as
+        # vision analysis and context compaction.
         try:
             from agent.bedrock_adapter import (
                 has_aws_credentials,
-                is_anthropic_bedrock_model,
                 resolve_bedrock_region,
             )
-            from agent.anthropic_adapter import build_anthropic_bedrock_client
         except ImportError:
             logger.warning("resolve_provider_client: bedrock requested but "
                            "boto3 or anthropic SDK not installed")
@@ -5080,25 +5080,9 @@ def resolve_provider_client(
         region = resolve_bedrock_region()
         default_model = "anthropic.claude-haiku-4-5-20251001-v1:0"
         final_model = _normalize_resolved_model(model or default_model, provider)
-        base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
-
-        if is_anthropic_bedrock_model(final_model):
-            try:
-                real_client = build_anthropic_bedrock_client(region)
-            except ImportError as exc:
-                logger.warning("resolve_provider_client: cannot create Bedrock "
-                               "client: %s", exc)
-                return None, None
-            client = AnthropicAuxiliaryClient(
-                real_client, final_model, api_key="aws-sdk",
-                base_url=base_url,
-            )
-            logger.debug("resolve_provider_client: bedrock anthropic (%s, %s)",
-                         final_model, region)
-        else:
-            client = BedrockAuxiliaryClient(region, final_model)
-            logger.debug("resolve_provider_client: bedrock converse (%s, %s)",
-                         final_model, region)
+        client = BedrockAuxiliaryClient(region, final_model)
+        logger.debug("resolve_provider_client: bedrock converse (%s, %s)",
+                     final_model, region)
 
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5653,3 +5653,69 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+
+class TestAuxiliaryBedrockRouting:
+    def test_anthropic_bedrock_aux_uses_converse_shim(self):
+        import agent.auxiliary_client as ac
+        registry = {"bedrock": SimpleNamespace(auth_type="aws_sdk")}
+
+        with patch(
+            "hermes_cli.auth.PROVIDER_REGISTRY",
+            registry,
+        ), patch(
+            "agent.bedrock_adapter.has_aws_credentials",
+            return_value=True,
+        ), patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="us-west-2",
+        ), patch(
+            "agent.auxiliary_client.BedrockAuxiliaryClient",
+        ) as mock_bedrock_client, patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            side_effect=AssertionError(
+                "auxiliary Claude-on-Bedrock should not use AnthropicBedrock SDK"
+            ),
+        ):
+            sentinel = MagicMock()
+            mock_bedrock_client.return_value = sentinel
+
+            client, model = ac.resolve_provider_client(
+                "bedrock",
+                "global.anthropic.claude-fable-5-20251010-v1:0",
+            )
+
+        assert client is sentinel
+        assert model == "global.anthropic.claude-fable-5-20251010-v1:0"
+        mock_bedrock_client.assert_called_once_with(
+            "us-west-2", "global.anthropic.claude-fable-5-20251010-v1:0"
+        )
+
+    def test_async_anthropic_bedrock_aux_wraps_converse_shim(self):
+        import agent.auxiliary_client as ac
+
+        registry = {"bedrock": SimpleNamespace(auth_type="aws_sdk")}
+
+        with patch(
+            "hermes_cli.auth.PROVIDER_REGISTRY",
+            registry,
+        ), patch(
+            "agent.bedrock_adapter.has_aws_credentials",
+            return_value=True,
+        ), patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="us-east-1",
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            side_effect=AssertionError(
+                "auxiliary Claude-on-Bedrock should not use AnthropicBedrock SDK"
+            ),
+        ):
+            client, model = ac.resolve_provider_client(
+                "bedrock",
+                "global.anthropic.claude-fable-5",
+                async_mode=True,
+            )
+
+        assert isinstance(client, ac.AsyncBedrockAuxiliaryClient)
+        assert model == "global.anthropic.claude-fable-5"


### PR DESCRIPTION
## Summary
- route Bedrock auxiliary Claude/Fable tasks through the existing Converse shim instead of the Anthropic Bedrock SDK
- keep auxiliary vision and compaction requests aligned with the main agent's Bedrock transport to avoid SDK-only request fields
- add focused regression tests for sync and async auxiliary Bedrock Claude routing

## Testing
- `git diff --check`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -k 'AuxiliaryBedrockRouting or (bedrock and auxiliary)'`\n- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_bedrock_1m_context.py tests/agent/test_anthropic_adapter.py -k 'bedrock_client_keeps_context_1m_beta or build_anthropic_bedrock_client_sends_1m_beta or bedrock_disables_sdk_retries'`\n\nFixes #62965