### PR TITLE
fix(model): merge configured models into picker rows

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1712,6 +1712,15 @@ def list_authenticated_providers(
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
+        # A providers.<built-in>.models block extends the provider's discovered
+        # catalog. Section 3 cannot emit it later because this built-in row owns
+        # the slug, so merge declarations here before applying max_models.
+        configured_models: list[str] = []
+        if isinstance(user_providers, dict):
+            configured = user_providers.get(hermes_id)
+            if isinstance(configured, dict):
+                configured_models = _declared_model_ids(configured.get("models"))
+        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
         total = len(model_ids)
         if hermes_id in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models

--- a/tests/hermes_cli/test_configured_builtin_models.py
+++ b/tests/hermes_cli/test_configured_builtin_models.py
@@ -1,0 +1,44 @@
+"""Configured models extend built-in picker rows."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def _provider_row(configured_models, *, max_models=None):
+    with (
+        patch(
+            "agent.models_dev.fetch_models_dev",
+            return_value={"deepseek": {"env": ["DEEPSEEK_API_KEY"], "name": "DeepSeek"}},
+        ),
+        patch(
+            "agent.models_dev.PROVIDER_TO_MODELS_DEV",
+            {"deepseek": "deepseek"},
+        ),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["live-a", "shared"],
+        ),
+        patch("hermes_cli.providers.HERMES_OVERLAYS", {}),
+        patch.dict("os.environ", {"DEEPSEEK_API_KEY": "test-key"}),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="deepseek",
+            user_providers={"deepseek": {"models": configured_models}},
+            max_models=max_models,
+        )
+    return next(row for row in rows if row["slug"] == "deepseek")
+
+
+def test_configured_models_precede_and_deduplicate_discovered_models():
+    row = _provider_row({"configured-x": {}, "shared": {}})
+
+    assert row["models"] == ["configured-x", "shared", "live-a"]
+    assert row["total_models"] == 3
+
+
+def test_configured_models_are_merged_before_picker_limit():
+    row = _provider_row(["configured-x", "configured-y"], max_models=2)
+
+    assert row["models"] == ["configured-x", "configured-y"]
+    assert row["total_models"] == 4


### PR DESCRIPTION
1|## Summary
2|Models declared under `providers.<built-in>.models` now appear in that provider's picker row instead of being discarded after the built-in row claims the provider slug.
3|
4|## Changes
5|- Preserve @liuhao1024's #43538 root-cause fix.
6|- Merge configured models before live/curated entries so explicit user choices remain visible under picker limits.
7|- Deduplicate while preserving order and support both mapping and list config shapes.
8|- Replace broad fixture-heavy coverage with focused precedence, deduplication, and limit invariants.
9|
10|## Validation
11|| Path | Result |
12||---|---|
13|| Configured-model + custom-provider suites | 43 passed |
14|| Mapping/list model declarations | Both preserved |
15|| Duplicate configured/live model | One row entry |
16|| `git diff --check` | Passed |
17|
18|Supersedes #43538; the linked issue #43528 is already closed.
19|
20|## Infographic
21|
22|![Configured models reach the picker](https://v3b.fal.media/files/b/0aa1edb2/2jcq6l2N5HqE-dbC-q_8G_gc9iLoXd.png)
23|