### PR TITLE
fix(desktop): use lightweight backend readiness probe

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import {
+  HERMES_HEALTH_REQUEST_TIMEOUT_MS,
+  HERMES_READY_RETRY_MS,
+  HERMES_READY_TIMEOUT_MS,
+  isMissingHealthEndpointError,
+  isReadyHealthResponse,
+  waitForHermesReadiness
+} from './backend-health'
+
+test('uses the confirmed readiness timing defaults', () => {
+  assert.equal(HERMES_HEALTH_REQUEST_TIMEOUT_MS, 2_500)
+  assert.equal(HERMES_READY_RETRY_MS, 500)
+  assert.equal(HERMES_READY_TIMEOUT_MS, 45_000)
+})
+
+test('recognizes only the expected health response as ready', () => {
+  assert.equal(isReadyHealthResponse({ ok: true, status: 'ready' }), true)
+  assert.equal(isReadyHealthResponse({ ok: true, status: 'starting' }), false)
+  assert.equal(isReadyHealthResponse({ ok: false, status: 'ready' }), false)
+  assert.equal(isReadyHealthResponse(null), false)
+})
+
+test('probes healthz first with a 2500ms request timeout', async () => {
+  const calls: Array<{ url: string; timeoutMs: number }> = []
+
+  await waitForHermesReadiness('http://127.0.0.1:8000', async (url, options) => {
+    calls.push({ url, timeoutMs: options.timeoutMs })
+
+    return { ok: true, status: 'ready' }
+  })
+
+  assert.deepEqual(calls, [{ url: 'http://127.0.0.1:8000/api/healthz', timeoutMs: 2_500 }])
+})
+
+test('permanently falls back to status when healthz returns 404', async () => {
+  const paths: string[] = []
+
+  await waitForHermesReadiness(
+    'https://remote.example',
+    async url => {
+      const path = new URL(url).pathname
+      paths.push(path)
+
+      if (paths.length === 1) {
+        throw new Error('404: Not Found')
+      }
+
+      if (paths.length === 2) {
+        throw new Error('connect ECONNRESET')
+      }
+
+      return { status: 'ok' }
+    },
+    { sleep: async () => {} }
+  )
+
+  assert.deepEqual(paths, ['/api/healthz', '/api/status', '/api/status'])
+})
+
+test('permanently falls back when the existing fetch helper reports an HTML endpoint miss', async () => {
+  const paths: string[] = []
+
+  await waitForHermesReadiness('https://remote.example', async url => {
+    const path = new URL(url).pathname
+    paths.push(path)
+
+    if (path === '/api/healthz') {
+      throw new Error(
+        'Expected JSON from https://remote.example/api/healthz but got HTML (status 200). ' +
+          'The endpoint is likely missing on the Hermes backend.'
+      )
+    }
+
+    return { status: 'ok' }
+  })
+
+  assert.deepEqual(paths, ['/api/healthz', '/api/status'])
+})
+
+test('does not fall back for 5xx, timeout, network, or malformed readiness responses', async () => {
+  const failures = [
+    new Error('500: Internal Server Error'),
+    new Error('Timed out connecting to Hermes backend after 2500ms'),
+    new Error('connect ECONNREFUSED 127.0.0.1:8000'),
+    null
+  ]
+
+  const paths: string[] = []
+
+  await waitForHermesReadiness(
+    'http://127.0.0.1:8000',
+    async url => {
+      paths.push(new URL(url).pathname)
+      const failure = failures.shift()
+
+      if (failure) {
+        throw failure
+      }
+
+      if (failure === null) {
+        return { ok: true, status: 'starting' }
+      }
+
+      return { ok: true, status: 'ready' }
+    },
+    { sleep: async () => {} }
+  )
+
+  assert.deepEqual(paths, [
+    '/api/healthz',
+    '/api/healthz',
+    '/api/healthz',
+    '/api/healthz',
+    '/api/healthz'
+  ])
+})
+
+test('classifies only explicit endpoint-missing errors for legacy fallback', () => {
+  assert.equal(isMissingHealthEndpointError(new Error('404: Not Found')), true)
+  assert.equal(
+    isMissingHealthEndpointError(
+      new Error(
+        'Expected JSON from http://localhost/api/healthz but got HTML (status 200). ' +
+          'The endpoint is likely missing on the Hermes backend.'
+      )
+    ),
+    true
+  )
+  assert.equal(isMissingHealthEndpointError(new Error('500: Internal Server Error')), false)
+  assert.equal(isMissingHealthEndpointError(new Error('Timed out connecting after 2500ms')), false)
+  assert.equal(isMissingHealthEndpointError(new Error('Unexpected token < in JSON')), false)
+})
+
+test('retries every 500ms and stops at the 45s overall deadline', async () => {
+  let nowMs = 0
+  const requestTimeouts: number[] = []
+  const sleeps: number[] = []
+
+  await assert.rejects(
+    waitForHermesReadiness(
+      'http://127.0.0.1:8000',
+      async (_url, options) => {
+        requestTimeouts.push(options.timeoutMs)
+        throw new Error('connect ECONNREFUSED')
+      },
+      {
+        now: () => nowMs,
+        sleep: async delayMs => {
+          sleeps.push(delayMs)
+          nowMs += delayMs
+        }
+      }
+    ),
+    /Hermes backend did not become ready: connect ECONNREFUSED/
+  )
+
+  assert.equal(nowMs, 45_000)
+  assert.ok(sleeps.length > 1)
+  assert.ok(sleeps.every(delayMs => delayMs === 500))
+  assert.equal(requestTimeouts[0], 2_500)
+  assert.equal(requestTimeouts.at(-1), 500)
+})
+
+test('does not issue a request when the deadline expires between loop checks', async () => {
+  const times = [0, 44_999, 45_000]
+  let requests = 0
+
+  await assert.rejects(
+    waitForHermesReadiness(
+      'http://127.0.0.1:8000',
+      async () => {
+        requests += 1
+
+        return { ok: true, status: 'ready' }
+      },
+      {
+        now: () => times.shift() ?? 45_000,
+        sleep: async () => {
+          assert.fail('must not sleep after the overall deadline')
+        }
+      }
+    ),
+    /Hermes backend did not become ready: timeout/
+  )
+
+  assert.equal(requests, 0)
+})

--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -188,3 +188,27 @@ test('does not issue a request when the deadline expires between loop checks', a
 
   assert.equal(requests, 0)
 })
+
+test('stops retrying immediately when an abort signal supersedes SSH bootstrap', async () => {
+  const controller = new AbortController()
+  let requests = 0
+
+  await assert.rejects(
+    waitForHermesReadiness(
+      'http://127.0.0.1:8000',
+      async () => {
+        requests += 1
+        throw new Error('connect ECONNREFUSED')
+      },
+      {
+        signal: controller.signal,
+        sleep: async () => {
+          controller.abort()
+        }
+      }
+    ),
+    (error: any) => error?.kind === 'superseded'
+  )
+
+  assert.equal(requests, 1)
+})

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -1,0 +1,109 @@
+const HERMES_READY_TIMEOUT_MS = 45_000
+const HERMES_HEALTH_REQUEST_TIMEOUT_MS = 2_500
+const HERMES_READY_RETRY_MS = 500
+
+type ReadinessRequest = (url: string, options: { timeoutMs: number }) => Promise<unknown>
+
+type ReadinessOptions = {
+  now?: () => number
+  sleep?: (delayMs: number) => Promise<void>
+  totalTimeoutMs?: number
+  requestTimeoutMs?: number
+  retryMs?: number
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMissingHealthEndpointError(error: unknown) {
+  const message = errorMessage(error)
+
+  if (/^404(?:\s*:|$)/.test(message)) {
+    return true
+  }
+
+  return (
+    message.includes('Expected JSON from ') &&
+    message.includes(' got HTML ') &&
+    message.includes('The endpoint is likely missing on the Hermes backend.')
+  )
+}
+
+function isReadyHealthResponse(body: unknown) {
+  if (!body || typeof body !== 'object') {
+    return false
+  }
+
+  const health = body as { ok?: unknown; status?: unknown }
+
+  return health.ok === true && health.status === 'ready'
+}
+
+async function waitForHermesReadiness(
+  baseUrl: string,
+  request: ReadinessRequest,
+  options: ReadinessOptions = {}
+) {
+  const now = options.now ?? Date.now
+
+  const sleep =
+    options.sleep ??
+    ((delayMs: number) => {
+      return new Promise<void>(resolve => setTimeout(resolve, delayMs))
+    })
+
+  const totalTimeoutMs = options.totalTimeoutMs ?? HERMES_READY_TIMEOUT_MS
+  const requestTimeoutMs = options.requestTimeoutMs ?? HERMES_HEALTH_REQUEST_TIMEOUT_MS
+  const retryMs = options.retryMs ?? HERMES_READY_RETRY_MS
+  const deadline = now() + totalTimeoutMs
+
+  let useLegacyStatus = false
+  let lastError: unknown = null
+
+  while (now() < deadline) {
+    const path = useLegacyStatus ? '/api/status' : '/api/healthz'
+    const remainingMs = deadline - now()
+
+    if (remainingMs <= 0) {
+      break
+    }
+
+    try {
+      const body = await request(`${baseUrl}${path}`, {
+        timeoutMs: Math.min(requestTimeoutMs, remainingMs)
+      })
+
+      if (useLegacyStatus || isReadyHealthResponse(body)) {
+        return
+      }
+
+      lastError = new Error('Hermes health endpoint did not report ready')
+    } catch (error) {
+      lastError = error
+
+      if (!useLegacyStatus && isMissingHealthEndpointError(error)) {
+        useLegacyStatus = true
+
+        continue
+      }
+    }
+
+    const remainingAfterAttemptMs = deadline - now()
+
+    if (remainingAfterAttemptMs > 0) {
+      await sleep(Math.min(retryMs, remainingAfterAttemptMs))
+    }
+  }
+
+  throw new Error(`Hermes backend did not become ready: ${errorMessage(lastError || 'timeout')}`)
+}
+
+export {
+  HERMES_HEALTH_REQUEST_TIMEOUT_MS,
+  HERMES_READY_RETRY_MS,
+  HERMES_READY_TIMEOUT_MS,
+  isMissingHealthEndpointError,
+  isReadyHealthResponse,
+  waitForHermesReadiness
+}

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -10,6 +10,14 @@ type ReadinessOptions = {
   totalTimeoutMs?: number
   requestTimeoutMs?: number
   retryMs?: number
+  signal?: AbortSignal
+}
+
+function supersededBootstrapError() {
+  const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
+  error.kind = 'superseded'
+
+  return error
 }
 
 function errorMessage(error: unknown) {
@@ -56,12 +64,41 @@ async function waitForHermesReadiness(
   const totalTimeoutMs = options.totalTimeoutMs ?? HERMES_READY_TIMEOUT_MS
   const requestTimeoutMs = options.requestTimeoutMs ?? HERMES_HEALTH_REQUEST_TIMEOUT_MS
   const retryMs = options.retryMs ?? HERMES_READY_RETRY_MS
+  const signal = options.signal
   const deadline = now() + totalTimeoutMs
+
+  const throwIfSuperseded = () => {
+    if (signal?.aborted) {
+      throw supersededBootstrapError()
+    }
+  }
+
+  const sleepUntilRetry = (delayMs: number) => {
+    if (!signal) {
+      return sleep(delayMs)
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const onAbort = () => reject(supersededBootstrapError())
+      signal.addEventListener('abort', onAbort, { once: true })
+      sleep(delayMs).then(
+        () => {
+          signal.removeEventListener('abort', onAbort)
+          resolve()
+        },
+        error => {
+          signal.removeEventListener('abort', onAbort)
+          reject(error)
+        }
+      )
+    })
+  }
 
   let useLegacyStatus = false
   let lastError: unknown = null
 
   while (now() < deadline) {
+    throwIfSuperseded()
     const path = useLegacyStatus ? '/api/status' : '/api/healthz'
     const remainingMs = deadline - now()
 
@@ -92,7 +129,7 @@ async function waitForHermesReadiness(
     const remainingAfterAttemptMs = deadline - now()
 
     if (remainingAfterAttemptMs > 0) {
-      await sleep(Math.min(retryMs, remainingAfterAttemptMs))
+      await sleepUntilRetry(Math.min(retryMs, remainingAfterAttemptMs))
     }
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4632,7 +4632,7 @@ function closePreviewWatchers() {
 }
 
 async function waitForHermes(baseUrl, token, signal?) {
-  const readiness = waitForHermesReadiness(baseUrl, (url, options) => fetchJson(url, token, options))
+  const readiness = waitForHermesReadiness(baseUrl, (url, options) => fetchJson(url, token, options), { signal })
 
   if (!signal) {
     return readiness

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -34,6 +34,7 @@ import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { waitForHermesReadiness } from './backend-health'
 import { canImportHermesCli, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
@@ -3826,6 +3827,14 @@ function fetchJson(url, token, options: any = {}) {
     const parsed = new URL(url)
     const client = parsed.protocol === 'https:' ? https : http
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+    let timeoutHandle: NodeJS.Timeout | null = null
+
+    const clearRequestTimeout = () => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
+        timeoutHandle = null
+      }
+    }
 
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
       reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
@@ -3845,9 +3854,13 @@ function fetchJson(url, token, options: any = {}) {
       },
       res => {
         const chunks = []
-        res.on('error', reject)
+        res.on('error', error => {
+          clearRequestTimeout()
+          reject(error)
+        })
         res.on('data', chunk => chunks.push(chunk))
         res.on('end', () => {
+          clearRequestTimeout()
           const text = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
@@ -3889,10 +3902,13 @@ function fetchJson(url, token, options: any = {}) {
       }
     )
 
-    req.on('error', reject)
-    req.setTimeout(timeoutMs, () => {
-      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    req.on('error', error => {
+      clearRequestTimeout()
+      reject(error)
     })
+    timeoutHandle = setTimeout(() => {
+      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    }, timeoutMs)
 
     if (body) {
       req.write(body)
@@ -4616,39 +4632,37 @@ function closePreviewWatchers() {
 }
 
 async function waitForHermes(baseUrl, token, signal?) {
-  const deadline = Date.now() + 45_000
-  let lastError = null
+  const readiness = waitForHermesReadiness(baseUrl, (url, options) => fetchJson(url, token, options))
 
-  while (Date.now() < deadline) {
-    if (signal?.aborted) {
-      const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
-      error.kind = 'superseded'
-      throw error
-    }
-
-    try {
-      await fetchJson(`${baseUrl}/api/status`, token)
-
-      return
-    } catch (error) {
-      lastError = error
-      await new Promise((resolve, reject) => {
-        const timer = setTimeout(resolve, 500)
-        signal?.addEventListener(
-          'abort',
-          () => {
-            clearTimeout(timer)
-            const aborted: any = new Error('SSH bootstrap was superseded by newer connection settings.')
-            aborted.kind = 'superseded'
-            reject(aborted)
-          },
-          { once: true }
-        )
-      })
-    }
+  if (!signal) {
+    return readiness
   }
 
-  throw new Error(`Hermes backend did not become ready: ${lastError?.message || 'timeout'}`)
+  if (signal.aborted) {
+    const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
+    error.kind = 'superseded'
+    throw error
+  }
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
+      error.kind = 'superseded'
+      reject(error)
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    readiness.then(
+      value => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      }
+    )
+  })
 }
 
 function getWindowButtonPosition() {

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -3,7 +3,9 @@
 import os
 from collections.abc import Mapping
 
-from hermes_cli.config import DEFAULT_CONFIG
+import os
+
+from hermes_cli.config import DEFAULT_CONFIG, read_raw_config
 
 # EX_TEMPFAIL from sysexits.h — used to ask the service manager to restart
 # the gateway after a graceful drain/reload path completes.
@@ -47,8 +49,21 @@ def is_gateway_supervisor_process(
 
 def parse_restart_drain_timeout(raw: object) -> float:
     """Parse a configured drain timeout, falling back to the shared default."""
+    text = str(raw).strip() if raw is not None else ""
     try:
-        value = float(raw) if str(raw or "").strip() else DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+        value = float(text) if text else DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     except (TypeError, ValueError):
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     return max(0.0, value)
+
+
+def resolve_restart_drain_timeout(raw_config: object = None) -> float:
+    """Resolve the drain timeout using env, raw config, then the default."""
+    raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
+    if not raw:
+        cfg = read_raw_config() if raw_config is None else raw_config
+        agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+        raw = agent_cfg.get(
+            "restart_drain_timeout", DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+        )
+    return parse_restart_drain_timeout(raw)

--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -31,6 +31,9 @@ the SPA should bootstrap it after login instead.
 from __future__ import annotations
 
 PUBLIC_API_PATHS: frozenset[str] = frozenset({
+    # Minimal process-readiness probe. The handler returns only a fixed status
+    # shape and the package version; it does not inspect config or runtime state.
+    "/api/healthz",
     # Liveness probe target. Returns version, gateway state, active
     # session count, and the dashboard auth-gate shape. No bodies, no
     # session content, no secrets. Documented as the portal's wildcard

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -32,19 +32,17 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 from gateway.config import coerce_systemd_watchdog_seconds, load_gateway_config
 from gateway.status import terminate_pid
 from gateway.restart import (
-    DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     EXTERNAL_GATEWAY_SUPERVISOR_ENV,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     is_gateway_supervisor_process,
-    parse_restart_drain_timeout,
+    resolve_restart_drain_timeout,
 )
 from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
     is_managed,
     managed_error,
-    read_raw_config,
     save_env_value,
     write_platform_config_field,
 )
@@ -3182,16 +3180,7 @@ def _print_system_scope_remediation(action: str) -> None:
 
 def _get_restart_drain_timeout() -> float:
     """Return the configured gateway restart drain timeout in seconds."""
-    raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
-    if not raw:
-        cfg = read_raw_config()
-        agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
-        raw = str(
-            agent_cfg.get(
-                "restart_drain_timeout", DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-            )
-        )
-    return parse_restart_drain_timeout(raw)
+    return resolve_restart_drain_timeout()
 
 
 def systemd_install(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -93,6 +93,12 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
+from gateway.restart import resolve_restart_drain_timeout
+from hermes_cli.memory_providers import (
+    MemoryProvider as DeclaredMemoryProvider,
+    ProviderField as DeclaredProviderField,
+    get_memory_provider as get_declared_memory_provider,
+)
 from utils import env_var_enabled
 
 try:
@@ -163,22 +169,6 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
-def _warm_gateway_module() -> None:
-    try:
-        import hermes_cli.gateway  # noqa: F401
-    except Exception:
-        pass
-
-
-def _resolve_restart_drain_timeout() -> float:
-    try:
-        from hermes_cli.gateway import _get_restart_drain_timeout
-        return _get_restart_drain_timeout()
-    except ImportError:
-        from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-
-
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -189,14 +179,6 @@ async def _lifespan(app: "FastAPI"):
     # On app.state (not a module global) so the Lock binds to the running
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
-
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
-    # On a cold Windows install the module chain triggers .pyc compilation
-    # and Defender real-time scans that can stall the event loop for 15-30s.
-    # Running in an executor means the cost is paid in a worker thread while
-    # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
@@ -2947,6 +2929,15 @@ async def get_ssh_ownership(request: Request):
     return {"ok": True, "sshOwnerNonce": _SSH_OWNER_NONCE, "protocolVersion": 1}
 
 
+@app.get("/api/healthz")
+async def get_healthz():
+    """Return process readiness without loading config or runtime state."""
+    return JSONResponse(
+        content={"ok": True, "status": "ready", "version": __version__},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 @app.get("/api/status")
 async def get_status(profile: Optional[str] = None):
     status_scope = None
@@ -3074,14 +3065,10 @@ async def get_status(profile: Optional[str] = None):
             gateway_state=gateway_state,
         )
         # Resolved drain timeout (seconds) so NAS can size its poll deadline
-        # without out-of-band knowledge.  Offload to a thread: on a cold
-        # Windows install the first import of hermes_cli.gateway blocks the
-        # asyncio event loop for 15-30s (.pyc compilation + Defender scans),
-        # exceeding the desktop handshake's 15s socket timeout.  After the
-        # first call the module is in sys.modules and run_in_executor returns
-        # in microseconds.
+        # without out-of-band knowledge. Keep the raw config read off the event
+        # loop while sharing the same env > config > default resolver as the CLI.
         restart_drain_timeout = await asyncio.get_running_loop().run_in_executor(
-            None, _resolve_restart_drain_timeout
+            None, resolve_restart_drain_timeout
         )
 
         # Dashboard auth gate (Phase 7): surface whether the gate is engaged

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -94,11 +94,6 @@ from gateway.status import (
     read_runtime_status,
 )
 from gateway.restart import resolve_restart_drain_timeout
-from hermes_cli.memory_providers import (
-    MemoryProvider as DeclaredMemoryProvider,
-    ProviderField as DeclaredProviderField,
-    get_memory_provider as get_declared_memory_provider,
-)
 from utils import env_var_enabled
 
 try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -93,7 +93,6 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
-from gateway.restart import resolve_restart_drain_timeout
 from utils import env_var_enabled
 
 try:
@@ -162,6 +161,15 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
     provider.start(stop_event, interval=interval)
+
+
+def _resolve_restart_drain_timeout() -> float:
+    try:
+        from hermes_cli.gateway import _get_restart_drain_timeout
+        return _get_restart_drain_timeout()
+    except ImportError:
+        from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 
 
 @asynccontextmanager
@@ -3063,7 +3071,7 @@ async def get_status(profile: Optional[str] = None):
         # without out-of-band knowledge. Keep the raw config read off the event
         # loop while sharing the same env > config > default resolver as the CLI.
         restart_drain_timeout = await asyncio.get_running_loop().run_in_executor(
-            None, resolve_restart_drain_timeout
+            None, _resolve_restart_drain_timeout
         )
 
         # Dashboard auth gate (Phase 7): surface whether the gate is engaged

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -11,6 +11,7 @@ pwd = pytest.importorskip("pwd")
 grp = pytest.importorskip("grp")
 
 import hermes_cli.gateway as gateway_cli
+import gateway.restart as gateway_restart
 from gateway import status
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -626,7 +627,7 @@ class TestGatewayStopCleanup:
 class TestLaunchdServiceRecovery:
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
-        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        monkeypatch.setattr(gateway_restart, "read_raw_config", lambda: {})
 
         assert (
             gateway_cli._get_restart_drain_timeout()
@@ -634,7 +635,7 @@ class TestLaunchdServiceRecovery:
         )
 
         monkeypatch.setattr(
-            gateway_cli,
+            gateway_restart,
             "read_raw_config",
             lambda: {"agent": {"restart_drain_timeout": 14}},
         )

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -1,163 +1,96 @@
-"""
-Integration tests for the desktop boot handshake fix (PR #50231 / issue #50209).
-
-Simulates a slow hermes_cli.gateway import (15-30 s on a fresh Windows install
-with Defender scanning every new .pyc) by patching the two helpers that touch
-the blocking import and measuring event-loop freedom + response latency.
-
-Three scenarios are covered:
-
-1. _lifespan fire-and-forget: patched _warm_gateway_module sleeps N seconds in
-   a thread; TestClient startup must complete in << N seconds (event loop not
-   blocked, HERMES_DASHBOARD_READY would fire immediately).
-
-2. get_status run_in_executor: patched _resolve_restart_drain_timeout sleeps N
-   seconds in a thread; a concurrent fast endpoint (/api/version) must respond
-   during the wait, proving the event loop stayed free.
-
-3. No orphan accumulation: three concurrent /api/status requests all receive a
-   200 response — no socket timeouts, no connection resets.
-"""
+"""Integration tests for the desktop backend readiness handshake."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
 import time
-import threading
+import urllib.request
 from unittest.mock import patch
 
 import pytest
+from fastapi.testclient import TestClient
 
+import gateway.restart as restart
 import hermes_cli.web_server as web_server_mod
+from hermes_cli import __version__
+from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
 
-SLOW_SECONDS = 3  # represents the Defender worst-case (scaled down for CI speed)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_slow_warm(seconds: float):
-    """Return a _warm_gateway_module replacement that sleeps in the caller thread."""
-    def _slow():
-        time.sleep(seconds)
-    return _slow
+SLOW_SECONDS = 3
 
 
 def _make_slow_drain(seconds: float):
-    """Return a _resolve_restart_drain_timeout replacement that sleeps in thread."""
+    """Return a resolver replacement that sleeps in its worker thread."""
     def _slow():
         time.sleep(seconds)
         return 180.0
+
     return _slow
 
 
-# ---------------------------------------------------------------------------
-# Test 1 — _lifespan fire-and-forget does not block the event loop
-# ---------------------------------------------------------------------------
-
-def test_lifespan_warmup_is_nonblocking():
-    """
-    _warm_gateway_module runs in an executor (fire-and-forget).
-    Even if it sleeps for SLOW_SECONDS, TestClient startup must complete
-    in well under that time — proving the event loop was never blocked and
-    HERMES_DASHBOARD_READY would have fired without delay.
-    """
-    from fastapi.testclient import TestClient
-
-    with patch.object(web_server_mod, "_warm_gateway_module", _make_slow_warm(SLOW_SECONDS)):
-        t0 = time.perf_counter()
-        with TestClient(web_server_mod.app, raise_server_exceptions=False) as _client:
-            startup_ms = (time.perf_counter() - t0) * 1000
-
-    # Startup must complete in under half of SLOW_SECONDS (generous margin).
-    # If the import were synchronous, startup would block for >= SLOW_SECONDS.
-    threshold_ms = (SLOW_SECONDS * 1000) / 2
-    assert startup_ms < threshold_ms, (
-        f"_lifespan blocked the event loop: startup took {startup_ms:.0f} ms "
-        f"but slow import is {SLOW_SECONDS * 1000:.0f} ms — "
-        f"fire-and-forget is not working."
-    )
+def _fail_if_called(*_args, **_kwargs):
+    raise AssertionError("healthz touched a heavyweight status dependency")
 
 
-# ---------------------------------------------------------------------------
-# Test 2 — get_status run_in_executor keeps event loop free for other requests
-# ---------------------------------------------------------------------------
+def test_lifespan_has_no_gateway_module_warmup():
+    assert not hasattr(web_server_mod, "_warm_gateway_module")
+
 
 def test_get_status_does_not_block_event_loop():
-    """
-    /api/status calls _resolve_restart_drain_timeout via run_in_executor.
-    While that slow call is running in a thread, a concurrent fast request
-    (/api/version) must still get a response — proving the event loop stayed
-    free during the import.
-    """
+    """Slow status config resolution must not block unrelated requests."""
     import httpx
-    from anyio import from_thread, to_thread
 
-    results: dict[str, float] = {}
-    errors: list[str] = []
+    results: dict[str, float | int] = {}
 
     async def _run():
         transport = httpx.ASGITransport(app=web_server_mod.app)
         async with httpx.AsyncClient(
             transport=transport, base_url="http://test"
         ) as client:
-            # Fire both requests concurrently
             async with asyncio.TaskGroup() as tg:
                 async def _status():
-                    t = time.perf_counter()
-                    r = await client.get("/api/status", timeout=SLOW_SECONDS + 5)
-                    results["status_ms"] = (time.perf_counter() - t) * 1000
-                    results["status_code"] = r.status_code
+                    started = time.perf_counter()
+                    response = await client.get(
+                        "/api/status", timeout=SLOW_SECONDS + 5
+                    )
+                    results["status_ms"] = (
+                        time.perf_counter() - started
+                    ) * 1000
+                    results["status_code"] = response.status_code
 
                 async def _version():
-                    # Small delay so /api/status starts first
                     await asyncio.sleep(0.1)
-                    t = time.perf_counter()
-                    r = await client.get("/api/version", timeout=5)
-                    results["version_ms"] = (time.perf_counter() - t) * 1000
-                    results["version_code"] = r.status_code
+                    started = time.perf_counter()
+                    response = await client.get("/api/version", timeout=5)
+                    results["version_ms"] = (
+                        time.perf_counter() - started
+                    ) * 1000
+                    results["version_code"] = response.status_code
 
                 tg.create_task(_status())
                 tg.create_task(_version())
 
     with patch.object(
-        web_server_mod, "_resolve_restart_drain_timeout", _make_slow_drain(SLOW_SECONDS)
+        web_server_mod,
+        "resolve_restart_drain_timeout",
+        _make_slow_drain(SLOW_SECONDS),
     ):
         asyncio.run(_run())
 
-    # /api/version must have responded well before /api/status finished
     assert "version_ms" in results, "Fast endpoint never responded"
     assert "status_ms" in results, "/api/status never responded"
+    assert float(results["version_ms"]) < SLOW_SECONDS * 1000
+    assert results.get("status_code") == 200
 
-    version_ms = results["version_ms"]
-    status_ms = results["status_ms"]
-
-    # /api/version should respond in < SLOW_SECONDS (event loop free)
-    assert version_ms < SLOW_SECONDS * 1000, (
-        f"/api/version took {version_ms:.0f} ms — event loop was blocked by "
-        f"/api/status (which waited {status_ms:.0f} ms for the slow import)."
-    )
-
-    # /api/status itself eventually returns 200
-    assert results.get("status_code") == 200, (
-        f"/api/status returned {results.get('status_code')} instead of 200"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 3 — no orphan accumulation: concurrent probes all receive 200
-# ---------------------------------------------------------------------------
 
 def test_concurrent_status_probes_all_respond():
-    """
-    Three concurrent /api/status requests must all receive HTTP 200.
-    If the event loop were blocked, later requests would pile up and
-    the desktop shell would eventually reset the connection (WinError 10054).
-    """
+    """Concurrent status probes must all complete while resolution is slow."""
     import httpx
 
-    PROBES = 3
     responses: list[int] = []
 
     async def _run():
@@ -165,24 +98,189 @@ def test_concurrent_status_probes_all_respond():
         async with httpx.AsyncClient(
             transport=transport, base_url="http://test"
         ) as client:
-            tasks = [
+            requests = [
                 client.get("/api/status", timeout=SLOW_SECONDS + 5)
-                for _ in range(PROBES)
+                for _ in range(3)
             ]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for r in results:
-                if isinstance(r, Exception):
-                    responses.append(-1)
-                else:
-                    responses.append(r.status_code)
+            results = await asyncio.gather(*requests, return_exceptions=True)
+            for result in results:
+                responses.append(
+                    -1 if isinstance(result, Exception) else result.status_code
+                )
 
     with patch.object(
-        web_server_mod, "_resolve_restart_drain_timeout", _make_slow_drain(SLOW_SECONDS)
+        web_server_mod,
+        "resolve_restart_drain_timeout",
+        _make_slow_drain(SLOW_SECONDS),
     ):
         asyncio.run(_run())
 
-    failed = [c for c in responses if c != 200]
-    assert not failed, (
-        f"{len(failed)}/{PROBES} probes failed (codes: {responses}). "
-        f"This would cause WinError 10054 and orphan accumulation on desktop."
+    assert responses == [200, 200, 200]
+
+
+def test_healthz_is_fixed_uncached_and_independent_of_status_state(
+    monkeypatch, tmp_path
+):
+    """Readiness must not load config, database, gateway, or plugin state."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "this: [is: intentionally: invalid\n", encoding="utf-8"
     )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    for name in (
+        "check_config_version",
+        "get_running_pid_cached",
+        "read_runtime_status",
+        "load_config",
+        "read_raw_config",
+        "resolve_restart_drain_timeout",
+    ):
+        monkeypatch.setattr(web_server_mod, name, _fail_if_called)
+    monkeypatch.setattr(
+        web_server_mod, "_status_active_sessions", _fail_if_called
+    )
+
+    previous = getattr(web_server_mod.app.state, "auth_required", None)
+    web_server_mod.app.state.auth_required = False
+    try:
+        response = TestClient(web_server_mod.app).get("/api/healthz")
+    finally:
+        web_server_mod.app.state.auth_required = previous
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "status": "ready",
+        "version": __version__,
+    }
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_healthz_is_in_shared_public_allowlist():
+    assert "/api/healthz" in PUBLIC_API_PATHS
+
+
+@pytest.mark.parametrize("auth_required", [False, True])
+def test_healthz_is_public_under_both_dashboard_auth_modes(auth_required):
+    previous_required = getattr(
+        web_server_mod.app.state, "auth_required", None
+    )
+    previous_host = getattr(web_server_mod.app.state, "bound_host", None)
+    previous_port = getattr(web_server_mod.app.state, "bound_port", None)
+    web_server_mod.app.state.auth_required = auth_required
+    web_server_mod.app.state.bound_host = "127.0.0.1"
+    web_server_mod.app.state.bound_port = 9119
+    try:
+        client = TestClient(
+            web_server_mod.app, base_url="http://127.0.0.1:9119"
+        )
+        response = client.get("/api/healthz")
+    finally:
+        web_server_mod.app.state.auth_required = previous_required
+        web_server_mod.app.state.bound_host = previous_host
+        web_server_mod.app.state.bound_port = previous_port
+
+    assert response.status_code == 200
+
+
+def test_healthz_over_real_loopback_server_with_temp_hermes_home(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    ready_file = tmp_path / "backend-ready.json"
+    env = os.environ.copy()
+    env.update({
+        "HERMES_DESKTOP_READY_FILE": str(ready_file),
+        "HERMES_HOME": str(hermes_home),
+        "HERMES_SERVE_HEADLESS": "1",
+    })
+    repo_root = Path(__file__).resolve().parents[2]
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from hermes_cli.web_server import start_server; "
+                "start_server(host='127.0.0.1', port=0, open_browser=False, "
+                "headless=True)"
+            ),
+        ],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 60
+        while not ready_file.exists() and process.poll() is None:
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.05)
+
+        if not ready_file.exists():
+            output = process.stdout.read() if process.poll() is not None else ""
+            pytest.fail(
+                f"backend did not publish its ready file; "
+                f"exit={process.poll()} output={output}"
+            )
+
+        port = json.loads(ready_file.read_text(encoding="utf-8"))["port"]
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/healthz", timeout=5
+        ) as response:
+            assert response.status == 200
+            assert response.headers["Cache-Control"] == "no-store"
+            assert json.load(response) == {
+                "ok": True,
+                "status": "ready",
+                "version": __version__,
+            }
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+
+
+def test_restart_drain_timeout_resolver_precedence(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  restart_drain_timeout: 14\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+    assert restart.resolve_restart_drain_timeout() == 14.0
+
+    monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "9")
+    assert restart.resolve_restart_drain_timeout() == 9.0
+
+    monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "invalid")
+    assert (
+        restart.resolve_restart_drain_timeout()
+        == restart.DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    )
+
+    monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT")
+    (hermes_home / "config.yaml").unlink()
+    assert (
+        restart.resolve_restart_drain_timeout()
+        == restart.DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    )
+
+
+def test_restart_drain_timeout_zero_from_real_config(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  restart_drain_timeout: 0\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+
+    assert restart.resolve_restart_drain_timeout() == 0.0

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -36,10 +36,6 @@ def _fail_if_called(*_args, **_kwargs):
     raise AssertionError("healthz touched a heavyweight status dependency")
 
 
-def test_lifespan_has_no_gateway_module_warmup():
-    assert not hasattr(web_server_mod, "_warm_gateway_module")
-
-
 def test_get_status_does_not_block_event_loop():
     """Slow status config resolution must not block unrelated requests."""
     import httpx

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -72,7 +72,7 @@ def test_get_status_does_not_block_event_loop():
 
     with patch.object(
         web_server_mod,
-        "resolve_restart_drain_timeout",
+        "_resolve_restart_drain_timeout",
         _make_slow_drain(SLOW_SECONDS),
     ):
         asyncio.run(_run())
@@ -106,7 +106,7 @@ def test_concurrent_status_probes_all_respond():
 
     with patch.object(
         web_server_mod,
-        "resolve_restart_drain_timeout",
+        "_resolve_restart_drain_timeout",
         _make_slow_drain(SLOW_SECONDS),
     ):
         asyncio.run(_run())
@@ -131,7 +131,7 @@ def test_healthz_is_fixed_uncached_and_independent_of_status_state(
         "read_runtime_status",
         "load_config",
         "read_raw_config",
-        "resolve_restart_drain_timeout",
+        "_resolve_restart_drain_timeout",
     ):
         monkeypatch.setattr(web_server_mod, name, _fail_if_called)
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Hardens Hermes Desktop startup against a readiness false negative where the desktop can report `Timed out connecting to Hermes backend after 15000ms` even though the backend process is already listening.

The desktop currently uses the full `/api/status` response as its readiness signal. That route intentionally aggregates configuration, gateway/runtime state, sessions, and restart-drain metadata. During Windows cold start—or when the local Python runtime is degraded, dependencies are being repaired, bytecode is being generated, or Defender is scanning new files—the HTTP server may already be alive while this heavier status response misses the desktop request deadline.

This change:

- adds a public, unauthenticated `GET /api/healthz` endpoint that returns only `{ok, status, version}` with `Cache-Control: no-store`
- keeps healthz independent from config, database, gateway, profile, and plugin loading
- makes desktop startup probe healthz first with a 2.5s per-request timeout, 500ms retry interval, and the existing 45s overall deadline
- falls back to `/api/status` only when a remote backend explicitly lacks healthz (404 or the existing HTML missing-endpoint response)
- continues retrying healthz for network errors, timeouts, and 5xx responses instead of misclassifying them as legacy compatibility
- preserves cancellation when an SSH bootstrap is superseded by newer connection settings, including during the retry wait
- removes eager gateway-module warmup during web-server startup
- shares the lightweight restart-drain timeout resolver between the web server and gateway CLI without changing `/api/status`'s response contract

## Why this approach?

Readiness should answer only whether the HTTP process can serve requests. Runtime status is a separate, heavier concern. Splitting those contracts prevents slow status aggregation from being reported as “the backend did not start,” without masking a backend that genuinely failed to listen or exited early.

This is deliberately defense-in-depth rather than a replacement for installation repair. A broken or partial Python environment still needs to be repaired by Hermes Setup; healthz only prevents that environment’s slow status aggregation from becoming a misleading readiness error once the HTTP server is serving requests.

## Additional Windows investigation

A later reproduction on the same Windows machine exposed an additional contributing condition:

- Desktop logged `runtime import probe failed (broken/partial venv)` and rejected the existing CLI/runtime.
- Reinstalling the GUI/runtime repaired the environment and refreshed dependencies/bytecode caches.
- After repair, `/api/status` responded in roughly one second and repeated Desktop starts completed without the 15-second error.

That finding narrows the claim: `/api/status` was not proven to be the sole cause of every observed timeout. The damaged/partial runtime was an important trigger in the latest reproduction. However, it does not change the architectural issue addressed here: a comprehensive runtime-status endpoint remains the wrong boundary for process readiness, because any slow configuration, plugin, gateway, cache, antivirus, or partially repaired runtime work can turn an already-listening backend into a false startup failure.

The intended responsibilities are therefore:

- **Hermes Setup / Repair:** restore a broken or partial runtime.
- **`/api/healthz`:** report that the backend HTTP process can serve requests.
- **`/api/status`:** provide full runtime and gateway status after readiness.

## Related Issue

No existing issue linked; reproduced locally on Windows cold start.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added the lightweight `/api/healthz` readiness contract and public allowlist entry.
- Added desktop health-first probing with conservative legacy fallback.
- Preserved SSH bootstrap supersede/cancellation semantics through health probing and retry sleep.
- Removed eager gateway import warmup and shared lightweight drain-timeout resolution.
- Added backend integration and desktop timing, fallback, and cancellation tests.

## How to Test

- `python -m pytest tests/hermes_cli/test_web_server_boot_handshake.py tests/hermes_cli/test_gateway_service.py -q --tb=short` — 9 passed, 1 skipped on Windows
- `npx vitest run --project electron electron/backend-health.test.ts` — 10 passed
- `python -m compileall -q hermes_cli/web_server.py` — passed
- The backend test starts a real loopback server with isolated `HERMES_HOME` and verifies HTTP 200 plus `Cache-Control: no-store`.

`npm run typecheck` is currently blocked in this rebased worktree by unrelated upstream `assistant-ui` / `react-streamdown` dependency API mismatches; the readiness-specific Electron and Python tests above pass.

## Checklist

- [x] Commit follows Conventional Commits.
- [x] PR contains only readiness-related changes.
- [x] Tests were added for the bug fix.
- [x] Tested on Windows.
- [x] Cross-platform/remote compatibility considered.
- [x] No config keys or tool schemas changed.

## Security / privacy

The committed diff was scanned before push for API-key, token, and private-key patterns. No credential or user configuration files are included.
