### PR TITLE
fix(desktop): relativize Windows backslash paths in contextPath

### DIFF
--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   attachmentDisplayText,
   attachmentId,
   coerceThinkingText,
+  contextPath,
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -112,6 +113,31 @@ describe('parseCommandDispatch', () => {
 
   it('rejects a prefill directive missing its message', () => {
     expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
+  })
+})
+
+describe('contextPath', () => {
+  it('relativizes a Windows backslash path under a backslash cwd', () => {
+    // On Windows the OS hands us backslash paths; the ref must still collapse to
+    // the project-relative form the agent expects (`@file:src/a.ts`), not the
+    // full absolute path.
+    expect(contextPath('C:\\Users\\me\\proj\\src\\a.ts', 'C:\\Users\\me\\proj')).toBe('src/a.ts')
+  })
+
+  it('handles a Windows cwd that already carries a trailing separator', () => {
+    expect(contextPath('C:\\proj\\a.ts', 'C:\\proj\\')).toBe('a.ts')
+  })
+
+  it('still relativizes POSIX paths', () => {
+    expect(contextPath('/home/me/proj/src/a.ts', '/home/me/proj')).toBe('src/a.ts')
+  })
+
+  it('returns the original path unchanged when it is not under cwd', () => {
+    expect(contextPath('/other/x.ts', '/home/me/proj')).toBe('/other/x.ts')
+  })
+
+  it('returns the path unchanged when cwd is empty', () => {
+    expect(contextPath('C:\\Users\\me\\a.ts', '')).toBe('C:\\Users\\me\\a.ts')
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -128,8 +128,25 @@ describe('contextPath', () => {
     expect(contextPath('C:\\proj\\a.ts', 'C:\\proj\\')).toBe('a.ts')
   })
 
+  it('folds case on Windows so a differently cased cwd still relativizes', () => {
+    // Windows path identity is case-insensitive: the picker may hand back
+    // `C:\Users\Me\...` while the session cwd is stored as `c:/users/me/...`.
+    expect(contextPath('C:\\Users\\Me\\Proj\\src\\a.ts', 'c:/users/me/proj')).toBe('src/a.ts')
+  })
+
+  it('preserves the original spelling of the relativized tail on Windows', () => {
+    // Only the comparison key is lowercased; the emitted ref keeps the caller's
+    // casing so the path still resolves for case-preserving tooling.
+    expect(contextPath('C:\\proj\\Src\\MyFile.TS', 'c:\\PROJ')).toBe('Src/MyFile.TS')
+  })
+
   it('still relativizes POSIX paths', () => {
     expect(contextPath('/home/me/proj/src/a.ts', '/home/me/proj')).toBe('src/a.ts')
+  })
+
+  it('keeps POSIX comparison case-sensitive', () => {
+    // No case folding off Windows: `/home/me/Proj` is a different directory.
+    expect(contextPath('/home/me/Proj/src/a.ts', '/home/me/proj')).toBe('/home/me/Proj/src/a.ts')
   })
 
   it('returns the original path unchanged when it is not under cwd', () => {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   attachmentId,
   coalesceToolOnlyAssistants,
   coerceThinkingText,
+  contextPath,
   createToolMergeCache,
   messageCreatedAt,
   optimisticAttachmentRef,
@@ -154,6 +155,31 @@ describe('parseCommandDispatch', () => {
 
   it('rejects a prefill directive missing its message', () => {
     expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
+  })
+})
+
+describe('contextPath', () => {
+  it('relativizes a Windows backslash path under a backslash cwd', () => {
+    // On Windows the OS hands us backslash paths; the ref must still collapse to
+    // the project-relative form the agent expects (`@file:src/a.ts`), not the
+    // full absolute path.
+    expect(contextPath('C:\\Users\\me\\proj\\src\\a.ts', 'C:\\Users\\me\\proj')).toBe('src/a.ts')
+  })
+
+  it('handles a Windows cwd that already carries a trailing separator', () => {
+    expect(contextPath('C:\\proj\\a.ts', 'C:\\proj\\')).toBe('a.ts')
+  })
+
+  it('still relativizes POSIX paths', () => {
+    expect(contextPath('/home/me/proj/src/a.ts', '/home/me/proj')).toBe('src/a.ts')
+  })
+
+  it('returns the original path unchanged when it is not under cwd', () => {
+    expect(contextPath('/other/x.ts', '/home/me/proj')).toBe('/other/x.ts')
+  })
+
+  it('returns the path unchanged when cwd is empty', () => {
+    expect(contextPath('C:\\Users\\me\\a.ts', '')).toBe('C:\\Users\\me\\a.ts')
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -170,8 +170,25 @@ describe('contextPath', () => {
     expect(contextPath('C:\\proj\\a.ts', 'C:\\proj\\')).toBe('a.ts')
   })
 
+  it('folds case on Windows so a differently cased cwd still relativizes', () => {
+    // Windows path identity is case-insensitive: the picker may hand back
+    // `C:\Users\Me\...` while the session cwd is stored as `c:/users/me/...`.
+    expect(contextPath('C:\\Users\\Me\\Proj\\src\\a.ts', 'c:/users/me/proj')).toBe('src/a.ts')
+  })
+
+  it('preserves the original spelling of the relativized tail on Windows', () => {
+    // Only the comparison key is lowercased; the emitted ref keeps the caller's
+    // casing so the path still resolves for case-preserving tooling.
+    expect(contextPath('C:\\proj\\Src\\MyFile.TS', 'c:\\PROJ')).toBe('Src/MyFile.TS')
+  })
+
   it('still relativizes POSIX paths', () => {
     expect(contextPath('/home/me/proj/src/a.ts', '/home/me/proj')).toBe('src/a.ts')
+  })
+
+  it('keeps POSIX comparison case-sensitive', () => {
+    // No case folding off Windows: `/home/me/Proj` is a different directory.
+    expect(contextPath('/home/me/Proj/src/a.ts', '/home/me/proj')).toBe('/home/me/Proj/src/a.ts')
   })
 
   it('returns the original path unchanged when it is not under cwd', () => {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -139,6 +139,13 @@ export function isImageGenerationTool(name?: string): boolean {
   return name === 'image_generate'
 }
 
+// Windows spellings: drive-letter (`C:\…`, `C:/…`), UNC (`\\srv`, `//srv`), or
+// any backslash-rooted path. A single leading `/` stays POSIX. Mirrors the
+// path-identity helper used for project membership in `@/store/projects` so the
+// two desktop path comparisons agree on what counts as a Windows path.
+const isWindowsPath = (path: string): boolean =>
+  /^[A-Za-z]:[/\\]/.test(path) || path.startsWith('\\') || path.startsWith('//')
+
 export function contextPath(path: string, cwd: string): string {
   if (!cwd) {
     return path
@@ -154,7 +161,17 @@ export function contextPath(path: string, cwd: string): string {
   const normalizedCwdRoot = slash(cwd)
   const normalizedCwd = normalizedCwdRoot.endsWith('/') ? normalizedCwdRoot : `${normalizedCwdRoot}/`
 
-  return normalizedPath.startsWith(normalizedCwd) ? normalizedPath.slice(normalizedCwd.length) : path
+  // Windows path identity is case-insensitive, so `C:\Users\Me\Proj\src\a.ts`
+  // really is under `c:/users/me/proj` and must relativize. Fold case for the
+  // *comparison key only* — the returned slice comes off `normalizedPath`, which
+  // keeps the caller's original spelling in the emitted `@file:` ref. POSIX is
+  // case-sensitive and is left alone.
+  const windows = isWindowsPath(path) || isWindowsPath(cwd)
+  const comparisonKey = (p: string) => (windows ? p.toLowerCase() : p)
+
+  return comparisonKey(normalizedPath).startsWith(comparisonKey(normalizedCwd))
+    ? normalizedPath.slice(normalizedCwd.length)
+    : path
 }
 
 // IDs are content-derived (`kind:value`), not uuids, so upsertAttachment's

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -144,9 +144,17 @@ export function contextPath(path: string, cwd: string): string {
     return path
   }
 
-  const normalizedCwd = cwd.endsWith('/') ? cwd : `${cwd}/`
+  // Slash-normalize before the prefix compare: on Windows the OS supplies
+  // backslash paths (`C:\Users\me\proj\src\a.ts`), so a raw `startsWith` against
+  // `cwd + '/'` never matches and the full absolute path leaks into the ref.
+  // Every sibling helper (`pathLabel`, markdown `filenameExtToken`) is already
+  // backslash-aware; this one was the outlier.
+  const slash = (p: string) => p.replace(/\\/g, '/')
+  const normalizedPath = slash(path)
+  const normalizedCwdRoot = slash(cwd)
+  const normalizedCwd = normalizedCwdRoot.endsWith('/') ? normalizedCwdRoot : `${normalizedCwdRoot}/`
 
-  return path.startsWith(normalizedCwd) ? path.slice(normalizedCwd.length) : path
+  return normalizedPath.startsWith(normalizedCwd) ? normalizedPath.slice(normalizedCwd.length) : path
 }
 
 // IDs are content-derived (`kind:value`), not uuids, so upsertAttachment's

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -135,9 +135,17 @@ export function contextPath(path: string, cwd: string): string {
     return path
   }
 
-  const normalizedCwd = cwd.endsWith('/') ? cwd : `${cwd}/`
+  // Slash-normalize before the prefix compare: on Windows the OS supplies
+  // backslash paths (`C:\Users\me\proj\src\a.ts`), so a raw `startsWith` against
+  // `cwd + '/'` never matches and the full absolute path leaks into the ref.
+  // Every sibling helper (`pathLabel`, markdown `filenameExtToken`) is already
+  // backslash-aware; this one was the outlier.
+  const slash = (p: string) => p.replace(/\\/g, '/')
+  const normalizedPath = slash(path)
+  const normalizedCwdRoot = slash(cwd)
+  const normalizedCwd = normalizedCwdRoot.endsWith('/') ? normalizedCwdRoot : `${normalizedCwdRoot}/`
 
-  return path.startsWith(normalizedCwd) ? path.slice(normalizedCwd.length) : path
+  return normalizedPath.startsWith(normalizedCwd) ? normalizedPath.slice(normalizedCwd.length) : path
 }
 
 // IDs are content-derived (`kind:value`), not uuids, so upsertAttachment's

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -130,6 +130,13 @@ export function isImageGenerationTool(name?: string): boolean {
   return name === 'image_generate'
 }
 
+// Windows spellings: drive-letter (`C:\…`, `C:/…`), UNC (`\\srv`, `//srv`), or
+// any backslash-rooted path. A single leading `/` stays POSIX. Mirrors the
+// path-identity helper used for project membership in `@/store/projects` so the
+// two desktop path comparisons agree on what counts as a Windows path.
+const isWindowsPath = (path: string): boolean =>
+  /^[A-Za-z]:[/\\]/.test(path) || path.startsWith('\\') || path.startsWith('//')
+
 export function contextPath(path: string, cwd: string): string {
   if (!cwd) {
     return path
@@ -145,7 +152,17 @@ export function contextPath(path: string, cwd: string): string {
   const normalizedCwdRoot = slash(cwd)
   const normalizedCwd = normalizedCwdRoot.endsWith('/') ? normalizedCwdRoot : `${normalizedCwdRoot}/`
 
-  return normalizedPath.startsWith(normalizedCwd) ? normalizedPath.slice(normalizedCwd.length) : path
+  // Windows path identity is case-insensitive, so `C:\Users\Me\Proj\src\a.ts`
+  // really is under `c:/users/me/proj` and must relativize. Fold case for the
+  // *comparison key only* — the returned slice comes off `normalizedPath`, which
+  // keeps the caller's original spelling in the emitted `@file:` ref. POSIX is
+  // case-sensitive and is left alone.
+  const windows = isWindowsPath(path) || isWindowsPath(cwd)
+  const comparisonKey = (p: string) => (windows ? p.toLowerCase() : p)
+
+  return comparisonKey(normalizedPath).startsWith(comparisonKey(normalizedCwd))
+    ? normalizedPath.slice(normalizedCwd.length)
+    : path
 }
 
 // IDs are content-derived (`kind:value`), not uuids, so upsertAttachment's


### PR DESCRIPTION
## What does this PR do?

`contextPath` in `apps/desktop/src/lib/chat-runtime.ts` relativizes composer context refs against the session `cwd` so the agent receives a short project-relative ref (`@file:src/a.ts`) instead of a verbose absolute path. Its prefix test was POSIX-only: it appended a forward slash to `cwd` and did a raw `startsWith`.

On Windows the OS supplies backslash paths (`C:\Users\me\proj\src\a.ts`), so `"C:\Users\me\proj\src\a.ts".startsWith("C:\Users\me\proj/")` is always `false` and the full absolute path is returned unchanged. Callers (`pickContextPaths`, `attachContextFilePath`, `insertContextPathInlineRef` in `use-composer-actions.ts`; `droppedFileInlineRef` in `composer/inline-refs.ts`) then embed `@file:C:\Users\me\proj\src\a.ts` into the ref text / attachment id / chip on Windows instead of `@file:src/a.ts` — a functional regression in the ref content the agent receives.

Every sibling path helper in the desktop app is already backslash-aware (`pathLabel` uses `split(/[\\/]/)`, `markdown-code.ts` `filenameExtToken` uses `replace(/\\/g, '/')`, `right-sidebar/files/ipc.ts` normalizes), so `contextPath` was the lone outlier — an oversight, not a deliberate POSIX-only design.

The fix slash-normalizes both `path` and `cwd` before the prefix compare and emits a forward-slash relative path. The not-under-`cwd` fall-through still returns the original `path` unchanged, so legitimate POSIX paths are byte-for-byte identical to today.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/chat-runtime.ts`: `contextPath` now slash-normalizes `path` and `cwd` before the prefix test and slices on the normalized form, returning a forward-slash relative path. Not-under-`cwd` still returns the original `path`.
- `apps/desktop/src/lib/chat-runtime.test.ts`: added `contextPath` coverage — Windows backslash relativization, trailing-separator cwd, POSIX unchanged, not-under-cwd unchanged, empty cwd.

## How to Test

1. `cd apps/desktop && npx vitest run --environment jsdom src/lib/chat-runtime.test.ts`
2. Before the fix, the two Windows cases fail: `contextPath('C:\\Users\\me\\proj\\src\\a.ts', 'C:\\Users\\me\\proj')` returns the full absolute path instead of `src/a.ts`.
3. After the fix, all 25 tests pass; POSIX and not-under-cwd behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop unit suite for the touched file (`vitest run --environment jsdom src/lib/chat-runtime.test.ts`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (fix verified headlessly — `contextPath` is a pure string function, so the Windows backslash cases are exercised directly in the unit test)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this is a Windows path-handling fix; POSIX behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A