### PR TITLE
fix(kanban): cap implicit local stale timeout

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -25,7 +25,11 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
+from hermes_cli.timeouts import (
+    get_provider_request_timeout,
+    get_provider_stale_timeout,
+    resolve_local_default_stale_timeout,
+)
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.gemini_native_adapter import is_native_gemini_base_url
@@ -2994,14 +2998,35 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
+        _uses_implicit_stream_stale_timeout = False
     else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+        _stream_stale_env = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+        _stream_stale_timeout_base = (
+            float(_stream_stale_env) if _stream_stale_env is not None else 180.0
+        )
+        _uses_implicit_stream_stale_timeout = _stream_stale_env is None
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
+    if (
+        _uses_implicit_stream_stale_timeout
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        _stream_stale_timeout = resolve_local_default_stale_timeout(
+            _stream_stale_timeout_base
+        )
+        if _stream_stale_timeout == float("inf"):
+            logger.debug(
+                "Local provider detected (%s) — stale stream timeout disabled",
+                agent.base_url,
+            )
+        else:
+            logger.info(
+                "Kanban local provider detected (%s) — stale stream timeout capped at %.0fs",
+                agent.base_url,
+                _stream_stale_timeout,
+            )
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 
 def _coerce_timeout(raw: object) -> float | None:
     try:
@@ -67,6 +69,17 @@ def get_provider_stale_timeout(
             return timeout
 
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
+
+
+def resolve_local_default_stale_timeout(default_timeout: float) -> float:
+    """Resolve the implicit stale-timeout policy for local providers."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return float("inf")
+
+    kanban_timeout = _coerce_timeout(os.getenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT"))
+    if kanban_timeout is None:
+        kanban_timeout = 900.0
+    return max(default_timeout, kanban_timeout)
 
 
 def _get_model_config(

--- a/run_agent.py
+++ b/run_agent.py
@@ -120,6 +120,7 @@ from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
     get_provider_stale_timeout,
+    resolve_local_default_stale_timeout,
 )
 
 _hermes_home = get_hermes_home()
@@ -1284,7 +1285,7 @@ class AIAgent:
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
-            return float("inf")
+            return resolve_local_default_stale_timeout(stale_base)
 
         from agent.chat_completion_helpers import estimate_request_context_tokens
         est_tokens = estimate_request_context_tokens(api_payload)

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -6,11 +6,13 @@ default 60s to HERMES_API_TIMEOUT (1800s) to avoid premature connection
 kills during long prefill phases.
 """
 
-import os
-import pytest
 from unittest.mock import patch
 
+import os
+import pytest
+
 from agent.model_metadata import is_local_endpoint
+from hermes_cli.timeouts import resolve_local_default_stale_timeout
 
 
 class TestLocalStreamReadTimeout:
@@ -138,3 +140,17 @@ class TestIsLocalEndpoint:
     def test_near_but_not_cgnat_is_remote(self, url):
         """Hosts adjacent to but outside 100.64.0.0/10 must not match."""
         assert is_local_endpoint(url) is False
+
+
+class TestLocalStreamStaleTimeout:
+    def test_default_local_stream_stale_timeout_stays_disabled_outside_kanban(self, monkeypatch):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT", raising=False)
+
+        assert resolve_local_default_stale_timeout(180.0) == float("inf")
+
+    def test_kanban_local_stream_stale_timeout_uses_finite_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "task-61048")
+        monkeypatch.delenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT", raising=False)
+
+        assert resolve_local_default_stale_timeout(180.0) == 900.0

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -5,6 +5,7 @@ import textwrap
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
     get_provider_stale_timeout,
+    resolve_local_default_stale_timeout,
 )
 
 
@@ -286,6 +287,38 @@ def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monk
     )
 
     assert agent._compute_non_stream_stale_timeout([]) == float("inf")
+
+
+def test_kanban_local_non_stream_stale_timeout_uses_finite_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-61048")
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT", raising=False)
+
+    from run_agent import AIAgent
+    agent = AIAgent(
+        model="qwen3:32b",
+        provider="ollama-local",
+        api_key="sk-dummy",
+        base_url="http://127.0.0.1:11434/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+    assert agent._compute_non_stream_stale_timeout([]) == 900.0
+
+
+def test_kanban_local_stale_timeout_override_is_respected(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-61048")
+    monkeypatch.setenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT", "1200")
+
+    assert resolve_local_default_stale_timeout(180.0) == 1200.0
+
+    monkeypatch.setenv("HERMES_KANBAN_LOCAL_STALE_TIMEOUT", "60")
+    assert resolve_local_default_stale_timeout(180.0) == 180.0
 
 
 def test_explicit_non_stream_stale_timeout_is_honored_for_local_endpoints(monkeypatch, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Caps the implicit local-provider stale timeout for kanban workers so wedged local LLM calls eventually raise and the existing fallback provider path can run. Normal interactive local sessions keep the legacy disabled stale detector, while kanban workers now get a finite default ceiling with an override knob.

## Related Issue

Fixes #61048

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `resolve_local_default_stale_timeout()` in `hermes_cli/timeouts.py` to keep normal local sessions on the legacy `inf` behavior while giving kanban workers a finite default timeout and `HERMES_KANBAN_LOCAL_STALE_TIMEOUT` override.
- Updated `run_agent.py` so implicit local non-stream stale timeouts use the shared kanban-aware helper instead of always returning `inf`.
- Updated `agent/chat_completion_helpers.py` so the streaming stale detector uses the same kanban-aware helper and distinguishes the implicit default from an explicit `HERMES_STREAM_STALE_TIMEOUT` setting.
- Added focused regression coverage in `tests/hermes_cli/test_timeouts.py` and `tests/agent/test_local_stream_timeout.py`.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_timeouts.py tests/agent/test_local_stream_timeout.py`.
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile hermes_cli/timeouts.py run_agent.py agent/chat_completion_helpers.py`.
3. Confirm `git diff --check` is clean and verify kanban workers use a finite implicit local stale timeout while non-kanban local sessions still resolve to `inf`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `pytest`: `58 passed, 1 skipped in 12.52s`
- `py_compile`: passed
- `git diff --check`: passed
