### PR TITLE
fix(gateway): send startup notification on fresh gateway start

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7295,16 +7295,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # a one-shot signal by the /restart redelivery guard so a missing
         # dedup marker only suppresses a /restart when we KNOW we just came out
         # of a restart cycle (see _is_stale_restart_redelivery).
-        if _restart_notification_pending() or planned_restart_notification_pending:
+        chat_originated_restart = _restart_notification_pending()
+        if chat_originated_restart or planned_restart_notification_pending:
             self._booted_from_restart = True
         await self._send_restart_notification()
 
         # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
+        # channels on every startup EXCEPT chat-originated /restart (which
+        # already has a precise reply target in .restart_notify.json so the
+        # reply notification is the lifecycle signal — no duplicate). Fresh
+        # starts and planned restarts (terminal/SIGUSR1/service paths) always
+        # notify the home channel so the operator knows the gateway is online.
+        if not chat_originated_restart:
             try:
                 await self._send_home_channel_startup_notifications(
                     skip_targets=None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7288,31 +7288,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if connected_count > 0:
             await asyncio.sleep(1.0)
 
-        # Notify the chat that initiated /restart that the gateway is back.
-        planned_restart_notification_pending = _planned_restart_notification_pending()
-        # Capture, before _send_restart_notification() unlinks the marker,
-        # whether this process booted from a chat-originated /restart. Used as
-        # a one-shot signal by the /restart redelivery guard so a missing
-        # dedup marker only suppresses a /restart when we KNOW we just came out
-        # of a restart cycle (see _is_stale_restart_redelivery).
-        chat_originated_restart = _restart_notification_pending()
-        if chat_originated_restart or planned_restart_notification_pending:
-            self._booted_from_restart = True
-        await self._send_restart_notification()
-
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels on every startup EXCEPT chat-originated /restart (which
-        # already has a precise reply target in .restart_notify.json so the
-        # reply notification is the lifecycle signal — no duplicate). Fresh
-        # starts and planned restarts (terminal/SIGUSR1/service paths) always
-        # notify the home channel so the operator knows the gateway is online.
-        if not chat_originated_restart:
-            try:
-                await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
-                )
-            finally:
-                _clear_planned_restart_notification()
+        await self._notify_startup_channels()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -14898,6 +14874,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
         finally:
             notify_path.unlink(missing_ok=True)
+
+    async def _notify_startup_channels(self) -> None:
+        """Notify home channels that the gateway is back.
+
+        Sends a startup notification to configured home channels on every
+        gateway start, except when the start follows a chat-originated
+        /restart (which already has a precise reply target in
+        .restart_notify.json so the reply notification is the lifecycle
+        signal — no duplicate home-channel notification needed).  Fresh
+        starts and planned restarts (terminal/SIGUSR1/service paths) always
+        notify the home channel.
+        """
+        planned_restart = _planned_restart_notification_pending()
+        chat_restart = _restart_notification_pending()
+        if chat_restart or planned_restart:
+            self._booted_from_restart = True
+        await self._send_restart_notification()
+        if not chat_restart:
+            try:
+                await self._send_home_channel_startup_notifications(
+                    skip_targets=None,
+                )
+            finally:
+                if _planned_restart_notification_pending():
+                    _clear_planned_restart_notification()
 
     async def _send_home_channel_startup_notifications(
         self,

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -688,3 +688,72 @@ async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "462",
     }
+
+
+# ── _notify_startup_channels (startup-flow orchestration) ─────────────
+
+
+def _make_notify_runner():
+    """Create a GatewayRunner partial instance for _notify_startup_channels tests."""
+    runner, adapter = make_restart_runner()
+    runner._booted_from_restart = False
+    runner._send_restart_notification = AsyncMock()
+    runner._send_home_channel_startup_notifications = AsyncMock(
+        return_value=set()
+    )
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_notify_fresh_start_sends_home_notification(tmp_path, monkeypatch):
+    """No restart markers → home-channel notification is sent."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = _make_notify_runner()
+
+    await runner._notify_startup_channels()
+
+    runner._send_home_channel_startup_notifications.assert_awaited_once_with(
+        skip_targets=None,
+    )
+    assert runner._booted_from_restart is False
+
+
+@pytest.mark.asyncio
+async def test_notify_chat_restart_suppresses_home_notification(tmp_path, monkeypatch):
+    """.restart_notify.json exists → home-channel notification is suppressed."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".restart_notify.json").write_text("{}")
+    runner, _adapter = _make_notify_runner()
+
+    await runner._notify_startup_channels()
+
+    runner._send_home_channel_startup_notifications.assert_not_awaited()
+    assert runner._booted_from_restart is True
+
+
+@pytest.mark.asyncio
+async def test_notify_planned_restart_sends_home_notification(tmp_path, monkeypatch):
+    """.restart_pending.json exists (terminal restart) → home notification is sent."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".restart_pending.json").write_text("{}")
+    runner, _adapter = _make_notify_runner()
+
+    await runner._notify_startup_channels()
+
+    runner._send_home_channel_startup_notifications.assert_awaited_once_with(
+        skip_targets=None,
+    )
+    assert runner._booted_from_restart is True
+
+
+@pytest.mark.asyncio
+async def test_notify_planned_restart_cleans_up_marker(tmp_path, monkeypatch):
+    """.restart_pending.json is removed after notification."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    marker = tmp_path / ".restart_pending.json"
+    marker.write_text("{}")
+    runner, _adapter = _make_notify_runner()
+
+    await runner._notify_startup_channels()
+
+    assert not marker.exists()


### PR DESCRIPTION
Fixes #62512

**Problem:** The home channel startup notification is only sent when `planned_restart_notification_pending` is True, which requires the `.restart_pending.json` marker file. That marker is created only by terminal/SIGUSR1/service restart paths, so a normal fresh gateway start never triggers the notification.

**Fix:** Capture the chat-originated-restart state (`_restart_notification_pending()`) *before* `_send_restart_notification()` unlinks the `.restart_notify.json` marker, then always send the home-channel startup notification unless this is a chat-originated `/restart` (which already has a reply).

**Behavior changes:**
- Fresh start: notification now sent to home channels
- Planned restart (terminal/SIGUSR1/service): notification sent (unchanged)
- Chat-originated /restart: no duplicate (unchanged)