### PR TITLE
fix(gateway): prune stale platform records on gateway restart

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -810,6 +810,16 @@ def write_runtime_status(
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    if (payload.get("pid"), payload.get("start_time")) != (
+        current_record["pid"],
+        current_record["start_time"],
+    ):
+        # New writer process (restart, or PID reuse caught by start_time):
+        # drop carried per-platform records instead of merging them forward.
+        # A platform this process manages re-registers on its first write;
+        # one it never touches would otherwise survive indefinitely as a
+        # fossil frozen at its pre-restart ``updated_at``.
+        payload["platforms"] = {}
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
@@ -839,6 +849,10 @@ def write_runtime_status(
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
+        # Writer-identity stamp (same value as the top-level ``start_time``):
+        # a record whose stamp differs from the live process is provably a
+        # fossil, so readers don't have to infer staleness from timestamps.
+        platform_payload["start_time"] = current_record["start_time"]
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -669,6 +669,121 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_write_runtime_status_prunes_platform_fossils_on_restart(self, tmp_path, monkeypatch):
+        """A new gateway process must not carry forward per-platform records
+        left by a previous process: a platform the new process never touches
+        would otherwise survive as a fossil frozen at its pre-restart
+        timestamp (e.g. a retired ``slack`` stuck ``connected`` for months)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000,
+            "kind": "hermes-gateway",
+            "platforms": {
+                "telegram": {"state": "connected", "updated_at": "2025-01-01T00:00:00Z"},
+                "slack": {"state": "connected", "updated_at": "2025-01-01T00:00:00Z"},
+            },
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(
+            gateway_state="running", platform="telegram", platform_state="connected"
+        )
+
+        payload = status.read_runtime_status()
+        assert "slack" not in payload["platforms"], "fossil record must be pruned on restart"
+        assert payload["platforms"]["telegram"]["state"] == "connected"
+        assert payload["platforms"]["telegram"]["start_time"] == 2000
+
+    def test_write_runtime_status_restart_startup_write_prunes_platforms(self, tmp_path, monkeypatch):
+        """The first write of a new process (``gateway_state="starting"``, no
+        platform argument) already drops carried platform records."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000,
+            "kind": "hermes-gateway",
+            "platforms": {
+                "slack": {"state": "connected", "updated_at": "2025-01-01T00:00:00Z"},
+            },
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(gateway_state="starting")
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"] == {}
+
+    def test_write_runtime_status_stamps_platform_with_writer_start_time(self, tmp_path, monkeypatch):
+        """Every platform write carries the writer's ``start_time`` so a reader
+        can tell a record written by the live process from a fossil."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(
+            gateway_state="running", platform="discord", platform_state="connected"
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["discord"]["start_time"] == 2000
+        assert payload["platforms"]["discord"]["start_time"] == payload["start_time"]
+
+    def test_write_runtime_status_foreign_platform_stamp_is_identifiable(self, tmp_path, monkeypatch):
+        """A hand-planted platform record stamped by another process stays
+        distinguishable from the live writer's records: same-process writes
+        never rewrite other platforms' stamps."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": 2000,
+            "kind": "hermes-gateway",
+            "platforms": {
+                "slack": {
+                    "state": "connected",
+                    "start_time": 1000,
+                    "updated_at": "2025-01-01T00:00:00Z",
+                },
+            },
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        status.write_runtime_status(platform="telegram", platform_state="connected")
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["telegram"]["start_time"] == payload["start_time"]
+        assert payload["platforms"]["slack"]["start_time"] != payload["start_time"]
+
+    def test_write_runtime_status_keeps_platforms_across_same_process_writes(self, tmp_path, monkeypatch):
+        """Regression guard for the prune: a single continuous process keeps
+        every managed platform's record across repeated writes."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(
+            gateway_state="running", platform="telegram", platform_state="connected"
+        )
+        status.write_runtime_status(platform="discord", platform_state="connected")
+        first_telegram_updated = (
+            status.read_runtime_status()["platforms"]["telegram"]["updated_at"]
+        )
+        status.write_runtime_status(platform="telegram", platform_state="disconnected")
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["telegram"]["state"] == "disconnected"
+        assert payload["platforms"]["discord"]["state"] == "connected"
+        assert payload["platforms"]["telegram"]["updated_at"] >= first_telegram_updated
+
 
 class TestGetProcessStartTime:
     """Start-time fingerprint backing the PID-reuse guard (#43846 / #50468).


### PR DESCRIPTION
## Problem

`write_runtime_status` merges the on-disk `gateway_state.json` payload forward on every write, so per-platform records written by a **previous** gateway process survive restarts indefinitely. A platform the new process never manages (retired integration, changed config) becomes a fossil frozen at its pre-restart state — e.g. a long-removed platform still reading `connected` months later — and status readers cannot distinguish it from a live record.

## Fix

Two changes in `gateway/status.py::write_runtime_status`:

1. **Prune on writer change.** Before the top-level fields are overwritten, compare the on-disk `(pid, start_time)` identity against the live process — the same identity pair the top-level record already relies on (`_get_process_start_time` is the existing PID-reuse guard). On mismatch, drop the carried `platforms` dict. Platforms managed by the new process re-register on their first write. Comparing the pair rather than `start_time` alone means a host where `_get_process_start_time` degrades to `None` still prunes on a PID change instead of treating `None == None` as same-process.

2. **Stamp writer identity per platform.** Every per-platform write records the writer's `start_time` next to the existing `updated_at`. A reader can now compare a platform record's stamp against the top-level `start_time` and *prove* it a fossil, instead of inferring staleness from timestamps.

Same-process behavior is unchanged: a continuous gateway keeps every managed platform's record across repeated writes (regression-tested), and same-process writes never rewrite other platforms' stamps.

## Tests

Five new tests appended to `TestGatewayRuntimeStatus` in `tests/gateway/test_status.py`, mirroring its existing conventions (HERMES_HOME tmp_path, hand-seeded state files, `_get_process_start_time` monkeypatch): restart prunes fossils while the touched platform re-registers; the real startup write path (`gateway_state="starting"`, no platform) prunes; the stamp equals the top-level `start_time`; a foreign-stamped record stays identifiable; continuous-process writes keep all platform records.

`tests/gateway/test_status.py` — 99 passed (94 pre-existing + 5 new), also green under `scripts/run_tests.sh`. Wider sweep: `tests/gateway` + zombie-cleanup + container-restart suites — 9090 passed, 1 failed (`test_media_files_routed_by_type`, a macOS `/var` vs `/private/var` tempdir assertion — fails identically at the base commit with this change stashed, i.e. pre-existing). `ruff check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
