### PR TITLE
fix(prompt): clarify Windows MSYS path mapping

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -921,7 +921,9 @@ _WINDOWS_BASH_SHELL_HINT = (
     "bash (git-bash / MSYS), NOT PowerShell or cmd.exe. Use POSIX shell "
     "syntax (`ls`, `$HOME`, `&&`, `|`, single-quoted strings) inside terminal "
     "calls. MSYS-style paths like `/c/Users/<user>/...` work alongside "
-    "native `C:\\Users\\<user>\\...` paths. PowerShell builtins "
+    "native `C:\\Users\\<user>\\...` paths; `/c/Users/<user>/...` maps to "
+    "`C:\\Users\\<user>\\...`, NOT `C:\\c\\Users\\<user>\\...`. Never prepend "
+    "`C:\\` to an MSYS path without stripping the leading `/c/`. PowerShell builtins "
     "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
     "POSIX equivalents (`ls`, `$FOO`, `grep`)."
 )

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -889,6 +889,11 @@ POSIX-newline files to CRLF.
 every Hermes tool and most Windows APIs. Prefer forward slashes in code
 and logs — avoids shell-escaping backslashes in bash.
 
+**MSYS path conversion.** In git-bash / MSYS, `/c/Users/foo` means
+`C:\Users\foo`, not `C:\c\Users\foo`. The leading `/c` is the drive mount
+point and must be stripped when converting to a native Windows path. Do not
+naively prepend `C:\` to an MSYS path.
+
 ---
 
 ## Troubleshooting

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1185,6 +1185,9 @@ class TestEnvironmentHints:
         assert "NOT the username" in result
         assert "bash" in result
         assert "PowerShell" in result
+        assert "/c/Users/<user>/..." in result
+        assert "C:\\Users\\<user>\\..." in result
+        assert "NOT `C:\\c\\Users\\<user>\\...`" in result
 
     def test_build_environment_hints_on_macos_local(self, monkeypatch):
         import agent.prompt_builder as _pb
@@ -1644,5 +1647,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
## What does this PR do?

Clarifies Hermes' always-on Windows bash/MSYS guidance so the model sees the exact `/c/Users/...` to `C:\Users\...` mapping rule, which avoids the recurring bad `C:\c\Users\...` path construction described in #62998. The same pitfall note is mirrored into the bundled Hermes skill's Windows quirks section, and a prompt-builder regression test now pins that wording.

## Related Issue

Fixes #62998

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/prompt_builder.py` to explicitly say `/c/Users/<user>/...` maps to `C:\Users\<user>\...`, not `C:\c\Users\<user>\...`, and to warn against prepending `C:\` to an MSYS path without stripping `/c/`.
- Added a regression assertion in `tests/agent/test_prompt_builder.py` so the Windows environment hint keeps that mapping rule.
- Added the same Windows/MSYS path-conversion pitfall to `skills/autonomous-ai-agents/hermes-agent/SKILL.md`.

## How to Test

1. Run `python -m pytest tests/agent/test_prompt_builder.py -q`.
2. Verify `test_build_environment_hints_on_windows_local` checks for the explicit `/c/Users/...` -> `C:\Users\...` mapping and rejects `C:\c\Users\...`.
3. Inspect the Windows shell hint text in `agent/prompt_builder.py` or via `build_environment_hints()` on a mocked `win32` platform.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS host for targeted prompt-builder verification; change is Windows-specific prompt guidance

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted proof: `python -m pytest tests/agent/test_prompt_builder.py -q` -> `160 passed, 1 skipped in 1.58s`