### PR TITLE
fix(kanban): honor configured kanban.failure_limit on crash and runtime-timeout paths

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6086,6 +6086,7 @@ def enforce_max_runtime(
     conn: sqlite3.Connection,
     *,
     signal_fn=None,
+    failure_limit: int = None,
 ) -> list[str]:
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
 
@@ -6098,6 +6099,12 @@ def enforce_max_runtime(
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
     test hook; defaults to ``os.kill`` on POSIX.
+
+    ``failure_limit`` is the configured ``kanban.failure_limit`` threshold
+    threaded through ``dispatch_once`` (same value ``recompute_ready``
+    receives). It governs how many timeouts a task may accrue before the
+    breaker trips. ``None`` (direct callers / tests) falls through to
+    ``DEFAULT_FAILURE_LIMIT`` inside ``_record_task_failure``.
     """
     import signal
     timed_out: list[str] = []
@@ -6189,6 +6196,10 @@ def enforce_max_runtime(
                 conn, tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                 outcome="timed_out",
+                # Honour the configured ``kanban.failure_limit`` on the
+                # runtime-timeout path too; None falls through to
+                # ``DEFAULT_FAILURE_LIMIT`` for direct callers / tests.
+                failure_limit=failure_limit,
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "sigkill": killed},
@@ -6343,8 +6354,20 @@ def _error_fingerprint(error_text: str) -> str:
     return fp.lower().strip()
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, *, failure_limit: int = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
+
+    ``failure_limit`` is the configured ``kanban.failure_limit`` threshold
+    (the gateway threads it through ``dispatch_once`` exactly like it does
+    for ``recompute_ready``). It governs how many times an *ordinary* single
+    crash may retry before the breaker trips. ``None`` (the default for
+    direct callers / tests) falls through to ``DEFAULT_FAILURE_LIMIT`` inside
+    ``_record_task_failure``. Note: a protocol-violation or systemic crash
+    still forces an immediate trip (limit 1) regardless of this value — that
+    anti-loop override is intentional; the configured floor only applies to
+    ordinary isolated crashes.
 
     Appends a ``crashed`` event and drops the task back to ``ready``.
     Different from ``release_stale_claims``: this checks liveness
@@ -6522,7 +6545,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if (protocol_violation or is_systemic) else None,
+                # Protocol-violation / systemic crashes force an immediate
+                # trip (anti-loop). An ordinary isolated crash honours the
+                # configured ``kanban.failure_limit`` (``failure_limit``);
+                # None falls through to ``DEFAULT_FAILURE_LIMIT``.
+                failure_limit=(
+                    1 if (protocol_violation or is_systemic)
+                    else failure_limit
+                ),
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
@@ -7064,7 +7094,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, failure_limit=failure_limit)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -7081,7 +7111,7 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
-    result.timed_out = enforce_max_runtime(conn)
+    result.timed_out = enforce_max_runtime(conn, failure_limit=failure_limit)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -788,6 +788,147 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             )
 
 
+def _arm_running_dead_pid(conn, tid, pid, host):
+    """Put ``tid`` into ``running`` with a (dead) worker pid + host-local
+    claim so the next ``detect_crashed_workers`` sweep sees it as crashed.
+    Leaves ``started_at`` NULL so the launch-window grace never suppresses
+    the reclaim (mirrors the sibling systemic/isolated tests)."""
+    conn.execute(
+        "UPDATE tasks SET status='running', worker_pid=?, "
+        "claim_lock=?, started_at=NULL WHERE id=?",
+        (pid, f"{host}:w{pid}", tid),
+    )
+    conn.commit()
+
+
+def test_detect_crashed_workers_isolated_honours_configured_failure_limit(
+    kanban_home, monkeypatch,
+):
+    """Regression: an ordinary (non-systemic, non-protocol) PID-death crash
+    must honour the configured ``kanban.failure_limit`` on the crash path.
+
+    Before the fix, ``detect_crashed_workers`` hardcoded
+    ``failure_limit=... else None`` which fell to ``DEFAULT_FAILURE_LIMIT``
+    (2), so a card with an owner-set limit of 4 auto-blocked at the 2nd
+    crash regardless of config. It must now stay retryable through the
+    3rd crash and only block on the 4th.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    host = _kb._claimer_id().split(":", 1)[0]
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="isolated-crasher", assignee="a")
+
+        # Crashes 1..3 with configured limit=4 must NOT block the card.
+        for attempt in range(1, 4):
+            _arm_running_dead_pid(conn, tid, 70000 + attempt, host)
+            crashed = kb.detect_crashed_workers(conn, failure_limit=4)
+            assert crashed == [tid]
+            task = kb.get_task(conn, tid)
+            assert task.consecutive_failures == attempt
+            assert task.status == "ready", (
+                f"crash #{attempt} with failure_limit=4 must stay retryable, "
+                f"got status={task.status} (config being ignored → capped at "
+                f"DEFAULT_FAILURE_LIMIT)"
+            )
+
+        # 4th crash reaches the configured threshold → auto-block.
+        _arm_running_dead_pid(conn, tid, 70004, host)
+        kb.detect_crashed_workers(conn, failure_limit=4)
+        task = kb.get_task(conn, tid)
+        assert task.consecutive_failures == 4
+        assert task.status == "blocked", (
+            f"crash #4 should trip the breaker at configured limit=4, "
+            f"got {task.status}"
+        )
+
+
+def test_detect_crashed_workers_systemic_trips_early_despite_high_limit(
+    kanban_home, monkeypatch,
+):
+    """The anti-loop override must survive the fix: a genuine systemic
+    failure (>=3 same-fingerprint crashes in one sweep) still trips at the
+    first sweep even when the configured ``failure_limit`` is high (4)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    host = _kb._claimer_id().split(":", 1)[0]
+
+    with kb.connect() as conn:
+        task_ids = []
+        for i in range(3):
+            tid = kb.create_task(conn, title=f"sys-{i}", assignee="a")
+            _arm_running_dead_pid(conn, tid, 60000 + i, host)
+            task_ids.append(tid)
+
+        crashed = kb.detect_crashed_workers(conn, failure_limit=4)
+        assert len(crashed) == 3
+
+        for tid in task_ids:
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked", (
+                f"systemic crash must force an early trip despite "
+                f"failure_limit=4; task {tid} got {task.status}"
+            )
+            assert task.consecutive_failures == 1
+
+
+def test_enforce_max_runtime_honours_configured_failure_limit(
+    kanban_home, monkeypatch,
+):
+    """The runtime-timeout path must also thread the configured
+    ``failure_limit``: two timeouts under limit=4 stay retryable where the
+    old hardcoded ``DEFAULT_FAILURE_LIMIT`` (2) would have auto-blocked."""
+    import hermes_cli.kanban_db as _kb
+
+    state = {"sent_term": False}
+    monkeypatch.setattr(
+        _kb, "_pid_alive", lambda _pid: not state["sent_term"],
+    )
+
+    def _signal(pid, sig):
+        import signal as _sig
+        if sig == _sig.SIGTERM:
+            state["sent_term"] = True
+
+    host = _kb._claimer_id().split(":", 1)[0]
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="slow", assignee="a", max_runtime_seconds=1,
+        )
+        for attempt in range(1, 3):
+            long_ago = int(time.time()) - 30
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status='running', claim_lock=?, "
+                    "claim_expires=?, worker_pid=?, started_at=? WHERE id=?",
+                    (f"{host}:lock", int(time.time()) + 3600,
+                     os.getpid(), long_ago, tid),
+                )
+                conn.execute(
+                    "INSERT INTO task_runs (task_id, status, claim_lock, "
+                    "claim_expires, worker_pid, started_at) "
+                    "VALUES (?, 'running', ?, ?, ?, ?)",
+                    (tid, f"{host}:lock", int(time.time()) + 3600,
+                     os.getpid(), long_ago),
+                )
+                rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+                conn.execute(
+                    "UPDATE tasks SET current_run_id=? WHERE id=?", (rid, tid),
+                )
+            state["sent_term"] = False
+            kb.enforce_max_runtime(conn, signal_fn=_signal, failure_limit=4)
+            task = kb.get_task(conn, tid)
+            assert task.consecutive_failures == attempt
+            assert task.status == "ready", (
+                f"timeout #{attempt} with failure_limit=4 must stay retryable, "
+                f"got {task.status}"
+            )
+
+
 def test_detect_crashed_workers_skips_freshly_claimed_tasks(
     kanban_home, monkeypatch,
 ):


### PR DESCRIPTION
### Problem
`detect_crashed_workers` and `enforce_max_runtime` call `_record_task_failure` with `failure_limit=1 if (protocol_violation or is_systemic) else None`; `None` falls to `DEFAULT_FAILURE_LIMIT=2`. Only `recompute_ready`/`dispatch_once` receive the configured `kanban.failure_limit`. Result: ordinary PID-death crashes and runtime timeouts block cards at 2 regardless of an operator's configured limit (e.g. 4), and on restart waves this produces `gave_up`→`promoted` events ~1s apart.

### Fix
Thread the already-loaded `kanban.failure_limit` (the gateway reads it and passes it to `dispatch_once`) into `detect_crashed_workers` and `enforce_max_runtime` too. The deliberate anti-loop override — protocol-violation OR systemic (≥3 same-fingerprint crashes in one sweep) forces limit 1 — is preserved verbatim. New params are keyword-only with `None` default, so all existing callers are unchanged.

### Tests
`tests/hermes_cli/test_kanban_db.py` +3: a plain crash with `failure_limit=4` stays `ready` through crashes #1–3 and blocks only on #4; a systemic burst still trips at the first sweep despite limit 4; the runtime-timeout path honors config too. Full `test_kanban_db.py` + `test_kanban_core_functionality.py` = 396 passed, no regressions.