### PR TITLE
fix(desktop): extend task-finished linger time for readability

### DIFF
--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -42,8 +42,8 @@ const dismissedBySession = new Map<string, Set<string>>()
 // Finished tasks self-clear so the stack only ever holds running work. Success
 // goes quick; failure lingers longer so its exit code stays readable (the output
 // also lives in the transcript). A manual X still drops either at once.
-const SUCCESS_LINGER_MS = 4_000
-const FAILURE_LINGER_MS = 12_000
+const SUCCESS_LINGER_MS = 30_000
+const FAILURE_LINGER_MS = 60_000
 const autoClearTimers = new Map<string, Map<string, ReturnType<typeof setTimeout>>>()
 
 function scheduleAutoDismiss(sid: string, id: string, delayMs: number) {

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -30,7 +30,7 @@ export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[]
 // Once a list finishes (every item completed/cancelled), the final state
 // lingers just long enough to see the last checkmark land, then the group
 // drops out of the stack on its own.
-const FINISHED_LINGER_MS = 4_000
+const FINISHED_LINGER_MS = 30_000
 const clearTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 function cancelScheduledClear(sid: string) {


### PR DESCRIPTION
## Why
User reported that the desktop composer-status stack cleared completed tasks too
quickly to read the final state. Specifically:
- `FINISHED_LINGER_MS` 4s — too fast to see "all todos completed" before vanish
- `SUCCESS_LINGER_MS` 4s — same problem for background processes
- `FAILURE_LINGER_MS` 12s — too short to copy exit code from a failed run

## What changed

```diff
# apps/desktop/src/store/todos.ts
-const FINISHED_LINGER_MS = 4_000
+const FINISHED_LINGER_MS = 30_000

# apps/desktop/src/store/composer-status.ts
-const SUCCESS_LINGER_MS = 4_000
-const FAILURE_LINGER_MS = 12_000
+const SUCCESS_LINGER_MS = 30_000
+const FAILURE_LINGER_MS = 60_000
```

## What did NOT change
- Manual X-dismiss path (bypasses these timers)
- Other linger constants in the codebase
- Behavior contracts, persistence, or restoration logic