### PR TITLE
fix(desktop): prevent first-send bounce during new chat creation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -70,7 +70,7 @@ function Harness({
   busyRef?: MutableRefObject<boolean>
   getRouteToken?: () => string
   onReady: (handle: HarnessHandle) => void
-  onSeedState?: (state: Record<string, unknown>) => void
+  onSeedState?: (state: Record<string, unknown>, storedSessionId?: string | null) => void
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -121,11 +121,11 @@ function Harness({
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (_sessionId, updater) => {
+    updateSessionState: (_sessionId, updater, storedSessionId) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
-      onSeedState?.(next)
+      onSeedState?.(next, storedSessionId)
 
       return next as never
     }
@@ -1433,6 +1433,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       return {} as never
     })
 
+    let seededStoredSessionId: string | null | undefined
     let handle: HarnessHandle | null = null
     render(
       <Harness
@@ -1441,6 +1442,9 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
         createBackendSessionForSend={createBackendSessionForSend}
         getRouteToken={() => routeToken}
         onReady={h => (handle = h)}
+        onSeedState={(_state, storedSessionId) => {
+          seededStoredSessionId = storedSessionId
+        }}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         selectedStoredSessionIdRef={selectedStoredSessionIdRef}
@@ -1454,6 +1458,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     releaseAttach()
 
     expect(await submitting).toBe(true)
+    expect(seededStoredSessionId).toBe(createdStoredSessionId)
     expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), 1_800_000)
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -79,7 +79,9 @@ function Harness({
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
-  createBackendSessionForSend?: () => Promise<null | string>
+  createBackendSessionForSend?: () => Promise<
+    null | { routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null }
+  >
 }) {
   const activeSessionIdRef: MutableRefObject<string | null> = activeSessionIdRefProp ?? {
     current: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
@@ -103,7 +105,13 @@ function Harness({
     activeSessionIdRef,
     branchCurrentSession: async () => true,
     busyRef: localBusyRef,
-    createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
+    createBackendSessionForSend:
+      createBackendSessionForSend ??
+      (async () => ({
+        routeToken: selectedStoredSessionIdRef.current ? `/${selectedStoredSessionIdRef.current}::` : null,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        storedSessionId: selectedStoredSessionIdRef.current
+      })),
     getRouteToken: getRouteToken ?? (() => 'token'),
     handleSkinCommand: () => '',
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
@@ -1260,7 +1268,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // conversation via session.resume — createBackendSessionForSend would
     // silently fork the user's chat in two.
     const calls: { method: string; params?: Record<string, unknown> }[] = []
-    const createBackendSessionForSend = vi.fn(async () => 'brand-new-session-WRONG')
+    const createBackendSessionForSend = vi.fn(async () => ({
+      routeToken: '/brand-new-stored-WRONG::',
+      runtimeSessionId: 'brand-new-session-WRONG',
+      storedSessionId: 'brand-new-stored-WRONG'
+    }))
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
@@ -1294,7 +1306,12 @@ describe('usePromptActions sleep/wake session recovery', () => {
   })
 
   it('still creates a new session for a genuine new-chat draft (no stored session selected)', async () => {
-    const createBackendSessionForSend = vi.fn(async () => RUNTIME_SESSION_ID)
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = RUNTIME_SESSION_ID
+
+      return { routeToken: null, runtimeSessionId: RUNTIME_SESSION_ID, storedSessionId: null }
+    })
     const calls: string[] = []
 
     const requestGateway = vi.fn(async (method: string) => {
@@ -1307,6 +1324,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     render(
       <Harness
         activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
         createBackendSessionForSend={createBackendSessionForSend}
         onReady={h => (handle = h)}
         refreshSessions={async () => undefined}
@@ -1331,6 +1349,265 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+  })
+
+  it('allows a genuine new-chat send to follow its own session-creation navigation', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      // Real session creation selects the persisted row and navigates from the
+      // new-chat route before returning the runtime session id.
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const accepted = await handle!.submitText('describe this image', {
+      attachments: [{ id: 'image:first', kind: 'image', label: 'first.png', refText: '@image:first.png' }]
+    })
+
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: createdRuntimeSessionId,
+        text: '@image:first.png\n\ndescribe this image'
+      },
+      1_800_000
+    )
+  })
+
+  it('allows the new-chat route token to update asynchronously during first attachment sync', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/::'
+    let releaseAttach: () => void = () => {}
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      // React Router has been asked to navigate, but routeTokenRef still exposes
+      // /new until the next render commit.
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+    const attachment = { id: 'image:first', kind: 'image' as const, label: 'first.png', path: 'C:/tmp/first.png' }
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+        return { attached: true, path: attachment.path } as never
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const submitting = handle!.submitText('describe this image', { attachments: [attachment] })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach', expect.anything()))
+    routeToken = `/${createdStoredSessionId}::`
+    releaseAttach()
+
+    expect(await submitting).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), 1_800_000)
+  })
+
+  it('aborts when the user switches chats after new-session navigation but before create returns', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      // The create flow first performs its expected self-navigation...
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+      // ...then the user genuinely switches to another chat during a later await.
+      activeSessionIdRef.current = RUNTIME_SESSION_B
+      selectedStoredSessionIdRef.current = STORED_SESSION_B
+      routeToken = `session:${STORED_SESSION_B}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const accepted = await handle!.submitText('must stay in the original draft', {
+      attachments: [{ id: 'image:first', kind: 'image', label: 'first.png', refText: '@image:first.png' }]
+    })
+
+    expect(accepted).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('aborts when create returns its own binding but the UI has already selected another stored route', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: createdRuntimeSessionId }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      selectedStoredSessionIdRef.current = STORED_SESSION_B
+      routeToken = `session:${STORED_SESSION_B}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('must not be rebound to B')).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('aborts an ABA switch that returns to the same stored route with a new runtime binding', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const reboundRuntimeSessionId = 'rt-created-chat-rebound'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+    let releaseAttach: () => void = () => {}
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+    const requestGateway = vi.fn(async (_method: string, _params?: Record<string, unknown>, _timeout?: number) => ({}) as never)
+    const attachment = { id: 'image:first', kind: 'image' as const, label: 'first.png', path: 'C:/tmp/first.png' }
+
+    // Hold attachment sync open while the user switches B → original stored
+    // route, whose resume produces a different live runtime binding.
+    requestGateway.mockImplementation(async method => {
+      if (method === 'image.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+
+        return { attached: true, path: attachment.path } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const submitting = handle!.submitText('must not use the stale runtime', { attachments: [attachment] })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach', expect.anything()))
+
+    activeSessionIdRef.current = RUNTIME_SESSION_B
+    selectedStoredSessionIdRef.current = STORED_SESSION_B
+    routeToken = `session:${STORED_SESSION_B}`
+    activeSessionIdRef.current = reboundRuntimeSessionId
+    selectedStoredSessionIdRef.current = createdStoredSessionId
+    routeToken = `session:${createdStoredSessionId}`
+    releaseAttach()
+
+    expect(await submitting).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
   })
 
   it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -157,7 +157,9 @@ interface PromptActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   branchCurrentSession: () => Promise<boolean>
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (
+    preview?: string | null
+  ) => Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null>
   getRouteToken: () => string
   handleSkinCommand: (arg: string) => string
   openMemoryGraph: () => void

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -48,7 +48,9 @@ interface SlashCommandDeps {
   branchCurrentSession: () => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (
+    preview?: string | null
+  ) => Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null>
   handleSkinCommand: (arg: string) => string
   handoffSession: (
     platform: string,
@@ -86,8 +88,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
   return useCallback(
     async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
-      const ensureSessionId = async (sessionHint?: string) =>
-        sessionHint || activeSessionIdRef.current || (await createBackendSessionForSend())
+      const ensureSessionId = async (sessionHint?: string) => {
+        if (sessionHint || activeSessionIdRef.current) {
+          return sessionHint || activeSessionIdRef.current
+        }
+
+        return (await createBackendSessionForSend())?.runtimeSessionId ?? null
+      }
 
       // Resolve the target session plus a writer for inline slash output, or
       // notify + return null when none can be created. Folds the ensure / bail /

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -202,7 +202,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          startingStoredSessionId
+          expectedStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -214,7 +214,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          startingStoredSessionId
+          expectedStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -233,7 +233,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          startingStoredSessionId
+          expectedStoredSessionId
         )
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -29,12 +29,18 @@ import {
   withSessionBusyRetry
 } from './utils'
 
+interface CreatedSessionBinding {
+  routeToken: string | null
+  runtimeSessionId: string
+  storedSessionId: string | null
+}
+
 interface SubmitPromptDeps {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (preview?: string | null) => Promise<CreatedSessionBinding | null>
   getRouteToken: () => string
   requestGateway: GatewayRequest
   selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -120,11 +126,28 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // redirect the user's text into a different chat (#54527).
       const startingActiveSessionId = activeSessionIdRef.current
       const startingStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
+      let expectedRuntimeSessionId = startingActiveSessionId
+      let expectedStoredSessionId = startingStoredSessionId
+      let expectedRouteToken = getRouteToken()
+      let pendingCreatedRouteToken: string | null = null
 
-      const sessionContextDrifted = (): boolean =>
-        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
-        getRouteToken() !== startingRouteToken
+      const sessionContextDrifted = (): boolean => {
+        if (
+          pendingCreatedRouteToken &&
+          activeSessionIdRef.current === expectedRuntimeSessionId &&
+          selectedStoredSessionIdRef.current === expectedStoredSessionId &&
+          getRouteToken() === pendingCreatedRouteToken
+        ) {
+          expectedRouteToken = pendingCreatedRouteToken
+          pendingCreatedRouteToken = null
+        }
+
+        return (
+          activeSessionIdRef.current !== expectedRuntimeSessionId ||
+          selectedStoredSessionIdRef.current !== expectedStoredSessionId ||
+          getRouteToken() !== expectedRouteToken
+        )
+      }
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
@@ -254,6 +277,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           if (resumed?.session_id) {
             sessionId = resumed.session_id
             activeSessionIdRef.current = sessionId
+            expectedRuntimeSessionId = sessionId
           }
         } catch {
           // Resume failed (session gone from state.db, gateway hiccup) —
@@ -271,8 +295,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       if (!sessionId) {
+        let createdBinding: CreatedSessionBinding | null
+
         try {
-          sessionId = await createBackendSessionForSend(visibleText)
+          createdBinding = await createBackendSessionForSend(visibleText)
         } catch (err) {
           dropOptimistic(null)
           releaseBusy()
@@ -281,11 +307,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        if (sessionContextDrifted()) {
-          return abortForSessionSwitch(sessionId)
-        }
-
-        if (!sessionId) {
+        if (!createdBinding) {
           dropOptimistic(null)
           releaseBusy()
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
@@ -293,6 +315,22 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
+        sessionId = createdBinding.runtimeSessionId
+
+        // Only accept the exact binding produced by this create operation. The
+        // UI may already point at another stored route while its runtime resume
+        // is still pending, so reading current stored/route state here is unsafe.
+        if (
+          activeSessionIdRef.current !== createdBinding.runtimeSessionId ||
+          selectedStoredSessionIdRef.current !== createdBinding.storedSessionId
+        ) {
+          return abortForSessionSwitch(sessionId)
+        }
+
+        expectedRuntimeSessionId = createdBinding.runtimeSessionId
+        expectedStoredSessionId = createdBinding.storedSessionId
+        expectedRouteToken = getRouteToken()
+        pendingCreatedRouteToken = createdBinding.routeToken
         seedOptimistic(sessionId)
       }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -57,26 +57,34 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 function Harness({
+  activeSessionIdRef: activeSessionIdRefProp,
+  getRouteToken,
   onReady,
-  requestGateway
+  requestGateway,
+  selectedStoredSessionIdRef: selectedStoredSessionIdRefProp
 }: {
+  activeSessionIdRef?: MutableRefObject<string | null>
+  getRouteToken?: () => string
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  selectedStoredSessionIdRef?: MutableRefObject<string | null>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+  const activeSessionIdRef = activeSessionIdRefProp ?? ref<string | null>(null)
+  const selectedStoredSessionIdRef = selectedStoredSessionIdRefProp ?? ref<string | null>(null)
 
   const actions = useSessionActions({
     activeSessionId: null,
-    activeSessionIdRef: ref<string | null>(null),
+    activeSessionIdRef,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
-    getRouteToken: () => 'token',
+    getRouteToken: getRouteToken ?? (() => 'token'),
     navigate: vi.fn() as never,
     requestGateway,
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: null,
-    selectedStoredSessionIdRef: ref<string | null>(null),
+    selectedStoredSessionIdRef,
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
@@ -136,6 +144,54 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentCwd.set('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
+  })
+
+  it('returns null when the user switches sessions during post-create YOLO setup', async () => {
+    const createdStoredSessionId = 'stored-created'
+    const createdRuntimeSessionId = 'rt-created'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/::'
+    let releaseYolo: () => void = () => {}
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: createdRuntimeSessionId, stored_session_id: createdStoredSessionId } as never
+      }
+      if (method === 'config.set') {
+        await new Promise<void>(resolve => {
+          releaseYolo = resolve
+        })
+      }
+      return {} as never
+    })
+
+    // Arm YOLO so createBackendSessionForSend has a real post-navigation await.
+    const { setYoloActive } = await import('@/store/session')
+    setYoloActive(true)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        getRouteToken={() => routeToken}
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const creating = handle!.createBackendSessionForSend('preview')
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('config.set', expect.anything()))
+
+    // User selects B while the new session's optional YOLO call is still pending.
+    selectedStoredSessionIdRef.current = 'stored-B'
+    routeToken = '/stored-B::'
+    releaseYolo()
+
+    expect(await creating).toBeNull()
+    setYoloActive(false)
   })
 
   it('routes a plain new chat (no explicit profile) to the live gateway profile', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -175,7 +175,9 @@ export function useSessionActions({
   )
 
   const createBackendSessionForSend = useCallback(
-    async (preview: string | null = null): Promise<string | null> => {
+    async (
+      preview: string | null = null
+    ): Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null> => {
       const startingActiveSessionId = activeSessionIdRef.current
       const startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
@@ -271,7 +273,21 @@ export function useSessionActions({
           await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
         }
 
-        return created.session_id
+        // The optional post-create setup above can yield after the self-navigation.
+        // If the user selected another chat meanwhile, do not return a stale
+        // binding to prompt or slash callers.
+        if (
+          activeSessionIdRef.current !== created.session_id ||
+          selectedStoredSessionIdRef.current !== stored
+        ) {
+          return null
+        }
+
+        return {
+          routeToken: stored ? `${sessionRoute(stored)}::` : null,
+          runtimeSessionId: created.session_id,
+          storedSessionId: stored
+        }
       } finally {
         window.setTimeout(() => {
           creatingSessionRef.current = false


### PR DESCRIPTION
## Summary

Fixes a Desktop race where the first image-and-text prompt in a new chat could be restored to the composer and require a second **Send** click.

Session creation navigates from the new-chat route to the persisted session. React Router commits that navigation asynchronously, so attachment staging can observe the route change after an `await`. The submit guard previously treated this expected self-navigation as a user-initiated session switch and aborted the send.

## Changes

- Return the exact `runtimeSessionId`, `storedSessionId`, and route token produced by session creation.
- Rebase submit-context validation onto that binding and accept only the expected new-session route transition once.
- Continue aborting on genuine session switches, partial stored-session switches, and ABA runtime rebinding.
- Revalidate the binding after optional asynchronous post-create setup so prompt and slash callers cannot receive a stale session.
- Keep optimistic seed/rewrite/drop cache writes associated with the created stored session.
- Preserve current workspace-target and project-CWD behavior on `main`.

## Why the explicit binding?

Related approaches in #62482 and #62571 re-pin context snapshots after creation. This PR carries the exact binding returned by the create operation instead, so validation does not have to infer ownership from live refs that may already represent another session. The additional regression coverage exercises attachment staging, real and partial session switches, ABA runtime rebinding, post-create async setup, and the slash caller.

## Testing

- `npm run test:ui -- src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-session-actions.test.tsx` — **66/66 passed** after rebasing onto current `main`.
- `npm run typecheck` — passed.
- `git diff --check` — passed.
- Verified in a packaged Windows Desktop build: a new chat with an image attachment and text sends on the first click.

## Compatibility and scope

- Internal Desktop session-creation contract only; no external API or configuration changes.
- Preserves genuine session-switch and stale-runtime protections.
- Intentionally excludes unrelated attachment-timeout and other local changes.

## Related

- Tracks the new-chat first-send regression cluster in #62481.
- Alternative implementations: #62482 and #62571.

## Checklist

- [x] Focused bug fix with no unrelated source changes
- [x] Regression tests added for the affected paths
- [x] Tested on Windows Desktop
- [x] Rebased onto current `main` and resolved conflicts
- [x] No documentation or configuration update required