### PR TITLE
fix(desktop): widen preview and review panes

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview.tsx
@@ -36,7 +36,7 @@ import { $dirtyPreviewUrls } from '@/store/preview-edit'
 import { PreviewPane } from './preview-pane'
 
 export const PREVIEW_RAIL_MIN_WIDTH = '18rem'
-export const PREVIEW_RAIL_MAX_WIDTH = '38rem'
+export const PREVIEW_RAIL_MAX_WIDTH = '76rem'
 
 const INTRINSIC = `clamp(${PREVIEW_RAIL_MIN_WIDTH}, 36vw, 32rem)`
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -30,6 +30,7 @@ import {
   FILE_BROWSER_MIN_WIDTH,
   pinSession,
   PREVIEW_PANE_ID,
+  REVIEW_PANE_MAX_WIDTH,
   restoreWorktree,
   setSidebarOverlayMounted,
   SIDEBAR_DEFAULT_WIDTH,
@@ -1239,7 +1240,7 @@ export function DesktopController() {
       hoverReveal
       id={REVIEW_PANE_ID}
       key="review"
-      maxWidth={FILE_BROWSER_MAX_WIDTH}
+      maxWidth={REVIEW_PANE_MAX_WIDTH}
       minWidth={FILE_BROWSER_MIN_WIDTH}
       // Mobile overlay sits at its min width — compact, doesn't bury the chat.
       overlayWidth={FILE_BROWSER_MIN_WIDTH}

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -13,6 +13,7 @@ export const SIDEBAR_MAX_WIDTH = 360
 export const FILE_BROWSER_DEFAULT_WIDTH = `${SIDEBAR_DEFAULT_WIDTH}px`
 export const FILE_BROWSER_MIN_WIDTH = '10rem'
 export const FILE_BROWSER_MAX_WIDTH = '20rem'
+export const REVIEW_PANE_MAX_WIDTH = '76rem'
 
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 


### PR DESCRIPTION
## Summary
- Double the maximum resizable width of the file preview/editor rail (38rem → 76rem).
- Raise the maximum resizable width of the Git review pane to 76rem.
- Leave the project file browser and all resize behavior unchanged.

## Verification
- `npm run test:ui -- src/app/right-sidebar/review/tree-data.test.ts`
- `npm run typecheck`
- `npm run build`