### PR TITLE
feat(discord): add opt-in bounded room observation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -860,6 +860,8 @@ platform_toolsets:
 #   require_mention: true            # Require @mention in server channels (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
+#   observe_unmentioned_group_messages: false  # Persist ambient context only in explicitly listed channels
+#   observed_channels: []            # Exact numeric channel/thread IDs eligible for observation
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -342,6 +342,36 @@ class GatewayAuthorizationMixin:
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
 
+        # Discord permits channel-only authorization only when no sender grant
+        # is configured. The adapter performs the channel check at intake;
+        # repeat it here because the gateway deliberately re-authorizes every
+        # event before persistence/dispatch. Do not return early when a Discord
+        # user/role or global user allowlist exists: those restrictions must be
+        # evaluated below. Threads inherit an allowed parent channel.
+        if source.platform == Platform.DISCORD and source.chat_type != "dm":
+            sender_grant_configured = any(
+                os.getenv(env_var, "").strip()
+                for env_var in (
+                    "DISCORD_ALLOWED_USERS",
+                    "DISCORD_ALLOWED_ROLES",
+                    "GATEWAY_ALLOWED_USERS",
+                )
+            )
+            raw_allowed_channels = os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip()
+            if raw_allowed_channels and not sender_grant_configured:
+                allowed_channel_ids = {
+                    channel_id.strip()
+                    for channel_id in raw_allowed_channels.split(",")
+                    if channel_id.strip()
+                }
+                source_channel_ids = {
+                    str(channel_id)
+                    for channel_id in (source.chat_id, source.parent_chat_id)
+                    if channel_id
+                }
+                if "*" in allowed_channel_ids or source_channel_ids & allowed_channel_ids:
+                    return True
+
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         # Checked before the no-user-id guard below: some platforms deliver
         # bot/automation traffic with no user_id at all -- e.g. Slack Workflow

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1210,8 +1210,12 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
-                if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
-                    bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
+                if "observe_unmentioned_group_messages" in platform_cfg:
+                    bridged["observe_unmentioned_group_messages"] = platform_cfg[
+                        "observe_unmentioned_group_messages"
+                    ]
+                if "observed_channels" in platform_cfg:
+                    bridged["observed_channels"] = platform_cfg["observed_channels"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:

--- a/gateway/platforms/__init__.py
+++ b/gateway/platforms/__init__.py
@@ -8,7 +8,13 @@ Each adapter handles:
 - Message formatting and media handling
 """
 
-from .base import BasePlatformAdapter, MessageEvent, SendResult
+from .base import (
+    BasePlatformAdapter,
+    MessageAddressing,
+    MessageDisposition,
+    MessageEvent,
+    SendResult,
+)
 
 # QQAdapter and YuanbaoAdapter were previously imported eagerly here, but
 # nothing in the codebase consumes ``from gateway.platforms import
@@ -24,6 +30,8 @@ from .base import BasePlatformAdapter, MessageEvent, SendResult
 # adapters from the package root.
 __all__ = [
     "BasePlatformAdapter",
+    "MessageAddressing",
+    "MessageDisposition",
     "MessageEvent",
     "SendResult",
     "QQAdapter",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1704,6 +1704,24 @@ class MessageType(Enum):
     COMMAND = "command"  # /command style
 
 
+class MessageDisposition(str, Enum):
+    """Handling disposition for a normalized incoming message."""
+
+    DROP = "drop"
+    OBSERVE = "observe"
+    DISPATCH = "dispatch"
+
+
+@dataclass(frozen=True)
+class MessageAddressing:
+    """Platform-neutral facts describing how a message was addressed."""
+
+    direct_mention: bool = False
+    reply_to_self: bool = False
+    mentions_other_bots: bool = False
+    mentions_other_users: bool = False
+
+
 class ProcessingOutcome(Enum):
     """Result classification for message-processing lifecycle hooks."""
 
@@ -1778,6 +1796,13 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
+
+    # Platform-neutral routing facts. These are appended to preserve the
+    # positional order of the existing public MessageEvent constructor.
+    # Adapters populate facts here instead of encoding them in free-form
+    # metadata; dispatch remains the backwards-compatible default.
+    addressing: MessageAddressing = field(default_factory=MessageAddressing)
+    disposition: MessageDisposition = MessageDisposition.DISPATCH
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
@@ -4591,6 +4616,15 @@ class BasePlatformAdapter(ABC):
         enabling interruption support.
         """
         if not self._message_handler:
+            return
+
+        # Observation events are persistence-only. Route them directly to the
+        # gateway before command coercion, per-session guards, typing/reaction
+        # hooks, pending-message queues, or response delivery can create visible
+        # room side effects. The gateway's OBSERVE branch authorizes, persists,
+        # and returns without invoking an agent.
+        if event.disposition is MessageDisposition.OBSERVE:
+            await self._message_handler(event)
             return
 
         coerce_plaintext_gateway_command(event)

--- a/gateway/room_observation.py
+++ b/gateway/room_observation.py
@@ -1,0 +1,97 @@
+"""Platform-neutral persistence helpers for ambient room observations."""
+
+import dataclasses
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+logger = logging.getLogger(__name__)
+OBSERVED_ROOM_CONTEXT_LIMIT = 25
+OBSERVED_ROOM_CONTEXT_MAX_AGE = timedelta(hours=6)
+ROOM_OBSERVATION_CHAT_TYPE = "room_observation"
+
+
+def room_scoped_source(source: SessionSource) -> SessionSource:
+    """Return a source in the dedicated room-observation session namespace."""
+
+    return dataclasses.replace(
+        source,
+        chat_type=ROOM_OBSERVATION_CHAT_TYPE,
+        user_id=None,
+        user_id_alt=None,
+        user_name=None,
+    )
+
+
+def observed_message_row(event: MessageEvent) -> dict[str, Any]:
+    """Build the attributed transcript row for one observed message."""
+
+    source = event.source
+    stable_user_id = source.user_id_alt or source.user_id or "unknown"
+    display_name = source.user_name or stable_user_id
+    return {
+        "role": "user",
+        "content": f"[{display_name}|{stable_user_id}]\n{event.text}",
+        "timestamp": event.timestamp.isoformat(),
+        "observed": True,
+        "message_id": event.message_id,
+    }
+
+
+def persist_room_observation(session_store: Any, event: MessageEvent) -> str:
+    """Append one observed row and return its room-scoped session id."""
+
+    source = room_scoped_source(event.source)
+    session = session_store.get_or_create_session(source)
+    session_store.append_to_transcript(
+        session.session_id,
+        observed_message_row(event),
+    )
+    return session.session_id
+
+
+def load_observed_room_context(
+    session_store: Any,
+    source: SessionSource,
+    *,
+    now: datetime | None = None,
+    limit: int = OBSERVED_ROOM_CONTEXT_LIMIT,
+    max_age: timedelta = OBSERVED_ROOM_CONTEXT_MAX_AGE,
+) -> str | None:
+    """Return bounded context from the existing room session, if one exists."""
+
+    if source.chat_type == "dm" or not source.chat_id:
+        return None
+    loader = getattr(session_store, "load_recent_observed_messages", None)
+    if not callable(loader):
+        return None
+    try:
+        rows = loader(
+            room_scoped_source(source),
+            now=now,
+            limit=limit,
+            max_age=max_age,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to load observed room context: platform=%s chat=%s thread=%s",
+            source.platform.value,
+            source.chat_id,
+            source.thread_id or "none",
+            exc_info=True,
+        )
+        return None
+    if not isinstance(rows, list):
+        return None
+    contents = [
+        row["content"].strip()
+        for row in rows
+        if isinstance(row, dict)
+        and isinstance(row.get("content"), str)
+        and row["content"].strip()
+    ]
+    return "\n".join(contents) or None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -774,6 +774,10 @@ def _build_replay_entry(
 _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
 _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
+_OBSERVED_ROOM_CONTEXT_HEADER = "[Observed room context — context only, not requests]"
+_CURRENT_ROOM_ADDRESSED_MESSAGE_HEADER = (
+    "[Current addressed message — answer only this unless it asks you to use room context]"
+)
 
 
 def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
@@ -961,6 +965,47 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
         return [{"type": "text", "text": prefix.rstrip()}] + wrapped
 
     return message
+
+
+def _wrap_current_message_with_room_context(message: Any, observed_context: Optional[str]) -> Any:
+    """Prepend generic observed-room context to the API-only current user turn."""
+
+    if not observed_context:
+        return message
+
+    prefix = (
+        f"{_OBSERVED_ROOM_CONTEXT_HEADER}\n"
+        f"{observed_context}\n\n"
+        f"{_CURRENT_ROOM_ADDRESSED_MESSAGE_HEADER}\n"
+    )
+
+    if isinstance(message, str):
+        return f"{prefix}{message}"
+
+    if isinstance(message, list):
+        wrapped = [dict(part) if isinstance(part, dict) else part for part in message]
+        for part in wrapped:
+            if isinstance(part, dict) and part.get("type") == "text":
+                part["text"] = f"{prefix}{part.get('text', '')}"
+                return wrapped
+        return [{"type": "text", "text": prefix.rstrip()}] + wrapped
+
+    return message
+
+
+def _apply_observed_context_persistence(
+    conversation_kwargs: Dict[str, Any],
+    *,
+    original_message: Any,
+    persist_override: Any,
+    observed_context: Optional[str],
+) -> None:
+    """Keep API-only context wrappers out of the persisted user transcript."""
+
+    if persist_override is not None:
+        conversation_kwargs["persist_user_message"] = persist_override
+    elif observed_context:
+        conversation_kwargs["persist_user_message"] = original_message
 
 
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
@@ -1760,6 +1805,7 @@ from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
+    MessageDisposition,
     MessageEvent,
     MessageType,
     _prefix_within_utf16_limit,
@@ -8893,6 +8939,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
+        is_observe = event.disposition is MessageDisposition.OBSERVE
+        if is_internal and is_observe:
+            logger.warning(
+                "Ignoring observe disposition on internal event: platform=%s chat=%s",
+                source.platform.value if source.platform else "unknown",
+                source.chat_id or "unknown",
+            )
+            return None
 
         # scale-to-zero (Phase 0, 0.B/F13): stamp the gateway-scoped last-inbound
         # clock for real (user-originated) inbound only. Internal/system events
@@ -8953,9 +9007,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # authorizes every member of the listed chat regardless of
             # sender). Defer to _is_user_authorized so that path runs.
             if not self._is_user_authorized(source):
+                if is_observe:
+                    logger.debug(
+                        "Dropping unauthorized room observation without user identity: "
+                        "platform=%s chat=%s",
+                        source.platform.value,
+                        source.chat_id,
+                    )
+                    return None
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
                 return None
         elif not self._is_user_authorized(source):
+            if is_observe:
+                logger.debug(
+                    "Dropping unauthorized room observation: user=%s platform=%s chat=%s",
+                    source.user_id,
+                    source.platform.value,
+                    source.chat_id,
+                )
+                return None
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if (
@@ -8996,7 +9066,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
-        
+
+        if is_observe:
+            try:
+                from gateway.room_observation import persist_room_observation
+
+                observation_session_id = persist_room_observation(
+                    self.session_store,
+                    event,
+                )
+                logger.info(
+                    "Persisted authorized room observation: platform=%s chat=%s "
+                    "thread=%s session=%s",
+                    source.platform.value,
+                    source.chat_id,
+                    source.thread_id or "none",
+                    observation_session_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to persist authorized room observation: platform=%s chat=%s",
+                    source.platform.value,
+                    source.chat_id,
+                    exc_info=True,
+                )
+            return None
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
@@ -18546,16 +18641,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             #      - These must be passed through intact so the API sees valid
             #        assistant→tool sequences (dropping tool_calls causes 500 errors)
             #
-            # Telegram observed group context is handled structurally here:
-            # observed=True transcript rows are withheld from replayable
-            # history and attached to the current addressed message as
-            # API-only context, so persisted history stores only the real
-            # addressed user turn.
+            # Telegram keeps its upstream marker-based shared-transcript path.
+            # Generic room observations (currently Discord) load from a separate
+            # namespaced transcript. Both are API-only context; neither changes
+            # the persisted current addressed turn.
             agent_history, observed_group_context = _build_gateway_agent_history(
                 history,
                 channel_prompt=channel_prompt,
                 inject_timestamps=_message_timestamps_enabled(_load_gateway_config()),
             )
+            from gateway.room_observation import load_observed_room_context
+
+            generic_observed_room_context = load_observed_room_context(
+                getattr(self, "session_store", None),
+                source,
+            )
+            observed_context = generic_observed_room_context or observed_group_context
 
             # FTS write-corruption guard (#50502): when message persistence
             # fails silently through corrupt FTS triggers, the reloaded
@@ -18891,18 +18992,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     _run_message = message
 
-                _api_run_message = _wrap_current_message_with_observed_context(
-                    _run_message,
-                    observed_group_context,
-                )
+                if generic_observed_room_context:
+                    _api_run_message = _wrap_current_message_with_room_context(
+                        _run_message,
+                        generic_observed_room_context,
+                    )
+                else:
+                    _api_run_message = _wrap_current_message_with_observed_context(
+                        _run_message,
+                        observed_group_context,
+                    )
                 _conversation_kwargs = {
                     "conversation_history": agent_history,
                     "task_id": session_id,
                 }
-                if _persist_user_message_override is not None:
-                    _conversation_kwargs["persist_user_message"] = _persist_user_message_override
-                elif observed_group_context:
-                    _conversation_kwargs["persist_user_message"] = message
+                _apply_observed_context_persistence(
+                    _conversation_kwargs,
+                    original_message=message,
+                    persist_override=_persist_user_message_override,
+                    observed_context=observed_context,
+                )
                 if moa_config is not None:
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import json
 import threading
 import uuid
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
@@ -1771,6 +1771,83 @@ class SessionStore:
         with self._lock:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
+
+    def get_existing_session(self, source: SessionSource) -> Optional[SessionEntry]:
+        """Return the routed session for *source* without creating or refreshing it."""
+
+        session_key = self._generate_session_key(source)
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
+    def load_recent_observed_messages(
+        self,
+        source: SessionSource,
+        *,
+        now: Optional[datetime] = None,
+        limit: int = 25,
+        max_age: timedelta = timedelta(hours=6),
+    ) -> List[Dict[str, Any]]:
+        """Load bounded observed user rows for an existing room-scoped session.
+
+        The lookup is deliberately non-creating: an addressed turn with no prior
+        ambient observations must not manufacture an empty room session. Rows
+        with missing or malformed timestamps fail closed so stale context cannot
+        bypass the age bound.
+        """
+
+        try:
+            effective_limit = max(0, int(limit))
+        except (TypeError, ValueError):
+            return []
+        if effective_limit == 0 or max_age.total_seconds() < 0:
+            return []
+
+        entry = self.get_existing_session(source)
+        if entry is None:
+            return []
+
+        reference = now or datetime.now(timezone.utc)
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=datetime.now().astimezone().tzinfo)
+        reference = reference.astimezone(timezone.utc)
+        cutoff = reference - max_age
+        bounded: List[tuple[datetime, Dict[str, Any]]] = []
+
+        for row in self.load_transcript(entry.session_id):
+            if (
+                not isinstance(row, dict)
+                or row.get("role") != "user"
+                or not row.get("observed")
+                or not isinstance(row.get("content"), str)
+                or not row.get("content")
+            ):
+                continue
+            raw_timestamp = row.get("timestamp")
+            try:
+                if isinstance(raw_timestamp, (int, float)) and not isinstance(
+                    raw_timestamp, bool
+                ):
+                    # SessionDB persists timestamps as Unix seconds (SQLite REAL),
+                    # while the JSONL fallback and older fixtures use ISO strings.
+                    parsed = datetime.fromtimestamp(float(raw_timestamp), tz=timezone.utc)
+                elif isinstance(raw_timestamp, str) and raw_timestamp.strip():
+                    parsed = datetime.fromisoformat(
+                        raw_timestamp.replace("Z", "+00:00")
+                    )
+                else:
+                    continue
+            except (OverflowError, OSError, TypeError, ValueError):
+                continue
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=datetime.now().astimezone().tzinfo)
+            parsed = parsed.astimezone(timezone.utc)
+            if parsed < cutoff:
+                continue
+            bounded.append((parsed, row))
+
+        bounded.sort(key=lambda item: item[0])
+        return [dict(row) for _timestamp, row in bounded[-effective_limit:]]
 
     def get_or_create_session(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -110,6 +110,8 @@ from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTr
 from utils import atomic_json_write, env_float, env_int
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageAddressing,
+    MessageDisposition,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
@@ -1164,7 +1166,16 @@ class DiscordAdapter(BasePlatformAdapter):
                         self._warn_if_fail_closed_default()
                         return
                     _role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
-                
+
+                # Authorized ambient observation must run before the legacy
+                # multi-agent mention filter and before _handle_message's
+                # dispatch-only side effects (threads, backfill, downloads).
+                if await adapter_self._maybe_observe_room_message(
+                    message,
+                    role_authorized=_role_authorized,
+                ):
+                    return
+
                 # Multi-agent filtering: if the message mentions specific bots
                 # but NOT this bot, the sender is talking to another agent —
                 # stay silent.  Messages with no bot mentions (general chat)
@@ -1174,34 +1185,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 # This replaces the older DISCORD_IGNORE_NO_MENTION logic
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
-                _raw_self_mention = self._self_is_explicitly_mentioned(message)
-                if not isinstance(message.channel, discord.DMChannel) and (
-                    message.mentions or _raw_self_mention
-                ):
-                    _self_mentioned = _raw_self_mention
-                    _other_bots_mentioned = any(
-                        m.bot and m != self._client.user
-                        for m in message.mentions
-                    )
-                    # If other bots are mentioned but we're not → not for us
-                    if _other_bots_mentioned and not _self_mentioned:
-                        return
-                    # If humans are mentioned but we're not → not for us
-                    # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior)
-                    # EXCEPT in free-response channels where the bot should
-                    # answer regardless of who is mentioned.
-                    _ignore_no_mention = os.getenv(
-                        "DISCORD_IGNORE_NO_MENTION", "true"
-                    ).lower() in {"true", "1", "yes"}
-                    if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        _channel_id = str(message.channel.id)
-                        _parent_id = None
-                        if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                            _parent_id = str(message.channel.parent_id)
-                        _free_channels = adapter_self._discord_free_response_channels()
-                        _channel_keys = adapter_self._discord_channel_keys(message, _parent_id)
-                        if "*" not in _free_channels and not (_channel_keys & _free_channels):
-                            return
+                if not adapter_self._discord_multi_agent_message_allowed(message):
+                    return
 
                 await self._handle_message(message, role_authorized=_role_authorized)
 
@@ -4760,6 +4745,27 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
 
+    def _discord_observation_enabled(self) -> bool:
+        """Return whether ambient Discord room observation is explicitly enabled."""
+
+        configured = self.config.extra.get("observe_unmentioned_group_messages", False)
+        if isinstance(configured, str):
+            return configured.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(configured)
+
+    def _discord_observed_channel_ids(self) -> set[str]:
+        """Return explicit Discord channel IDs eligible for ambient observation."""
+
+        raw = self.config.extra.get("observed_channels", [])
+        if isinstance(raw, (list, tuple, set)):
+            candidates = {str(part).strip() for part in raw if str(part).strip()}
+        else:
+            value = str(raw).strip() if raw is not None else ""
+            candidates = {part.strip() for part in value.split(",") if part.strip()}
+        # Observation is retention. Accept snowflake IDs only: no names or
+        # wildcard that could silently widen after a channel rename/reorg.
+        return {candidate for candidate in candidates if candidate.isdigit()}
+
     def _discord_allow_any_attachment(self) -> bool:
         """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
 
@@ -4849,30 +4855,146 @@ class DiscordAdapter(BasePlatformAdapter):
         content = getattr(message, "content", "") or ""
         return {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
 
-    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
-        """Return True when this bot is explicitly @mentioned in the message.
+    def _raw_mentioned_role_ids(self, message: Any) -> set[str]:
+        """Extract Discord role-mention IDs from raw ``<@&ROLE_ID>`` tokens."""
 
-        Treats the bot as mentioned if it is either present in the resolved
-        ``message.mentions`` list OR referenced by its raw ``<@ID>`` / ``<@!ID>``
-        form in the message content.
+        content = getattr(message, "content", "") or ""
+        return {match.group(1) for match in re.finditer(r"<@&(\d+)>", content)}
+
+    def _role_is_managed_by_self(self, role: Any) -> bool:
+        """Return whether ``role`` is the current bot's managed Discord role."""
+
+        if not self._client or not self._client.user or role is None:
+            return False
+        tags = getattr(role, "tags", None)
+        return str(getattr(tags, "bot_id", "")) == str(self._client.user.id)
+
+    def _self_managed_role_ids(self, message: Any) -> set[str]:
+        """Return mentioned role IDs that Discord marks as managed by this bot."""
+
+        raw_role_ids = self._raw_mentioned_role_ids(message)
+        if not raw_role_ids:
+            return set()
+
+        roles = list(getattr(message, "role_mentions", []) or [])
+        resolved_ids = {str(getattr(role, "id", "")) for role in roles}
+        guild = getattr(message, "guild", None)
+        get_role = getattr(guild, "get_role", None)
+        if callable(get_role):
+            for role_id in raw_role_ids - resolved_ids:
+                try:
+                    role = get_role(int(role_id))
+                except (TypeError, ValueError):
+                    role = None
+                if role is not None:
+                    roles.append(role)
+
+        return {
+            str(getattr(role, "id", ""))
+            for role in roles
+            if str(getattr(role, "id", "")) in raw_role_ids
+            and self._role_is_managed_by_self(role)
+        }
+
+    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+        """Return True when this bot or its managed role is explicitly mentioned.
+
+        User mentions can be resolved through ``message.mentions`` or raw
+        ``<@ID>`` / ``<@!ID>`` content. Discord bot integrations also own a
+        managed role; an inline ``<@&ROLE_ID>`` counts only when RoleTags.bot_id
+        identifies the current bot, never merely by role name or assignment.
         """
         if not self._client or not self._client.user:
             return False
         if self._client.user in getattr(message, "mentions", []):
             return True
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        return self._self_is_raw_mentioned(message)
 
     def _self_is_raw_mentioned(self, message: Any) -> bool:
-        """Return True only when this bot has an inline mention token.
+        """Return True only when this bot has an inline user or managed-role token.
 
         Discord reply-pings can add the replied-to bot to ``message.mentions``
-        without a literal ``<@bot>`` token in ``message.content``. This helper
-        intentionally ignores the resolved mentions list so the bot admission
-        gate can distinguish an explicit cross-bot address from a reply chip.
+        without a literal token in ``message.content``. This helper intentionally
+        ignores that resolved user list so the bot admission gate can distinguish
+        an explicit cross-bot address from a reply chip.
         """
         if not self._client or not self._client.user:
             return False
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        raw_user_mention = str(self._client.user.id) in self._raw_mentioned_user_ids(
+            message
+        )
+        return raw_user_mention or bool(self._self_managed_role_ids(message))
+
+    def _discord_reply_to_self(self, message: Any) -> bool:
+        """Return True when a Discord reply targets a message authored by this bot."""
+
+        if not self._client or not self._client.user:
+            return False
+        reference = getattr(message, "reference", None)
+        resolved = getattr(reference, "resolved", None) if reference else None
+        author = getattr(resolved, "author", None) if resolved is not None else None
+        return bool(
+            author is not None
+            and str(getattr(author, "id", "")) == str(self._client.user.id)
+        )
+
+    def _discord_message_addressing(self, message: Any) -> MessageAddressing:
+        """Normalize Discord mention/reply facts without applying gateway policy."""
+
+        self_id = ""
+        if self._client and self._client.user:
+            self_id = str(self._client.user.id)
+        reply_to_self = self._discord_reply_to_self(message)
+        resolved_self_mention = any(
+            str(getattr(mention, "id", "")) == self_id
+            for mention in getattr(message, "mentions", [])
+        )
+        direct_mention = self._self_is_raw_mentioned(message) or (
+            resolved_self_mention and not reply_to_self
+        )
+        mentions_other_bots = False
+        mentions_other_users = False
+        for mention in getattr(message, "mentions", []):
+            if str(getattr(mention, "id", "")) == self_id:
+                continue
+            if getattr(mention, "bot", False):
+                mentions_other_bots = True
+            else:
+                mentions_other_users = True
+        return MessageAddressing(
+            direct_mention=direct_mention,
+            reply_to_self=reply_to_self,
+            mentions_other_bots=mentions_other_bots,
+            mentions_other_users=mentions_other_users,
+        )
+
+    def _discord_multi_agent_message_allowed(self, message: Any) -> bool:
+        """Apply Discord's existing bot/human mention admission rule."""
+
+        if discord is not None and isinstance(message.channel, discord.DMChannel):
+            return True
+        addressing = self._discord_message_addressing(message)
+        self_addressed = addressing.direct_mention or addressing.reply_to_self
+        if not getattr(message, "mentions", []) and not self_addressed:
+            return True
+        if addressing.mentions_other_bots and not self_addressed:
+            return False
+        ignore_no_mention = os.getenv(
+            "DISCORD_IGNORE_NO_MENTION",
+            "true",
+        ).lower() in {"true", "1", "yes"}
+        if (
+            ignore_no_mention
+            and not self_addressed
+            and not addressing.mentions_other_bots
+        ):
+            parent_id = None
+            if getattr(message.channel, "parent_id", None):
+                parent_id = str(message.channel.parent_id)
+            free_channels = self._discord_free_response_channels()
+            channel_keys = self._discord_channel_keys(message, parent_id)
+            return "*" in free_channels or bool(channel_keys & free_channels)
+        return True
 
     def _discord_bots_require_inline_mention(self) -> bool:
         """Whether another bot must type an inline @mention to trigger us.
@@ -6118,6 +6240,143 @@ class DiscordAdapter(BasePlatformAdapter):
                     raise Exception(f"HTTP {resp.status}")
                 return await resp.read()
 
+    async def _maybe_observe_room_message(
+        self,
+        message: Any,
+        *,
+        role_authorized: bool = False,
+    ) -> bool:
+        """Emit one lightweight OBSERVE event for an eligible ambient message.
+
+        Returns True only when the message was consumed as an observation.
+        Dispatch candidates and ineligible traffic return False so the existing
+        Discord gates retain ownership of their behavior.
+        """
+
+        if not self._discord_observation_enabled():
+            return False
+        channel = getattr(message, "channel", None)
+        guild = getattr(message, "guild", None) or getattr(channel, "guild", None)
+        is_dm = bool(
+            discord is not None and isinstance(channel, discord.DMChannel)
+        )
+        if channel is None or guild is None or is_dm:
+            return False
+        if getattr(getattr(message, "author", None), "bot", False):
+            return False
+
+        channel_id = str(getattr(channel, "id", ""))
+        if channel_id not in self._discord_observed_channel_ids():
+            return False
+
+        is_thread = bool(
+            discord is not None and isinstance(channel, discord.Thread)
+        )
+        parent_channel_id = self._get_parent_channel_id(channel) if is_thread else None
+        channel_keys = self._discord_channel_keys(message, parent_channel_id)
+
+        # Observation is persistence: retain only from channels that also pass
+        # the adapter's established dispatch allow/ignore controls.
+        allowed_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip()
+        if allowed_raw:
+            allowed = {part.strip() for part in allowed_raw.split(",") if part.strip()}
+            if "*" not in allowed and not (channel_keys & allowed):
+                return False
+        ignored_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "").strip()
+        ignored = {part.strip() for part in ignored_raw.split(",") if part.strip()}
+        if "*" in ignored or channel_keys & ignored:
+            return False
+
+        addressing = self._discord_message_addressing(message)
+        if addressing.direct_mention or addressing.reply_to_self:
+            return False
+
+        # Observation mode must not steal messages from existing ambient
+        # dispatch modes (global mention-off, free-response, active bot threads,
+        # or voice-linked text channels).
+        if not self._discord_require_mention():
+            return False
+        free_channels = self._discord_free_response_channels()
+        if "*" in free_channels or channel_keys & free_channels:
+            return False
+        if (
+            is_thread
+            and channel_id in self._threads
+            and not self._discord_thread_require_mention()
+        ):
+            return False
+        voice_linked_ids = {str(value) for value in self._voice_text_channels.values()}
+        if channel_id in voice_linked_ids:
+            return False
+
+        content = str(getattr(message, "content", "") or "").strip()
+        metadata_lines = []
+        for attachment in list(getattr(message, "attachments", []) or []):
+            filename = " ".join(
+                str(getattr(attachment, "filename", None) or "attachment").split()
+            )
+            content_type = " ".join(
+                str(getattr(attachment, "content_type", None) or "unknown").split()
+            )
+            size = getattr(attachment, "size", None)
+            size_label = f"{size} bytes" if size is not None else "size unknown"
+            metadata_lines.append(
+                f"[Attachment: {filename}; {content_type}; {size_label}]"
+            )
+        event_text = "\n".join(part for part in [content, *metadata_lines] if part).strip()
+        if not event_text:
+            return False
+
+        thread_id = channel_id if is_thread else None
+        if is_thread:
+            chat_type = "thread"
+            chat_name = self._format_thread_chat_name(channel)
+        else:
+            chat_type = "group"
+            channel_name = getattr(channel, "name", channel_id)
+            chat_name = f"{guild.name} / #{channel_name}"
+        author = message.author
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=str(author.id),
+            user_name=getattr(author, "display_name", None)
+            or getattr(author, "name", None)
+            or str(author.id),
+            thread_id=thread_id,
+            chat_topic=self._get_effective_topic(channel, is_thread=is_thread),
+            is_bot=False,
+            guild_id=str(guild.id),
+            parent_chat_id=parent_channel_id,
+            message_id=str(message.id),
+            role_authorized=role_authorized,
+        )
+        reference = getattr(message, "reference", None)
+        resolved_reference = getattr(reference, "resolved", None) if reference else None
+        event = MessageEvent(
+            text=event_text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=message,
+            message_id=str(message.id),
+            reply_to_message_id=(
+                str(reference.message_id)
+                if reference is not None and getattr(reference, "message_id", None) is not None
+                else None
+            ),
+            reply_to_text=(
+                getattr(resolved_reference, "content", None)
+                if resolved_reference is not None
+                else None
+            ),
+            timestamp=message.created_at,
+            addressing=addressing,
+            disposition=MessageDisposition.OBSERVE,
+        )
+        await self.handle_message(event)
+        return True
+
     async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""
         # In server channels (not DMs), require the bot to be @mentioned
@@ -6146,6 +6405,7 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_content = message.content.strip()
         normalized_content = raw_content
         mention_prefix = False
+        addressing = self._discord_message_addressing(message)
 
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
@@ -6157,11 +6417,19 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
-        if self._self_is_explicitly_mentioned(message):
+        if addressing.direct_mention or addressing.reply_to_self:
             mention_prefix = True
-            if self._client.user:
-                normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
-                normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            if addressing.direct_mention and self._client and self._client.user:
+                normalized_content = normalized_content.replace(
+                    f"<@{self._client.user.id}>", ""
+                ).strip()
+                normalized_content = normalized_content.replace(
+                    f"<@!{self._client.user.id}>", ""
+                ).strip()
+                for role_id in self._self_managed_role_ids(message):
+                    normalized_content = normalized_content.replace(
+                        f"<@&{role_id}>", ""
+                    ).strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
@@ -6491,7 +6759,21 @@ class DiscordAdapter(BasePlatformAdapter):
         # to keep the partition rule clean.
         _channel_context = None
         _is_dm = isinstance(message.channel, discord.DMChannel)
-        if not _is_dm and self._discord_history_backfill():
+        # Durable room observation is the single source of ambient context for
+        # explicitly observed channels. Running Discord's legacy history scan
+        # as well duplicates the same messages, persists them into the addressed
+        # user session, and can replay missed requests on a later turn.
+        _durable_observation_owns_context = (
+            not _is_dm
+            and self._discord_observation_enabled()
+            and str(getattr(message.channel, "id", ""))
+            in self._discord_observed_channel_ids()
+        )
+        if (
+            not _is_dm
+            and self._discord_history_backfill()
+            and not _durable_observation_owns_context
+        ):
             # Run backfill when there's a real gap to fill:
             #   - mention-gated channels with no free-response override
             #     (messages between bot turns aren't in the transcript)
@@ -6587,6 +6869,8 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            addressing=addressing,
+            disposition=MessageDisposition.DISPATCH,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/tests/e2e/test_discord_room_observation.py
+++ b/tests/e2e/test_discord_room_observation.py
@@ -1,0 +1,509 @@
+"""Composed Discord room-observation tests with real durable session state.
+
+These tests stop at the agent boundary but exercise the actual adapter, base
+adapter routing, gateway authorization/disposition path, and SessionStore.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import hermes_state
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.room_observation import load_observed_room_context, room_scoped_source
+from gateway.session import SessionSource, SessionStore
+from tests.e2e.conftest import (
+    BOT_USER_ID,
+    CHANNEL_ID,
+    _make_discord_adapter_wired,
+    make_discord_message,
+    make_fake_text_channel,
+    make_fake_thread,
+    make_runner,
+)
+
+pytestmark = pytest.mark.asyncio
+_REAL_SESSION_DB = hermes_state.SessionDB
+
+
+def _author(user_id: int, name: str):
+    return SimpleNamespace(
+        id=user_id,
+        name=name.lower(),
+        display_name=name,
+        bot=False,
+    )
+
+
+def _source_for(author, channel) -> SessionSource:
+    parent_id = getattr(channel, "parent_id", None)
+    is_thread = parent_id is not None
+    return SessionSource(
+        platform=Platform.DISCORD,
+        scope_id=str(channel.guild.id),
+        chat_id=str(channel.id),
+        chat_name=f"{channel.guild.name} / #{channel.name}",
+        chat_type="thread" if is_thread else "group",
+        user_id=str(author.id),
+        user_name=author.display_name,
+        thread_id=str(channel.id) if is_thread else None,
+        parent_chat_id=str(parent_id) if parent_id is not None else None,
+    )
+
+
+def _new_store(*, sessions_dir, db_path, config) -> SessionStore:
+    with patch.object(
+        hermes_state,
+        "SessionDB",
+        side_effect=lambda: _REAL_SESSION_DB(db_path),
+    ):
+        return SessionStore(sessions_dir=sessions_dir, config=config)
+
+
+async def _drain_adapter(adapter) -> None:
+    """Wait until all BasePlatformAdapter processing tasks have completed."""
+
+    for _ in range(20):
+        tasks = list(adapter._background_tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
+        await asyncio.sleep(0)
+        if not adapter._background_tasks:
+            return
+    raise AssertionError("adapter background tasks did not drain")
+
+
+async def _route_authorized_message(stack, message) -> bool:
+    """Mirror the authorized portion of Discord's on_message callback."""
+
+    observed = await stack.adapter._maybe_observe_room_message(message)
+    if not observed and stack.adapter._discord_multi_agent_message_allowed(message):
+        await stack.adapter._handle_message(message)
+    await _drain_adapter(stack.adapter)
+    return observed
+
+
+def _room_context(stack, author, channel) -> str | None:
+    return load_observed_room_context(
+        stack.store,
+        _source_for(author, channel),
+        now=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture()
+def presence_stack(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+    monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0")
+    monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "0")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+    sessions_dir = tmp_path / "sessions"
+    db_path = tmp_path / "state.db"
+    platform_config = PlatformConfig(
+        enabled=True,
+        token="e2e-test-token",
+        extra={
+            "require_mention": True,
+            "observe_unmentioned_group_messages": True,
+            "observed_channels": [str(CHANNEL_ID)],
+            "free_response_channels": [],
+        },
+    )
+    config = GatewayConfig(platforms={Platform.DISCORD: platform_config})
+    config.sessions_dir = sessions_dir
+
+    runner = make_runner(Platform.DISCORD)
+    runner.config = config
+    runner._is_user_authorized = MagicMock(return_value=True)
+    store = _new_store(
+        sessions_dir=sessions_dir,
+        db_path=db_path,
+        config=config,
+    )
+    runner.session_store = store
+
+    adapter, _ = _make_discord_adapter_wired(runner)
+    adapter.config = platform_config
+
+    agent_calls = []
+
+    async def fake_agent_boundary(event, source, session_key, run_generation):
+        entry = store.get_or_create_session(source)
+        context = load_observed_room_context(
+            store,
+            source,
+            now=datetime.now(timezone.utc),
+        )
+        agent_calls.append(
+            SimpleNamespace(
+                event=event,
+                source=source,
+                session_key=session_key,
+                run_generation=run_generation,
+                session_id=entry.session_id,
+                room_context=context,
+            )
+        )
+        return None
+
+    runner._handle_message_with_agent = AsyncMock(side_effect=fake_agent_boundary)
+    stack = SimpleNamespace(
+        adapter=adapter,
+        runner=runner,
+        store=store,
+        sessions_dir=sessions_dir,
+        db_path=db_path,
+        config=config,
+        agent_calls=agent_calls,
+    )
+    yield stack
+    db = store._db
+    if db is not None:
+        db.close()
+
+
+async def test_alice_ambient_persists_once_without_agent_reply_or_typing(presence_stack):
+    alice = _author(101, "Alice")
+    channel = make_fake_text_channel()
+    message = make_discord_message(
+        content="The launch moved to Tuesday.",
+        author=alice,
+        channel=channel,
+    )
+    message.add_reaction = AsyncMock()
+    message.remove_reaction = AsyncMock()
+
+    observed = await _route_authorized_message(presence_stack, message)
+
+    assert observed is True
+    assert _room_context(presence_stack, alice, channel) == (
+        "[Alice|101]\nThe launch moved to Tuesday."
+    )
+    presence_stack.runner._handle_message_with_agent.assert_not_awaited()
+    presence_stack.adapter.send.assert_not_awaited()
+    presence_stack.adapter.send_typing.assert_not_awaited()
+    message.add_reaction.assert_not_awaited()
+    message.remove_reaction.assert_not_awaited()
+
+
+async def test_bob_and_alice_share_room_stream_with_stable_attribution(presence_stack):
+    alice = _author(101, "Alice")
+    bob = _author(202, "Bob")
+    channel = make_fake_text_channel()
+
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(content="Tuesday works.", author=alice, channel=channel),
+    )
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(content="I will update the brief.", author=bob, channel=channel),
+    )
+
+    expected = (
+        "[Alice|101]\nTuesday works.\n"
+        "[Bob|202]\nI will update the brief."
+    )
+    assert _room_context(presence_stack, alice, channel) == expected
+    assert _room_context(presence_stack, bob, channel) == expected
+    room_entry = presence_stack.store.get_existing_session(
+        room_scoped_source(_source_for(alice, channel))
+    )
+    assert room_entry is not None
+    rows = presence_stack.store.load_transcript(room_entry.session_id)
+    assert [row["content"] for row in rows] == [
+        "[Alice|101]\nTuesday works.",
+        "[Bob|202]\nI will update the brief.",
+    ]
+    presence_stack.runner._handle_message_with_agent.assert_not_awaited()
+
+
+async def test_alice_mention_uses_alice_session_and_shared_room_context(presence_stack):
+    alice = _author(101, "Alice")
+    channel = make_fake_text_channel()
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(content="The launch moved.", author=alice, channel=channel),
+    )
+
+    observed = await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content=f"<@{BOT_USER_ID}> when is the launch?",
+            author=alice,
+            channel=channel,
+            mentions=[presence_stack.adapter._client.user],
+        ),
+    )
+
+    assert observed is False
+    presence_stack.runner._handle_message_with_agent.assert_awaited_once()
+    call = presence_stack.agent_calls[0]
+    assert call.source.user_id == "101"
+    assert call.room_context == "[Alice|101]\nThe launch moved."
+    assert call.session_key.endswith(":101")
+
+
+async def test_shared_thread_observation_session_is_distinct_from_conversation(
+    presence_stack,
+):
+    alice = _author(101, "Alice")
+    parent = make_fake_text_channel()
+    thread = make_fake_thread(parent=parent)
+    presence_stack.adapter.config.extra["observed_channels"].append(str(thread.id))
+    presence_stack.config.thread_sessions_per_user = False
+
+    assert await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="Ambient thread fact.",
+            author=alice,
+            channel=thread,
+        ),
+    ) is True
+
+    room_entry = presence_stack.store.get_existing_session(
+        room_scoped_source(_source_for(alice, thread))
+    )
+    assert room_entry is not None
+
+    assert await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content=f"<@{BOT_USER_ID}> what was the ambient fact?",
+            author=alice,
+            channel=thread,
+            mentions=[presence_stack.adapter._client.user],
+        ),
+    ) is False
+
+    call = presence_stack.agent_calls[0]
+    assert call.room_context == "[Alice|101]\nAmbient thread fact."
+    assert call.session_id != room_entry.session_id
+    assert call.session_key != room_entry.session_key
+    assert presence_stack.store.load_transcript(room_entry.session_id)[0]["observed"] is True
+
+
+async def test_managed_self_role_dispatches_without_delayed_room_observation(
+    presence_stack,
+):
+    lucy = _author(451517281223180310, "LucyferOS")
+    channel = make_fake_text_channel()
+    self_role = SimpleNamespace(
+        id=1501871552705204237,
+        tags=SimpleNamespace(bot_id=BOT_USER_ID),
+        managed=True,
+    )
+    role_question = make_discord_message(
+        content=(
+            f"<@&{self_role.id}> what did ciacon and Destruxus "
+            "contribute to our conversation?"
+        ),
+        author=lucy,
+        channel=channel,
+    )
+    role_question.role_mentions = [self_role]
+
+    observed = await _route_authorized_message(presence_stack, role_question)
+
+    assert observed is False
+    assert len(presence_stack.agent_calls) == 1
+    first_call = presence_stack.agent_calls[0]
+    assert first_call.event.text == (
+        "what did ciacon and Destruxus contribute to our conversation?"
+    )
+    assert first_call.event.addressing.direct_mention is True
+    assert first_call.room_context is None
+    assert _room_context(presence_stack, lucy, channel) is None
+
+    observed = await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content=f"<@{BOT_USER_ID}> are you there?",
+            author=lucy,
+            channel=channel,
+            mentions=[presence_stack.adapter._client.user],
+        ),
+    )
+
+    assert observed is False
+    assert len(presence_stack.agent_calls) == 2
+    second_call = presence_stack.agent_calls[1]
+    assert second_call.event.text == "are you there?"
+    assert second_call.room_context is None
+    assert _room_context(presence_stack, lucy, channel) is None
+
+
+async def test_bob_mention_gets_separate_session_and_same_room_context(presence_stack):
+    alice = _author(101, "Alice")
+    bob = _author(202, "Bob")
+    channel = make_fake_text_channel()
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(content="The launch moved.", author=alice, channel=channel),
+    )
+
+    for author, question in (
+        (alice, "when is it?"),
+        (bob, "what changed?"),
+    ):
+        await _route_authorized_message(
+            presence_stack,
+            make_discord_message(
+                content=f"<@{BOT_USER_ID}> {question}",
+                author=author,
+                channel=channel,
+                mentions=[presence_stack.adapter._client.user],
+            ),
+        )
+
+    alice_call, bob_call = presence_stack.agent_calls
+    assert alice_call.session_key != bob_call.session_key
+    assert alice_call.session_id != bob_call.session_id
+    assert alice_call.room_context == bob_call.room_context
+    assert bob_call.room_context == "[Alice|101]\nThe launch moved."
+
+
+async def test_other_room_and_thread_are_absent_from_observed_context(presence_stack):
+    alice = _author(101, "Alice")
+    observed_channel = make_fake_text_channel()
+    other_channel = make_fake_text_channel(channel_id=CHANNEL_ID + 1, name="other")
+    observed_thread = make_fake_thread(parent=observed_channel)
+    presence_stack.adapter.config.extra["observed_channels"].append(
+        str(observed_thread.id)
+    )
+
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="Visible only elsewhere.",
+            author=alice,
+            channel=other_channel,
+        ),
+    )
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="Visible here.",
+            author=alice,
+            channel=observed_channel,
+        ),
+    )
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="Visible only in the thread.",
+            author=alice,
+            channel=observed_thread,
+        ),
+    )
+
+    context = _room_context(presence_stack, alice, observed_channel)
+    assert context == "[Alice|101]\nVisible here."
+    assert "elsewhere" not in context
+    assert "thread" not in context
+    assert _room_context(presence_stack, alice, other_channel) is None
+    assert _room_context(presence_stack, alice, observed_thread) == (
+        "[Alice|101]\nVisible only in the thread."
+    )
+
+
+async def test_message_to_another_bot_observes_but_never_dispatches(presence_stack):
+    alice = _author(101, "Alice")
+    other_bot = SimpleNamespace(id=303, name="OtherBot", bot=True)
+    channel = make_fake_text_channel()
+
+    observed = await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="<@303> please update the ticket",
+            author=alice,
+            channel=channel,
+            mentions=[other_bot],
+        ),
+    )
+
+    assert observed is True
+    context = _room_context(
+        presence_stack,
+        alice,
+        channel,
+    )
+    assert context is not None
+    assert "please update the ticket" in context
+    presence_stack.runner._handle_message_with_agent.assert_not_awaited()
+    presence_stack.adapter.send.assert_not_awaited()
+
+
+async def test_feature_disabled_preserves_legacy_ambient_drop(presence_stack):
+    presence_stack.adapter.config.extra["observe_unmentioned_group_messages"] = False
+    alice = _author(101, "Alice")
+    channel = make_fake_text_channel()
+    message = make_discord_message(
+        content="ambient legacy traffic",
+        author=alice,
+        channel=channel,
+    )
+    before = message.content
+
+    observed = await _route_authorized_message(presence_stack, message)
+
+    assert observed is False
+    assert message.content == before
+    assert presence_stack.store._entries == {}
+    presence_stack.runner._handle_message_with_agent.assert_not_awaited()
+    presence_stack.adapter.send.assert_not_awaited()
+    presence_stack.adapter.send_typing.assert_not_awaited()
+
+
+async def test_restart_reloads_observations_without_creating_pending_work(presence_stack):
+    alice = _author(101, "Alice")
+    channel = make_fake_text_channel()
+    await _route_authorized_message(
+        presence_stack,
+        make_discord_message(
+            content="Durable room fact.",
+            author=alice,
+            channel=channel,
+        ),
+    )
+    original_db = presence_stack.store._db
+    assert original_db is not None
+    original_db.close()
+    presence_stack.store._db = None
+
+    reloaded = _new_store(
+        sessions_dir=presence_stack.sessions_dir,
+        db_path=presence_stack.db_path,
+        config=presence_stack.config,
+    )
+    try:
+        assert load_observed_room_context(
+            reloaded,
+            _source_for(alice, channel),
+            now=datetime.now(timezone.utc),
+        ) == "[Alice|101]\nDurable room fact."
+
+        fresh_runner = make_runner(Platform.DISCORD)
+        fresh_runner.config = presence_stack.config
+        fresh_runner.session_store = reloaded
+        fresh_runner._handle_message_with_agent = AsyncMock()
+        fresh_adapter, _ = _make_discord_adapter_wired(fresh_runner)
+        await asyncio.sleep(0)
+
+        fresh_runner._handle_message_with_agent.assert_not_awaited()
+        assert fresh_adapter._background_tasks == set()
+        assert fresh_adapter._pending_messages == {}
+        cast(AsyncMock, fresh_adapter.send).assert_not_awaited()
+    finally:
+        reloaded_db = reloaded._db
+        if reloaded_db is not None:
+            reloaded_db.close()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -719,6 +719,26 @@ class TestLoadGatewayConfig:
             "123456789012345678,999888777666555444"
         )
 
+    def test_bridges_discord_room_observation_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  observe_unmentioned_group_messages: true\n"
+            "  observed_channels:\n"
+            '    - "123456789012345678"\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        discord_config = config.platforms[Platform.DISCORD]
+        assert discord_config.extra["observe_unmentioned_group_messages"] is True
+        assert discord_config.extra["observed_channels"] == ["123456789012345678"]
+
     def test_bridges_discord_platform_extra_allow_from_to_env(self, tmp_path, monkeypatch):
         """platforms.discord.extra.allow_from should reach DISCORD_ALLOWED_USERS too."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_room_observation.py
+++ b/tests/gateway/test_discord_room_observation.py
@@ -1,0 +1,463 @@
+"""Discord adapter contract for opt-in ambient room observation."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageDisposition
+import plugins.platforms.discord.adapter as discord_platform
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1):
+        self.id = channel_id
+        self.name = "dm"
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int = 123, name: str = "bots"):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(id=456, name="Test Guild")
+        self.topic = None
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        async def _iter():
+            return
+            yield
+
+        return _iter()
+
+
+class FakeThread(FakeTextChannel):
+    def __init__(self, channel_id: int = 789, parent=None):
+        super().__init__(channel_id=channel_id, name="thread")
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", self.guild)
+
+
+@pytest.fixture
+def adapter(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for name in (
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_AUTO_THREAD",
+        "DISCORD_HISTORY_BACKFILL",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    config.extra.update(
+        {
+            "require_mention": True,
+            "free_response_channels": [],
+            "history_backfill": False,
+        }
+    )
+    result = DiscordAdapter(config)
+    setattr(result, "_client", SimpleNamespace(user=SimpleNamespace(id=999, bot=True, name="Hermes")))
+    setattr(result, "_text_batch_delay_seconds", 0)
+    setattr(result, "handle_message", AsyncMock())
+    setattr(result, "_auto_create_thread", AsyncMock())
+    setattr(result, "_cache_discord_image", AsyncMock())
+    setattr(result, "_cache_discord_audio", AsyncMock())
+    setattr(result, "_cache_discord_document", AsyncMock())
+    return result
+
+
+def make_message(
+    *,
+    adapter,
+    channel=None,
+    content: str = "ambient hello",
+    mentions=None,
+    role_mentions=None,
+    author=None,
+    reference=None,
+    attachments=None,
+    msg_type=None,
+):
+    channel = channel or FakeTextChannel()
+    author = author or SimpleNamespace(
+        id=42,
+        display_name="Alice",
+        name="Alice",
+        bot=False,
+    )
+    return SimpleNamespace(
+        id=12345,
+        content=content,
+        clean_content=content,
+        mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
+        attachments=list(attachments or []),
+        message_snapshots=[],
+        reference=reference,
+        created_at=datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc),
+        channel=channel,
+        guild=getattr(channel, "guild", None),
+        author=author,
+        type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
+    )
+
+
+def enable_observation(adapter, *channel_ids: str) -> None:
+    adapter.config.extra["observe_unmentioned_group_messages"] = True
+    adapter.config.extra["observed_channels"] = list(channel_ids)
+
+
+def test_observation_config_defaults_off_and_rejects_wildcards_or_names(adapter):
+    assert adapter._discord_observation_enabled() is False
+    assert adapter._discord_observed_channel_ids() == set()
+
+    adapter.config.extra["observe_unmentioned_group_messages"] = True
+    adapter.config.extra["observed_channels"] = ["*", "bots", "#bots", "123"]
+
+    assert adapter._discord_observation_enabled() is True
+    assert adapter._discord_observed_channel_ids() == {"123"}
+
+
+@pytest.mark.asyncio
+async def test_durable_observation_suppresses_legacy_history_backfill(adapter):
+    enable_observation(adapter, "123")
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(
+        return_value="[Recent channel messages]\n[Alice] duplicate context"
+    )
+    message = make_message(
+        adapter=adapter,
+        content="<@999> current request",
+        mentions=[adapter._client.user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._fetch_channel_context.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "current request"
+
+
+@pytest.mark.asyncio
+async def test_legacy_history_backfill_remains_active_outside_observed_channel(adapter):
+    enable_observation(adapter, "999")
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(
+        return_value="[Recent channel messages]\n[Alice] legacy context"
+    )
+    message = make_message(
+        adapter=adapter,
+        content="<@999> current request",
+        mentions=[adapter._client.user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._fetch_channel_context.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_existing_channel_allow_and_ignore_gates_win_before_observation(
+    adapter,
+    monkeypatch,
+):
+    enable_observation(adapter, "123")
+    message = make_message(adapter=adapter)
+
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "123")
+    assert await adapter._maybe_observe_room_message(message) is False
+
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    assert await adapter._maybe_observe_room_message(message) is False
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_free_response_channel_keeps_dispatch_precedence(adapter):
+    enable_observation(adapter, "123")
+    adapter.config.extra["free_response_channels"] = ["123"]
+    message = make_message(adapter=adapter)
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.DISPATCH
+
+
+@pytest.mark.asyncio
+async def test_ambient_text_in_unconfigured_room_remains_dropped(adapter):
+    enable_observation(adapter, "999999")
+    message = make_message(adapter=adapter, channel=FakeTextChannel(channel_id=123))
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ambient_text_in_exact_observed_room_emits_one_observe_event(adapter):
+    enable_observation(adapter, "123")
+    message = make_message(adapter=adapter)
+
+    observed = await adapter._maybe_observe_room_message(message, role_authorized=True)
+
+    assert observed is True
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.OBSERVE
+    assert event.text == "ambient hello"
+    assert event.source.chat_id == "123"
+    assert event.source.scope_id == "456"
+    assert event.source.user_id == "42"
+    assert event.source.user_name == "Alice"
+    assert event.source.role_authorized is True
+    assert event.addressing.direct_mention is False
+    assert event.addressing.reply_to_self is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_self_mention_dispatches_once_and_never_observes(adapter):
+    enable_observation(adapter, "123")
+    message = make_message(
+        adapter=adapter,
+        content="<@999> answer this",
+        mentions=[adapter._client.user],
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.DISPATCH
+    assert event.addressing.direct_mention is True
+
+
+@pytest.mark.asyncio
+async def test_self_managed_role_mention_dispatches_once_and_never_observes(adapter):
+    enable_observation(adapter, "123")
+    self_role = SimpleNamespace(
+        id=777,
+        tags=SimpleNamespace(bot_id=adapter._client.user.id),
+        managed=True,
+    )
+    message = make_message(
+        adapter=adapter,
+        content="<@&777> what did ciacon and Destruxus contribute?",
+        role_mentions=[self_role],
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.DISPATCH
+    assert event.addressing.direct_mention is True
+    assert event.text == "what did ciacon and Destruxus contribute?"
+
+
+@pytest.mark.asyncio
+async def test_raw_self_managed_role_resolves_from_guild_cache(adapter):
+    enable_observation(adapter, "123")
+    self_role = SimpleNamespace(
+        id=777,
+        tags=SimpleNamespace(bot_id=adapter._client.user.id),
+        managed=True,
+    )
+    channel = FakeTextChannel()
+    channel.guild.get_role = lambda role_id: self_role if role_id == 777 else None
+    message = make_message(
+        adapter=adapter,
+        channel=channel,
+        content="<@&777> cached role mention",
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.DISPATCH
+    assert event.addressing.direct_mention is True
+    assert event.text == "cached role mention"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_managed_role_mention_remains_ambient_observation(adapter):
+    enable_observation(adapter, "123")
+    other_role = SimpleNamespace(
+        id=888,
+        tags=SimpleNamespace(bot_id=123456),
+        managed=True,
+    )
+    message = make_message(
+        adapter=adapter,
+        content="<@&888> unrelated role question",
+        role_mentions=[other_role],
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is True
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.OBSERVE
+    assert event.addressing.direct_mention is False
+    assert event.text == "<@&888> unrelated role question"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_self_dispatches_and_never_observes(adapter):
+    enable_observation(adapter, "123")
+    reference = SimpleNamespace(
+        message_id=41,
+        resolved=SimpleNamespace(author=adapter._client.user, content="Prior answer"),
+    )
+    message = make_message(
+        adapter=adapter,
+        content="follow up",
+        mentions=[adapter._client.user],
+        msg_type=discord_platform.discord.MessageType.reply,
+        reference=reference,
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+    if not observed:
+        await adapter._handle_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.DISPATCH
+    assert event.addressing.reply_to_self is True
+
+
+def test_reply_to_self_bypasses_other_bot_multi_agent_filter(adapter):
+    other_bot = SimpleNamespace(id=1234, bot=True, name="Other Bot")
+    ordinary_message = make_message(adapter=adapter, mentions=[other_bot])
+    assert adapter._discord_multi_agent_message_allowed(ordinary_message) is False
+
+    reference = SimpleNamespace(
+        message_id=41,
+        resolved=SimpleNamespace(author=adapter._client.user, content="Prior answer"),
+    )
+    reply = make_message(
+        adapter=adapter,
+        content="follow up",
+        mentions=[other_bot],
+        msg_type=discord_platform.discord.MessageType.reply,
+        reference=reference,
+    )
+    assert adapter._discord_multi_agent_message_allowed(reply) is True
+
+
+@pytest.mark.asyncio
+async def test_human_text_mentioning_another_bot_observes_without_dispatch(adapter):
+    enable_observation(adapter, "123")
+    other_bot = SimpleNamespace(id=555, display_name="OtherBot", name="OtherBot", bot=True)
+    message = make_message(
+        adapter=adapter,
+        content="<@555> your turn",
+        mentions=[other_bot],
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is True
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.OBSERVE
+    assert event.addressing.mentions_other_bots is True
+    assert event.addressing.direct_mention is False
+
+
+@pytest.mark.asyncio
+async def test_other_bot_messages_remain_unobserved_by_default(adapter):
+    enable_observation(adapter, "123")
+    other_bot = SimpleNamespace(id=555, display_name="OtherBot", name="OtherBot", bot=True)
+    message = make_message(adapter=adapter, author=other_bot)
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dm_never_enters_room_observation(adapter):
+    enable_observation(adapter, "1")
+    message = make_message(adapter=adapter, channel=FakeDMChannel(channel_id=1))
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_passive_attachment_uses_metadata_without_read_or_cache(adapter):
+    enable_observation(adapter, "123")
+    attachment = SimpleNamespace(
+        filename="evidence.png",
+        content_type="image/png",
+        size=2048,
+        url="https://cdn.discord.invalid/evidence.png",
+        read=AsyncMock(return_value=b"not-used"),
+    )
+    message = make_message(
+        adapter=adapter,
+        content="",
+        attachments=[attachment],
+    )
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is True
+    event = adapter.handle_message.await_args.args[0]
+    assert event.disposition is MessageDisposition.OBSERVE
+    assert event.text == "[Attachment: evidence.png; image/png; 2048 bytes]"
+    assert event.media_urls == []
+    assert event.media_types == []
+    attachment.read.assert_not_awaited()
+    adapter._cache_discord_image.assert_not_awaited()
+    adapter._cache_discord_audio.assert_not_awaited()
+    adapter._cache_discord_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_observation_path_never_attempts_auto_thread(adapter):
+    enable_observation(adapter, "123")
+    message = make_message(adapter=adapter)
+
+    observed = await adapter._maybe_observe_room_message(message)
+
+    assert observed is True
+    adapter._auto_create_thread.assert_not_awaited()

--- a/tests/gateway/test_message_event_disposition.py
+++ b/tests/gateway/test_message_event_disposition.py
@@ -1,0 +1,42 @@
+"""Tests for normalized message addressing and dispatch disposition."""
+
+from gateway.platforms import (
+    MessageAddressing,
+    MessageDisposition,
+    MessageEvent,
+)
+
+
+def test_message_event_defaults_to_dispatch_with_empty_addressing():
+    event = MessageEvent(text="x")
+
+    assert event.disposition is MessageDisposition.DISPATCH
+    assert event.addressing == MessageAddressing()
+    assert event.metadata == {}
+
+
+def test_message_event_keeps_addressing_and_disposition_out_of_metadata():
+    addressing = MessageAddressing(
+        direct_mention=True,
+        reply_to_self=True,
+        mentions_other_bots=True,
+        mentions_other_users=True,
+    )
+    metadata = {"platform_signal": "kept"}
+
+    event = MessageEvent(
+        text="observe this",
+        addressing=addressing,
+        disposition=MessageDisposition.OBSERVE,
+        metadata=metadata,
+    )
+
+    assert event.addressing is addressing
+    assert event.disposition is MessageDisposition.OBSERVE
+    assert [member.value for member in MessageDisposition] == [
+        "drop",
+        "observe",
+        "dispatch",
+    ]
+    assert event.metadata is metadata
+    assert event.metadata == {"platform_signal": "kept"}

--- a/tests/gateway/test_room_observation.py
+++ b/tests/gateway/test_room_observation.py
@@ -1,0 +1,609 @@
+"""Tests for the platform-neutral observe-only gateway path."""
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms import MessageDisposition, MessageEvent
+from gateway.session import SessionSource, build_session_key
+
+
+class _RecordingSessionStore:
+    """Minimal store that exercises real room session-key construction."""
+
+    def __init__(self) -> None:
+        self.sources = []
+        self.session_ids = {}
+        self.rows = []
+
+    def _generate_session_key(self, source: SessionSource) -> str:
+        return build_session_key(source, group_sessions_per_user=True)
+
+    def get_or_create_session(self, source: SessionSource):
+        self.sources.append(source)
+        key = self._generate_session_key(source)
+        session_id = self.session_ids.setdefault(key, f"session-{len(self.session_ids) + 1}")
+        return SimpleNamespace(session_id=session_id, session_key=key)
+
+    def append_to_transcript(self, session_id: str, message: dict) -> None:
+        self.rows.append((session_id, message))
+
+
+def _make_source(
+    *,
+    user_id: str = "user-1",
+    user_name: str = "Alice",
+    chat_type: str = "channel",
+    thread_id: str | None = "thread-1",
+) -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        scope_id="guild-1",
+        parent_chat_id="parent-1",
+        chat_id="room-1",
+        chat_name="bots",
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+        user_id_alt=f"stable-{user_id}",
+        user_name=user_name,
+    )
+
+
+def _make_event(
+    *,
+    text: str = "ambient message",
+    user_id: str = "user-1",
+    user_name: str = "Alice",
+    chat_type: str = "channel",
+    thread_id: str | None = "thread-1",
+    disposition: MessageDisposition = MessageDisposition.OBSERVE,
+    message_id: str = "message-1",
+    timestamp: datetime | None = None,
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(
+            user_id=user_id,
+            user_name=user_name,
+            chat_type=chat_type,
+            thread_id=thread_id,
+        ),
+        message_id=message_id,
+        timestamp=timestamp or datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc),
+        disposition=disposition,
+    )
+
+
+def _make_runner(*, authorized: bool = True):
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+    )
+    runner: Any = object.__new__(GatewayRunner)
+    runner.config = config
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner.pairing_store.generate_code.return_value = "12345"
+    runner.session_store = _RecordingSessionStore()
+    runner._running_agents = {}
+    runner._update_prompt_pending = {}
+    runner._is_user_authorized = MagicMock(return_value=authorized)
+    runner._get_unauthorized_dm_behavior = MagicMock(return_value="pair")
+    runner._handle_message_with_agent = AsyncMock(return_value="agent-result")
+    return runner, adapter
+
+
+def _set_hook(monkeypatch, results) -> None:
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda name, **kwargs: results if name == "pre_gateway_dispatch" else [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorized_observe_event_appends_exactly_one_observed_row(monkeypatch):
+    _set_hook(monkeypatch, [])
+    runner, adapter = _make_runner(authorized=True)
+    event = _make_event()
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert runner.session_store.rows == [
+        (
+            "session-1",
+            {
+                "role": "user",
+                "content": "[Alice|stable-user-1]\nambient message",
+                "timestamp": "2026-07-10T12:00:00+00:00",
+                "observed": True,
+                "message_id": "message-1",
+            },
+        )
+    ]
+    observed_source = runner.session_store.sources[0]
+    assert observed_source.user_id is None
+    assert observed_source.user_id_alt is None
+    assert observed_source.user_name is None
+    assert observed_source.scope_id == "guild-1"
+    assert observed_source.parent_chat_id == "parent-1"
+    assert observed_source.chat_id == "room-1"
+    assert observed_source.thread_id == "thread-1"
+    runner._handle_message_with_agent.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allowed_channel", "chat_type", "thread_id"),
+    (
+        ("room-1", "channel", None),
+        ("parent-1", "thread", "thread-1"),
+    ),
+)
+async def test_discord_channel_only_grant_authorizes_observation(
+    monkeypatch,
+    allowed_channel,
+    chat_type,
+    thread_id,
+):
+    """The gateway must honor the same channel grant as Discord intake."""
+    _set_hook(monkeypatch, [])
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", allowed_channel)
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLES", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner, _adapter = _make_runner(authorized=False)
+    del runner._is_user_authorized
+
+    result = await runner._handle_message(
+        _make_event(chat_type=chat_type, thread_id=thread_id)
+    )
+
+    assert result is None
+    assert len(runner.session_store.rows) == 1
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_channel_only_grant_authorizes_dispatch(monkeypatch):
+    _set_hook(monkeypatch, [])
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "room-1")
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLES", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner, _adapter = _make_runner(authorized=False)
+    del runner._is_user_authorized
+
+    result = await runner._handle_message(
+        _make_event(
+            chat_type="channel",
+            thread_id=None,
+            disposition=MessageDisposition.DISPATCH,
+        )
+    )
+
+    assert result == "agent-result"
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+def test_discord_channel_grant_never_authorizes_dm_or_unrelated_channel(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "different-room")
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLES", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner, _adapter = _make_runner(authorized=False)
+    del runner._is_user_authorized
+
+    dm_source = _make_event(chat_type="dm", thread_id=None).source
+    channel_source = _make_event(chat_type="channel", thread_id=None).source
+
+    assert runner._is_user_authorized(dm_source) is False
+    assert runner._is_user_authorized(channel_source) is False
+
+
+@pytest.mark.parametrize(
+    ("sender_grant_env", "sender_grant"),
+    (
+        pytest.param("GATEWAY_ALLOWED_USERS", "owner", id="global-user-allowlist"),
+        pytest.param("DISCORD_ALLOWED_USERS", "owner", id="discord-user-allowlist"),
+        pytest.param("DISCORD_ALLOWED_ROLES", "moderator", id="discord-role-allowlist"),
+    ),
+)
+def test_discord_channel_grant_does_not_bypass_sender_allowlist(
+    monkeypatch,
+    sender_grant_env,
+    sender_grant,
+):
+    """An allowed room must not turn a configured sender restriction into allow-all."""
+
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "room-1")
+    for env_var in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv(sender_grant_env, sender_grant)
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner, _adapter = _make_runner(authorized=False)
+    del runner._is_user_authorized
+
+    assert runner._is_user_authorized(
+        _make_event(chat_type="channel", thread_id=None, user_id="intruder").source
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_observed_users_share_room_session_but_keep_content_attribution(monkeypatch):
+    _set_hook(monkeypatch, [])
+    runner, _adapter = _make_runner(authorized=True)
+
+    await runner._handle_message(
+        _make_event(
+            text="first",
+            user_id="user-1",
+            user_name="Alice",
+            message_id="m1",
+            thread_id=None,
+        )
+    )
+    await runner._handle_message(
+        _make_event(
+            text="second",
+            user_id="user-2",
+            user_name="Bob",
+            message_id="m2",
+            thread_id=None,
+        )
+    )
+
+    assert len(runner.session_store.session_ids) == 1
+    assert [session_id for session_id, _row in runner.session_store.rows] == [
+        "session-1",
+        "session-1",
+    ]
+    assert [row["content"] for _session_id, row in runner.session_store.rows] == [
+        "[Alice|stable-user-1]\nfirst",
+        "[Bob|stable-user-2]\nsecond",
+    ]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_observe_event_is_silently_dropped_before_pairing(monkeypatch):
+    _set_hook(monkeypatch, [])
+    runner, adapter = _make_runner(authorized=False)
+    event = _make_event(chat_type="dm")
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert runner.session_store.rows == []
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_internal_observe_event_is_dropped_without_persistence_or_dispatch(monkeypatch):
+    _set_hook(monkeypatch, [])
+    runner, adapter = _make_runner(authorized=True)
+    event = _make_event()
+    event.internal = True
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert runner.session_store.rows == []
+    runner._is_user_authorized.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plugin_skip_prevents_observation_storage(monkeypatch):
+    _set_hook(monkeypatch, [{"action": "skip", "reason": "plugin-handled"}])
+    runner, adapter = _make_runner(authorized=True)
+
+    result = await runner._handle_message(_make_event())
+
+    assert result is None
+    assert runner.session_store.rows == []
+    runner._is_user_authorized.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_event_still_uses_ordinary_agent_path(monkeypatch):
+    _set_hook(monkeypatch, [])
+    runner, _adapter = _make_runner(authorized=True)
+    event = _make_event(disposition=MessageDisposition.DISPATCH)
+
+    result = await runner._handle_message(event)
+
+    assert result == "agent-result"
+    assert runner.session_store.rows == []
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+class _TranscriptDB:
+    def __init__(self) -> None:
+        self.messages: dict[str, list[dict]] = {}
+
+    def get_messages_as_conversation(self, session_id: str) -> list[dict]:
+        return [dict(row) for row in self.messages.get(session_id, [])]
+
+
+def _make_retrieval_store():
+    from gateway.session import SessionStore
+
+    store: Any = object.__new__(SessionStore)
+    store.config = GatewayConfig()
+    store.sessions_dir = None
+    store._entries = {}
+    store._loaded = True
+    store._lock = Lock()
+    store._db = _TranscriptDB()
+    return store
+
+
+def _route_room_transcript(store, source: SessionSource, rows: list[dict], session_id: str) -> None:
+    from gateway.room_observation import room_scoped_source
+
+    room_source = room_scoped_source(source)
+    key = store._generate_session_key(room_source)
+    store._entries[key] = SimpleNamespace(session_id=session_id)
+    store._db.messages[session_id] = rows
+
+
+def _observed_row(content: str, timestamp: datetime) -> dict:
+    return {
+        "role": "user",
+        "content": content,
+        "timestamp": timestamp.isoformat(),
+        "observed": True,
+    }
+
+
+def test_bounded_observation_retrieval_reads_same_room_only():
+    from gateway.room_observation import room_scoped_source
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    source = _make_source(thread_id=None)
+    store = _make_retrieval_store()
+    row = _observed_row("[Alice|1]\nsame room", now - timedelta(minutes=5))
+    _route_room_transcript(store, source, [row], "room-session")
+
+    result = store.load_recent_observed_messages(
+        room_scoped_source(source),
+        now=now,
+    )
+
+    assert result == [row]
+
+
+def test_bounded_observation_retrieval_does_not_create_missing_room_session():
+    from gateway.room_observation import room_scoped_source
+
+    source = _make_source(thread_id=None)
+    store = _make_retrieval_store()
+
+    result = store.load_recent_observed_messages(room_scoped_source(source))
+
+    assert result == []
+    assert store._entries == {}
+
+
+def test_bounded_observation_retrieval_never_crosses_room_or_thread():
+    from gateway.room_observation import room_scoped_source
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    source = _make_source(thread_id="thread-1")
+    other_room = _make_source(thread_id="thread-1")
+    other_room.chat_id = "room-2"
+    other_thread = _make_source(thread_id="thread-2")
+    other_platform = _make_source(thread_id="thread-1")
+    other_platform.platform = Platform.SLACK
+    store = _make_retrieval_store()
+    expected = _observed_row("same", now - timedelta(minutes=3))
+    _route_room_transcript(store, source, [expected], "same-session")
+    _route_room_transcript(
+        store,
+        other_room,
+        [_observed_row("wrong room", now - timedelta(minutes=2))],
+        "other-room-session",
+    )
+    _route_room_transcript(
+        store,
+        other_thread,
+        [_observed_row("wrong thread", now - timedelta(minutes=1))],
+        "other-thread-session",
+    )
+    _route_room_transcript(
+        store,
+        other_platform,
+        [_observed_row("wrong platform", now - timedelta(seconds=30))],
+        "other-platform-session",
+    )
+
+    result = store.load_recent_observed_messages(
+        room_scoped_source(source),
+        now=now,
+    )
+
+    assert result == [expected]
+
+
+def test_bounded_observation_retrieval_applies_age_limit_count_limit_and_order():
+    from gateway.room_observation import room_scoped_source
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    source = _make_source(thread_id=None)
+    store = _make_retrieval_store()
+    recent = [
+        _observed_row(f"message-{index:02d}", now - timedelta(minutes=30 - index))
+        for index in range(30)
+    ]
+    noise = [
+        _observed_row("too old", now - timedelta(hours=7)),
+        {"role": "user", "content": "missing timestamp", "observed": True},
+        {"role": "user", "content": "bad timestamp", "timestamp": "nope", "observed": True},
+        {
+            "role": "assistant",
+            "content": "not an observation",
+            "timestamp": now.isoformat(),
+            "observed": True,
+        },
+        {
+            "role": "user",
+            "content": "ordinary user row",
+            "timestamp": now.isoformat(),
+            "observed": False,
+        },
+    ]
+    _route_room_transcript(store, source, list(reversed(recent + noise)), "bounded-session")
+
+    result = store.load_recent_observed_messages(
+        room_scoped_source(source),
+        now=now,
+        limit=25,
+        max_age=timedelta(hours=6),
+    )
+
+    assert [row["content"] for row in result] == [
+        f"message-{index:02d}" for index in range(5, 30)
+    ]
+
+
+def test_observation_retrieval_accepts_sqlite_numeric_timestamps():
+    from gateway.room_observation import room_scoped_source
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    source = _make_source(thread_id=None)
+    store = _make_retrieval_store()
+    row = _observed_row("persisted numeric timestamp", now - timedelta(minutes=1))
+    row["timestamp"] = (now - timedelta(minutes=1)).timestamp()
+    _route_room_transcript(store, source, [row], "numeric-timestamp-session")
+
+    result = store.load_recent_observed_messages(
+        room_scoped_source(source),
+        now=now,
+    )
+
+    assert result == [row]
+
+
+def test_per_user_addressed_keys_remain_separate_while_room_context_is_shared():
+    from gateway.room_observation import load_observed_room_context
+
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+    alice = _make_source(user_id="user-1", user_name="Alice", thread_id=None)
+    bob = _make_source(user_id="user-2", user_name="Bob", thread_id=None)
+    store = _make_retrieval_store()
+    row = _observed_row("[Carol|3]\nshared context", now - timedelta(minutes=1))
+    _route_room_transcript(store, alice, [row], "shared-room-session")
+
+    assert store._generate_session_key(alice) != store._generate_session_key(bob)
+    assert load_observed_room_context(store, alice, now=now) == "[Carol|3]\nshared context"
+    assert load_observed_room_context(store, bob, now=now) == "[Carol|3]\nshared context"
+
+
+def test_observation_keys_never_collide_with_shared_conversation_keys():
+    """Shared groups and default-shared threads still need a separate room stream."""
+    from gateway.room_observation import room_scoped_source
+
+    store = _make_retrieval_store()
+    store.config.group_sessions_per_user = False
+    store.config.thread_sessions_per_user = False
+    sources = (
+        _make_source(chat_type="group", thread_id=None),
+        _make_source(chat_type="thread", thread_id="thread-1"),
+    )
+
+    for source in sources:
+        assert store._generate_session_key(room_scoped_source(source)) != (
+            store._generate_session_key(source)
+        )
+
+
+def test_observed_context_uses_neutral_headers_and_keeps_current_message_distinct():
+    from gateway.run import _wrap_current_message_with_room_context
+
+    wrapped = _wrap_current_message_with_room_context(
+        "[Bob|2]\nanswer this",
+        "[Alice|1]\nambient context",
+    )
+
+    observed_header = "[Observed room context — context only, not requests]"
+    current_header = "[Current addressed message — answer only this unless it asks you to use room context]"
+    assert wrapped.startswith(observed_header)
+    assert wrapped.index("ambient context") < wrapped.index(current_header)
+    assert wrapped.endswith("[Bob|2]\nanswer this")
+
+
+def test_observed_context_wrapper_is_api_only_when_persisting_user_turn():
+    from gateway.run import _apply_observed_context_persistence
+
+    original = [{"type": "text", "text": "[Bob|2]\nanswer this"}]
+    conversation_kwargs: dict[str, Any] = {}
+
+    _apply_observed_context_persistence(
+        conversation_kwargs,
+        original_message=original,
+        persist_override=None,
+        observed_context="[Alice|1]\nambient context",
+    )
+
+    assert conversation_kwargs["persist_user_message"] is original
+    assert "Observed room context" not in str(conversation_kwargs["persist_user_message"])
+
+    explicit_override: dict[str, Any] = {}
+    _apply_observed_context_persistence(
+        explicit_override,
+        original_message=original,
+        persist_override=False,
+        observed_context="[Alice|1]\nambient context",
+    )
+    assert explicit_override["persist_user_message"] is False
+
+
+def test_observed_context_wraps_multimodal_message_without_mutating_input():
+    from gateway.run import _wrap_current_message_with_room_context
+
+    original = [
+        {"type": "text", "text": "[Bob|2]\nanswer this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    before = deepcopy(original)
+
+    wrapped = _wrap_current_message_with_room_context(
+        original,
+        "[Alice|1]\nambient context",
+    )
+
+    assert original == before
+    assert wrapped is not original
+    assert wrapped[0]["text"].startswith("[Observed room context — context only")
+    assert wrapped[0]["text"].endswith("[Bob|2]\nanswer this image")
+    assert wrapped[1] == original[1]

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -317,6 +317,8 @@ discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
+  observe_unmentioned_group_messages: false  # Persist ambient context in explicit channels
+  observed_channels: []           # Exact numeric channel/thread IDs to observe
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
@@ -451,6 +453,49 @@ Behavior:
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
+#### `discord.observe_unmentioned_group_messages`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, Hermes can retain unmentioned messages from the exact channels or
+threads listed in `discord.observed_channels`. Observation is silent: it does not
+invoke the agent, run tools, add processing reactions, or send a response. On a
+later addressed message in the same room, Hermes injects up to 25 observations
+from the preceding six hours as attributed context.
+
+Both settings are required, so enabling observation without an explicit channel
+list retains nothing:
+
+```yaml
+discord:
+  require_mention: true
+  observe_unmentioned_group_messages: true
+  observed_channels:
+    - "123456789012345678"  # exact channel ID
+    - "234567890123456789"  # exact thread ID, if desired
+```
+
+`observed_channels` accepts a YAML list or comma-separated string. Entries must
+be numeric Discord snowflake IDs; channel names and wildcards are ignored so a
+rename or server reorganization cannot silently widen retention. Threads must be
+listed by their own ID rather than inheriting observation from a parent channel.
+
+Observation is limited to ordinary, unmentioned messages in mention-gated server
+rooms that also pass the existing allowed/ignored-channel and authorization
+checks. DMs, bot-authored messages, directly addressed messages, free-response
+channels, active bot threads, and voice-linked text channels keep their existing
+dispatch behavior and are not observed.
+
+Observed rows use a dedicated room namespace rather than an ordinary user or
+shared conversation transcript. In an observed channel, durable observation owns
+the missed-message context, so `history_backfill` is skipped for that room.
+
+:::warning Retention and privacy
+Ambient observation persists channel messages even though Hermes does not reply.
+Enable it only in channels whose participants expect that retention, and keep the
+explicit channel list as narrow as practical.
+:::
+
 #### `discord.history_backfill`
 
 **Type:** boolean — **Default:** `true`
@@ -463,6 +508,7 @@ Behavior by surface:
 - **Threads**: backfill scans the thread only — Discord's `channel.history()` on a thread returns only that thread's messages, not the parent channel. This is the right scope because threads are usually self-contained conversations.
 - **DMs**: skipped. Every DM message triggers the bot, so the session transcript is already complete — there's no mention gap to fill.
 - **Free-response channels** and **bot's own auto-created threads**: skipped for the same reason — no mention gating means no gap.
+- **Observed channels**: skipped because their bounded durable observation context owns the gap instead.
 
 Per-user sessions (`group_sessions_per_user: true`, the default) also benefit: a user's session is missing the context posted by other channel participants and the user's own messages from before they tagged the bot. Backfill fills both gaps.
 


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, disabled-by-default Discord room-observation mode for mention-gated channels. In channels selected by numeric ID, unmentioned messages are retained silently and supplied as bounded context when Hermes is later addressed.

The implementation uses a platform-neutral `MessageDisposition.OBSERVE` contract while keeping the opt-in policy in the Discord adapter. Observation does not invoke the agent, run tools, add processing reactions, or send a response.

Privacy and isolation are deliberate:

- observation requires both the disabled-by-default feature flag and an explicit numeric channel/thread ID;
- authorization and existing allowed/ignored-channel gates run before persistence;
- observed rows use a dedicated room namespace, separate from ordinary user and shared conversation transcripts;
- replay is bounded to 25 messages from the previous six hours;
- DMs, bot-authored messages, directly addressed messages, free-response channels, active bot threads, and voice-linked channels retain their existing behavior;
- durable observation replaces Discord history backfill only in explicitly observed rooms.

## Related Issue

None found. Searched open and closed issues and PRs for Discord room observation, ambient context, unmentioned-message observation, and channel-history mention behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a normalized gateway message-disposition contract with an `OBSERVE` path that persists without dispatching inference.
- Added explicit Discord `observe_unmentioned_group_messages` and `observed_channels` configuration.
- Added dedicated room-scoped observation sessions and bounded context loading.
- Enforced Discord authorization and explicit channel retention boundaries before persistence.
- Limited channel-only authorization to deployments with no Discord user/role or global user allowlist, preventing allowed channels from bypassing configured sender restrictions.
- Preserved Discord's existing dispatch modes and disabled redundant history backfill in observed rooms.
- Added unit, adapter-contract, authorization, and real-store end-to-end coverage.
- Documented configuration, bounds, interaction with history backfill, and retention/privacy implications.

## How to Test

1. Configure a mention-gated Discord channel:

   ```yaml
   discord:
     require_mention: true
     observe_unmentioned_group_messages: true
     observed_channels:
       - "<numeric-channel-id>"
   ```

2. Send an unmentioned message in the configured channel. Verify Hermes sends no response, runs no agent turn, and stores one attributed observation in the dedicated `room_observation` session namespace.
3. Mention Hermes in the same channel. Verify the recent observed message is included as context, while observations older than six hours or beyond the 25-message limit are excluded.
4. Set `GATEWAY_ALLOWED_USERS=<owner-user-id>` while keeping the channel allowed. Verify a different channel member is rejected; the channel allowlist must not bypass the configured sender allowlist.
5. Verify messages in unlisted, ignored, unauthorized, DM, free-response, active-thread, and voice-linked surfaces retain their existing behavior.
6. Run the focused suite with the repository's per-file isolation harness:

   ```bash
   scripts/run_tests.sh -j 4 \
     tests/e2e/test_discord_room_observation.py \
     tests/gateway/test_room_observation.py \
     tests/gateway/test_discord_room_observation.py \
     tests/gateway/test_message_event_disposition.py \
     tests/gateway/test_discord_allowed_channels.py \
     tests/gateway/test_config_driven_access_policy.py \
     tests/gateway/test_config.py \
     tests/gateway/test_session.py
   ```

7. Run repository gates:

   ```bash
   scripts/run_tests.sh
   ruff check .
   python scripts/check-windows-footguns.py --all
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — a fresh all-extras environment passed 40,354 tests and reproduced the same four container/browser-sensitive failures on the feature branch and pristine current `upstream/main`; GitHub's `ubuntu-latest` CI must establish the VM result
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux 43; focused automated and real-store E2E coverage on the final commit

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/discord.md`)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` architecture or workflow update: N/A
- [x] I've considered cross-platform impact; the change adds no OS-specific file, process, terminal, signal, or path behavior, and the Windows-footgun scan passes
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused validation on the final implementation:

```text
565 passed in the isolated 21-file authorization/Discord/session/rebase compatibility matrix
ruff check .: passed
targeted ty check: passed
Windows footgun scanner: passed
python compileall (changed Python): passed
git diff --check: clean
docs diagram lint: passed
Docusaurus production build: passed
```

A prior exploratory Discord canary validated silent observation and later contextual replay. The final dedicated-namespace and authorization hardening were validated through the real session-store E2E test rather than deployed to that live canary.

Complete isolated-suite validation used a detached worktree, fresh `.venv`,
`uv sync --locked --python 3.11 --extra all --extra dev`, and an empty temporary
`HOME`:

```text
1,979 files
40,354 tests passed
4 tests failed in 3 files
```

The three failing files were rerun on the feature SHA and pristine current
`upstream/main` with the same dependencies and fresh homes. Both produced the
same four assertions: one Copilot ACP HOME test and two voice-environment tests
detect this containerized host, while one browser test expects a local
Chromium-family binary. None overlap this PR. Leave the all-tests checkbox
unchecked unless GitHub's `ubuntu-latest` VM or another non-container clean
environment passes the complete suite.