### PR TITLE
fix(tui): keep unresolved session models unset

### DIFF
--- a/tests/tui_gateway/test_empty_model_persistence.py
+++ b/tests/tui_gateway/test_empty_model_persistence.py
@@ -1,0 +1,28 @@
+"""Unresolved model config must not become a sticky placeholder."""
+
+from unittest.mock import patch
+
+import tui_gateway.server as server
+
+
+def test_resolve_model_returns_empty_without_user_selection():
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.object(server, "_load_cfg", return_value={"model": {"provider": "custom"}}),
+    ):
+        assert server._resolve_model() == ""
+
+
+def test_resolve_model_uses_corrected_config_on_next_read():
+    configs = iter(
+        [
+            {"model": {"provider": "custom"}},
+            {"model": {"provider": "custom", "default": "real-model"}},
+        ]
+    )
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.object(server, "_load_cfg", side_effect=lambda: next(configs)),
+    ):
+        assert server._resolve_model() == ""
+        assert server._resolve_model() == "real-model"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1751,7 +1751,7 @@ def _ensure_session_db_row(session: dict) -> None:
         db.create_session(
             key,
             source=_session_source(session),
-            model=row_model,
+            model=row_model or None,
             model_config=model_config or None,
             parent_session_id=parent_session_id,
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
@@ -2096,7 +2096,10 @@ def _resolve_model() -> str:
         return str(m.get("default", "") or "").strip()
     if isinstance(m, str) and m:
         return m.strip()
-    return "anthropic/claude-sonnet-4"
+    # Empty means no user-selected model. Keep it unset so a corrected config
+    # can self-heal this session on the next resolution instead of persisting a
+    # provider-specific placeholder that may 404 forever.
+    return ""
 
 
 def _resolve_session_platform() -> str:
@@ -8062,7 +8065,7 @@ def _(rid, params: dict) -> dict:
         db.create_session(
             new_key,
             source=source,
-            model=_resolve_model(),
+            model=_resolve_model() or None,
             # Stable _branched_from marker so list_sessions_rich() keeps the
             # branch visible in /resume and /sessions. The TUI branch leaves
             # the parent live (no end_reason='branched'), so the legacy


### PR DESCRIPTION
1|## Summary
2|An unresolved model configuration now remains unset instead of being converted into a concrete placeholder and persisted as permanent session state.
3|
4|## Changes
5|- Return an empty model when config provides no selection.
6|- Persist `None` at both desktop-session and branch-session creation sites.
7|- Let later config correction self-heal the existing session rather than remain pinned to a provider-specific placeholder.
8|- Add regression coverage for unresolved and corrected consecutive reads.
9|
10|## Validation
11|| Path | Result |
12||---|---|
13|| TUI gateway model/session subset | 10 passed |
14|| Real consecutive config probe | Empty → corrected model |
15|| Sticky placeholder persistence | Eliminated at both write sites |
16|
17|Fixes #52410.
18|
19|## Infographic
20|
21|![Unresolved is not a model](https://v3b.fal.media/files/b/0aa1ede9/IgJpX4Q_xdvmaHTsgJtlx_mIzpHqU8.png)
22|