### PR TITLE
fix(computer-use): normalize cua-driver result envelopes

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1421,6 +1421,114 @@ def _make_cua_backend_with_windows(windows: List[Dict[str, Any]]):
     return backend
 
 
+def _make_cua_backend_with_tool_result(result: Dict[str, Any]):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = result
+    return backend
+
+
+class TestCuaDriverWindowResultShapes:
+    def test_extracts_windows_from_structured_content(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({
+            "structuredContent": {"windows": windows},
+            "data": {},
+        }) == windows
+
+    def test_extracts_windows_from_data_windows(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({
+            "structuredContent": None,
+            "data": {"windows": windows},
+        }) == windows
+
+    def test_extracts_windows_from_legacy_data_windows(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({
+            "structuredContent": None,
+            "data": {"_legacy_windows": windows},
+        }) == windows
+
+    def test_extract_windows_missing_fields_returns_empty(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        assert _windows_from_tool_result({
+            "structuredContent": None,
+            "data": {},
+        }) == []
+
+    def test_capture_uses_data_windows_shape(self):
+        windows = [
+            {"app_name": "Terminal", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "shell", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_tool_result({
+            "data": {"windows": windows},
+            "images": [],
+            "isError": False,
+            "structuredContent": None,
+        })
+        backend._session.call_tool.side_effect = [
+            {"data": {"windows": windows}, "images": [], "isError": False,
+             "structuredContent": None},
+            {"data": "ok", "images": [], "isError": False, "structuredContent": None},
+        ]
+
+        cap = backend.capture(mode="ax", app="Terminal")
+
+        assert cap.app == "Terminal"
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 7
+
+    def test_focus_app_uses_legacy_data_windows_shape(self):
+        windows = [
+            {"app_name": "Terminal", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "shell", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_tool_result({
+            "data": {"_legacy_windows": windows},
+            "images": [],
+            "isError": False,
+            "structuredContent": None,
+        })
+
+        res = backend.focus_app("Terminal")
+
+        assert res.ok is True
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 7
+
+    def test_list_apps_derives_apps_from_data_windows_shape(self):
+        windows = [
+            {"app_name": "Terminal", "pid": 100, "window_id": 7},
+            {"app_name": "Terminal", "pid": 100, "window_id": 8},
+            {"app_name": "Notes", "pid": 200, "window_id": 9},
+        ]
+        backend = _make_cua_backend_with_tool_result({
+            "data": {"windows": windows},
+            "images": [],
+            "isError": False,
+            "structuredContent": None,
+        })
+
+        assert backend.list_apps() == [
+            {"name": "Terminal", "pid": 100},
+            {"name": "Notes", "pid": 200},
+        ]
+
+
 class TestCuaDriverSessionReconnect:
     """Verify reconnect-once on a closed-resource error. After the
     lifecycle-owner refactor (Sun Jun 21 2026) the session no longer goes

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1461,6 +1461,30 @@ class TestCuaDriverWindowResultShapes:
             "data": {"_legacy_windows": windows},
         }) == windows
 
+    def test_empty_structured_windows_falls_through_to_data_windows(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({
+            "structuredContent": {"windows": []},
+            "data": {"windows": windows},
+        }) == windows
+
+    def test_extracts_windows_from_top_level_windows(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({"windows": windows}) == windows
+
+    def test_extracts_windows_from_top_level_legacy_windows(self):
+        from tools.computer_use.cua_backend import _windows_from_tool_result
+
+        windows = [{"app_name": "Terminal", "pid": 1, "window_id": 2}]
+
+        assert _windows_from_tool_result({"_legacy_windows": windows}) == windows
+
     def test_extract_windows_missing_fields_returns_empty(self):
         from tools.computer_use.cua_backend import _windows_from_tool_result
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1493,6 +1493,27 @@ class TestCuaDriverWindowResultShapes:
             "data": {},
         }) == []
 
+    def test_ingest_windows_skips_malformed_members(self):
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        valid = {"app_name": "Terminal", "pid": 100, "window_id": 7}
+
+        assert _ingest_windows([None, "bad", [], valid]) == [  # type: ignore[list-item]
+            {"app_name": "Terminal", "pid": 100, "window_id": 7,
+             "off_screen": False, "title": "", "z_index": 0},
+        ]
+
+    def test_ingest_windows_normalizes_untrusted_display_fields(self):
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        assert _ingest_windows([{
+            "app_name": None, "pid": "100", "window_id": "7",
+            "title": ["bad"], "z_index": "bad",
+        }]) == [{
+            "app_name": "", "pid": 100, "window_id": 7,
+            "off_screen": False, "title": "", "z_index": 0,
+        }]
+
     def test_capture_uses_data_windows_shape(self):
         windows = [
             {"app_name": "Terminal", "pid": 100, "window_id": 7,
@@ -1533,6 +1554,42 @@ class TestCuaDriverWindowResultShapes:
         assert res.ok is True
         assert backend._active_pid == 100
         assert backend._active_window_id == 7
+
+    def test_list_apps_accepts_top_level_windows_without_data(self):
+        windows = [
+            {"app_name": "Terminal", "pid": 100, "window_id": 7},
+            {"app_name": "Notes", "pid": 200, "window_id": 9},
+        ]
+        backend = _make_cua_backend_with_tool_result({
+            "windows": windows,
+            "images": [],
+            "isError": False,
+        })
+
+        assert backend.list_apps() == [
+            {"name": "Terminal", "pid": 100},
+            {"name": "Notes", "pid": 200},
+        ]
+
+    def test_list_apps_accepts_top_level_legacy_windows_without_data(self):
+        windows = [{"app_name": "Terminal", "pid": 100, "window_id": 7}]
+        backend = _make_cua_backend_with_tool_result({
+            "_legacy_windows": windows,
+            "images": [],
+            "isError": False,
+        })
+
+        assert backend.list_apps() == [{"name": "Terminal", "pid": 100}]
+
+    def test_list_apps_prefers_structured_apps_over_data_apps(self):
+        backend = _make_cua_backend_with_tool_result({
+            "structuredContent": {"apps": [{"name": "Canonical", "pid": 1}]},
+            "data": {"apps": [{"name": "Stale", "pid": 2}]},
+            "images": [],
+            "isError": False,
+        })
+
+        assert backend.list_apps() == [{"name": "Canonical", "pid": 1}]
 
     def test_list_apps_derives_apps_from_data_windows_shape(self):
         windows = [

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1149,17 +1149,24 @@ def _windows_from_tool_result(out: Dict[str, Any]) -> List[Dict[str, Any]]:
     structured = out.get("structuredContent")
     if isinstance(structured, dict):
         windows = structured.get("windows")
-        if isinstance(windows, list):
+        if isinstance(windows, list) and windows:
             return windows
 
     data = out.get("data")
     if isinstance(data, dict):
         windows = data.get("windows")
-        if isinstance(windows, list):
+        if isinstance(windows, list) and windows:
             return windows
         legacy_windows = data.get("_legacy_windows")
-        if isinstance(legacy_windows, list):
+        if isinstance(legacy_windows, list) and legacy_windows:
             return legacy_windows
+
+    windows = out.get("windows")
+    if isinstance(windows, list) and windows:
+        return windows
+    legacy_windows = out.get("_legacy_windows")
+    if isinstance(legacy_windows, list) and legacy_windows:
+        return legacy_windows
     return []
 
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1144,6 +1144,40 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return windows
 
 
+def _windows_from_tool_result(out: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return list_windows payloads across cua-driver result shapes."""
+    structured = out.get("structuredContent")
+    if isinstance(structured, dict):
+        windows = structured.get("windows")
+        if isinstance(windows, list):
+            return windows
+
+    data = out.get("data")
+    if isinstance(data, dict):
+        windows = data.get("windows")
+        if isinstance(windows, list):
+            return windows
+        legacy_windows = data.get("_legacy_windows")
+        if isinstance(legacy_windows, list):
+            return legacy_windows
+    return []
+
+
+def _apps_from_windows(windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    apps: List[Dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for summary in _ingest_windows(windows):
+        name = summary["app_name"]
+        if not name:
+            continue
+        key = (name, summary["pid"])
+        if key in seen:
+            continue
+        seen.add(key)
+        apps.append({"name": name, "pid": summary["pid"]})
+    return apps
+
+
 # ---------------------------------------------------------------------------
 # The backend itself
 # ---------------------------------------------------------------------------
@@ -1264,8 +1298,7 @@ class CuaDriverBackend(ComputerUseBackend):
         )
 
         def _windows_from(out: Dict[str, Any]) -> List[Dict[str, Any]]:
-            raw_ = (out.get("structuredContent") or {}).get("windows") or []
-            wins_ = _ingest_windows(raw_)
+            wins_ = _ingest_windows(_windows_from_tool_result(out))
             # Sort by z_index descending (lowest z_index = frontmost on macOS).
             wins_.sort(key=lambda w: w["z_index"])
             return wins_
@@ -1721,10 +1754,23 @@ class CuaDriverBackend(ComputerUseBackend):
     def list_apps(self) -> List[Dict[str, Any]]:
         out = self._session.call_tool("list_apps", {"session": self._session_id})
         data = out["data"]
+        structured = out.get("structuredContent")
         if isinstance(data, list):
             return data
         if isinstance(data, dict):
-            return data.get("apps", [])
+            apps = data.get("apps")
+            if isinstance(apps, list):
+                return apps
+            if isinstance(structured, dict):
+                structured_apps = structured.get("apps")
+                if isinstance(structured_apps, list):
+                    return structured_apps
+            return _apps_from_windows(_windows_from_tool_result(out))
+        if isinstance(structured, dict):
+            apps = structured.get("apps")
+            if isinstance(apps, list):
+                return apps
+            return _apps_from_windows(_windows_from_tool_result(out))
         # list_apps returns plain text — parse app lines.
         if isinstance(data, str):
             apps = []
@@ -1752,8 +1798,7 @@ class CuaDriverBackend(ComputerUseBackend):
             "list_windows",
             {"on_screen_only": True, "session": self._session_id},
         )
-        raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
-        windows = _ingest_windows(raw_windows)
+        windows = _ingest_windows(_windows_from_tool_result(lw_out))
         windows.sort(key=lambda w: w["z_index"])
 
         app_lower = app.lower()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1126,6 +1126,8 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     windows: List[Dict[str, Any]] = []
     for w in raw_windows:
+        if not isinstance(w, dict):
+            continue
         pid, window_id = w.get("pid"), w.get("window_id")
         if pid is None or window_id is None:
             continue
@@ -1133,13 +1135,19 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             pid_int, window_id_int = int(pid), int(window_id)
         except (TypeError, ValueError):
             continue
+        app_name = w.get("app_name", "")
+        title = w.get("title", "")
+        try:
+            z_index = int(w.get("z_index", 0))
+        except (TypeError, ValueError):
+            z_index = 0
         windows.append({
-            "app_name": w.get("app_name", ""),
+            "app_name": app_name if isinstance(app_name, str) else "",
             "pid": pid_int,
             "window_id": window_id_int,
             "off_screen": not w.get("is_on_screen", True),
-            "title": w.get("title", ""),
-            "z_index": w.get("z_index", 0),
+            "title": title if isinstance(title, str) else "",
+            "z_index": z_index,
         })
     return windows
 
@@ -1760,32 +1768,37 @@ class CuaDriverBackend(ComputerUseBackend):
     # ── Introspection ──────────────────────────────────────────────
     def list_apps(self) -> List[Dict[str, Any]]:
         out = self._session.call_tool("list_apps", {"session": self._session_id})
-        data = out["data"]
         structured = out.get("structuredContent")
-        if isinstance(data, list):
+        data = out.get("data")
+
+        # structuredContent is the canonical MCP payload. Empty lists fall
+        # through so a populated compatibility envelope can still recover.
+        if isinstance(structured, dict):
+            apps = structured.get("apps")
+            if isinstance(apps, list) and apps:
+                return apps
+        if isinstance(data, list) and data:
             return data
         if isinstance(data, dict):
             apps = data.get("apps")
-            if isinstance(apps, list):
+            if isinstance(apps, list) and apps:
                 return apps
-            if isinstance(structured, dict):
-                structured_apps = structured.get("apps")
-                if isinstance(structured_apps, list):
-                    return structured_apps
-            return _apps_from_windows(_windows_from_tool_result(out))
-        if isinstance(structured, dict):
-            apps = structured.get("apps")
-            if isinstance(apps, list):
-                return apps
-            return _apps_from_windows(_windows_from_tool_result(out))
-        # list_apps returns plain text — parse app lines.
+        apps = out.get("apps")
+        if isinstance(apps, list) and apps:
+            return apps
+
+        derived = _apps_from_windows(_windows_from_tool_result(out))
+        if derived:
+            return derived
+
+        # Older list_apps builds return plain text — parse app lines last.
         if isinstance(data, str):
-            apps = []
+            parsed_apps = []
             for line in data.splitlines():
                 m = re.search(r'(.+?)\s+\(pid\s+(\d+)\)', line)
                 if m:
-                    apps.append({"name": m.group(1).strip(), "pid": int(m.group(2))})
-            return apps
+                    parsed_apps.append({"name": m.group(1).strip(), "pid": int(m.group(2))})
+            return parsed_apps
         return []
 
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:


### PR DESCRIPTION
## Summary

Salvages #57961 onto current `main` while preserving Koho Zheng's original commit authorship, then extends the normalizer for the top-level payloads emitted by cua-driver 0.7.1.

- normalize `list_windows` from `structuredContent.windows`, `data.windows`, and `data._legacy_windows`
- also accept top-level `windows` and `_legacy_windows` from direct CLI responses
- skip empty higher-priority envelopes when a lower envelope contains valid windows
- reuse current `main`'s malformed-window filtering and MCP-to-CLI fallback
- normalize app discovery from structured app/window payloads
- route capture and focus selection through one normalization helper

## Reproduction

On Windows with cua-driver 0.7.1:

```text
computer_use list_apps -> []
computer_use capture    -> 0x0
```

In the same user, Windows session, and integrity level, direct cua-driver calls returned usable data:

```text
list_windows       -> top-level windows + _legacy_windows
get_desktop_state  -> 5120x1440 PNG
```

This ruled out Session 0 and UAC isolation for that lane. The wrapper was discarding valid result shapes.

A live integration run from this branch now reports 116 applications (including Google Chrome Canary) and normalizes five usable windows from the MCP driver envelope. A separate direct CLI probe emitted the top-level `windows` / `_legacy_windows` form covered here.

## Tests

- Added coverage for structured, nested data, legacy nested data, top-level, empty-envelope fallback, and missing payload shapes.
- Added capture, focus, app derivation, malformed-record, untrusted-field normalization, precedence, top-level end-to-end, and deduplication coverage.
- `ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use.py` passes.
- `py_compile` passes for both changed Python files.
- All 15 `TestCuaDriverWindowResultShapes` tests pass when invoked in-process on Windows.
- Native pytest executes the assertions but this host's teardown hits an unrelated Windows `WinError 1463` while following pytest's `*current` temp symlink; CI is the authoritative full pytest run.

## Scope

This fixes the result-envelope compatibility bug from #57905. It complements, but does not duplicate, #60081's explicit full-desktop capture bypass. Chrome-specific UIA provider timeouts remain a cua-driver concern tracked in trycua/cua#2110, #2113, and #2117.

Fixes #57905

Credits: preserves the original implementation commit from @kohoj / #57961 and resolves it against current `main` rather than reimplementing it without attribution.