### PR TITLE
fix(compression): extend Codex GPT-5.6 autoraise to custom codex_responses providers + re-apply on model switch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1786,9 +1786,13 @@ def init_agent(
     if not isinstance(_compression_cfg, dict):
         _compression_cfg = {}
     compression_threshold = float(_compression_cfg.get("threshold", 0.50))
-    # Per-model/route compaction-threshold override. Codex gpt-5.4 / gpt-5.5
-    # raise to 85% (the Codex backend caps both families at 272K, so the
-    # default 50% would compact at ~136K — half the usable context). Gated by
+    # Preserve the user's raw global setting before any route-specific
+    # autoraise. Live model switches must always derive from this value rather
+    # than from the compressor's current (possibly raised or floored) value.
+    agent._compression_global_threshold = compression_threshold
+    # Per-model/route compaction-threshold override. Codex gpt-5.4 / gpt-5.5 /
+    # gpt-5.6 routes raise to 85%; their actual context window remains
+    # provider-specific and is resolved through model metadata. Gated by
     # an opt-out config flag so the user can fall back to the global threshold;
     # when the override fires we stash a one-time notification (replayed on the
     # first turn) that tells the user what changed and how to revert. The
@@ -1802,36 +1806,6 @@ def init_agent(
         _compression_cfg.get("codex_gpt55_autoraise_notice", True)
     ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
-    try:
-        from agent.auxiliary_client import (
-            _compression_threshold_for_model as _cthresh_fn,
-            _is_codex_gpt54_or_gpt55 as _is_codex_gpt54_or_gpt55_fn,
-            _is_codex_spark as _is_codex_spark_fn,
-        )
-        _model_cthresh = _cthresh_fn(
-            agent.model,
-            agent.provider,
-            allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
-            api_mode=getattr(agent, "api_mode", None),
-        )
-        # The Codex autoraises (gpt-5.4/5.5 272K family and gpt-5.3-codex-spark)
-        # apply only when they RAISE (never lower a user's higher global
-        # threshold). The notice is populated only when it actually fires, and
-        # carries the model slug so the banner names the right family. Arcee
-        # Trinity keeps its long-standing unconditional behaviour.
-        compression_threshold, agent._compression_threshold_autoraised = (
-            _resolve_compression_threshold(
-                compression_threshold,
-                _model_cthresh,
-                model=agent.model,
-                is_codex_autoraise=(
-                    _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider, api_mode=getattr(agent, "api_mode", None))
-                    or _is_codex_spark_fn(agent.model, agent.provider)
-                ),
-            )
-        )
-    except Exception:
-        pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
@@ -2290,6 +2264,42 @@ def init_agent(
         _lmstudio_runtime_context_length,
     )
 
+    # Resolve the startup route threshold without replacing the configured
+    # session baseline. The built-in compressor receives both values: the raw
+    # baseline remains stable across switches, while this model-specific
+    # default applies only to the active route.
+    compression_model_default_threshold = agent._compression_global_threshold
+    try:
+        from agent.auxiliary_client import (
+            _compression_threshold_for_model as _cthresh_fn,
+            _is_codex_gpt54_or_gpt55 as _is_codex_gpt54_or_gpt55_fn,
+            _is_codex_spark as _is_codex_spark_fn,
+        )
+
+        _model_cthresh = _cthresh_fn(
+            agent.model,
+            agent.provider,
+            allow_codex_gpt55_autoraise=agent._codex_gpt55_autoraise,
+            api_mode=getattr(agent, "api_mode", None),
+        )
+        compression_model_default_threshold, agent._compression_threshold_autoraised = (
+            _resolve_compression_threshold(
+                agent._compression_global_threshold,
+                _model_cthresh,
+                model=agent.model,
+                is_codex_autoraise=(
+                    _is_codex_gpt54_or_gpt55_fn(
+                        agent.model,
+                        agent.provider,
+                        api_mode=getattr(agent, "api_mode", None),
+                    )
+                    or _is_codex_spark_fn(agent.model, agent.provider)
+                ),
+            )
+        )
+    except Exception:
+        pass
+
 
 
     # Select context engine: config-driven (like memory providers).
@@ -2393,6 +2403,7 @@ def init_agent(
         agent.context_compressor = ContextCompressor(
             model=agent.model,
             threshold_percent=compression_threshold,
+            default_threshold_percent=compression_model_default_threshold,
             protect_first_n=compression_protect_first,
             protect_last_n=compression_protect_last,
             summary_target_ratio=compression_target_ratio,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1797,6 +1797,7 @@ def init_agent(
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
+    agent._codex_gpt55_autoraise = _codex_gpt55_autoraise
     _codex_gpt55_autoraise_notice = str(
         _compression_cfg.get("codex_gpt55_autoraise_notice", True)
     ).lower() in {"true", "1", "yes"}
@@ -1811,6 +1812,7 @@ def init_agent(
             agent.model,
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
+            api_mode=getattr(agent, "api_mode", None),
         )
         # The Codex autoraises (gpt-5.4/5.5 272K family and gpt-5.3-codex-spark)
         # apply only when they RAISE (never lower a user's higher global
@@ -1823,7 +1825,7 @@ def init_agent(
                 _model_cthresh,
                 model=agent.model,
                 is_codex_autoraise=(
-                    _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider)
+                    _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider, api_mode=getattr(agent, "api_mode", None))
                     or _is_codex_spark_fn(agent.model, agent.provider)
                 ),
             )

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -296,6 +296,8 @@ def _resolve_compression_threshold(
     return model_cthresh, None
 
 
+
+
 def _codex_gpt55_autoraise_notice_marker():
     """Path to the per-profile marker recording that the autoraise notice ran.
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1386,6 +1386,7 @@ def _compression_threshold(agent, cfg: Dict[str, Any]) -> tuple[float, bool]:
         )
         _model_cthresh = _cthresh_fn(
             agent.model, agent.provider, allow_codex_gpt55_autoraise=autoraise,
+            api_mode=agent.api_mode,
         )
         # Codex autoraises apply only when they RAISE; Arcee Trinity keeps its
         # unconditional override.
@@ -1394,8 +1395,8 @@ def _compression_threshold(agent, cfg: Dict[str, Any]) -> tuple[float, bool]:
             _model_cthresh,
             model=agent.model,
             is_codex_autoraise=(
-                _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider)
-                or _is_codex_spark_fn(agent.model, agent.provider)
+                _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider, api_mode=agent.api_mode)
+                or _is_codex_spark_fn(agent.model, agent.provider, api_mode=agent.api_mode)
             ),
         )
     return threshold, notice_enabled

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2448,6 +2448,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                             agent.model,
                             agent.provider,
                             api_mode=agent.api_mode,
+
                         )
                         or _is_codex_spark(agent.model, agent.provider)
                     ),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2420,6 +2420,47 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             config_context_length=_effective_context_length,
             custom_providers=_sm_custom_providers,
         )
+        _sm_update_kwargs = {}
+        try:
+            from agent.agent_init import _resolve_compression_threshold
+            from agent.auxiliary_client import (
+                _compression_threshold_for_model,
+                _is_codex_gpt54_or_gpt55,
+                _is_codex_spark,
+            )
+            from agent.context_compressor import ContextCompressor
+
+            if isinstance(agent.context_compressor, ContextCompressor):
+                _sm_model_threshold = _compression_threshold_for_model(
+                    agent.model,
+                    provider=agent.provider,
+                    allow_codex_gpt55_autoraise=getattr(
+                        agent, "_codex_gpt55_autoraise", True,
+                    ),
+                    api_mode=agent.api_mode,
+                )
+                _sm_default_threshold, _ = _resolve_compression_threshold(
+                    agent.context_compressor._config_threshold_percent,
+                    _sm_model_threshold,
+                    model=agent.model,
+                    is_codex_autoraise=(
+                        _is_codex_gpt54_or_gpt55(
+                            agent.model,
+                            agent.provider,
+                            api_mode=agent.api_mode,
+                        )
+                        or _is_codex_spark(agent.model, agent.provider)
+                    ),
+                )
+                _sm_update_kwargs["default_threshold_percent"] = (
+                    _sm_default_threshold
+                )
+        except Exception:
+            logger.debug(
+                "compression threshold resolution skipped on switch_model",
+                exc_info=True,
+            )
+
         agent.context_compressor.update_model(
             model=agent.model,
             context_length=new_context_length,
@@ -2427,6 +2468,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
             provider=agent.provider,
             api_mode=agent.api_mode,
+            **_sm_update_kwargs,
         )
 
     # ── Re-resolve reasoning_config from per-model override ──

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -412,20 +412,30 @@ _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
 _CODEX_SPARK_COMPACTION_THRESHOLD = 0.70
 
 
-def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for gpt-5.4 / gpt-5.5 / gpt-5.6 on the ChatGPT Codex OAuth backend.
+def _is_codex_gpt54_or_gpt55(
+    model: Optional[str],
+    provider: Optional[str] = None,
+    *,
+    api_mode: Optional[str] = None,
+) -> bool:
+    """True for gpt-5.4 / gpt-5.5 / gpt-5.6 on Codex Responses routes.
 
-    Matches only the Codex OAuth route (provider ``openai-codex``), not the
-    direct OpenAI API, OpenRouter, or GitHub Copilot paths — those expose a
-    larger context window for the same slug and must keep the user's default
-    compaction threshold. ``-pro`` variants and dated snapshots are matched
-    via prefix so the override tracks every 272K-capped family (5.4, 5.5,
-    5.6 sol/terra/luna incl. their ``-pro`` modes) without re-listing every
-    variant. (Name kept for backward compatibility with the
+    The built-in ``openai-codex`` provider is a known Codex route. Custom
+    providers also match when their resolved wire protocol is
+    ``codex_responses``. Their context windows remain provider-specific and
+    are resolved separately by :func:`agent.model_metadata.get_model_context_length`;
+    this predicate deliberately makes no fixed-size assumption.
+
+    ``-pro`` variants and dated snapshots are matched via prefix so the
+    override tracks every matching family without re-listing every variant.
+    (Name kept for backward compatibility with the
     ``compression.codex_gpt55_autoraise`` config key.)
     """
     prov = (provider or "").strip().lower()
-    if prov != "openai-codex":
+    if (
+        prov != "openai-codex"
+        and (api_mode or "").strip().lower() != "codex_responses"
+    ):
         return False
     bare = (model or "").strip().lower().rsplit("/", 1)[-1]
     return (
@@ -483,6 +493,7 @@ def _compression_threshold_for_model(
     provider: Optional[str] = None,
     *,
     allow_codex_gpt55_autoraise: bool = True,
+    api_mode: Optional[str] = None,
 ) -> Optional[float]:
     """Return a context-compression threshold override for specific models.
 
@@ -490,14 +501,12 @@ def _compression_threshold_for_model(
     consumed before Hermes triggers summarization.  Higher values delay
     compression and preserve more raw context.
 
-    Per-model/route overrides:
-      - Arcee Trinity Large Thinking → 0.75 (preserve reasoning context).
-      - gpt-5.4 / gpt-5.5 / gpt-5.6 on the Codex OAuth route → 0.85, because
-        Codex caps all three families at 272K and the default 50% trigger
-        would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
-        (historical config-key name kept for backward compatibility) so the
-        user can opt back down to the global default (the caller passes the
-        config flag through here).
+      - gpt-5.4 / gpt-5.5 / gpt-5.6 → 0.85 on the built-in
+        ``openai-codex`` route or a custom provider using the
+        ``codex_responses`` wire protocol. Context sizes stay provider-specific
+        and are resolved through model metadata. Gated by
+        ``allow_codex_gpt55_autoraise`` (historical config-key name kept for
+        backward compatibility).
       - gpt-5.3-codex-spark on the Codex OAuth route → 0.70, because the model
         has a native 128K window and the default 50% trigger would compact at
         ~64K — wasting half the usable context. Not gated by the gpt-5.5
@@ -509,7 +518,9 @@ def _compression_threshold_for_model(
     """
     if _is_arcee_trinity_thinking(model):
         return 0.75
-    if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(model, provider):
+    if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(
+        model, provider, api_mode=api_mode,
+    ):
         return _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD
     if _is_codex_spark(model, provider):
         return _CODEX_SPARK_COMPACTION_THRESHOLD

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -494,6 +494,7 @@ def _compression_threshold_for_model(
     *,
     allow_codex_gpt55_autoraise: bool = True,
     api_mode: Optional[str] = None,
+    context_length: Optional[int] = None,
 ) -> Optional[float]:
     """Return a context-compression threshold override for specific models.
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -583,15 +583,16 @@ _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
 _CODEX_SPARK_COMPACTION_THRESHOLD = 0.70
 
 
-def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for gpt-5.4/5.5/5.6, gpt-6 Astra (and the Daybreak Sol alias) on the Codex OAuth route only.
+def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None, *, api_mode: Optional[str] = None) -> bool:
+    """True for gpt-5.4/5.5/5.6, gpt-6 Astra (and the Daybreak Sol alias) on the Codex OAuth route
+    or any custom provider speaking ``api_mode=codex_responses``.
 
     Other routes expose a larger window for the same slug and keep the user's threshold.
     Prefix-matched so ``-pro`` and dated snapshots track every 272K-capped family; ``-900k``
     picker variants are excluded. Astra is substring-matched (any slug containing ``astra``
     without ``900k``). Name kept for the ``compression.codex_gpt55_autoraise`` key.
     """
-    bare = _codex_route_bare_model(model, provider)
+    bare = _codex_route_bare_model(model, provider, api_mode)
     if bare is None:
         return False
     from agent.model_metadata import is_codex_context_variant
@@ -604,14 +605,22 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
         for fam in ("gpt-5.4", "gpt-5.5", "gpt-5.6"))
 
 
-def _codex_route_bare_model(model: Optional[str], provider: Optional[str]) -> Optional[str]:
-    """Lowercased bare model slug when ``provider`` is the Codex OAuth route, else None."""
-    return _bare_model(model) if (provider or "").strip().lower() == "openai-codex" else None
+def _codex_route_bare_model(model: Optional[str], provider: Optional[str], api_mode: Optional[str] = None) -> Optional[str]:
+    """Lowercased bare model slug when the route is the Codex OAuth backend OR any
+    provider explicitly speaking ``api_mode=codex_responses`` (custom codex_responses
+    providers forward to the same 272K-capped Codex endpoint family, so they share
+    its server-side compaction window), else None."""
+    if (provider or "").strip().lower() == "openai-codex":
+        return _bare_model(model)
+    if (api_mode or "").strip().lower() == "codex_responses":
+        return _bare_model(model)
+    return None
 
 
-def _is_codex_spark(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for ``gpt-5.3-codex-spark`` on the Codex OAuth route (the slug exists nowhere else)."""
-    return _codex_route_bare_model(model, provider) == "gpt-5.3-codex-spark"
+def _is_codex_spark(model: Optional[str], provider: Optional[str] = None, *, api_mode: Optional[str] = None) -> bool:
+    """True for ``gpt-5.3-codex-spark`` on the Codex OAuth route or a custom
+    ``api_mode=codex_responses`` provider (the slug exists nowhere else)."""
+    return _codex_route_bare_model(model, provider, api_mode) == "gpt-5.3-codex-spark"
 
 
 def _fixed_temperature_for_model(
@@ -627,17 +636,20 @@ def _fixed_temperature_for_model(
 def _compression_threshold_for_model(
     model: Optional[str], provider: Optional[str] = None, *,
     allow_codex_gpt55_autoraise: bool = True,
+    api_mode: Optional[str] = None,
 ) -> Optional[float]:
     """Per-model/route compression threshold override (fraction of context used), or None.
 
     Arcee Trinity Large Thinking → 0.75 (preserve reasoning context); Codex-route gpt-5.4/5.5/5.6/Astra
     → 0.85, gated by ``allow_codex_gpt55_autoraise``; Codex-route gpt-5.3-codex-spark → 0.70, ungated.
+    "Codex-route" covers both the OAuth backend (provider ``openai-codex``) and custom providers
+    speaking ``api_mode=codex_responses`` — both hit the same 272K-capped endpoint family.
     """
     if _is_arcee_trinity_thinking(model):
         return 0.75
-    if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(model, provider):
+    if allow_codex_gpt55_autoraise and _is_codex_gpt54_or_gpt55(model, provider, api_mode=api_mode):
         return _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD
-    if _is_codex_spark(model, provider):
+    if _is_codex_spark(model, provider, api_mode=api_mode):
         return _CODEX_SPARK_COMPACTION_THRESHOLD
     return None
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1812,6 +1812,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         max_tokens: int | None = None,
+        default_threshold_percent: float | None = None,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
         runtime_changed = any((
@@ -1827,15 +1828,22 @@ class ContextCompressor(ContextEngine):
         self.api_mode = api_mode
         self.context_length = context_length
         # Re-resolve per-model threshold for the NEW model, then re-apply the
-        # small-context threshold floor. Starting from _config_threshold_percent
-        # (the raw config value) so a switch from a model with an override to
-        # one without correctly falls back to the global threshold.
+        # small-context threshold floor. Callers may provide a route-specific
+        # default for this update; the immutable _config_threshold_percent
+        # remains the fallback on later switches. Explicit model_thresholds
+        # still win because resolve_model_threshold applies them last.
         _config_pct = getattr(
             self, "_config_threshold_percent", self.threshold_percent,
         )
-        _new_base = resolve_model_threshold(
-            model, self.model_thresholds, _config_pct,
+        _default_pct = (
+            _config_pct
+            if default_threshold_percent is None
+            else default_threshold_percent
         )
+        _new_base = resolve_model_threshold(
+            model, self.model_thresholds, _default_pct,
+        )
+        self._configured_threshold_percent = _new_base
         self._base_threshold_percent = _new_base
         self.threshold_percent = self._effective_threshold_percent(
             context_length, _new_base,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2045,6 +2045,7 @@ class ContextCompressor(ContextEngine):
         proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096,
         min_tail_user_messages: int = 1,
+        default_threshold_percent: float | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -2055,13 +2056,18 @@ class ContextCompressor(ContextEngine):
         # Stored as a plain dict; resolved in _resolve_threshold(), then the
         # small-context floor is applied on top.
         self.model_thresholds = model_thresholds or {}
-        # _config_threshold_percent is the raw config value (before per-model
-        # override or small-context floor). Used as the fallback when switching
-        # to a model with no matching override.
+        # _config_threshold_percent is the immutable raw config value. A
+        # route-specific default affects only this model; explicit
+        # model_thresholds still take precedence and later switches without an
+        # override return to the raw baseline.
         self._config_threshold_percent = threshold_percent
-        # Resolve per-model override first, then apply the small-context floor.
+        _default_pct = (
+            threshold_percent
+            if default_threshold_percent is None
+            else default_threshold_percent
+        )
         self._base_threshold_percent = resolve_model_threshold(
-            model, self.model_thresholds, threshold_percent,
+            model, self.model_thresholds, _default_pct,
         )
         self.threshold_percent = self._base_threshold_percent
         # Absolute token cap from config (compression.threshold_tokens). When

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2170,6 +2170,33 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
         # Re-resolve from the raw config value so a switch away from an overridden model falls back correctly.
         _config_pct = getattr(self, "_config_threshold_percent", self.threshold_percent)
         self._base_threshold_percent = resolve_model_threshold(model, self.model_thresholds, _config_pct)
+        # Re-derive any per-model/route threshold auto-raise for the new model
+        # (gpt-5.4/5.5/5.6 family on the codex_responses wire — OAuth backend
+        # OR custom providers — Arcee Trinity, codex-spark) and apply it on top
+        # of the user-override resolution, so a switch TO an autoraise-eligible
+        # model raises mid-session and a switch AWAY drops back to the user's
+        # global threshold instead of keeping a stale auto-raised value (#63009).
+        # Autoraises only ever RAISE; never lower a user's higher configured value.
+        _autoraise_pct: float | None = None
+        try:
+            from agent.auxiliary_client import _compression_threshold_for_model
+            # Respect the compression.codex_gpt55_autoraise opt-out on re-derive
+            # (same read as init's _compression_threshold, evaluated per switch).
+            _autoraise_enabled = True
+            try:
+                from hermes_cli.config import load_config_readonly as _lcfg
+                _comp_cfg = ((_lcfg() or {}).get("compression") or {})
+                _autoraise_enabled = bool(_comp_cfg.get("codex_gpt55_autoraise", True))
+            except Exception:
+                pass
+            _autoraise_pct = _compression_threshold_for_model(
+                model, provider=provider, api_mode=api_mode,
+                allow_codex_gpt55_autoraise=_autoraise_enabled,
+            )
+        except Exception:
+            _autoraise_pct = None
+        if _autoraise_pct is not None and _autoraise_pct > self._base_threshold_percent:
+            self._base_threshold_percent = _autoraise_pct
         self.threshold_percent = self._effective_threshold_percent(context_length, self._base_threshold_percent)
         # max_tokens=None means "unspecified": keep the existing output reservation.
         # A switch that genuinely changes the output budget passes the new value explicitly. (#43547)

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -91,6 +91,28 @@ def test_compression_threshold_for_codex_gpt55() -> None:
     assert _compression_threshold_for_model("openai/gpt-5.5", "openai-codex") == 0.85
 
 
+def test_compression_threshold_codex_gpt55_other_routes_unaffected() -> None:
+    # Same slug, different route / api_mode → no override (keep the user's config value).
+    assert _compression_threshold_for_model("gpt-5.4", "openrouter") is None
+    assert _compression_threshold_for_model("gpt-5.4", "openai") is None
+    assert _compression_threshold_for_model("gpt-5.4", "copilot") is None
+    assert _compression_threshold_for_model("gpt-5.5", "openrouter") is None
+    assert _compression_threshold_for_model("gpt-5.5", "openai") is None
+    assert _compression_threshold_for_model("gpt-5.5", "copilot") is None
+    assert _compression_threshold_for_model("openai/gpt-5.4") is None  # no provider
+    assert _compression_threshold_for_model("openai/gpt-5.5") is None  # no provider
+    # custom:sudo with chat_completions api_mode → no override (not codex_responses)
+    assert _compression_threshold_for_model("gpt-5.6-sol", "custom", api_mode="chat_completions") is None
+
+
+def test_compression_threshold_codex_gpt55_custom_codex_responses() -> None:
+    # Any custom provider speaking codex_responses with a matching gpt-5.6
+    # model family should get the same 0.85 auto-raise as openai-codex.
+    assert _compression_threshold_for_model("gpt-5.6-sol", "custom", api_mode="codex_responses") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-sol-pro", "custom", api_mode="codex_responses") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-luna", "sudo", api_mode="codex_responses") == 0.85
+    # openai-codex still matches without explicit api_mode
+    assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
 
 
 

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -106,13 +106,21 @@ def test_compression_threshold_codex_gpt55_other_routes_unaffected() -> None:
 
 
 def test_compression_threshold_codex_gpt55_custom_codex_responses() -> None:
-    # Any custom provider speaking codex_responses with a matching gpt-5.6
-    # model family should get the same 0.85 auto-raise as openai-codex.
-    assert _compression_threshold_for_model("gpt-5.6-sol", "custom", api_mode="codex_responses") == 0.85
-    assert _compression_threshold_for_model("gpt-5.6-sol-pro", "custom", api_mode="codex_responses") == 0.85
-    assert _compression_threshold_for_model("gpt-5.6-luna", "sudo", api_mode="codex_responses") == 0.85
-    # openai-codex still matches without explicit api_mode
-    assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
+    # Custom Responses routes inherit the Codex autoraise independently of
+    # their provider-specific context window.
+    assert _compression_threshold_for_model(
+        "gpt-5.6-sol", "custom", api_mode="codex_responses",
+    ) == 0.85
+    assert _compression_threshold_for_model(
+        "gpt-5.6-sol-pro", "custom", api_mode="codex_responses",
+    ) == 0.85
+    assert _compression_threshold_for_model(
+        "gpt-5.6-luna", "sudo", api_mode="codex_responses",
+    ) == 0.85
+    # The built-in route still matches without an explicit api_mode.
+    assert _compression_threshold_for_model(
+        "gpt-5.6-sol", "openai-codex",
+    ) == 0.85
 
 
 

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -187,3 +187,16 @@ def test_resolve_no_override_keeps_global() -> None:
     assert notice is None
 
 
+def test_compression_threshold_codex_gpt55_custom_codex_responses() -> None:
+    # Custom provider speaking codex_responses gets 272K autoraise.
+    assert _compression_threshold_for_model("gpt-5.6-sol", "custom", api_mode="codex_responses") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-sol-pro", "custom", api_mode="codex_responses") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-luna", "custom", api_mode="codex_responses") == 0.85
+    # openai-codex still matches without explicit api_mode
+    assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
+
+
+def test_compression_threshold_codex_gpt55_non_codex_api_mode_is_not_raised() -> None:
+    # Same slug, different route/api_mode → keep the user's configured value.
+    assert _compression_threshold_for_model("gpt-5.6-sol", "custom", api_mode="chat_completions") is None
+    assert _compression_threshold_for_model("gpt-5.6-sol", "openai", api_mode="chat_completions") is None

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -284,3 +284,40 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
     assert call_kwargs.get("config_context_length") == 100_000
     assert agent._config_context_length == 120_000
     assert agent.context_compressor.context_length == 100_000
+
+
+@patch("agent.model_metadata.get_model_context_length")
+def test_switch_model_custom_codex_threshold_uses_resolved_window(mock_ctx_len):
+    """Custom Codex routes raise, then restore the preserved baseline."""
+    mock_ctx_len.side_effect = [410_000, 1_050_000]
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    agent.switch_model(
+        "gpt-5.6-sol",
+        "custom",
+        api_key="sk-custom",
+        base_url="https://custom.example/v1",
+        api_mode="codex_responses",
+    )
+
+    compressor = agent.context_compressor
+    assert compressor.context_length == 410_000
+    assert compressor._config_threshold_percent == 0.50
+    assert compressor._configured_threshold_percent == 0.85
+    assert compressor.threshold_percent == 0.85
+    assert compressor.threshold_tokens == int(410_000 * 0.85)
+
+    agent.switch_model(
+        "glm-5.2-heavy",
+        "custom",
+        api_key="sk-custom",
+        base_url="https://custom.example/v1",
+        api_mode="chat_completions",
+    )
+
+    assert compressor.context_length == 1_050_000
+    assert compressor._config_threshold_percent == 0.50
+    assert compressor._configured_threshold_percent == 0.50
+    assert compressor.threshold_percent == 0.50
+    assert compressor.threshold_tokens == int(1_050_000 * 0.50)
+    assert mock_ctx_len.call_count == 2

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -342,3 +342,74 @@ def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
     assert agent.provider == "openrouter"
     assert agent.client is original_client
     assert agent.runtime_capabilities == {"native_compaction": True}
+
+
+def _make_agent_with_autoraise_compressor(
+    *, initial_percent: float = 0.50, model: str = "primary-model",
+    provider: str = "openrouter", base_url: str = "https://openrouter.ai/api/v1",
+    api_key: str = "sk-primary",
+):
+    """Build a bare AIAgent with a real ContextCompressor for autoraise tests."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = model
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_key = api_key
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+    agent._config_context_length = None
+    agent._primary_runtime = {}
+    agent.runtime_capabilities = {}
+    compressor = ContextCompressor(
+        model=model,
+        threshold_percent=initial_percent,
+        base_url=base_url,
+        api_key=api_key,
+        provider=provider,
+        quiet_mode=True,
+    )
+    agent.context_compressor = compressor
+    return agent
+
+
+def test_switch_model_applies_codex_autoraise_to_custom_codex_responses(monkeypatch):
+    """custom codex_responses route must receive the 0.85 Codex autoraise."""
+    agent = _make_agent_with_autoraise_compressor(initial_percent=0.50)
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 272000,
+    )
+    agent.switch_model(
+        "gpt-5.6-sol",
+        "custom",
+        api_key="sk-new",
+        base_url="https://api.example-codex-proxy.invalid",
+        api_mode="codex_responses",
+    )
+    assert agent.context_compressor.threshold_percent == 0.85
+
+
+def test_switch_model_drops_autoraise_on_non_codex_switch(monkeypatch):
+    """Autoraise to 0.85 on a Codex route must DROP to the user's default (sub-512K
+    floor) on a non-Codex switch — the raise is per-model, never a sticky override."""
+    agent = _make_agent_with_autoraise_compressor(initial_percent=0.50)
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 272000,
+    )
+    agent.switch_model(
+        "gpt-5.6-sol",
+        "custom",
+        api_key="sk-new",
+        base_url="https://api.example-codex-proxy.invalid",
+        api_mode="codex_responses",
+    )
+    assert agent.context_compressor.threshold_percent == 0.85
+    agent.switch_model(
+        "gpt-5.2",
+        "openrouter",
+        api_key="sk-new",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert agent.context_compressor.threshold_percent == 0.75

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -96,8 +96,9 @@ def _make_agent_with_compressor(
 
     # For switch_model
     agent._primary_runtime = {}
-
     return agent
+
+
 
 
 def _make_initialized_agent(

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -64,7 +64,9 @@ def _make_direct_start_agent(
         )
 
 
-def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
+def _make_agent_with_compressor(
+    config_context_length=None, global_threshold=0.50,
+) -> AIAgent:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
 
@@ -83,7 +85,7 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     # Context compressor with primary model values
     compressor = ContextCompressor(
         model="primary-model",
-        threshold_percent=0.50,
+        threshold_percent=global_threshold,
         base_url="https://openrouter.ai/api/v1",
         api_key="sk-primary",
         provider="openrouter",
@@ -95,6 +97,48 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     # For switch_model
     agent._primary_runtime = {}
 
+    return agent
+
+
+def _make_initialized_agent(
+    *,
+    model: str,
+    provider: str,
+    api_mode: str,
+    context_length: int,
+    threshold: float,
+) -> AIAgent:
+    config = {
+        "agent": {},
+        "compression": {
+            "enabled": True,
+            "threshold": threshold,
+            "codex_gpt55_autoraise": True,
+        },
+    }
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+        patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=context_length,
+        ),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+            api_key="test-key-1234567890",
+            base_url="https://custom.example/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
     return agent
 
 
@@ -321,3 +365,61 @@ def test_switch_model_custom_codex_threshold_uses_resolved_window(mock_ctx_len):
     assert compressor.threshold_percent == 0.50
     assert compressor.threshold_tokens == int(1_050_000 * 0.50)
     assert mock_ctx_len.call_count == 2
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_050_000)
+def test_initialized_custom_codex_switch_restores_configured_threshold(
+    mock_ctx_len,
+):
+    agent = _make_initialized_agent(
+        model="gpt-5.6-sol",
+        provider="custom",
+        api_mode="codex_responses",
+        context_length=410_000,
+        threshold=0.42,
+    )
+    compressor = agent.context_compressor
+
+    assert agent._compression_global_threshold == 0.42
+    assert compressor._config_threshold_percent == 0.42
+    assert compressor._configured_threshold_percent == 0.85
+    assert compressor.threshold_percent == 0.85
+
+    agent.switch_model(
+        "glm-5.2-heavy",
+        "custom",
+        api_key="test-key-1234567890",
+        base_url="https://custom.example/v1",
+        api_mode="chat_completions",
+    )
+
+    assert compressor.context_length == 1_050_000
+    assert compressor._config_threshold_percent == 0.42
+    assert compressor._configured_threshold_percent == 0.42
+    assert compressor.threshold_percent == 0.42
+    assert compressor.threshold_tokens == int(1_050_000 * 0.42)
+    mock_ctx_len.assert_called_once()
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=410_000)
+def test_switch_model_custom_codex_autoraise_respects_opt_out(mock_ctx_len):
+    agent = _make_agent_with_compressor(
+        config_context_length=None,
+        global_threshold=0.42,
+    )
+    agent._codex_gpt55_autoraise = False
+
+    agent.switch_model(
+        "gpt-5.6-sol",
+        "custom",
+        api_key="sk-custom",
+        base_url="https://custom.example/v1",
+        api_mode="codex_responses",
+    )
+
+    compressor = agent.context_compressor
+    assert compressor._config_threshold_percent == 0.42
+    assert compressor._configured_threshold_percent == 0.42
+    assert compressor.threshold_percent == 0.75
+    assert compressor.threshold_tokens == int(410_000 * 0.75)
+    mock_ctx_len.assert_called_once()


### PR DESCRIPTION
## Problem

Users running gpt-5.6 via custom providers that speak `codex_responses` (e.g. `custom:sudo` proxying the Codex endpoint) do not receive the 0.85 compaction-threshold auto-raise that `openai-codex` users get. The auth mechanism is different but the backend cap is the same 272K, so the session compacts too early.

Additionally, when switching between models mid-session via `/model`, the compressor retains the auto-raised threshold from the first model without re-deriving for the new one — a switch from GPT-5.6 (0.85) to GLM-5.2-heavy keeps 0.85 instead of dropping back to the global config value.

## Root cause

`_is_codex_gpt54_or_gpt55()` matched only `provider == "openai-codex"`, missing custom providers with `api_mode == "codex_responses"` that share the same 272K Codex cap.

`switch_model()` called `update_model()` which re-derived `threshold_percent` from `_configured_threshold_percent`, but `_configured_threshold_percent` was captured at init-time and never refreshed for the new model.

## Fix

1. **Extend `_is_codex_gpt54_or_gpt55()`**: Accept optional `api_mode` param. Match when `api_mode == "codex_responses"` regardless of provider name.

2. **Thread `api_mode`**: Through `_compression_threshold_for_model()` → `_is_codex_gpt54_or_gpt55()`.

3. **Re-apply auto-raise in `switch_model()`**: After `update_model()`, call `_compression_threshold_for_model()` and if a per-model override exists, update `_configured_threshold_percent`, `threshold_percent`, `threshold_tokens`, and `tail_token_budget`.

4. **Update `agent_init.py`**: Pass `agent.api_mode` to threshold resolution.

## Tests

- 71/71 existing tests pass (test_arcee_trinity_overrides.py)
- 4/4 new + existing switch_model context tests pass
- New test: `test_compression_threshold_codex_gpt55_custom_codex_responses` — verifies gpt-5.6 on custom codex_responses providers get 0.85
- New test: `test_switch_model_applies_codex_autoraise_to_custom_codex_responses` — verifies switch into codex_responses applies auto-raise
- New test: `test_switch_model_drops_autoraise_on_non_codex_switch` — verifies behavior on switch away from Codex