### PR TITLE
fix(cron): honor non-spawnable assignee containment in kanban auto-decompose

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1364,10 +1364,13 @@ class GatewayKanbanWatchersMixin:
                 try:
                     os.environ["HERMES_KANBAN_BOARD"] = slug
                     try:
-                        triage_ids = _decomp.list_triage_ids()
+                        # Excludes parked (non-spawnable-assignee) cards so
+                        # they don't consume auto_decompose_per_tick and
+                        # starve eligible cards behind them (#62994 followup).
+                        triage_ids = _decomp.list_spawnable_triage_ids()
                     except Exception as exc:
                         logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                            "kanban auto-decompose: list_spawnable_triage_ids failed on board %s (%s)",
                             slug, exc,
                         )
                         triage_ids = []

--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -256,9 +256,11 @@ class _KanbanDispatcher:
             try:
                 os.environ["HERMES_KANBAN_BOARD"] = slug
                 try:
-                    triage_ids = _decomp.list_triage_ids()
+                    # Excludes parked (non-spawnable-assignee) cards so they don't consume
+                    # auto_decompose_per_tick and starve eligible cards behind them (#62985).
+                    triage_ids = _decomp.list_spawnable_triage_ids()
                 except Exception as exc:
-                    logger.debug("kanban auto-decompose: list_triage_ids failed on board %s (%s)", slug, exc)
+                    logger.debug("kanban auto-decompose: list_spawnable_triage_ids failed on board %s (%s)", slug, exc)
                     triage_ids = []
                 for tid in triage_ids:
                     if attempted >= auto_decompose_per_tick:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -289,6 +289,20 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
         )
+    if task.assignee:
+        try:
+            assignee_is_spawnable = profiles_mod.profile_exists(task.assignee)
+        except Exception:
+            assignee_is_spawnable = False
+        if not assignee_is_spawnable:
+            # Mirrors the dispatcher's has_spawnable_ready/profile_exists gate
+            # (#62985): a task deliberately parked under a non-profile
+            # assignee must stay parked, not get silently fanned out and
+            # reassigned to the orchestrator/default_assignee.
+            return DecomposeOutcome(
+                task_id, False,
+                f"assignee {task.assignee!r} is not a spawnable profile — parked",
+            )
 
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -268,6 +268,21 @@ def _normalize_assignee_choice(
     return chosen
 
 
+def _is_spawnable_assignee(assignee: Optional[str]) -> bool:
+    """True if *assignee* is empty (unassigned) or resolves to a real profile.
+
+    False means the task was deliberately parked under a non-profile name —
+    the same containment convention the dispatcher already respects via
+    ``has_spawnable_ready``/``profile_exists`` (#62985).
+    """
+    if not assignee:
+        return True
+    try:
+        return profiles_mod.profile_exists(assignee)
+    except Exception:
+        return False
+
+
 def decompose_task(
     task_id: str,
     *,
@@ -289,20 +304,15 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
         )
-    if task.assignee:
-        try:
-            assignee_is_spawnable = profiles_mod.profile_exists(task.assignee)
-        except Exception:
-            assignee_is_spawnable = False
-        if not assignee_is_spawnable:
-            # Mirrors the dispatcher's has_spawnable_ready/profile_exists gate
-            # (#62985): a task deliberately parked under a non-profile
-            # assignee must stay parked, not get silently fanned out and
-            # reassigned to the orchestrator/default_assignee.
-            return DecomposeOutcome(
-                task_id, False,
-                f"assignee {task.assignee!r} is not a spawnable profile — parked",
-            )
+    if not _is_spawnable_assignee(task.assignee):
+        # Mirrors the dispatcher's has_spawnable_ready/profile_exists gate
+        # (#62985): a task deliberately parked under a non-profile assignee
+        # must stay parked, not get silently fanned out and reassigned to
+        # the orchestrator/default_assignee.
+        return DecomposeOutcome(
+            task_id, False,
+            f"assignee {task.assignee!r} is not a spawnable profile — parked",
+        )
 
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)
@@ -480,3 +490,25 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             limit=1000,
         )
     return [row.id for row in rows]
+
+
+def list_spawnable_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+    """Like ``list_triage_ids``, but excludes tasks parked under a
+    non-spawnable assignee (see ``_is_spawnable_assignee`` / #62985).
+
+    The auto-decompose tick consumes this so it doesn't burn its
+    per-tick attempt budget on cards ``decompose_task`` will reject every
+    time — parked cards never leave triage, so without this filter enough
+    of them ahead of an eligible card in priority order can starve it
+    indefinitely. Manual/CLI/dashboard listing paths intentionally keep
+    using ``list_triage_ids`` unfiltered, so a user can still see their
+    own parked cards.
+    """
+    with kb.connect_closing() as conn:
+        rows = kb.list_tasks(
+            conn,
+            status="triage",
+            tenant=tenant,
+            limit=1000,
+        )
+    return [row.id for row in rows if _is_spawnable_assignee(row.assignee)]

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -296,6 +296,21 @@ def _apply_fanout(task_id: str, parsed: dict, routing: _Routing, author: str) ->
     )
 
 
+def _is_spawnable_assignee(assignee: Optional[str]) -> bool:
+    """True if *assignee* is empty (unassigned) or resolves to a real profile.
+
+    False means the task was deliberately parked under a non-profile name —
+    the same containment convention the dispatcher already respects via
+    ``has_spawnable_ready``/``profile_exists`` (#62985)."""
+    if not assignee:
+        return True
+    try:
+        return profiles_mod.profile_exists(assignee)
+    except Exception as exc:
+        logger.warning("decompose: failed to resolve assignee %r as a profile: %s", assignee, exc)
+        return False
+
+
 def decompose_task(
     task_id: str,
     *,
@@ -308,6 +323,11 @@ def decompose_task(
     task, reason = _load_triage_task(task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, reason)
+    if not _is_spawnable_assignee(task.assignee):
+        # Mirrors the dispatcher's has_spawnable_ready/profile_exists gate (#62985): a task
+        # deliberately parked under a non-profile assignee must stay parked, not get silently
+        # fanned out and reassigned to the orchestrator/default_assignee.
+        return DecomposeOutcome(task_id, False, f"assignee {task.assignee!r} is not a spawnable profile — parked")
 
     routing = _load_routing()
     raw, reason = _call_aux(
@@ -337,6 +357,29 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     with kbc.connect_closing() as conn:
         rows = kb.list_tasks(conn, status="triage", tenant=tenant, limit=1000)
     return [row.id for row in rows]
+
+
+def list_spawnable_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+    """Like ``list_triage_ids``, but excludes tasks parked under a non-spawnable
+    assignee (see ``_is_spawnable_assignee`` / #62985).
+
+    The auto-decompose tick consumes this so it doesn't burn its per-tick attempt
+    budget on cards ``decompose_task`` rejects every time — parked cards never leave
+    triage, so enough of them ahead of an eligible card in priority order would
+    starve it indefinitely. Manual/CLI/dashboard listing paths keep using
+    ``list_triage_ids`` unfiltered, so a user can still see their own parked cards.
+    Each distinct assignee is resolved once per call: one coherent profile snapshot
+    per tick, no repeated lookups for a board full of same-assignee cards."""
+    with kbc.connect_closing() as conn:
+        rows = kb.list_tasks(conn, status="triage", tenant=tenant, limit=1000)
+    spawnable_by_assignee: dict[Optional[str], bool] = {}
+    spawnable_ids: list[str] = []
+    for row in rows:
+        if row.assignee not in spawnable_by_assignee:
+            spawnable_by_assignee[row.assignee] = _is_spawnable_assignee(row.assignee)
+        if spawnable_by_assignee[row.assignee]:
+            spawnable_ids.append(row.id)
+    return spawnable_ids
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -222,3 +222,39 @@ def test_decompose_proceeds_when_assignee_is_real_profile(kanban_home):
             p.stop()
 
     assert outcome.ok, outcome.reason
+def test_list_spawnable_triage_ids_excludes_parked_assignees(kanban_home):
+    """#62994 followup: the auto-decompose tick must not burn its
+    per-tick attempt budget on parked cards. If enough of them sit ahead
+    of an eligible card in priority/creation order, list_triage_ids()
+    alone would let them starve the eligible card indefinitely (parked
+    cards never leave triage — decompose_task() rejects them every tick).
+    list_spawnable_triage_ids() must exclude them entirely so the eligible
+    card is always reachable within the budget."""
+    with kb.connect() as conn:
+        parked_ids = [
+            kb.create_task(
+                conn, title=f"parked {i}", assignee="not-a-profile", triage=True,
+            )
+            for i in range(3)
+        ]
+        eligible_id = kb.create_task(
+            conn, title="do this", assignee="engineer", triage=True,
+        )
+        unassigned_id = kb.create_task(conn, title="pick me up", triage=True)
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        spawnable_ids = decomp.list_spawnable_triage_ids()
+        all_ids = decomp.list_triage_ids()
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert eligible_id in spawnable_ids
+    assert unassigned_id in spawnable_ids
+    assert not any(pid in spawnable_ids for pid in parked_ids)
+    # Unfiltered listing (CLI/dashboard) still surfaces every card,
+    # including the parked ones, so a user can see what's contained.
+    assert set(parked_ids) | {eligible_id, unassigned_id} <= set(all_ids)

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,64 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_parks_task_with_nonspawnable_assignee(kanban_home):
+    """#62985: a task deliberately parked under a non-profile assignee must
+    stay parked, not get silently fanned out and reassigned. Mirrors the
+    dispatcher's has_spawnable_ready/profile_exists containment gate — this
+    must reject before ever reaching the aux client (no LLM call, no DB
+    mutation of assignee/status)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="parked task - do not run",
+            assignee="not-a-profile", triage=True,
+        )
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "not-a-profile" in outcome.reason
+    assert "spawnable" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.assignee == "not-a-profile"
+
+
+def test_decompose_proceeds_when_assignee_is_real_profile(kanban_home):
+    """Sanity check for the new guard: a task whose assignee IS a real
+    profile must not be blocked by the nonspawnable-assignee check."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="already routed", assignee="engineer", triage=True,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened title",
+        "body": "Keep existing lane.",
+        "assignee": "engineer",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"default_assignee": "engineer"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -162,3 +162,117 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_parks_task_with_nonspawnable_assignee(kanban_home):
+    """#62985: a task deliberately parked under a non-profile assignee must stay
+    parked, not get silently fanned out and reassigned. Mirrors the dispatcher's
+    has_spawnable_ready/profile_exists containment gate — this must reject before
+    ever reaching the aux client (no LLM call, no DB mutation of assignee/status)."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="parked task - do not run", assignee="not-a-profile", triage=True)
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch("agent.auxiliary_client.call_llm") as call_llm:
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "not-a-profile" in outcome.reason
+    assert "spawnable" in outcome.reason
+    call_llm.assert_not_called()
+    with kbc.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.assignee == "not-a-profile"
+
+
+def test_decompose_proceeds_when_assignee_is_real_profile(kanban_home):
+    """A task whose assignee IS a real profile must not be blocked by the
+    nonspawnable-assignee guard."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="already routed", assignee="engineer", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened title",
+        "body": "Keep existing lane.",
+        "assignee": "engineer",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"default_assignee": "engineer"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+
+
+def test_list_spawnable_triage_ids_excludes_parked_assignees(kanban_home):
+    """The auto-decompose tick must not burn its per-tick attempt budget on parked
+    cards: enough of them ahead of an eligible card would let list_triage_ids()
+    starve it indefinitely (parked cards never leave triage — decompose_task()
+    rejects them every tick). list_spawnable_triage_ids() excludes them so the
+    eligible card is always reachable within the budget."""
+    with kbc.connect() as conn:
+        parked_ids = [
+            kb.create_task(conn, title=f"parked {i}", assignee="not-a-profile", triage=True)
+            for i in range(3)
+        ]
+        eligible_id = kb.create_task(conn, title="do this", assignee="engineer", triage=True)
+        unassigned_id = kb.create_task(conn, title="pick me up", triage=True)
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        spawnable_ids = decomp.list_spawnable_triage_ids()
+        all_ids = decomp.list_triage_ids()
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert eligible_id in spawnable_ids
+    assert unassigned_id in spawnable_ids
+    assert not any(pid in spawnable_ids for pid in parked_ids)
+    # Unfiltered listing (CLI/dashboard) still surfaces every card, including the
+    # parked ones, so a user can see what's contained.
+    assert set(parked_ids) | {eligible_id, unassigned_id} <= set(all_ids)
+
+
+def test_list_spawnable_triage_ids_uses_one_assignee_snapshot_per_call(kanban_home):
+    with kbc.connect() as conn:
+        first_id = kb.create_task(conn, title="first", assignee="engineer", triage=True)
+        second_id = kb.create_task(conn, title="second", assignee="engineer", triage=True)
+
+    profile_states = iter([True, False])
+    with patch("hermes_cli.profiles.profile_exists", side_effect=lambda _name: next(profile_states)):
+        spawnable_ids = decomp.list_spawnable_triage_ids()
+
+    assert {first_id, second_id} <= set(spawnable_ids)
+
+
+def test_list_spawnable_triage_ids_logs_profile_lookup_failure(kanban_home, caplog):
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="retry next tick", assignee="engineer", triage=True)
+
+    caplog.set_level("WARNING", logger=decomp.__name__)
+    with patch("hermes_cli.profiles.profile_exists", side_effect=OSError("profile store unavailable")):
+        spawnable_ids = decomp.list_spawnable_triage_ids()
+
+    assert task_id not in spawnable_ids
+    assert "failed to resolve assignee 'engineer'" in caplog.text
+    assert "profile store unavailable" in caplog.text


### PR DESCRIPTION
## What does this PR do?

`dispatch_once` deliberately respects a "non-spawnable assignee" containment convention: a ready/review task whose assignee doesn't resolve to a real profile is skipped (`profile_exists` filter, tracked in `skipped_nonspawnable`). `decompose_task()` (the auto-decomposer) has no equivalent guard — it only checks `task.status == "triage"`. A triage task deliberately parked under a non-profile assignee name gets fanned out into children assigned to real profiles via `_normalize_assignee_choice`, with the root task unconditionally reassigned to `orchestrator_profile`, and (with the default `auto_promote_children: true`) the children auto-promote to `ready` and live workers spawn — silently un-parking and executing work a user intentionally contained for human review.

## Related Issue

Fixes #62985

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

_Rebased onto current main (`f8456248d9`) as a single commit; the auto-decompose tick has since moved from `gateway/kanban_watchers.py` to `gateway/kanban_watchers_dispatcher.py`, and `decompose_task()` now loads the card through `_load_triage_task()`, so the gate sits right after that call._

- `hermes_cli/kanban_decompose.py`:
  - `decompose_task()` gains a `profile_exists` gate right after the triage-status check, mirroring the dispatcher's `has_spawnable_ready` semantics. A non-empty `task.assignee` that doesn't resolve to a real profile returns `ok=False` with a `"... is not a spawnable profile — parked"` reason instead of proceeding to fan-out/reassignment.
  - Added `list_spawnable_triage_ids()`, which filters out parked cards. `list_triage_ids()` itself is left unfiltered so human-facing CLI/dashboard listings still show a user's own parked cards.
  - Spawnable-assignee checks are cached per tick so the added gate doesn't re-resolve the same profiles repeatedly.
- `gateway/kanban_watchers_dispatcher.py`: `auto_decompose_tick()` now calls `list_spawnable_triage_ids()` instead of `list_triage_ids()`, so parked cards no longer consume `auto_decompose_per_tick` and starve eligible cards queued behind them.
- `tests/hermes_cli/test_kanban_decompose.py`: regression test for the exact issue scenario (task parked under `assignee="not-a-profile"`, rejected *before* any DB mutation — status and assignee both unchanged); a sanity check that a real-profile assignee is unaffected; plus coverage for the starvation fix and the per-tick cache.

## How to Test

1. `config.yaml`: `kanban.auto_decompose: true`, with `orchestrator_profile` and `default_assignee` set to a real profile.
2. `hermes kanban create "parked task - do not run" --assignee not-a-profile --triage`
3. Before this fix: within one dispatcher tick (~60s) the card fans out, the root gets reassigned to the orchestrator, children promote to `ready`, and workers spawn.
4. After this fix: the decompose attempt returns `ok=False` with a "not a spawnable profile — parked" reason; the task's status and assignee are untouched.
5. `pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_db.py -q` — 235 passed. Reverting just the guard reproduces the original bypass (verified locally via `git stash`) — without it, the test task proceeds past the check and attempts a real auxiliary-client call.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (by issue number and by file/mechanism — `kanban_decompose`, `_auto_decompose_tick`, `decompose_triage_task`) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_db.py -q` — 235/235 pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI Disclosure

This bug was identified and fixed with AI assistance.

