### PR TITLE
feat(kanban): opt-in per-worker systemd scope + fleet-wide concurrency cap

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -929,6 +929,37 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        # Read kanban.max_in_progress_global — a FLEET-WIDE concurrency cap
+        # across every board. max_in_progress / max_spawn are per-board, but
+        # the dispatcher ticks all boards each cycle, so N boards each at their
+        # per-board cap can still overwhelm the host (the worker-pool OOM /
+        # throttle failure mode). When set, the total number of workers running
+        # across all boards combined is held at or below this value, in
+        # addition to the per-board caps. Default None = unchanged behavior.
+        raw_max_in_progress_global = kanban_cfg.get("max_in_progress_global", None)
+        max_in_progress_global = None
+        if raw_max_in_progress_global is not None:
+            try:
+                max_in_progress_global = int(raw_max_in_progress_global)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "kanban dispatcher: invalid kanban.max_in_progress_global=%r; ignoring",
+                    raw_max_in_progress_global,
+                )
+                max_in_progress_global = None
+            else:
+                if max_in_progress_global < 1:
+                    logger.warning(
+                        "kanban dispatcher: kanban.max_in_progress_global=%r is below 1; ignoring",
+                        raw_max_in_progress_global,
+                    )
+                    max_in_progress_global = None
+                else:
+                    logger.info(
+                        "kanban dispatcher: max_in_progress_global=%d",
+                        max_in_progress_global,
+                    )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -972,7 +1003,35 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
-        def _tick_once_for_board(slug: str) -> "Optional[object]":
+        def _board_running_count(slug: str) -> int:
+            """Count tasks in ``status='running'`` on a single board.
+
+            Used to seed the fleet-wide (cross-board) concurrency cap: the
+            dispatcher needs the total in-flight worker count across every
+            board before it decides how many more it may spawn this tick.
+            Best-effort — any error (corrupt/locked DB) counts as 0 so a
+            single bad board never blocks dispatch on the others.
+            """
+            conn = None
+            try:
+                conn = _kb.connect(board=slug)
+                return int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                    ).fetchone()[0]
+                )
+            except Exception:
+                return 0
+            finally:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+
+        def _tick_once_for_board(
+            slug: str, *, global_in_progress: int = 0
+        ) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
             Runs in a worker thread via `asyncio.to_thread`. `board=slug`
@@ -980,6 +1039,11 @@ class GatewayKanbanWatchersMixin:
             `_default_spawn` see the right paths. The per-board DB is
             opened explicitly so concurrent boards never share a
             connection handle or accidentally claim across each other.
+
+            ``global_in_progress`` is the number of workers already running
+            on *other* boards (plus spawns made earlier this tick); it is
+            threaded into ``dispatch_once`` so the fleet-wide cap
+            ``max_in_progress_global`` is honored across boards.
             """
             conn = None
             fingerprint = _board_db_fingerprint(slug)
@@ -1022,6 +1086,8 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    max_in_progress_global=max_in_progress_global,
+                    global_in_progress=global_in_progress,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
@@ -1071,10 +1137,39 @@ class GatewayKanbanWatchersMixin:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            slugs = [b.get("slug") or _kb.DEFAULT_BOARD for b in boards]
+
+            # Fleet-wide cap bookkeeping. When kanban.max_in_progress_global is
+            # set, pre-scan every board's live worker count so each board's
+            # dispatch knows how many workers are already running elsewhere;
+            # accumulate this tick's spawns so later boards see the earlier
+            # boards' fresh workers too. Skipped entirely (zero extra queries)
+            # when the global cap is unset.
+            running_by_board: dict[str, int] = {}
+            total_running = 0
+            if max_in_progress_global is not None:
+                for slug in slugs:
+                    c = _board_running_count(slug)
+                    running_by_board[slug] = c
+                    total_running += c
+            spawned_global = 0
+
             out: list[tuple[str, "Optional[object]"]] = []
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                out.append((slug, _tick_once_for_board(slug)))
+            for slug in slugs:
+                if max_in_progress_global is not None:
+                    # Workers on all *other* boards (initial snapshot) plus
+                    # spawns already made this tick on earlier boards.
+                    global_other = (
+                        total_running
+                        - running_by_board.get(slug, 0)
+                        + spawned_global
+                    )
+                else:
+                    global_other = 0
+                res = _tick_once_for_board(slug, global_in_progress=global_other)
+                if max_in_progress_global is not None and res is not None:
+                    spawned_global += len(getattr(res, "spawned", []) or [])
+                out.append((slug, res))
             return out
 
         def _ready_nonempty() -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6960,6 +6960,8 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_in_progress_global: Optional[int] = None,
+    global_in_progress: int = 0,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -6994,6 +6996,8 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_in_progress_global=max_in_progress_global,
+            global_in_progress=global_in_progress,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -7010,6 +7014,8 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_in_progress_global=max_in_progress_global,
+            global_in_progress=global_in_progress,
         )
 
 
@@ -7026,6 +7032,8 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_in_progress_global: Optional[int] = None,
+    global_in_progress: int = 0,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -7118,6 +7126,27 @@ def _dispatch_once_locked(
         remaining = max_in_progress - in_progress
         if max_spawn is None or max_spawn > remaining:
             max_spawn = remaining
+    # Fleet-wide (cross-board) concurrency cap (kanban.max_in_progress_global).
+    # max_in_progress / max_spawn are per-board, but the dispatcher ticks every
+    # board each cycle, so N boards each running up to their per-board cap can
+    # still melt the host. ``global_in_progress`` is the count of workers
+    # already running on *other* boards (plus spawns made earlier this tick),
+    # supplied by the multi-board caller; we add this board's own live count and
+    # refuse to push the total past the global cap. Like max_in_progress, this
+    # only ever shrinks max_spawn — it never authorizes more work — so it
+    # composes safely with the per-board caps above.
+    if max_in_progress_global is not None and ready_rows:
+        board_running = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            ).fetchone()[0]
+        )
+        total_in_flight = int(global_in_progress) + board_running
+        if total_in_flight >= max_in_progress_global:
+            return result
+        remaining_global = max_in_progress_global - total_in_flight
+        if max_spawn is None or max_spawn > remaining_global:
+            max_spawn = remaining_global
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -7677,6 +7706,144 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+# ---------------------------------------------------------------------------
+# Optional per-worker systemd scope isolation (opt-in)
+# ---------------------------------------------------------------------------
+#
+# By default a dispatcher launches each kanban worker with a plain
+# ``subprocess.Popen``. The child then inherits the dispatcher's systemd
+# cgroup — and therefore the dispatcher unit's ``CPUQuota`` / ``MemoryHigh``
+# limits. When many workers fan out on one board they all share that single
+# cgroup's budget: the pool gets throttled and, once it trips ``MemoryMax``,
+# ``systemd-oomd`` can kill the *entire* gateway unit (all workers + the
+# dispatcher) at once.
+#
+# When ``kanban.worker_slice`` is enabled AND the host is Linux AND
+# ``systemd-run`` is on PATH, each worker is instead launched via
+# ``systemd-run --scope`` under a configurable parent slice. Crucially,
+# ``systemd-run --scope`` *execs* into the worker command (it does not stay
+# resident as a wrapper), so:
+#   * the PID captured by ``Popen`` is the worker's real PID — crash
+#     detection (``_pid_alive``) and termination (``os.kill``) behave
+#     exactly as they do without the wrapper; and
+#   * the worker runs in its own transient ``run-*.scope`` cgroup nested
+#     under the shared parent slice, decoupled from the dispatcher's cgroup.
+# Operators cap the whole worker pool by setting resource limits on the
+# parent slice (or per-worker via ``worker_slice_properties``) instead of
+# starving the gateway unit.
+#
+# The feature is OFF by default and falls back to a plain ``Popen`` argv
+# whenever the config flag is unset, the platform is not Linux, or
+# ``systemd-run`` is unavailable — so non-systemd environments never regress.
+
+
+def _valid_slice_name(name: str) -> bool:
+    """True if ``name`` is a plausible systemd slice unit name.
+
+    systemd slice names must end in ``.slice`` and contain only a
+    conservative set of characters. We validate rather than sanitize so a
+    typo in config fails closed (plain Popen) instead of silently placing
+    workers in an unexpected slice.
+    """
+    if not name.endswith(".slice"):
+        return False
+    stem = name[: -len(".slice")]
+    if not stem:
+        return False
+    return all(c.isalnum() or c in "-_." for c in stem)
+
+
+def _worker_slice_config(kanban_cfg=None):
+    """Resolve the opt-in per-worker systemd-scope settings.
+
+    Returns ``(enabled, slice_name, use_user, properties)``. ``enabled`` is
+    ``True`` only when the operator turned the feature on with a valid slice
+    name; callers still gate on platform + ``systemd-run`` availability.
+    """
+    if kanban_cfg is None:
+        try:
+            from hermes_cli.config import load_config
+
+            kanban_cfg = (load_config().get("kanban") or {})
+        except Exception:
+            kanban_cfg = {}
+    kanban_cfg = kanban_cfg or {}
+    enabled = bool(kanban_cfg.get("worker_slice", False))
+    slice_name = str(kanban_cfg.get("worker_slice_name") or "hermes-workers.slice")
+    if not _valid_slice_name(slice_name):
+        # Fail closed: a malformed slice name disables the wrapper rather
+        # than launching workers into an unintended / invalid slice.
+        if enabled:
+            _log.warning(
+                "kanban worker: ignoring invalid kanban.worker_slice_name=%r "
+                "(must end in .slice); launching workers without a scope",
+                slice_name,
+            )
+        enabled = False
+    # Default to the per-user manager (--user). Operators running the
+    # dispatcher as a system service without a user manager can flip
+    # worker_slice_user: false to use a system scope (needs privilege).
+    use_user = bool(kanban_cfg.get("worker_slice_user", True))
+    props_raw = kanban_cfg.get("worker_slice_properties") or {}
+    properties: list[str] = []
+    if isinstance(props_raw, dict):
+        for k, v in props_raw.items():
+            if k is None or v is None:
+                continue
+            properties.append(f"{k}={v}")
+    elif isinstance(props_raw, (list, tuple)):
+        for item in props_raw:
+            if item:
+                properties.append(str(item))
+    return enabled, slice_name, use_user, properties
+
+
+def _maybe_wrap_worker_scope(cmd: "list[str]", kanban_cfg=None) -> "list[str]":
+    """Return ``cmd`` wrapped in ``systemd-run --scope`` when opted in.
+
+    No-op (returns ``cmd`` unchanged) unless every condition holds:
+      * ``kanban.worker_slice`` is enabled with a valid slice name;
+      * the host is Linux; and
+      * ``systemd-run`` is discoverable on PATH.
+
+    ``systemd-run --scope`` execs the target, so the returned argv can be
+    handed to ``Popen`` exactly like the bare command: the captured PID is
+    the worker's, and no wrapper process survives to confuse crash/kill
+    tracking.
+    """
+    enabled, slice_name, use_user, properties = _worker_slice_config(kanban_cfg)
+    if not enabled:
+        return cmd
+    if sys.platform != "linux":
+        return cmd
+    systemd_run = shutil.which("systemd-run")
+    if not systemd_run:
+        _log.warning(
+            "kanban worker: kanban.worker_slice is enabled but systemd-run "
+            "is not on PATH; launching workers without a scope",
+        )
+        return cmd
+    wrapper = [
+        systemd_run,
+        "--scope",
+        # Suppress "Running as unit ..." chatter so it doesn't pollute the
+        # per-task worker log.
+        "--quiet",
+        # Garbage-collect the transient scope once the worker exits, so
+        # finished/failed scopes don't accumulate under the slice.
+        "--collect",
+        f"--slice={slice_name}",
+    ]
+    if use_user:
+        wrapper.append("--user")
+    for prop in properties:
+        wrapper.append(f"--property={prop}")
+    # `--` terminates systemd-run's own option parsing; everything after is
+    # the worker argv (which begins with the hermes binary path).
+    wrapper.append("--")
+    return wrapper + list(cmd)
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -7832,11 +7999,19 @@ def _default_spawn(
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
+    # Opt-in: launch the worker in its own transient systemd scope under a
+    # shared parent slice so its cgroup (and resource limits) are decoupled
+    # from the dispatcher's unit. `systemd-run --scope` execs into the
+    # worker, so `launch_cmd`'s captured PID is still the worker's PID and
+    # kill/crash tracking below is unchanged. No-op unless enabled + Linux +
+    # systemd-run present.
+    launch_cmd = _maybe_wrap_worker_scope(cmd)
+
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
+            launch_cmd,
             cwd=workspace if os.path.isdir(workspace) else None,
             stdin=subprocess.DEVNULL,
             stdout=log_f,

--- a/tests/hermes_cli/test_kanban_worker_slice_and_global_cap.py
+++ b/tests/hermes_cli/test_kanban_worker_slice_and_global_cap.py
@@ -1,0 +1,280 @@
+"""Tests for two related dispatcher resilience fixes.
+
+1. Opt-in per-worker systemd scope isolation
+   (``kanban.worker_slice``): the ``_maybe_wrap_worker_scope`` helper wraps
+   a worker argv in ``systemd-run --scope`` when the feature is enabled AND
+   the host is Linux AND ``systemd-run`` is on PATH, and otherwise returns
+   the plain argv unchanged. This decouples each worker's cgroup /
+   resource limits from the dispatcher's unit.
+
+2. Fleet-wide (cross-board) concurrency cap
+   (``kanban.max_in_progress_global``): the dispatcher ticks every board, so
+   a per-board ``max_in_progress`` cannot bound total host concurrency. The
+   global cap counts in-flight workers ACROSS boards and stops dispatch once
+   the fleet-wide limit is reached.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Change 1 — per-worker systemd scope wrapper
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def kb_module():
+    """Import kanban_db under an isolated HERMES_HOME (no real fleet config)."""
+    test_home = tempfile.mkdtemp(prefix="kanban_worker_slice_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    os.environ["HERMES_HOME"] = test_home
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("hermes_cli")
+            or mod.startswith("hermes_state")
+            or mod == "hermes_constants"
+        ):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+BASE_CMD = ["/opt/hermes/bin/hermes", "-p", "alpha", "--cli", "chat", "-q", "work"]
+
+
+def test_wrap_disabled_by_default_returns_plain(kb_module, monkeypatch):
+    """No config flag → plain argv, even if systemd-run exists."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "linux")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg={})
+    assert out == BASE_CMD
+
+
+def test_wrap_enabled_linux_with_systemd_run_wraps(kb_module, monkeypatch):
+    """Enabled + Linux + systemd-run present → systemd-run --scope wrapper."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "linux")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+    cfg = {
+        "worker_slice": True,
+        "worker_slice_name": "hermes-workers.slice",
+        "worker_slice_properties": {"MemoryHigh": "900M", "CPUQuota": "50%"},
+    }
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg=cfg)
+    assert out[0] == "/usr/bin/systemd-run"
+    assert "--scope" in out
+    assert "--slice=hermes-workers.slice" in out
+    assert "--user" in out  # default manager
+    assert "--property=MemoryHigh=900M" in out
+    assert "--property=CPUQuota=50%" in out
+    # `--` must separate systemd-run's options from the worker argv, and the
+    # worker argv must follow intact so the captured PID is the worker's.
+    assert "--" in out
+    assert out[out.index("--") + 1:] == BASE_CMD
+
+
+def test_wrap_enabled_but_systemd_run_absent_falls_back(kb_module, monkeypatch):
+    """Enabled + Linux but systemd-run not on PATH → plain argv."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "linux")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: None)
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg={"worker_slice": True})
+    assert out == BASE_CMD
+
+
+def test_wrap_enabled_but_not_linux_falls_back(kb_module, monkeypatch):
+    """Enabled + systemd-run present but non-Linux host → plain argv."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "darwin")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg={"worker_slice": True})
+    assert out == BASE_CMD
+
+
+def test_wrap_invalid_slice_name_fails_closed(kb_module, monkeypatch):
+    """A slice name that isn't a valid unit name disables the wrapper."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "linux")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+    cfg = {"worker_slice": True, "worker_slice_name": "not-a-slice"}
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg=cfg)
+    assert out == BASE_CMD
+
+
+def test_wrap_system_manager_when_user_false(kb_module, monkeypatch):
+    """worker_slice_user: false → no --user flag (system scope)."""
+    kb = kb_module
+    monkeypatch.setattr(kb.sys, "platform", "linux")
+    monkeypatch.setattr(kb.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+    cfg = {"worker_slice": True, "worker_slice_user": False}
+    out = kb._maybe_wrap_worker_scope(BASE_CMD, kanban_cfg=cfg)
+    assert out[0] == "/usr/bin/systemd-run"
+    assert "--user" not in out
+
+
+# ---------------------------------------------------------------------------
+# Change 2 — fleet-wide (cross-board) concurrency cap
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def kb_two_boards():
+    """Fresh HERMES_HOME with two kanban boards + an 'alpha' profile."""
+    test_home = tempfile.mkdtemp(prefix="kanban_global_cap_test_")
+    for prof in ("alpha", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    os.environ["HERMES_HOME"] = test_home
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("hermes_cli")
+            or mod.startswith("hermes_state")
+            or mod == "hermes_constants"
+        ):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db as kb
+    kb.create_board(slug="boardA", name="Board A")
+    kb.create_board(slug="boardB", name="Board B")
+    yield kb
+
+
+def _fake_spawn(*args, **kwargs):
+    return 4242
+
+
+def _mark_running(kb, slug, n):
+    """Force ``n`` tasks into 'running' on a board (simulates in-flight)."""
+    with kb.connect_closing(board=slug) as conn:
+        for i in range(n):
+            tid = kb.create_task(conn, title=f"run{i}", assignee="alpha")
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status='running', claim_lock=? WHERE id=?",
+                    (f"test:{i}", tid),
+                )
+
+
+def _add_ready(kb, slug, n):
+    with kb.connect_closing(board=slug) as conn:
+        for i in range(n):
+            kb.create_task(conn, title=f"ready{i}", assignee="alpha")
+
+
+def test_no_global_cap_dispatches_all(kb_two_boards):
+    """Baseline: without the global cap, all ready tasks dispatch."""
+    kb = kb_two_boards
+    _add_ready(kb, "boardA", 4)
+    with kb.connect_closing(board="boardA") as conn:
+        res = kb.dispatch_once(
+            conn, board="boardA", spawn_fn=_fake_spawn, dry_run=True,
+        )
+    assert len(res.spawned) == 4
+
+
+def test_global_cap_accounts_for_other_boards(kb_two_boards):
+    """boardB already runs 3; global cap=4 → boardA may spawn only 1."""
+    kb = kb_two_boards
+    _mark_running(kb, "boardB", 3)
+    _add_ready(kb, "boardA", 5)
+    with kb.connect_closing(board="boardA") as conn:
+        res = kb.dispatch_once(
+            conn, board="boardA", spawn_fn=_fake_spawn, dry_run=False,
+            max_in_progress_global=4,
+            global_in_progress=3,  # boardB's live workers, per the watcher
+        )
+    assert len(res.spawned) == 1
+
+
+def test_global_cap_already_reached_spawns_nothing(kb_two_boards):
+    """Other boards already at the cap → boardA spawns nothing this tick."""
+    kb = kb_two_boards
+    _add_ready(kb, "boardA", 5)
+    with kb.connect_closing(board="boardA") as conn:
+        res = kb.dispatch_once(
+            conn, board="boardA", spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress_global=4,
+            global_in_progress=4,
+        )
+    assert len(res.spawned) == 0
+
+
+def test_global_cap_counts_this_boards_own_running(kb_two_boards):
+    """This board's own running workers count toward the global total."""
+    kb = kb_two_boards
+    _mark_running(kb, "boardA", 2)  # boardA already has 2 in flight
+    _add_ready(kb, "boardA", 5)
+    with kb.connect_closing(board="boardA") as conn:
+        # cap=3, other boards contribute 0 → 2 already local, 1 slot left.
+        res = kb.dispatch_once(
+            conn, board="boardA", spawn_fn=_fake_spawn, dry_run=False,
+            max_in_progress_global=3,
+            global_in_progress=0,
+        )
+    assert len(res.spawned) == 1
+
+
+def test_global_cap_stops_dispatch_across_two_boards(kb_two_boards):
+    """End-to-end of the watcher's cross-board accumulation.
+
+    Replicates the sequential per-board tick the gateway watcher performs:
+    pre-scan running per board, then dispatch each board passing the count
+    of workers already running on the OTHER boards plus spawns made earlier
+    this tick. With cap=3 and both boards holding ready work, exactly 3
+    workers should be dispatched across the two boards combined.
+    """
+    kb = kb_two_boards
+    _add_ready(kb, "boardA", 5)
+    _add_ready(kb, "boardB", 5)
+    cap = 3
+
+    slugs = ["boardA", "boardB"]
+    # Pre-scan (mirrors _tick_once): running per board, total across boards.
+    running_by_board = {}
+    total_running = 0
+    for slug in slugs:
+        with kb.connect_closing(board=slug) as conn:
+            c = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM tasks WHERE status='running'"
+                ).fetchone()[0]
+            )
+        running_by_board[slug] = c
+        total_running += c
+
+    spawned_global = 0
+    per_board_spawned = {}
+    for slug in slugs:
+        global_other = total_running - running_by_board[slug] + spawned_global
+        with kb.connect_closing(board=slug) as conn:
+            res = kb.dispatch_once(
+                conn, board=slug, spawn_fn=_fake_spawn, dry_run=False,
+                max_in_progress_global=cap,
+                global_in_progress=global_other,
+            )
+        n = len(res.spawned)
+        per_board_spawned[slug] = n
+        spawned_global += n
+
+    assert spawned_global == cap, per_board_spawned
+    # boardA is dispatched first and fills the cap; boardB gets the remainder.
+    assert per_board_spawned["boardA"] == 3
+    assert per_board_spawned["boardB"] == 0
+
+
+def test_global_and_per_board_caps_compose(kb_two_boards):
+    """The tighter of (per-board max_in_progress, global cap) wins."""
+    kb = kb_two_boards
+    _add_ready(kb, "boardA", 10)
+    with kb.connect_closing(board="boardA") as conn:
+        # per-board cap 2 is tighter than the global headroom of 5 → spawn 2.
+        res = kb.dispatch_once(
+            conn, board="boardA", spawn_fn=_fake_spawn, dry_run=False,
+            max_in_progress=2,
+            max_in_progress_global=8,
+            global_in_progress=3,
+        )
+    assert len(res.spawned) == 2


### PR DESCRIPTION
### Problem
The embedded dispatcher spawns workers with plain `subprocess.Popen`, so every worker inherits the dispatcher service's cgroup and its resource limits — many workers sharing one gateway's CPU/memory budget can starve each other and OOM-kill the whole unit. Separately, `max_in_progress` is per-board and the dispatcher loops every board, so host concurrency is `N_boards × cap` with no fleet ceiling.

### Fix (two opt-in, default-off changes)
1. **Per-worker scope:** when `kanban.worker_slice` is enabled (Linux + `systemd-run` present), launch each worker via `systemd-run --scope --quiet --collect --slice=<name> [--user] -- <cmd>`, decoupling worker resources from the dispatcher cgroup. `systemd-run --scope` execs into the worker, so PID capture / `_pid_alive` / `os.kill` are unchanged (verified empirically). Falls back to plain Popen otherwise / on invalid config.
2. **Fleet-wide cap:** new `kanban.max_in_progress_global` (default None). The dispatch tick pre-scans running-per-board and passes a cross-board in-flight count into `dispatch_once`, which shrinks `max_spawn` once the global cap is reached — composes with per-board caps, only ever tightens.

### Tests
`tests/hermes_cli/test_kanban_worker_slice_and_global_cap.py` +12 (all green): wrapper selection under every gating condition; global cap accounting across two boards; composition with per-board cap. Regression: 393 + 19 passed. systemd-run pid/kill/cgroup semantics verified on a live host.