### PR TITLE
fix(agent): split concatenated tool_call args in streaming assembler

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
+    _split_concatenated_json_objects,
 )
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -2478,6 +2479,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     try:
                         json.loads(arguments)
                     except json.JSONDecodeError:
+                        # Gemini's OpenAI-compat endpoint sends parallel tool
+                        # calls with index=None, so the assembler merges all
+                        # argument fragments into one entry. Split them back
+                        # into individual calls before attempting repair
+                        # (#62937).
+                        split_args = _split_concatenated_json_objects(arguments)
+                        if split_args:
+                            for _i, _obj in enumerate(split_args):
+                                mock_tool_calls.append(SimpleNamespace(
+                                    id=tc["id"] if _i == 0 else f'{tc["id"]}_split{_i}',
+                                    type=tc["type"],
+                                    extra_content=tc.get("extra_content") if _i == 0 else None,
+                                    function=SimpleNamespace(
+                                        name=tool_name,
+                                        arguments=_obj,
+                                    ),
+                                ))
+                            logger.info(
+                                "Split concatenated tool_call arguments into "
+                                "%d separate calls for %s (index=None parallel batch)",
+                                len(split_args), tool_name,
+                            )
+                            continue
                         # Attempt repair before flagging as truncated.
                         # Models like GLM-5.1 via Ollama produce trailing
                         # commas, unclosed brackets, Python None, etc.

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,6 +182,42 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _split_concatenated_json_objects(raw_args: str) -> list[str] | None:
+    """Split a string of multiple concatenated top-level JSON objects.
+
+    Gemini's OpenAI-compatible endpoint sometimes delivers parallel tool
+    calls with ``index=None``, so the streaming assembler merges all
+    argument fragments into a single entry (e.g.
+    ``'{"date":"x"}{"date":"y"}{"date":"z"}'``).  ``json.loads`` rejects
+    this with "Extra data" and ``_repair_tool_call_arguments`` replaces
+    the whole blob with ``"{}"``, silently dropping every call.  This
+    helper uses ``JSONDecoder.raw_decode`` to peel off each complete
+    object so the caller can emit one tool call per object (#62937).
+
+    Returns a list of individual compact JSON strings when the input
+    contains **two or more** valid top-level objects, otherwise ``None``.
+    """
+    raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
+    if not raw_stripped:
+        return None
+    decoder = json.JSONDecoder()
+    objects: list[str] = []
+    pos = 0
+    length = len(raw_stripped)
+    while pos < length:
+        while pos < length and raw_stripped[pos].isspace():
+            pos += 1
+        if pos >= length:
+            break
+        try:
+            obj, end = decoder.raw_decode(raw_stripped, pos)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        objects.append(json.dumps(obj, separators=(",", ":")))
+        pos = end
+    return objects if len(objects) > 1 else None
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -469,6 +505,7 @@ __all__ = [
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
     "_repair_tool_call_arguments",
+    "_split_concatenated_json_objects",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",
     "_sanitize_tools_non_ascii",

--- a/run_agent.py
+++ b/run_agent.py
@@ -172,6 +172,7 @@ from agent.message_sanitization import (  # noqa: F401
     _sanitize_messages_surrogates,
     _escape_invalid_chars_in_json_strings,
     _repair_tool_call_arguments,
+    _split_concatenated_json_objects,
     _strip_non_ascii,
     _sanitize_messages_non_ascii,
     _sanitize_tools_non_ascii,

--- a/tests/run_agent/test_streaming_tool_call_repair.py
+++ b/tests/run_agent/test_streaming_tool_call_repair.py
@@ -113,3 +113,64 @@ class TestStreamingAssemblyRepair:
         parsed = json.loads(result)
         assert parsed["command"] == "ls -la /tmp"
         assert parsed["timeout"] == 30
+
+
+class TestConcatenatedObjectsSplit:
+    """Tests for _split_concatenated_json_objects — the helper that splits
+    Gemini OpenAI-compat concatenated parallel tool-call arguments (#62937).
+
+    When Gemini's OpenAI-compat endpoint delivers parallel tool calls with
+    index=None, the streaming assembler merges all argument fragments into
+    one entry.  json.loads rejects the result with "Extra data" and
+    _repair_tool_call_arguments replaces it with "{}".  This helper lets the
+    assembler emit one tool call per concatenated object instead.
+    """
+
+    def test_three_concatenated_objects(self):
+        """Real-world Gemini payload: three calendar events glued together."""
+        from run_agent import _split_concatenated_json_objects
+        raw = '{"title":"Opening","date":"2026-07-01"}{"title":"Semi","date":"2026-07-05"}{"title":"Final","date":"2026-07-09"}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 3
+        for obj_str in result:
+            parsed = json.loads(obj_str)
+            assert "title" in parsed and "date" in parsed
+        assert json.loads(result[0])["title"] == "Opening"
+        assert json.loads(result[2])["title"] == "Final"
+
+    def test_single_object_returns_none(self):
+        """A single valid JSON object is NOT a concatenation."""
+        from run_agent import _split_concatenated_json_objects
+        assert _split_concatenated_json_objects('{"a": 1}') is None
+
+    def test_empty_and_garbage_return_none(self):
+        """Empty strings, None, and garbage must return None."""
+        from run_agent import _split_concatenated_json_objects
+        assert _split_concatenated_json_objects("") is None
+        assert _split_concatenated_json_objects(None) is None
+        assert _split_concatenated_json_objects("garbage") is None
+
+    def test_whitespace_between_objects(self):
+        """Objects separated by whitespace/newlines still split correctly."""
+        from run_agent import _split_concatenated_json_objects
+        raw = '{"x": 1}\n\n  {"y": 2}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_partial_concatenation_returns_none(self):
+        """One valid + one broken object is not a clean concatenation."""
+        from run_agent import _split_concatenated_json_objects
+        raw = '{"x": 1}{broken'
+        assert _split_concatenated_json_objects(raw) is None
+
+    def test_two_objects(self):
+        """Minimum concatenation: exactly two objects."""
+        from run_agent import _split_concatenated_json_objects
+        raw = '{"a":1}{"b":2}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 2
+        assert json.loads(result[0]) == {"a": 1}
+        assert json.loads(result[1]) == {"b": 2}


### PR DESCRIPTION
## What does this PR do?

When Gemini's OpenAI-compatible endpoint delivers parallel tool calls, it sends them with `index=None`. The streaming assembler treats all deltas at the same raw index as one call, so the argument fragments get concatenated into a single string (e.g. `{"date":"2026-07-01"}{"date":"2026-07-05"}{"date":"2026-07-09"}`). `json.loads` rejects this with "Extra data", `_repair_tool_call_arguments` can't fix concatenated objects, and replaces the whole blob with `{}` — silently dropping every parallel tool call. The agent responds claiming it performed actions but nothing actually happens.

This PR adds `_split_concatenated_json_objects()` which detects the "Extra data" pattern, peels off each top-level JSON object using `JSONDecoder.raw_decode`, and emits one `mock_tool_call` per object at assembly time. This recovers all N parallel calls instead of losing all of them. The function returns `None` for single objects or non-concatenated malformations, so the existing repair path handles those as before.

## Related Issue

Fixes #62937

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py`: Added `_split_concatenated_json_objects(raw_args)` helper that splits a string of 2+ concatenated top-level JSON objects into individual compact JSON strings; returns `None` for anything else (single object, garbage, partial concatenation).
- `agent/chat_completion_helpers.py`: In `interruptible_streaming_api_call`'s `mock_tool_calls` assembly loop, when `json.loads` fails on tool call arguments, try `_split_concatenated_json_objects` first. On success, emit one `mock_tool_call` per object (with `_splitN` id suffixes for uniqueness) and `continue`. On failure, fall through to the existing `_repair_tool_call_arguments` path unchanged.
- `run_agent.py`: Added `_split_concatenated_json_objects` to the re-export list (mirrors `_repair_tool_call_arguments`).

## How to Test

1. Run the unit tests for the new helper and existing repair tests:
   ```
   python -m pytest tests/run_agent/test_streaming_tool_call_repair.py tests/run_agent/test_repair_tool_call_arguments.py -q
   ```
   Observed result: 39 tests should pass (33 existing + 6 new).

2. Verify the split function handles the exact payload from the issue:
   ```python
   from run_agent import _split_concatenated_json_objects
   import json
   raw = '{"title":"Opening","date":"2026-07-01"}{"title":"Semi","date":"2026-07-05"}{"title":"Final","date":"2026-07-09"}'
   result = _split_concatenated_json_objects(raw)
   assert len(result) == 3
   assert [json.loads(o)["title"] for o in result] == ["Opening", "Semi", "Final"]
   ```
   Observed result: 3 objects correctly split, all individually valid JSON.

3. Verify non-concatenated malformations still go through the existing repair path (no regression):
   ```python
   from run_agent import _split_concatenated_json_objects
   assert _split_concatenated_json_objects('{"a":1}') is None  # single object
   assert _split_concatenated_json_objects('{"truncated":') is None  # not concat
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
