### PR TITLE
fix(cli): resolve MoA presets in non-interactive mode

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -35,6 +35,26 @@ class CLIAgentSetupMixin:
             format_runtime_provider_error,
         )
 
+        # MoA virtual provider (#56828): recognize `-m moa:<preset>` /
+        # `--provider moa` here so classic non-interactive chat resolves the
+        # virtual provider instead of sending the literal model string to a
+        # real API. Idempotent: once normalized, re-resolution is a no-op.
+        from hermes_cli.moa_config import resolve_moa_request
+
+        _cli_config = getattr(self, "config", None)
+        try:
+            _moa = resolve_moa_request(
+                self.requested_provider,
+                self.model,
+                _cli_config if isinstance(_cli_config, dict) else {},
+                model_explicit=not getattr(self, "_model_is_default", True),
+            )
+        except ValueError as exc:
+            ChatConsole().print(f"[bold red]{exc}[/]")
+            return False
+        if _moa is not None:
+            self.requested_provider, self.model = _moa
+
         _primary_exc = None
         runtime = None
         try:

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -272,5 +272,62 @@ def build_moa_turn_prompt(user_prompt: str, config: Any = None, preset: str | No
     return encode_moa_turn(user_prompt, config, preset=preset)
 
 
+def resolve_moa_request(
+    provider: Any,
+    model: Any,
+    config: Any,
+    *,
+    model_explicit: bool,
+) -> tuple[str, str] | None:
+    """Normalize a non-interactive provider/model request onto MoA.
+
+    Returns ``("moa", <bare preset name>)`` when the request targets the MoA
+    virtual provider, else ``None``. This is the resolution seam for
+    ``hermes chat -q``/``hermes -z`` (#56828), which previously sent literal
+    ``moa:<preset>`` model strings to real provider APIs.
+
+    Rules:
+    - A ``moa:`` / ``moa/`` model prefix (case-insensitive scheme) is an
+      EXPLICIT selection: it wins over a conflicting ``provider`` and may
+      target disabled presets — the ``enabled`` opt-out only guards implicit
+      bare-name matches (see ``exact_moa_preset_name``, #55187). An unknown
+      preset raises ``ValueError`` naming the available presets.
+    - ``provider == "moa"``: a model naming a known preset is used as-is; an
+      empty model or a config-inherited non-preset model
+      (``model_explicit=False``) falls back to ``default_preset``; an
+      explicitly requested non-preset model raises ``ValueError`` (mirrors
+      the interactive ``/model`` acceptance rule in ``hermes_cli/models.py``).
+
+    ``config`` is the full loaded config dict (the ``moa`` section is read
+    from it); non-dict values behave as an empty config.
+    """
+    provider_norm = str(provider or "").strip().lower()
+    model_norm = str(model or "").strip()
+    lowered = model_norm.lower()
+
+    prefixed = lowered.startswith(("moa:", "moa/"))
+    if prefixed:
+        preset = model_norm[4:].strip()
+    elif provider_norm == "moa":
+        preset = model_norm
+    else:
+        return None
+
+    moa_section = config.get("moa") if isinstance(config, dict) else {}
+    cfg = normalize_moa_config(moa_section)
+    if not preset:
+        return ("moa", cfg["default_preset"])
+    if preset in cfg["presets"]:
+        return ("moa", preset)
+    if prefixed or model_explicit:
+        available = ", ".join(sorted(cfg["presets"])) or "(none configured)"
+        raise ValueError(
+            f"Unknown MoA preset {preset!r}. Available presets: {available}"
+        )
+    # provider=moa with a stale config-inherited real-model default: the
+    # user never asked for that model here, so run the default preset.
+    return ("moa", cfg["default_preset"])
+
+
 def moa_usage() -> str:
     return "Usage: /moa <prompt>  (runs one prompt through the default MoA preset, then restores your model; pick a preset from the model picker to switch for the session)"

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -196,6 +196,30 @@ def run_oneshot(
     # the mismatch.  Require the caller to be explicit.  Validate BEFORE the
     # stderr redirect so the message actually reaches the terminal.
     env_model_early = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
+
+    # MoA virtual provider (#56828): normalize BEFORE the provider/model
+    # guard and the stderr redirect. `--provider moa` alone has a
+    # well-defined default (the configured default_preset) so it must not
+    # be rejected by the guard below, and an unknown-preset error must
+    # reach the real stderr — everything inside the redirect goes to
+    # devnull. _run_agent() repeats this normalization for direct callers;
+    # it is idempotent.
+    from hermes_cli.config import load_config as _load_config
+    from hermes_cli.moa_config import resolve_moa_request
+
+    try:
+        _moa = resolve_moa_request(
+            provider,
+            (model or "").strip() or env_model_early,
+            _load_config(),
+            model_explicit=bool((model or "").strip() or env_model_early),
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"hermes -z: {exc}\n")
+        return 2
+    if _moa is not None:
+        provider, model = _moa
+
     if provider and not ((model or "").strip() or env_model_early):
         sys.stderr.write(
             "hermes -z: --provider requires --model (or HERMES_INFERENCE_MODEL). "

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -333,6 +333,25 @@ def _run_agent(
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
     explicit_base_url_from_alias: Optional[str] = None
+
+    # MoA virtual provider (#56828): normalize BEFORE alias/catalog
+    # detection so `-m moa:<preset>` and `--provider moa` resolve onto the
+    # virtual provider instead of leaking the literal string to a real API.
+    from hermes_cli.moa_config import resolve_moa_request
+
+    try:
+        _moa = resolve_moa_request(
+            effective_provider,
+            effective_model,
+            cfg,
+            model_explicit=bool((model or "").strip() or env_model),
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"hermes: {exc}\n")
+        raise SystemExit(2) from exc
+    if _moa is not None:
+        effective_provider, effective_model = _moa
+
     if effective_provider is None and (model or env_model):
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"

--- a/tests/hermes_cli/test_moa_noninteractive_resolution.py
+++ b/tests/hermes_cli/test_moa_noninteractive_resolution.py
@@ -164,6 +164,27 @@ def test_oneshot_unknown_preset_exits_with_preset_list(oneshot_rig, capsys):
     assert "strategy" in combined
 
 
+def test_run_oneshot_provider_moa_defaults_preset(oneshot_rig, capsys):
+    """PUBLIC path: `hermes -z --provider moa` (no --model) must reach the
+    default preset instead of being rejected by the provider/model guard."""
+    rc = oneshot_rig.run_oneshot("hi", provider="moa")
+    assert rc == 0
+    kwargs = _CapturedAgent.last_kwargs
+    assert kwargs["provider"] == "moa"
+    assert kwargs["model"] == "strategy"
+    assert "ok" in capsys.readouterr().out
+
+
+def test_run_oneshot_unknown_preset_reports_on_real_stderr(oneshot_rig, capsys):
+    """PUBLIC path: unknown-preset diagnostics must reach the real stderr —
+    everything inside run_oneshot's redirect goes to devnull."""
+    rc = oneshot_rig.run_oneshot("hi", model="moa:bogus")
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "bogus" in err
+    assert "strategy" in err
+
+
 # -- integration: classic chat mixin -------------------------------------------
 
 

--- a/tests/hermes_cli/test_moa_noninteractive_resolution.py
+++ b/tests/hermes_cli/test_moa_noninteractive_resolution.py
@@ -1,0 +1,198 @@
+"""Non-interactive MoA resolution (#56828).
+
+``hermes chat -m moa:<preset> -Q`` and ``hermes -z`` previously sent the
+literal ``moa:<preset>`` string to a real provider API (HTTP 401). These
+tests pin the resolution seam: model strings / --provider moa normalize to
+the MoA virtual provider with a bare preset name BEFORE
+resolve_runtime_provider runs.
+"""
+
+import pytest
+
+from hermes_cli.moa_config import resolve_moa_request
+
+MOA_CFG = {
+    "moa": {
+        "default_preset": "strategy",
+        "presets": {
+            "strategy": {
+                "reference_models": [
+                    {"provider": "openai-codex", "model": "gpt-5.5"},
+                ],
+                "aggregator": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+            },
+            "review": {
+                "reference_models": [
+                    {"provider": "deepseek", "model": "deepseek-v4-pro"},
+                ],
+                "aggregator": {"provider": "openai-codex", "model": "gpt-5.5"},
+            },
+            "retired": {
+                "enabled": False,
+                "reference_models": [
+                    {"provider": "deepseek", "model": "deepseek-v4-pro"},
+                ],
+                "aggregator": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+            },
+        },
+    }
+}
+
+
+# -- unit: resolve_moa_request -------------------------------------------------
+
+
+def test_moa_prefix_resolves_regardless_of_provider():
+    assert resolve_moa_request("auto", "moa:strategy", MOA_CFG, model_explicit=True) == (
+        "moa", "strategy",
+    )
+    assert resolve_moa_request(None, "moa/review", MOA_CFG, model_explicit=True) == (
+        "moa", "review",
+    )
+    # explicit prefix wins over a conflicting provider (issue repro #2)
+    assert resolve_moa_request(
+        "openai-codex", "moa:strategy", MOA_CFG, model_explicit=True
+    ) == ("moa", "strategy")
+    # case-insensitive scheme
+    assert resolve_moa_request("auto", "MoA:strategy", MOA_CFG, model_explicit=True) == (
+        "moa", "strategy",
+    )
+
+
+def test_moa_prefix_unknown_preset_raises_with_available_names():
+    with pytest.raises(ValueError) as exc:
+        resolve_moa_request("auto", "moa:bogus", MOA_CFG, model_explicit=True)
+    message = str(exc.value)
+    assert "bogus" in message
+    assert "strategy" in message  # names the available presets
+
+
+def test_explicit_selection_reaches_disabled_preset():
+    # enabled: false only guards IMPLICIT bare-name matches (#55187);
+    # explicit moa: prefix / --provider moa may still select it.
+    assert resolve_moa_request("auto", "moa:retired", MOA_CFG, model_explicit=True) == (
+        "moa", "retired",
+    )
+    assert resolve_moa_request("moa", "retired", MOA_CFG, model_explicit=True) == (
+        "moa", "retired",
+    )
+
+
+def test_provider_moa_normalizes_model():
+    # bare preset name accepted as-is
+    assert resolve_moa_request("moa", "review", MOA_CFG, model_explicit=True) == (
+        "moa", "review",
+    )
+    # no model / config-inherited non-preset model -> default preset
+    assert resolve_moa_request("moa", "", MOA_CFG, model_explicit=False) == (
+        "moa", "strategy",
+    )
+    assert resolve_moa_request("moa", "claude-x", MOA_CFG, model_explicit=False) == (
+        "moa", "strategy",
+    )
+    # explicitly requested non-preset model with provider moa -> clear error
+    with pytest.raises(ValueError):
+        resolve_moa_request("moa", "claude-x", MOA_CFG, model_explicit=True)
+
+
+def test_non_moa_requests_pass_through():
+    assert resolve_moa_request("auto", "gpt-5.5", MOA_CFG, model_explicit=True) is None
+    assert resolve_moa_request("deepseek", "", MOA_CFG, model_explicit=False) is None
+    # bare preset name WITHOUT provider moa is not claimed (implicit match
+    # is the interactive /model path's job, not this seam's)
+    assert resolve_moa_request("auto", "strategy", MOA_CFG, model_explicit=True) is None
+
+
+# -- integration: oneshot ------------------------------------------------------
+
+
+class _CapturedAgent:
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        _CapturedAgent.last_kwargs = kwargs
+        self.suppress_status_output = False
+        self.stream_delta_callback = None
+        self.tool_gen_callback = None
+
+    def run_conversation(self, prompt):
+        return {"final_response": "ok"}
+
+
+@pytest.fixture
+def oneshot_rig(monkeypatch, tmp_path):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({**MOA_CFG, "model": {"default": "gpt-5.5", "provider": "openai-codex"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    import run_agent as run_agent_mod
+    from hermes_cli import oneshot as oneshot_mod
+
+    # _run_agent does `from run_agent import AIAgent` inside the function.
+    monkeypatch.setattr(run_agent_mod, "AIAgent", _CapturedAgent)
+    _CapturedAgent.last_kwargs = None
+    return oneshot_mod
+
+
+def test_oneshot_moa_prefix_builds_virtual_provider(oneshot_rig):
+    text, _ = oneshot_rig._run_agent("hi", model="moa:review", provider=None)
+    assert text == "ok"
+    kwargs = _CapturedAgent.last_kwargs
+    assert kwargs["provider"] == "moa"
+    assert kwargs["model"] == "review"
+    assert kwargs["base_url"] == "moa://local"
+
+
+def test_oneshot_provider_moa_defaults_preset(oneshot_rig):
+    oneshot_rig._run_agent("hi", model=None, provider="moa")
+    kwargs = _CapturedAgent.last_kwargs
+    assert kwargs["provider"] == "moa"
+    assert kwargs["model"] == "strategy"
+
+
+def test_oneshot_unknown_preset_exits_with_preset_list(oneshot_rig, capsys):
+    with pytest.raises(SystemExit):
+        oneshot_rig._run_agent("hi", model="moa:bogus", provider=None)
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "bogus" in combined
+    assert "strategy" in combined
+
+
+# -- integration: classic chat mixin -------------------------------------------
+
+
+def test_chat_mixin_resolves_moa_prefix(monkeypatch, tmp_path):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(MOA_CFG), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import cli as cli_mod
+
+    hc = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    hc.requested_provider = "auto"
+    hc.model = "moa:review"
+    hc._model_is_default = False
+    hc.config = MOA_CFG
+    hc._explicit_api_key = None
+    hc._explicit_base_url = None
+    hc._fallback_model = []
+    hc.api_mode = "chat_completions"
+    hc.api_key = None
+    hc.base_url = None
+    hc.provider = None
+    hc.acp_command = None
+    hc.acp_args = []
+    hc.agent = None
+
+    assert hc._ensure_runtime_credentials() is True
+    assert hc.requested_provider == "moa"
+    assert hc.model == "review"
+    assert hc.provider == "moa"
+    assert hc.base_url == "moa://local"


### PR DESCRIPTION
Fixes #56828

## Root cause

MoA routing keys entirely off `provider == "moa"` (`resolve_runtime_provider`'s short-circuit, `agent_init.py`'s `MoAClient` construction). Only the interactive paths ever set it — `/moa`, the model picker, and `/model moa:<preset>` (which already works via the acceptance rule in `hermes_cli/models.py`). The two non-interactive choke points never did:

- **Classic chat** (`hermes chat -q/-Q`): `-m moa:strategy` lands raw on `HermesCLI.model`, `requested_provider` stays `auto`, `_ensure_runtime_credentials` resolves a real provider, and the literal `moa:strategy` string goes to that API → HTTP 401/400 (the issue's repros).
- **Oneshot** (`hermes -z`): `detect_provider_for_model` has no MoA branch — same leak. `--provider moa` did reach the resolver's moa short-circuit, but nothing normalized the model to a bare preset name, so `resolve_moa_preset` raised `KeyError` downstream.

The MoA execution core (`agent/moa_loop.py`) is already TUI-independent (it self-loads config), so only resolution was missing.

## Fix

New `hermes_cli/moa_config.py::resolve_moa_request(provider, model, config, *, model_explicit)` — returns `("moa", <bare preset>)` or `None` — called at both choke points immediately before `resolve_runtime_provider`:

- `hermes_cli/cli_agent_setup_mixin.py::_ensure_runtime_credentials` (classic chat; idempotent across per-turn re-resolution)
- `hermes_cli/oneshot.py::_run_agent` (ahead of the DIRECT_ALIASES/catalog detection block)

Semantics:
- `moa:<preset>` / `moa/<preset>` model prefix (case-insensitive scheme) = **explicit** selection: wins over a conflicting `--provider`, may target `enabled: false` presets (consistent with #55187, where `enabled` only guards *implicit* bare-name matches). Unknown preset → clear error naming the available presets.
- `--provider moa`: bare preset name accepted as-is; empty or config-inherited non-preset model falls back to `default_preset` (mirrors the interactive PATH A behavior); an explicitly requested non-preset model errors with the preset list (mirrors the interactive acceptance rule).
- Bare preset names *without* the prefix or provider are deliberately NOT claimed here — implicit matching stays the interactive `/model` path's job.

No changes to `resolve_runtime_provider`, `detect_provider_for_model`, agent construction, or any interactive path. The TUI env-var launch path (`HERMES_TUI_PROVIDER`) is out of scope.

## Tests

`tests/hermes_cli/test_moa_noninteractive_resolution.py` (9 tests, written first and observed failing):
- unit matrix for `resolve_moa_request` (prefix forms, provider conflicts, disabled-preset explicit selection, default-preset fallbacks, unknown-preset errors, non-MoA pass-through)
- oneshot integration through the real `_run_agent` with `AIAgent` captured: `-m moa:<preset>` → `provider="moa"`, bare preset model, `base_url="moa://local"`; `--provider moa` → default preset; unknown preset → exit 2 with preset names on stderr
- classic-chat integration through the real `_ensure_runtime_credentials`

`scripts/run_tests.sh` on the new file + `test_moa_config.py`, `test_moa_command.py`, `test_moa_one_shot_restore.py`, `test_moa_switch_api_mode.py`, `test_moa_loop_mode.py`: **70 passed, 0 failed**. `ruff` clean; `ty` diagnostic count unchanged from base.
