### PR TITLE
fix(matrix): recover transport after sync failure

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -809,8 +809,20 @@ class MatrixAdapter(BasePlatformAdapter):
         self._device_id_unverified: bool = False
 
         self._client: Any = None  # mautrix.client.Client
+        self._client_ready = asyncio.Event()
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
+        self._sync_reconnect_task: Optional[asyncio.Task] = None
+        self._reconnect_retry_delays: tuple[float, ...] = (
+            0.0,
+            1.0,
+            2.0,
+            5.0,
+            10.0,
+            20.0,
+            30.0,
+        )
+        self._reconnect_attempt_timeout: float = 30.0
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
         self._closing = False
         self._startup_ts: float = 0.0
@@ -1152,6 +1164,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the Matrix homeserver and start syncing."""
+        self._client_ready.clear()
         self._device_id_unverified = False
         if self._client is not None:
             try:
@@ -1523,18 +1536,131 @@ class MatrixAdapter(BasePlatformAdapter):
         # Share keys after initial sync if E2EE is enabled.
         if self._encryption and getattr(client, "crypto", None):
             try:
-                await client.crypto.share_keys()
+                await self._share_keys_with_timeout(client.crypto)
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
         # Start the sync loop.
-        self._sync_task = asyncio.create_task(self._sync_loop())
+        self._start_sync_task()
         self._mark_connected()
+        self._client_ready.set()
         return True
 
-    async def disconnect(self) -> None:
+    async def _share_keys_with_timeout(self, crypto: Any) -> None:
+        """Share E2EE keys without blocking Matrix reconnect indefinitely."""
+        try:
+            await asyncio.wait_for(
+                crypto.share_keys(),
+                timeout=self._reconnect_attempt_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Matrix: E2EE key sharing timed out after %.1fs; continuing",
+                self._reconnect_attempt_timeout,
+            )
+
+    def _start_sync_task(self) -> asyncio.Task:
+        """Start Matrix sync and surface terminal exits to the gateway."""
+        task = asyncio.create_task(self._sync_loop())
+        self._sync_task = task
+        task.add_done_callback(self._handle_sync_task_done)
+        return task
+
+    def _handle_sync_task_done(self, task: asyncio.Task) -> None:
+        """Recover Matrix in place when the sync task exits unexpectedly."""
+        if self._closing or task.cancelled():
+            return
+        if self._sync_task is not task:
+            return
+
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+
+        if self.has_fatal_error:
+            message = self.fatal_error_message or "Matrix sync stopped"
+            logger.error("Matrix: %s", message, exc_info=exc if exc else False)
+            self._schedule_fatal_notification()
+            return
+
+        if exc is None:
+            message = "Matrix sync task exited without an exception"
+            self._set_fatal_error("matrix_sync_task_exited", message, retryable=True)
+            logger.error("Matrix: %s", message)
+            self._schedule_fatal_notification()
+            return
+
+        logger.error("Matrix: sync task exited: %s — reconnecting in place", exc, exc_info=True)
+        self._schedule_sync_reconnect(exc)
+
+    def _schedule_fatal_notification(self) -> None:
+        async def _notify() -> None:
+            try:
+                await self._notify_fatal_error()
+            except Exception as notify_exc:
+                logger.warning(
+                    "Matrix: failed to notify gateway supervisor about sync exit: %s",
+                    notify_exc,
+                    exc_info=True,
+                )
+
+        asyncio.create_task(_notify())
+
+    def _schedule_sync_reconnect(self, reason: BaseException) -> None:
+        if self._sync_reconnect_task and not self._sync_reconnect_task.done():
+            return
+        self._sync_reconnect_task = asyncio.create_task(
+            self._reconnect_sync_in_place(reason)
+        )
+
+    async def _reconnect_sync_in_place(self, reason: BaseException) -> None:
+        """Replace only the Matrix client, preserving this adapter and its tasks."""
+        retry_delays = self._reconnect_retry_delays
+        try:
+            await self.disconnect(for_reconnect=True)
+            for attempt, delay in enumerate(retry_delays, start=1):
+                if delay:
+                    await asyncio.sleep(delay)
+                if self._closing:
+                    return
+                try:
+                    if await asyncio.wait_for(
+                        self.connect(is_reconnect=True),
+                        timeout=self._reconnect_attempt_timeout,
+                    ):
+                        logger.info(
+                            "Matrix: reconnected in place after sync failure "
+                            "(attempt %d)",
+                            attempt,
+                        )
+                        return
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Matrix: in-place reconnect attempt %d timed out after %.1fs",
+                        attempt,
+                        self._reconnect_attempt_timeout,
+                    )
+                except Exception as reconnect_exc:
+                    logger.warning(
+                        "Matrix: in-place reconnect attempt %d failed: %s",
+                        attempt,
+                        reconnect_exc,
+                    )
+                await self.disconnect(for_reconnect=True)
+            raise RuntimeError("Matrix reconnect attempts exhausted")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            message = f"Matrix in-place reconnect failed after {reason}: {exc}"
+            self._set_fatal_error("matrix_sync_reconnect_failed", message, retryable=True)
+            logger.error("Matrix: %s", message, exc_info=True)
+            await self._notify_fatal_error()
+
+    async def disconnect(self, *, for_reconnect: bool = False) -> None:
         """Disconnect from Matrix."""
-        self._closing = True
+        self._closing = not for_reconnect
+        self._client_ready.clear()
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -1587,6 +1713,26 @@ class MatrixAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=True)
 
+        client = self._client
+        if client is None:
+            if self._closing:
+                return SendResult(success=False, error="Matrix adapter is shutting down")
+            try:
+                await asyncio.wait_for(self._client_ready.wait(), timeout=90)
+            except asyncio.TimeoutError:
+                return SendResult(
+                    success=False,
+                    error="Matrix client did not become ready during reconnect",
+                    retryable=True,
+                )
+            client = self._client
+            if client is None:
+                return SendResult(
+                    success=False,
+                    error="Matrix client unavailable after reconnect",
+                    retryable=True,
+                )
+
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
 
@@ -1598,7 +1744,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
             try:
                 event_id = await asyncio.wait_for(
-                    self._client.send_message_event(
+                    client.send_message_event(
                         RoomID(chat_id),
                         EventType.ROOM_MESSAGE,
                         msg_content,
@@ -1608,12 +1754,16 @@ class MatrixAdapter(BasePlatformAdapter):
                 last_event_id = str(event_id)
                 logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
             except Exception as exc:
+                # If reconnect replaced or cleared this client, let the base
+                # delivery retry re-enter send() and wait for the new client.
+                if client is not self._client or not self._client_ready.is_set():
+                    return SendResult(success=False, error=str(exc), retryable=True)
                 # On E2EE errors, retry after sharing keys.
-                if self._encryption and getattr(self._client, "crypto", None):
+                if self._encryption and getattr(client, "crypto", None):
                     try:
-                        await self._client.crypto.share_keys()
+                        await client.crypto.share_keys()
                         event_id = await asyncio.wait_for(
-                            self._client.send_message_event(
+                            client.send_message_event(
                                 RoomID(chat_id),
                                 EventType.ROOM_MESSAGE,
                                 msg_content,
@@ -2289,6 +2439,11 @@ class MatrixAdapter(BasePlatformAdapter):
                             "Matrix: permanent auth error from sync: %s — stopping",
                             _sync_msg,
                         )
+                        self._set_fatal_error(
+                            "matrix_sync_auth",
+                            _sync_msg,
+                            retryable=False,
+                        )
                         return
 
                 if isinstance(sync_data, dict):
@@ -2334,9 +2489,14 @@ class MatrixAdapter(BasePlatformAdapter):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc
                     )
+                    self._set_fatal_error(
+                        "matrix_sync_auth",
+                        str(exc),
+                        retryable=False,
+                    )
                     return
-                logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
-                await asyncio.sleep(5)
+                logger.error("Matrix: sync error: %s — stopping for reconnect", exc)
+                raise
 
     # ------------------------------------------------------------------
     # Event callbacks

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1891,6 +1891,311 @@ class TestMatrixSyncLoop:
         mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
 
     @pytest.mark.asyncio
+    async def test_sync_transport_failure_escalates_when_in_place_reconnect_fails(self):
+        """A failed in-place recovery should fall back to retryable fatal state."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._running = True
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=ConnectionError("socket closed"))
+        fake_client.sync_store = mock_sync_store
+        adapter._client = fake_client
+        adapter.connect = AsyncMock(return_value=False)
+        adapter._reconnect_retry_delays = (0.0, 0.0)
+
+        task = adapter._start_sync_task()
+        try:
+            await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=0.2)
+            reconnect_task = adapter._sync_reconnect_task
+            assert reconnect_task is not None
+            await asyncio.wait_for(asyncio.shield(reconnect_task), timeout=0.2)
+        finally:
+            adapter._closing = True
+            reconnect_task = adapter._sync_reconnect_task
+            if reconnect_task and not reconnect_task.done():
+                reconnect_task.cancel()
+            if reconnect_task is not None:
+                await asyncio.gather(task, reconnect_task, return_exceptions=True)
+            else:
+                await asyncio.gather(task, return_exceptions=True)
+
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is True
+        assert adapter.fatal_error_code == "matrix_sync_reconnect_failed"
+
+    @pytest.mark.asyncio
+    async def test_sync_auth_failure_notifies_non_retryable_fatal_error(self):
+        """A permanent Matrix auth failure must not enter reconnect backoff."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._running = True
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(
+            return_value=types.SimpleNamespace(message="M_UNKNOWN_TOKEN")
+        )
+        fake_client.sync_store = mock_sync_store
+        adapter._client = fake_client
+
+        task = asyncio.create_task(adapter._sync_loop())
+        adapter._sync_task = task
+        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=0.2)
+
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "matrix_sync_auth"
+
+    @pytest.mark.asyncio
+    async def test_sync_task_cancellation_during_disconnect_does_not_notify(self):
+        """Intentional gateway shutdown must not enqueue a reconnect."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._running = True
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        fake_client = MagicMock()
+        sync_started = asyncio.Event()
+        sync_blocked = asyncio.Event()
+
+        async def _blocked_sync(**kwargs):
+            sync_started.set()
+            await sync_blocked.wait()
+
+        fake_client.sync = AsyncMock(side_effect=_blocked_sync)
+        fake_client.sync_store = mock_sync_store
+        adapter._client = fake_client
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+
+        task = asyncio.create_task(adapter._sync_loop())
+        adapter._sync_task = task
+        await asyncio.wait_for(sync_started.wait(), timeout=0.2)
+        adapter._closing = True
+        task.cancel()
+        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=0.2)
+
+        fatal_handler.assert_not_awaited()
+        assert adapter.has_fatal_error is False
+
+    @pytest.mark.asyncio
+    async def test_terminal_sync_failure_reconnects_same_adapter(self):
+        """A transport failure should recover the adapter in place."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._running = True
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=ConnectionError("socket closed"))
+        fake_client.sync_store = mock_sync_store
+        adapter._client = fake_client
+
+        reconnected = asyncio.Event()
+        reconnect_calls = []
+
+        async def reconnect(*, is_reconnect=False):
+            reconnect_calls.append(is_reconnect)
+            adapter._closing = False
+            adapter._running = True
+            reconnected.set()
+            return True
+
+        adapter.connect = AsyncMock(side_effect=reconnect)
+        adapter.set_fatal_error_handler(AsyncMock())
+
+        task = adapter._start_sync_task()
+        try:
+            await asyncio.wait_for(reconnected.wait(), timeout=0.2)
+        finally:
+            adapter._closing = True
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert reconnect_calls == [True]
+        assert adapter.has_fatal_error is False
+
+    @pytest.mark.asyncio
+    async def test_inflight_turn_delivers_after_in_place_reconnect(self):
+        """An active turn should finish through the recovered Matrix adapter."""
+        from gateway.platforms.base import MessageEvent, MessageType, SendResult
+
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._running = True
+
+        old_client = MagicMock()
+        old_client.sync_store = MagicMock()
+        old_client.sync_store.get_next_batch = AsyncMock(return_value=None)
+        old_client.sync = AsyncMock(side_effect=ConnectionError("socket closed"))
+        adapter._client = old_client
+
+        new_client = MagicMock()
+        reconnected = asyncio.Event()
+
+        async def reconnect(*, is_reconnect=False):
+            assert is_reconnect is True
+            adapter._client = new_client
+            adapter._closing = False
+            adapter._running = True
+            reconnected.set()
+            return True
+
+        adapter.connect = AsyncMock(side_effect=reconnect)
+
+        async def fatal_handler(_failed_adapter):
+            await adapter.disconnect()
+
+        adapter.set_fatal_error_handler(fatal_handler)
+
+        turn_started = asyncio.Event()
+        release_turn = asyncio.Event()
+
+        async def message_handler(_event):
+            turn_started.set()
+            await release_turn.wait()
+            return "response after reconnect"
+
+        adapter.set_message_handler(message_handler)
+
+        async def send(_chat_id, _content, **_kwargs):
+            return SendResult(success=adapter._client is new_client)
+
+        adapter.send = AsyncMock(side_effect=send)
+
+        source = adapter.build_source(
+            "!room:example.org",
+            chat_type="dm",
+            user_id="@alice:example.org",
+        )
+        event = MessageEvent(
+            text="start work",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+
+        sync_task = adapter._start_sync_task()
+        await adapter.handle_message(event)
+        await asyncio.wait_for(turn_started.wait(), timeout=0.2)
+        await asyncio.wait_for(reconnected.wait(), timeout=0.2)
+        release_turn.set()
+
+        session_key = next(iter(adapter._session_tasks))
+        turn_task = adapter._session_tasks[session_key]
+        await asyncio.wait_for(asyncio.shield(turn_task), timeout=0.2)
+
+        assert adapter._client is new_client
+        adapter.send.assert_awaited()
+
+        adapter._closing = True
+        if not sync_task.done():
+            sync_task.cancel()
+        await asyncio.gather(sync_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_send_waits_for_client_during_in_place_reconnect(self):
+        """An active turn should wait for the same adapter's client to return."""
+        from gateway.platforms.base import SendResult
+
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._client = None
+        adapter._client_ready = asyncio.Event()
+
+        fake_client = MagicMock()
+        fake_client.send_message_event = AsyncMock(return_value="$event-after-reconnect")
+
+        async def restore_client():
+            await asyncio.sleep(0.01)
+            adapter._client = fake_client
+            adapter._client_ready.set()
+
+        restore_task = asyncio.create_task(restore_client())
+        result = await asyncio.wait_for(
+            adapter.send("!room:example.org", "response after reconnect"),
+            timeout=0.2,
+        )
+        await restore_task
+
+        assert isinstance(result, SendResult)
+        assert result.success is True
+        fake_client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_in_place_reconnect_retries_transient_failure(self):
+        """Transient reconnect failure should not replace the adapter immediately."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._client = MagicMock()
+        adapter._reconnect_retry_delays = (0.0, 0.0)
+        new_client = MagicMock()
+        reconnect_calls = 0
+
+        async def reconnect(*, is_reconnect=False):
+            nonlocal reconnect_calls
+            assert is_reconnect is True
+            reconnect_calls += 1
+            if reconnect_calls == 1:
+                return False
+            adapter._client = new_client
+            adapter._client_ready.set()
+            return True
+
+        adapter.connect = AsyncMock(side_effect=reconnect)
+        await adapter._reconnect_sync_in_place(ConnectionError("502"))
+
+        assert reconnect_calls == 2
+        assert adapter._client is new_client
+        assert adapter.has_fatal_error is False
+
+    @pytest.mark.asyncio
+    async def test_reconnect_attempt_has_a_bounded_timeout(self):
+        """A hung connect attempt must not stall the in-place retry ladder."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._reconnect_retry_delays = (0.0, 0.0)
+        adapter._reconnect_attempt_timeout = 0.01
+        connect_started = asyncio.Event()
+
+        async def hanging_connect(*, is_reconnect=False):
+            assert is_reconnect is True
+            connect_started.set()
+            await asyncio.Event().wait()
+
+        adapter.connect = AsyncMock(side_effect=hanging_connect)
+        await asyncio.wait_for(
+            adapter._reconnect_sync_in_place(ConnectionError("transport closed")),
+            timeout=0.1,
+        )
+
+        assert connect_started.is_set()
+        assert adapter.connect.await_count == 2
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "matrix_sync_reconnect_failed"
+
+    @pytest.mark.asyncio
+    async def test_e2ee_key_sharing_timeout_does_not_block_connect(self):
+        """A stuck optional key-share must not hold Matrix reconnect hostage."""
+        adapter = _make_adapter()
+        adapter._reconnect_attempt_timeout = 0.01
+        crypto = MagicMock()
+
+        async def hanging_share_keys():
+            await asyncio.Event().wait()
+
+        crypto.share_keys = AsyncMock(side_effect=hanging_share_keys)
+        await adapter._share_keys_with_timeout(crypto)
+        crypto.share_keys.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_sync_loop_reconciles_pending_invites(self):
         """Pending rooms.invite entries should be joined if callbacks were missed."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

When a Synapse/Matrix homeserver briefly becomes unavailable, the Matrix sync task can terminate while the Hermes gateway itself remains alive. The Matrix adapter can then appear present but no longer receive or send messages.

This change makes the adapter recover its underlying Matrix client in place:

- detect unexpected sync-task termination;
- retain the existing adapter and its conversation ownership;
- rebuild the Matrix client and restore readiness;
- make outbound sends wait for restored transport instead of immediately failing when the client is temporarily unavailable;
- retry transient reconnect failures with bounded backoff;
- escalate to supervisor replacement only after in-place recovery is exhausted.

## Validation

- Focused Matrix reconnect and send-continuity tests: 9 passed.
- Matrix sync-loop tests: 16 passed; 1 existing connect test is blocked by missing local `libolm`, `asyncpg`, and `aiosqlite` dependencies.
- Gateway recovery suites: 11 passed.
- Python compilation and `git diff --check`: passed.
- Manual Synapse/Matrix homeserver restart: the existing adapter detected the sync failure, retried in place, rebuilt the client, completed initial sync, and became ready again without a gateway restart.

## Boundary

This preserves continuity while the existing Matrix adapter remains alive. If in-place recovery is exhausted and the supervisor must create a replacement adapter, migrating arbitrary in-flight turns from the old adapter is not included here and should be a separate follow-up.
