### PR TITLE
fix(telegram): route PTB NetworkError/TimedOut from polling heartbeat into reconnect path (#62047)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1188,6 +1188,20 @@ class TelegramAdapter(BasePlatformAdapter):
         return isinstance(error, OSError)
 
     @staticmethod
+    def _is_request_validation_error(error: Exception) -> bool:
+        """Return True for PTB request-validation failures (HTTP 400).
+
+        PTB's ``BadRequest`` subclasses ``NetworkError``, so
+        ``_looks_like_network_error`` alone would classify a 400 response as a
+        connectivity symptom and feed it to the reconnect ladder.
+        """
+        try:
+            from telegram.error import BadRequest
+        except ImportError:
+            return False
+        return isinstance(error, BadRequest)
+
+    @staticmethod
     def _looks_like_connect_timeout(error: Exception) -> bool:
         """Return True when a Telegram TimedOut wraps a connect-timeout.
 
@@ -2203,10 +2217,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._probe_pending_updates(bot, PROBE_TIMEOUT)
             except asyncio.CancelledError:
                 return
-            except (asyncio.TimeoutError, OSError) as probe_err:
+            except Exception as probe_err:
+                # Non-connectivity errors (e.g. TelegramError 401, BadRequest
+                # 400 — which PTB derives from NetworkError) are not
+                # CLOSE-WAIT symptoms — let PTB's own handlers surface them.
+                if not self._looks_like_network_error(probe_err) or self._is_request_validation_error(probe_err):
+                    continue
                 logger.warning(
                     "[%s] Polling heartbeat probe failed (%s); triggering reconnect",
-                    self.name, probe_err,
+                    self.name, _redact_telegram_error_text(probe_err),
                 )
                 if self._polling_error_task and not self._polling_error_task.done():
                     continue   # reconnect already in progress
@@ -2214,10 +2233,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_task = loop.create_task(
                     self._handle_polling_network_error(probe_err)
                 )
-            except Exception:
-                # Non-connectivity errors (e.g. TelegramError 401) are not
-                # CLOSE-WAIT symptoms — let PTB's own handlers surface them.
-                pass
 
     async def _probe_pending_updates(self, bot, probe_timeout: float) -> None:
         """Detect a wedged getUpdates consumer via pending_update_count.
@@ -2293,9 +2308,14 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         try:
             info = await asyncio.wait_for(get_webhook_info(), probe_timeout)  # type: ignore[arg-type]
-        except (asyncio.TimeoutError, OSError):
+        except Exception as probe_err:
             # A failed probe is a connectivity symptom the get_me() path or the
             # outer handler will catch; don't treat it as a stuck-queue signal.
+            # PTB connectivity errors (NetworkError/TimedOut) get the same
+            # deliberate deferral the TimeoutError/OSError path always had
+            # (#62047) instead of leaking to the heartbeat's classifier.
+            if not self._looks_like_network_error(probe_err):
+                raise
             return
         pending = int(getattr(info, "pending_update_count", 0) or 0)
         if pending <= 0:

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -27,13 +27,35 @@ def _ensure_telegram_mock():
     telegram_mod.constants.ChatType.CHANNEL = "channel"
     telegram_mod.constants.ChatType.PRIVATE = "private"
 
+    telegram_mod.error.TelegramError = type("TelegramError", (Exception,), {})
+    telegram_mod.error.NetworkError = type("NetworkError", (telegram_mod.error.TelegramError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (telegram_mod.error.NetworkError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (telegram_mod.error.NetworkError,), {})
+    telegram_mod.error.InvalidToken = type("InvalidToken", (telegram_mod.error.TelegramError,), {})
+
     for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
         sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
 
 
 _ensure_telegram_mock()
 
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+# Real-PTB-shaped exception stand-ins for the #62047 classification tests.
+# The gateway conftest's telegram mock derives NetworkError/TimedOut from
+# OSError, which the pre-#62047 handler already caught — tests raising those
+# classes pass with or without the fix. Real PTB derives them from
+# TelegramError (never OSError); the adapter then classifies by class NAME,
+# so these fakes exercise the same branch production hits.
+class _FakeTelegramError(Exception):
+    pass
+
+
+_FakeNetworkError = type("NetworkError", (_FakeTelegramError,), {})
+_FakeTimedOut = type("TimedOut", (_FakeNetworkError,), {})
+_FakeInvalidToken = type("InvalidToken", (_FakeTelegramError,), {})
 
 
 @pytest.fixture(autouse=True)
@@ -608,6 +630,42 @@ async def test_heartbeat_loop_triggers_reconnect_on_os_error():
     assert adapter._polling_error_task is not None
 
 
+@pytest.mark.parametrize("exc_cls", [_FakeNetworkError, _FakeTimedOut])
+@pytest.mark.asyncio
+async def test_heartbeat_loop_triggers_reconnect_on_ptb_network_errors(exc_cls):
+    """PTB connectivity errors from get_me() must trigger the reconnect ladder."""
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+    probe_error = exc_cls("connection lost")
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 2:
+            raise asyncio.CancelledError()
+
+    async def ptb_error_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise probe_error
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch(
+            "plugins.platforms.telegram.adapter.asyncio.wait_for",
+            side_effect=ptb_error_wait_for,
+        ):
+            await adapter._polling_heartbeat_loop()
+
+    assert adapter._polling_error_task is not None
+    await adapter._polling_error_task
+    adapter._handle_polling_network_error.assert_awaited_once_with(probe_error)
+
+
 @pytest.mark.asyncio
 async def test_heartbeat_loop_skips_reconnect_if_already_in_progress():
     """If a reconnect task is already running, the heartbeat must not spawn another."""
@@ -675,6 +733,80 @@ async def test_heartbeat_loop_ignores_non_connectivity_errors():
             await adapter._polling_heartbeat_loop()
 
     # No reconnect should have been triggered for a non-connectivity error.
+    adapter._handle_polling_network_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_does_not_reconnect_on_invalid_token():
+    """Auth/request-validation failures must not enter network reconnect."""
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+    auth_error = _FakeInvalidToken("invalid token")
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 2:
+            raise asyncio.CancelledError()
+
+    async def invalid_token_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise auth_error
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch(
+            "plugins.platforms.telegram.adapter.asyncio.wait_for",
+            side_effect=invalid_token_wait_for,
+        ):
+            await adapter._polling_heartbeat_loop()
+
+    assert adapter._polling_error_task is None
+    adapter._handle_polling_network_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_does_not_reconnect_on_bad_request():
+    """PTB BadRequest subclasses NetworkError but is a request-validation
+    failure (HTTP 400), not a connectivity symptom — it must not enter the
+    reconnect ladder."""
+    from telegram.error import BadRequest
+
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    sleep_call = 0
+    # Mirror real PTB's hierarchy: an error that classifies as a NetworkError
+    # (by name) while being a BadRequest instance.
+    bad_request = type("NetworkError", (BadRequest,), {})("message text invalid")
+
+    async def fast_sleep(seconds):
+        nonlocal sleep_call
+        sleep_call += 1
+        if sleep_call >= 2:
+            raise asyncio.CancelledError()
+
+    async def bad_request_wait_for(coro, timeout):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise bad_request
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        with patch(
+            "plugins.platforms.telegram.adapter.asyncio.wait_for",
+            side_effect=bad_request_wait_for,
+        ):
+            await adapter._polling_heartbeat_loop()
+
+    assert adapter._polling_error_task is None
     adapter._handle_polling_network_error.assert_not_awaited()
 
 
@@ -867,4 +999,3 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     # The reconnect ladder must have advanced past the hung stop().
     assert drain_called, "_drain_polling_connections was not called after stop() timeout"
     assert start_polling_called, "start_polling was not called after stop() timeout"
-

--- a/tests/gateway/test_telegram_pending_update_probe.py
+++ b/tests/gateway/test_telegram_pending_update_probe.py
@@ -36,6 +36,10 @@ _ensure_telegram_mock()
 
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
+# Real PTB derives NetworkError from TelegramError, never OSError — this fake
+# classifies via the adapter's name-based branch, like production (#62047).
+_FakeNetworkError = type("NetworkError", (Exception,), {})
+
 
 def _make_adapter(*, pending: int) -> TelegramAdapter:
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
@@ -88,6 +92,41 @@ async def test_zero_pending_resets_counter():
         await adapter._probe_pending_updates(adapter._app.bot, 5)
     assert adapter._polling_pending_stuck_count == 0
     rec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_info_network_error_defers_to_heartbeat():
+    """Connectivity failures of the webhook-info probe are deliberately
+    deferred — the get_me() heartbeat owns reconnect scheduling, and a
+    transient get_webhook_info() failure must not tear down a healthy poller.
+    PTB errors get the same deferral the TimeoutError/OSError path always had
+    (#62047)."""
+    adapter = _make_adapter(pending=0)
+    probe_error = _FakeNetworkError("connection lost")
+    adapter._app.bot.get_webhook_info = AsyncMock(side_effect=probe_error)
+    recovery = AsyncMock()
+
+    with patch.object(adapter, "_handle_polling_network_error", new=recovery):
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+
+    assert adapter._polling_error_task is None
+    recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_webhook_info_non_network_error_propagates():
+    """Non-connectivity probe errors propagate to the heartbeat's classifier."""
+    adapter = _make_adapter(pending=0)
+    adapter._app.bot.get_webhook_info = AsyncMock(
+        side_effect=RuntimeError("api contract change")
+    )
+
+    with patch.object(adapter, "_handle_polling_network_error", new=AsyncMock()) as rec:
+        with pytest.raises(RuntimeError):
+            await adapter._probe_pending_updates(adapter._app.bot, 5)
+
+    assert adapter._polling_error_task is None
+    rec.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes #62047 — the polling heartbeat's probe handler only routed `asyncio.TimeoutError`/`OSError` into the reconnect path. In PTB 22.x, `telegram.error.NetworkError` and `TimedOut` inherit from `TelegramError` (not `OSError`), so real connectivity failures fell through to a generic `except Exception` and were silently ignored — the gateway kept reporting Telegram as connected while the heartbeat never initiated recovery.

## Related Issue

Closes #62047

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Heartbeat probe handler now catches `Exception` and classifies via the existing `_looks_like_network_error()` helper, so PTB `NetworkError`/`TimedOut` enter the same recovery ladder as `TimeoutError`/`OSError`. Non-connectivity errors keep the old behavior (deferred to PTB's own handlers).
  - New `_is_request_validation_error()` guard: PTB's `BadRequest` **subclasses** `NetworkError`, so classification by base class alone would send HTTP 400 request-validation failures into the reconnect ladder — where a successful `start_polling` resets the retry counter and the churn never escalates to fatal. BadRequest stays non-retryable.
  - Reconnect-trigger log line now redacts the error via `_redact_telegram_error_text()` (PTB transport errors can embed the bot-token request URL), matching every sibling logging site.
  - `_probe_pending_updates`' webhook-info handler keeps its original deliberate deferral (a failed probe is the get_me() path's job to confirm; first-failure teardown of a healthy poller would regress #42909's debounce design) — PTB connectivity errors now get that same deferral instead of leaking upward as unclassified exceptions.
- Tests (`tests/gateway/test_telegram_network_reconnect.py`, `test_telegram_pending_update_probe.py`)
  - Reconnect triggers on PTB `NetworkError`/`TimedOut` (parametrized); no reconnect on `InvalidToken`; no reconnect on `BadRequest` despite it being a `NetworkError` subclass; webhook-info probe defers connectivity errors and propagates non-connectivity errors.
  - Test exceptions are built with real-PTB-shaped hierarchies (`TelegramError`-derived, not `OSError`-derived): the pre-existing gateway-conftest mock derives `NetworkError` from `OSError`, which the unfixed code already caught — tests written against it pass with or without this fix. Verified these tests fail on unfixed `main`.
  - Fixed the file-local telegram mock in both files to register `telegram.error` (the new top-level import made the standalone fallback a guaranteed `ModuleNotFoundError`).

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_pending_update_probe.py -- -q
```

43 passed. Also verified the regression tests fail against unfixed `main` (reverted adapter, reran: 3 failures, all new tests).

## Notes for reviewers

- The conftest-level telegram mock (`tests/gateway/conftest.py`) still models `NetworkError` as an `OSError` subclass, diverging from real PTB. This PR works around it locally; aligning the shared mock with PTB's real hierarchy would benefit the whole gateway suite but touches many tests, so it's left out of this fix.
- `_verify_polling_after_reconnect` has the mirror-image gap (routes *every* `get_me()` failure, including `InvalidToken`, into recovery, and bypasses the `_polling_error_task` dedup guard). Deliberately out of scope; can file separately if useful.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes (6 new tests; verified non-vacuous against unfixed main)
- [x] I've tested on my platform: macOS
- [x] I've considered cross-platform impact (exception classification only; no platform-specific code)
