### PR TITLE
fix(photon): install sidecar deps under hermes home

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -64,6 +64,7 @@ from gateway.platforms.base import (
 from gateway.platforms.helpers import strip_markdown
 
 from .auth import load_project_credentials
+from .sidecar_runtime import ensure_runtime_sidecar_files, get_runtime_sidecar_dir
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +83,6 @@ _MAX_MESSAGE_LENGTH = 8000
 # reconnect can replay, so keep at least 1k ids for ~48h.
 _DEDUP_MAX_SIZE = 4000
 _DEDUP_WINDOW_SECONDS = 48 * 3600
-
-_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
 # Cap on a self-heal `npm ci`/`npm install` of the sidecar deps. A cold
 # install of the pinned spectrum-ts tree normally takes well under a minute;
@@ -135,7 +134,7 @@ def check_requirements() -> bool:
         return False
     if not shutil.which(os.getenv("PHOTON_NODE_BIN") or "node"):
         return False
-    if not (_SIDECAR_DIR / "node_modules").exists():
+    if not (get_runtime_sidecar_dir() / "node_modules").exists():
         # spectrum-ts not installed yet — `hermes photon setup` will
         # install it.  check_fn still returns False so the gateway
         # surfaces the missing-deps state in `hermes setup` / status.
@@ -153,8 +152,9 @@ def _sidecar_deps_stale() -> bool:
     same signal ``npm ci`` uses. Returns False (do nothing) if either file is
     missing or unreadable, so a first-run or odd filesystem never blocks start.
     """
-    lockfile = _SIDECAR_DIR / "package-lock.json"
-    marker = _SIDECAR_DIR / "node_modules" / ".package-lock.json"
+    runtime_dir = get_runtime_sidecar_dir()
+    lockfile = runtime_dir / "package-lock.json"
+    marker = runtime_dir / "node_modules" / ".package-lock.json"
     try:
         return lockfile.stat().st_mtime > marker.stat().st_mtime
     except OSError:
@@ -174,10 +174,11 @@ def _reinstall_sidecar_deps() -> None:
     if not npm:
         logger.warning("[photon] cannot reinstall stale sidecar deps: npm not on PATH")
         return
+    runtime_dir = ensure_runtime_sidecar_files()
     try:
         result = subprocess.run(  # noqa: S603
             [npm, "ci"],
-            cwd=str(_SIDECAR_DIR),
+            cwd=str(runtime_dir),
             capture_output=True,
             text=True,
             check=False,
@@ -189,7 +190,7 @@ def _reinstall_sidecar_deps() -> None:
             )
             result = subprocess.run(  # noqa: S603
                 [npm, "install"],
-                cwd=str(_SIDECAR_DIR),
+                cwd=str(runtime_dir),
                 capture_output=True,
                 text=True,
                 check=False,
@@ -913,10 +914,11 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
     async def _start_sidecar(self) -> None:
-        if not (_SIDECAR_DIR / "node_modules").exists():
+        sidecar_dir = ensure_runtime_sidecar_files()
+        if not (sidecar_dir / "node_modules").exists():
             raise RuntimeError(
-                f"Photon sidecar deps not installed. Run: "
-                f"cd {_SIDECAR_DIR} && npm install   (or `hermes photon setup`)"
+                "Photon sidecar deps not installed. "
+                "Run `hermes photon install-sidecar` (or `hermes photon setup`)."
             )
         # A `hermes update` that bumps the spectrum-ts pin rewrites
         # package-lock.json but never reinstalls node_modules, so the sidecar
@@ -948,8 +950,8 @@ class PhotonAdapter(BasePlatformAdapter):
             patch = subprocess.run(  # noqa: S603
                 [
                     self._node_bin,
-                    str(_SIDECAR_DIR / "patch-spectrum-mixed-attachments.mjs"),
-                    str(_SIDECAR_DIR),
+                    str(sidecar_dir / "patch-spectrum-mixed-attachments.mjs"),
+                    str(sidecar_dir),
                 ],
                 capture_output=True,
                 text=True,
@@ -967,7 +969,7 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         self._sidecar_proc = subprocess.Popen(  # noqa: S603
-            [self._node_bin, str(_SIDECAR_DIR / "index.mjs")],
+            [self._node_bin, str(sidecar_dir / "index.mjs")],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -24,13 +24,11 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
 
 from hermes_cli.colors import Colors, color
 
 from . import auth as photon_auth
-
-_SIDECAR_DIR = Path(__file__).parent / "sidecar"
+from .sidecar_runtime import ensure_runtime_sidecar_files, get_runtime_sidecar_dir
 
 
 # ---------------------------------------------------------------------------
@@ -310,9 +308,11 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     # cli.py keeps zero taint flow according to CodeQL.
     photon_auth.print_credential_summary(print)
     node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node")
-    sidecar_installed = (_SIDECAR_DIR / "node_modules").exists()
+    runtime_dir = get_runtime_sidecar_dir()
+    sidecar_installed = (runtime_dir / "node_modules").exists()
     print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
     print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
+    print(f"  sidecar runtime dir : {runtime_dir}")
     print(f"  telemetry           : {'on' if _telemetry_enabled() else 'off'} (`hermes photon telemetry on|off`)")
     return 0
 
@@ -374,6 +374,7 @@ def _install_sidecar() -> int:
             file=sys.stderr,
         )
         return 1
+    runtime_dir = ensure_runtime_sidecar_files()
     # spectrum-ts is pinned exactly in package.json/package-lock.json because
     # the SDK ships breaking majors (v2 removed defineFusorPlatform; v3
     # reworked space construction; v5 split it into @spectrum-ts/* packages).
@@ -382,17 +383,17 @@ def _install_sidecar() -> int:
     # `npm ci` installs the committed lockfile verbatim; fall back to
     # `npm install` when the lockfile is missing or drifted (e.g. a dev
     # checkout mid-upgrade).
-    print(f"  $ cd {_SIDECAR_DIR} && {npm} ci")
+    print(f"  $ cd {runtime_dir} && {npm} ci")
     proc = subprocess.run(  # noqa: S603
         [npm, "ci"],
-        cwd=str(_SIDECAR_DIR),
+        cwd=str(runtime_dir),
         check=False,
     )
     if proc.returncode != 0:
         print(f"  npm ci failed — falling back to:  {npm} install")
         proc = subprocess.run(  # noqa: S603
             [npm, "install"],
-            cwd=str(_SIDECAR_DIR),
+            cwd=str(runtime_dir),
             check=False,
         )
     if proc.returncode != 0:

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -225,8 +225,8 @@ try {
 } catch (e) {
   console.error(
     "photon-sidecar: spectrum mixed attachment patch failed. " +
-      "Run `npm install` inside plugins/platforms/photon/sidecar/ or " +
-      "upgrade the Photon sidecar patch for the pinned spectrum-ts version. " +
+      "Run `hermes photon install-sidecar` or upgrade the Photon sidecar " +
+      "patch for the pinned spectrum-ts version. " +
       "Original error: " +
       (e && e.stack ? e.stack : String(e))
   );
@@ -251,8 +251,8 @@ try {
   ({ imessage } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
   console.error(
-    "photon-sidecar: spectrum-ts is not installed. Run `npm install` " +
-      "inside plugins/platforms/photon/sidecar/. Original error: " +
+    "photon-sidecar: spectrum-ts is not installed. Run `hermes photon " +
+      "install-sidecar`. Original error: " +
       (e && e.stack ? e.stack : String(e))
   );
   process.exit(3);

--- a/plugins/platforms/photon/sidecar_runtime.py
+++ b/plugins/platforms/photon/sidecar_runtime.py
@@ -1,0 +1,41 @@
+"""Helpers for the writable Photon sidecar runtime directory.
+
+The bundled plugin source tree may be installed under an immutable prefix
+(`/opt/hermes` in containers). The Node sidecar's mutable npm install state
+therefore lives under HERMES_HOME, while the committed JS entrypoints are
+mirrored from the bundled source on demand.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+_SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
+_RUNTIME_FILES = (
+    "index.mjs",
+    "package.json",
+    "package-lock.json",
+    "patch-spectrum-mixed-attachments.mjs",
+)
+
+
+def get_source_sidecar_dir() -> Path:
+    """Return the bundled, read-only Photon sidecar source directory."""
+    return _SOURCE_SIDECAR_DIR
+
+
+def get_runtime_sidecar_dir() -> Path:
+    """Return the writable sidecar directory for the active HERMES_HOME."""
+    return get_hermes_home() / "platforms" / "photon" / "sidecar"
+
+
+def ensure_runtime_sidecar_files() -> Path:
+    """Mirror the committed sidecar sources into the writable runtime dir."""
+    runtime_dir = get_runtime_sidecar_dir()
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    for name in _RUNTIME_FILES:
+        shutil.copy2(_SOURCE_SIDECAR_DIR / name, runtime_dir / name)
+    return runtime_dir

--- a/tests/plugins/platforms/photon/test_sidecar_deps_stale.py
+++ b/tests/plugins/platforms/photon/test_sidecar_deps_stale.py
@@ -31,7 +31,7 @@ def test_stale_when_lockfile_newer_than_marker(tmp_path, monkeypatch) -> None:
     """The update-rewrites-lockfile-but-skips-install case must reinstall."""
     sidecar = tmp_path / "sidecar"
     _seed(sidecar, lock_mtime=2000.0, marker_mtime=1000.0)
-    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar)
+    monkeypatch.setattr(photon_adapter, "get_runtime_sidecar_dir", lambda: sidecar)
     assert photon_adapter._sidecar_deps_stale() is True
 
 
@@ -39,7 +39,7 @@ def test_fresh_when_marker_newer_than_lockfile(tmp_path, monkeypatch) -> None:
     """A normal install (marker at/after lockfile) must NOT trigger a reinstall."""
     sidecar = tmp_path / "sidecar"
     _seed(sidecar, lock_mtime=1000.0, marker_mtime=2000.0)
-    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar)
+    monkeypatch.setattr(photon_adapter, "get_runtime_sidecar_dir", lambda: sidecar)
     assert photon_adapter._sidecar_deps_stale() is False
 
 
@@ -47,5 +47,5 @@ def test_not_stale_when_marker_missing(tmp_path, monkeypatch) -> None:
     """No marker (first run / unreadable) must fail safe to False, never block start."""
     sidecar = tmp_path / "sidecar"
     _seed(sidecar, lock_mtime=2000.0, marker_mtime=None)
-    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar)
+    monkeypatch.setattr(photon_adapter, "get_runtime_sidecar_dir", lambda: sidecar)
     assert photon_adapter._sidecar_deps_stale() is False

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -135,7 +135,7 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
 
     monkeypatch.setattr(adapter, "_reap_stale_sidecar", _no_reap)
     (tmp_path / "node_modules").mkdir()
-    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
+    monkeypatch.setattr(photon_adapter, "ensure_runtime_sidecar_files", lambda: tmp_path)
 
     spawned: Dict[str, Any] = {}
 
@@ -153,6 +153,12 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
         spawned["kwargs"] = kwargs
         return _FakeProc()
 
+    class _PatchResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", lambda *a, **k: _PatchResult())
     monkeypatch.setattr(photon_adapter.subprocess, "Popen", _fake_popen)
 
     class _HealthyClient(_ProbeClient):
@@ -167,5 +173,6 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     await adapter._start_sidecar()
 
     kwargs = spawned["kwargs"]
+    assert spawned["cmd"] == [adapter._node_bin, str(tmp_path / "index.mjs")]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"

--- a/tests/plugins/platforms/photon/test_sidecar_runtime.py
+++ b/tests/plugins/platforms/photon/test_sidecar_runtime.py
@@ -1,0 +1,60 @@
+"""Regression tests for Photon sidecar runtime placement.
+
+The bundled plugin tree can be immutable in managed installs, so Photon must
+install and run its Node sidecar from a writable HERMES_HOME mirror instead of
+writing into `/opt/hermes/plugins/.../sidecar`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugins.platforms.photon import adapter as photon_adapter
+from plugins.platforms.photon import cli
+
+
+def test_install_sidecar_uses_writable_runtime_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/fake/{Path(str(name)).name}")
+
+    calls: list[tuple[list[str], str]] = []
+
+    class _Proc:
+        returncode = 0
+
+    def _fake_run(cmd, cwd, check):  # type: ignore[no-untyped-def]
+        calls.append((list(cmd), cwd))
+        return _Proc()
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    rc = cli._install_sidecar()
+
+    runtime_dir = hermes_home / "platforms" / "photon" / "sidecar"
+    assert rc == 0
+    assert calls == [(["/fake/npm", "ci"], str(runtime_dir))]
+    assert (runtime_dir / "index.mjs").is_file()
+    assert (runtime_dir / "package.json").is_file()
+    assert (runtime_dir / "package-lock.json").is_file()
+    assert (runtime_dir / "patch-spectrum-mixed-attachments.mjs").is_file()
+
+
+def test_check_requirements_uses_runtime_node_modules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    runtime_dir = hermes_home / "platforms" / "photon" / "sidecar" / "node_modules"
+    runtime_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(photon_adapter, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(
+        photon_adapter.shutil,
+        "which",
+        lambda name: "/fake/node" if Path(str(name)).name == "node" else None,
+    )
+
+    assert photon_adapter.check_requirements() is True


### PR DESCRIPTION
## What does this PR do?

Fixes Photon setup in managed/container installs where the bundled Hermes code tree is intentionally read-only. The Photon plugin now mirrors its Node sidecar entrypoints into a writable `HERMES_HOME/platforms/photon/sidecar` runtime directory, installs `node_modules` there, and starts the sidecar from that runtime copy instead of trying to create `/opt/hermes/plugins/platforms/photon/sidecar/node_modules`.

## Related Issue

Fixes #62975

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added [`plugins/platforms/photon/sidecar_runtime.py`](https://github.com/NousResearch/hermes-agent/blob/main/plugins/platforms/photon/sidecar_runtime.py) to mirror the committed sidecar files into a writable runtime directory under `HERMES_HOME`.
- Updated [`plugins/platforms/photon/cli.py`](https://github.com/NousResearch/hermes-agent/blob/main/plugins/platforms/photon/cli.py) so `hermes photon install-sidecar` and `status` use the runtime directory instead of the bundled plugin path.
- Updated [`plugins/platforms/photon/adapter.py`](https://github.com/NousResearch/hermes-agent/blob/main/plugins/platforms/photon/adapter.py) so dependency checks, stale-lockfile reinstall, patching, and sidecar startup all run from the writable runtime copy.
- Updated the Photon sidecar error hints in [`plugins/platforms/photon/sidecar/index.mjs`](https://github.com/NousResearch/hermes-agent/blob/main/plugins/platforms/photon/sidecar/index.mjs) to point users at `hermes photon install-sidecar`.
- Added regression coverage in `tests/plugins/platforms/photon/` for runtime-dir installs, runtime `node_modules` detection, and sidecar startup from the mirrored runtime copy.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile plugins/platforms/photon/cli.py plugins/platforms/photon/adapter.py plugins/platforms/photon/sidecar_runtime.py tests/plugins/platforms/photon/test_sidecar_runtime.py tests/plugins/platforms/photon/test_sidecar_lifecycle.py tests/plugins/platforms/photon/test_sidecar_deps_stale.py`.
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/plugins/platforms/photon/test_sidecar_runtime.py tests/plugins/platforms/photon/test_sidecar_lifecycle.py tests/plugins/platforms/photon/test_sidecar_deps_stale.py tests/plugins/platforms/photon/test_setup_access.py -q`.
3. Reproduce the original container flow and confirm Photon setup installs sidecar deps under `$HERMES_HOME/platforms/photon/sidecar` instead of failing on `/opt/hermes/plugins/platforms/photon/sidecar/node_modules`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (targeted Photon regression proof)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Original failure from the issue:

```text
Error: EACCES: permission denied, mkdir '/opt/hermes/plugins/platforms/photon/sidecar/node_modules'
```

This change moves the mutable npm install target under `HERMES_HOME/platforms/photon/sidecar` so the containerized setup flow writes to the data volume instead of the immutable code bundle.
