### PR TITLE
fix(cli): wire Anthropic model picker to live /v1/models discovery

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2845,7 +2845,7 @@ def _model_flow_anthropic(config, current_model=""):
         save_config,
         save_anthropic_api_key,
     )
-    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.models import provider_model_ids
 
     # Check ALL credential sources
     from hermes_cli.auth import get_anthropic_key
@@ -2947,7 +2947,7 @@ def _model_flow_anthropic(config, current_model=""):
     print()
 
     # Model selection
-    model_list = _PROVIDER_MODELS.get("anthropic", [])
+    model_list = provider_model_ids("anthropic")
     if model_list:
         selected = _prompt_model_selection(
             model_list,

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2845,7 +2845,7 @@ def _model_flow_anthropic(config, current_model=""):
         save_config,
         save_anthropic_api_key,
     )
-    from hermes_cli.models import provider_model_ids
+    from hermes_cli.models import cached_provider_model_ids
 
     # Check ALL credential sources
     from hermes_cli.auth import get_anthropic_key
@@ -2947,7 +2947,7 @@ def _model_flow_anthropic(config, current_model=""):
     print()
 
     # Model selection
-    model_list = provider_model_ids("anthropic")
+    model_list = cached_provider_model_ids("anthropic")
     if model_list:
         selected = _prompt_model_selection(
             model_list,

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -8,6 +8,7 @@ import pytest
 
 from hermes_cli.auth import AuthError
 from hermes_cli import main as hermes_main
+from hermes_cli import models as M
 
 
 # ---------------------------------------------------------------------------
@@ -469,6 +470,58 @@ def test_model_flow_anthropic_clears_stale_custom_key_and_mode(tmp_path, monkeyp
     assert "api_key" not in model
     assert "api" not in model
     assert "api_mode" not in model
+
+
+def test_model_flow_anthropic_passes_live_discovery_list_to_picker(tmp_path, monkeypatch):
+    """Regression for PR #62986 review: _model_flow_anthropic() must forward
+    provider_model_ids("anthropic")'s result to _prompt_model_selection() rather
+    than reading the static _PROVIDER_MODELS list directly. Patches
+    provider_model_ids() with a live-only sentinel absent from the static
+    catalog and asserts the picker receives exactly that list.
+    """
+    config_path = _seed_stale_custom_model(tmp_path, monkeypatch)
+
+    monkeypatch.setattr("hermes_cli.auth.get_anthropic_key", lambda: "sk-ant-api03-test")
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.is_claude_code_token_valid",
+        lambda creds: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_setup_flows._prompt_auth_credentials_choice",
+        lambda title: "use",
+    )
+
+    live_only_sentinel = "claude-live-only-sentinel-9999"
+    assert live_only_sentinel not in M._PROVIDER_MODELS["anthropic"]
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider, **kwargs: [live_only_sentinel],
+    )
+
+    received = {}
+
+    def _fake_prompt_model_selection(model_list, **kwargs):
+        received["model_list"] = model_list
+        return live_only_sentinel
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        _fake_prompt_model_selection,
+    )
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    hermes_main._model_flow_anthropic({}, current_model="glm-5.2")
+
+    assert received["model_list"] == [live_only_sentinel]
+
+    import yaml
+
+    config = yaml.safe_load(config_path.read_text()) or {}
+    assert config["model"]["default"] == live_only_sentinel
 
 
 def test_model_flow_nous_offers_tool_gateway_prompt_when_unconfigured(monkeypatch, capsys):

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -520,7 +520,10 @@ def test_model_flow_anthropic_passes_live_discovery_list_to_picker(tmp_path, mon
 
     import yaml
 
-    config = yaml.safe_load(config_path.read_text()) or {}
+    # save_config() writes UTF-8 (template comments include non-ASCII box
+    # drawing); pin the read encoding so the assertion also passes on
+    # Windows locales like cp949.
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     assert config["model"]["default"] == live_only_sentinel
 
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -474,10 +474,10 @@ def test_model_flow_anthropic_clears_stale_custom_key_and_mode(tmp_path, monkeyp
 
 def test_model_flow_anthropic_passes_live_discovery_list_to_picker(tmp_path, monkeypatch):
     """Regression for PR #62986 review: _model_flow_anthropic() must forward
-    provider_model_ids("anthropic")'s result to _prompt_model_selection() rather
-    than reading the static _PROVIDER_MODELS list directly. Patches
-    provider_model_ids() with a live-only sentinel absent from the static
-    catalog and asserts the picker receives exactly that list.
+    cached_provider_model_ids("anthropic")'s result to _prompt_model_selection()
+    rather than reading the static _PROVIDER_MODELS list directly. Patches the
+    resolver with a live-only sentinel absent from the static catalog and
+    asserts the picker receives exactly that list.
     """
     config_path = _seed_stale_custom_model(tmp_path, monkeypatch)
 
@@ -498,7 +498,7 @@ def test_model_flow_anthropic_passes_live_discovery_list_to_picker(tmp_path, mon
     live_only_sentinel = "claude-live-only-sentinel-9999"
     assert live_only_sentinel not in M._PROVIDER_MODELS["anthropic"]
     monkeypatch.setattr(
-        "hermes_cli.models.provider_model_ids",
+        "hermes_cli.models.cached_provider_model_ids",
         lambda provider, **kwargs: [live_only_sentinel],
     )
 


### PR DESCRIPTION
## What does this PR do?

Wires the Anthropic model picker (`hermes model` / `hermes fallback add`) to the shared model resolver, so newly released Claude models appear without a Hermes release.

`_model_flow_anthropic()` in `hermes_cli/model_setup_flows.py` reads the static `_PROVIDER_MODELS["anthropic"]` list directly, bypassing the resolver that every other model-switch path already uses.

The fix is small because **everything needed already exists** in `cached_provider_model_ids("anthropic")` → `provider_model_ids("anthropic")` (`hermes_cli/models.py`):

- live `/v1/models` fetch via `_fetch_anthropic_models()`
- curated-first merge, so newly-routed curated aliases stay visible even while the live endpoint lags
- fallback to the **same** static `_PROVIDER_MODELS["anthropic"]` list when the live fetch fails or no credentials are configured
- credential-fingerprinted TTL cache that `hermes model --refresh` invalidates explicitly

**When the live fetch is unavailable, behavior is identical to today** — so there is no regression surface.

### Why this keeps mattering

Manual static-list updates keep falling behind. `07f39cf` added `claude-sonnet-5` to the curated Anthropic list, which closed #55846 — but the live Anthropic catalog now serves **`claude-opus-5`**, which the static list again omits. Every new Claude release repeats this cycle until the picker resolves the catalog rather than a hardcoded list.

## Related Issue

Related to #55846 (now closed by the static-list update in `07f39cf`). This PR addresses the recurrence path rather than the individual model, so future releases don't need a manual list edit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_setup_flows.py` — inside `_model_flow_anthropic()`:
  - import: `_PROVIDER_MODELS` → `cached_provider_model_ids`
  - model selection: `_PROVIDER_MODELS.get("anthropic", [])` → `cached_provider_model_ids("anthropic")`
- `tests/cli/test_cli_provider_resolution.py` — new flow-level regression test `test_model_flow_anthropic_passes_live_discovery_list_to_picker`

Per review feedback, the picker calls `cached_provider_model_ids()` (not `provider_model_ids()` directly) to match `hermes_cli/model_switch.py` and avoid a live catalog request each time `hermes fallback add` reuses this flow.

## How to Test

1. `python -m pytest tests/cli/test_cli_provider_resolution.py -q` — 24 passed
2. Regression check: revert only the source change and keep the new test — `test_model_flow_anthropic_passes_live_discovery_list_to_picker` is the sole failure, confirming it pins the wiring
3. Live path: with Anthropic credentials configured, `hermes model` → Anthropic lists the live catalog (13 models locally, including `claude-opus-5`), curated entries first
4. Fallback path: with no credentials / live fetch failing, the picker shows exactly the curated static list — identical to current behavior

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the static-list PRs patch catalogs; none wire the picker to the resolver
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suites covering this flow — `tests/cli/test_cli_provider_resolution.py` (24), plus `tests/hermes_cli/test_anthropic_picker_curated.py`, `test_anthropic_model_flow_stale_oauth.py`, `test_anthropic_provider_persistence.py`, `test_model_provider_persistence.py`
- [x] I've added tests for my changes — flow-level regression test, verified to fail against the pre-fix wiring
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs describe the static-only picker behavior)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — no platform-specific code; the test pins `encoding="utf-8"` on its config read for Windows locales
- [x] I've updated tool descriptions/schemas — N/A
