### PR TITLE
fix: classify quota-style 429 usage limits as billing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2847,14 +2847,34 @@ def _is_payment_error(exc: Exception) -> bool:
     resets — and should trigger the same provider-fallback logic.
     """
     status = getattr(exc, "status_code", None)
-    if status == 402:
-        return True
     err_lower = str(exc).lower()
+    has_usage_limit = any(kw in err_lower for kw in (
+        "usage limit",
+        "key limit exceeded",
+        "quota",
+    ))
+    has_usage_limit_retry_signal = any(kw in err_lower for kw in (
+        "try again",
+        "retry",
+        "resets at",
+        "resets in",
+        "reset in",
+        "wait",
+        "requests remaining",
+        "periodic",
+        "window",
+    ))
+    if status == 402:
+        if has_usage_limit and has_usage_limit_retry_signal:
+            return False
+        return True
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     # Daily quota exhaustion from Bedrock, Vertex AI, and similar providers
     # uses different language but is semantically identical to credit exhaustion.
     if status in {402, 403, 404, 429, None}:
+        if has_usage_limit:
+            return not has_usage_limit_retry_signal
         if any(kw in err_lower for kw in (
             "credits", "insufficient funds",
             "can only afford", "billing",
@@ -2898,6 +2918,22 @@ def _is_rate_limit_error(exc: Exception) -> bool:
     """
     status = getattr(exc, "status_code", None)
     err_lower = str(exc).lower()
+    has_usage_limit = any(kw in err_lower for kw in (
+        "usage limit",
+        "key limit exceeded",
+        "quota",
+    ))
+    has_usage_limit_retry_signal = any(kw in err_lower for kw in (
+        "try again",
+        "retry",
+        "resets at",
+        "resets in",
+        "reset in",
+        "wait",
+        "requests remaining",
+        "periodic",
+        "window",
+    ))
 
     # OpenAI SDK's RateLimitError sometimes omits .status_code —
     # detect by class name so we don't miss these.  (PR #8023 pattern)
@@ -2905,6 +2941,8 @@ def _is_rate_limit_error(exc: Exception) -> bool:
         return True
 
     if status == 429:
+        if has_usage_limit:
+            return has_usage_limit_retry_signal
         # Distinguish rate-limit from billing: billing keywords are handled
         # by _is_payment_error, everything else on 429 is a rate limit.
         if any(kw in err_lower for kw in (

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -180,6 +180,7 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "try again",
     "retry",
     "resets at",
+    "resets in",
     "reset in",
     "wait",
     "requests remaining",
@@ -980,6 +981,25 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        has_usage_limit = any(p in error_msg for p in (
+            "usage limit",
+            "quota",
+        ))
+        if has_usage_limit:
+            has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+            if has_transient_signal:
+                return result_fn(
+                    FailoverReason.rate_limit,
+                    retryable=True,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1682,6 +1682,11 @@ class TestIsPaymentError:
         setattr(exc, "status_code", 429)
         assert _is_payment_error(exc) is True
 
+    def test_429_usage_limit_reached_is_payment(self):
+        exc = Exception("The usage limit has been reached")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
     def test_404_generic_not_found_is_not_payment(self):
         exc = Exception("Not Found")
         exc.status_code = 404
@@ -1741,6 +1746,11 @@ class TestIsPaymentError:
     def test_429_transient_rate_limit_not_quota(self):
         """Transient 429 rate limit without quota keywords is NOT a payment error."""
         exc = Exception("Rate limit exceeded. Retry after 10s.")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is False
+
+    def test_429_usage_limit_with_reset_is_not_payment(self):
+        exc = Exception("Weekly usage limit reached. Resets in 6hr 29min.")
         exc.status_code = 429
         assert _is_payment_error(exc) is False
 
@@ -1936,6 +1946,16 @@ class TestIsRateLimitError:
         exc = Exception("you can only afford 1000 tokens")
         exc.status_code = 429
         assert _is_rate_limit_error(exc) is False
+
+    def test_429_usage_limit_reached_is_not_rate_limit(self):
+        exc = Exception("The usage limit has been reached")
+        exc.status_code = 429
+        assert _is_rate_limit_error(exc) is False
+
+    def test_429_usage_limit_with_reset_is_rate_limit(self):
+        exc = Exception("Weekly usage limit reached. Resets in 6hr 29min.")
+        exc.status_code = 429
+        assert _is_rate_limit_error(exc) is True
 
     def test_402_is_not_rate_limit(self):
         exc = Exception("Payment Required")
@@ -3681,7 +3701,7 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 class TestAuxiliaryPoolRotationRetry:
-    def test_call_llm_rotates_explicit_codex_pool_on_429(self):
+    def test_call_llm_rotates_explicit_codex_pool_on_usage_limit_without_retrying_same_key(self):
         rate_err = Exception("usage limit reached")
         rate_err.status_code = 429
 
@@ -3724,14 +3744,14 @@ class TestAuxiliaryPoolRotationRetry:
             )
 
         assert resp.choices[0].message.content == "rotated-sync"
-        assert stale_client.chat.completions.create.call_count == 2
+        assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
         assert len(pool.rotate_calls) == 1
         assert pool.rotate_calls[0]["status_code"] == 429
         mock_fallback.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_async_call_llm_rotates_explicit_codex_pool_on_429(self):
+    async def test_async_call_llm_rotates_explicit_codex_pool_on_usage_limit_without_retrying_same_key(self):
         rate_err = Exception("usage limit reached")
         rate_err.status_code = 429
 
@@ -3774,7 +3794,7 @@ class TestAuxiliaryPoolRotationRetry:
             )
 
         assert resp.choices[0].message.content == "rotated-async"
-        assert stale_client.chat.completions.create.await_count == 2
+        assert stale_client.chat.completions.create.await_count == 1
         assert fresh_client.chat.completions.create.await_count == 1
         assert len(pool.rotate_calls) == 1
         assert pool.rotate_calls[0]["status_code"] == 429

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -291,6 +291,21 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    def test_429_usage_limit_without_retry_is_billing(self):
+        e = MockAPIError("The usage limit has been reached", status_code=429)
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.4")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_usage_limit_with_reset_is_rate_limit(self):
+        e = MockAPIError(
+            "Weekly usage limit reached. Resets in 6hr 29min.",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.4")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_403_plan_entitlement_billing(self):
         e = MockAPIError("This plan does not include the requested model", status_code=403)
         result = classify_api_error(e)
@@ -2066,4 +2081,3 @@ class Test408RequestTimeout:
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
         assert result.should_compress is False
-


### PR DESCRIPTION
Fixes #62449

## Summary
- classify HTTP 429 usage-limit and quota messages without retry/reset signals as billing instead of transient rate limits
- keep periodic usage-limit responses with retry/reset wording on the existing rate-limit path
- align auxiliary-client recovery so exhausted Codex OAuth credentials rotate immediately instead of retrying the same exhausted key

## Verification
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_error_classifier.py tests/agent/test_auxiliary_client.py -q
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/error_classifier.py agent/auxiliary_client.py tests/agent/test_error_classifier.py tests/agent/test_auxiliary_client.py
- git diff --check