### PR TITLE
fix(qqbot): drain and reap the ffmpeg subprocess in _convert_ffmpeg_to_wav

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2125,18 +2125,34 @@ class QQAdapter(BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(proc.wait(), timeout=30)
-            if proc.returncode != 0:
-                stderr = await proc.stderr.read() if proc.stderr else b""
-                logger.warning(
-                    "[%s] ffmpeg failed for %s: %s",
-                    self._log_tag,
-                    Path(src_path).name,
-                    stderr[:200].decode(errors="replace"),
-                )
-                return None
-        except (asyncio.TimeoutError, FileNotFoundError) as exc:
+        except FileNotFoundError as exc:
             logger.warning("[%s] ffmpeg conversion error: %s", self._log_tag, exc)
+            return None
+        try:
+            # communicate() drains the stderr pipe; proc.wait() alone would
+            # deadlock if ffmpeg writes more than the ~64KB pipe buffer.
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        except asyncio.TimeoutError:
+            # wait_for only cancels the local await — kill and reap the child
+            # so we don't leak an orphaned ffmpeg process and its pipe fd.
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+            logger.warning(
+                "[%s] ffmpeg conversion timed out for %s",
+                self._log_tag,
+                Path(src_path).name,
+            )
+            return None
+        if proc.returncode != 0:
+            logger.warning(
+                "[%s] ffmpeg failed for %s: %s",
+                self._log_tag,
+                Path(src_path).name,
+                (stderr or b"")[:200].decode(errors="replace"),
+            )
             return None
 
         if not Path(wav_path).exists() or Path(wav_path).stat().st_size <= 44:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2254,3 +2254,56 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+class TestConvertFfmpegToWav:
+    @staticmethod
+    def _adapter():
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = object.__new__(QQAdapter)
+        adapter._app_id = "test"  # _log_tag is a read-only property over this
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_child_and_returns_none(self, monkeypatch):
+        # A hung/verbose ffmpeg must be killed on timeout, not left orphaned.
+        killed = {"v": False}
+
+        class _FakeProc:
+            returncode = None
+
+            async def communicate(self):
+                await asyncio.sleep(3600)  # never resolves within the timeout
+
+            def kill(self):
+                killed["v"] = True
+
+            async def wait(self):
+                return 0
+
+        async def _fake_exec(*args, **kwargs):
+            return _FakeProc()
+
+        real_wait_for = asyncio.wait_for
+
+        async def _fast_wait_for(coro, timeout):
+            return await real_wait_for(coro, timeout=0.05)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(asyncio, "wait_for", _fast_wait_for)
+
+        result = await self._adapter()._convert_ffmpeg_to_wav("in.amr", "out.wav")
+        assert result is None
+        assert killed["v"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_ffmpeg_binary_returns_none(self, monkeypatch):
+        # FileNotFoundError is raised before `proc` is bound — the handler must
+        # not try to kill a nonexistent process.
+        async def _raise(*args, **kwargs):
+            raise FileNotFoundError("ffmpeg")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _raise)
+        result = await self._adapter()._convert_ffmpeg_to_wav("in.amr", "out.wav")
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

`_convert_ffmpeg_to_wav` (used to transcode inbound QQ voice/audio messages for STT) leaks a subprocess and can deadlock:

```python
proc = await asyncio.create_subprocess_exec("ffmpeg", ..., stderr=asyncio.subprocess.PIPE)
await asyncio.wait_for(proc.wait(), timeout=30)   # (1)
...
except (asyncio.TimeoutError, FileNotFoundError):  # (2)
    return None
```

1. **Deadlock / guaranteed timeout.** `proc.wait()` does not read the pipes. If ffmpeg writes more than the ~64KB OS pipe buffer to stderr (common on malformed/warning-heavy input), it blocks on write and never exits — so every such conversion hits the 30s timeout.
2. **Orphaned process on timeout.** `asyncio.wait_for` only cancels the local `proc.wait()` coroutine; the ffmpeg child is never killed, so each timeout leaks a process **and** its open pipe fd. Under repeated bad inputs (the audio bytes come straight from the attachment), this exhausts process/fd limits.

The sibling converter `gateway/platforms/whatsapp_cloud.py::_convert_to_opus` already uses `proc.communicate()` and avoids both problems.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py` — use `proc.communicate()` (drains stderr) instead of `proc.wait()`, and on timeout `proc.kill()` + `await proc.wait()` to reap the child. Split `FileNotFoundError` (ffmpeg binary missing) into its own handler, since it is raised *before* `proc` is bound — calling `proc.kill()` in a combined handler would raise `UnboundLocalError`.

## How to Test

`uv run pytest tests/gateway/test_qqbot.py::TestConvertFfmpegToWav -q` — 2 passed.

New tests:
- `test_timeout_kills_child_and_returns_none` — a hung ffmpeg is killed (not orphaned) on timeout and the method returns `None`. Asserts `kill()` is invoked, which the pre-fix path never does.
- `test_missing_ffmpeg_binary_returns_none` — `FileNotFoundError` returns `None` without trying to kill an unbound process.

(Note: two unrelated tests in `test_qqbot.py` — `TestVoiceAttachmentSSRFProtection::test_connect_uses_redirect_guard_hook` and `TestQQWebSocketProxy::test_open_ws_honors_proxy_env` — fail on a clean `main` too in this environment, unrelated to this change.)

## Checklist

- [x] Conventional Commits
- [x] Searched existing PRs (none touches the ffmpeg drain/reap)
- [x] Only changes related to this fix
- [x] Added tests; touched suite passes
- [x] Tested on: Ubuntu (WSL2), Python 3.12