### PR TITLE
fix(agent): normalize composite tool_call ids to prevent silent tool result drops

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,6 +34,7 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
+from agent.tool_dispatch_helpers import _normalize_tool_call_id
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -4521,7 +4522,7 @@ def run_conversation(
                         messages.append({
                             "role": "tool",
                             "name": tc.function.name,
-                            "tool_call_id": tc.id,
+                            "tool_call_id": _normalize_tool_call_id(tc.id),
                             "content": content,
                         })
                     continue
@@ -4613,7 +4614,7 @@ def run_conversation(
                             messages.append({
                                 "role": "tool",
                                 "name": tc.function.name,
-                                "tool_call_id": tc.id,
+                                "tool_call_id": _normalize_tool_call_id(tc.id),
                                 "content": tool_result,
                             })
                         continue

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -336,6 +336,19 @@ def _extract_error_preview(result: Any, max_len: int = 180) -> str:
     return text
 
 
+def _normalize_tool_call_id(tool_call_id: str) -> str:
+    """Normalize composite tool_call ids to the short form.
+
+    Providers that bridge Chat Completions to the Responses API (e.g. OpenRouter)
+    may return composite ids like ``call_xxx|fc_yyy``.  The assistant message
+    stores only the short form (``call_xxx``), so tool-result messages must use
+    the same short id or they are silently dropped by the provider.
+    """
+    if isinstance(tool_call_id, str) and "|" in tool_call_id:
+        return tool_call_id.split("|", 1)[0]
+    return tool_call_id
+
+
 def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     """Strip image blobs from a message for trajectory saving.
 
@@ -393,8 +406,7 @@ def make_tool_result_message(
     """
     # Normalize composite tool_call ids (e.g., call_xxx|fc_yyy -> call_xxx)
     # to match the short id stored in assistant tool_calls entries.
-    if isinstance(tool_call_id, str) and "|" in tool_call_id:
-        tool_call_id = tool_call_id.split("|", 1)[0]
+    tool_call_id = _normalize_tool_call_id(tool_call_id)
     wrapped = _maybe_wrap_untrusted(name, content)
     message = {
         "role": "tool",

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -370,6 +370,12 @@ def make_tool_result_message(
     field (required by the wire format and provider adapters) and the internal
     ``tool_name`` field (written to the session DB messages table).
 
+    Normalizes composite tool_call ids (e.g., ``call_xxx|fc_yyy``) to the
+    short form (``call_xxx``) before building the message, ensuring
+    compatibility with providers that bridge Chat Completions to the Responses
+    API. The full composite id is already persisted separately as
+    ``response_item_id`` in the assistant message.
+
     Content from high-risk tools (``web_extract``, ``web_search``, ``browser_*``,
     ``mcp_*``) gets wrapped in semantic delimiters telling the model the content
     is untrusted data, not instructions.  This is the architectural defense
@@ -385,6 +391,10 @@ def make_tool_result_message(
     The outer list itself is rebuilt rather than returned by identity, so
     callers should compare by value, not by ``is``.
     """
+    # Normalize composite tool_call ids (e.g., call_xxx|fc_yyy -> call_xxx)
+    # to match the short id stored in assistant tool_calls entries.
+    if isinstance(tool_call_id, str) and "|" in tool_call_id:
+        tool_call_id = tool_call_id.split("|", 1)[0]
     wrapped = _maybe_wrap_untrusted(name, content)
     message = {
         "role": "tool",

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -356,16 +356,30 @@ class TestMakeToolResultMessage:
         # Composite id gets normalized to short form
         msg = make_tool_result_message("terminal", "ls output", "call_abc|fc_def")
         assert msg["tool_call_id"] == "call_abc"
-        
+
         # Short ids pass through unchanged
         msg = make_tool_result_message("terminal", "ls output", "call_xyz")
         assert msg["tool_call_id"] == "call_xyz"
-        
+
         # Other fields unaffected
         assert msg["role"] == "tool"
         assert msg["name"] == "terminal"
         assert msg["tool_name"] == "terminal"
         assert msg["content"] == "ls output"
+
+    def test_normalize_tool_call_id_helper(self):
+        """The _normalize_tool_call_id helper covers all three construction paths:
+        make_tool_result_message, and both recovery branches in conversation_loop.
+        """
+        from agent.tool_dispatch_helpers import _normalize_tool_call_id
+
+        # Composite id → short form
+        assert _normalize_tool_call_id("call_abc|fc_def") == "call_abc"
+        # Plain id → unchanged
+        assert _normalize_tool_call_id("call_xyz") == "call_xyz"
+        # Non-string → unchanged (defensive)
+        assert _normalize_tool_call_id(None) is None
+        assert _normalize_tool_call_id(123) == 123
 
 
 class TestFileMutationTargets:

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -347,6 +347,27 @@ class TestMakeToolResultMessage:
         }
 
 
+    def test_composite_tool_call_id_normalized(self):
+        """Composite tool_call ids (e.g., call_xxx|fc_yyy) are normalized to
+        the short form (call_xxx) to match the id stored in assistant tool_calls.
+        This fixes the silent drop of tool results from OpenAI-compatible gateways
+        that bridge Chat Completions to the Responses API (#63000).
+        """
+        # Composite id gets normalized to short form
+        msg = make_tool_result_message("terminal", "ls output", "call_abc|fc_def")
+        assert msg["tool_call_id"] == "call_abc"
+        
+        # Short ids pass through unchanged
+        msg = make_tool_result_message("terminal", "ls output", "call_xyz")
+        assert msg["tool_call_id"] == "call_xyz"
+        
+        # Other fields unaffected
+        assert msg["role"] == "tool"
+        assert msg["name"] == "terminal"
+        assert msg["tool_name"] == "terminal"
+        assert msg["content"] == "ls output"
+
+
 class TestFileMutationTargets:
     def test_v4a_move_file_includes_source_and_destination(self):
         targets = _extract_file_mutation_targets(


### PR DESCRIPTION
## What does this PR do?

Normalizes composite tool_call ids (e.g., `call_xxx|fc_yyy`) to the short form (`call_xxx`) in `make_tool_result_message`. This fixes a silent failure where tool results were dropped when using OpenAI-compatible gateways that bridge Chat Completions to the Responses API.

The root cause: assistant messages stored the short id from `_split_responses_tool_id`, but tool results used the full composite id from the SDK's `tool_call.id`. This id mismatch caused `repair_message_sequence` to classify the tool result as a stray orphan, which was then replaced with a `[Result unavailable]` stub. The model never saw the actual tool output and would confabulate plausible-looking answers.

The fix normalizes the id at the source in `make_tool_result_message`, ensuring tool result messages always carry the same id shape as the persisted assistant `tool_calls` entries. Short ids are accepted end-to-end by these gateways (the `fc_yyy` part is already persisted separately as `response_item_id`).

## Related Issue

Fixes #63000

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_dispatch_helpers.py`: Added id normalization in `make_tool_result_message` (4 lines + docstring update)
- `tests/agent/test_tool_dispatch_helpers.py`: Added regression test `test_composite_tool_call_id_normalized` (21 lines)

## How to Test

1. Configure a `custom_providers` entry pointing at a gateway that returns composite ids like `call_abc|fc_def` (e.g., a Chat-Completions→Responses bridge behind LiteLLM)
2. Ask the agent to run a tool that produces output, e.g., `terminal` with `grep -c pattern file.txt`
3. Before the fix: the outbound follow-up request contains `[Result unavailable — see context summary above]` instead of the actual grep count
4. After the fix: the tool result is correctly included in the follow-up request and the model sees the actual output
5. Unit test: `pytest tests/agent/test_tool_dispatch_helpers.py::TestMakeToolResultMessage::test_composite_tool_call_id_normalized` should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_tool_dispatch_helpers.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
