### PR TITLE
feat(dashboard): add native web chat page for session history browsing

### DIFF
--- a/PR_DESCRIPTION_20845.md
+++ b/PR_DESCRIPTION_20845.md
@@ -1,0 +1,119 @@
+# feat(dashboard): add native web chat page for session history browsing
+
+## What does this PR do?
+
+Adds a **Web Chat** page (`/webchat`) to the Hermes dashboard that renders session history as native browser HTML instead of embedding a terminal emulator.
+
+The existing `/chat` page works by spawning `hermes --tui` inside an xterm.js PTY over WebSocket. That is great on a local LAN, but it breaks or feels sluggish when the dashboard is served over a Cloudflare Tunnel, a reverse proxy, or a mobile connection: PTY streams are character-by-character and the VT100 escape sequences make the output hard to read on small screens.
+
+The new `/webchat` page solves this by talking directly to the existing REST API endpoints (`/api/sessions`, `/api/sessions/:id/messages`) and rendering conversations with native React components — role-based message bubbles, inline tool-call badges, relative timestamps, and a searchable session sidebar. No PTY, no xterm, no terminal font required.
+
+## Related Issue
+
+Fixes #20845
+
+## Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [x] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 🔒 Security fix
+- [ ] 📝 Documentation update
+- [ ] ✅ Tests (adding or improving test coverage)
+- [ ] ♻️ Refactor (no behavior change)
+- [ ] 🎯 New skill (bundled or hub)
+
+## Changes Made
+
+### `web/src/pages/NativeWebChatPage.tsx` *(new file, ~260 lines)*
+
+Self-contained page with three visual regions:
+
+**Session sidebar** (left, 256 px)
+- Loads up to 100 sessions via `api.getSessions()` on mount.
+- Live search/filter by title or model name.
+- Refresh button to re-fetch without a full page reload.
+- Each row shows: session title (or preview fallback), relative last-active time, message count, and model short name.
+- Active/live sessions are flagged with a green indicator dot.
+- Clicking a row pushes `?session=<id>` to the URL so the view is deep-linkable and survives a browser refresh.
+
+**Message pane** (right, flex-1)
+- Fetches `api.getSessionMessages(id)` when the active session changes.
+- User messages are right-aligned with a `User` icon; assistant messages left-aligned with a `Bot` icon.
+- Tool-result rows (`role: "tool"`) are rendered as compact mono lines with a `Wrench` icon rather than full bubbles.
+- Assistant messages that have `tool_calls` show inline badges listing the called tool names before the text.
+- Auto-scrolls to the bottom on load.
+- **"Open in Chat"** button in the pane header navigates to `/chat?resume=<id>` so the user can immediately pick up the conversation in the TUI if they want to send a new message.
+
+**Model badge** (top-right of header)
+- Calls `api.getModelInfo()` once on mount and displays the active model's short name.
+- Clicking it navigates to `/models` for model switching.
+
+### `web/src/App.tsx` *(2 small edits)*
+
+1. `import NativeWebChatPage from "@/pages/NativeWebChatPage"` — adds the import.
+2. `"/webchat": NativeWebChatPage` added to `BUILTIN_ROUTES_CORE`.
+3. `{ path: "/webchat", label: "Web Chat", icon: Globe }` prepended to `BUILTIN_NAV_REST` so the page appears at the top of the sidebar nav, above Sessions.
+
+The `Globe` icon was already imported in `App.tsx` (it's in the `ICON_MAP`), so no new Lucide import is needed.
+
+## How to Test
+
+1. Start Hermes with the dashboard enabled (`hermes dashboard` or `hermes gateway --dashboard`).
+2. Have at least one completed session with messages.
+3. Navigate to `http://localhost:<port>/webchat` (or click **Web Chat** in the sidebar).
+4. The session sidebar loads; click any session to view its message history.
+5. Verify user / assistant / tool messages render correctly with the expected layout.
+6. Type in the search box and confirm the session list filters in real time.
+7. Click **Open in Chat** in the message pane header — the browser should navigate to `/chat?resume=<session-id>` and the TUI should resume that session.
+8. Click the model badge in the top-right — the browser should navigate to `/models`.
+9. Test over a tunnelled connection (e.g. Cloudflare Tunnel or `ngrok`) — the page should load and scroll smoothly without PTY lag.
+
+## Checklist
+
+### Code
+
+- [x] I've read the Contributing Guide
+- [x] My commit messages follow Conventional Commits (`feat(dashboard):`)
+- [x] I searched for existing PRs to make sure this isn't a duplicate
+- [x] My PR contains **only** changes related to this feature
+- [ ] I've run `pytest tests/ -q` and all tests pass
+- [x] I've added the page as a route and nav item consistently with every other built-in page
+- [x] Tested on Ubuntu 24.04
+
+### Documentation & Housekeeping
+
+- [x] No new config keys — N/A
+- [x] No tool schema changes — N/A
+- [x] No cross-platform concerns (pure front-end React, no OS primitives) — N/A
+
+## Screenshots / Logs
+
+**Session sidebar + message pane (assistant response with tool call badges):**
+
+```
+┌─ Web Chat ───────────────────────────────────────────────────────────┐
+│ [🔍 Search sessions…]                                    [Model: claude-…] │
+├──────────────────────┬───────────────────────────────────────────────┤
+│ ● Fix deploy script  │  Fix deploy script        [Open in Chat ↗]   │
+│   2m ago · 14 msgs   │                                               │
+│                      │  ┌─[User]──────────────────────────────┐     │
+│ Review PR #42        │  │ Can you fix the deploy.sh script?   │     │
+│   1h ago · 8 msgs    │  └─────────────────────────────────────┘     │
+│                      │                                               │
+│ Refactor auth layer  │  [Bot] 🔧 read_file  🔧 write_file           │
+│   3h ago · 31 msgs   │  I've updated deploy.sh to use the           │
+│                      │  correct environment variable…               │
+│ …                    │                                               │
+└──────────────────────┴───────────────────────────────────────────────┘
+```
+
+## Notes
+
+- **Read-only by design.** Sending new messages still requires the TUI (`/chat`). A follow-up PR could add a REST-based compose input once `POST /api/sessions/:id/prompt` is exposed publicly, but that is out of scope here and noted in #20845.
+- **No PTY spawn.** The page makes only two REST calls (`getSessions`, `getSessionMessages`) — it is safe to use over any HTTP proxy including Cloudflare Tunnel with no extra configuration.
+- The `/webchat` route is a standard built-in route and respects the existing profile-scope switcher, management profile `?profile=` injection, and session-token auth exactly like every other dashboard page.
+
+---
+
+Branch: `private/issue-20845-native-webchat`
+Base: `main`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -91,6 +91,7 @@ import ChannelsPage from "@/pages/ChannelsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
 import SystemPage from "@/pages/SystemPage";
 import ChatPage from "@/pages/ChatPage";
+import NativeWebChatPage from "@/pages/NativeWebChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -150,6 +151,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/config": ConfigPage,
   "/env": EnvPage,
   "/docs": DocsPage,
+  "/webchat": NativeWebChatPage,
 };
 
 // Route placeholder for /chat.  The persistent ChatPage host (rendered
@@ -161,6 +163,11 @@ function ChatRouteSink() {
 }
 
 const BUILTIN_NAV_REST: NavItem[] = [
+  {
+    path: "/webchat",
+    label: "Web Chat",
+    icon: Globe,
+  },
   {
     path: "/sessions",
     labelKey: "sessions",

--- a/web/src/pages/NativeWebChatPage.tsx
+++ b/web/src/pages/NativeWebChatPage.tsx
@@ -1,0 +1,361 @@
+/**
+ * NativeWebChatPage — a browser-native conversation view for the dashboard.
+ *
+ * Unlike ChatPage (which embeds `hermes --tui` via xterm + WebSocket PTY),
+ * this page reads sessions and message history through the existing REST API
+ * and renders them as native HTML elements.  Users can:
+ *
+ *   • Browse and search all sessions in a sidebar
+ *   • Read any session's full message history with role-based bubbles
+ *   • See the active model at a glance and jump to /models to change it
+ *   • Resume a session in the TUI chat (opens /chat?resume=<id>)
+ *
+ * This makes the dashboard useful over Cloudflare Tunnel / low-bandwidth
+ * connections where the xterm PTY stream is impractical, and gives mobile
+ * clients a readable conversation history without a terminal font.
+ */
+
+import { Bot, MessageSquare, RefreshCw, Search, Terminal, User, Wrench } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api";
+import type { SessionInfo, SessionMessage } from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { useI18n } from "@/i18n";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts * 1000;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function sessionTitle(s: SessionInfo): string {
+  if (s.title && s.title.trim()) return s.title;
+  if (s.preview && s.preview.trim()) return s.preview.slice(0, 60);
+  return `Session ${s.id.slice(0, 8)}`;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function MessageBubble({ msg }: { msg: SessionMessage }) {
+  const isUser = msg.role === "user";
+  const isAssistant = msg.role === "assistant";
+  const isTool = msg.role === "tool";
+
+  if (isTool) {
+    return (
+      <div className="flex items-start gap-2 px-2 py-1 text-xs text-text-tertiary">
+        <Wrench className="mt-0.5 h-3 w-3 shrink-0" />
+        <span className="font-mono break-all whitespace-pre-wrap">
+          {msg.tool_name ?? "tool"}: {msg.content ?? ""}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 px-4 py-3",
+        isUser ? "flex-row-reverse" : "flex-row",
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-current/20",
+          isUser ? "bg-midground/10 text-midground" : "bg-background-base text-text-secondary",
+        )}
+      >
+        {isUser ? <User className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5" />}
+      </span>
+
+      <div
+        className={cn(
+          "max-w-[78%] rounded border border-current/10 px-3 py-2 text-sm",
+          isUser
+            ? "bg-midground/10 text-midground"
+            : "bg-background-base/60 text-text-primary",
+        )}
+      >
+        {msg.tool_calls && msg.tool_calls.length > 0 && (
+          <div className="mb-1 flex flex-wrap gap-1">
+            {msg.tool_calls.map((tc) => (
+              <span
+                key={tc.id}
+                className="inline-flex items-center gap-1 rounded bg-current/10 px-1.5 py-0.5 font-mono text-xs text-text-secondary"
+              >
+                <Wrench className="h-2.5 w-2.5" />
+                {tc.function.name}
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="whitespace-pre-wrap break-words leading-relaxed">
+          {msg.content ?? (isAssistant ? "…" : "")}
+        </p>
+        {msg.timestamp && (
+          <p className="mt-1 text-right text-[0.65rem] text-text-tertiary">
+            {formatRelative(msg.timestamp)}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionListItem({
+  active,
+  session,
+  onClick,
+}: {
+  active: boolean;
+  session: SessionInfo;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "w-full px-4 py-3 text-left transition-colors",
+        "border-b border-current/5",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+        active
+          ? "bg-midground/10 text-midground"
+          : "text-text-secondary hover:bg-midground/5 hover:text-text-primary",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {session.is_active && (
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-success" aria-label="active" />
+        )}
+        <span className="truncate text-sm font-medium leading-tight">
+          {sessionTitle(session)}
+        </span>
+      </div>
+      <div className="mt-0.5 flex items-center gap-2 text-xs text-text-tertiary">
+        <span>{formatRelative(session.last_active)}</span>
+        <span>·</span>
+        <span>{session.message_count} msgs</span>
+        {session.model && (
+          <>
+            <span>·</span>
+            <span className="truncate font-mono">{session.model.split("/").pop()}</span>
+          </>
+        )}
+      </div>
+    </button>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function NativeWebChatPage() {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setTitle } = usePageHeader();
+
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  const activeId = searchParams.get("session") ?? "";
+  const [messages, setMessages] = useState<SessionMessage[]>([]);
+  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [activeSession, setActiveSession] = useState<SessionInfo | null>(null);
+  const [activeModel, setActiveModel] = useState<string | null>(null);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTitle("Web Chat");
+  }, [setTitle]);
+
+  // Fetch model info once on mount
+  useEffect(() => {
+    api.getModelInfo().then((info) => {
+      setActiveModel(info.active_model ?? null);
+    }).catch(() => {});
+  }, []);
+
+  // Load session list
+  const loadSessions = useCallback(async () => {
+    setSessionsLoading(true);
+    try {
+      const data = await api.getSessions(100, 0);
+      setSessions(data.sessions ?? []);
+    } finally {
+      setSessionsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadSessions(); }, [loadSessions]);
+
+  // Load messages when active session changes
+  useEffect(() => {
+    if (!activeId) {
+      setMessages([]);
+      setActiveSession(null);
+      return;
+    }
+    setMessagesLoading(true);
+    api.getSessionMessages(activeId)
+      .then((resp) => {
+        setMessages(resp.messages ?? []);
+        const found = sessions.find((s) => s.id === activeId) ?? null;
+        setActiveSession(found);
+      })
+      .catch(() => setMessages([]))
+      .finally(() => setMessagesLoading(false));
+  }, [activeId, sessions]);
+
+  // Scroll to bottom when messages load
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const selectSession = useCallback(
+    (id: string) => setSearchParams({ session: id }, { replace: true }),
+    [setSearchParams],
+  );
+
+  const openInTui = useCallback(() => {
+    if (activeId) navigate(`/chat?resume=${encodeURIComponent(activeId)}`);
+  }, [activeId, navigate]);
+
+  const filtered = query.trim()
+    ? sessions.filter(
+        (s) =>
+          sessionTitle(s).toLowerCase().includes(query.toLowerCase()) ||
+          s.model?.toLowerCase().includes(query.toLowerCase()),
+      )
+    : sessions;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Page header */}
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <Typography as="h1" className="text-lg font-bold text-midground">
+            Web Chat
+          </Typography>
+          <Typography className="text-sm text-text-tertiary">
+            Browse session history natively — no terminal required.
+          </Typography>
+        </div>
+        {activeModel && (
+          <button
+            type="button"
+            onClick={() => navigate("/models")}
+            className="rounded border border-current/20 bg-background-base/60 px-3 py-1.5 text-xs text-text-secondary hover:text-midground transition-colors"
+          >
+            Model: <span className="font-mono">{activeModel.split("/").pop()}</span>
+          </button>
+        )}
+      </div>
+
+      {/* Main layout */}
+      <div className="flex min-h-0 flex-1 gap-3 overflow-hidden rounded border border-current/10">
+        {/* Session sidebar */}
+        <aside className="flex w-64 shrink-0 flex-col border-r border-current/10">
+          <div className="flex items-center gap-2 border-b border-current/10 px-3 py-2">
+            <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+            <input
+              className="min-w-0 flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none"
+              placeholder="Search sessions…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <button
+              type="button"
+              aria-label="Refresh sessions"
+              onClick={loadSessions}
+              className="text-text-tertiary hover:text-midground transition-colors"
+            >
+              <RefreshCw className="h-3 w-3" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {sessionsLoading ? (
+              <div className="flex items-center justify-center py-8 text-text-tertiary">
+                <Spinner className="mr-2" /> Loading…
+              </div>
+            ) : filtered.length === 0 ? (
+              <p className="px-4 py-6 text-center text-sm text-text-tertiary">
+                {query ? "No matching sessions." : "No sessions yet."}
+              </p>
+            ) : (
+              filtered.map((s) => (
+                <SessionListItem
+                  key={s.id}
+                  active={s.id === activeId}
+                  session={s}
+                  onClick={() => selectSession(s.id)}
+                />
+              ))
+            )}
+          </div>
+        </aside>
+
+        {/* Message pane */}
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {!activeId ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-3 text-text-tertiary">
+              <MessageSquare className="h-10 w-10 opacity-30" />
+              <p className="text-sm">Select a session from the sidebar.</p>
+            </div>
+          ) : (
+            <>
+              {/* Pane header */}
+              <div className="flex shrink-0 items-center justify-between gap-2 border-b border-current/10 px-4 py-2">
+                <span className="truncate text-sm font-medium text-midground">
+                  {activeSession ? sessionTitle(activeSession) : activeId}
+                </span>
+                <Button
+                  ghost
+                  size="sm"
+                  onClick={openInTui}
+                  className="shrink-0 gap-1.5 text-xs text-text-secondary hover:text-midground"
+                >
+                  <Terminal className="h-3.5 w-3.5" />
+                  Open in Chat
+                </Button>
+              </div>
+
+              {/* Messages */}
+              <div className="min-h-0 flex-1 overflow-y-auto py-2">
+                {messagesLoading ? (
+                  <div className="flex items-center justify-center py-8 text-text-tertiary">
+                    <Spinner className="mr-2" /> Loading messages…
+                  </div>
+                ) : messages.length === 0 ? (
+                  <p className="px-4 py-8 text-center text-sm text-text-tertiary">
+                    No messages in this session.
+                  </p>
+                ) : (
+                  messages.map((msg, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <MessageBubble key={i} msg={msg} />
+                  ))
+                )}
+                <div ref={bottomRef} />
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# feat(dashboard): add native web chat page for session history browsing

## What does this PR do?

Adds a **Web Chat** page (`/webchat`) to the Hermes dashboard that renders session history as native browser HTML instead of embedding a terminal emulator.

The existing `/chat` page works by spawning `hermes --tui` inside an xterm.js PTY over WebSocket. That is great on a local LAN, but it breaks or feels sluggish when the dashboard is served over a Cloudflare Tunnel, a reverse proxy, or a mobile connection: PTY streams are character-by-character and the VT100 escape sequences make the output hard to read on small screens.

The new `/webchat` page solves this by talking directly to the existing REST API endpoints (`/api/sessions`, `/api/sessions/:id/messages`) and rendering conversations with native React components — role-based message bubbles, inline tool-call badges, relative timestamps, and a searchable session sidebar. No PTY, no xterm, no terminal font required.

## Related Issue

Fixes #20845

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### `web/src/pages/NativeWebChatPage.tsx` *(new file, ~260 lines)*

Self-contained page with three visual regions:

**Session sidebar** (left, 256 px)
- Loads up to 100 sessions via `api.getSessions()` on mount.
- Live search/filter by title or model name.
- Refresh button to re-fetch without a full page reload.
- Each row shows: session title (or preview fallback), relative last-active time, message count, and model short name.
- Active/live sessions are flagged with a green indicator dot.
- Clicking a row pushes `?session=<id>` to the URL so the view is deep-linkable and survives a browser refresh.

**Message pane** (right, flex-1)
- Fetches `api.getSessionMessages(id)` when the active session changes.
- User messages are right-aligned with a `User` icon; assistant messages left-aligned with a `Bot` icon.
- Tool-result rows (`role: "tool"`) are rendered as compact mono lines with a `Wrench` icon rather than full bubbles.
- Assistant messages that have `tool_calls` show inline badges listing the called tool names before the text.
- Auto-scrolls to the bottom on load.
- **"Open in Chat"** button in the pane header navigates to `/chat?resume=<id>` so the user can immediately pick up the conversation in the TUI if they want to send a new message.

**Model badge** (top-right of header)
- Calls `api.getModelInfo()` once on mount and displays the active model's short name.
- Clicking it navigates to `/models` for model switching.

### `web/src/App.tsx` *(2 small edits)*

1. `import NativeWebChatPage from "@/pages/NativeWebChatPage"` — adds the import.
2. `"/webchat": NativeWebChatPage` added to `BUILTIN_ROUTES_CORE`.
3. `{ path: "/webchat", label: "Web Chat", icon: Globe }` prepended to `BUILTIN_NAV_REST` so the page appears at the top of the sidebar nav, above Sessions.

The `Globe` icon was already imported in `App.tsx` (it's in the `ICON_MAP`), so no new Lucide import is needed.

## How to Test

1. Start Hermes with the dashboard enabled (`hermes dashboard` or `hermes gateway --dashboard`).
2. Have at least one completed session with messages.
3. Navigate to `http://localhost:<port>/webchat` (or click **Web Chat** in the sidebar).
4. The session sidebar loads; click any session to view its message history.
5. Verify user / assistant / tool messages render correctly with the expected layout.
6. Type in the search box and confirm the session list filters in real time.
7. Click **Open in Chat** in the message pane header — the browser should navigate to `/chat?resume=<session-id>` and the TUI should resume that session.
8. Click the model badge in the top-right — the browser should navigate to `/models`.
9. Test over a tunnelled connection (e.g. Cloudflare Tunnel or `ngrok`) — the page should load and scroll smoothly without PTY lag.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(dashboard):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added the page as a route and nav item consistently with every other built-in page
- [x] Tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] No new config keys — N/A
- [x] No tool schema changes — N/A
- [x] No cross-platform concerns (pure front-end React, no OS primitives) — N/A



Branch: `private/issue-20845-native-webchat`
Base: `main`
