### PR TITLE
fix(google_meet): give id-less say-queue entries a stable id

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -273,7 +273,12 @@ class RealtimeSpeaker:
             if not isinstance(entry, dict):
                 continue
             if "id" not in entry:
-                entry["id"] = str(uuid.uuid4())
+                # Derive a *stable* id from the line content. A fresh uuid4
+                # per read meant run_until_stopped's post-speak drop-by-id
+                # never matched (each _read_queue minted a different id), so
+                # an id-less entry — e.g. one written by the `say` producer as
+                # {"text": ..., "ts": ...} — was spoken twice before removal.
+                entry["id"] = str(uuid.uuid5(uuid.NAMESPACE_OID, line))
             out.append(entry)
         return out
 

--- a/tests/plugins/test_google_meet_realtime.py
+++ b/tests/plugins/test_google_meet_realtime.py
@@ -288,3 +288,36 @@ def test_speaker_drops_line_without_processed_path_when_none(tmp_path):
     speaker.run_until_stopped(_stop, poll_interval=0.01)
     assert stub.spoken == ["once"]
     assert queue.read_text().strip() == ""
+
+
+def test_speaker_speaks_idless_entry_once(tmp_path):
+    # An entry written without an "id" (the `say` producer writes
+    # {"text", "ts"}) must be spoken exactly once. A fresh uuid per read
+    # used to make the post-speak drop-by-id miss, so it was spoken twice.
+    from plugins.google_meet.realtime.openai_client import RealtimeSpeaker
+
+    queue = tmp_path / "q.jsonl"
+    queue.write_text(json.dumps({"text": "once", "ts": 1.0}) + "\n")  # no "id"
+
+    stub = _StubSession()
+    speaker = RealtimeSpeaker(stub, queue_path=queue, processed_path=None)
+
+    def _stop():
+        return queue.read_text().strip() == ""
+
+    speaker.run_until_stopped(_stop, poll_interval=0.01)
+    assert stub.spoken == ["once"]
+    assert queue.read_text().strip() == ""
+
+
+def test_read_queue_assigns_stable_id_across_reads(tmp_path):
+    from plugins.google_meet.realtime.openai_client import RealtimeSpeaker
+
+    queue = tmp_path / "q.jsonl"
+    queue.write_text(json.dumps({"text": "hi", "ts": 1.0}) + "\n")  # no "id"
+    speaker = RealtimeSpeaker(_StubSession(), queue_path=queue, processed_path=None)
+
+    first = speaker._read_queue()
+    second = speaker._read_queue()
+    assert first[0]["id"] == second[0]["id"]
+    assert first[0]["text"] == "hi"


### PR DESCRIPTION
## What does this PR do?

A queued `say` message with no `"id"` is spoken **twice** in a realtime meeting.

`RealtimeSpeaker._read_queue` mints a fresh `uuid4` for every entry lacking an `"id"`, on every read:

```python
if "id" not in entry:
    entry["id"] = str(uuid.uuid4())
```

`run_until_stopped` reads the queue, speaks `entries[0]`, then **re-reads** the file and drops the head by matching its id:

```python
latest = self._read_queue()
if latest and latest[0].get("id") == head.get("id"):
    self._rewrite_queue(latest[1:])
else:
    self._rewrite_queue([e for e in latest if e.get("id") != head.get("id")])
```

For an id-less on-disk entry, the re-read mints a *different* uuid, so `latest[0].id != head.id`. The fast path misses, and the fallback keeps the entry (its id doesn't equal the head's either). The entry survives, gets a persisted id on the rewrite, and is spoken a second time on the next loop before finally being dropped. The `say` producer (`node/server.py`) writes `{"text": ..., "ts": ...}` with **no id**, so every message sent through it is spoken twice.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/realtime/openai_client.py` — derive the id from the line content with `uuid5` instead of a random `uuid4`, so the same on-disk entry gets the same id across reads and the drop-by-id logic matches. Entries that already carry an id are unaffected.

## How to Test

`uv run pytest tests/plugins/test_google_meet_realtime.py -q` — 11 passed.

New tests:
- `test_speaker_speaks_idless_entry_once` — an entry written as `{"text", "ts"}` (no id) is spoken exactly once (fails on `main`: spoken twice).
- `test_read_queue_assigns_stable_id_across_reads` — two reads of the same id-less entry return the same id (fails on `main`: two different uuids).

## Checklist

- [x] Conventional Commits
- [x] Searched existing PRs (none touches the say-queue id/duplicate-speak)
- [x] Only changes related to this fix
- [x] Added tests; full realtime suite passes
- [x] Tested on: Ubuntu (WSL2), Python 3.12