### PR TITLE
fix(matrix): batch text per-sender so shared-thread messages aren't merged under one identity

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4096,10 +4096,27 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
+        """Session-scoped, per-sender key for text message batching.
+
+        Batching coalesces one participant's client-side message splits, so the
+        key must isolate senders. In a *shared* thread
+        (``thread_sessions_per_user=False``, the default) ``build_session_key``
+        intentionally omits ``user_id`` — every participant in the thread shares
+        one session key. Without an explicit sender component two different
+        users posting within the batch window would then share a batch key, and
+        ``_enqueue_text_event`` would concatenate their text into a single event
+        under the *first* sender's identity: the second sender's authorship is
+        lost, and because downstream authorization reads ``event.source.user_id``
+        an unauthorized user's text could ride an authorized user's merged event.
+
+        The sender component is internal to the batch bookkeeping
+        (``_pending_text_batches`` / ``_pending_text_batch_tasks``) and does not
+        change session-key semantics; a single sender's split chunks still share
+        it and batch as before.
+        """
         from gateway.session import build_session_key
 
-        return build_session_key(
+        session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get(
                 "group_sessions_per_user", True
@@ -4109,6 +4126,8 @@ class MatrixAdapter(BasePlatformAdapter):
             ),
             profile=event.source.profile,
         )
+        sender = event.source.user_id or event.source.user_id_alt or ""
+        return f"{session_key}|sender={sender}"
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer."""

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -147,6 +147,81 @@ class TestMatrixTextBatching:
         assert "first part" in text
         assert "second part" in text
 
+    @pytest.mark.asyncio
+    async def test_different_senders_in_shared_thread_not_merged(self):
+        """Two participants in one shared thread must not batch together.
+
+        In a shared thread (``thread_sessions_per_user=False``, the default)
+        ``build_session_key`` omits ``user_id``, so both senders resolve to the
+        same session key. Batching must still key off the sender: otherwise both
+        messages merge into one event attributed to the first sender — dropping
+        the second sender's authorship (and letting their text ride the first
+        sender's identity through downstream authorization).
+        """
+        adapter = _make_matrix_adapter()
+
+        def _thread_event(text: str, user_id: str) -> MessageEvent:
+            return MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=SessionSource(
+                    platform=Platform.MATRIX,
+                    chat_id="!room:matrix.org",
+                    chat_type="group",
+                    thread_id="$thread:matrix.org",
+                    user_id=user_id,
+                ),
+            )
+
+        adapter._enqueue_text_event(_thread_event("hi from alice", "@alice:matrix.org"))
+        await asyncio.sleep(0.02)
+        adapter._enqueue_text_event(_thread_event("hi from bob", "@bob:matrix.org"))
+
+        await asyncio.sleep(0.2)
+
+        # Each sender is dispatched as its own event — never fused into one.
+        assert adapter.handle_message.call_count == 2
+        dispatched = {
+            call.args[0].source.user_id: call.args[0].text
+            for call in adapter.handle_message.call_args_list
+        }
+        assert dispatched == {
+            "@alice:matrix.org": "hi from alice",
+            "@bob:matrix.org": "hi from bob",
+        }
+        # No single dispatched event carries both senders' text.
+        for text in dispatched.values():
+            assert not ("alice" in text and "bob" in text)
+
+    @pytest.mark.asyncio
+    async def test_same_sender_in_shared_thread_still_batches(self):
+        """One participant's split chunks in a shared thread still aggregate."""
+        adapter = _make_matrix_adapter()
+
+        def _thread_event(text: str) -> MessageEvent:
+            return MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=SessionSource(
+                    platform=Platform.MATRIX,
+                    chat_id="!room:matrix.org",
+                    chat_type="group",
+                    thread_id="$thread:matrix.org",
+                    user_id="@alice:matrix.org",
+                ),
+            )
+
+        adapter._enqueue_text_event(_thread_event("first part"))
+        await asyncio.sleep(0.02)
+        adapter._enqueue_text_event(_thread_event("second part"))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        text = adapter.handle_message.call_args[0][0].text
+        assert "first part" in text
+        assert "second part" in text
+
 
 # =====================================================================
 # WeCom text batching


### PR DESCRIPTION
## What does this PR do?

The Matrix adapter batches rapid successive text messages to reassemble a client-side split (one user's long message chunked by Element). The batch key comes from `_text_batch_key`, which returns `build_session_key(..., thread_sessions_per_user=False)` (the default).

In a **shared thread**, `build_session_key` deliberately omits `user_id` — every participant in the thread resolves to one session key (see `gateway/session.py`: "threads are *shared* unless `thread_sessions_per_user` is True"). So the batch key is shared across senders too. When a second participant posts within the batch window (`HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS`, default 0.6s), `_enqueue_text_event` finds the first participant's pending event and concatenates the new text into it:

```python
existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
```

`_flush_text_batch` then dispatches only that first event. The result:

- **Authorship loss:** two users' text is fused into one `MessageEvent` whose `source` is the *first* sender; the second sender's `user_id`/`user_name` is discarded.
- **Authorization dimension:** `_on_room_message` defers authorization to `handle_message` (`gateway/run.py`), which reads `event.source.user_id`. An unauthorized user's in-thread text, merged into an authorized user's event, rides the authorized identity and gets processed. Reachable on default config (`require_mention=true` + `auto_thread=true`: in-thread replies bypass require-mention and reach `_handle_text_message` → enqueue).

Batching only ever needed to coalesce **one** participant's split chunks, so the fix keys the batch on the sender as well: `_text_batch_key` now appends `event.source.user_id` (falling back to `user_id_alt`) to the session key. Different senders get distinct batch keys and are never fused; a single sender's split chunks share the key and batch exactly as before.

The sender component is internal to the batch bookkeeping (`_pending_text_batches` / `_pending_text_batch_tasks`) and does **not** change `build_session_key` or session-routing semantics. Narrow single-adapter change; the identical pattern in the SimpleX adapter is intentionally left for a separate follow-up.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (authorization: unauthorized in-thread text no longer rides an authorized sender's merged event)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: `_text_batch_key` now appends the sender identity (`event.source.user_id or event.source.user_id_alt or ""`) to the session-derived batch key, so distinct senders in a shared thread never share a batch.
- `tests/gateway/test_text_batching.py`: added two `TestMatrixTextBatching` cases — different senders in one shared thread dispatch as two independent events (fails before the fix: they merge into one event under the first sender), and one sender's split chunks in a shared thread still aggregate into a single event.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_text_batching.py -k Matrix -v`
2. Before the fix, `test_different_senders_in_shared_thread_not_merged` fails: `handle_message.call_count == 1` (two senders fused into one event attributed to the first).
3. After the fix, all Matrix batching tests pass — cross-sender messages dispatch separately, same-sender split chunks still batch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_text_batching.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_text_batch_key` docstring; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A