### PR TITLE
fix(discord): restore bot-owned thread follow-ups

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6138,6 +6138,16 @@ class DiscordAdapter(BasePlatformAdapter):
         if is_thread:
             thread_id = str(message.channel.id)
             parent_channel_id = self._get_parent_channel_id(message.channel)
+            bot_user = getattr(self._client, "user", None)
+            bot_user_id = getattr(bot_user, "id", None)
+            thread_owner_id = getattr(message.channel, "owner_id", None)
+            bot_owns_thread = (
+                bot_user_id is not None
+                and thread_owner_id is not None
+                and str(thread_owner_id) == str(bot_user_id)
+            )
+            if bot_owns_thread and not self._discord_thread_require_mention():
+                self._threads.mark(thread_id)
 
         is_voice_linked_channel = False
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -81,12 +81,20 @@ class FakeForumChannel:
 
 
 class FakeThread:
-    def __init__(self, channel_id: int = 1, name: str = "thread", parent=None, guild_name: str = "Hermes Server"):
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "thread",
+        parent=None,
+        guild_name: str = "Hermes Server",
+        owner_id: int | None = None,
+    ):
         self.id = channel_id
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
         self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.owner_id = owner_id
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -598,6 +606,24 @@ async def test_discord_unknown_thread_still_requires_mention(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_owned_thread_allows_first_unmentioned_followup(adapter, monkeypatch):
+    """A bot-created thread remains mention-free after a gateway restart."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    thread = FakeThread(channel_id=790, name="daily plan", owner_id=999)
+    assert "790" not in adapter._threads
+    message = make_message(channel=thread, content="first follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    assert "790" in adapter._threads
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -627,6 +627,28 @@ async def test_discord_bot_owned_thread_allows_first_unmentioned_followup(adapte
 
 
 @pytest.mark.asyncio
+async def test_discord_bot_owned_thread_respects_explicit_mention_requirement(adapter, monkeypatch):
+    """The explicit thread mention requirement remains a hard safety override."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    thread = FakeThread(
+        channel_id=791,
+        name="shared bot thread",
+        owner_id=adapter._client.user.id,
+    )
+    assert "791" not in adapter._threads
+    message = make_message(channel=thread, content="unmentioned follow-up")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    assert "791" not in adapter._threads
+
+
+@pytest.mark.asyncio
 async def test_discord_auto_thread_tracks_participation(adapter, monkeypatch):
     """Auto-created threads should be tracked for future mention-free replies."""
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)


### PR DESCRIPTION
## Summary
- recognize a Discord thread owned by the current bot as participated before mention gating
- preserve `thread_require_mention: true` as the explicit safety override
- add regression coverage for both the restart follow-up path and the explicit mention override

## Problem
Thread participation state can be absent after a gateway restart, especially for threads created by scheduled delivery. The first human follow-up is then dropped unless it explicitly mentions the bot, even though Discord durably identifies the thread owner.

## Review follow-up
Addresses the automated review on #62970 by adding a bot-owned-thread case with `DISCORD_THREAD_REQUIRE_MENTION=true`. The test asserts that an unmentioned message is not dispatched and the participation tracker remains unmodified.

Supersedes #62970 because its deleted fork could not be re-associated after recreation.

## Verification
- `tests/gateway/test_discord_free_response.py`: 61 passed
- mutation check: removing the explicit override guard makes the new regression test fail
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
