### PR TITLE
fix(claw): default archive cleanup prompt to No with unbootable warning (salvage of #8611 by @SHL0MS)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -670,7 +670,10 @@ def _cmd_cleanup(args):
         elif not auto_yes and not sys.stdin.isatty():
             print_info(f"Non-interactive session — would archive: {source_dir}")
             print_info("To execute, re-run with: hermes claw cleanup --yes")
-        elif auto_yes or prompt_yes_no(f"Archive {source_dir}?", default=True):
+        elif auto_yes or prompt_yes_no(
+            f"Archive {source_dir}? (⚠ This will make OpenClaw unbootable until renamed back)",
+            default=False,
+        ):
             try:
                 archive_path = _archive_directory(source_dir)
                 print_success(f"Archived: {source_dir} → {archive_path}")


### PR DESCRIPTION
## Summary

- Salvages #8611 by @SHL0MS onto current `main`.
- Interactive `hermes claw cleanup` no longer archives on plain Enter.
- Prompt warns that archiving makes OpenClaw unbootable until renamed back.

## Motivation

Closes/supersedes #8611 (CONFLICTING). Related context: issue #7907 class of “Hermes archived my .openclaw”.

**Problem:** cleanup used `prompt_yes_no(..., default=True)`, so pressing Enter archived `$HOME/.openclaw` (or sibling names) without an intentional yes.

**Root cause:** unsafe affirmative default on a destructive migration cleanup path.

**Fix:** `default=False` plus unbootable warning in the question. `hermes claw cleanup --yes` is unchanged.

## Changes from original #8611

- Rebased to current prompt site in `hermes_cli/claw.py`
- Added regression test asserting default=False + warning text

## Verification

- `python3 -m pytest tests/hermes_cli/test_claw.py::TestCmdCleanup -q` — 8 passed

## Files

- `hermes_cli/claw.py`
- `tests/hermes_cli/test_claw.py`