### PR TITLE
fix(kanban): worker process exits promptly after its task reaches a terminal state

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4737,6 +4737,41 @@ def run_conversation(
                                 pass
                     break
 
+                # ── Kanban worker self-exit ──────────────────────────
+                # A dispatcher-spawned worker that just drove its OWN
+                # assigned task to a terminal state (kanban_complete →
+                # done, or kanban_block → blocked) has no more work in
+                # this session. Break immediately so the process exits
+                # and releases its memory, instead of letting the model
+                # keep thinking/acting until the iteration budget runs
+                # out. In the field, finished workers free-ran 40-86 min
+                # past kanban_complete, pinning the dispatcher cgroup at
+                # MemoryHigh → systemd-oomd killed the whole dispatcher
+                # unit. The signal is set inside the kanban tool ONLY for
+                # a worker completing its exact HERMES_KANBAN_TASK, so
+                # non-kanban `chat -q` and interactive sessions never
+                # trip it. Env re-check here is belt-and-braces.
+                if os.environ.get("HERMES_KANBAN_TASK"):
+                    try:
+                        from tools.kanban_tools import (
+                            consume_worker_terminal_signal as _kb_consume_terminal,
+                        )
+                        _kb_terminal_tid = _kb_consume_terminal()
+                    except Exception:
+                        _kb_terminal_tid = None
+                    if _kb_terminal_tid:
+                        _turn_exit_reason = "kanban_worker_task_terminal"
+                        if not (final_response or "").strip():
+                            final_response = (
+                                getattr(agent, "_last_content_with_tools", None)
+                                or f"Task {_kb_terminal_tid} reached a terminal "
+                                "state; worker session complete."
+                            )
+                        messages.append(
+                            {"role": "assistant", "content": final_response}
+                        )
+                        break
+
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the
                 # entire conversation.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -233,6 +233,14 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Clear any stale kanban worker self-exit signal so it only ever
+    # reflects a terminal transition made during THIS turn (defensive:
+    # consume_worker_terminal_signal already clears on read).
+    try:
+        from tools.kanban_tools import reset_worker_terminal_signal
+        reset_worker_terminal_signal()
+    except Exception:
+        pass
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2221,3 +2221,77 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
     d = json.loads(out)
     assert d["ok"] is True, d
     assert d["subscribed"] is False, d
+
+
+# ---------------------------------------------------------------------------
+# Worker self-exit signal (prompt exit after terminal transition)
+# ---------------------------------------------------------------------------
+#
+# A dispatcher-spawned worker must EXIT promptly once its own assigned task
+# reaches a terminal state, instead of free-running and pinning the
+# dispatcher cgroup at MemoryHigh (→ systemd-oomd kills the whole unit). The
+# kanban tool sets a process-global signal on genuine success; the agent
+# conversation loop consumes it after each tool batch and breaks. These tests
+# pin the signal contract the loop depends on.
+
+def test_complete_sets_worker_terminal_signal(worker_env):
+    from tools import kanban_tools as kt
+    kt.reset_worker_terminal_signal()
+    out = kt._handle_complete({"summary": "done"})
+    assert json.loads(out)["ok"] is True
+    # The loop's exit condition: env var set + signal returns our task id.
+    assert os.environ.get("HERMES_KANBAN_TASK") == worker_env
+    assert kt.consume_worker_terminal_signal() == worker_env
+    # Consume is one-shot — a second read is clear so a later turn can't
+    # spuriously break.
+    assert kt.consume_worker_terminal_signal() is None
+
+
+def test_block_sets_worker_terminal_signal_when_landed_blocked(worker_env):
+    from tools import kanban_tools as kt
+    kt.reset_worker_terminal_signal()
+    out = kt._handle_block({"reason": "need clarification"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["status"] == "blocked"
+    assert kt.consume_worker_terminal_signal() == worker_env
+
+
+def test_orchestrator_complete_does_not_set_signal(monkeypatch, worker_env):
+    """A non-worker context (no HERMES_KANBAN_TASK) closing a task must NOT
+    arm the worker self-exit signal — only the dispatcher-spawned worker for
+    that exact task may."""
+    from tools import kanban_tools as kt
+    kt.reset_worker_terminal_signal()
+    # Drop the worker scoping → orchestrator/CLI context.
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    out = kt._handle_complete({"summary": "closed by orchestrator",
+                               "task_id": worker_env})
+    assert json.loads(out)["ok"] is True
+    assert kt.consume_worker_terminal_signal() is None
+
+
+def test_mark_worker_task_terminal_ignores_foreign_task(monkeypatch):
+    """The signal only arms for the process's own HERMES_KANBAN_TASK."""
+    from tools import kanban_tools as kt
+    kt.reset_worker_terminal_signal()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_self")
+    kt._mark_worker_task_terminal("t_other")   # foreign id → no-op
+    assert kt.consume_worker_terminal_signal() is None
+    kt._mark_worker_task_terminal("t_self")     # own id → arms
+    assert kt.consume_worker_terminal_signal() == "t_self"
+
+
+def test_reset_clears_stale_worker_terminal_signal(monkeypatch):
+    """reset_worker_terminal_signal (called per agent turn from
+    agent.turn_context.build_turn_context) must clear a stale signal so it
+    only ever reflects a terminal transition made during the current turn."""
+    from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_stale")
+    kt._mark_worker_task_terminal("t_stale")
+    assert kt._WORKER_TERMINAL_TASK_ID == "t_stale"
+    kt.reset_worker_terminal_signal()
+    assert kt.consume_worker_terminal_signal() is None
+    # The per-turn reset path imports the symbol from tools.kanban_tools;
+    # verify that import target exists so the loop wiring can't silently rot.
+    from tools.kanban_tools import reset_worker_terminal_signal  # noqa: F401

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -42,6 +42,58 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Worker self-exit signal
+# ---------------------------------------------------------------------------
+#
+# A dispatcher-spawned worker runs as ``hermes -p <profile> chat -q "work
+# kanban task <id>"`` (see hermes_cli.kanban_db._default_spawn). Once the
+# worker drives its OWN assigned task to a terminal state — kanban_complete
+# (done) or kanban_block (blocked) — there is nothing left to do in that
+# session, but the agent loop would otherwise keep thinking/acting until the
+# model volunteers a no-tool turn or the iteration budget runs out. Measured
+# in the field: finished workers free-ran 40-86 min past kanban_complete,
+# pinning the dispatcher cgroup at MemoryHigh until systemd-oomd killed the
+# whole dispatcher unit (taking every in-flight worker with it).
+#
+# The completion/block handlers set this process-global signal on genuine
+# success; the agent conversation loop (agent/conversation_loop.py) reads it
+# after each tool batch and breaks the loop so the worker process exits
+# promptly. Each worker is its own subprocess, so a per-process global is the
+# right scope. It is set ONLY when this process is the dispatcher-spawned
+# worker for that exact task (``HERMES_KANBAN_TASK == task_id``); interactive
+# and non-kanban ``chat -q`` sessions never set the env var, so they can never
+# trip it and are unaffected.
+
+_WORKER_TERMINAL_TASK_ID: Optional[str] = None
+
+
+def _mark_worker_task_terminal(task_id: str) -> None:
+    """Record that THIS worker just drove its own assigned task terminal.
+
+    No-op unless the process is the dispatcher-spawned worker for
+    ``task_id`` (``HERMES_KANBAN_TASK == task_id``). Orchestrator/CLI
+    callers completing *other* tasks never set the signal.
+    """
+    global _WORKER_TERMINAL_TASK_ID
+    if task_id and os.environ.get("HERMES_KANBAN_TASK") == task_id:
+        _WORKER_TERMINAL_TASK_ID = task_id
+
+
+def consume_worker_terminal_signal() -> Optional[str]:
+    """Return and clear the pending worker-self-terminated task id (or None)."""
+    global _WORKER_TERMINAL_TASK_ID
+    tid = _WORKER_TERMINAL_TASK_ID
+    _WORKER_TERMINAL_TASK_ID = None
+    return tid
+
+
+def reset_worker_terminal_signal() -> None:
+    """Clear the signal at the start of an agent turn (defensive)."""
+    global _WORKER_TERMINAL_TASK_ID
+    _WORKER_TERMINAL_TASK_ID = None
+
+
+# ---------------------------------------------------------------------------
 # Gating
 # ---------------------------------------------------------------------------
 
@@ -655,6 +707,11 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
+            # The worker's own task is now done — signal the agent loop to
+            # exit promptly so the process frees its memory instead of
+            # free-running (see _mark_worker_task_terminal). No-op unless
+            # this process is the dispatcher-spawned worker for `tid`.
+            _mark_worker_task_terminal(tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
             conn.close()
@@ -728,6 +785,11 @@ def _handle_block(args: dict, **kw) -> str:
             # Tell the worker where the task actually landed so it doesn't
             # assume it's sitting in 'blocked' when routing sent it elsewhere.
             landed = kb.get_task(conn, tid)
+            # Only self-exit when the task genuinely landed terminal for this
+            # worker (blocked). If routing bounced it back to ready/running,
+            # leave the loop alone rather than force an early exit.
+            if landed is not None and landed.status == "blocked":
+                _mark_worker_task_terminal(tid)
             return _ok(
                 task_id=tid,
                 run_id=run.id if run else None,


### PR DESCRIPTION
### Problem
A dispatcher-spawned worker (`chat -q "work kanban task <id>"`) keeps thinking/acting after it calls `kanban_complete`/`kanban_block`, until the model volunteers a no-tool turn or the iteration budget drains — 40–86 min of free-running observed after completion. Lingering workers pin the dispatcher cgroup at MemoryHigh → systemd-oomd kills the whole unit → every in-flight worker dies.

### Fix
A per-process terminal signal armed by `_handle_complete` (on success) and `_handle_block` (only when the task actually landed `blocked`), and only when `HERMES_KANBAN_TASK == task_id` (this process is the dispatcher-spawned worker for that exact card). The conversation loop consumes the signal right after tool execution — gated on `HERMES_KANBAN_TASK` — and breaks; `finalize_turn` reports completed → the quiet path exits 0. Double-gated so non-kanban / interactive / foreign-task / goal-mode sessions are unaffected.

### Tests
`tests/tools/test_kanban_tools.py` +5 (102 passed); goal-mode + goals suites 113 passed; turn-context 14 passed. Non-kanban and orchestrator/foreign-task cases covered by negative tests.