### PR TITLE
fix(terminal): reject long pure foreground sleep (salvage of #8612 by @SHL0MS)

### DIFF
--- a/tests/tools/test_long_sleep_rejection.py
+++ b/tests/tools/test_long_sleep_rejection.py
@@ -1,0 +1,54 @@
+"""Salvage of #8612 by @SHL0MS — long foreground sleep must not hang the agent."""
+
+from __future__ import annotations
+
+import json
+
+from tools.terminal_tool import _long_foreground_sleep_rejection, terminal_tool
+
+
+def test_sleep_over_30s_rejected_in_helper():
+    err = _long_foreground_sleep_rejection("sleep 180", background=False)
+    assert err is not None
+    assert "sleep 180" in err
+    assert "background=true" in err
+
+
+def test_short_sleep_allowed_in_helper():
+    assert _long_foreground_sleep_rejection("sleep 30", background=False) is None
+    assert _long_foreground_tool_sleep_ok() is True
+
+
+def _long_foreground_tool_sleep_ok() -> bool:
+    return _long_foreground_sleep_rejection("  sleep 5  ", background=False) is None
+
+
+def test_background_long_sleep_allowed_in_helper():
+    assert _long_foreground_sleep_rejection("sleep 600", background=True) is None
+
+
+def test_non_pure_sleep_not_blocked():
+    # Keep path for readiness scripts using sleep as part of a pipeline.
+    assert _long_foreground_sleep_rejection("sleep 120 && echo ok", background=False) is None
+
+
+def test_terminal_tool_rejects_long_foreground_sleep(monkeypatch):
+    # Avoid creating real environments if rejection fails.
+    called = {"env": False}
+
+    def _boom(*_a, **_k):
+        called["env"] = True
+        raise AssertionError("should not create env for rejected sleep")
+
+    monkeypatch.setattr("tools.terminal_tool._get_or_create_env", _boom, raising=False)
+    # Prefer patching create path inside module if present
+    import tools.terminal_tool as tt
+
+    if hasattr(tt, "_get_or_create_env"):
+        monkeypatch.setattr(tt, "_get_or_create_env", _boom)
+
+    raw = terminal_tool(command="sleep 90", background=False)
+    data = json.loads(raw)
+    assert data.get("exit_code") == -1
+    assert "sleep 90" in data.get("error", "")
+    assert "Rejected" in data.get("error", "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1919,6 +1919,31 @@ def _looks_like_help_or_version_command(command: str) -> bool:
     )
 
 
+
+def _long_foreground_sleep_rejection(command: str, *, background: bool) -> str | None:
+    """Reject pure long foreground `sleep N` that stalls the agent loop.
+
+    Interrupt is only checked between tool calls, so multi-minute foreground
+    sleeps hang the turn. Short sleeps and background sleeps are allowed.
+    Salvage of #8612 by @SHL0MS / issue #4162.
+    """
+    if background or not isinstance(command, str):
+        return None
+    match = re.match(r"^\s*sleep\s+(\d+)\s*$", command)
+    if not match:
+        return None
+    sleep_secs = int(match.group(1))
+    if sleep_secs <= 30:
+        return None
+    return (
+        f"Rejected: 'sleep {sleep_secs}' would block the agent for "
+        f"{sleep_secs}s, preventing user interaction. "
+        "Instead: run your long process with background=true, then "
+        "use process(action='poll', session_id=...) to check progress. "
+        "For short waits, use sleep values <= 30."
+    )
+
+
 def _foreground_background_guidance(command: str) -> str | None:
     """Suggest background mode when a foreground command looks long-lived.
 
@@ -2125,6 +2150,16 @@ def terminal_tool(
                     f"{FOREGROUND_MAX_TIMEOUT}s. Use background=true with "
                     f"notify_on_complete=true for long-running commands."
                 ),
+            }, ensure_ascii=False)
+
+        # Intercept long pure sleep commands that block the agent turn.
+        sleep_error = _long_foreground_sleep_rejection(command, background=background)
+        if sleep_error:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": sleep_error,
+                "status": "error",
             }, ensure_ascii=False)
 
         # Guardrail: long-lived server/watch commands should run as managed


### PR DESCRIPTION
## Summary

- Salvages #8612 by @SHL0MS onto current `main`.
- Pure foreground `sleep N` with N > 30 is rejected before env execution.
- Guides the model to `background=true` + process poll instead of hanging the turn.

## Motivation

Original work links issue #4162 (agent sleep+tail hang). PR #8612 is still OPEN but CONFLICTING against modern `terminal_tool.py`.

**Problem:** long `sleep` in the terminal tool runs to completion; user interrupt only applies between tool calls.

**Root cause:** no guard distinguishing interruptible tool boundaries from long subprocess sleeps.

**Fix:** `_long_foreground_sleep_rejection` gates pure `sleep N` > 30s when `background=false`. Compound scripts (`sleep 120 && …`) are not blocked so readiness patterns still work.

## Changes from original #8612

- Re-homed onto current guardrail section near FOREGROUND_MAX_TIMEOUT / long-lived command checks
- Extracted helper for unit tests
- Added `tests/tools/test_long_sleep_rejection.py`
- Pure-command match (`^\s*sleep\s+(\d+)\s*$`) to avoid false positives on pipelines

## Verification

- `python3 -m pytest tests/tools/test_long_sleep_rejection.py -q` — 5 passed

## Files

- `tools/terminal_tool.py`
- `tests/tools/test_long_sleep_rejection.py`