### PR TITLE
fix(cli): report windowed tool-result count in session recap Recent line

### DIFF
--- a/hermes_cli/session_recap.py
+++ b/hermes_cli/session_recap.py
@@ -278,7 +278,7 @@ def build_recap(
 
     users, assistants, tool_msgs = _count_visible_turns(messages)
     window = _recent_window(messages)
-    win_users, win_assistants, _ = _count_visible_turns(window)
+    win_users, win_assistants, win_tools = _count_visible_turns(window)
 
     scope = (
         f"{win_users} user turn{'s' if win_users != 1 else ''} / "
@@ -286,7 +286,14 @@ def build_recap(
     )
     if (users, assistants) != (win_users, win_assistants):
         scope += f" (of {users}/{assistants} total)"
-    lines.append(f"  Recent: {scope}, {tool_msgs} tool result{'s' if tool_msgs != 1 else ''}")
+    # The "Recent:" line is scoped to the window, so its tool-result count must be
+    # the windowed one too — reporting the whole-session ``tool_msgs`` here
+    # overstated recent activity by the entire out-of-window history. Mirror the
+    # turn-count "(of … total)" annotation when the window omits earlier results.
+    tool_scope = f"{win_tools} tool result{'s' if win_tools != 1 else ''}"
+    if win_tools != tool_msgs:
+        tool_scope += f" (of {tool_msgs} total)"
+    lines.append(f"  Recent: {scope}, {tool_scope}")
 
     tool_calls = list(_iter_assistant_tool_calls(window))
     tool_counts, files = _summarise_tool_activity(tool_calls)

--- a/tests/hermes_cli/test_session_recap.py
+++ b/tests/hermes_cli/test_session_recap.py
@@ -60,3 +60,21 @@ def test_escape_sequences_sanitized_in_previews():
     assert "\x07" not in out
     assert "do the thing" in out
     assert "with it" in out
+
+
+def test_recent_line_reports_windowed_tool_count_not_whole_session():
+    # 30 [user, assistant, tool] turns (90 messages). The recent 20-turn window
+    # (user+assistant) covers ~10 turns, so ~10 tool results — but the "Recent:"
+    # line used to print the whole-session count (30), overstating activity by
+    # the entire out-of-window history.
+    msgs = []
+    for i in range(30):
+        msgs.append(_user(f"question {i}"))
+        msgs.append(_assistant(f"answer {i}"))
+        msgs.append(_tool_result(f"result {i}"))
+    out = build_recap(msgs)
+    recent_line = next(line for line in out.splitlines() if "Recent:" in line)
+    # Windowed count is reported; the global total rides along as an annotation.
+    assert "10 tool results" in recent_line
+    assert "(of 30 total)" in recent_line
+    assert "30 tool results" not in recent_line


### PR DESCRIPTION
## What does this PR do?

`build_recap` in `hermes_cli/session_recap.py` prints a one-line "Recent:" summary scoped to the most recent `_RECENT_TURN_WINDOW` (20) user+assistant turns. The user/assistant counts on that line are correctly windowed (with a `(of X/Y total)` annotation when they differ from the whole session), but the **tool-result count** printed on the same line is the whole-session total:

```python
users, assistants, tool_msgs = _count_visible_turns(messages)   # FULL history
window = _recent_window(messages)
win_users, win_assistants, _ = _count_visible_turns(window)      # windowed tool count discarded with `_`
...
lines.append(f"  Recent: {scope}, {tool_msgs} tool result...")   # uses whole-session tool_msgs
```

The windowed tool count is computed on the `win_users, win_assistants, _` line and then thrown away with `_` — the tell that a windowed count was intended. Inside a line framed "Recent:", the tool-result count overstates recent activity by the entire out-of-window history.

**Reproduced:** 30 × `[user, assistant, tool_result]` (90 messages) → `Recent: 10 user turns / 10 assistant replies (of 30/30 total), 30 tool results` — the recent 20-turn window holds ~10 tool results, but the line claims 30.

The fix captures the windowed tool count (`win_tools`) and reports it on the "Recent:" line, appending `(of {tool_msgs} total)` when the window omits earlier results — mirroring the existing turn-count `(of …/… total)` annotation, so the whole-session figure is still visible.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_recap.py`: capture the windowed tool count (`win_tools`) instead of discarding it, and report it on the "Recent:" line with a `(of {tool_msgs} total)` annotation when it differs from the whole-session count. The whole-session `users`/`assistants`/`tool_msgs` are still used by the existing turn-count `(of …/… total)` logic.
- `tests/hermes_cli/test_session_recap.py`: added a regression test — 30 `[user, assistant, tool]` turns (most outside the 20-turn window) assert the "Recent:" line reports the windowed count (10) with `(of 30 total)`, not the bare whole-session 30.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_session_recap.py -v`
2. Before the fix, `test_recent_line_reports_windowed_tool_count_not_whole_session` fails: the "Recent:" line prints `30 tool results`.
3. After the fix, all 14 tests pass. `test_tool_message_count_reported` (history fully inside the window, so windowed == total) is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_session_recap.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python display logic, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A