### PR TITLE
chore(desktop): drop the dev-only "soft switch" preview from gateway settings

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -10,7 +10,6 @@ import { ExternalLink } from '@/lib/external-link'
 import { AlertCircle, Check, Cloud, FileText, Globe, HelpCircle, Loader2, LogIn, Monitor, RefreshCw } from '@/lib/icons'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { cn } from '@/lib/utils'
-import { previewGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
 import { $profiles, refreshActiveProfile } from '@/store/profile'
 
@@ -117,7 +116,6 @@ export function GatewaySettings() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
-  const [previewingSwitch, setPreviewingSwitch] = useState(false)
   const [signingIn, setSigningIn] = useState(false)
   const [state, setState] = useState<GatewaySettingsState>(EMPTY_STATE)
   const [remoteToken, setRemoteToken] = useState('')
@@ -1065,26 +1063,6 @@ export function GatewaySettings() {
           description={g.diagnosticsDesc}
           title={g.diagnostics}
         />
-        {import.meta.env.DEV ? (
-          <ListRow
-            action={
-              <Button
-                disabled={previewingSwitch}
-                onClick={() => {
-                  setPreviewingSwitch(true)
-                  void previewGatewaySwitch().finally(() => setPreviewingSwitch(false))
-                }}
-                size="sm"
-                variant="textStrong"
-              >
-                {previewingSwitch ? <Loader2 className="animate-spin" /> : null}
-                Preview soft switch
-              </Button>
-            }
-            description="Wipe session lists so sidebar skeletons retrigger — no real backend teardown."
-            title="Dev · soft switch"
-          />
-        ) : null}
       </div>
     </SettingsContent>
   )

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -16,7 +16,7 @@ import {
   setSessionsTotal
 } from '@/store/session'
 
-import { $gatewaySwitching, previewGatewaySwitch, wipeSessionListsForGatewaySwitch } from './gateway-switch'
+import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
 
 vi.mock('@/lib/query-client', () => ({
   queryClient: { invalidateQueries: vi.fn() }
@@ -53,13 +53,5 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
-  })
-
-  it('previewGatewaySwitch holds skeletons then clears loading', async () => {
-    await previewGatewaySwitch(20)
-
-    expect($sessions.get()).toEqual([])
-    expect($sessionsLoading.get()).toBe(false)
-    expect($gatewaySwitching.get()).toBe(false)
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -24,8 +24,6 @@ import {
 // overlay from resurrecting when startHermes re-emits boot progress.
 export const $gatewaySwitching = atom(false)
 
-const PREVIEW_HOLD_MS = 1400
-
 /**
  * Clear gateway-bound session UI so sidebar skeletons retrigger.
  *
@@ -57,27 +55,4 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setFreshDraftReady(true)
 
   void queryClient.invalidateQueries()
-}
-
-/**
- * Dev review beat: wipe → skeletons for PREVIEW_HOLD_MS → clear loading.
- * Does not tear down a real backend. Fired from the Settings button (Electron
- * has no easy `?query=` entry).
- */
-export async function previewGatewaySwitch(holdMs = PREVIEW_HOLD_MS): Promise<void> {
-  if ($gatewaySwitching.get()) {
-    return
-  }
-
-  $gatewaySwitching.set(true)
-  wipeSessionListsForGatewaySwitch()
-
-  try {
-    await new Promise<void>(resolve => {
-      window.setTimeout(resolve, holdMs)
-    })
-  } finally {
-    setSessionsLoading(false)
-    $gatewaySwitching.set(false)
-  }
 }


### PR DESCRIPTION
## Summary
Removes the `import.meta.env.DEV`-gated **"Dev · soft switch"** row (and its `previewGatewaySwitch` helper) from Settings → Gateway. It was a temporary review affordance for exercising the soft-switch reconnect (wipe session lists → skeletons, no real backend teardown). It's dead-stripped from production, but it shouldn't live in the tree.

Kept: `wipeSessionListsForGatewaySwitch` (the real soft-switch path) and `$gatewaySwitching` — both used by `use-gateway-boot`.

## Changes
- `apps/desktop/src/app/settings/gateway-settings.tsx` — remove the dev ListRow, its `previewingSwitch` state, and the `previewGatewaySwitch` import.
- `apps/desktop/src/store/gateway-switch.ts` — remove `previewGatewaySwitch` + `PREVIEW_HOLD_MS`.
- `apps/desktop/src/store/gateway-switch.test.ts` — drop the preview test.

## Test plan
- [x] `npx vitest run --environment jsdom src/store/gateway-switch.test.ts` (passes)
- [x] `npm run typecheck` (app + electron)
- [x] `eslint` on changed files (0 errors)