### PR TITLE
fix(titles): use active runtime for gateway sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1623,6 +1623,13 @@ class HermesACPAgent(acp.Agent):
                     user_text,
                     final_response,
                     state.history,
+                    main_runtime={
+                        "model": getattr(state.agent, "model", None),
+                        "provider": getattr(state.agent, "provider", None),
+                        "base_url": getattr(state.agent, "base_url", None),
+                        "api_key": getattr(state.agent, "api_key", None),
+                        "api_mode": getattr(state.agent, "api_mode", None),
+                    },
                     title_callback=_notify_title_update,
                 )
             except Exception:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1323,6 +1323,11 @@ class TestPrompt:
     async def test_prompt_auto_titles_session(self, agent):
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.model = "gpt-5.6-sol"
+        state.agent.provider = "openai-codex"
+        state.agent.base_url = "https://chatgpt.example.test/backend-api/codex"
+        state.agent.api_key = object()
+        state.agent.api_mode = "codex_responses"
         state.agent.run_conversation = MagicMock(return_value={
             "final_response": "Here is the fix.",
             "messages": [
@@ -1343,6 +1348,13 @@ class TestPrompt:
         assert mock_title.call_args.args[1] == new_resp.session_id
         assert mock_title.call_args.args[2] == "fix the broken ACP history"
         assert mock_title.call_args.args[3] == "Here is the fix."
+        assert mock_title.call_args.kwargs["main_runtime"] == {
+            "model": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.example.test/backend-api/codex",
+            "api_key": state.agent.api_key,
+            "api_mode": "codex_responses",
+        }
         assert callable(mock_title.call_args.kwargs["title_callback"])
 
     @pytest.mark.asyncio

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6194,6 +6194,12 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
     """maybe_auto_title is called after a successful (complete) prompt."""
 
     class _Agent:
+        model = "gpt-5.6-sol"
+        provider = "openai-codex"
+        base_url = "https://chatgpt.example.test/backend-api/codex"
+        api_key = object()
+        api_mode = "codex_responses"
+
         def run_conversation(
             self, prompt, conversation_history=None, stream_callback=None
         ):
@@ -6226,6 +6232,13 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
     assert args[1] == "session-key"
     assert args[2] == "Tell me about Rome"
     assert args[3] == "Rome was founded in 753 BC."
+    assert mock_title.call_args.kwargs["main_runtime"] == {
+        "model": "gpt-5.6-sol",
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.example.test/backend-api/codex",
+        "api_key": _Agent.api_key,
+        "api_mode": "codex_responses",
+    }
 
 
 def test_prompt_submit_skips_auto_title_when_interrupted(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9249,6 +9249,17 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         text,
                         raw,
                         session.get("history", []),
+                        # Keep auxiliary auto-detection aligned with the active
+                        # Desktop/Webapp session. Without this, providers that
+                        # rely on runtime auth (for example OpenAI Codex OAuth)
+                        # are skipped and the new session remains untitled.
+                        main_runtime={
+                            "model": getattr(agent, "model", None),
+                            "provider": getattr(agent, "provider", None),
+                            "base_url": getattr(agent, "base_url", None),
+                            "api_key": getattr(agent, "api_key", None),
+                            "api_mode": getattr(agent, "api_mode", None),
+                        },
                         # Push the generated title live so the sidebar renames
                         # without waiting for the next list refresh (the titler
                         # runs async, after this turn's refresh already fired).


### PR DESCRIPTION
## Summary

- pass the active agent runtime into `maybe_auto_title()` for TUI Gateway sessions
- do the same for ACP sessions so auxiliary auto-detection can reuse runtime-authenticated providers such as OpenAI Codex OAuth
- add focused regression coverage proving model, provider, endpoint, credential object, and API mode are forwarded

## Problem

Desktop/Webapp and ACP sessions could complete their first response without receiving an automatic title when the active provider depended on runtime authentication. These call sites invoked `maybe_auto_title()` without `main_runtime`, so auxiliary provider auto-detection could not reuse the active session runtime and skipped title generation.

The existing title callback and sidebar update path only run after a title is generated; they cannot compensate for the missing runtime handoff.

## Test plan

- `uv run pytest -q tests/test_tui_gateway_server.py -k 'auto_title'` — 3 passed
- `uv run pytest -q tests/acp/test_server.py -k 'auto_title'` — 2 passed
- `uv run pytest -q tests/agent/test_title_generator.py tests/gateway/test_title_command.py` — 43 passed; 2 pre-existing AsyncMock warnings in gateway title-command tests
- `python -m py_compile acp_adapter/server.py tui_gateway/server.py`
- `ruff check acp_adapter/server.py tui_gateway/server.py tests/acp/test_server.py tests/test_tui_gateway_server.py`
- `git diff --check origin/main...HEAD`
- independent security/logic review passed with no blockers

## Related / overlap checked

- #44810, by @MP329COde, previously identified the TUI runtime/callback gap. Current `main` already contains callback plumbing; this rebased patch preserves credit for that diagnosis, supplies the missing runtime handoff on current code, extends it to ACP, and adds regression tests.
- #48136 covers Desktop sidebar refresh after title generation. This patch addresses the earlier prerequisite: giving title generation the active runtime credentials so a title can be produced.

## Privacy

The patch contains no secrets, personal configuration, machine-specific paths, or generated artifacts. Commit author and committer use the contributor's GitHub noreply identity.
