### PR TITLE
fix(update): fail safely on Git index locks

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9412,6 +9412,56 @@ def _cmd_update_pip(args):
     print("✓ Update complete! Restart hermes to use the new version.")
 
 
+def _update_index_lock_path(project_root: Path) -> Path | None:
+    """Return the checkout's index lock path, including linked worktrees."""
+    git_marker = project_root / ".git"
+    if git_marker.is_dir():
+        return git_marker / "index.lock"
+    if not git_marker.is_file():
+        return None
+
+    try:
+        marker = git_marker.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not marker.lower().startswith(prefix):
+        return None
+
+    git_dir = Path(marker[len(prefix) :].strip())
+    if not git_dir.is_absolute():
+        git_dir = (project_root / git_dir).resolve()
+    return git_dir / "index.lock"
+
+
+def _abort_if_update_index_locked(project_root: Path) -> None:
+    """Refuse to update while Git's index lock exists.
+
+    ``index.lock`` does not record its owner, so neither its age nor contents
+    can prove that no live Git operation owns it. Preserve the lock and give
+    the user an explicit recovery command instead of risking repository
+    corruption by unlinking it.
+    """
+    lock_path = _update_index_lock_path(project_root)
+    if lock_path is None or not lock_path.exists():
+        return
+
+    if _is_windows():
+        quoted_path = str(lock_path).replace("'", "''")
+        recovery = f"Remove-Item -LiteralPath '{quoted_path}'"
+    else:
+        import shlex
+
+        recovery = f"rm -f -- {shlex.quote(str(lock_path))}"
+
+    print(f"✗ Git index lock exists: {lock_path}")
+    print("  Another Git operation may still be using this repository.")
+    print("  Close or wait for it to finish, then retry `hermes update`.")
+    print("  If no Git operation is running, remove the orphaned lock:")
+    print(f"    {recovery}")
+    sys.exit(2)
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -9461,6 +9511,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if concurrent:
                 print(_format_concurrent_instances_message(concurrent, scripts_dir))
                 sys.exit(2)
+
+    # Git's lock file has no reliable ownership metadata. Refuse before backup
+    # or checkout mutation rather than guessing from its age and racing a
+    # legitimate long-running Git operation.
+    _abort_if_update_index_locked(PROJECT_ROOT)
 
     # Pre-update backup — runs before any git/file mutation so users can
     # always roll back to the exact state they had before this update.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2029,6 +2029,7 @@ def select_provider_and_model(args=None):
 _FROZEN_UPDATER_SURFACE: dict[str, tuple[str, ...]] = {
     "hermes_cli.update_cmd": (
         "_abort_dependency_sync_if_self_locked", "_assess_parked_branch_switch",
+        "_abort_if_update_index_locked",
         "_capture_active_lazy_features", "_capture_active_tool_dependencies",
         "_cold_start_windows_gateway_after_update", "_defer_update_for_self_lock",
         "_dependency_sync_would_rewrite", "_detect_self_loaded_native_modules",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1246,6 +1246,44 @@ def _apply_pulled_update(
         node_failures=node_failures, update_complete=update_complete)
 
 
+def _update_index_lock_path(project_root: Path) -> Path | None:
+    """Return the checkout's index lock path, including linked worktrees."""
+    git_marker = project_root / ".git"
+    if git_marker.is_dir():
+        return git_marker / "index.lock"
+    if not git_marker.is_file():
+        return None
+    try:
+        marker = git_marker.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not marker.lower().startswith(prefix):
+        return None
+    git_dir = Path(marker[len(prefix):].strip())
+    if not git_dir.is_absolute():
+        git_dir = (project_root / git_dir).resolve()
+    return git_dir / "index.lock"
+
+
+def _abort_if_update_index_locked(project_root: Path) -> None:
+    """Refuse to update while Git's index lock exists; never delete it."""
+    lock_path = _update_index_lock_path(project_root)
+    if lock_path is None or not lock_path.exists():
+        return
+    if _m()._is_windows():
+        quoted_path = str(lock_path).replace("'", "''")
+        recovery = f"Remove-Item -LiteralPath '{quoted_path}'"
+    else:
+        recovery = f"rm -f -- {shlex.quote(str(lock_path))}"
+    print(f"✗ Git index lock exists: {lock_path}")
+    print("  Another Git operation may still be using this repository.")
+    print("  Close or wait for it to finish, then retry `hermes update`.")
+    print("  If no Git operation is running, remove the orphaned lock:")
+    print(f"    {recovery}")
+    sys.exit(2)
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always restore stdio even on
     ``sys.exit``. Self-lock deferral deliberately does NOT run here (pre-fetch it stranded users
@@ -1257,6 +1295,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
     print()
 
     _pre_update_plan = _begin_update_receipt_and_plan(args)
+
+    # index.lock has no reliable ownership metadata. Refuse before backup or
+    # checkout mutation rather than guessing from its age and racing Git.
+    _m()._abort_if_update_index_locked(_m().PROJECT_ROOT)
 
     # Backup before any git/file mutation; the snapshot id (None if disabled/failed) feeds
     # the post-update cron-jobs safety net.

--- a/tests/hermes_cli/test_update_orphan_backend_reap.py
+++ b/tests/hermes_cli/test_update_orphan_backend_reap.py
@@ -261,6 +261,8 @@ def _run_guard(detect_side_effect, orphan_return):
 
     with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
         cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_abort_if_update_index_locked"
     ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
         cli_main, "_pause_windows_gateways_for_update", return_value=None
     ), patch.object(

--- a/tests/hermes_cli/test_update_stale_index_lock.py
+++ b/tests/hermes_cli/test_update_stale_index_lock.py
@@ -1,0 +1,94 @@
+"""Regression tests for index locks wedging ``hermes update`` (#63038)."""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli import main as hermes_main
+
+
+@pytest.mark.parametrize("age_seconds", [0, 7200])
+def test_update_index_lock_aborts_without_deleting(
+    tmp_path, capsys, monkeypatch, age_seconds
+):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    lock = git_dir / "index.lock"
+    lock.touch()
+    if age_seconds:
+        old_time = time.time() - age_seconds
+        os.utime(lock, (old_time, old_time))
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._abort_if_update_index_locked(tmp_path)
+
+    assert exc_info.value.code == 2
+    assert lock.exists()
+    output = capsys.readouterr().out
+    assert f"Git index lock exists: {lock}" in output
+    assert "rm -f -- " in output
+    assert str(lock) in output
+
+
+def test_missing_update_index_lock_is_noop(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert hermes_main._abort_if_update_index_locked(tmp_path) is None
+
+
+def test_linked_worktree_index_lock_aborts_without_deleting(
+    tmp_path, capsys, monkeypatch
+):
+    git_dir = tmp_path / "actual-git-dir"
+    git_dir.mkdir()
+    lock = git_dir / "index.lock"
+    lock.touch()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: ../actual-git-dir\n", encoding="utf-8")
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._abort_if_update_index_locked(worktree)
+
+    assert exc_info.value.code == 2
+    assert lock.exists()
+    assert str(lock) in capsys.readouterr().out
+
+
+def test_windows_index_lock_recovery_uses_powershell(tmp_path, capsys, monkeypatch):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    lock = git_dir / "index.lock"
+    lock.touch()
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    with pytest.raises(SystemExit):
+        hermes_main._abort_if_update_index_locked(tmp_path)
+
+    assert lock.exists()
+    assert "Remove-Item -LiteralPath" in capsys.readouterr().out
+
+
+def test_update_aborts_before_backup_or_git_mutation(tmp_path, monkeypatch):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "index.lock").touch()
+    backup = Mock()
+    git_run = Mock()
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(hermes_main, "_run_pre_update_backup", backup)
+    monkeypatch.setattr(hermes_main.subprocess, "run", git_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._cmd_update_impl(SimpleNamespace(), gateway_mode=False)
+
+    assert exc_info.value.code == 2
+    backup.assert_not_called()
+    git_run.assert_not_called()

--- a/tests/hermes_cli/test_update_stale_index_lock.py
+++ b/tests/hermes_cli/test_update_stale_index_lock.py
@@ -1,0 +1,70 @@
+"""Regression tests for index locks wedging ``hermes update`` (#63038)."""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli import update_cmd
+
+
+pytestmark = pytest.mark.windows_only
+
+
+@pytest.mark.parametrize("age_seconds", [0, 7200], ids=["fresh", "old"])
+@pytest.mark.parametrize("linked_worktree", [False, True], ids=["normal-git", "linked-git"])
+def test_update_index_lock_aborts_without_deleting(
+    tmp_path, capsys, age_seconds, linked_worktree
+):
+    if linked_worktree:
+        git_dir = tmp_path / "actual-git-dir"
+        project_root = tmp_path / "worktree"
+        git_dir.mkdir()
+        project_root.mkdir()
+        (project_root / ".git").write_text(
+            "gitdir: ../actual-git-dir\n", encoding="utf-8"
+        )
+    else:
+        project_root = tmp_path
+        git_dir = project_root / ".git"
+        git_dir.mkdir()
+
+    lock = git_dir / "index.lock"
+    lock.touch()
+    if age_seconds:
+        old_time = time.time() - age_seconds
+        os.utime(lock, (old_time, old_time))
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._abort_if_update_index_locked(project_root)
+
+    assert exc_info.value.code == 2
+    assert lock.exists()
+    output = capsys.readouterr().out
+    assert f"Git index lock exists: {lock}" in output
+    assert "Remove-Item -LiteralPath" in output
+    assert str(lock) in output
+
+
+def test_update_aborts_before_backup_or_git_mutation(tmp_path, monkeypatch):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    lock = git_dir / "index.lock"
+    lock.touch()
+    backup = Mock()
+    git_run = Mock()
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_run_pre_update_backup", backup)
+    monkeypatch.setattr(update_cmd.subprocess, "run", git_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._cmd_update_impl(SimpleNamespace(), gateway_mode=False)
+
+    assert exc_info.value.code == 2
+    backup.assert_not_called()
+    git_run.assert_not_called()

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -183,6 +183,8 @@ def _run_update_until_guard(args):
 
     with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
         cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_abort_if_update_index_locked"
     ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
         cli_main, "_pause_windows_gateways_for_update", return_value=None
     ), patch.object(


### PR DESCRIPTION
## What does this PR do?

Makes `hermes update` fail safely when Git's `index.lock` exists. The updater no longer treats lock age as proof of ownership and never deletes the lock automatically. It exits before backup or Git mutation, prints the exact lock path, and gives a platform-specific recovery command for use only after the user confirms no Git operation is running.

The guard resolves both normal `.git/` directories and linked-worktree `.git` pointer files.

## Related Issue

Refs #3523. The narrower report #63038 was closed in favor of the existing updater issue.

## Relationship to existing #3523 PRs

- #20112 and #62962 address fetch visibility and unnecessary stash timing; neither checks `index.lock` before updater mutation.
- #14998 protected explicitly configured custom update workflows, but did not cover the default managed checkout and is closed.
- #39707 fixed one Hermes-generated untracked marker being autostashed; it does not cover Git operation locks.
- #52887 applies stale-lock handling only to serialized checkpoint shadow repositories.

This PR adds the missing default-checkout preflight. It follows the stronger fail-closed lesson from prior update work: preserve every lock, abort before backup/Git mutation, and provide exact recovery guidance rather than guessing ownership from mtime.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`: resolve the real index-lock path for normal checkouts and linked worktrees; abort before backup/Git mutation without deleting the lock.
- `hermes_cli/main.py`: re-export the moved helpers through the existing compatibility surface.
- `tests/hermes_cli/test_update_stale_index_lock.py`: cover fresh and old locks, missing locks, linked worktrees, Windows recovery guidance, and the no-mutation call order.
- Existing later-stage update-guard harnesses: stub the new earlier preflight so they continue testing their own guard boundaries.

## How to Test

1. `python -m pytest -q tests/hermes_cli/test_update_orphan_backend_reap.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_stale_index_lock.py` — 27 passed.
2. `uv.exe tool run ruff check hermes_cli/main.py hermes_cli/update_cmd.py tests/hermes_cli/test_update_stale_index_lock.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_orphan_backend_reap.py` — passed.
3. `python scripts/check-windows-footguns.py --all` — no Windows footguns in 964 files.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; regression coverage exercises the CLI output and preserves the lock file.
