### PR TITLE
fix(plugins): warn when required env vars are missing, handle str/dict manifest entries

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1764,16 +1764,55 @@ class PluginManager:
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
                 loaded.enabled = True
+
+                # Warn when all required env vars are present but the plugin
+                # registered nothing on any surface. Normalize requires_env
+                # entries (str or dict) before checking the process environment,
+                # mirroring hermes_cli/plugins_cmd.py:307-314.
+                _missing_env: list[str] = []
+                for _entry in manifest.requires_env or []:
+                    if isinstance(_entry, str):
+                        _var_name = _entry
+                    elif isinstance(_entry, dict):
+                        _var_name = _entry.get("name", "")
+                    else:
+                        _var_name = ""
+                    if _var_name and not os.environ.get(_var_name):
+                        _missing_env.append(_var_name)
+
+                if _missing_env:
+                    logger.warning(
+                        "Plugin '%s': required env var(s) not set: %s "
+                        "-- plugin may be non-functional",
+                        manifest.name, ", ".join(_missing_env),
+                    )
+
+                _cli_cmd_count = sum(
+                    1 for c in self._cli_commands
+                    if self._cli_commands[c].get("plugin") == manifest.name
+                )
+                _nothing_registered = not any([
+                    loaded.tools_registered,
+                    loaded.hooks_registered,
+                    loaded.middleware_registered,
+                    loaded.commands_registered,
+                    _cli_cmd_count,
+                ])
+                if _nothing_registered and not manifest.requires_env:
+                    logger.debug(
+                        "Plugin '%s' registered no tools, hooks, middleware, "
+                        "or commands -- it may register a provider or be a "
+                        "no-op stub",
+                        manifest.name,
+                    )
+
                 logger.debug(
                     "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
                     len(loaded.tools_registered),
                     len(loaded.hooks_registered),
                     len(loaded.middleware_registered),
                     len(loaded.commands_registered),
-                    sum(
-                        1 for c in self._cli_commands
-                        if self._cli_commands[c].get("plugin") == manifest.name
-                    ),
+                    _cli_cmd_count,
                 )
 
         except Exception as exc:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2201,3 +2201,125 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestRequiresEnvWarning:
+    """Regression tests for issue #2768: _load_plugin() warns when required
+    env vars are missing, handling both str and dict manifest entries.
+    """
+
+    def _make_manager(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mgr = PluginManager()
+        return mgr
+
+    def test_requires_env_str_missing_emits_warning(self, tmp_path, monkeypatch, caplog):
+        """A missing env var declared as a plain string must produce a WARNING."""
+        import logging
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("_TEST_MISSING_VAR_2768", raising=False)
+
+        plugin_dir = tmp_path / "plugins" / "envtest"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text("def register(ctx): pass\n")
+
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="envtest",
+            source="user",
+            path=str(plugin_dir),
+            requires_env=["_TEST_MISSING_VAR_2768"],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest)
+
+        assert any(
+            "_TEST_MISSING_VAR_2768" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), "Expected WARNING about missing env var, got: " + str([r.message for r in caplog.records])
+
+    def test_requires_env_dict_missing_emits_warning(self, tmp_path, monkeypatch, caplog):
+        """A missing env var declared as a dict {name: ...} must also warn."""
+        import logging
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("_TEST_DICT_VAR_2768", raising=False)
+
+        plugin_dir = tmp_path / "plugins" / "envtest_dict"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text("def register(ctx): pass\n")
+
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="envtest_dict",
+            source="user",
+            path=str(plugin_dir),
+            requires_env=[{"name": "_TEST_DICT_VAR_2768", "description": "test var"}],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest)
+
+        assert any(
+            "_TEST_DICT_VAR_2768" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_requires_env_present_no_warning(self, tmp_path, monkeypatch, caplog):
+        """When the required env var IS set, no missing-env warning must fire."""
+        import logging
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("_TEST_PRESENT_VAR_2768", "set")
+
+        plugin_dir = tmp_path / "plugins" / "envtest_ok"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text("def register(ctx): pass\n")
+
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="envtest_ok",
+            source="user",
+            path=str(plugin_dir),
+            requires_env=["_TEST_PRESENT_VAR_2768"],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest)
+
+        assert not any(
+            "_TEST_PRESENT_VAR_2768" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_provider_only_plugin_no_false_positive(self, tmp_path, monkeypatch, caplog):
+        """A plugin that registers only a provider (no tools/hooks/commands)
+        must not produce a spurious empty-registration warning -- provider
+        registrations are not tracked in LoadedPlugin.
+        """
+        import logging
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        plugin_dir = tmp_path / "plugins" / "provider_only"
+        plugin_dir.mkdir(parents=True)
+        # Simulates a provider-only plugin like plugins/image_gen/fal
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n    pass  # registers a provider internally\n"
+        )
+
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="provider_only",
+            source="user",
+            path=str(plugin_dir),
+            requires_env=[],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest)
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("registered no tools" in m for m in warning_msgs), (
+            f"False positive warning for provider-only plugin: {warning_msgs}"
+        )


### PR DESCRIPTION
## Problem

_load_plugin() emitted only a DEBUG registration count, so a plugin whose required env vars were absent loaded silently (issue #2768).

## Fix

Normalize requires_env entries (str or dict, matching hermes_cli/plugins_cmd.py:307-314) before checking the process environment. Emit a WARNING when any required env var is not set. The empty-registration note is demoted to DEBUG to avoid false positives for provider-only plugins (e.g. image_gen/fal) whose registrations are not tracked in LoadedPlugin.

Addresses all three points from the maintainer review of #2768: requires_env normalization for both manifest forms, correct registration surface accounting (no false WARNING for providers), and tests ported to tests/hermes_cli/test_plugins.py.

## Verification

4 new tests: str-form missing env, dict-form missing env, present env no warning, provider-only no false-positive. 4/4 pass alongside 100 existing plugin tests.

Fixes #2768