### PR TITLE
fix(desktop): send first prompt after session creation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1333,6 +1333,64 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     vi.restoreAllMocks()
   })
 
+  it('sends the first prompt after the expected new-session route transition', async () => {
+    // Creating the backend session is part of this submit. It intentionally
+    // changes both refs and navigates / -> /<stored-id>; that transition must
+    // become the pinned context, not be mistaken for a user switching chats.
+    const createdRuntimeId = 'rt-new-session'
+    const createdStoredId = 'stored-new-session'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let sessionCreated = false
+    let routeReadsAfterCreate = 0
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeId
+      selectedStoredSessionIdRef.current = createdStoredId
+      sessionCreated = true
+
+      return createdRuntimeId
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => {
+          if (!sessionCreated) {
+            return '/::'
+          }
+
+          routeReadsAfterCreate += 1
+
+          // React Router can still expose / to the outer submit continuation,
+          // then commit the created-session route before the next await settles.
+          return routeReadsAfterCreate === 1 ? '/::' : `/${createdStoredId}::`
+        }}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    expect(await handle!.submitText('hello')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: createdRuntimeId,
+        text: 'hello'
+      },
+      1_800_000
+    )
+  })
+
   it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {
     // Exact #54527 failure: user submits in Session A while its runtime binding
     // is gone; before resume returns they switch to Session B. Without a pinned

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -15,6 +15,7 @@ import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 
+import { sessionRoute } from '../../../routes'
 import type { ClientSessionState } from '../../../types'
 
 import {
@@ -119,12 +120,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
       const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
+      let startingStoredSessionId = selectedStoredSessionIdRef.current
+      let pinnedRouteTokens = new Set([getRouteToken()])
 
       const sessionContextDrifted = (): boolean =>
         selectedStoredSessionIdRef.current !== startingStoredSessionId ||
-        getRouteToken() !== startingRouteToken
+        !pinnedRouteTokens.has(getRouteToken())
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
@@ -281,16 +282,30 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        if (sessionContextDrifted()) {
-          return abortForSessionSwitch(sessionId)
-        }
-
         if (!sessionId) {
           dropOptimistic(null)
           releaseBusy()
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
 
           return false
+        }
+
+        // A successful first send intentionally changes the selected stored
+        // session and route: createBackendSessionForSend creates the runtime,
+        // seeds the sidebar row, and navigates / -> /<stored-id>. It already
+        // guards its own await against a real user switch, so adopt that newly
+        // created session as the pinned context for the rest of this submit.
+        // Without this rebase, sessionContextDrifted treats the expected create
+        // navigation as a switch, aborts before prompt.submit, and restores the
+        // first message to the composer while leaving a blank titled session.
+        startingStoredSessionId = selectedStoredSessionIdRef.current
+        pinnedRouteTokens = new Set([getRouteToken()])
+
+        if (startingStoredSessionId) {
+          // React Router may commit the navigation after this async continuation
+          // resumes. Accept both the route visible right now (often /) and
+          // the deterministic target createBackendSessionForSend requested.
+          pinnedRouteTokens.add(`${sessionRoute(startingStoredSessionId)}::`)
         }
 
         seedOptimistic(sessionId)


### PR DESCRIPTION
## What does this PR do?

Fixes a Hermes Desktop regression where the first message in a newly created chat was not submitted.

The prompt-submit pipeline pinned the selected stored session and route before creating the backend session. Successful creation intentionally changes both values and navigates from the new-chat route (`/`) to the stored-session route. The outer context-drift guard treated that authorized transition as a user switching chats, aborted before `prompt.submit`, and returned `false`; the composer then restored the draft while leaving a blank session titled from the first prompt.

This change adopts the created session as the pinned submit context while continuing to reject genuine session switches. It accepts both the currently rendered new-chat route and the deterministic created-session route because React Router may commit after the async continuation resumes.

## Related Issue

No linked issue. This was reproduced from a user-reported Hermes Desktop failure on current `main`. Searches of open and merged issues/PRs found no duplicate for the symptom or submit path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts`
  - rebase the pinned stored-session context after successful session creation
  - permit the expected `/` → `/<stored-session-id>` transition, including a delayed router commit
  - preserve the existing session-switch isolation guard for actual context changes
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`
  - add regression coverage for the first-message path and delayed route transition

## How to Test

1. Launch Hermes Desktop and choose **New session**.
2. Type `hello` and press Enter.
3. Verify the first user message appears and `prompt.submit` is sent. Before this fix, Hermes created a blank session titled `hello` and restored `hello` to the composer.
4. Run:
   ```bash
   cd apps/desktop
   npx vitest run --environment jsdom \
     src/app/session/hooks/use-prompt-actions/index.test.tsx \
     src/app/chat/composer/enter-submit-dom-race.test.tsx
   npm run typecheck
   npm run build
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Python `pytest` is N/A for this frontend-only change; the affected desktop Vitest suite, TypeScript checks, and production build pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Apple Silicon (`arm64`)

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; this corrects existing runtime behavior without changing the public interface
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact: the change is renderer/session state logic with no platform-specific APIs; manual verification was on macOS
- [x] Tool description/schema updates are N/A; no model tools changed

## Screenshots / Logs

Manual before/after verification:

- Before: first Enter created a blank session titled from the prompt and restored the prompt to the composer.
- After: the first prompt is submitted normally in the newly created session.

Validation completed:

- targeted desktop tests: **48 passed**
- desktop TypeScript typecheck: **passed**
- targeted ESLint: **no errors** (one pre-existing warning outside the added test)
- production desktop build/package: **passed**
- macOS code-sign verification: **passed**
