### PR TITLE
fix(agent): surface unrepairable tool arguments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -32,6 +32,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.message_sanitization import (
+    _repair_tool_call_arguments,
+)
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -324,7 +327,17 @@ def sanitize_tool_call_arguments(
                     function_name,
                     preview,
                 )
-                function["arguments"] = "{}"
+                # Use the repair pipeline instead of blindly setting {}.
+                # Genuinely empty/None/whitespace args are handled above;
+                # repairable malformations get fixed; truly unrepairable
+                # args fall back to {} so the outgoing API message stays
+                # valid (the marker/stub on the adjacent tool result is
+                # the real corruption signal for the model; #35151).
+                repair_result = _repair_tool_call_arguments(arguments, function_name)
+                if repair_result is not None:
+                    function["arguments"] = repair_result
+                else:
+                    function["arguments"] = "{}"
 
                 existing_tool_msg = None
                 scan_index = message_index + 1

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2483,10 +2483,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # commas, unclosed brackets, Python None, etc.
                         # Without repair, these hit the truncation handler
                         # and kill the session.  _repair_tool_call_arguments
-                        # returns "{}" for unrepairable args, which is far
-                        # better than a crashed session.
+                        # returns None for unrepairable args (issue #35151),
+                        # which is far better than a crashed session.
                         repaired = _repair_tool_call_arguments(arguments, tool_name)
-                        if repaired != "{}":
+                        if repaired is not None:
                             # Successfully repaired — use the fixed args
                             arguments = repaired
                         else:

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,14 +182,17 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
-def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
+def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str | None:
     """Attempt to repair malformed tool_call argument JSON.
 
     Models like GLM-5.1 via Ollama can produce truncated JSON, trailing
     commas, Python ``None``, etc.  The API proxy rejects these with HTTP 400
     "invalid tool call arguments".  This function applies common repairs;
-    if all fail it returns ``"{}"`` so the request succeeds (better than
-    crashing the session).  All repairs are logged at WARNING level.
+    genuinely empty / None / whitespace args return ``"{}"``, repairable
+    malformations return the fixed string, and truly unrepairable args
+    return ``None`` so callers can use existing marker/truncation handling
+    instead of silently executing with empty arguments (issue #35151).
+    All repairs are logged at WARNING level.
     """
     raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
 
@@ -269,14 +272,15 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
-    # Last resort: replace with empty object so the API request doesn't
-    # crash the entire session.
+    # Last resort: signal unrepairable so callers can use existing
+    # marker/truncation handling instead of silently executing with
+    # empty arguments (issue #35151).
     logger.warning(
-        "Unrepairable tool_call arguments for %s — "
-        "replaced with empty object (was: %s)",
+        "Unrepairable tool_call arguments for %s -- "
+        "returning None (was: %s)",
         tool_name, raw_stripped[:80],
     )
-    return "{}"
+    return None
 
 
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -54,10 +54,10 @@ class TestRepairToolCallArguments:
 
     def test_unclosed_bracket_and_brace(self):
         result = _repair_tool_call_arguments('{"a": [1, 2', "t")
-        # Bracket counting adds ']' then '}', producing {"a": [1, 2]}
-        # which is valid JSON.  But the naive count can't always recover
-        # complex nesting — verify we at least get valid JSON.
-        json.loads(result)
+        # The naive bracket-counting adds ] then } in the wrong order,
+        # producing invalid JSON.  This is genuinely unrepairable by the
+        # current logic (issue #35151).
+        assert result is None
 
     # -- Stage 5: excess closing delimiters --
 
@@ -68,17 +68,35 @@ class TestRepairToolCallArguments:
 
     def test_extra_closing_bracket(self):
         result = _repair_tool_call_arguments('{"a": [1]]}', "t")
-        # Should produce valid JSON
-        json.loads(result)
+        # Excess closing delimiters with mismatched nesting is
+        # genuinely unrepairable by the current logic (issue #35151).
+        assert result is None
 
     # -- Stage 6: last resort --
 
     def test_unrepairable_garbage_returns_empty_object(self):
-        assert _repair_tool_call_arguments("totally not json", "t") == "{}"
+        assert _repair_tool_call_arguments("totally not json", "t") is None
 
     def test_unrepairable_partial_returns_empty_object(self):
         # Truncated in the middle of a string key — bracket closing won't help
-        assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
+        assert _repair_tool_call_arguments('{"truncated": "val', "t") is None
+
+    # -- Stage 6b: new sentinel — None means "truly unrepairable" (issue #35151) --
+
+    def test_unrepairable_garbage_returns_none(self):
+        assert _repair_tool_call_arguments("totally not json", "t") is None
+
+    def test_unrepairable_partial_returns_none(self):
+        assert _repair_tool_call_arguments('{"truncated": "val', "t") is None
+
+    def test_empty_string_still_returns_empty_object(self):
+        assert _repair_tool_call_arguments("", "t") == "{}"
+
+    def test_none_type_still_returns_empty_object(self):
+        assert _repair_tool_call_arguments(None, "t") == "{}"
+
+    def test_whitespace_only_still_returns_empty_object(self):
+        assert _repair_tool_call_arguments("   \n  ", "t") == "{}"
 
     # -- Valid JSON passthrough (this path is via except, but still works) --
 
@@ -94,16 +112,18 @@ class TestRepairToolCallArguments:
 
     def test_trailing_comma_plus_unclosed_brace(self):
         result = _repair_tool_call_arguments('{"a": 1, "b": 2,', "t")
-        # Trailing comma stripped first, then closing brace added.
-        # May or may not fully recover — verify valid JSON at minimum.
-        json.loads(result)
+        # Trailing comma is stripped, then } is added -- but {a:1, b:2,}
+        # is still invalid JSON (trailing comma before }).  The current
+        # logic cannot repair this case (issue #35151).
+        assert result is None
 
     def test_real_world_glm_truncation(self):
         """Simulates GLM-5.1 truncating mid-argument."""
         raw = '{"command": "ls -la /tmp", "timeout": 30, "background":'
         result = _repair_tool_call_arguments(raw, "terminal")
-        # Should at least be valid JSON, even if background is lost
-        json.loads(result)
+        # Hanging colon before the closing brace is genuinely
+        # unrepairable by the current logic (issue #35151).
+        assert result is None
 
     # -- Stage 0: strict=False (literal control chars in strings) --
     # llama.cpp backends sometimes emit literal tabs/newlines inside JSON

--- a/tests/run_agent/test_streaming_tool_call_repair.py
+++ b/tests/run_agent/test_streaming_tool_call_repair.py
@@ -43,11 +43,11 @@ class TestStreamingAssemblyRepair:
         assert parsed["path"] == "/tmp/foo"
 
     def test_truncated_mid_value(self):
-        """Model cuts off mid-string-value."""
-        raw = '{"command": "git clone ht'
-        result = _repair_tool_call_arguments(raw, "terminal")
-        # Should produce valid JSON (even if command value is lost)
-        json.loads(result)
+            """Model cuts off mid-string-value -- genuinely unrepairable."""
+            raw = '{"command": "git clone ht'
+            result = _repair_tool_call_arguments(raw, "terminal")
+            # Truncated mid-string cannot be repaired; returns None (#35151)
+            assert result is None
 
     # -- Trailing comma cases (Ollama/GLM common) --
 
@@ -93,18 +93,15 @@ class TestStreamingAssemblyRepair:
     # -- Real-world GLM-5.1 truncation pattern --
 
     def test_glm_truncation_pattern(self):
-        """GLM-5.1 via Ollama commonly truncates like this.
+            """GLM-5.1 via Ollama commonly truncates like this.
 
-        This pattern has an unclosed colon at the end ("background":) which
-        makes it unrepairable — the last-resort empty object {} is the
-        safest option.  The important thing is that repairable patterns
-        (trailing comma, unclosed brace WITHOUT hanging colon) DO get fixed.
-        """
-        raw = '{"command": "ls -la /tmp", "timeout": 30, "background":'
-        result = _repair_tool_call_arguments(raw, "terminal")
-        # Unrepairable — returns empty object (hanging colon can't be fixed)
-        parsed = json.loads(result)
-        assert parsed == {}
+            This pattern has an unclosed colon at the end ("background":) which
+            makes it unrepairable -- returns None (issue #35151).
+            """
+            raw = '{"command": "ls -la /tmp", "timeout": 30, "background":'
+            result = _repair_tool_call_arguments(raw, "terminal")
+            # Hanging colon is genuinely unrepairable
+            assert result is None
 
     def test_glm_truncation_repairable(self):
         """GLM-5.1 truncation pattern that IS repairable."""

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -63,6 +63,9 @@ def test_truncated_arguments_replaced_with_empty_object(caplog):
         )
 
     assert repaired == 1
+    # Unrepairable args become {} (valid JSON for the API message)
+    # while the marker/stub on the tool result signals the corruption
+    # to the model (issue #35151).
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
     assert any(
         "session=session-123" in record.message
@@ -123,9 +126,11 @@ def test_multiple_corrupted_tool_calls_in_one_message():
     repaired = AIAgent._sanitize_tool_call_arguments(messages)
 
     assert repaired == 2
+    # call_1 is unrepairable -- becomes {} (valid API JSON)
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
     assert messages[0]["tool_calls"][1]["function"]["arguments"] == '{"path":"/tmp/bar"}'
-    assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{}"
+    # call_3 gets repaired by bracket-closing pass: {"mode":"tail" -> {"mode":"tail"}
+    assert messages[0]["tool_calls"][2]["function"]["arguments"] == '{"mode":"tail"}'
     assert messages[1]["tool_call_id"] == "call_1"
     assert messages[1]["content"] == marker
     assert messages[2]["tool_call_id"] == "call_3"


### PR DESCRIPTION
Fixes #35151

## Summary

This prevents unrepairable/truncated tool call arguments from being treated the same as genuinely empty arguments.

Previously, `_repair_tool_call_arguments()` returned `"{}"` both for intentionally empty arguments and for malformed arguments that could not be repaired. That made some corrupted tool calls look like valid empty-argument calls, which could lead to silent success behavior such as `write_file` retry loops.

This PR changes the repair contract so:

* empty / `None` / whitespace-only arguments still return `"{}"`
* repairable malformed arguments still return repaired JSON
* truly unrepairable arguments now return `None`

Callers then use that distinction:

* the streaming assembly path treats `None` as unrepairable/truncated and keeps the existing truncation handling path
* the before-request sanitizer still keeps the outgoing API message valid by using `"{}"`, but preserves the existing corruption marker/stub tool result so the model sees that the call was corrupted
* repairable malformed arguments are still repaired as before

This keeps the patch narrow and avoids inventing a new tool error mechanism.

## Tests

```text id="p5jtwr"
python -m pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_streaming_tool_call_repair.py -q
```

Result:

45 passed