### PR TITLE
fix(env): close pipe fds on fdopen failure in _ThreadedProcessHandle

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -225,7 +225,12 @@ class _ThreadedProcessHandle:
 
         # Pipe for stdout — drain thread in _wait_for_process reads the read end.
         read_fd, write_fd = os.pipe()
-        self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        try:
+            self._stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        except Exception:
+            os.close(read_fd)
+            os.close(write_fd)
+            raise
         self._write_fd = write_fd
 
         def _worker():


### PR DESCRIPTION
## Summary

Guard against file descriptor leaks when `os.fdopen()` fails during pipe setup in `_ThreadedProcessHandle`.

## Problem

In `tools/environments/base.py`, `__init__` creates a pipe pair via `os.pipe()`, then wraps `read_fd` with `os.fdopen()`. If `fdopen` raises (e.g. invalid encoding), the `write_fd` and potentially `read_fd` are never closed — the worker thread (which closes `write_fd` in its `finally` block) hasn't been started yet, so both fds leak.

While `fdopen` failures are rare, leaked fds accumulate over time in long-running gateway processes and can eventually hit per-process fd limits.

## Fix

Wrapped the `os.fdopen()` call in a try/except that closes both fds on failure before re-raising.

## Testing
- Syntax check passed (py_compile)
- Behavior verified