### PR TITLE
fix(model): hide exhausted providers from pickers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1394,6 +1394,25 @@ import threading as _threading  # noqa: E402
 _picker_prewarm_done = _threading.Event()
 
 
+def _credential_pool_is_usable(provider: str, *, raw_pool_present: bool = False) -> bool:
+    """Return whether *provider* has a credential that can be selected now.
+
+    ``auth.json`` historically allowed opaque token-style pool values that do
+    not deserialize into ``PooledCredential`` entries. Preserve visibility for
+    those legacy values, but when a real pool exists its availability state is
+    authoritative: an all-exhausted/dead pool is not authenticated.
+    """
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider)
+        if pool.has_credentials():
+            return pool.has_available()
+    except Exception:
+        pass
+    return raw_pool_present
+
+
 def _extra_headers_from_config(entry: Any) -> dict[str, str]:
     if not isinstance(entry, dict):
         return {}
@@ -1696,22 +1715,13 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and store.get("credential_pool", {}).get(hermes_id):
-                    has_creds = True
-                    # ...but if it parses into a full pool whose every entry is
-                    # exhausted/dead, it has no usable credential right now, so
-                    # don't treat it as authenticated -- otherwise an aggregator
-                    # whose quota is spent hijacks no-provider model resolution
-                    # and sticks as the session provider (#45759). Simple
-                    # token-style entries (no exhaustion-tracked entries) keep
-                    # the prior behaviour.
-                    try:
-                        from agent.credential_pool import load_pool as _load_pool
-                        _pool = _load_pool(hermes_id)
-                        if _pool.has_credentials() and not _pool.has_available():
-                            has_creds = False
-                    except Exception:
-                        pass
+                raw_pool_present = bool(
+                    store and store.get("credential_pool", {}).get(hermes_id)
+                )
+                if raw_pool_present:
+                    has_creds = _credential_pool_is_usable(
+                        hermes_id, raw_pool_present=True
+                    )
             except Exception:
                 pass
         if not has_creds:
@@ -1800,12 +1810,7 @@ def list_authenticated_providers(
         # imports on demand but aren't in the raw auth.json yet.
         if not has_creds:
             try:
-                from agent.credential_pool import load_pool
-                pool = load_pool(hermes_slug)
-                # has_available(), not has_credentials(): an all-exhausted pool
-                # holds entries but no usable credential, so it must not count
-                # as authenticated (#45759).
-                if pool.has_available():
+                if _credential_pool_is_usable(hermes_slug):
                     has_creds = True
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
@@ -1944,11 +1949,7 @@ def list_authenticated_providers(
                 pass
         if not _cp_has_creds:
             try:
-                from agent.credential_pool import load_pool
-                _cp_pool = load_pool(_cp.slug)
-                # has_available(): exclude pools whose every entry is exhausted
-                # (#45759).
-                if _cp_pool.has_available():
+                if _credential_pool_is_usable(_cp.slug):
                     _cp_has_creds = True
             except Exception:
                 pass

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1698,6 +1698,20 @@ def list_authenticated_providers(
                 store = _load_auth_store()
                 if store and store.get("credential_pool", {}).get(hermes_id):
                     has_creds = True
+                    # ...but if it parses into a full pool whose every entry is
+                    # exhausted/dead, it has no usable credential right now, so
+                    # don't treat it as authenticated -- otherwise an aggregator
+                    # whose quota is spent hijacks no-provider model resolution
+                    # and sticks as the session provider (#45759). Simple
+                    # token-style entries (no exhaustion-tracked entries) keep
+                    # the prior behaviour.
+                    try:
+                        from agent.credential_pool import load_pool as _load_pool
+                        _pool = _load_pool(hermes_id)
+                        if _pool.has_credentials() and not _pool.has_available():
+                            has_creds = False
+                    except Exception:
+                        pass
             except Exception:
                 pass
         if not has_creds:
@@ -1788,7 +1802,10 @@ def list_authenticated_providers(
             try:
                 from agent.credential_pool import load_pool
                 pool = load_pool(hermes_slug)
-                if pool.has_credentials():
+                # has_available(), not has_credentials(): an all-exhausted pool
+                # holds entries but no usable credential, so it must not count
+                # as authenticated (#45759).
+                if pool.has_available():
                     has_creds = True
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
@@ -1929,7 +1946,9 @@ def list_authenticated_providers(
             try:
                 from agent.credential_pool import load_pool
                 _cp_pool = load_pool(_cp.slug)
-                if _cp_pool.has_credentials():
+                # has_available(): exclude pools whose every entry is exhausted
+                # (#45759).
+                if _cp_pool.has_available():
                     _cp_has_creds = True
             except Exception:
                 pass

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -76,3 +76,22 @@ def test_pool_provider_with_available_credential_is_authenticated(monkeypatch):
     _patch_opencode_pool(monkeypatch, available=True)
     slugs = get_authenticated_provider_slugs(current_provider="alibaba")
     assert "opencode-go" in slugs
+
+
+def test_opaque_legacy_pool_value_stays_visible(monkeypatch):
+    """Legacy token-style auth-store values have no parsed pool entries."""
+    from hermes_cli.model_switch import _credential_pool_is_usable
+
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda _provider: type(
+            "EmptyPool",
+            (),
+            {
+                "has_credentials": lambda self: False,
+                "has_available": lambda self: False,
+            },
+        )(),
+    )
+
+    assert _credential_pool_is_usable("opencode-go", raw_pool_present=True)

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -1,0 +1,78 @@
+"""Regression test for #45759.
+
+An all-exhausted credential pool holds entries but no *usable* credential.
+``list_authenticated_providers`` must not treat such a provider as
+authenticated -- otherwise an aggregator whose quota is spent gets matched
+during no-provider ``/model`` resolution, wins the model name, and sticks as
+the session provider (the "sticky provider fallback pollution" bug).
+"""
+
+import pytest
+
+
+class _FakePool:
+    def __init__(self, available: bool):
+        self._available = available
+
+    def has_credentials(self) -> bool:
+        # The pool still holds entries...
+        return True
+
+    def has_available(self) -> bool:
+        # ...but none of them are usable when exhausted/dead.
+        return self._available
+
+
+def _patch_opencode_pool(monkeypatch, *, available: bool):
+    """Make the opencode-go aggregator look configured but with a pool whose
+    only credential is (un)available, depending on ``available``."""
+    import hermes_cli.auth as auth
+    import agent.credential_pool as cp
+
+    monkeypatch.setattr(
+        auth,
+        "_load_auth_store",
+        lambda: {
+            "version": 1,
+            "providers": {},
+            "active_provider": None,
+            "credential_pool": {"opencode-go": {"entries": [{"id": "x"}]}},
+        },
+    )
+    monkeypatch.setattr(
+        cp,
+        "load_pool",
+        lambda provider: _FakePool(available if provider == "opencode-go" else True),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _strip_provider_env(monkeypatch):
+    """Don't let real provider keys in the environment authenticate providers
+    through a different code path than the pool gate under test."""
+    import os
+
+    for key in list(os.environ):
+        if "OPENCODE" in key or key.endswith("_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_exhausted_pool_provider_is_not_authenticated(monkeypatch):
+    """The fix: an exhausted pool is NOT authenticated. Fails on main, where
+    the gate accepted any stored pool entry regardless of usability."""
+    from hermes_cli.model_switch import get_authenticated_provider_slugs
+
+    _patch_opencode_pool(monkeypatch, available=False)
+    slugs = get_authenticated_provider_slugs(current_provider="alibaba")
+    assert "opencode-go" not in slugs
+
+
+def test_pool_provider_with_available_credential_is_authenticated(monkeypatch):
+    """Control: with a usable credential the provider IS authenticated, proving
+    the test drives the credential gate rather than excluding it for some other
+    reason."""
+    from hermes_cli.model_switch import get_authenticated_provider_slugs
+
+    _patch_opencode_pool(monkeypatch, available=True)
+    slugs = get_authenticated_provider_slugs(current_provider="alibaba")
+    assert "opencode-go" in slugs


### PR DESCRIPTION
1|## Summary
2|Model pickers no longer treat providers with only exhausted or dead pooled credentials as authenticated, preventing unusable aggregators from hijacking model resolution.
3|
4|The inventory previously checked whether a pool contained entries, not whether any entry could be selected now. An exhausted aggregator could therefore win a no-provider model match and become sticky despite having no callable credential.
5|
6|## Changes
7|- Preserve @AIalliAI's #45810 availability fix and regression case.
8|- Centralize the three duplicated credential-pool gates behind one availability predicate.
9|- Keep legacy opaque token-style auth-store values visible when they cannot deserialize into a modern pool.
10|- Test exhausted, healthy, and legacy pool contracts independently.
11|
12|## Validation
13|| Path | Result |
14||---|---|
15|| Exhausted-pool, overlay, and inventory suites | 52 passed |
16|| Real `CredentialPool` with exhausted-only entries | Hidden |
17|| Real pool with one healthy entry | Visible |
18|| `git diff --check` | Passed |
19|
20|Fixes #45759. Supersedes #45810.
21|
22|## Infographic
23|
24|![Credential availability mission](https://v3b.fal.media/files/b/0aa1ed41/JnbeoyUkO82Zq8SmF3Hlp_0PxMb3eL.png)
25|