### PR TITLE
fix(context): count fallback compactions as ineffective

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1186,13 +1186,23 @@ class ContextCompressor(ContextEngine):
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
+            fallback_compaction = (
+                self._verify_compaction_cleared_threshold
+                and self._last_summary_fallback_used
+            )
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
                 # Any real provider reading below the trigger proves the prompt
-                # fits again. Clear the episode latch even when this response was
-                # not the one immediately following compaction.
-                self._ineffective_compression_count = 0
+                # fits again, UNLESS the just-finished compaction had to fall
+                # back to the deterministic placeholder summary. That path
+                # does shrink the prompt, but it is still a degraded compaction
+                # attempt and must count toward the anti-thrashing strike limit.
+                # Otherwise repeated empty-summary failures can rotate through
+                # fallback markers forever while each smaller prompt reading
+                # resets the counter back to zero (#63008 / R1).
+                if not fallback_compaction:
+                    self._ineffective_compression_count = 0
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
 
@@ -1213,7 +1223,17 @@ class ContextCompressor(ContextEngine):
             # Keying on real usage compares like with like and fires exactly once
             # per compaction.
             if self._verify_compaction_cleared_threshold:
-                if self.last_prompt_tokens >= self.threshold_tokens:
+                if fallback_compaction:
+                    self._ineffective_compression_count += 1
+                    if not self.quiet_mode:
+                        logger.warning(
+                            "Compaction completed with a deterministic fallback "
+                            "summary. Counting this as a degraded attempt to "
+                            "avoid repeated fallback-only compaction loops. "
+                            "ineffective_compression_count=%d",
+                            self._ineffective_compression_count,
+                        )
+                elif self.last_prompt_tokens >= self.threshold_tokens:
                     self._ineffective_compression_count += 1
                     if not self.quiet_mode:
                         logger.warning(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -65,6 +65,61 @@ class TestUpdateFromResponse:
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
 
+    def test_fallback_compaction_counts_as_ineffective_even_when_prompt_fits(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_compression_rough_tokens = 90_000
+        compressor._verify_compaction_cleared_threshold = True
+        compressor._last_summary_fallback_used = True
+
+        compressor.update_from_response({
+            "prompt_tokens": 5_000,
+            "completion_tokens": 100,
+            "total_tokens": 5_100,
+        })
+
+        assert compressor.last_real_prompt_tokens == 5_000
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 90_000
+        assert compressor._ineffective_compression_count == 1
+        assert compressor._verify_compaction_cleared_threshold is False
+        assert compressor.awaiting_real_usage_after_compression is False
+
+    def test_successful_compaction_fit_still_clears_prior_ineffective_count(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_compression_rough_tokens = 90_000
+        compressor._verify_compaction_cleared_threshold = True
+        compressor._last_summary_fallback_used = False
+        compressor._ineffective_compression_count = 1
+
+        compressor.update_from_response({
+            "prompt_tokens": 5_000,
+            "completion_tokens": 100,
+            "total_tokens": 5_100,
+        })
+
+        assert compressor._ineffective_compression_count == 0
+
+    def test_second_fallback_strike_blocks_future_compression(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.last_prompt_tokens = 90_000
+        assert compressor.should_compress() is True
+
+        for expected in (1, 2):
+            compressor.awaiting_real_usage_after_compression = True
+            compressor.last_compression_rough_tokens = 90_000
+            compressor._verify_compaction_cleared_threshold = True
+            compressor._last_summary_fallback_used = True
+            compressor.update_from_response({
+                "prompt_tokens": 5_000,
+                "completion_tokens": 100,
+                "total_tokens": 5_100,
+            })
+            assert compressor._ineffective_compression_count == expected
+            compressor.last_prompt_tokens = 90_000
+
+        assert compressor.should_compress() is False
+
 
 class TestPreflightDeferral:
     def test_defers_when_recent_real_usage_fit_and_rough_growth_is_small(self, compressor):


### PR DESCRIPTION
## What does this PR do?

Treats deterministic fallback compactions as degraded attempts in the existing anti-thrash guard.

Today, a failed summary call can still shrink the prompt enough that the next real `prompt_tokens` reading falls below threshold and resets `_ineffective_compression_count` back to `0`. That lets repeated empty-summary fallback rewrites loop indefinitely without ever tripping the existing breaker. This patch keeps the real-usage-based guard intact, but consumes a strike whenever the completed compaction had to fall back to the placeholder summary.

## Related Issue

Part of #63008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: preserve anti-thrash strikes when a verified compaction used the deterministic fallback summary, even if the resulting prompt fits under threshold.
- `agent/context_compressor.py`: log fallback-marker compactions as degraded attempts through the same ineffective-compression counter.
- `tests/agent/test_context_compressor.py`: add coverage for fallback strikes, normal successful reset behavior, and the second-strike suppression path.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_context_compressor.py -q`
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/context_compressor.py tests/agent/test_context_compressor.py`
3. Run `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Proof log: `/tmp/hermes-63008-proof.txt`
