### PR TITLE
fix(lsp): reap idle servers and terminate process groups

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -162,6 +163,7 @@ class LSPClient:
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
+        self._process_group_id: Optional[int] = None
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
 
@@ -263,13 +265,12 @@ class LSPClient:
             cmd = self._win_wrap_cmd(cmd)
 
         try:
-            # start_new_session=True detaches the LSP server into its own
-            # process group / session. Without this, the LSP server inherits
-            # the gateway's pgid (= TUI parent PID). When mcp_tool's
-            # _kill_orphaned_mcp_children races with LSP spawn and sweeps the
-            # gateway's child set, it captures the LSP PID, records the
-            # inherited pgid, and killpg() then kills the TUI parent itself.
-            # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
+            spawn_kwargs: Dict[str, Any] = {}
+            if sys.platform != "win32":
+                # Detach the LSP server into its own process group/session.
+                # This prevents unrelated orphan sweeps from targeting the
+                # gateway's group and lets cleanup terminate all descendants.
+                spawn_kwargs["start_new_session"] = True
             self._proc = await asyncio.create_subprocess_exec(
                 cmd[0],
                 *cmd[1:],
@@ -278,8 +279,10 @@ class LSPClient:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=self._cwd,
-                start_new_session=True,
+                **spawn_kwargs,
             )
+            if sys.platform != "win32":
+                self._process_group_id = self._proc.pid
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
@@ -446,19 +449,42 @@ class LSPClient:
                 pass
         proc = self._proc
         self._proc = None
+        process_group_id = self._process_group_id
+        self._process_group_id = None
         if proc is None:
             return
         if proc.returncode is None:
             try:
-                proc.terminate()
+                if process_group_id is not None:
+                    os.killpg(process_group_id, signal.SIGTERM)
+                else:
+                    proc.terminate()
                 try:
                     await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
                 except asyncio.TimeoutError:
                     try:
-                        proc.kill()
+                        if process_group_id is not None:
+                            os.killpg(process_group_id, signal.SIGKILL)
+                        else:
+                            proc.kill()
                         await proc.wait()
                     except ProcessLookupError:
                         pass
+            except ProcessLookupError:
+                pass
+        elif process_group_id is not None:
+            # The leader can exit before a worker; a live process group with
+            # this id then consists only of descendants from our own session.
+            try:
+                os.killpg(process_group_id, signal.SIGTERM)
+                deadline = asyncio.get_running_loop().time() + SHUTDOWN_GRACE
+                while asyncio.get_running_loop().time() < deadline:
+                    await asyncio.sleep(0.05)
+                    try:
+                        os.killpg(process_group_id, 0)
+                    except ProcessLookupError:
+                        return
+                os.killpg(process_group_id, signal.SIGKILL)
             except ProcessLookupError:
                 pass
 

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -175,13 +175,30 @@ class LSPService:
         self._broken: set = set()
         self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
         self._last_used: Dict[Tuple[str, str], float] = {}
+        self._active_uses: Dict[Tuple[str, str], int] = {}
         self._state_lock = threading.Lock()
+        self._reaper_run_lock = threading.Lock()
+        self._shutdown_lock = threading.Lock()
+        self._shutting_down = False
 
         # Delta baseline: file path → snapshot of diagnostics taken
         # immediately before a write.  ``get_diagnostics_sync`` filters
         # out anything in the baseline so the agent only sees errors
         # introduced by the current edit.
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
+
+        # Gateways live for days and may edit files in many unrelated
+        # repositories. Reap idle clients independently of future tool calls;
+        # otherwise the last server in an old workspace lives indefinitely.
+        self._reaper_stop = threading.Event()
+        self._reaper_thread: Optional[threading.Thread] = None
+        if self._enabled and self._idle_timeout > 0:
+            self._reaper_thread = threading.Thread(
+                target=self._reaper_main,
+                name="hermes-lsp-reaper",
+                daemon=True,
+            )
+            self._reaper_thread.start()
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -435,34 +452,80 @@ class LSPService:
         """Tear down all clients and stop the background loop."""
         if not self._enabled:
             return
-        try:
-            self._loop.run(self._shutdown_async(), timeout=10.0)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("LSP shutdown error: %s", e)
-        self._loop.stop()
-        clear_cache()
+        with self._shutdown_lock:
+            if self._shutting_down:
+                return
+            self._shutting_down = True
+            self._reaper_stop.set()
+            if self._reaper_thread is not None:
+                self._reaper_thread.join(timeout=12.0)
+                self._reaper_thread = None
+            with self._reaper_run_lock:
+                try:
+                    self._loop.run(self._shutdown_async(), timeout=10.0)
+                except Exception as e:  # noqa: BLE001
+                    logger.debug("LSP shutdown error: %s", e)
+            self._loop.stop()
+            clear_cache()
 
     # ------------------------------------------------------------------
     # async internals
     # ------------------------------------------------------------------
 
+    def _reaper_main(self) -> None:
+        """Periodically close clients even when no more edits arrive."""
+        interval = min(60.0, self._idle_timeout)
+        while not self._reaper_stop.wait(interval):
+            try:
+                with self._reaper_run_lock:
+                    if self._reaper_stop.is_set():
+                        break
+                    self._loop.run(self._reap_idle_async(), timeout=10.0)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("LSP idle reaper error: %s", e)
+
+    async def _reap_idle_async(self) -> int:
+        """Remove and shut down clients unused past ``idle_timeout``."""
+        cutoff = time.time() - self._idle_timeout
+        with self._state_lock:
+            stale = [
+                (key, client)
+                for key, client in self._clients.items()
+                if self._last_used.get(key, 0) < cutoff
+                and self._active_uses.get(key, 0) == 0
+            ]
+            for key, _client in stale:
+                self._clients.pop(key, None)
+                self._last_used.pop(key, None)
+
+        # Never hold the state lock while waiting for a child process.
+        if stale:
+            await asyncio.gather(
+                *(client.shutdown() for _key, client in stale),
+                return_exceptions=True,
+            )
+        return len(stale)
+
     async def _snapshot_async(self, file_path: str) -> List[Dict[str, Any]]:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return []
+        key = self._begin_use(client)
         try:
             version = await client.open_file(file_path, language_id=language_id_for(file_path))
             await client.wait_for_diagnostics(file_path, version, mode=self._wait_mode)
         except Exception as e:  # noqa: BLE001
             logger.debug("snapshot open/wait failed: %s", e)
             return []
-        self._last_used[(client.server_id, client.workspace_root)] = time.time()
+        finally:
+            self._end_use(key)
         return list(client.diagnostics_for(file_path))
 
     async def _open_and_wait_async(self, file_path: str) -> List[Dict[str, Any]]:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return []
+        key = self._begin_use(client)
         try:
             version = await client.open_file(file_path, language_id=language_id_for(file_path))
             await client.save_file(file_path)
@@ -470,8 +533,26 @@ class LSPService:
         except Exception as e:  # noqa: BLE001
             logger.debug("open/wait failed for %s: %s", file_path, e)
             return []
-        self._last_used[(client.server_id, client.workspace_root)] = time.time()
+        finally:
+            self._end_use(key)
         return list(client.diagnostics_for(file_path))
+
+    def _begin_use(self, client: LSPClient) -> Tuple[str, str]:
+        """Lease a client so the idle reaper cannot close it mid-request."""
+        key = (client.server_id, client.workspace_root)
+        with self._state_lock:
+            self._active_uses[key] = self._active_uses.get(key, 0) + 1
+        return key
+
+    def _end_use(self, key: Tuple[str, str]) -> None:
+        with self._state_lock:
+            remaining = self._active_uses.get(key, 1) - 1
+            if remaining > 0:
+                self._active_uses[key] = remaining
+            else:
+                self._active_uses.pop(key, None)
+            if key in self._clients:
+                self._last_used[key] = time.time()
 
     async def _current_diags_async(self, file_path: str) -> List[Dict[str, Any]]:
         ws, gated = resolve_workspace_for_file(file_path)
@@ -558,7 +639,7 @@ class LSPService:
                 return None
             with self._state_lock:
                 self._clients[key] = client
-            self._last_used[key] = time.time()
+                self._last_used[key] = time.time()
             eventlog.log_active(srv.server_id, per_server_root)
             spawn_future.set_result(client)
             return client
@@ -572,6 +653,7 @@ class LSPService:
             self._clients.clear()
             self._broken.clear()
             self._last_used.clear()
+            self._active_uses.clear()
         await asyncio.gather(
             *(c.shutdown() for c in clients),
             return_exceptions=True,

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,12 +7,166 @@ on.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
 from agent.lsp.manager import LSPService
+
+
+class _IdleClient:
+    def __init__(self):
+        self.shutdown_calls = 0
+        self.shutdown_event = threading.Event()
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+        self.shutdown_event.set()
+
+
+def test_reap_idle_clients_closes_and_forgets_stale_workspaces(monkeypatch):
+    """Long-lived gateways must not retain one server per old workspace."""
+    svc = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=1,
+        install_strategy="manual",
+        idle_timeout=10,
+    )
+    stale = _IdleClient()
+    fresh = _IdleClient()
+    stale_key = ("typescript", "/old/project")
+    fresh_key = ("typescript", "/active/project")
+    svc._clients = {stale_key: stale, fresh_key: fresh}
+    svc._last_used = {stale_key: 80, fresh_key: 95}
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 100)
+
+    reaped = __import__("asyncio").run(svc._reap_idle_async())
+
+    assert reaped == 1
+    assert stale.shutdown_calls == 1
+    assert fresh.shutdown_calls == 0
+    assert stale_key not in svc._clients
+    assert stale_key not in svc._last_used
+    assert fresh_key in svc._clients
+
+
+def test_background_reaper_runs_without_a_later_tool_call():
+    """An abandoned workspace is reaped while the gateway is otherwise idle."""
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=1,
+        install_strategy="manual",
+        idle_timeout=0.02,
+    )
+    client = _IdleClient()
+    key = ("typescript", "/abandoned/project")
+    with svc._state_lock:
+        svc._clients[key] = client
+        svc._last_used[key] = 0
+    try:
+        assert client.shutdown_event.wait(1.0), "background reaper did not run"
+        assert client.shutdown_calls == 1
+        assert key not in svc._clients
+    finally:
+        svc.shutdown()
+
+
+def test_reap_idle_clients_does_not_hold_state_lock_during_shutdown(monkeypatch):
+    """A slow language-server exit must not block unrelated client lookups."""
+    svc = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=1,
+        install_strategy="manual",
+        idle_timeout=10,
+    )
+
+    class _LockCheckingClient(_IdleClient):
+        async def shutdown(self):
+            assert svc._state_lock.acquire(blocking=False)
+            svc._state_lock.release()
+            await super().shutdown()
+
+    client = _LockCheckingClient()
+    key = ("typescript", "/old/project")
+    svc._clients[key] = client
+    svc._last_used[key] = 0
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 100)
+
+    asyncio.run(svc._reap_idle_async())
+    assert client.shutdown_calls == 1
+
+
+def test_request_crossing_idle_timeout_is_not_reaped(monkeypatch):
+    """The timeout measures completed idle time, not request duration."""
+    svc = LSPService(enabled=False, wait_mode="document", wait_timeout=1,
+                     install_strategy="manual", idle_timeout=10)
+
+    class _BusyClient(_IdleClient):
+        server_id = "typescript"
+        workspace_root = "/project"
+        def __init__(self):
+            super().__init__()
+            self.started = asyncio.Event()
+            self.finish = asyncio.Event()
+        async def open_file(self, *_args, **_kwargs):
+            self.started.set()
+            await self.finish.wait()
+            return 1
+        async def wait_for_diagnostics(self, *_args, **_kwargs):
+            pass
+        def diagnostics_for(self, _file_path):
+            return []
+
+    client = _BusyClient()
+    key = (client.server_id, client.workspace_root)
+    svc._clients[key] = client
+    svc._last_used[key] = 80
+
+    async def fake_get_or_spawn(_file_path):
+        return client
+
+    monkeypatch.setattr(svc, "_get_or_spawn", fake_get_or_spawn)
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 100)
+
+    async def exercise():
+        request = asyncio.create_task(svc._snapshot_async("/project/a.ts"))
+        await client.started.wait()
+        assert await svc._reap_idle_async() == 0
+        assert client.shutdown_calls == 0
+        client.finish.set()
+        await request
+        assert svc._last_used[key] == 100
+
+    asyncio.run(exercise())
+
+
+def test_shutdown_waits_for_reaper_critical_section():
+    svc = LSPService(enabled=True, wait_mode="document", wait_timeout=1,
+                     install_strategy="manual", idle_timeout=60)
+    client = _IdleClient()
+    key = ("typescript", "/project")
+    with svc._state_lock:
+        svc._clients[key] = client
+        svc._last_used[key] = 0
+    svc._reaper_run_lock.acquire()
+    thread = threading.Thread(target=svc.shutdown)
+    thread.start()
+    time.sleep(0.05)
+    assert thread.is_alive()
+    assert client.shutdown_calls == 0
+    svc._reaper_run_lock.release()
+    thread.join(2)
+    assert not thread.is_alive()
+    assert client.shutdown_calls == 1
+
+
 from agent.lsp.servers import (
     SERVERS,
     ServerContext,


### PR DESCRIPTION
## Summary
- add an idle background reaper with active-use protection and shutdown locking
- isolate POSIX language servers in process groups and terminate descendants on cleanup
- add lifecycle race, reaper, and lock-ordering regression tests

## Verification
- `pytest -q tests/agent/lsp` — 150 passed
- real process-tree smoke: live leader + child both gone after cleanup
- dead leader + SIGTERM-ignoring child both gone after cleanup
- independent Claude Sonnet review: PASS

## Note
A full repository test run was attempted but exceeded the 10-minute execution window at 32%; the complete LSP suite passes.