### PR TITLE
fix(fallback): dedup by full provider/model/base_url identity (runtime + CLI)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1391,18 +1391,29 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         )
         return agent._try_activate_fallback(reason)
 
-    # Skip entries that resolve to the current (provider, model) — falling
-    # back to the same backend that just failed loops the failure. Compare
-    # base_url too so two distinct custom_providers entries pointing at the
-    # same shim/proxy URL also dedup. See issue #22548.
+    # Skip entries that resolve to the *same backend* that just failed —
+    # falling back to it only loops the same failure. A backend is identified
+    # by (provider, model, base_url), so provider+model matching is NOT enough
+    # on its own: the base_url must also match (or be absent from the fallback
+    # entry, in which case it inherits the provider default). Distinct base_urls
+    # that share a provider+model — e.g. a pool of LM Studio servers all serving
+    # the same model — are genuinely different endpoints and must stay live
+    # fallback targets. The second check additionally dedups two entries that
+    # point at the same shim/proxy URL under different provider labels.
+    # See issues #22548 (same-URL dedup) and the multi-server skip regression.
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     current_model = (getattr(agent, "model", "") or "").strip()
     current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
     fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
-    if fb_provider == current_provider and fb_model == current_model:
+    same_backend = (
+        fb_provider == current_provider
+        and fb_model == current_model
+        and (not fb_base_url_for_dedup or fb_base_url_for_dedup == current_base_url)
+    )
+    if same_backend:
         logger.warning(
-            "Fallback skip: chain entry %s/%s matches current provider/model",
-            fb_provider, fb_model,
+            "Fallback skip: chain entry %s/%s matches current backend (base_url %s)",
+            fb_provider, fb_model, fb_base_url_for_dedup or "<provider-default>",
         )
         return agent._try_activate_fallback(reason)
     if (

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import _entry_identity, get_fallback_chain
 
 
 # ---------------------------------------------------------------------------
@@ -184,10 +184,13 @@ def cmd_fallback_add(args) -> None:
         return
 
     # Picker picked the same thing that's already the primary → nothing changed,
-    # and there's nothing useful to add as a fallback to itself.
+    # and there's nothing useful to add as a fallback to itself.  Compare on the
+    # full (provider, model, base_url) identity — the same tuple get_fallback_chain()
+    # dedups on — so keeping the current model as primary on endpoint A while adding
+    # endpoint B (same provider+model, different base_url) as a fallback is not
+    # wrongly rejected as "same as primary".  See #54251.
     primary_entry = _extract_fallback_from_model_cfg(model_before)
-    if primary_entry and primary_entry["provider"] == new_entry["provider"] \
-            and primary_entry["model"] == new_entry["model"]:
+    if primary_entry and _entry_identity(primary_entry) == _entry_identity(new_entry):
         _restore_model_cfg(model_before)
         _restore_auth_active_provider(active_provider_before)
         print()
@@ -205,10 +208,13 @@ def cmd_fallback_add(args) -> None:
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
 
-    # Reject exact-duplicate fallback entries.
+    # Reject exact-duplicate fallback entries — matched on the chain's own
+    # (provider, model, base_url) identity so two routes that share a provider
+    # label and model name but target different base_urls are kept as separate
+    # entries.  See #54251.
+    new_identity = _entry_identity(new_entry)
     for existing in chain:
-        if existing.get("provider") == new_entry["provider"] \
-                and existing.get("model") == new_entry["model"]:
+        if _entry_identity(existing) == new_identity:
             print()
             print(f"  {_format_entry(new_entry)} is already in the fallback chain — skipped.")
             return

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -277,6 +277,105 @@ class TestAddCommand:
         out = capsys.readouterr().out
         assert "matches the current primary" in out
 
+    def test_add_allows_same_model_as_primary_different_base_url(self, isolated_home, capsys):
+        # Primary is openai/gpt-oss on endpoint A. Adding openai/gpt-oss on a
+        # DIFFERENT base_url (endpoint B) is a distinct route, so the "same as
+        # primary" guard must NOT reject it. Pre-fix it compared only
+        # (provider, model) and blocked this. See #54251.
+        _write_config(isolated_home, {
+            "model": {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostA:8000/v1",
+            },
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostB:8000/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        # Primary preserved on endpoint A; endpoint B added as a fallback.
+        assert cfg["model"]["base_url"] == "http://hostA:8000/v1"
+        assert cfg["fallback_providers"] == [
+            {"provider": "openai", "model": "gpt-oss", "base_url": "http://hostB:8000/v1"},
+        ]
+        out = capsys.readouterr().out
+        assert "Added fallback" in out
+        assert "matches the current primary" not in out
+
+    def test_add_allows_same_model_different_base_url_in_chain(self, isolated_home, capsys):
+        # A backup server sharing provider+model with an existing chain entry but
+        # a different base_url must be added, not rejected as a duplicate. See #54251.
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            "fallback_providers": [
+                {"provider": "lmstudio", "model": "qwen", "base_url": "http://10.0.0.2:1234/v1"},
+            ],
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "lmstudio",
+                "default": "qwen",
+                "base_url": "http://10.0.0.3:1234/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        base_urls = {e.get("base_url") for e in cfg["fallback_providers"]}
+        assert base_urls == {"http://10.0.0.2:1234/v1", "http://10.0.0.3:1234/v1"}
+        out = capsys.readouterr().out
+        assert "already in the fallback chain" not in out
+
+    def test_add_rejects_identical_entry_same_base_url(self, isolated_home, capsys):
+        # Negative case: an entry identical on (provider, model, base_url) to an
+        # existing chain entry is still a true duplicate and must be rejected.
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            "fallback_providers": [
+                {"provider": "lmstudio", "model": "qwen", "base_url": "http://10.0.0.2:1234/v1"},
+            ],
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "lmstudio",
+                "default": "qwen",
+                "base_url": "http://10.0.0.2:1234/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        assert len(cfg["fallback_providers"]) == 1
+        out = capsys.readouterr().out
+        assert "already in the fallback chain" in out
+
     def test_add_preserves_primary_when_picker_changes_it(self, isolated_home):
         """The picker mutates config["model"]; fallback_add must restore the primary."""
         _write_config(isolated_home, {

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -334,3 +334,45 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+    def test_does_not_skip_same_provider_model_different_base_url(self):
+        """Regression: a pool of backends sharing provider+model but with
+        distinct base_urls (e.g. several LM Studio servers running the same
+        model) are different endpoints. provider+model matching alone must
+        NOT dedup them, or every backup server gets skipped and no fallback
+        ever activates."""
+        fbs = [
+            # Backup servers: same provider+model as the (intermittent) primary,
+            # different URLs. Neither may be skipped.
+            {"provider": "lmstudio", "model": "qwen/qwen3.6-35b-a3b",
+             "base_url": "http://10.0.0.2:1234/v1"},
+            {"provider": "lmstudio", "model": "qwen/qwen3.6-35b-a3b",
+             "base_url": "http://10.0.0.3:1234/v1"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        # Currently active on the fast, intermittently-online primary server.
+        agent.provider = "lmstudio"
+        agent.model = "qwen/qwen3.6-35b-a3b"
+        agent.base_url = "http://10.0.0.1:1234/v1"
+
+        called = []
+
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            url = kwargs.get("explicit_base_url")
+            called.append((provider, model, url))
+            return _mock_client(base_url=url), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch("hermes_cli.model_normalize.normalize_model_for_provider",
+                        side_effect=lambda m, p: m):
+                # First activation: must land on the first backup server, not skip it.
+                assert agent._try_activate_fallback() is True
+                assert agent.base_url == "http://10.0.0.2:1234/v1"
+                # Second activation: advances to the next distinct server.
+                assert agent._try_activate_fallback() is True
+                assert agent.base_url == "http://10.0.0.3:1234/v1"
+
+        assert called == [
+            ("lmstudio", "qwen/qwen3.6-35b-a3b", "http://10.0.0.2:1234/v1"),
+            ("lmstudio", "qwen/qwen3.6-35b-a3b", "http://10.0.0.3:1234/v1"),
+        ], f"expected both backup servers tried in order, got: {called}"


### PR DESCRIPTION
## What does this PR do?

The fallback dedup in `try_activate_fallback()` skipped any chain entry whose `provider`+`model` matched the current backend, without comparing `base_url`. That check returned early, before the `base_url`-aware check could run — so a pool of servers sharing one provider+model (e.g. several LM Studio endpoints all serving the same model) were all treated as the current backend and skipped. No fallback ever activated when the primary went offline.

A backend is identified by `(provider, model, base_url)`. This changes the dedup to skip only when the `base_url` also matches, or when the fallback entry omits `base_url` (inheriting the provider default). Distinct `base_url`s with the same provider+model are different endpoints and stay live fallback targets. The separate same-URL/different-provider-label dedup check (#22548) is unchanged.

The same `(provider, model)`-only comparison also lived in the CLI `hermes fallback add` command, which refused to add a same-model/different-`base_url` server to the chain (and refused it as "same as the primary"). Both CLI checks now route through `fallback_config._entry_identity` — the `(provider, model, base_url)` tuple `get_fallback_chain()` already dedups on — so the config path and the runtime path agree.

## Related Issue

Fixes #54251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py` — in `try_activate_fallback()`, replaced the bare `provider+model` skip with a `same_backend` check that also compares `base_url` (treating an absent fallback `base_url` as the provider default). Updated the explanatory comment and the skip log line to include the `base_url`.
- `hermes_cli/fallback_cmd.py` — in `cmd_fallback_add()`, route the "same as primary" and chain-dedup checks through `fallback_config._entry_identity` instead of comparing `(provider, model)` only, so a same-model server on a different `base_url` is added rather than rejected.
- `tests/run_agent/test_provider_fallback.py` — added `TestFallbackChainDedup::test_does_not_skip_same_provider_model_different_base_url`, a two-server LM Studio pool that must activate both backups in order instead of skipping them.
- `tests/hermes_cli/test_fallback_cmd.py` — added three tests: same-model/different-`base_url` allowed as a fallback and as a chain addition, and an identical `(provider, model, base_url)` entry still rejected.

## How to Test

1. Configure a fallback chain where every entry shares `provider: lmstudio` and `model: qwen/qwen3.6-35b-a3b` but points at a different `base_url` (one fast primary + several always-on backups).
2. Take the primary server offline and send a request. **Before:** the log shows `Fallback skip: chain entry lmstudio/... matches current provider/model` for every backup and the request fails with no fallback. **After:** the agent activates the first reachable backup URL and the request completes.
3. On the CLI: with a primary of `provider: lmstudio` / model `qwen` on one `base_url`, run `hermes fallback add` and pick the same model on a *different* `base_url`. **Before:** rejected as "matches the current primary." **After:** added as a distinct fallback route.
4. Run the unit tests: `pytest tests/run_agent/test_provider_fallback.py::TestFallbackChainDedup tests/hermes_cli/test_fallback_cmd.py -q` — all pass, including the new multi-server and CLI cases (existing #22548 dedup tests unaffected).

## Relationship to existing PRs

This PR is intended to **supersede #54250**, which targets the same issue (#54251) across the same two locations but whose runtime fix does not take effect:

- **#54250** — its `try_activate_fallback()` change adds a "different endpoint → proceed" branch (`pass`) but leaves the pre-existing skip block in place directly below it, so that branch falls straight through and same-`provider`+`model`/different-`base_url` fallbacks are *still* skipped. Verified on its own branch (`775f539`): its added test `test_does_not_skip_entry_with_same_provider_model_but_different_base_url` **fails** (`assert False is True`), with the trailing `Fallback skip: … matches current provider/model` warning firing via the fall-through. Its CI hasn't surfaced this because the workflow is still awaiting maintainer approval. This PR fixes the runtime path with a single `same_backend` condition (confirmed by applying it to #54250's branch: that same test then passes).
- **#57584** independently fixes the CLI `hermes fallback add` path via `_entry_identity`. This PR takes the same approach for that path, so if #57584 lands first, this PR's CLI commit can be dropped and only the runtime commit is needed.
- **#54313** was an earlier attempt at the runtime fix and is now closed.

Happy to instead hand the runtime one-liner to #54250 as a review suggestion if the maintainers prefer that — flagging the overlap up front.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate <!-- overlaps #54250 / #57584 — see "Relationship to existing PRs" above; not a functional duplicate -->
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior fix; in-code comment updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure provider/model/URL string comparison, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Skip log line now records which backend matched, and no longer fires for distinct backup URLs:

```
# before — every backup skipped:
Fallback skip: chain entry lmstudio/qwen/qwen3.6-35b-a3b matches current provider/model

# after — only a true same-backend match skips (base_url shown):
Fallback skip: chain entry lmstudio/qwen/qwen3.6-35b-a3b matches current backend (base_url http://10.0.0.1:1234/v1)
```

```
$ pytest tests/run_agent/test_provider_fallback.py::TestFallbackChainDedup tests/hermes_cli/test_fallback_cmd.py -q
.......................................                                  [100%]
39 passed
```
