### PR TITLE
fix(desktop): add structured fallback model editor

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -19,6 +19,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
+import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
@@ -99,6 +100,13 @@ function ConfigField({
   const row = (action: ReactNode, wide = false) => (
     <ListRow action={action} description={descriptionNode} title={label} wide={wide} />
   )
+
+  // `fallback_providers` is a list of {provider, model} objects; the generic
+  // `list` branch below would stringify them to "[object Object]". Render the
+  // dedicated structured editor instead.
+  if (schemaKey === 'fallback_providers') {
+    return row(<FallbackModelsField onChange={onChange} value={value} />, true)
+  }
 
   if (schema.type === 'boolean') {
     return row(

--- a/apps/desktop/src/app/settings/fallback-models-field.test.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.test.tsx
@@ -43,6 +43,23 @@ async function renderField(value: unknown, onChange = vi.fn()) {
   return onChange
 }
 
+async function renderFieldWithRerender(value: unknown, onChange = vi.fn()) {
+  const { FallbackModelsField } = await import('./fallback-models-field')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={client}>
+      <FallbackModelsField onChange={onChange} value={value} />
+    </QueryClientProvider>
+  )
+
+  return (next: unknown) =>
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <FallbackModelsField onChange={onChange} value={next} />
+      </QueryClientProvider>
+    )
+}
+
 const CHAIN = [
   { provider: 'copilot', model: 'gpt-5-mini' },
   { provider: 'openai-codex', model: 'gpt-5.4-mini' }
@@ -83,5 +100,14 @@ describe('FallbackModelsField', () => {
 
     expect(screen.getByText(/No fallback models/)).toBeTruthy()
     expect(screen.queryAllByLabelText('Remove')).toHaveLength(0)
+  })
+
+  it('resyncs rows when persisted config changes', async () => {
+    const rerender = await renderFieldWithRerender(CHAIN)
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(2)
+
+    rerender([{ provider: 'nous', model: 'hermes-4' }])
+
+    await waitFor(() => expect(screen.getAllByLabelText('Remove')).toHaveLength(1))
   })
 })

--- a/apps/desktop/src/app/settings/fallback-models-field.test.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Radix Select calls scrollIntoView / pointer-capture APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: () => getGlobalModelOptions()
+}))
+
+beforeEach(() => {
+  getGlobalModelOptions.mockResolvedValue({
+    providers: [
+      { name: 'GitHub Copilot', slug: 'copilot', models: ['gpt-5-mini', 'gpt-5.4-mini'] },
+      { name: 'OpenAI Codex', slug: 'openai-codex', models: ['gpt-5.4-mini'] },
+      { name: 'Nous', slug: 'nous', models: ['hermes-4'] }
+    ]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderField(value: unknown, onChange = vi.fn()) {
+  const { FallbackModelsField } = await import('./fallback-models-field')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <FallbackModelsField onChange={onChange} value={value} />
+    </QueryClientProvider>
+  )
+
+  return onChange
+}
+
+const CHAIN = [
+  { provider: 'copilot', model: 'gpt-5-mini' },
+  { provider: 'openai-codex', model: 'gpt-5.4-mini' }
+]
+
+describe('FallbackModelsField', () => {
+  it('renders each {provider, model} entry as its own row (never "[object Object]")', async () => {
+    await renderField(CHAIN)
+
+    // One Remove control per entry proves the object list became rows — the old
+    // generic `list` input stringified the array to "[object Object]".
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(2)
+    expect(screen.getByText('Add fallback')).toBeTruthy()
+    expect(screen.queryByText(/\[object Object\]/)).toBeNull()
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+  })
+
+  it('removing a row emits the remaining entries', async () => {
+    const onChange = await renderField(CHAIN)
+
+    fireEvent.click(screen.getAllByLabelText('Remove')[0])
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([{ provider: 'openai-codex', model: 'gpt-5.4-mini' }])
+  })
+
+  it('adding a blank row does not persist a partial entry', async () => {
+    const onChange = await renderField(CHAIN)
+
+    fireEvent.click(screen.getByText('Add fallback'))
+
+    // The new empty row stays in the UI but only complete pairs are emitted.
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual(CHAIN)
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(3)
+  })
+
+  it('shows an empty-state hint when there are no fallbacks', async () => {
+    await renderField([])
+
+    expect(screen.getByText(/No fallback models/)).toBeTruthy()
+    expect(screen.queryAllByLabelText('Remove')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/settings/fallback-models-field.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.tsx
@@ -1,0 +1,137 @@
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getGlobalModelOptions } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { Plus, X } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { CONTROL_TEXT } from './constants'
+
+interface FallbackEntry {
+  provider: string
+  model: string
+}
+
+// Normalize the raw config value (`fallback_providers`: a list of
+// `{provider, model}` dicts) into editor rows. Defensive against legacy string
+// entries ("provider/model") so the editor never crashes on odd data.
+function normalizeEntries(value: unknown): FallbackEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.map(item => {
+    if (item && typeof item === 'object') {
+      const record = item as Record<string, unknown>
+
+      return { provider: String(record.provider ?? ''), model: String(record.model ?? '') }
+    }
+
+    if (typeof item === 'string') {
+      const slash = item.indexOf('/')
+
+      return slash > 0 ? { provider: item.slice(0, slash), model: item.slice(slash + 1) } : { provider: '', model: item }
+    }
+
+    return { provider: '', model: '' }
+  })
+}
+
+/**
+ * Structured editor for the top-level `fallback_providers` config list — a
+ * chain of `{provider, model}` pairs tried in order when the default model
+ * fails. Replaces the generic comma-string `list` input, which stringified the
+ * objects to "[object Object], [object Object]".
+ *
+ * Mirrors the Auxiliary Models picker in `model-settings.tsx`: provider + model
+ * selects sourced from `getGlobalModelOptions()`. Half-filled rows are kept in
+ * local state and only complete pairs are emitted upward, so the config
+ * autosave never persists a partial `{provider, model: ''}`.
+ */
+export function FallbackModelsField({
+  value,
+  onChange
+}: {
+  value: unknown
+  onChange: (next: FallbackEntry[]) => void
+}) {
+  const { t } = useI18n()
+  const m = t.settings.model
+
+  const modelOptions = useQuery({
+    queryKey: ['model-options', 'global'],
+    queryFn: () => getGlobalModelOptions()
+  })
+
+  const providers = (modelOptions.data?.providers ?? []).filter(provider => provider.slug)
+
+  const [rows, setRows] = useState<FallbackEntry[]>(() => normalizeEntries(value))
+
+  const commit = (next: FallbackEntry[]) => {
+    setRows(next)
+    onChange(next.filter(entry => entry.provider && entry.model))
+  }
+
+  const updateRow = (index: number, patch: Partial<FallbackEntry>) =>
+    commit(rows.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)))
+
+  return (
+    <div className="grid w-full gap-1.5">
+      {rows.length === 0 && <p className="text-xs text-muted-foreground">{m.fallbackEmpty}</p>}
+      {rows.map((entry, index) => {
+        const providerRow = providers.find(provider => provider.slug === entry.provider)
+        const catalog = providerRow?.models ?? []
+        // Keep an out-of-catalog model selectable so an existing custom
+        // provider/model renders instead of showing a blank box.
+        const modelItems = entry.model && !catalog.includes(entry.model) ? [entry.model, ...catalog] : catalog
+
+        return (
+          <div className="flex flex-wrap items-center gap-2" key={index}>
+            <span className="w-4 shrink-0 text-center font-mono text-[0.7rem] text-muted-foreground">{index + 1}</span>
+            <Select onValueChange={provider => updateRow(index, { provider, model: '' })} value={entry.provider}>
+              <SelectTrigger className={cn('min-w-36', CONTROL_TEXT)}>
+                <SelectValue placeholder={m.provider} />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map(provider => (
+                  <SelectItem key={provider.slug} value={provider.slug}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select onValueChange={model => updateRow(index, { model })} value={entry.model}>
+              <SelectTrigger className={cn('min-w-52 flex-1', CONTROL_TEXT)}>
+                <SelectValue placeholder={m.model} />
+              </SelectTrigger>
+              <SelectContent>
+                {modelItems.map(model => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              aria-label={t.common.remove}
+              onClick={() => commit(rows.filter((_, i) => i !== index))}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+        )
+      })}
+      <div>
+        <Button onClick={() => commit([...rows, { provider: '', model: '' }])} size="sm" variant="textStrong">
+          <Plus className="size-3.5" />
+          {m.fallbackAdd}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/settings/fallback-models-field.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -69,6 +69,12 @@ export function FallbackModelsField({
   const providers = (modelOptions.data?.providers ?? []).filter(provider => provider.slug)
 
   const [rows, setRows] = useState<FallbackEntry[]>(() => normalizeEntries(value))
+
+  // Settings can reload after a profile/config change while this component
+  // stays mounted. Avoid displaying or saving the previous profile's chain.
+  useEffect(() => {
+    setRows(normalizeEntries(value))
+  }, [value])
 
   const commit = (next: FallbackEntry[]) => {
     setRows(next)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -707,6 +707,9 @@ export const en: Translations = {
       change: 'Change',
       autoUseMain: 'auto · use main model',
       providerDefault: '(provider default)',
+      fallbackAdd: 'Add fallback',
+      fallbackEmpty: 'No fallback models — the default model is used unless it fails.',
+      notInCatalog: "isn't in this provider's model list — calls may fall back to a backup.",
       tasks: {
         vision: { label: 'Vision', hint: 'Image analysis' },
         web_extract: { label: 'Web extract', hint: 'Page summarization' },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -611,6 +611,9 @@ export interface Translations {
       change: string
       autoUseMain: string
       providerDefault: string
+      fallbackAdd: string
+      fallbackEmpty: string
+      notInCatalog: string
       tasks: Record<string, AuxTaskCopy>
     }
     providers: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -895,6 +895,9 @@ export const zh: Translations = {
       change: '更改',
       autoUseMain: '自动 · 使用主模型',
       providerDefault: '(提供方默认)',
+      fallbackAdd: '添加备用模型',
+      fallbackEmpty: '未配置备用模型 — 默认模型失败时才会使用备用模型。',
+      notInCatalog: '不在该提供方的模型列表中 — 调用可能回退到备用模型。',
       tasks: {
         vision: { label: '视觉', hint: '图片分析' },
         web_extract: { label: '网页提取', hint: '页面总结' },


### PR DESCRIPTION
## Summary
Desktop Settings now edits `fallback_providers` as an ordered provider/model chain instead of rendering object entries as `[object Object]`.

## Changes
- Salvage @MarkVLK's structured fallback editor and focused tests from #47522.
- Omit the separately committed out-of-catalog picker change already shipped on main.
- Keep half-filled rows local so autosave never persists incomplete fallback entries.
- Preserve existing out-of-catalog models in the editor.
- Resync local rows when profile or persisted config changes while the component remains mounted.

## Validation
| Path | Result |
|---|---|
| Fallback editor UI suite | 5 passed |
| Desktop TypeScript checks | Passed |
| Partial row autosave | Blocked |
| Config/profile reload | Editor resynced |

Supersedes the remaining fallback-editor scope of #47522.

## Infographic

![Fallback chains become editable](https://v3b.fal.media/files/b/0aa1ee16/Qo3KgKLfnaeez53q0Cz3p_EebTCVeI.png)
