### PR TITLE
fix(kanban): honor explicit board overrides under ambient pins

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1304,7 +1304,7 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
-        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+        ws_kind, ws_path = _parse_workspace_flag(args.workspace or "scratch")
         branch_name = _parse_branch_flag(getattr(args, "branch", None))
     except argparse.ArgumentTypeError as exc:
         print(f"kanban: {exc}", file=sys.stderr)
@@ -1325,7 +1325,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    with kb.connect_closing() as conn:
+    current_board = kb.get_current_board()
+    with kb.connect_closing(board=current_board) as conn:
         task_id = kb.create_task(
             conn,
             title=args.title,
@@ -1347,6 +1348,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            board=current_board,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -512,25 +512,47 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+def _scoped_board_override_slug() -> Optional[str]:
+    """Return the normalized in-process board override, if one is active.
+
+    ``scoped_current_board(...)`` is the CLI's first-class explicit-board
+    override path. When present it must outrank ambient worker DB/workspace
+    pins, otherwise ``hermes kanban --board <slug> ...`` can open the wrong
+    sqlite file even though the command is explicitly scoped.
+    """
+    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+    if not scoped:
+        return None
+    try:
+        return _normalize_board_slug(scoped)
+    except ValueError:
+        return None
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
     Resolution (highest precedence first):
 
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
-       back-compat and for the dispatcher→worker handoff (defense in
-       depth: dispatcher injects this into worker env so workers are
-       immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
-       :func:`get_current_board` is used.
-    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
+    1. Explicit board intent — either the ``board`` arg or an active
+       ``scoped_current_board(...)`` override.
+    2. ``HERMES_KANBAN_DB`` env var — pins the path directly when there is no
+       explicit board override. Honoured for back-compat and for the
+       dispatcher→worker handoff (defense in depth: dispatcher injects this
+       into worker env so workers are immune to any path-resolution
+       disagreement).
+    3. When neither explicit-board path above is present, the active board
+       from :func:`get_current_board` is used.
+    4. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
     """
-    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
-    if override:
-        return Path(override).expanduser()
     slug = _normalize_board_slug(board)
     if slug is None:
+        slug = _scoped_board_override_slug()
+    if slug is None:
+        override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+        if override:
+            return Path(override).expanduser()
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home() / "kanban.db"
@@ -541,18 +563,23 @@ def workspaces_root(board: Optional[str] = None) -> Path:
     """Return the directory under which ``scratch`` workspaces are created.
 
     Anchored per-board so workspaces don't leak between projects.
-    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (highest
-    precedence) — the dispatcher injects this into worker env.
+    Explicit board intent (``board=`` or ``scoped_current_board(...)``)
+    outranks ambient worker pins so ``--board <slug>`` commands stay on their
+    requested board. Without an explicit board,
+    ``HERMES_KANBAN_WORKSPACES_ROOT`` still pins the path directly — the
+    dispatcher injects this into worker env.
 
     ``default`` keeps the legacy path ``<root>/kanban/workspaces/`` so
     that existing scratch workspaces from before the boards feature are
     preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
     """
-    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
-    if override:
-        return Path(override).expanduser()
     slug = _normalize_board_slug(board)
     if slug is None:
+        slug = _scoped_board_override_slug()
+    if slug is None:
+        override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+        if override:
+            return Path(override).expanduser()
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home() / "kanban" / "workspaces"

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -126,17 +126,39 @@ class TestPathResolution:
             fresh_home / "kanban" / "boards" / "other" / "logs"
         )
 
-    def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+    def test_explicit_board_arg_beats_env_var_db_override(self, fresh_home, tmp_path, monkeypatch):
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
-        assert kb.kanban_db_path(board="ignored") == forced
+        assert kb.kanban_db_path(board="override") == (
+            fresh_home / "kanban" / "boards" / "override" / "kanban.db"
+        )
 
-    def test_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
+    def test_scoped_board_beats_env_var_db_override(self, fresh_home, tmp_path, monkeypatch):
+        forced = tmp_path / "custom.db"
+        kb.create_board("scoped")
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        with kb.scoped_current_board("scoped"):
+            assert kb.kanban_db_path() == (
+                fresh_home / "kanban" / "boards" / "scoped" / "kanban.db"
+            )
+
+    def test_explicit_board_arg_beats_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
         forced = tmp_path / "ws"
         monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
-        assert kb.workspaces_root(board="any") == forced
+        assert kb.workspaces_root() == forced
+        assert kb.workspaces_root(board="any") == (
+            fresh_home / "kanban" / "boards" / "any" / "workspaces"
+        )
+
+    def test_scoped_board_beats_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
+        forced = tmp_path / "ws"
+        kb.create_board("scoped")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
+        with kb.scoped_current_board("scoped"):
+            assert kb.workspaces_root() == (
+                fresh_home / "kanban" / "boards" / "scoped" / "workspaces"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +484,55 @@ class TestWorkerSpawnEnv:
         assert env["HERMES_KANBAN_BOARD"] == "default"
         assert env["HERMES_KANBAN_DB"] == str(fresh_home / "kanban.db")
 
+    def test_default_spawn_explicit_board_beats_ambient_env_pins(self, fresh_home, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            pid = 2
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        kb.create_board("ambient")
+        kb.create_board("override")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            str(fresh_home / "kanban" / "boards" / "ambient" / "kanban.db"),
+        )
+        monkeypatch.setenv(
+            "HERMES_KANBAN_WORKSPACES_ROOT",
+            str(fresh_home / "kanban" / "boards" / "ambient" / "workspaces"),
+        )
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "ambient")
+        task = kb.Task(
+            id="t_override",
+            title="",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+        kb._default_spawn(task, str(fresh_home / "ws"), board="override")
+        env = captured["env"]
+        assert env["HERMES_KANBAN_BOARD"] == "override"
+        assert env["HERMES_KANBAN_DB"] == str(
+            fresh_home / "kanban" / "boards" / "override" / "kanban.db"
+        )
+        assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(
+            fresh_home / "kanban" / "boards" / "override" / "workspaces"
+        )
+
 
 # ---------------------------------------------------------------------------
 # CLI surface
@@ -531,6 +602,47 @@ class TestCLI:
         assert titlesA == ["Task A"]
         assert titlesB == ["Task B"]
         assert titlesD == []
+
+    def test_cli_board_override_create_and_comment_beat_ambient_pins(self, tmp_path, monkeypatch):
+        env = {"HERMES_HOME": str(tmp_path)}
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert _cli(["boards", "create", "ambient"], env_extra=env).returncode == 0
+        assert _cli(["boards", "create", "override"], env_extra=env).returncode == 0
+        env.update({
+            "HERMES_KANBAN_BOARD": "ambient",
+            "HERMES_KANBAN_DB": str(tmp_path / "kanban" / "boards" / "ambient" / "kanban.db"),
+            "HERMES_KANBAN_WORKSPACES_ROOT": str(tmp_path / "kanban" / "boards" / "ambient" / "workspaces"),
+        })
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "ambient")
+        monkeypatch.setenv("HERMES_KANBAN_DB", env["HERMES_KANBAN_DB"])
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", env["HERMES_KANBAN_WORKSPACES_ROOT"])
+
+        created = _cli(
+            [
+                "--board", "override", "create", "Task Override",
+                "--assignee", "dev", "--json",
+            ],
+            env_extra=env,
+        )
+        assert created.returncode == 0, created.stderr
+        task = json.loads(created.stdout)
+        task_id = task["id"]
+
+        show = _cli(["--board", "override", "show", task_id, "--json"], env_extra=env)
+        assert show.returncode == 0, show.stderr
+        assert json.loads(show.stdout)["task"]["id"] == task_id
+
+        comment = _cli(["--board", "override", "comment", task_id, "hello"], env_extra=env)
+        assert comment.returncode == 0, comment.stderr
+
+        with kb.connect_closing(board="ambient") as conn:
+            assert kb.get_task(conn, task_id) is None
+        with kb.connect_closing(board="override") as conn:
+            stored = kb.get_task(conn, task_id)
+            assert stored is not None
+            comments = kb.list_comments(conn, task_id)
+            assert len(comments) == 1
+            assert comments[0].body == "hello"
 
     def test_board_flag_rejects_unknown(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -196,6 +196,55 @@ def test_show_explicit_task_id(worker_env):
     assert d["task"]["id"] == other
 
 
+def test_tool_board_override_create_and_comment_beat_ambient_pins(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    kb.create_board("ambient")
+    kb.create_board("override")
+    monkeypatch.setenv(
+        "HERMES_KANBAN_DB",
+        str(home / "kanban" / "boards" / "ambient" / "kanban.db"),
+    )
+    monkeypatch.setenv(
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        str(home / "kanban" / "boards" / "ambient" / "workspaces"),
+    )
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "ambient")
+
+    from tools import kanban_tools as kt
+    created = json.loads(kt._handle_create({
+        "title": "override child",
+        "assignee": "peer",
+        "board": "override",
+    }))
+    assert created["ok"] is True
+    task_id = created["task_id"]
+
+    commented = json.loads(kt._handle_comment({
+        "task_id": task_id,
+        "body": "hello",
+        "board": "override",
+    }))
+    assert commented["ok"] is True
+
+    with kb.connect_closing(board="ambient") as conn:
+        assert kb.get_task(conn, task_id) is None
+    with kb.connect_closing(board="override") as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert comments[0].body == "hello"
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)


### PR DESCRIPTION
## Summary
- make explicit board intent outrank ambient `HERMES_KANBAN_DB` / `HERMES_KANBAN_WORKSPACES_ROOT` pins in `kanban_db_path()` and `workspaces_root()`
- make CLI `kanban create` connect to the resolved board before inserting the task row
- add regression coverage for helper precedence, create/show/comment isolation, tool-surface create/comment isolation, and spawn-env coherence under ambient board pins

## Why
From a worker-scoped process pinned to board A, `hermes kanban --board B create ...` was physically writing into board A's sqlite DB while only stamping board B as metadata. That leaked later review/block/router surfaces into the ambient board. This PR fixes the create-time routing seam and the shared helper precedence that also affected spawned worker env derivation.

Related upstream paper trail:
- closes the failure class documented in #30678
- refreshes the same seam previously attempted in #30681 and the closed duplicate #61819

## How to test
Focused patch verification:
```bash
python -m pytest tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py -q
python scripts/check-windows-footguns.py hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py
```

Live canary verification used for this patch:
- ambient pins set to `fleet-infra`
- explicit board create/comment/block executed against throwaway board `qa-canary-enforce-2026-07-12`
- resulting rows landed in the canary board DB and were absent from `fleet-infra`
- bridge cursor advanced on the canary board and a reviewer child task/workspace/log path materialized under that same canary board

## Validation run notes
- Focused suites on this branch: `158 passed in 11.87s`
- Windows footgun scan: pass
- `scripts/run_tests.sh` is not green on this host/branch, but sampled failing areas reproduce on `origin/main` too:
  - `tests/agent/test_anthropic_adapter.py`
  - `tests/test_live_system_guard_self_test.py`
  - `tests/tools/test_file_tools.py`
  - `tests/hermes_cli/test_model_switch_custom_providers.py`

## Platforms tested
- macOS 26.5.2

## Artifacts
- governed patch/export: `/Users/alimai/.hermes/patches/hermes-kanban-explicit-board-override-routing-33a558fc1-20260712.patch`
- verification report: `/Users/alimai/.hermes/audits/t_8cf5b78c/board-override-verification-report-2026-07-12.md`
- canary packet: `/Users/alimai/.hermes/audits/t_8cf5b78c/canary-rerun-CANARY-RERUN-1783838060.json`
