### PR TITLE
fix(kanban): give respawned workers a resume directive instead of a bare kickoff prompt

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7677,6 +7677,84 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _resume_directive(conn: sqlite3.Connection, task: Task, workspace: str) -> str:
+    """Return a resume hint for a *respawn*, or ``""`` on a task's first run.
+
+    The dispatcher re-dispatches a task whenever its prior worker run was
+    reclaimed by a restart wave, killed, crashed, or timed out. Left to the
+    bare ``work kanban task <id>`` kickoff prompt, the new worker starts a
+    FRESH session and re-discovers everything from scratch — re-cloning the
+    worktree, re-running ``npm ci``, re-reading the repo — burning runs and
+    hours redoing setup that a prior run already committed.
+
+    This returns a one-shot directive, appended to the kickoff prompt ONLY
+    when the task has >=1 prior run that did NOT complete (``ended_at`` set
+    and ``outcome`` != ``completed`` — reclaimed / crashed / timed_out /
+    spawn_failed / gave_up). It points the worker at the card comments and
+    prior-run evidence (already rendered by :func:`build_worker_context`) and
+    at the concrete worktree/branch to reuse, so it resumes from committed
+    progress instead of rebuilding the environment.
+
+    Fresh tasks (no prior closed runs) get ``""`` so first-run behaviour is
+    byte-for-byte unchanged. Best-effort: any error returns ``""`` — a
+    resume hint must never block a worker from spawning.
+    """
+    try:
+        prior = [
+            r
+            for r in list_runs(conn, task.id, include_active=False)
+            if (r.outcome or "") != "completed"
+        ]
+    except Exception:
+        return ""
+    if not prior:
+        return ""
+
+    n = len(prior)
+    # Prefer the freshly-persisted workspace/branch (dispatch_once writes them
+    # just before spawn); fall back to the spawn arg / claimed object.
+    fresh = None
+    try:
+        fresh = get_task(conn, task.id)
+    except Exception:
+        fresh = None
+    ws = (getattr(fresh, "workspace_path", None) or task.workspace_path or workspace or "").strip()
+    branch = (getattr(fresh, "branch_name", None) or task.branch_name or "").strip()
+    kind = getattr(fresh, "workspace_kind", None) or task.workspace_kind
+
+    where = ""
+    if ws:
+        where = f" Work in the existing workspace at `{ws}`"
+        if branch and kind == "worktree":
+            where += f" on branch `{branch}`"
+        where += " — do NOT create a new worktree/clone."
+
+    return (
+        f"NOTE — RESUMING A PRIOR RUN: this task already has {n} prior run(s) "
+        f"that did not complete (reclaimed by a restart wave, killed, or timed "
+        f"out). Do NOT start over from scratch. FIRST read this card's comments "
+        f"and the prior-run evidence in your task context (see the 'Prior "
+        f"attempts on this task' section, or run `hermes kanban context "
+        f"{task.id}`)." + where + " Resume from the last committed progress and "
+        f"re-run only steps that are genuinely unverified — skip environment "
+        f"setup and already-verified work."
+    )
+
+
+def _worker_kickoff_prompt(conn: sqlite3.Connection, task: Task, workspace: str) -> str:
+    """Build the ``hermes chat -q`` kickoff prompt for a dispatched worker.
+
+    First run: the bare ``work kanban task <id>`` prompt (unchanged). On a
+    respawn, a resume directive is appended so the new worker reuses the
+    prior run's committed worktree instead of rebuilding from scratch.
+    """
+    prompt = f"work kanban task {task.id}"
+    directive = _resume_directive(conn, task, workspace)
+    if directive:
+        prompt = f"{prompt}\n\n{directive}"
+    return prompt
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -7703,7 +7781,21 @@ def _default_spawn(
 
     profile_arg = normalize_profile_name(task.assignee)
 
+    # Kickoff prompt. On a respawn (prior run reclaimed/killed/timed-out) this
+    # appends a resume directive pointing the new worker at the existing
+    # worktree + prior-run evidence so it doesn't rebuild the environment from
+    # scratch. Best-effort read on a short-lived connection: a plain kickoff
+    # prompt (first-run behaviour) is the fallback if anything goes wrong.
     prompt = f"work kanban task {task.id}"
+    try:
+        with contextlib.closing(connect(board=board)) as _resume_conn:
+            prompt = _worker_kickoff_prompt(_resume_conn, task, workspace)
+    except Exception as _resume_exc:
+        _log.debug(
+            "kanban worker: could not build resume directive for task %s (%s)",
+            task.id,
+            _resume_exc,
+        )
     env = dict(os.environ)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml

--- a/tests/hermes_cli/test_kanban_worker_resume_directive.py
+++ b/tests/hermes_cli/test_kanban_worker_resume_directive.py
@@ -1,0 +1,115 @@
+"""Tests: a respawned kanban worker gets a resume directive in its kickoff prompt.
+
+When a worker run is reclaimed/killed (restart wave, timeout, stale-claim
+reclaim) and the dispatcher re-dispatches the task, the new worker used to
+start from the bare ``work kanban task <id>`` prompt and re-discover everything
+from scratch — re-cloning worktrees, re-running env setup — burning runs/hours.
+
+``_worker_kickoff_prompt`` now appends a resume directive ONLY on a respawn
+(the task has >=1 prior run that did not complete). The directive names the
+existing worktree/branch to reuse and points at the prior-run evidence. A
+task's first dispatch (no prior closed runs) keeps the bare kickoff prompt.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kb.connect() as c:
+        yield c
+
+
+def test_first_run_prompt_is_bare(conn):
+    """A task on its first dispatch (no prior closed runs) gets the bare
+    ``work kanban task <id>`` prompt — first-run behaviour is unchanged."""
+    tid = kb.create_task(
+        conn, title="fresh", assignee="w",
+        workspace_kind="worktree", branch_name="wt/fresh",
+    )
+    # Claim opens the first (active) run — no prior CLOSED runs exist yet.
+    kb.claim_task(conn, tid, claimer=f"{kb._claimer_id().split(':', 1)[0]}:A")
+    task = kb.get_task(conn, tid)
+
+    prompt = kb._worker_kickoff_prompt(conn, task, "/tmp/ws")
+
+    assert prompt == f"work kanban task {tid}"
+    assert "RESUMING" not in prompt
+
+
+def test_respawn_prompt_has_resume_directive_and_worktree(conn):
+    """After a prior run is reclaimed, the respawn kickoff prompt carries the
+    resume directive, the concrete worktree path, and the branch."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(
+        conn, title="resume me", assignee="w",
+        workspace_kind="worktree", branch_name="wt/resume",
+    )
+
+    # Attempt 1: claim then reclaim (simulates a restart-wave kill). This
+    # closes the run with outcome='reclaimed' and resets the task to ready.
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    dead = subprocess.Popen(["true"])
+    dead.wait()
+    kb._set_worker_pid(conn, tid, dead.pid)
+    assert kb.reclaim_task(conn, tid, reason="restart wave") is True
+
+    # Dispatcher re-dispatches: new claim (active run) + persisted workspace.
+    kb.claim_task(conn, tid, claimer=f"{host}:B")
+    worktree = "/repos/app/.worktrees/" + tid
+    kb.set_workspace_path(conn, tid, worktree)
+    kb.set_branch_name(conn, tid, "wt/resume")
+    task = kb.get_task(conn, tid)
+
+    prompt = kb._worker_kickoff_prompt(conn, task, worktree)
+
+    # Bare kickoff still leads.
+    assert prompt.startswith(f"work kanban task {tid}")
+    # Resume directive present.
+    assert "RESUMING A PRIOR RUN" in prompt
+    assert "1 prior run" in prompt
+    # Concrete worktree + branch are named so the worker reuses them.
+    assert worktree in prompt
+    assert "wt/resume" in prompt
+    assert "do NOT create a new worktree" in prompt
+    # Points at the prior-run evidence.
+    assert f"hermes kanban context {tid}" in prompt
+
+
+def test_completed_prior_run_does_not_trigger_directive(conn):
+    """A prior run that COMPLETED is not a failed respawn — no directive.
+
+    Only runs that did not complete (reclaimed/crashed/timed_out) count."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="stepwise", assignee="w")
+
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    # Close the first run as a success (the only prior run completed).
+    kb._end_run(conn, tid, outcome="completed", status="done", summary="ok")
+    task = kb.get_task(conn, tid)
+
+    prompt = kb._worker_kickoff_prompt(conn, task, "/tmp/ws")
+
+    assert prompt == f"work kanban task {tid}"
+    assert "RESUMING" not in prompt


### PR DESCRIPTION
### Problem
The dispatcher's kickoff prompt is the bare `work kanban task <id>` for a task's first dispatch AND every respawn. `build_worker_context` already renders prior-run evidence + worktree path + branch, but nothing tells a respawned worker to *resume* from it — so after a reclaim/timeout kill the new worker re-clones worktrees, re-runs setup, and rediscovers the repo from scratch (measured: 5 runs / 7h redoing setup). Reclaimed runs record `outcome='reclaimed'`, so `consecutive_failures` doesn't catch restart-wave kills — a run-history query is the reliable respawn signal.

### Fix
`_resume_directive(conn, task, workspace)` returns `""` on first run; on a respawn (≥1 prior closed, non-completed run) it returns a directive naming the concrete worktree path + branch and pointing at the prior-run evidence + `hermes kanban context <id>`, instructing the worker to reuse committed progress and re-run only unverified steps. Built via a best-effort short-lived read wrapped in try/except — can never block a spawn. First-run path is byte-for-byte unchanged.

### Tests
`tests/hermes_cli/test_kanban_worker_resume_directive.py` +3 (green): bare prompt on first run; resume directive + worktree path + branch on respawn; completed prior run does not trigger it. Affected files pass in isolation (239 passed); the 17 `-k kanban` failures are pre-existing cross-file ordering pollution (baseline shows 20).