### PR TITLE
fix(secrets): restore per-profile vault scoping

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -55,6 +55,8 @@ from agent.secret_sources.base import ErrorKind, SecretSource
 
 logger = logging.getLogger(__name__)
 
+_FLEET_GRANTS_CACHE: Dict[str, Tuple[float, dict]] = {}
+
 
 # ---------------------------------------------------------------------------
 # Configuration constants
@@ -487,6 +489,147 @@ def _run_bws_list(
     return secrets, warnings
 
 
+def _profile_namespace(home_path: Optional[Path]) -> Optional[str]:
+    """Return the vault namespace for the active Hermes profile."""
+    try:
+        home = Path(home_path or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    except Exception:
+        return None
+    profile_name = home.name.strip()
+    if not profile_name or profile_name.startswith("."):
+        return None
+    namespace = "".join(
+        character.upper() if character.isalnum() else "_"
+        for character in profile_name
+    ).strip("_")
+    return namespace or None
+
+
+def _is_credential_shaped(key: str) -> bool:
+    return (
+        key.endswith("_API_KEY")
+        or key == "API_KEY"
+        or key.endswith("_AUTH_JSON")
+        or key == "AUTH_JSON"
+    )
+
+
+def _load_fleet_grants(path: str) -> Optional[dict]:
+    try:
+        modified_at = os.path.getmtime(path)
+    except OSError:
+        return None
+    cached = _FLEET_GRANTS_CACHE.get(path)
+    if cached and cached[0] == modified_at:
+        return cached[1]
+    try:
+        with open(path, "r", encoding="utf-8") as grants_file:
+            data = json.load(grants_file)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("secrets"), dict):
+        return None
+    _FLEET_GRANTS_CACHE[path] = (modified_at, data)
+    return data
+
+
+def _grant_allows(entry: object, profile_slug: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    agents = entry.get("agents")
+    if agents == "*":
+        return True
+    if isinstance(agents, list):
+        return profile_slug in {
+            str(agent).strip().lower()
+            for agent in agents
+        }
+    return False
+
+
+def _apply_fleet_grants(
+    secrets: Dict[str, str],
+    profile_secrets: Dict[str, str],
+    *,
+    profile_slug: Optional[str],
+    skipped: List[str],
+    warnings: List[str],
+) -> None:
+    grants_path = os.environ.get("FLEET_SECRET_GRANTS", "").strip()
+    if not grants_path or not profile_slug:
+        return
+    grants_document = _load_fleet_grants(grants_path)
+    if grants_document is None:
+        warnings.append(
+            f"FLEET_SECRET_GRANTS={grants_path!r} is missing or unreadable; "
+            "credential grant filtering is inactive for this startup"
+        )
+        return
+    if grants_document.get("enforce") is not True:
+        return
+
+    grants = grants_document["secrets"]
+    deny_unlisted = os.environ.get(
+        "FLEET_SECRET_GRANTS_DENY_UNLISTED", ""
+    ).strip().lower() in {"1", "true", "yes"}
+    for key in list(secrets):
+        if not _is_credential_shaped(key) or key in profile_secrets:
+            continue
+        grant = grants.get(key)
+        if grant is None and not deny_unlisted:
+            continue
+        if grant is None or not _grant_allows(grant, profile_slug):
+            del secrets[key]
+            skipped.append(key)
+
+
+def _scope_secrets_for_profile(
+    secrets: Dict[str, str],
+    *,
+    home_path: Optional[Path],
+) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Map this profile's ``PROFILE__KEY`` secrets to ordinary env names.
+
+    Shared keys remain available. The active profile's namespaced value wins
+    over a shared value with the same target name, while every foreign profile
+    namespace is excluded from the process environment.
+    """
+    namespace = _profile_namespace(home_path)
+    shared_secrets: Dict[str, str] = {}
+    profile_secrets: Dict[str, str] = {}
+    skipped: List[str] = []
+    warnings: List[str] = []
+
+    for key, value in secrets.items():
+        if "__" not in key:
+            shared_secrets[key] = value
+            continue
+
+        prefix, target = key.split("__", 1)
+        if not target or not _is_valid_env_name(target):
+            warnings.append(
+                f"Skipping secret {key!r}: namespaced target is not a valid env-var name"
+            )
+            skipped.append(key)
+            continue
+
+        if namespace and prefix.upper() == namespace:
+            profile_secrets[target] = value
+        else:
+            skipped.append(key)
+
+    scoped_secrets = {**shared_secrets, **profile_secrets}
+    profile_slug = Path(home_path).name.strip().lower() if home_path else None
+    _apply_fleet_grants(
+        scoped_secrets,
+        profile_secrets,
+        profile_slug=profile_slug,
+        skipped=skipped,
+        warnings=warnings,
+    )
+    return scoped_secrets, skipped, warnings
+
+
 # ---------------------------------------------------------------------------
 # Public entry point — called from hermes_cli.env_loader
 # ---------------------------------------------------------------------------
@@ -558,8 +701,14 @@ def apply_bitwarden_secrets(
         result.error = str(exc)
         return result
 
+    secrets, namespace_skipped, namespace_warnings = _scope_secrets_for_profile(
+        secrets,
+        home_path=home_path,
+    )
     result.secrets = secrets
+    result.skipped.extend(namespace_skipped)
     result.warnings.extend(warnings)
+    result.warnings.extend(namespace_warnings)
 
     for key, value in secrets.items():
         if key == access_token_env:
@@ -692,8 +841,14 @@ class BitwardenSource(SecretSource):
             result.error_kind = _classify_bws_error(str(exc))
             return result
 
+        secrets, namespace_skipped, namespace_warnings = _scope_secrets_for_profile(
+            secrets,
+            home_path=home_path,
+        )
         result.secrets = secrets
+        result.skipped.extend(namespace_skipped)
         result.warnings.extend(warnings)
+        result.warnings.extend(namespace_warnings)
         return result
 
 
@@ -727,3 +882,4 @@ def _reset_cache_for_tests(home_path: Optional[Path] = None) -> None:
     """
     _CACHE.clear()
     _DISK_CACHE.clear(home_path)
+    _FLEET_GRANTS_CACHE.clear()

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -664,6 +664,95 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
     assert os.environ.get("MY_BSM_KEY") == "from-bsm"
 
 
+def test_env_loader_maps_only_the_active_profile_namespace(tmp_path, monkeypatch):
+    """A profile receives its namespaced secret under Hermes' ordinary env name."""
+    home = tmp_path / "profiles" / "iris"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: 'proj-1'\n"
+        "    access_token_env: 'BWS_ACCESS_TOKEN'\n"
+        "    cache_ttl_seconds: 0\n"
+        "    override_existing: true\n"
+        "    auto_install: false\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.t")
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("IRIS__TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("LEXI__TELEGRAM_BOT_TOKEN", raising=False)
+
+    def fake_fetch(**_kwargs):
+        return {
+            "IRIS__TELEGRAM_BOT_TOKEN": "iris-token",
+            "LEXI__TELEGRAM_BOT_TOKEN": "lexi-token",
+        }, []
+
+    monkeypatch.setattr(
+        "agent.secret_sources.bitwarden.find_bws",
+        lambda **_kwargs: Path("/fake/bws"),
+    )
+    monkeypatch.setattr(
+        "agent.secret_sources.bitwarden.fetch_bitwarden_secrets",
+        fake_fetch,
+    )
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+
+    from hermes_cli.env_loader import _apply_external_secret_sources
+    _apply_external_secret_sources(home)
+
+    assert os.environ.get("TELEGRAM_BOT_TOKEN") == "iris-token"
+    assert "IRIS__TELEGRAM_BOT_TOKEN" not in os.environ
+    assert "LEXI__TELEGRAM_BOT_TOKEN" not in os.environ
+
+
+def test_env_loader_drops_a_shared_credential_not_granted_to_the_profile(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "iris"
+    home.mkdir(parents=True)
+    grants_path = tmp_path / ".fleet-secret-grants.json"
+    grants_path.write_text(json.dumps({
+        "version": 1,
+        "enforce": True,
+        "secrets": {
+            "EXAMPLE_API_KEY": {"agents": ["lexi"], "env": "EXAMPLE_API_KEY"},
+        },
+    }))
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: 'proj-1'\n"
+        "    access_token_env: 'BWS_ACCESS_TOKEN'\n"
+        "    cache_ttl_seconds: 0\n"
+        "    override_existing: true\n"
+        "    auto_install: false\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.t")
+    monkeypatch.setenv("FLEET_SECRET_GRANTS", str(grants_path))
+    monkeypatch.delenv("EXAMPLE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "agent.secret_sources.bitwarden.find_bws",
+        lambda **_kwargs: Path("/fake/bws"),
+    )
+    monkeypatch.setattr(
+        "agent.secret_sources.bitwarden.fetch_bitwarden_secrets",
+        lambda **_kwargs: ({"EXAMPLE_API_KEY": "not-for-iris"}, []),
+    )
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+
+    from hermes_cli.env_loader import _apply_external_secret_sources
+    _apply_external_secret_sources(home)
+
+    assert "EXAMPLE_API_KEY" not in os.environ
+
+
 # ---------------------------------------------------------------------------
 # Disk-persisted cache (cross-process — speeds up back-to-back CLI invocations)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Restores per-profile Bitwarden secret scoping that is required when one Bitwarden project stores several Hermes profiles' credentials as `PROFILE__ENV_NAME` keys.

Without this mapping, a profile receives raw prefixed keys such as `IRIS__TELEGRAM_BOT_TOKEN`, while the gateway looks only for `TELEGRAM_BOT_TOKEN`. The messaging platform then starts disabled even though the profile's token exists in the vault. Foreign profiles' prefixed secrets also enter the process environment.

The fix maps only the active profile's namespace to ordinary environment names, excludes every foreign profile namespace, preserves shared keys, and reapplies the existing optional Fleet grants contract for shared API/OAuth credentials.

## Related Issue

No public issue. This fixes a live multi-profile gateway regression reproduced after upgrading to Hermes 0.18.2.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added active-profile namespace resolution in `agent/secret_sources/bitwarden.py`.
- Mapped `PROFILE__KEY` to `KEY` only for the active profile and dropped foreign namespaces before registry injection.
- Restored opt-in shared credential grant enforcement when `FLEET_SECRET_GRANTS` points to an enforced grants document.
- Added real env-loader regressions covering active-profile mapping, foreign-token exclusion, and ungranted shared credentials.

## How to Test

1. Configure a temporary profile with Bitwarden enabled.
2. Return both `IRIS__TELEGRAM_BOT_TOKEN` and `LEXI__TELEGRAM_BOT_TOKEN` from the source while loading the Iris profile.
3. Confirm only `TELEGRAM_BOT_TOKEN=iris-token` enters the environment and run:
   `scripts/run_tests.sh tests/test_bitwarden_secrets.py tests/secret_sources/ tests/hermes_cli/test_env_loader.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues for this regression
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3, Apple Silicon

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is internal and documented by focused docstrings and tests
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: uses `pathlib`, JSON, and environment operations only
- [x] Tool descriptions/schemas: N/A; no tool surface changed

## Screenshots / Logs

Screenshots are not applicable because this is a non-visual secret-resolution and gateway-startup fix. Value-redacted live proof on macOS:

```text
Bitwarden Secrets Manager: applied 10 secrets (..., TELEGRAM_BOT_TOKEN)
telegram_token_present=True
foreign_namespaced_telegram_tokens_present=0

DiVinci  ok  running; telegram connected
Jarvis   ok  running; telegram connected
Lexi     ok  running; telegram connected
Neo      ok  running; telegram connected

115 tests passed, 0 failed
ruff: All checks passed
```
