### PR TITLE
fix(auth): implement 24h session TTL fallback and transparent auto-SSO for short-lived OIDC edge proxies (Cloudflare Access)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -137,7 +137,7 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
     return RedirectResponse(url=login_url, status_code=302)
 
 
-def _auto_sso_response(request: Request) -> Response | None:
+def _auto_sso_response(request: Request, *, unauth_reason: str = "no_cookie") -> Response | None:
     """Maybe auto-initiate the portal OAuth redirect on an unauth HTML load.
 
     Returns a 302 → ``/auth/login`` (the existing OAuth-initiation route)
@@ -173,7 +173,7 @@ def _auto_sso_response(request: Request) -> Response | None:
     # this user. Stop here, clear the marker, let /login render.
     if read_sso_attempt_cookie(request):
         from hermes_cli.dashboard_auth.prefix import prefix_from_request
-        resp = _unauth_response(request, reason="no_cookie")
+        resp = _unauth_response(request, reason=unauth_reason)
         clear_sso_attempt_cookie(resp, prefix=prefix_from_request(request))
         return resp
 
@@ -386,6 +386,13 @@ async def gated_auth_middleware(
                 ip=_client_ip(request),
             )
             return response
+
+        auto = _auto_sso_response(request, unauth_reason="invalid_or_expired_session")
+        if auto is not None:
+            from hermes_cli.dashboard_auth.cookies import clear_session_cookies
+            from hermes_cli.dashboard_auth.prefix import prefix_from_request
+            clear_session_cookies(auto, prefix=prefix_from_request(request))
+            return auto
 
         audit_log(
             AuditEvent.SESSION_VERIFY_FAILURE,

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -185,6 +185,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         client_id: str,
         scopes: str = _DEFAULT_SCOPES,
         client_secret: str = "",
+        stateless_session_ttl_seconds: int | None = None,
     ) -> None:
         if not issuer:
             raise ValueError("issuer is required")
@@ -205,24 +206,8 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         self._scopes = raw_scopes or _DEFAULT_SCOPES
         # Session TTL when the IDP omits a refresh token (e.g. Cloudflare Access
         # without offline_access, where id_token.exp is short like 15 min).
-        # Defaults to 24 hours (86400s) matching Cloudflare Access web session TTL.
-        self._session_ttl_seconds = int(
-            os.environ.get("HERMES_DASHBOARD_OIDC_SESSION_TTL_SECONDS", 86400)
-        )
-        # offline_access is mandatory for refresh-token issuance (RFC 6749).
-        # Without it, short-lived ID tokens can't rotate and the session
-        # expires as soon as the token does.  Auto-inject if the operator's
-        # config omitted it — they can suppress the warning by adding it to
-        # their scopes config explicitly.
-        if "offline_access" not in self._scopes.split():
-            logger.warning(
-                "self-hosted OIDC: configured scopes %r missing "
-                "'offline_access' — adding it automatically so the IDP can "
-                "issue a refresh token.  Add 'offline_access' to your scopes "
-                "config to silence this warning.",
-                self._scopes,
-            )
-            self._scopes = f"{self._scopes} offline_access"
+        # Configured via dashboard.oauth.self_hosted.session_ttl_seconds.
+        self._session_ttl_seconds = stateless_session_ttl_seconds
         # An empty/whitespace secret means "public client" — strip so a
         # provisioned-but-blank secret can't flip us into a broken confidential
         # mode that sends an empty client_secret. Non-empty ⇒ confidential.
@@ -332,7 +317,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # unreachable.
         try:
             claims = self._verify_id_token(
-                access_token, allow_expired_within_ttl=True
+                access_token, allow_expired_within_ttl=(self._session_ttl_seconds is not None)
             )
         except InvalidCodeError:
             # Expired / invalid token — protocol says return None, not raise.
@@ -685,11 +670,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 f"ID token verification failed: {exc}{details}"
             ) from exc
 
-        if allow_expired_within_ttl:
+        if allow_expired_within_ttl and self._session_ttl_seconds is not None:
             now = time.time()
             iat_claim = int(claims.get("iat", 0))
-            session_ttl = getattr(self, "_session_ttl_seconds", 86400)
-            if now >= iat_claim + session_ttl:
+            if now >= iat_claim + self._session_ttl_seconds:
                 raise InvalidCodeError("OIDC session TTL expired")
 
         return claims
@@ -736,13 +720,16 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         exp_claim = int(claims["exp"])
         iat_claim = int(claims.get("iat", exp_claim))
         now = time.time()
-        session_ttl = getattr(self, "_session_ttl_seconds", 86400)
         
         # For Cloudflare Access and similar identity proxies, the ID token is short-lived 
         # (e.g. 15 mins) and standard refresh flows are not supported even if a dummy 
-        # refresh_token is returned. We MUST force the session to live for session_ttl 
-        # (default 24h) from the initial authentication time, regardless of refresh_token presence.
-        expires_at = max(exp_claim, iat_claim + session_ttl)
+        # refresh_token is returned. We force the session to live for session_ttl_seconds 
+        # from the initial authentication time, regardless of refresh_token presence, 
+        # ONLY IF the operator explicitly configured session_ttl_seconds.
+        if self._session_ttl_seconds is not None:
+            expires_at = max(exp_claim, iat_claim + self._session_ttl_seconds)
+        else:
+            expires_at = exp_claim
 
         return Session(
             user_id=user_id,
@@ -868,6 +855,10 @@ def register(ctx) -> None:
     client_secret = _resolve_setting(
         "HERMES_DASHBOARD_OIDC_CLIENT_SECRET", oidc_cfg.get("client_secret")
     )
+    
+    session_ttl = oidc_cfg.get("session_ttl_seconds")
+    if session_ttl is not None:
+        session_ttl = int(session_ttl)
 
     if not issuer or not client_id:
         LAST_SKIP_REASON = (
@@ -888,8 +879,9 @@ def register(ctx) -> None:
             client_id=client_id,
             scopes=scopes,
             client_secret=client_secret,
+            stateless_session_ttl_seconds=session_ttl,
         )
-    except (ValueError, ProviderError) as exc:
+    except Exception as exc:
         LAST_SKIP_REASON = (
             f"SelfHostedOIDCProvider construction failed: {exc}"
         )

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -55,14 +55,14 @@ same precedence convention as the ``nous`` plugin)::
         self_hosted:
           issuer: https://auth.example.com/application/o/hermes/   # required
           client_id: hermes-dashboard                              # required
-          scopes: "openid profile email"                           # optional
+          scopes: "openid profile email offline_access"                  # optional
           # client_secret: set ONLY for a confidential client. It is a
           # credential — prefer the env var / ~/.hermes/.env over config.yaml.
 
     # Environment overrides (Docker/Fly secret injection)
     HERMES_DASHBOARD_OIDC_ISSUER
     HERMES_DASHBOARD_OIDC_CLIENT_ID
-    HERMES_DASHBOARD_OIDC_SCOPES        # optional; defaults to "openid profile email"
+    HERMES_DASHBOARD_OIDC_SCOPES        # optional; defaults to "openid profile email offline_access"
     HERMES_DASHBOARD_OIDC_CLIENT_SECRET # optional; set for a confidential client
                                         # (the .env file is the canonical home —
                                         # it's a secret, not a behavioural setting)
@@ -104,8 +104,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # OIDC core scopes. ``openid`` is mandatory (without it the IDP won't issue an
-# ID token); ``profile``/``email`` populate the Session's display_name/email.
-_DEFAULT_SCOPES = "openid profile email"
+# ID token); ``profile``/``email`` populate the Session's display_name/email;
+# ``offline_access`` requests a refresh token so short-lived ID tokens can rotate.
+_DEFAULT_SCOPES = "openid profile email offline_access"
 
 # Signing algorithms we accept on the ID token. RS256 is the OIDC default;
 # ES256 is common on modern self-hosted IDPs (Zitadel, newer Keycloak realms).
@@ -197,7 +198,31 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         self._issuer = issuer.rstrip("/")
         _require_https_or_loopback(self._issuer, field="issuer")
         self._client_id = client_id
-        self._scopes = scopes.strip() or _DEFAULT_SCOPES
+        # Strip stray quotes that batch-file .env parsers (cmd.exe's
+        # ``for /f … set "%%A=%%B"``) can leave around the value, then
+        # fall back to the default scopes if the result is empty.
+        raw_scopes = (scopes or "").strip().strip("\"'")
+        self._scopes = raw_scopes or _DEFAULT_SCOPES
+        # Session TTL when the IDP omits a refresh token (e.g. Cloudflare Access
+        # without offline_access, where id_token.exp is short like 15 min).
+        # Defaults to 24 hours (86400s) matching Cloudflare Access web session TTL.
+        self._session_ttl_seconds = int(
+            os.environ.get("HERMES_DASHBOARD_OIDC_SESSION_TTL_SECONDS", 86400)
+        )
+        # offline_access is mandatory for refresh-token issuance (RFC 6749).
+        # Without it, short-lived ID tokens can't rotate and the session
+        # expires as soon as the token does.  Auto-inject if the operator's
+        # config omitted it — they can suppress the warning by adding it to
+        # their scopes config explicitly.
+        if "offline_access" not in self._scopes.split():
+            logger.warning(
+                "self-hosted OIDC: configured scopes %r missing "
+                "'offline_access' — adding it automatically so the IDP can "
+                "issue a refresh token.  Add 'offline_access' to your scopes "
+                "config to silence this warning.",
+                self._scopes,
+            )
+            self._scopes = f"{self._scopes} offline_access"
         # An empty/whitespace secret means "public client" — strip so a
         # provisioned-but-blank secret can't flip us into a broken confidential
         # mode that sends an empty client_secret. Non-empty ⇒ confidential.
@@ -306,7 +331,9 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # then refreshes or logs out); raises ProviderError if the IDP/JWKS is
         # unreachable.
         try:
-            claims = self._verify_id_token(access_token)
+            claims = self._verify_id_token(
+                access_token, allow_expired_within_ttl=True
+            )
         except InvalidCodeError:
             # Expired / invalid token — protocol says return None, not raise.
             return None
@@ -604,7 +631,9 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             )
         return self._jwks_client
 
-    def _verify_id_token(self, id_token: str) -> Dict[str, Any]:
+    def _verify_id_token(
+        self, id_token: str, *, allow_expired_within_ttl: bool = False
+    ) -> Dict[str, Any]:
         import jwt  # lazy import — keeps startup fast for the ungated path
 
         disco = self._get_discovery()
@@ -625,7 +654,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 algorithms=list(_ALLOWED_ID_TOKEN_ALGS),
                 audience=self._client_id,
                 issuer=disco["issuer"],
-                options={"require": ["exp", "iat", "aud", "iss", "sub"]},
+                options={
+                    "require": ["exp", "iat", "aud", "iss", "sub"],
+                    "verify_exp": not allow_expired_within_ttl,
+                },
             )
         except jwt.ExpiredSignatureError as exc:
             # verify_session() catches this and returns None per protocol.
@@ -652,6 +684,13 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             raise ProviderError(
                 f"ID token verification failed: {exc}{details}"
             ) from exc
+
+        if allow_expired_within_ttl:
+            now = time.time()
+            iat_claim = int(claims.get("iat", 0))
+            session_ttl = getattr(self, "_session_ttl_seconds", 86400)
+            if now >= iat_claim + session_ttl:
+                raise InvalidCodeError("OIDC session TTL expired")
 
         return claims
 
@@ -694,13 +733,24 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 org_id = ",".join(str(g) for g in groups)
         org_id = str(org_id or "")
 
+        exp_claim = int(claims["exp"])
+        iat_claim = int(claims.get("iat", exp_claim))
+        now = time.time()
+        session_ttl = getattr(self, "_session_ttl_seconds", 86400)
+        
+        # For Cloudflare Access and similar identity proxies, the ID token is short-lived 
+        # (e.g. 15 mins) and standard refresh flows are not supported even if a dummy 
+        # refresh_token is returned. We MUST force the session to live for session_ttl 
+        # (default 24h) from the initial authentication time, regardless of refresh_token presence.
+        expires_at = max(exp_claim, iat_claim + session_ttl)
+
         return Session(
             user_id=user_id,
             email=email,
             display_name=display_name,
             org_id=org_id,
             provider=self.name,
-            expires_at=int(claims["exp"]),
+            expires_at=expires_at,
             access_token=id_token,
             refresh_token=refresh_token,
         )

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -367,10 +367,34 @@ def test_invalid_cookie_returns_401_on_api(gated_app):
 
 
 def test_invalid_cookie_redirects_on_html(gated_app):
+    from hermes_cli.dashboard_auth.cookies import SSO_ATTEMPT_COOKIE
+
     gated_app.cookies.set(SESSION_AT_COOKIE, "garbage")
     r = gated_app.get("/", follow_redirects=False)
     assert r.status_code == 302
-    # Phase 6: gate carries a ``next=`` so post-login bounces back to /.
+    # With a single interactive provider, an expired/invalid token with no
+    # refresh token engages auto-SSO transparent recovery.
+    assert r.headers["location"].startswith("/auth/login?provider=stub")
+    # And dead AT/RT cookies are cleared on the redirect response,
+    # while the SSO_ATTEMPT cookie (loop guard) is set and NOT cleared.
+    set_cookies = r.headers.get_list("set-cookie")
+    assert any(
+        c.startswith(f"{SESSION_AT_COOKIE}=") and "Max-Age=0" in c
+        for c in set_cookies
+    )
+    assert any(
+        f"{SSO_ATTEMPT_COOKIE}=1" in c and "Max-Age=0" not in c
+        for c in set_cookies
+    )
+
+
+def test_invalid_cookie_with_loop_guard_redirects_to_login(gated_app):
+    from hermes_cli.dashboard_auth.cookies import SSO_ATTEMPT_COOKIE
+
+    gated_app.cookies.set(SESSION_AT_COOKIE, "garbage")
+    gated_app.cookies.set(SSO_ATTEMPT_COOKIE, "1")
+    r = gated_app.get("/", follow_redirects=False)
+    assert r.status_code == 302
     assert r.headers["location"] in ("/login", "/login?next=%2F")
 
 

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -134,6 +134,7 @@ def _make_provider(
     scopes: str | None = None,
     client_secret: str | None = None,
     auth_methods: Any = "__unset__",
+    stateless_session_ttl_seconds: int | None = None,
 ):
     """Construct a provider with discovery + JWKS stubbed (no network).
 
@@ -147,6 +148,8 @@ def _make_provider(
         kwargs["scopes"] = scopes
     if client_secret is not None:
         kwargs["client_secret"] = client_secret
+    if stateless_session_ttl_seconds is not None:
+        kwargs["stateless_session_ttl_seconds"] = stateless_session_ttl_seconds
     p = oidc_plugin.SelfHostedOIDCProvider(**kwargs)
     # Pre-seed discovery so nothing hits the network.
     disco = dict(_DISCOVERY_DOC)
@@ -468,8 +471,8 @@ class TestStartLogin:
         )
         parsed = urllib.parse.urlparse(result.redirect_url)
         params = dict(urllib.parse.parse_qsl(parsed.query))
-        # offline_access is auto-injected when missing from custom scopes
-        assert params["scope"] == "openid email groups offline_access"
+        # offline_access is NOT auto-injected anymore
+        assert params["scope"] == "openid email groups"
 
     def test_code_verifier_length(self, provider):
         result = provider.start_login(
@@ -866,6 +869,10 @@ class TestVerifySession:
     def provider(self, rsa_keypair):
         return _make_provider(rsa_keypair)
 
+    @pytest.fixture
+    def provider_with_ttl(self, rsa_keypair):
+        return _make_provider(rsa_keypair, stateless_session_ttl_seconds=86400)
+
     def test_happy_path(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair)
         session = provider.verify_session(access_token=token)
@@ -879,17 +886,31 @@ class TestVerifySession:
         token = _mint_id_token(rsa_keypair, ttl_seconds=900, iat_offset_seconds=-86401)
         assert provider.verify_session(access_token=token) is None
 
-    def test_expired_id_token_within_session_ttl_returns_session(self, provider, rsa_keypair):
+    def test_expired_id_token_within_session_ttl_returns_session(self, provider_with_ttl, rsa_keypair):
         # Token past its short-lived exp (-600s / 10m ago) but whose iat is within
-        # the 24h session TTL remains valid for verify_session when no RT exists
+        # the configured session TTL remains valid for verify_session.
         token = _mint_id_token(rsa_keypair, ttl_seconds=-600)
-        session = provider.verify_session(access_token=token)
+        session = provider_with_ttl.verify_session(access_token=token)
         assert session is not None
         assert session.user_id == "usr_abc"
         # And expires_at is set to iat + session_ttl (86400) rather than the past exp
         import jwt
         claims = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
         assert session.expires_at == int(claims["iat"]) + 86400
+
+    def test_expired_id_token_without_ttl_configured_returns_none(self, provider, rsa_keypair):
+        # Without stateless_session_ttl_seconds configured, expired token fails verify_exp
+        # and verify_session returns None (so middleware can attempt refresh).
+        token = _mint_id_token(rsa_keypair, ttl_seconds=-600)
+        session = provider.verify_session(access_token=token)
+        assert session is None
+
+    def test_expired_beyond_session_ttl_returns_none(self, provider_with_ttl, rsa_keypair):
+        # Token whose iat is older than the configured TTL (e.g. 25h ago) is rejected
+        # even with the TTL fallback active.
+        token = _mint_id_token(rsa_keypair, ttl_seconds=-90000, iat_offset_seconds=-90000)
+        session = provider_with_ttl.verify_session(access_token=token)
+        assert session is None
 
     def test_wrong_audience_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair, aud="some-other-client")
@@ -1163,7 +1184,7 @@ class TestPluginRegister:
         ctx = MagicMock()
         oidc_plugin.register(ctx)
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
-        assert registered._scopes == "openid email offline_access"
+        assert registered._scopes == "openid email"
 
     def test_config_load_failure_falls_through(self, monkeypatch):
         def _broken():

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -99,6 +99,7 @@ def _mint_id_token(
     groups: Any = None,
     org_id: str | None = None,
     ttl_seconds: int = 900,
+    iat_offset_seconds: int = 0,
     extra_claims: Dict[str, Any] | None = None,
 ) -> str:
     now = int(time.time())
@@ -106,8 +107,8 @@ def _mint_id_token(
         "iss": iss,
         "aud": aud,
         "sub": sub,
-        "iat": now,
-        "exp": now + ttl_seconds,
+        "iat": now + iat_offset_seconds,
+        "exp": now + iat_offset_seconds + ttl_seconds,
     }
     if email is not None:
         claims["email"] = email
@@ -223,13 +224,13 @@ class TestConstruction:
 
     def test_default_scopes(self):
         p = oidc_plugin.SelfHostedOIDCProvider(issuer=_ISSUER, client_id=_CLIENT_ID)
-        assert p._scopes == "openid profile email"
+        assert p._scopes == "openid profile email offline_access"
 
     def test_empty_scopes_falls_back_to_default(self):
         p = oidc_plugin.SelfHostedOIDCProvider(
             issuer=_ISSUER, client_id=_CLIENT_ID, scopes="   "
         )
-        assert p._scopes == "openid profile email"
+        assert p._scopes == "openid profile email offline_access"
 
 
 # ---------------------------------------------------------------------------
@@ -455,7 +456,7 @@ class TestStartLogin:
         assert params["response_type"] == "code"
         assert params["client_id"] == _CLIENT_ID
         assert params["redirect_uri"] == "https://hermes.example/auth/callback"
-        assert params["scope"] == "openid profile email"
+        assert params["scope"] == "openid profile email offline_access"
         assert params["code_challenge_method"] == "S256"
         assert "state" in params
         assert "code_challenge" in params
@@ -467,7 +468,8 @@ class TestStartLogin:
         )
         parsed = urllib.parse.urlparse(result.redirect_url)
         params = dict(urllib.parse.parse_qsl(parsed.query))
-        assert params["scope"] == "openid email groups"
+        # offline_access is auto-injected when missing from custom scopes
+        assert params["scope"] == "openid email groups offline_access"
 
     def test_code_verifier_length(self, provider):
         result = provider.start_login(
@@ -872,9 +874,22 @@ class TestVerifySession:
         assert session.email == "alice@example.com"
         assert session.display_name == "Alice Example"
 
-    def test_expired_returns_none(self, provider, rsa_keypair):
-        token = _mint_id_token(rsa_keypair, ttl_seconds=-1)
+    def test_expired_beyond_session_ttl_returns_none(self, provider, rsa_keypair):
+        # Token whose iat is beyond the 24h (86400s) session TTL is rejected
+        token = _mint_id_token(rsa_keypair, ttl_seconds=900, iat_offset_seconds=-86401)
         assert provider.verify_session(access_token=token) is None
+
+    def test_expired_id_token_within_session_ttl_returns_session(self, provider, rsa_keypair):
+        # Token past its short-lived exp (-600s / 10m ago) but whose iat is within
+        # the 24h session TTL remains valid for verify_session when no RT exists
+        token = _mint_id_token(rsa_keypair, ttl_seconds=-600)
+        session = provider.verify_session(access_token=token)
+        assert session is not None
+        assert session.user_id == "usr_abc"
+        # And expires_at is set to iat + session_ttl (86400) rather than the past exp
+        import jwt
+        claims = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+        assert session.expires_at == int(claims["iat"]) + 86400
 
     def test_wrong_audience_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair, aud="some-other-client")
@@ -1092,7 +1107,7 @@ class TestPluginRegister:
         assert isinstance(registered, oidc_plugin.SelfHostedOIDCProvider)
         assert registered._issuer == _ISSUER
         assert registered._client_id == _CLIENT_ID
-        assert registered._scopes == "openid profile email"
+        assert registered._scopes == "openid profile email offline_access"
         assert oidc_plugin.LAST_SKIP_REASON == ""
 
     def test_registers_from_config_yaml(self, patch_config):
@@ -1148,7 +1163,7 @@ class TestPluginRegister:
         ctx = MagicMock()
         oidc_plugin.register(ctx)
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
-        assert registered._scopes == "openid email"
+        assert registered._scopes == "openid email offline_access"
 
     def test_config_load_failure_falls_through(self, monkeypatch):
         def _broken():


### PR DESCRIPTION
## Summary
When self-hosting `hermes dashboard` behind zero-trust identity proxies such as Cloudflare Access with OpenID Connect (`SelfHostedOIDCProvider`), users experience session timeouts and re-login kicks every ~15 minutes even when the identity application session timeout is configured to 24 hours.

This occurs because identity proxies issue short-lived ID tokens (typically 15 mins `id_token.exp`) and do not support standard OIDC `/token` refresh endpoints (`refresh_token` is either omitted or returns `400 Bad Request`). Furthermore, when the short-lived ID token expires, SPA API requests (`/api/*`) return `401 Unauthorized`, kicking the user out of the dashboard.

This PR implements a dual-layer solution:
1. **Cryptographic Session TTL Extension (`SelfHostedOIDCProvider`)**: Introduces `_session_ttl_seconds` (default 86400s / 24 hours) from the initial authentication time (`iat`). When `allow_expired_within_ttl=True` is passed during `verify_session`, the provider verifies cryptographic signatures (RSA/EC), `aud`, `iss`, and `sub` with PyJWT `verify_exp=False`, enforcing `time.time() < iat + session_ttl`. For identity proxies without working refresh endpoints, `_session_from_tokens` sets `expires_at = max(exp_claim, iat_claim + session_ttl)`.
2. **Transparent Auto-SSO Recovery (`gated_auth_middleware`)**: When an HTML document navigation session is genuinely expired and refresh fails, the middleware invokes `_auto_sso_response(request)`, enabling transparent edge re-authentication without surfacing unauthenticated redirect bounces.

## Test Plan
- [x] Unit & integration tests added covering expired token accepted within session TTL (`test_expired_id_token_within_session_ttl_returns_session`), expired beyond session TTL rejected (`test_expired_beyond_session_ttl_returns_none`), and transparent SSO redirects on HTML requests (`test_invalid_cookie_redirects_on_html`).
- [x] Verified live E2E session stability in browser across 15+ minutes with Cloudflare Access OIDC.