### PR TITLE
fix(honcho): use _resolve_observer_target for user context fetch

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -733,7 +733,8 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
         try:
-            user_ctx = self._fetch_peer_context(session.user_peer_id, search_query=user_message or None, target=session.user_peer_id)
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, "user")
+            user_ctx = self._fetch_peer_context(observer_peer_id, search_query=user_message or None, target=target_peer_id or session.user_peer_id)
             result["representation"] = user_ctx["representation"]
             result["card"] = "\n".join(user_ctx["card"])
         except Exception as e:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -328,6 +328,46 @@ class TestPeerLookupHelpers:
         user_peer.context.assert_called_once_with(target=session.user_peer_id)
         ai_peer.context.assert_called_once_with(target=session.assistant_peer_id)
 
+    def test_get_prefetch_context_uses_assistant_observer_for_user_when_ai_observe_others(self):
+        """With ai_observe_others enabled, get_prefetch_context must query
+        the user context through the assistant observer, not the user peer."""
+        mgr, session = self._make_cached_manager()
+        mgr._ai_observe_others = True
+
+        assistant_peer = MagicMock()
+
+        def _assistant_context(**kwargs):
+            if kwargs.get("target") == session.user_peer_id:
+                return SimpleNamespace(
+                    representation="User via assistant",
+                    peer_card=["Name: Robert"],
+                )
+            if kwargs.get("target") == session.assistant_peer_id:
+                return SimpleNamespace(
+                    representation="AI self",
+                    peer_card=["Role: Assistant"],
+                )
+            return SimpleNamespace(representation="Unknown", peer_card=[])
+
+        assistant_peer.context.side_effect = _assistant_context
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=[assistant_peer, assistant_peer],
+        )
+
+        result = mgr.get_prefetch_context(session.key)
+
+        assert result == {
+            "representation": "User via assistant",
+            "card": "Name: Robert",
+            "ai_representation": "AI self",
+            "ai_card": "Role: Assistant",
+        }
+        assert assistant_peer.context.call_count == 2
+        assistant_peer.context.assert_any_call(
+            target=session.user_peer_id, search_query=None,
+        )
+        assistant_peer.context.assert_any_call(target=session.assistant_peer_id)
+
     def test_get_ai_representation_uses_peer_api(self):
         mgr, session = self._make_cached_manager()
         ai_peer = MagicMock()


### PR DESCRIPTION
## Problem

`_fetch_session_context` in `plugins/memory/honcho/session.py` was calling `_fetch_peer_context` with `user_peer_id` directly as the observer, bypassing `_resolve_observer_target`. This caused `honcho_context` to return empty data because the observer perspective was wrong — it used the user's own peer ID instead of the hermes (assistant) peer ID as the observer.

All other call sites (`get_peer_card`, `honcho_search`, `honcho_reasoning`, etc.) correctly use `_resolve_observer_target` to resolve the proper observer before calling `_fetch_peer_context`. This was the one missing call site.

## Fix

Line 736: Changed from passing `session.user_peer_id` directly to resolving observer via `_resolve_observer_target(session, "user")`, consistent with all other call sites.

```python
# Before:
user_ctx = self._fetch_peer_context(session.user_peer_id, ...)

# After:
observer_peer_id, target_peer_id = self._resolve_observer_target(session, "user")
user_ctx = self._fetch_peer_context(observer_peer_id, search_query=user_message or None, target=target_peer_id or session.user_peer_id)
```

## Verification

Tested with a running gateway — `honcho_context` now correctly returns summary, representation, card, and recent messages.