### PR TITLE
fix(codex): keep the post-tool quiet watchdog from killing a live turn

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -561,11 +561,15 @@ class CodexAppServerSession:
                 # tool-shaped item completes.
                 last_tool_completion_at = time.monotonic()
             else:
-                # Any non-tool projected activity (assistant message,
-                # status update, etc.) means codex is still producing
-                # output — clear the quiet timer so we don't fast-fail.
-                if projection.messages or projection.final_text is not None:
-                    last_tool_completion_at = None
+                # We only get here after take_notification returned a real
+                # notification (None already `continue`d above), so codex is
+                # still alive — clear the quiet timer unconditionally. Empty
+                # projections (item/started for the next tool, *outputDelta,
+                # reasoning items) are liveness too, matching the watchdog's
+                # documented "goes quiet without emitting another item" intent.
+                # Gating this on messages/final_text let a long second tool or
+                # reasoning phase trip the watchdog and kill a live turn.
+                last_tool_completion_at = None
             if projection.final_text is not None:
                 # Codex can emit multiple agentMessage items in one turn
                 # (e.g. partial then final). Take the last one as canonical.

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -950,6 +950,58 @@ class TestSessionRetirement:
         assert r.should_retire is False
         assert r.interrupted is False
 
+    def test_post_tool_watchdog_reset_on_empty_projection_activity(self):
+        """A tool completion followed by a notification that projects to
+        nothing (a reasoning item, the next tool's item/started, an
+        outputDelta) still means codex is alive and must reset the quiet
+        watchdog. Regression: a long second tool or reasoning phase used to
+        trip the watchdog and kill a live turn."""
+        clock = [1000.0]
+
+        class BumpingClient(FakeClient):
+            def take_notification(self, timeout: float = 0.0):
+                note = super().take_notification(timeout)
+                if note is not None and note.get("method") == "item/completed":
+                    item = (note.get("params") or {}).get("item") or {}
+                    if item.get("type") == "reasoning":
+                        # >post_tool_quiet_timeout passes while codex is still
+                        # streaming reasoning, but well under the turn deadline.
+                        clock[0] += 0.5
+                return note
+
+        client = BumpingClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution", "id": "ex1",
+                "command": "echo hi", "cwd": "/tmp",
+                "status": "completed", "aggregatedOutput": "hi",
+                "exitCode": 0, "commandActions": [],
+            },
+            threadId="t", turnId="tu1",
+        )
+        # Empty-projection activity (reasoning) after the tool — still alive.
+        client.queue_notification(
+            "item/completed",
+            item={"type": "reasoning", "id": "r1", "content": ["thinking..."]},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)
+        with patch.object(
+            session_mod.time, "monotonic", side_effect=lambda: clock[0]
+        ):
+            r = s.run_turn(
+                "tool then reasoning then done", turn_timeout=30.0,
+                notification_poll_timeout=0.0,
+                post_tool_quiet_timeout=0.15,
+            )
+        assert r.interrupted is False
+        assert r.should_retire is False
+
     def test_turn_aborted_marker_in_text_is_terminal(self):
         """If codex emits `<turn_aborted>` in agent text and never sends
         turn/completed, we still exit promptly instead of burning the


### PR DESCRIPTION
## What does this PR do?

`CodexAppServerSession.run_turn` has a *post-tool quiet watchdog*: after a tool item completes it arms `last_tool_completion_at`, and if codex then stays silent past `post_tool_quiet_timeout` (default **90s**) it interrupts the turn and retires the session instead of waiting for the full turn deadline.

The timer was only cleared when a projected notification carried `messages` or `final_text`:

```python
if projection.is_tool_iteration:
    ...
    last_tool_completion_at = time.monotonic()
else:
    if projection.messages or projection.final_text is not None:
        last_tool_completion_at = None
```

But several notifications project to **nothing** — `item/started` for the *next* tool, `commandExecution` `*outputDelta`, and `reasoning` items (`codex_event_projector` returns a bare `ProjectionResult()` for reasoning). None of those reset the timer. So once one tool completes, if the very next tool is long-running (a build / test run / `npm install`) or codex enters a long reasoning phase **without an intervening assistant message**, the watchdog fires and force-interrupts a turn that is still actively streaming output. This is a common coding-agent pattern (two tools back-to-back). The watchdog's own docstring says it should only fire when codex "goes quiet ... without emitting another item" — but `item/started` *is* emitting another item.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/codex_app_server_session.py` — in the non-tool branch, clear `last_tool_completion_at` unconditionally. `take_notification` returning `None` already `continue`s earlier in the loop, so reaching this branch means a real notification arrived (codex is alive). Tool completions still re-arm the timer, so genuine silence is still caught.

## How to Test

`uv run pytest tests/agent/transports/test_codex_app_server_session.py -q` — 64 passed.

New test `test_post_tool_watchdog_reset_on_empty_projection_activity`: a tool completes, then a `reasoning` item arrives while `post_tool_quiet_timeout` elapses (monotonic advanced via a controllable clock), then `turn/completed`. It asserts the turn is **not** interrupted/retired. The test fails on `main` (`interrupted is True` — the watchdog wrongly fires) and passes with this change. The three existing watchdog tests (`trips_and_retires`, `uses_monotonic_clock`, `resets_on_further_activity`) still pass — genuine silence (`take_notification` → `None`) still trips it.

## Checklist

- [x] Conventional Commits
- [x] Searched existing PRs (the open codex watchdog PRs target the TTFB/no-byte watchdog, not the post-tool quiet reset)
- [x] Only changes related to this fix
- [x] Added tests; full suite passes
- [x] Tested on: Ubuntu (WSL2), Python 3.12