### PR TITLE
feat(desktop): configurable review-pane diff context (full-file view)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3281,6 +3281,13 @@ DEFAULT_CONFIG = {
         #   false   - always keep GPU acceleration on, even over a remote display.
         # Bridged to the HERMES_DESKTOP_DISABLE_GPU env var the Electron app reads.
         "disable_gpu": "auto",
+        # Unified-diff context lines for the desktop review pane's per-file diff.
+        # Mirrors lazygit's `git.diffContextSize`. The default matches git's
+        # standard 3 lines; set it high (e.g. 999999) to show the ENTIRE file with
+        # changes highlighted inline. Files larger than the renderer can
+        # comfortably draw fall back to the default context (see web_git.py) so a
+        # huge file never floods the non-virtualized diff view.
+        "review_diff_context": 3,
     },
 
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -305,21 +305,44 @@ def review_list(cwd: str, scope: str, base_ref: str | None) -> dict:
     return {"files": files, "base": None}
 
 
-def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool) -> str:
+# Above this many lines, a large `review_diff_context` (e.g. full-file 999999)
+# falls back to git's standard 3-line context — the desktop review pane renders
+# every diff line without virtualization, so a huge full-file diff would flood it.
+REVIEW_DIFF_FULL_CONTEXT_MAX_LINES = 3000
+
+
+def _review_diff_unified_flag(cwd: str, file_path: str, context: int) -> str:
+    """`--unified=N` for the review diff, clamped so a large (full-file) context
+    is only honored for files small enough for the non-virtualized renderer."""
+    if context <= 3:
+        return f"--unified={context}"
+    try:
+        with open(os.path.join(cwd, file_path), "rb") as fh:
+            if sum(1 for _ in fh) > REVIEW_DIFF_FULL_CONTEXT_MAX_LINES:
+                return "--unified=3"
+    except OSError:
+        pass
+    return f"--unified={context}"
+
+
+def review_diff(
+    cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool, context: int = 3
+) -> str:
     if not _is_dir(cwd):
         return ""
+    unified = _review_diff_unified_flag(cwd, file_path, context)
     if scope == "branch":
         base = _branch_base(cwd)
-        return _git_out(cwd, ["diff", f"{base}...HEAD", "--", file_path]) if base else ""
+        return _git_out(cwd, ["diff", unified, f"{base}...HEAD", "--", file_path]) if base else ""
     if scope == "lastTurn":
-        return _git_out(cwd, ["diff", base_ref, "--", file_path]) if base_ref else ""
+        return _git_out(cwd, ["diff", unified, base_ref, "--", file_path]) if base_ref else ""
     if staged:
-        return _git_out(cwd, ["diff", "--cached", "--", file_path])
-    worktree = _git_out(cwd, ["diff", "--", file_path])
+        return _git_out(cwd, ["diff", unified, "--cached", "--", file_path])
+    worktree = _git_out(cwd, ["diff", unified, "--", file_path])
     if worktree.strip():
         return worktree
     # Untracked: synthesize an all-add diff (exits non-zero by design).
-    _, out, _ = _git(cwd, ["diff", "--no-index", "--", os.devnull, file_path])
+    _, out, _ = _git(cwd, ["diff", "--no-index", unified, "--", os.devnull, file_path])
     return out
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2319,7 +2319,13 @@ async def git_review_list_route(path: str, scope: str = "uncommitted", base: Opt
 async def git_review_diff_route(
     path: str, file: str, scope: str = "uncommitted", base: Optional[str] = None, staged: bool = False
 ):
-    return {"diff": await _git_op(_web_git.review_diff, _git_path(path), file, scope, base, staged)}
+    # Diff context lines are configurable (desktop.review_diff_context) so the
+    # review pane can show the whole file, mirroring lazygit's diffContextSize.
+    try:
+        context = int((load_config() or {}).get("desktop", {}).get("review_diff_context", 3) or 3)
+    except (TypeError, ValueError):
+        context = 3
+    return {"diff": await _git_op(_web_git.review_diff, _git_path(path), file, scope, base, staged, context)}
 
 
 @app.get("/api/git/file-diff")


### PR DESCRIPTION
## Problem

The desktop review pane fetches each file's diff with git's **default 3-line context**, so you only ever see the changed hunk — never the rest of the file. Reviewers who want to read a change in the context of the whole file (à la lazygit's `git.diffContextSize: 999999`) have no way to do so.

## Change

Add a **`desktop.review_diff_context`** config setting (default `3`, matching git's standard context). Set it high (e.g. `999999`) to render the **entire file with changes highlighted inline**.

- `config.py` — new setting under the existing `desktop` block, documented alongside `disable_gpu`.
- `web_git.py` — `review_diff()` takes a `context` arg and injects `--unified=<context>` into each diff invocation (worktree / staged / branch / lastTurn / untracked).
- `web_server.py` — the `/api/git/review/diff` route reads the setting and passes it through.

## Large-file guard

The review pane renders diff lines **without virtualization**, so a huge full-file diff could flood the DOM. `review_diff` clamps a large requested context back to 3 lines for files over `REVIEW_DIFF_FULL_CONTEXT_MAX_LINES` (3000). Default behavior (`context=3`) is completely unchanged.

## Scope / follow-up

Wired through the **served/gateway path** (`web_server → web_git`), which covers the web dashboard and remote desktop sessions. The **local Electron IPC git path** (`apps/desktop/electron/git-review-ops.ts`) can honor the same setting in a follow-up (it doesn't read config today).

## Testing

- `py_compile` clean on all three files.
- Verified the context flag and the large-file cap select the expected `--unified=` value for small/large/missing files and default context.