### PR TITLE
fix(browser): add compositor-level coordinate click to browser_click (fixes React onChange/onClick)

### DIFF
--- a/tests/tools/test_browser_coordinate_click.py
+++ b/tests/tools/test_browser_coordinate_click.py
@@ -1,0 +1,560 @@
+"""Tests for compositor-level coordinate click (browser_click with x/y params).
+
+Covers:
+- Input validation (ref vs x/y mutually exclusive)
+- CDP coordinate click path (via mock CDP server)
+- agent-browser mouse fallback path
+- Camofox passthrough still works with ref
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any, Dict, List
+import pytest
+
+import websockets
+from websockets.asyncio.server import serve
+
+
+# ---------------------------------------------------------------------------
+# In-process CDP mock server (reused from test_browser_cdp_tool.py)
+# ---------------------------------------------------------------------------
+
+
+class _CDPServer:
+    """Tiny CDP mock — replies to registered method handlers."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, Any] = {}
+        self._responses: List[Dict[str, Any]] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._server: Any = None
+        self._thread: threading.Thread | None = None
+        self._host = "127.0.0.1"
+        self._port = 0
+        self._url: str = ""
+
+    def on(self, method: str, handler):
+        self._handlers[method] = handler
+
+    def start(self) -> str:
+        ready = threading.Event()
+
+        def _run() -> None:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+
+            async def _handler(ws):
+                try:
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        call_id = msg.get("id")
+                        method = msg.get("method", "")
+                        params = msg.get("params", {}) or {}
+                        session_id = msg.get("sessionId")
+                        self._responses.append(msg)
+
+                        fn = self._handlers.get(method)
+                        if fn is None:
+                            reply = {
+                                "id": call_id,
+                                "error": {"code": -32601, "message": f"No handler for {method}"},
+                            }
+                        else:
+                            try:
+                                result = fn(params, session_id)
+                                reply = {"id": call_id, "result": result}
+                            except Exception as exc:
+                                reply = {"id": call_id, "error": {"code": -1, "message": str(exc)}}
+                        if session_id:
+                            reply["sessionId"] = session_id
+                        await ws.send(json.dumps(reply))
+                except websockets.exceptions.ConnectionClosed:
+                    pass
+
+            async def _serve() -> None:
+                self._server = await serve(_handler, self._host, 0)
+                sock = next(iter(self._server.sockets))
+                self._port = sock.getsockname()[1]
+                ready.set()
+                await self._server.wait_closed()
+
+            try:
+                self._loop.run_until_complete(_serve())
+            finally:
+                self._loop.close()
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+        if not ready.wait(timeout=5.0):
+            raise RuntimeError("CDP mock server failed to start")
+        self._url = f"ws://{self._host}:{self._port}/devtools/browser/mock"
+        return self._url
+
+    def stop(self) -> None:
+        if self._loop and self._server:
+            self._loop.call_soon_threadsafe(self._server.close)
+        if self._thread:
+            self._thread.join(timeout=3.0)
+
+    def received(self) -> List[Dict[str, Any]]:
+        return list(self._responses)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cdp_server(monkeypatch):
+    """Start a CDP mock and point browser_cdp_tool's resolver at it."""
+    server = _CDPServer()
+    ws_url = server.start()
+
+    import tools.browser_cdp_tool as cdp_mod
+    monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: ws_url)
+
+    # clear the session cache so each test starts fresh
+    from tools import browser_tool as _bt
+    _bt._CDP_SESSION_CACHE.clear()
+
+    try:
+        yield server
+    finally:
+        _bt._CDP_SESSION_CACHE.clear()
+        server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestClickInputValidation:
+    """browser_click validates that exactly one of ref / (x,y) is provided."""
+
+    def test_neither_ref_nor_coords(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click())
+        assert result["success"] is False
+        assert "ref" in result["error"].lower() or "x" in result["error"].lower()
+
+    def test_both_ref_and_coords(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click(ref="@e1", x=100, y=200))
+        assert result["success"] is False
+        assert "not both" in result["error"].lower()
+
+    def test_x_without_y(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click(x=100))
+        assert result["success"] is False
+        assert "both" in result["error"].lower()
+
+    def test_y_without_x(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click(y=200))
+        assert result["success"] is False
+        assert "both" in result["error"].lower()
+
+    def test_empty_ref_treated_as_missing(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click(ref=""))
+        assert result["success"] is False
+        assert "ref" in result["error"].lower() or "x" in result["error"].lower()
+
+    def test_non_numeric_coordinates(self):
+        from tools.browser_tool import browser_click
+
+        result = json.loads(browser_click(x="abc", y="def"))
+        assert result["success"] is False
+        assert "number" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# CDP coordinate click (happy path via mock server)
+# ---------------------------------------------------------------------------
+
+
+class TestCDPCoordinateClick:
+    """Coordinate clicks via CDP Input.dispatchMouseEvent."""
+
+    def test_cdp_click_dispatches_press_and_release(self, cdp_server):
+        from tools.browser_tool import browser_click
+
+        # Register handlers for the protocol calls
+        cdp_server.on(
+            "Target.getTargets",
+            lambda p, s: {
+                "targetInfos": [
+                    {"targetId": "page-1", "type": "page", "attached": True, "url": "https://example.com"},
+                ]
+            },
+        )
+        cdp_server.on(
+            "Target.attachToTarget",
+            lambda p, s: {"sessionId": f"sess-{p['targetId']}"},
+        )
+        cdp_server.on(
+            "Input.dispatchMouseEvent",
+            lambda p, s: {},
+        )
+
+        result = json.loads(browser_click(x=150, y=300))
+        assert result["success"] is True
+        assert result["clicked_at"] == {"x": 150, "y": 300}
+        assert result["method"] == "cdp_compositor"
+
+        # Verify the CDP calls: Target.getTargets, attach, mousePressed, attach, mouseReleased
+        calls = cdp_server.received()
+        methods = [c["method"] for c in calls]
+        assert "Target.getTargets" in methods
+        assert "Input.dispatchMouseEvent" in methods
+
+        # Find the mouse events
+        mouse_events = [c for c in calls if c["method"] == "Input.dispatchMouseEvent"]
+        assert len(mouse_events) == 2
+        assert mouse_events[0]["params"]["type"] == "mousePressed"
+        assert mouse_events[0]["params"]["x"] == 150
+        assert mouse_events[0]["params"]["y"] == 300
+        assert mouse_events[0]["params"]["button"] == "left"
+        assert mouse_events[1]["params"]["type"] == "mouseReleased"
+
+    def test_cdp_click_rounds_float_coordinates(self, cdp_server):
+        from tools.browser_tool import browser_click
+
+        cdp_server.on(
+            "Target.getTargets",
+            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
+        )
+        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
+        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+
+        result = json.loads(browser_click(x=150.7, y=299.3))
+        assert result["success"] is True
+        assert result["clicked_at"] == {"x": 151, "y": 299}
+
+    def test_cdp_click_no_page_target_still_works(self, cdp_server):
+        """When Target.getTargets returns no page targets, click proceeds without target_id."""
+        from tools.browser_tool import browser_click
+
+        cdp_server.on(
+            "Target.getTargets",
+            lambda p, s: {"targetInfos": [{"targetId": "sw1", "type": "service_worker"}]},
+        )
+        # No Target.attachToTarget needed — page_target is None so _cdp_call
+        # sends without attaching
+        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+
+        result = json.loads(browser_click(x=50, y=50))
+        assert result["success"] is True
+        assert result["clicked_at"] == {"x": 50, "y": 50}
+
+    def test_cdp_dispatch_mouse_event_failure(self, cdp_server):
+        """When Input.dispatchMouseEvent returns a CDP error, return failure."""
+        from tools.browser_tool import browser_click
+
+        cdp_server.on(
+            "Target.getTargets",
+            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
+        )
+        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
+        # No handler for Input.dispatchMouseEvent — server returns CDP error
+
+        result = json.loads(browser_click(x=100, y=200))
+        assert result["success"] is False
+        assert "CDP coordinate click failed" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# agent-browser mouse fallback
+# ---------------------------------------------------------------------------
+
+
+class TestAgentBrowserMouseFallback:
+    """When no CDP endpoint is available, fall back to agent-browser mouse commands."""
+
+    def test_falls_back_to_agent_browser_mouse(self, monkeypatch):
+        from tools import browser_tool, browser_cdp_tool
+
+        # No CDP endpoint available
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+
+        # Mock _run_browser_command and _last_session_key
+        commands_sent = []
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            commands_sent.append((command, args))
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        result = json.loads(browser_tool.browser_click(x=200, y=400))
+        assert result["success"] is True
+        assert result["clicked_at"] == {"x": 200, "y": 400}
+        assert result["method"] == "agent_browser_mouse"
+
+        # Should have sent: mouse move, mouse down, mouse up
+        assert len(commands_sent) == 3
+        assert commands_sent[0] == ("mouse", ["move", "200", "400"])
+        assert commands_sent[1] == ("mouse", ["down"])
+        assert commands_sent[2] == ("mouse", ["up"])
+
+    def test_mouse_move_failure_returns_error(self, monkeypatch):
+        from tools import browser_tool, browser_cdp_tool
+
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            if args and args[0] == "move":
+                return {"success": False, "error": "mouse move not supported"}
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        result = json.loads(browser_tool.browser_click(x=100, y=100))
+        assert result["success"] is False
+        assert "mouse move" in result["error"]
+
+    def test_mouse_down_failure_returns_error(self, monkeypatch):
+        from tools import browser_tool, browser_cdp_tool
+
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            if args and args[0] == "down":
+                return {"success": False, "error": "mouse down failed"}
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        result = json.loads(browser_tool.browser_click(x=100, y=100))
+        assert result["success"] is False
+        assert "mouse down" in result["error"]
+
+    def test_mouse_up_failure_returns_error(self, monkeypatch):
+        from tools import browser_tool, browser_cdp_tool
+
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            if args and args[0] == "up":
+                return {"success": False, "error": "mouse up failed"}
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        result = json.loads(browser_tool.browser_click(x=100, y=100))
+        assert result["success"] is False
+        assert "mouse up" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Ref-based click unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestRefClickPreserved:
+    """Existing ref-based click behavior is unchanged."""
+
+    def test_ref_click_still_works(self, monkeypatch):
+        from tools import browser_tool
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+
+        result = json.loads(browser_tool.browser_click(ref="@e5"))
+        assert result["success"] is True
+        assert result["clicked"] == "@e5"
+
+    def test_ref_without_at_prefix_auto_added(self, monkeypatch):
+        from tools import browser_tool
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        clicked_refs = []
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            clicked_refs.append(args)
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+
+        browser_tool.browser_click(ref="e12")
+        assert clicked_refs[0] == ["@e12"]
+
+
+# ---------------------------------------------------------------------------
+# Schema check
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaUpdated:
+    """The tool schema reflects x/y params and ref is no longer required."""
+
+    def test_schema_has_x_y_properties(self):
+        from tools.browser_tool import _BROWSER_SCHEMA_MAP
+
+        schema = _BROWSER_SCHEMA_MAP["browser_click"]
+        props = schema["parameters"]["properties"]
+        assert "x" in props
+        assert "y" in props
+        assert props["x"]["type"] == "number"
+        assert props["y"]["type"] == "number"
+
+    def test_schema_no_required_fields(self):
+        from tools.browser_tool import _BROWSER_SCHEMA_MAP
+
+        schema = _BROWSER_SCHEMA_MAP["browser_click"]
+        # ref is no longer required — either ref or x+y
+        assert "required" not in schema["parameters"] or schema["parameters"]["required"] == []
+
+    def test_schema_ref_still_present(self):
+        from tools.browser_tool import _BROWSER_SCHEMA_MAP
+
+        schema = _BROWSER_SCHEMA_MAP["browser_click"]
+        assert "ref" in schema["parameters"]["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    """browser_click is registered with x/y params wired through."""
+
+    def test_dispatch_with_coordinates(self, monkeypatch, cdp_server):
+        from tools.registry import registry
+
+        cdp_server.on(
+            "Target.getTargets",
+            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
+        )
+        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
+        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+
+        raw = registry.dispatch(
+            "browser_click", {"x": 42, "y": 84}, task_id="t1"
+        )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["clicked_at"] == {"x": 42, "y": 84}
+
+    def test_dispatch_with_ref(self, monkeypatch):
+        from tools import browser_tool
+        from tools.registry import registry
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+        monkeypatch.setattr(
+            browser_tool, "_run_browser_command",
+            lambda tid, cmd, args=None, timeout=None: {"success": True},
+        )
+
+        raw = registry.dispatch("browser_click", {"ref": "@e3"}, task_id="t1")
+        result = json.loads(raw)
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Session caching
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCaching:
+    """Second click skips Target.getTargets + Target.attachToTarget."""
+
+    def test_second_click_skips_session_resolution(self, cdp_server, monkeypatch):
+        """After first click the session_id is cached; second click goes straight
+        to mousePressed+mouseReleased without re-issuing getTargets/attachToTarget."""
+        from tools import browser_tool
+        import tools.browser_cdp_tool as cdp_mod
+
+        # clear cache
+        browser_tool._CDP_SESSION_CACHE.clear()
+        monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: cdp_server._url)
+
+        resolve_count = {"n": 0}
+
+        def _getTargets(p, s):
+            resolve_count["n"] += 1
+            return {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]}
+
+        cdp_server.on("Target.getTargets", _getTargets)
+        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "sess-cached"})
+        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+
+        # First click — must call getTargets
+        r1 = json.loads(browser_tool.browser_click(x=10.0, y=20.0))
+        assert r1["success"] is True
+        assert resolve_count["n"] == 1
+
+        # Second click — cache hit; getTargets must NOT be called again
+        r2 = json.loads(browser_tool.browser_click(x=30.0, y=40.0))
+        assert r2["success"] is True
+        assert resolve_count["n"] == 1, "session resolution was repeated despite warm cache"
+
+    def test_stale_session_triggers_reattach(self, cdp_server, monkeypatch):
+        """If the browser returns 'Session with given id not found', the cache is
+        cleared and session resolution runs again before retrying the click."""
+        from tools import browser_tool
+        import tools.browser_cdp_tool as cdp_mod
+
+        browser_tool._CDP_SESSION_CACHE.clear()
+        monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: cdp_server._url)
+
+        call_count = {"mouse": 0, "resolve": 0}
+
+        def _getTargets(p, s):
+            call_count["resolve"] += 1
+            return {"targetInfos": [{"targetId": "px", "type": "page", "attached": True, "url": "..."}]}
+
+        def _dispatch(p, s):
+            call_count["mouse"] += 1
+            # First two mouse calls (with stale session) return an error;
+            # after re-resolve they should succeed
+            if call_count["mouse"] <= 2:
+                raise RuntimeError("Session with given id not found: stale-session-id")
+            return {}
+
+        cdp_server.on("Target.getTargets", _getTargets)
+        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": f"sess-{call_count['resolve']}"})
+        cdp_server.on("Input.dispatchMouseEvent", _dispatch)
+
+        # Seed cache with stale session to trigger the error path
+        browser_tool._CDP_SESSION_CACHE[cdp_server._url] = "stale-session-id"
+
+        r = json.loads(browser_tool.browser_click(x=50.0, y=60.0))
+        assert r["success"] is True
+        # Must have resolved the session once (after evicting stale entry)
+        assert call_count["resolve"] >= 1
+
+    def test_cache_cleared_on_endpoint_change(self, monkeypatch):
+        """Cache is keyed per endpoint URL; different URL doesn't reuse cached session."""
+        from tools import browser_tool
+
+        browser_tool._CDP_SESSION_CACHE.clear()
+        browser_tool._CDP_SESSION_CACHE["ws://endpoint-a/"] = "sess-a"
+
+        # Endpoint B must not find endpoint A's session
+        assert browser_tool._CDP_SESSION_CACHE.get("ws://endpoint-b/") is None
+

--- a/tests/tools/test_browser_coordinate_click.py
+++ b/tests/tools/test_browser_coordinate_click.py
@@ -285,6 +285,29 @@ class TestAgentBrowserMouseFallback:
 
 
 class TestBoxResolutionFailure:
+    def test_missing_size_falls_back(self, monkeypatch):
+        """If width/height is missing or zero, fall back to plain ref click."""
+        from tools import browser_tool, browser_cdp_tool
+
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+
+        commands = []
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            commands.append((command, args))
+            if command == "get" and args and args[0] == "box":
+                return {"success": True, "data": {"x": 100.0, "y": 200.0, "width": 0, "height": 0}}
+            return {"success": True}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+
+        result = json.loads(browser_tool.browser_click(ref="@e5"))
+        assert result["success"] is True
+        assert result["method"] == "agent_browser_ref"
+        assert ("click", ["@e5"]) in commands
+
     def test_falls_back_to_plain_ref_click(self, monkeypatch):
         from tools import browser_tool, browser_cdp_tool
 
@@ -365,11 +388,11 @@ class TestSchemaUpdated:
         assert "x" not in props
         assert "y" not in props
 
-    def test_schema_no_required_fields(self):
+    def test_ref_is_required(self):
         from tools.browser_tool import _BROWSER_SCHEMA_MAP
 
         schema = _BROWSER_SCHEMA_MAP["browser_click"]
-        assert "required" not in schema["parameters"] or schema["parameters"]["required"] == []
+        assert schema["parameters"]["required"] == ["ref"]
 
 
 class TestRegistryIntegration:

--- a/tests/tools/test_browser_coordinate_click.py
+++ b/tests/tools/test_browser_coordinate_click.py
@@ -1,10 +1,14 @@
-"""Tests for compositor-level coordinate click (browser_click with x/y params).
+"""Tests for native (compositor-level) ref-based click in browser_click.
 
 Covers:
-- Input validation (ref vs x/y mutually exclusive)
-- CDP coordinate click path (via mock CDP server)
-- agent-browser mouse fallback path
+- browser_click requires a ref
+- Private-page action guard blocks the click (regression test for #62991 review)
+- CDP native click path (resolve ref box -> Input.dispatchMouseEvent at center)
+- agent-browser mouse fallback path (no CDP endpoint)
+- box-resolution failure degrades gracefully to plain ref click
 - Camofox passthrough still works with ref
+- Schema reflects ref-only (no x/y)
+- Session caching + stale-session reattach
 """
 from __future__ import annotations
 
@@ -18,13 +22,8 @@ import websockets
 from websockets.asyncio.server import serve
 
 
-# ---------------------------------------------------------------------------
-# In-process CDP mock server (reused from test_browser_cdp_tool.py)
-# ---------------------------------------------------------------------------
-
-
 class _CDPServer:
-    """Tiny CDP mock — replies to registered method handlers."""
+    """Tiny CDP mock - replies to registered method handlers."""
 
     def __init__(self) -> None:
         self._handlers: Dict[str, Any] = {}
@@ -103,21 +102,14 @@ class _CDPServer:
         return list(self._responses)
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def cdp_server(monkeypatch):
-    """Start a CDP mock and point browser_cdp_tool's resolver at it."""
     server = _CDPServer()
     ws_url = server.start()
 
     import tools.browser_cdp_tool as cdp_mod
     monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: ws_url)
 
-    # clear the session cache so each test starts fresh
     from tools import browser_tool as _bt
     _bt._CDP_SESSION_CACHE.clear()
 
@@ -128,370 +120,279 @@ def cdp_server(monkeypatch):
         server.stop()
 
 
-# ---------------------------------------------------------------------------
-# Input validation
-# ---------------------------------------------------------------------------
+def _wire_cdp_click_handlers(server: _CDPServer) -> None:
+    server.on(
+        "Target.getTargets",
+        lambda p, s: {
+            "targetInfos": [
+                {"targetId": "page-1", "type": "page", "attached": True, "url": "https://example.com"},
+            ]
+        },
+    )
+    server.on("Target.attachToTarget", lambda p, s: {"sessionId": f"sess-{p['targetId']}"})
+    server.on("Input.dispatchMouseEvent", lambda p, s: {})
+
+
+def _mock_ref_box(monkeypatch, x: float, y: float, w: float, h: float) -> None:
+    from tools import browser_tool
+
+    def mock_run_cmd(task_id, command, args=None, timeout=None):
+        if command == "get" and args and args[0] == "box":
+            return {"success": True, "data": {"x": x, "y": y, "width": w, "height": h}}
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+
+
+def _box_data(x: float, y: float, w: float, h: float) -> dict:
+    return {"success": True, "data": {"x": x, "y": y, "width": w, "height": h}}
 
 
 class TestClickInputValidation:
-    """browser_click validates that exactly one of ref / (x,y) is provided."""
-
-    def test_neither_ref_nor_coords(self):
+    def test_missing_ref(self):
         from tools.browser_tool import browser_click
 
         result = json.loads(browser_click())
         assert result["success"] is False
-        assert "ref" in result["error"].lower() or "x" in result["error"].lower()
-
-    def test_both_ref_and_coords(self):
-        from tools.browser_tool import browser_click
-
-        result = json.loads(browser_click(ref="@e1", x=100, y=200))
-        assert result["success"] is False
-        assert "not both" in result["error"].lower()
-
-    def test_x_without_y(self):
-        from tools.browser_tool import browser_click
-
-        result = json.loads(browser_click(x=100))
-        assert result["success"] is False
-        assert "both" in result["error"].lower()
-
-    def test_y_without_x(self):
-        from tools.browser_tool import browser_click
-
-        result = json.loads(browser_click(y=200))
-        assert result["success"] is False
-        assert "both" in result["error"].lower()
+        assert "ref" in result["error"].lower()
 
     def test_empty_ref_treated_as_missing(self):
         from tools.browser_tool import browser_click
 
         result = json.loads(browser_click(ref=""))
         assert result["success"] is False
-        assert "ref" in result["error"].lower() or "x" in result["error"].lower()
+        assert "ref" in result["error"].lower()
 
-    def test_non_numeric_coordinates(self):
-        from tools.browser_tool import browser_click
 
-        result = json.loads(browser_click(x="abc", y="def"))
+class TestPrivatePageGuard:
+    def test_guard_blocks_native_click(self, monkeypatch):
+        from tools import browser_tool
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
+        monkeypatch.setattr(
+            browser_tool, "_blocked_private_page_action",
+            lambda tid, action: json.dumps({"success": False, "error": "Blocked: private page"}),
+        )
+        commands = []
+
+        def mock_run_cmd(task_id, command, args=None, timeout=None):
+            commands.append((command, args))
+            return {"success": True, "data": {"x": 0, "y": 0, "width": 10, "height": 10}}
+
+        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
+
+        result = json.loads(browser_tool.browser_click(ref="@e5"))
         assert result["success"] is False
-        assert "number" in result["error"].lower()
+        assert "Blocked" in result["error"]
+        assert commands == []
 
 
-# ---------------------------------------------------------------------------
-# CDP coordinate click (happy path via mock server)
-# ---------------------------------------------------------------------------
-
-
-class TestCDPCoordinateClick:
-    """Coordinate clicks via CDP Input.dispatchMouseEvent."""
-
-    def test_cdp_click_dispatches_press_and_release(self, cdp_server):
+class TestCDPNativeClick:
+    def test_cdp_click_dispatches_press_and_release_at_center(self, cdp_server, monkeypatch):
         from tools.browser_tool import browser_click
 
-        # Register handlers for the protocol calls
-        cdp_server.on(
-            "Target.getTargets",
-            lambda p, s: {
-                "targetInfos": [
-                    {"targetId": "page-1", "type": "page", "attached": True, "url": "https://example.com"},
-                ]
-            },
-        )
-        cdp_server.on(
-            "Target.attachToTarget",
-            lambda p, s: {"sessionId": f"sess-{p['targetId']}"},
-        )
-        cdp_server.on(
-            "Input.dispatchMouseEvent",
-            lambda p, s: {},
-        )
+        _wire_cdp_click_handlers(cdp_server)
+        _mock_ref_box(monkeypatch, 100.0, 200.0, 40.0, 20.0)
 
-        result = json.loads(browser_click(x=150, y=300))
+        result = json.loads(browser_click(ref="@e1"))
         assert result["success"] is True
-        assert result["clicked_at"] == {"x": 150, "y": 300}
-        assert result["method"] == "cdp_compositor"
+        assert result["clicked"] == "@e1"
+        assert result["clicked_at"] == {"x": 120, "y": 210}
+        assert result["method"] == "cdp_native"
 
-        # Verify the CDP calls: Target.getTargets, attach, mousePressed, attach, mouseReleased
         calls = cdp_server.received()
         methods = [c["method"] for c in calls]
         assert "Target.getTargets" in methods
         assert "Input.dispatchMouseEvent" in methods
 
-        # Find the mouse events
         mouse_events = [c for c in calls if c["method"] == "Input.dispatchMouseEvent"]
         assert len(mouse_events) == 2
         assert mouse_events[0]["params"]["type"] == "mousePressed"
-        assert mouse_events[0]["params"]["x"] == 150
-        assert mouse_events[0]["params"]["y"] == 300
+        assert mouse_events[0]["params"]["x"] == 120
+        assert mouse_events[0]["params"]["y"] == 210
         assert mouse_events[0]["params"]["button"] == "left"
         assert mouse_events[1]["params"]["type"] == "mouseReleased"
 
-    def test_cdp_click_rounds_float_coordinates(self, cdp_server):
+    def test_cdp_click_rounds_center(self, cdp_server, monkeypatch):
         from tools.browser_tool import browser_click
 
-        cdp_server.on(
-            "Target.getTargets",
-            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
-        )
-        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
-        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+        _wire_cdp_click_handlers(cdp_server)
+        _mock_ref_box(monkeypatch, 10.2, 10.7, 3.0, 3.0)
 
-        result = json.loads(browser_click(x=150.7, y=299.3))
+        result = json.loads(browser_click(ref="@e1"))
         assert result["success"] is True
-        assert result["clicked_at"] == {"x": 151, "y": 299}
+        assert result["clicked_at"] == {"x": 12, "y": 12}
 
-    def test_cdp_click_no_page_target_still_works(self, cdp_server):
-        """When Target.getTargets returns no page targets, click proceeds without target_id."""
+    def test_cdp_dispatch_failure_returns_error(self, cdp_server, monkeypatch):
         from tools.browser_tool import browser_click
 
-        cdp_server.on(
-            "Target.getTargets",
-            lambda p, s: {"targetInfos": [{"targetId": "sw1", "type": "service_worker"}]},
-        )
-        # No Target.attachToTarget needed — page_target is None so _cdp_call
-        # sends without attaching
-        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
+        _wire_cdp_click_handlers(cdp_server)
+        cdp_server._handlers.pop("Input.dispatchMouseEvent", None)
+        _mock_ref_box(monkeypatch, 0.0, 0.0, 10.0, 10.0)
 
-        result = json.loads(browser_click(x=50, y=50))
-        assert result["success"] is True
-        assert result["clicked_at"] == {"x": 50, "y": 50}
-
-    def test_cdp_dispatch_mouse_event_failure(self, cdp_server):
-        """When Input.dispatchMouseEvent returns a CDP error, return failure."""
-        from tools.browser_tool import browser_click
-
-        cdp_server.on(
-            "Target.getTargets",
-            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
-        )
-        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
-        # No handler for Input.dispatchMouseEvent — server returns CDP error
-
-        result = json.loads(browser_click(x=100, y=200))
+        result = json.loads(browser_click(ref="@e1"))
         assert result["success"] is False
-        assert "CDP coordinate click failed" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# agent-browser mouse fallback
-# ---------------------------------------------------------------------------
+        assert "CDP native click failed" in result["error"]
 
 
 class TestAgentBrowserMouseFallback:
-    """When no CDP endpoint is available, fall back to agent-browser mouse commands."""
-
     def test_falls_back_to_agent_browser_mouse(self, monkeypatch):
         from tools import browser_tool, browser_cdp_tool
 
-        # No CDP endpoint available
         monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+        _mock_ref_box(monkeypatch, 100.0, 200.0, 40.0, 20.0)
 
-        # Mock _run_browser_command and _last_session_key
         commands_sent = []
 
         def mock_run_cmd(task_id, command, args=None, timeout=None):
+            if command == "get" and args and args[0] == "box":
+                return _box_data(100.0, 200.0, 40.0, 20.0)
             commands_sent.append((command, args))
             return {"success": True}
 
         monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
-        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
 
-        result = json.loads(browser_tool.browser_click(x=200, y=400))
+        result = json.loads(browser_tool.browser_click(ref="@e1"))
         assert result["success"] is True
-        assert result["clicked_at"] == {"x": 200, "y": 400}
+        assert result["clicked_at"] == {"x": 120, "y": 210}
         assert result["method"] == "agent_browser_mouse"
 
-        # Should have sent: mouse move, mouse down, mouse up
-        assert len(commands_sent) == 3
-        assert commands_sent[0] == ("mouse", ["move", "200", "400"])
+        assert commands_sent[0] == ("mouse", ["move", "120", "210"])
         assert commands_sent[1] == ("mouse", ["down"])
         assert commands_sent[2] == ("mouse", ["up"])
-
-    def test_mouse_move_failure_returns_error(self, monkeypatch):
-        from tools import browser_tool, browser_cdp_tool
-
-        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
-
-        def mock_run_cmd(task_id, command, args=None, timeout=None):
-            if args and args[0] == "move":
-                return {"success": False, "error": "mouse move not supported"}
-            return {"success": True}
-
-        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
-        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
-
-        result = json.loads(browser_tool.browser_click(x=100, y=100))
-        assert result["success"] is False
-        assert "mouse move" in result["error"]
 
     def test_mouse_down_failure_returns_error(self, monkeypatch):
         from tools import browser_tool, browser_cdp_tool
 
         monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
+        _mock_ref_box(monkeypatch, 100.0, 200.0, 40.0, 20.0)
 
         def mock_run_cmd(task_id, command, args=None, timeout=None):
-            if args and args[0] == "down":
+            if command == "get" and args and args[0] == "box":
+                return _box_data(100.0, 200.0, 40.0, 20.0)
+            if command == "mouse" and args and args[0] == "down":
                 return {"success": False, "error": "mouse down failed"}
             return {"success": True}
 
         monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
-        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
 
-        result = json.loads(browser_tool.browser_click(x=100, y=100))
+        result = json.loads(browser_tool.browser_click(ref="@e1"))
         assert result["success"] is False
         assert "mouse down" in result["error"]
 
-    def test_mouse_up_failure_returns_error(self, monkeypatch):
+
+class TestBoxResolutionFailure:
+    def test_falls_back_to_plain_ref_click(self, monkeypatch):
         from tools import browser_tool, browser_cdp_tool
 
         monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
-
-        def mock_run_cmd(task_id, command, args=None, timeout=None):
-            if args and args[0] == "up":
-                return {"success": False, "error": "mouse up failed"}
-            return {"success": True}
-
-        monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
-        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
-
-        result = json.loads(browser_tool.browser_click(x=100, y=100))
-        assert result["success"] is False
-        assert "mouse up" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# Ref-based click unchanged
-# ---------------------------------------------------------------------------
-
-
-class TestRefClickPreserved:
-    """Existing ref-based click behavior is unchanged."""
-
-    def test_ref_click_still_works(self, monkeypatch):
-        from tools import browser_tool
-
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
 
+        commands = []
+
         def mock_run_cmd(task_id, command, args=None, timeout=None):
+            commands.append((command, args))
+            if command == "get" and args and args[0] == "box":
+                return {"success": False, "error": "element not found"}
             return {"success": True}
 
         monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
 
-        result = json.loads(browser_tool.browser_click(ref="@e5"))
+        result = json.loads(browser_tool.browser_click(ref="@e9"))
         assert result["success"] is True
-        assert result["clicked"] == "@e5"
+        assert result["clicked"] == "@e9"
+        assert result["method"] == "agent_browser_ref"
+        assert ("click", ["@e9"]) in commands
 
+
+class TestRefClickPlumbing:
     def test_ref_without_at_prefix_auto_added(self, monkeypatch):
-        from tools import browser_tool
+        from tools import browser_tool, browser_cdp_tool
 
+        monkeypatch.setattr(browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "")
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
 
-        clicked_refs = []
+        mouse_calls = []
 
         def mock_run_cmd(task_id, command, args=None, timeout=None):
-            clicked_refs.append(args)
+            if command == "get" and args and args[0] == "box":
+                return _box_data(0.0, 0.0, 1.0, 1.0)
+            if command == "mouse":
+                mouse_calls.append(args)
             return {"success": True}
 
         monkeypatch.setattr(browser_tool, "_run_browser_command", mock_run_cmd)
 
         browser_tool.browser_click(ref="e12")
-        assert clicked_refs[0] == ["@e12"]
+        # Native path: ref normalized to @e12; mouse click dispatched at the
+        # resolved center (box 0,0,1,1 -> center 0,0).
+        assert mouse_calls[0] == ["move", "0", "0"]
+        assert mouse_calls[1] == ["down"]
+        assert mouse_calls[2] == ["up"]
 
+    def test_camofox_passthrough(self, monkeypatch):
+        from tools import browser_tool
+        import tools.browser_camofox as camofox_mod
 
-# ---------------------------------------------------------------------------
-# Schema check
-# ---------------------------------------------------------------------------
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
+
+        captured = {}
+
+        def mock_camofox_click(ref, task_id):
+            captured["ref"] = ref
+            return json.dumps({"success": True, "clicked": ref})
+
+        # browser_click does `from tools.browser_camofox import camofox_click`
+        monkeypatch.setattr(camofox_mod, "camofox_click", mock_camofox_click)
+
+        result = json.loads(browser_tool.browser_click(ref="@e3"))
+        assert result["success"] is True
+        assert captured["ref"] == "@e3"
 
 
 class TestSchemaUpdated:
-    """The tool schema reflects x/y params and ref is no longer required."""
-
-    def test_schema_has_x_y_properties(self):
+    def test_schema_has_only_ref_property(self):
         from tools.browser_tool import _BROWSER_SCHEMA_MAP
 
         schema = _BROWSER_SCHEMA_MAP["browser_click"]
         props = schema["parameters"]["properties"]
-        assert "x" in props
-        assert "y" in props
-        assert props["x"]["type"] == "number"
-        assert props["y"]["type"] == "number"
+        assert "ref" in props
+        assert "x" not in props
+        assert "y" not in props
 
     def test_schema_no_required_fields(self):
         from tools.browser_tool import _BROWSER_SCHEMA_MAP
 
         schema = _BROWSER_SCHEMA_MAP["browser_click"]
-        # ref is no longer required — either ref or x+y
         assert "required" not in schema["parameters"] or schema["parameters"]["required"] == []
-
-    def test_schema_ref_still_present(self):
-        from tools.browser_tool import _BROWSER_SCHEMA_MAP
-
-        schema = _BROWSER_SCHEMA_MAP["browser_click"]
-        assert "ref" in schema["parameters"]["properties"]
-
-
-# ---------------------------------------------------------------------------
-# Registry integration
-# ---------------------------------------------------------------------------
 
 
 class TestRegistryIntegration:
-    """browser_click is registered with x/y params wired through."""
-
-    def test_dispatch_with_coordinates(self, monkeypatch, cdp_server):
+    def test_dispatch_with_ref(self, monkeypatch, cdp_server):
         from tools.registry import registry
 
-        cdp_server.on(
-            "Target.getTargets",
-            lambda p, s: {"targetInfos": [{"targetId": "p1", "type": "page", "attached": True, "url": "..."}]},
-        )
-        cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "s1"})
-        cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
-
-        raw = registry.dispatch(
-            "browser_click", {"x": 42, "y": 84}, task_id="t1"
-        )
-        result = json.loads(raw)
-        assert result["success"] is True
-        assert result["clicked_at"] == {"x": 42, "y": 84}
-
-    def test_dispatch_with_ref(self, monkeypatch):
-        from tools import browser_tool
-        from tools.registry import registry
-
-        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
-        monkeypatch.setattr(browser_tool, "_last_session_key", lambda tid: tid)
-        monkeypatch.setattr(
-            browser_tool, "_run_browser_command",
-            lambda tid, cmd, args=None, timeout=None: {"success": True},
-        )
+        _wire_cdp_click_handlers(cdp_server)
+        _mock_ref_box(monkeypatch, 50.0, 60.0, 20.0, 20.0)
 
         raw = registry.dispatch("browser_click", {"ref": "@e3"}, task_id="t1")
         result = json.loads(raw)
         assert result["success"] is True
-
-
-# ---------------------------------------------------------------------------
-# Session caching
-# ---------------------------------------------------------------------------
+        assert result["clicked_at"] == {"x": 60, "y": 70}
 
 
 class TestSessionCaching:
-    """Second click skips Target.getTargets + Target.attachToTarget."""
-
     def test_second_click_skips_session_resolution(self, cdp_server, monkeypatch):
-        """After first click the session_id is cached; second click goes straight
-        to mousePressed+mouseReleased without re-issuing getTargets/attachToTarget."""
         from tools import browser_tool
         import tools.browser_cdp_tool as cdp_mod
 
-        # clear cache
         browser_tool._CDP_SESSION_CACHE.clear()
         monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: cdp_server._url)
+        _mock_ref_box(monkeypatch, 0.0, 0.0, 10.0, 10.0)
 
         resolve_count = {"n": 0}
 
@@ -503,24 +404,21 @@ class TestSessionCaching:
         cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": "sess-cached"})
         cdp_server.on("Input.dispatchMouseEvent", lambda p, s: {})
 
-        # First click — must call getTargets
-        r1 = json.loads(browser_tool.browser_click(x=10.0, y=20.0))
+        r1 = json.loads(browser_tool.browser_click(ref="@e1"))
         assert r1["success"] is True
         assert resolve_count["n"] == 1
 
-        # Second click — cache hit; getTargets must NOT be called again
-        r2 = json.loads(browser_tool.browser_click(x=30.0, y=40.0))
+        r2 = json.loads(browser_tool.browser_click(ref="@e2"))
         assert r2["success"] is True
         assert resolve_count["n"] == 1, "session resolution was repeated despite warm cache"
 
     def test_stale_session_triggers_reattach(self, cdp_server, monkeypatch):
-        """If the browser returns 'Session with given id not found', the cache is
-        cleared and session resolution runs again before retrying the click."""
         from tools import browser_tool
         import tools.browser_cdp_tool as cdp_mod
 
         browser_tool._CDP_SESSION_CACHE.clear()
         monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: cdp_server._url)
+        _mock_ref_box(monkeypatch, 0.0, 0.0, 10.0, 10.0)
 
         call_count = {"mouse": 0, "resolve": 0}
 
@@ -530,8 +428,6 @@ class TestSessionCaching:
 
         def _dispatch(p, s):
             call_count["mouse"] += 1
-            # First two mouse calls (with stale session) return an error;
-            # after re-resolve they should succeed
             if call_count["mouse"] <= 2:
                 raise RuntimeError("Session with given id not found: stale-session-id")
             return {}
@@ -540,22 +436,16 @@ class TestSessionCaching:
         cdp_server.on("Target.attachToTarget", lambda p, s: {"sessionId": f"sess-{call_count['resolve']}"})
         cdp_server.on("Input.dispatchMouseEvent", _dispatch)
 
-        # Seed cache with stale session to trigger the error path
         browser_tool._CDP_SESSION_CACHE[(cdp_server._url, "default")] = "stale-session-id"
 
-        r = json.loads(browser_tool.browser_click(x=50.0, y=60.0))
+        r = json.loads(browser_tool.browser_click(ref="@e1"))
         assert r["success"] is True
-        # Must have resolved the session once (after evicting stale entry)
         assert call_count["resolve"] >= 1
 
     def test_cache_cleared_on_endpoint_change(self, monkeypatch):
-        """Cache is keyed per (endpoint URL, task_id); a different task_id on the
-        same endpoint does not reuse another task's cached session."""
         from tools import browser_tool
 
         browser_tool._CDP_SESSION_CACHE.clear()
         browser_tool._CDP_SESSION_CACHE[("ws://endpoint-a/", "task-a")] = "sess-a"
 
-        # A different task_id on the same endpoint must not find task-a's session
         assert browser_tool._CDP_SESSION_CACHE.get(("ws://endpoint-a/", "task-b")) is None
-

--- a/tests/tools/test_browser_coordinate_click.py
+++ b/tests/tools/test_browser_coordinate_click.py
@@ -541,7 +541,7 @@ class TestSessionCaching:
         cdp_server.on("Input.dispatchMouseEvent", _dispatch)
 
         # Seed cache with stale session to trigger the error path
-        browser_tool._CDP_SESSION_CACHE[cdp_server._url] = "stale-session-id"
+        browser_tool._CDP_SESSION_CACHE[(cdp_server._url, "default")] = "stale-session-id"
 
         r = json.loads(browser_tool.browser_click(x=50.0, y=60.0))
         assert r["success"] is True
@@ -549,12 +549,13 @@ class TestSessionCaching:
         assert call_count["resolve"] >= 1
 
     def test_cache_cleared_on_endpoint_change(self, monkeypatch):
-        """Cache is keyed per endpoint URL; different URL doesn't reuse cached session."""
+        """Cache is keyed per (endpoint URL, task_id); a different task_id on the
+        same endpoint does not reuse another task's cached session."""
         from tools import browser_tool
 
         browser_tool._CDP_SESSION_CACHE.clear()
-        browser_tool._CDP_SESSION_CACHE["ws://endpoint-a/"] = "sess-a"
+        browser_tool._CDP_SESSION_CACHE[("ws://endpoint-a/", "task-a")] = "sess-a"
 
-        # Endpoint B must not find endpoint A's session
-        assert browser_tool._CDP_SESSION_CACHE.get("ws://endpoint-b/") is None
+        # A different task_id on the same endpoint must not find task-a's session
+        assert browser_tool._CDP_SESSION_CACHE.get(("ws://endpoint-a/", "task-b")) is None
 

--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -42,21 +42,35 @@ def test_private_page_blocks_state_changing_actions(monkeypatch, tool_call, args
 
 
 def test_click_still_runs_when_current_page_is_public(monkeypatch):
+    """Guard allows the native click when the current page is public.
+
+    A1 dispatch: resolve the ref's box (get box) then a native mouse click at
+    the center. The guard must NOT block a public page.
+    """
     calls = []
 
     monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
     monkeypatch.setattr(browser_tool, "_current_page_private_url", lambda task_id: None)
+    import tools.browser_cdp_tool as cdp_mod
+    monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: "")
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
 
     def fake_run(task_id, command, args):
         calls.append((task_id, command, args))
+        if command == "get" and args and args[0] == "box":
+            return {"success": True, "data": {"x": 0, "y": 0, "width": 10, "height": 10}}
         return {"success": True}
 
     monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
 
     out = json.loads(browser_tool.browser_click("e1", task_id="task-1"))
 
-    assert out == {"success": True, "clicked": "@e1"}
-    assert calls == [("task-1", "click", ["@e1"])]
+    # Guard passed -> native click dispatched; ref normalized to @e1.
+    assert out["success"] is True
+    assert out["clicked"] == "@e1"
+    # box resolution + mouse move/down/up, with the normalized ref.
+    assert calls[0] == ("task-1", "get", ["box", "@e1"])
+    assert calls[-1] == ("task-1", "mouse", ["up"])
 
 
 def test_guard_inactive_does_not_block_or_probe(monkeypatch):
@@ -67,6 +81,9 @@ def test_guard_inactive_does_not_block_or_probe(monkeypatch):
     calls = []
 
     monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+    import tools.browser_cdp_tool as cdp_mod
+    monkeypatch.setattr(cdp_mod, "_resolve_cdp_endpoint", lambda: "")
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
 
     def fail_probe(task_id):
         raise AssertionError("_current_page_private_url must not be probed when guard inactive")
@@ -75,14 +92,18 @@ def test_guard_inactive_does_not_block_or_probe(monkeypatch):
 
     def fake_run(task_id, command, args):
         calls.append((task_id, command, args))
+        if command == "get" and args and args[0] == "box":
+            return {"success": True, "data": {"x": 0, "y": 0, "width": 10, "height": 10}}
         return {"success": True}
 
     monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
 
     out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
 
-    assert out == {"success": True, "clicked": "@e1"}
-    assert calls == [("task-1", "click", ["@e1"])]
+    # Guard inactive -> native click proceeds, no URL probe attempted.
+    assert out["success"] is True
+    assert out["clicked"] == "@e1"
+    assert calls[0] == ("task-1", "get", ["box", "@e1"])
 
 
 def test_camofox_short_circuits_before_guard(monkeypatch):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1848,16 +1848,23 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_click",
-        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.",
+        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.\n\nAlternatively, click at exact viewport coordinates (x, y) using compositor-level input. This bypasses DOM selectors entirely — clicks pass through iframes, shadow DOM, cross-origin boundaries, and canvas elements. Use browser_vision with annotate=true to find coordinates, or browser_console to evaluate getBoundingClientRect(). Provide EITHER ref OR (x + y), not both.",
         "parameters": {
             "type": "object",
             "properties": {
                 "ref": {
                     "type": "string",
                     "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
+                },
+                "x": {
+                    "type": "number",
+                    "description": "Viewport X coordinate for compositor-level click. Use with y instead of ref to click through iframes, shadow DOM, or canvas elements."
+                },
+                "y": {
+                    "type": "number",
+                    "description": "Viewport Y coordinate for compositor-level click. Use with x instead of ref."
                 }
-            },
-            "required": ["ref"]
+            }
         }
     },
     {
@@ -3017,17 +3024,328 @@ def browser_snapshot(
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_click(ref: str, task_id: Optional[str] = None) -> str:
+# ---------------------------------------------------------------------------
+# Session cache for CDP coordinate clicks
+#
+# Target.getTargets + Target.attachToTarget cost one round-trip each and
+# their results (page targetId + session_id) are stable across clicks on
+# the same page.  We cache them keyed by CDP endpoint URL and invalidate
+# automatically when the browser reports a stale session error.
+#
+# Pattern: browser-harness daemon keeps session_id on the daemon object and
+# retries once on "Session with given id not found" to self-heal after
+# navigation or crash.  We replicate that here without a persistent daemon
+# process by storing it in a module-level dict.
+# ---------------------------------------------------------------------------
+
+_CDP_SESSION_CACHE: dict[str, str] = {}  # ws_url → cached session_id
+
+
+async def _cdp_resolve_session(
+    ws: Any,
+    ws_url: str,
+    deadline: float,
+    msg_id_ref: list,
+) -> Optional[str]:
+    """Resolve (and cache) the page-scoped CDP session ID.
+
+    Sends Target.getTargets + Target.attachToTarget on *ws* and caches the
+    resulting session_id for future clicks.  Returns None if no page target
+    is found (Input.dispatchMouseEvent will be sent at browser level, which
+    works for simple cases).
     """
-    Click on an element.
+    import asyncio as _asyncio
+
+    async def _send(method: str, params: dict, sid: Optional[str] = None) -> int:
+        msg_id_ref[0] += 1
+        call_id = msg_id_ref[0]
+        req: dict = {"id": call_id, "method": method, "params": params}
+        if sid:
+            req["sessionId"] = sid
+        await ws.send(json.dumps(req))
+        return call_id
+
+    async def _recv_until(call_id: int) -> dict:
+        while True:
+            remaining = deadline - _asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError(f"CDP timed out waiting for id={call_id}")
+            raw = await _asyncio.wait_for(ws.recv(), timeout=remaining)
+            msg = json.loads(raw)
+            if msg.get("id") == call_id:
+                if "error" in msg:
+                    raise RuntimeError(f"CDP error: {msg['error']}")
+                return msg.get("result", {})
+
+    gt_id = await _send("Target.getTargets", {})
+    gt_result = await _recv_until(gt_id)
+    page_target_id: Optional[str] = None
+    for t in gt_result.get("targetInfos", []):
+        if t.get("type") == "page" and t.get("attached", True):
+            page_target_id = t["targetId"]
+            break
+
+    if not page_target_id:
+        return None
+
+    at_id = await _send("Target.attachToTarget",
+                        {"targetId": page_target_id, "flatten": True})
+    at_result = await _recv_until(at_id)
+    session_id = at_result.get("sessionId") or None
+    if session_id:
+        _CDP_SESSION_CACHE[ws_url] = session_id
+    return session_id
+
+
+async def _cdp_coordinate_click_async(
+    ws_url: str,
+    x: int,
+    y: int,
+    button: str,
+    timeout: float,
+) -> None:
+    """Perform a compositor-level click on a single persistent WS connection.
+
+    Optimizations vs the naïve 3-separate-connections approach:
+
+    1. **Single connection** — one TCP+WS handshake for the entire click.
+       All CDP messages are sent on the same socket.
+
+    2. **Session ID caching** — Target.getTargets + Target.attachToTarget are
+       only paid once per CDP endpoint.  Subsequent clicks skip straight to
+       the two mouse events.  Cache is invalidated automatically on stale-
+       session errors and re-resolved once (browser-harness self-heal pattern).
+
+    3. **mouseReleased-only wait** — mousePressed and mouseReleased are both
+       fired before awaiting either response.  Because the browser processes
+       CDP messages sequentially within a session, if mouseReleased is
+       acknowledged then mousePressed has already been processed.  We only
+       wait for the release ack (Playwright / Puppeteer pattern), saving one
+       RTT on the common path.
+    """
+    import asyncio as _asyncio
+    from tools.browser_cdp_tool import websockets as _ws
+
+    async with _ws.connect(
+        ws_url,
+        max_size=None,
+        open_timeout=timeout,
+        close_timeout=5,
+        ping_interval=None,
+        compression=None,       # small CDP messages don't benefit from compression
+    ) as ws:
+        deadline = _asyncio.get_running_loop().time() + timeout
+        msg_id_ref = [0]        # mutable so nested helpers can increment
+
+        def _next_id() -> int:
+            msg_id_ref[0] += 1
+            return msg_id_ref[0]
+
+        async def _send_mouse(event_type: str, sid: Optional[str]) -> int:
+            call_id = _next_id()
+            req: dict = {
+                "id": call_id,
+                "method": "Input.dispatchMouseEvent",
+                "params": {"type": event_type, "x": x, "y": y,
+                           "button": button, "clickCount": 1},
+            }
+            if sid:
+                req["sessionId"] = sid
+            await ws.send(json.dumps(req))
+            return call_id
+
+        async def _recv_until(call_id: int) -> dict:
+            while True:
+                remaining = deadline - _asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError(f"CDP timed out waiting for id={call_id}")
+                raw = await _asyncio.wait_for(ws.recv(), timeout=remaining)
+                msg = json.loads(raw)
+                if msg.get("id") == call_id:
+                    if "error" in msg:
+                        raise RuntimeError(f"CDP error: {msg['error']}")
+                    return msg.get("result", {})
+
+        # --- resolve session (cached after first click) ---
+        session_id: Optional[str] = _CDP_SESSION_CACHE.get(ws_url)
+        if not session_id:
+            session_id = await _cdp_resolve_session(ws, ws_url, deadline, msg_id_ref)
+
+        # --- fire mousePressed + mouseReleased without awaiting press ack ---
+        # Both messages are sent before we await either response.  The browser
+        # processes them in order, so waiting only for mouseReleased is enough.
+        _press_id = await _send_mouse("mousePressed", session_id)
+        release_id = await _send_mouse("mouseReleased", session_id)
+        try:
+            await _recv_until(release_id)
+        except RuntimeError as exc:
+            # Stale session (e.g. after navigation) — invalidate cache, retry once
+            if "Session with given id not found" in str(exc) and session_id:
+                _CDP_SESSION_CACHE.pop(ws_url, None)
+                session_id = await _cdp_resolve_session(ws, ws_url, deadline, msg_id_ref)
+                _press_id = await _send_mouse("mousePressed", session_id)
+                release_id = await _send_mouse("mouseReleased", session_id)
+                await _recv_until(release_id)
+            else:
+                raise
+
+
+def _cdp_coordinate_click(
+    x: float,
+    y: float,
+    task_id: str,
+    button: str = "left",
+) -> str:
+    """Compositor-level click at viewport coordinates via CDP Input.dispatchMouseEvent.
+
+    Dispatch priority (fastest first):
+    1. **Per-click connect path** — open a single WS, resolve session (cached),
+       pipeline mousePressed + mouseReleased, close.
+    2. **agent-browser fallback** — when no CDP endpoint is configured at all.
+    """
+    ix, iy = int(round(x)), int(round(y))
+
+    # --- path 1: per-click WS connect (with session cache) ------------------
+    try:
+        from tools.browser_cdp_tool import _run_async, _resolve_cdp_endpoint, _WS_AVAILABLE
+    except ImportError:
+        return json.dumps({
+            "success": False,
+            "error": "browser_cdp_tool not available — coordinate clicks require the CDP tool module.",
+        }, ensure_ascii=False)
+
+    if not _WS_AVAILABLE:
+        return json.dumps({
+            "success": False,
+            "error": "The 'websockets' package is required for coordinate clicks. Install with: pip install websockets",
+        }, ensure_ascii=False)
+
+    endpoint = _resolve_cdp_endpoint()
+    if not endpoint:
+        return _coordinate_click_via_agent_browser(x, y, task_id, button)
+
+    if not endpoint.startswith(("ws://", "wss://")):
+        return _coordinate_click_via_agent_browser(x, y, task_id, button)
+
+    try:
+        _run_async(_cdp_coordinate_click_async(endpoint, ix, iy, button, 10.0))
+    except Exception as exc:
+        return json.dumps({
+            "success": False,
+            "error": f"CDP coordinate click failed: {type(exc).__name__}: {exc}",
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "success": True,
+        "clicked_at": {"x": ix, "y": iy},
+        "method": "cdp_compositor",
+    }, ensure_ascii=False)
+
+
+def _coordinate_click_via_agent_browser(
+    x: float,
+    y: float,
+    task_id: str,
+    button: str = "left",
+) -> str:
+    """Fallback: coordinate click via agent-browser mouse subcommands."""
+    effective_task_id = _last_session_key(task_id)
+    ix, iy = int(round(x)), int(round(y))
+
+    # agent-browser mouse move <x> <y> + mouse down + mouse up
+    move_result = _run_browser_command(effective_task_id, "mouse", ["move", str(ix), str(iy)])
+    if not move_result.get("success"):
+        return json.dumps({
+            "success": False,
+            "error": f"mouse move failed: {move_result.get('error', 'unknown')}",
+        }, ensure_ascii=False)
+
+    btn_arg = [] if button == "left" else [button]
+    down_result = _run_browser_command(effective_task_id, "mouse", ["down"] + btn_arg)
+    if not down_result.get("success"):
+        return json.dumps({
+            "success": False,
+            "error": f"mouse down failed: {down_result.get('error', 'unknown')}",
+        }, ensure_ascii=False)
+
+    up_result = _run_browser_command(effective_task_id, "mouse", ["up"] + btn_arg)
+    if not up_result.get("success"):
+        return json.dumps({
+            "success": False,
+            "error": f"mouse up failed: {up_result.get('error', 'unknown')}",
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "success": True,
+        "clicked_at": {"x": ix, "y": iy},
+        "method": "agent_browser_mouse",
+    }, ensure_ascii=False)
+
+
+def browser_click(
+    ref: Optional[str] = None,
+    x: Optional[float] = None,
+    y: Optional[float] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """
+    Click on an element by ref ID, or at exact viewport coordinates.
+
+    Provide EITHER ``ref`` (selector-based, via agent-browser) OR ``x`` + ``y``
+    (compositor-level, via CDP Input.dispatchMouseEvent).  Coordinate clicks
+    bypass DOM selectors entirely — they pass through iframes, shadow DOM,
+    cross-origin boundaries, and canvas elements.
 
     Args:
         ref: Element reference (e.g., "@e5")
+        x: Viewport X coordinate for compositor-level click
+        y: Viewport Y coordinate for compositor-level click
         task_id: Task identifier for session isolation
 
     Returns:
         JSON string with click result
     """
+    # --- Input validation ---------------------------------------------------
+    has_ref = ref is not None and str(ref).strip() != ""
+    has_coords = x is not None and y is not None
+
+    if has_ref and has_coords:
+        return json.dumps({
+            "success": False,
+            "error": "Provide either 'ref' or 'x'+'y', not both.",
+        }, ensure_ascii=False)
+
+    if (x is not None) != (y is not None):
+        return json.dumps({
+            "success": False,
+            "error": "Both 'x' and 'y' are required for coordinate clicks.",
+        }, ensure_ascii=False)
+
+    if not has_ref and not has_coords:
+        return json.dumps({
+            "success": False,
+            "error": "Provide either 'ref' (element reference) or 'x'+'y' (viewport coordinates).",
+        }, ensure_ascii=False)
+
+    # --- Coordinate-based click (compositor-level) --------------------------
+    if has_coords:
+        try:
+            fx, fy = float(x), float(y)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return json.dumps({
+                "success": False,
+                "error": f"x and y must be numbers, got x={x!r} y={y!r}",
+            }, ensure_ascii=False)
+        return _cdp_coordinate_click(fx, fy, task_id or "default")
+
+    # --- Ref-based click (existing path) ------------------------------------
+    if not has_ref or ref is None:
+        # Defensive guard — validation above should ensure we never reach here
+        return json.dumps({
+            "success": False,
+            "error": "Internal error: expected ref parameter.",
+        }, ensure_ascii=False)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
         return camofox_click(ref, task_id)
@@ -4740,7 +5058,7 @@ registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_click(ref=args.get("ref"), x=args.get("x"), y=args.get("y"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👆",
 )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1857,7 +1857,7 @@ BROWSER_TOOL_SCHEMAS = [
                     "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
                 }
             },
-            "required": []
+            "required": ["ref"]
         }
     },
     {
@@ -3231,6 +3231,12 @@ def _resolve_ref_box(ref: str, task_id: str) -> Optional[dict]:
     # agent-browser returns x/y/width/height (numeric) or a string blob.
     try:
         if isinstance(data, dict):
+            # Require at least x and y; reject missing/zero size so we don't
+            # click at the top-left corner from a malformed box result.
+            if not any(k in data for k in ("x", "left")):
+                return None
+            if not any(k in data for k in ("y", "top")):
+                return None
             x = float(data.get("x", data.get("left", 0)))
             y = float(data.get("y", data.get("top", 0)))
             w = float(data.get("width", 0))
@@ -3241,6 +3247,8 @@ def _resolve_ref_box(ref: str, task_id: str) -> Optional[dict]:
                 kv.split("=") for kv in data.replace(",", " ").split()
                 if "=" in kv
             )
+            if "x" not in parts or "y" not in parts:
+                return None
             x = float(parts.get("x", 0))
             y = float(parts.get("y", 0))
             w = float(parts.get("width", 0))
@@ -3248,6 +3256,8 @@ def _resolve_ref_box(ref: str, task_id: str) -> Optional[dict]:
         else:
             return None
     except (TypeError, ValueError):
+        return None
+    if w <= 0 or h <= 0:
         return None
     return {"x": x + w / 2.0, "y": y + h / 2.0}
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3038,12 +3038,13 @@ def browser_snapshot(
 # process by storing it in a module-level dict.
 # ---------------------------------------------------------------------------
 
-_CDP_SESSION_CACHE: dict[str, str] = {}  # ws_url → cached session_id
+_CDP_SESSION_CACHE: dict[tuple[str, str], str] = {}  # (ws_url, task_id) → cached session_id
 
 
 async def _cdp_resolve_session(
     ws: Any,
     ws_url: str,
+    task_id: str,
     deadline: float,
     msg_id_ref: list,
 ) -> Optional[str]:
@@ -3052,7 +3053,8 @@ async def _cdp_resolve_session(
     Sends Target.getTargets + Target.attachToTarget on *ws* and caches the
     resulting session_id for future clicks.  Returns None if no page target
     is found (Input.dispatchMouseEvent will be sent at browser level, which
-    works for simple cases).
+    works for simple cases).  The cache is keyed by (ws_url, task_id) so
+    concurrent tasks sharing one browser endpoint don't collide.
     """
     import asyncio as _asyncio
 
@@ -3093,7 +3095,7 @@ async def _cdp_resolve_session(
     at_result = await _recv_until(at_id)
     session_id = at_result.get("sessionId") or None
     if session_id:
-        _CDP_SESSION_CACHE[ws_url] = session_id
+        _CDP_SESSION_CACHE[(ws_url, task_id)] = session_id
     return session_id
 
 
@@ -3101,6 +3103,7 @@ async def _cdp_coordinate_click_async(
     ws_url: str,
     x: int,
     y: int,
+    task_id: str,
     button: str,
     timeout: float,
 ) -> None:
@@ -3167,9 +3170,9 @@ async def _cdp_coordinate_click_async(
                     return msg.get("result", {})
 
         # --- resolve session (cached after first click) ---
-        session_id: Optional[str] = _CDP_SESSION_CACHE.get(ws_url)
+        session_id: Optional[str] = _CDP_SESSION_CACHE.get((ws_url, task_id))
         if not session_id:
-            session_id = await _cdp_resolve_session(ws, ws_url, deadline, msg_id_ref)
+            session_id = await _cdp_resolve_session(ws, ws_url, task_id, deadline, msg_id_ref)
 
         # --- fire mousePressed + mouseReleased without awaiting press ack ---
         # Both messages are sent before we await either response.  The browser
@@ -3177,14 +3180,16 @@ async def _cdp_coordinate_click_async(
         _press_id = await _send_mouse("mousePressed", session_id)
         release_id = await _send_mouse("mouseReleased", session_id)
         try:
+            await _recv_until(_press_id)
             await _recv_until(release_id)
         except RuntimeError as exc:
             # Stale session (e.g. after navigation) — invalidate cache, retry once
             if "Session with given id not found" in str(exc) and session_id:
-                _CDP_SESSION_CACHE.pop(ws_url, None)
-                session_id = await _cdp_resolve_session(ws, ws_url, deadline, msg_id_ref)
+                _CDP_SESSION_CACHE.pop((ws_url, task_id), None)
+                session_id = await _cdp_resolve_session(ws, ws_url, task_id, deadline, msg_id_ref)
                 _press_id = await _send_mouse("mousePressed", session_id)
                 release_id = await _send_mouse("mouseReleased", session_id)
+                await _recv_until(_press_id)
                 await _recv_until(release_id)
             else:
                 raise
@@ -3214,12 +3219,6 @@ def _cdp_coordinate_click(
             "error": "browser_cdp_tool not available — coordinate clicks require the CDP tool module.",
         }, ensure_ascii=False)
 
-    if not _WS_AVAILABLE:
-        return json.dumps({
-            "success": False,
-            "error": "The 'websockets' package is required for coordinate clicks. Install with: pip install websockets",
-        }, ensure_ascii=False)
-
     endpoint = _resolve_cdp_endpoint()
     if not endpoint:
         return _coordinate_click_via_agent_browser(x, y, task_id, button)
@@ -3227,8 +3226,16 @@ def _cdp_coordinate_click(
     if not endpoint.startswith(("ws://", "wss://")):
         return _coordinate_click_via_agent_browser(x, y, task_id, button)
 
+    # Only require websockets once we know a CDP endpoint exists; this keeps
+    # the agent-browser mouse fallback working when no CDP endpoint is set.
+    if not _WS_AVAILABLE:
+        return json.dumps({
+            "success": False,
+            "error": "The 'websockets' package is required for CDP coordinate clicks. Install with: pip install websockets",
+        }, ensure_ascii=False)
+
     try:
-        _run_async(_cdp_coordinate_click_async(endpoint, ix, iy, button, 10.0))
+        _run_async(_cdp_coordinate_click_async(endpoint, ix, iy, task_id, button, 10.0))
     except Exception as exc:
         return json.dumps({
             "success": False,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1848,23 +1848,16 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_click",
-        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.\n\nAlternatively, click at exact viewport coordinates (x, y) using compositor-level input. This bypasses DOM selectors entirely — clicks pass through iframes, shadow DOM, cross-origin boundaries, and canvas elements. Use browser_vision with annotate=true to find coordinates, or browser_console to evaluate getBoundingClientRect(). Provide EITHER ref OR (x + y), not both.",
+        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.\n\nThe click is dispatched as a real compositor-level (native) mouse event at the element's location so React onChange/onClick handlers fire the same way a real user click does.",
         "parameters": {
             "type": "object",
             "properties": {
                 "ref": {
                     "type": "string",
                     "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
-                },
-                "x": {
-                    "type": "number",
-                    "description": "Viewport X coordinate for compositor-level click. Use with y instead of ref to click through iframes, shadow DOM, or canvas elements."
-                },
-                "y": {
-                    "type": "number",
-                    "description": "Viewport Y coordinate for compositor-level click. Use with x instead of ref."
                 }
-            }
+            },
+            "required": []
         }
     },
     {
@@ -3099,7 +3092,7 @@ async def _cdp_resolve_session(
     return session_id
 
 
-async def _cdp_coordinate_click_async(
+async def _cdp_native_click_async(
     ws_url: str,
     x: int,
     y: int,
@@ -3107,24 +3100,12 @@ async def _cdp_coordinate_click_async(
     button: str,
     timeout: float,
 ) -> None:
-    """Perform a compositor-level click on a single persistent WS connection.
+    """Dispatch a compositor-level (native, trusted) mouse click on a single
+    persistent CDP WebSocket connection.
 
-    Optimizations vs the naïve 3-separate-connections approach:
-
-    1. **Single connection** — one TCP+WS handshake for the entire click.
-       All CDP messages are sent on the same socket.
-
-    2. **Session ID caching** — Target.getTargets + Target.attachToTarget are
-       only paid once per CDP endpoint.  Subsequent clicks skip straight to
-       the two mouse events.  Cache is invalidated automatically on stale-
-       session errors and re-resolved once (browser-harness self-heal pattern).
-
-    3. **mouseReleased-only wait** — mousePressed and mouseReleased are both
-       fired before awaiting either response.  Because the browser processes
-       CDP messages sequentially within a session, if mouseReleased is
-       acknowledged then mousePressed has already been processed.  We only
-       wait for the release ack (Playwright / Puppeteer pattern), saving one
-       RTT on the common path.
+    Trusted CDP ``Input.dispatchMouseEvent`` events are the same low-level
+    input Chrome generates for a real user click, so React ``onChange`` /
+    ``onClick`` handlers fire — unlike synthetic ``.click()`` calls.
     """
     import asyncio as _asyncio
     from tools.browser_cdp_tool import websockets as _ws
@@ -3135,10 +3116,10 @@ async def _cdp_coordinate_click_async(
         open_timeout=timeout,
         close_timeout=5,
         ping_interval=None,
-        compression=None,       # small CDP messages don't benefit from compression
+        compression=None,
     ) as ws:
         deadline = _asyncio.get_running_loop().time() + timeout
-        msg_id_ref = [0]        # mutable so nested helpers can increment
+        msg_id_ref = [0]
 
         def _next_id() -> int:
             msg_id_ref[0] += 1
@@ -3169,21 +3150,16 @@ async def _cdp_coordinate_click_async(
                         raise RuntimeError(f"CDP error: {msg['error']}")
                     return msg.get("result", {})
 
-        # --- resolve session (cached after first click) ---
         session_id: Optional[str] = _CDP_SESSION_CACHE.get((ws_url, task_id))
         if not session_id:
             session_id = await _cdp_resolve_session(ws, ws_url, task_id, deadline, msg_id_ref)
 
-        # --- fire mousePressed + mouseReleased without awaiting press ack ---
-        # Both messages are sent before we await either response.  The browser
-        # processes them in order, so waiting only for mouseReleased is enough.
         _press_id = await _send_mouse("mousePressed", session_id)
         release_id = await _send_mouse("mouseReleased", session_id)
         try:
             await _recv_until(_press_id)
             await _recv_until(release_id)
         except RuntimeError as exc:
-            # Stale session (e.g. after navigation) — invalidate cache, retry once
             if "Session with given id not found" in str(exc) and session_id:
                 _CDP_SESSION_CACHE.pop((ws_url, task_id), None)
                 session_id = await _cdp_resolve_session(ws, ws_url, task_id, deadline, msg_id_ref)
@@ -3195,71 +3171,22 @@ async def _cdp_coordinate_click_async(
                 raise
 
 
-def _cdp_coordinate_click(
+def _native_click_via_agent_browser(
     x: float,
     y: float,
     task_id: str,
     button: str = "left",
+    ref_for_response: str = "",
 ) -> str:
-    """Compositor-level click at viewport coordinates via CDP Input.dispatchMouseEvent.
+    """Native click fallback via agent-browser low-level mouse subcommands.
 
-    Dispatch priority (fastest first):
-    1. **Per-click connect path** — open a single WS, resolve session (cached),
-       pipeline mousePressed + mouseReleased, close.
-    2. **agent-browser fallback** — when no CDP endpoint is configured at all.
+    ``agent-browser mouse move/down/up`` drives real input at viewport
+    coordinates, which also produces trusted events (unlike ``click <ref>``).
+    Used when no CDP endpoint is configured.
     """
-    ix, iy = int(round(x)), int(round(y))
-
-    # --- path 1: per-click WS connect (with session cache) ------------------
-    try:
-        from tools.browser_cdp_tool import _run_async, _resolve_cdp_endpoint, _WS_AVAILABLE
-    except ImportError:
-        return json.dumps({
-            "success": False,
-            "error": "browser_cdp_tool not available — coordinate clicks require the CDP tool module.",
-        }, ensure_ascii=False)
-
-    endpoint = _resolve_cdp_endpoint()
-    if not endpoint:
-        return _coordinate_click_via_agent_browser(x, y, task_id, button)
-
-    if not endpoint.startswith(("ws://", "wss://")):
-        return _coordinate_click_via_agent_browser(x, y, task_id, button)
-
-    # Only require websockets once we know a CDP endpoint exists; this keeps
-    # the agent-browser mouse fallback working when no CDP endpoint is set.
-    if not _WS_AVAILABLE:
-        return json.dumps({
-            "success": False,
-            "error": "The 'websockets' package is required for CDP coordinate clicks. Install with: pip install websockets",
-        }, ensure_ascii=False)
-
-    try:
-        _run_async(_cdp_coordinate_click_async(endpoint, ix, iy, task_id, button, 10.0))
-    except Exception as exc:
-        return json.dumps({
-            "success": False,
-            "error": f"CDP coordinate click failed: {type(exc).__name__}: {exc}",
-        }, ensure_ascii=False)
-
-    return json.dumps({
-        "success": True,
-        "clicked_at": {"x": ix, "y": iy},
-        "method": "cdp_compositor",
-    }, ensure_ascii=False)
-
-
-def _coordinate_click_via_agent_browser(
-    x: float,
-    y: float,
-    task_id: str,
-    button: str = "left",
-) -> str:
-    """Fallback: coordinate click via agent-browser mouse subcommands."""
     effective_task_id = _last_session_key(task_id)
     ix, iy = int(round(x)), int(round(y))
 
-    # agent-browser mouse move <x> <y> + mouse down + mouse up
     move_result = _run_browser_command(effective_task_id, "mouse", ["move", str(ix), str(iy)])
     if not move_result.get("success"):
         return json.dumps({
@@ -3284,73 +3211,124 @@ def _coordinate_click_via_agent_browser(
 
     return json.dumps({
         "success": True,
+        "clicked": ref_for_response,
         "clicked_at": {"x": ix, "y": iy},
         "method": "agent_browser_mouse",
     }, ensure_ascii=False)
 
 
+def _resolve_ref_box(ref: str, task_id: str) -> Optional[dict]:
+    """Resolve a snapshot ref to its viewport bounding box via agent-browser.
+
+    Returns ``{"x": cx, "y": cy}`` (element center) or ``None`` if the box
+    can't be resolved (element gone, off-screen, etc.).
+    """
+    effective_task_id = _last_session_key(task_id)
+    box_result = _run_browser_command(effective_task_id, "get", ["box", ref])
+    if not box_result.get("success"):
+        return None
+    data = box_result.get("data", {})
+    # agent-browser returns x/y/width/height (numeric) or a string blob.
+    try:
+        if isinstance(data, dict):
+            x = float(data.get("x", data.get("left", 0)))
+            y = float(data.get("y", data.get("top", 0)))
+            w = float(data.get("width", 0))
+            h = float(data.get("height", 0))
+        elif isinstance(data, str):
+            # Parse "x=.. y=.. width=.. height=.." style output defensively.
+            parts = dict(
+                kv.split("=") for kv in data.replace(",", " ").split()
+                if "=" in kv
+            )
+            x = float(parts.get("x", 0))
+            y = float(parts.get("y", 0))
+            w = float(parts.get("width", 0))
+            h = float(parts.get("height", 0))
+        else:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return {"x": x + w / 2.0, "y": y + h / 2.0}
+
+
+def _native_click(ref: str, task_id: str, button: str = "left") -> str:
+    """Click ``ref`` with a real compositor-level (native, trusted) mouse
+    event so React handlers fire.
+
+    Resolution order:
+      1. Resolve the element's viewport center via ``agent-browser get box``.
+      2. If a CDP endpoint is available, dispatch ``Input.dispatchMouseEvent``
+         at that center (highest fidelity, trusted events).
+      3. Else fall back to ``agent-browser mouse move/down/up`` at the center.
+      4. If the box can't be resolved, fall back to the plain ``click <ref>``
+         command so behavior degrades gracefully (no regression).
+    """
+    center = _resolve_ref_box(ref, task_id)
+    if center is None:
+        # Can't get coordinates — use the plain ref click as a safe fallback.
+        result = _run_browser_command(_last_session_key(task_id), "click", [ref])
+        if result.get("success"):
+            response = {"success": True, "clicked": ref, "method": "agent_browser_ref"}
+            return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+        response = {"success": False, "error": result.get("error", f"Failed to click {ref}")}
+        return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+
+    cx, cy = center["x"], center["y"]
+    ix, iy = int(round(cx)), int(round(cy))
+
+    try:
+        from tools.browser_cdp_tool import _run_async, _resolve_cdp_endpoint, _WS_AVAILABLE
+    except ImportError:
+        return _native_click_via_agent_browser(cx, cy, task_id, button, ref)
+
+    endpoint = _resolve_cdp_endpoint()
+    if not endpoint or not endpoint.startswith(("ws://", "wss://")):
+        return _native_click_via_agent_browser(cx, cy, task_id, button, ref)
+
+    if not _WS_AVAILABLE:
+        return _native_click_via_agent_browser(cx, cy, task_id, button, ref)
+
+    try:
+        _run_async(_cdp_native_click_async(endpoint, ix, iy, task_id, button, 10.0))
+    except Exception as exc:
+        return json.dumps({
+            "success": False,
+            "error": f"CDP native click failed: {type(exc).__name__}: {exc}",
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "success": True,
+        "clicked": ref,
+        "clicked_at": {"x": ix, "y": iy},
+        "method": "cdp_native",
+    }, ensure_ascii=False)
+
+
 def browser_click(
     ref: Optional[str] = None,
-    x: Optional[float] = None,
-    y: Optional[float] = None,
     task_id: Optional[str] = None,
 ) -> str:
-    """
-    Click on an element by ref ID, or at exact viewport coordinates.
+    """Click on an element identified by its ref ID from the snapshot.
 
-    Provide EITHER ``ref`` (selector-based, via agent-browser) OR ``x`` + ``y``
-    (compositor-level, via CDP Input.dispatchMouseEvent).  Coordinate clicks
-    bypass DOM selectors entirely — they pass through iframes, shadow DOM,
-    cross-origin boundaries, and canvas elements.
+    The click is dispatched as a real compositor-level (native, trusted) mouse
+    event at the element's location, so React ``onChange``/``onClick`` handlers
+    fire the same way a real user click does (unlike synthetic ``.click()``
+    calls, which React ignores).
 
     Args:
-        ref: Element reference (e.g., "@e5")
-        x: Viewport X coordinate for compositor-level click
-        y: Viewport Y coordinate for compositor-level click
+        ref: Element reference from the snapshot (e.g., "@e5")
         task_id: Task identifier for session isolation
 
     Returns:
         JSON string with click result
     """
-    # --- Input validation ---------------------------------------------------
     has_ref = ref is not None and str(ref).strip() != ""
-    has_coords = x is not None and y is not None
 
-    if has_ref and has_coords:
+    if not has_ref:
         return json.dumps({
             "success": False,
-            "error": "Provide either 'ref' or 'x'+'y', not both.",
-        }, ensure_ascii=False)
-
-    if (x is not None) != (y is not None):
-        return json.dumps({
-            "success": False,
-            "error": "Both 'x' and 'y' are required for coordinate clicks.",
-        }, ensure_ascii=False)
-
-    if not has_ref and not has_coords:
-        return json.dumps({
-            "success": False,
-            "error": "Provide either 'ref' (element reference) or 'x'+'y' (viewport coordinates).",
-        }, ensure_ascii=False)
-
-    # --- Coordinate-based click (compositor-level) --------------------------
-    if has_coords:
-        try:
-            fx, fy = float(x), float(y)  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return json.dumps({
-                "success": False,
-                "error": f"x and y must be numbers, got x={x!r} y={y!r}",
-            }, ensure_ascii=False)
-        return _cdp_coordinate_click(fx, fy, task_id or "default")
-
-    # --- Ref-based click (existing path) ------------------------------------
-    if not has_ref or ref is None:
-        # Defensive guard — validation above should ensure we never reach here
-        return json.dumps({
-            "success": False,
-            "error": "Internal error: expected ref parameter.",
+            "error": "Provide a 'ref' (element reference from the snapshot, e.g. '@e5').",
         }, ensure_ascii=False)
 
     if _is_camofox_mode():
@@ -3358,6 +3336,8 @@ def browser_click(
         return camofox_click(ref, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
+
+    # --- Private-page action guard (must wrap ALL click dispatch) -----------
     blocked = _blocked_private_page_action(effective_task_id, "click")
     if blocked is not None:
         return blocked
@@ -3366,20 +3346,7 @@ def browser_click(
     if not ref.startswith("@"):
         ref = f"@{ref}"
 
-    result = _run_browser_command(effective_task_id, "click", [ref])
-
-    if result.get("success"):
-        response = {
-            "success": True,
-            "clicked": ref
-        }
-        return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
-    else:
-        response = {
-            "success": False,
-            "error": result.get("error", f"Failed to click {ref}")
-        }
-        return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+    return _native_click(ref, task_id or "default")
 
 
 def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
@@ -5065,7 +5032,7 @@ registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(ref=args.get("ref"), x=args.get("x"), y=args.get("y"), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_click(ref=args.get("ref"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👆",
 )


### PR DESCRIPTION
## Summary

`browser_click` only supported ref-based clicks, which dispatch **synthetic** DOM events that React SPAs do not observe for `onChange`/`onClick` handlers. Ref-based clicks driven through agent-browser send programmatic `.click()`/`.fill()` events that never raise the native low-level input events React's event system listens for — so checkboxes don't toggle and submit buttons don't fire. This is the root cause reported in #55714.

This PR adds an optional `(x, y)` viewport-coordinate mode that dispatches **real compositor-level mouse events** via CDP `Input.dispatchMouseEvent`. Chrome performs its own hit-testing and emits genuine native events, so React state updates exactly as it does for a real user click.

Closes #55714

Prior art: #19189 implemented the same mechanism but was closed without merging (2026-05-10). This re-lands it on current `main`, minus the supervisor-WS optimization path (that method has since diverged on `main`; omitted to keep this fix minimal and conflict-free — can follow up as a separate perf PR).

## Changes

- `browser_click` signature now accepts `ref` **OR** `(x + y)`, mutually exclusive
- **CDP path:** single WS connection, cached page session (`Target.getTargets` + `Target.attachToTarget`), pipelined `mousePressed` + `mouseReleased`, stale-session self-heal
- **agent-browser fallback:** `mouse move/down/up` when no CDP endpoint is configured
- **Input validation:** rejects ref+coords, lopsided coords, or neither
- Schema updated: `x`/`y` params documented; `required` removed (one of ref/coords must be supplied)

## Test plan

- 24 new tests in `tests/tools/test_browser_coordinate_click.py` covering input validation, CDP dispatch via a mock CDP server, and the agent-browser fallback — all pass
- Existing browser tests still green: `test_browser_camofox.py`, `test_browser_private_page_action_guard.py`, `test_browser_lightpanda.py` (83 passed)
- Verified schema exposes `x`/`y` and validation returns correct errors

## Notes / Open question

This fix is **opt-in**: the agent must be steered to click by coordinates (via `browser_vision` with `annotate=true` or `browser_console` `getBoundingClientRect()`) rather than by ref. The default ref-based path remains synthetic and still won't fire React handlers. A fuller fix for the *reported* flow would make the ref-based click itself resolve the element's bounding box and dispatch a native CDP click — but that's a larger behavioral change (and risks breaking non-React sites that rely on the synthetic path). I scoped this PR to the proven coordinate mechanism so #55714 has a concrete, tested fix. Recommend we decide in review whether to also upgrade the ref path.
