### PR TITLE
fix(tools): don't report interrupted read_file as File not found (#63069)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -633,6 +633,49 @@ class TestShellFileOpsHelpers:
         assert result.content == "alpha\n"
 
 
+class TestReadStatProbeAborted:
+    """A killed ``wc -c`` stat probe must not masquerade as a missing file.
+
+    When a client disconnects mid-turn the in-flight stat subprocess is
+    killed with SIGINT (exit 130); a coreutils deadline is exit 124. Both
+    are read aborts, not deletions — see issue #63069.
+    """
+
+    def _stat_exit(self, mock_env, code):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": code}
+            return {"output": "", "returncode": 0}
+        mock_env.execute.side_effect = side_effect
+        return ShellFileOperations(mock_env)
+
+    def test_read_file_interrupt_reports_interrupted(self, mock_env):
+        ops = self._stat_exit(mock_env, 130)
+        result = ops.read_file("/tmp/test/present.md")
+        assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
+        assert result.similar_files == []
+
+    def test_read_file_timeout_reports_timed_out(self, mock_env):
+        ops = self._stat_exit(mock_env, 124)
+        result = ops.read_file("/tmp/test/present.md")
+        assert result.error == "Read timed out while checking file: /tmp/test/present.md"
+
+    def test_read_file_other_error_still_file_not_found(self, mock_env):
+        ops = self._stat_exit(mock_env, 1)
+        result = ops.read_file("/tmp/test/missing.md")
+        assert result.error == "File not found: /tmp/test/missing.md"
+
+    def test_read_file_raw_interrupt_reports_interrupted(self, mock_env):
+        ops = self._stat_exit(mock_env, 130)
+        result = ops.read_file_raw("/tmp/test/present.md")
+        assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
+
+    def test_read_file_raw_other_error_still_file_not_found(self, mock_env):
+        ops = self._stat_exit(mock_env, 1)
+        result = ops.read_file_raw("/tmp/test/missing.md")
+        assert result.error == "File not found: /tmp/test/missing.md"
+
+
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -670,6 +670,11 @@ class TestReadStatProbeAborted:
         result = ops.read_file_raw("/tmp/test/present.md")
         assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
 
+    def test_read_file_raw_timeout_reports_timed_out(self, mock_env):
+        ops = self._stat_exit(mock_env, 124)
+        result = ops.read_file_raw("/tmp/test/present.md")
+        assert result.error == "Read timed out while checking file: /tmp/test/present.md"
+
     def test_read_file_raw_other_error_still_file_not_found(self, mock_env):
         ops = self._stat_exit(mock_env, 1)
         result = ops.read_file_raw("/tmp/test/missing.md")

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -409,7 +409,9 @@ class TestReadStatProbeAborted:
 
     def _stat_exit(self, mock_env, code):
         def side_effect(command, **kwargs):
-            if command.startswith("wc -c"):
+            # The size probe wraps ``wc -c`` in an ``[ -f ]`` guard
+            # (_size_probe_cmd); match the wc fragment wherever it appears.
+            if "wc -c" in command:
                 return {"output": "", "returncode": code}
             return {"output": "", "returncode": 0}
         mock_env.execute.side_effect = side_effect
@@ -435,6 +437,11 @@ class TestReadStatProbeAborted:
         ops = self._stat_exit(mock_env, 130)
         result = ops.read_file_raw("/tmp/test/present.md")
         assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
+
+    def test_read_file_raw_timeout_reports_timed_out(self, mock_env):
+        ops = self._stat_exit(mock_env, 124)
+        result = ops.read_file_raw("/tmp/test/present.md")
+        assert result.error == "Read timed out while checking file: /tmp/test/present.md"
 
     def test_read_file_raw_other_error_still_file_not_found(self, mock_env):
         ops = self._stat_exit(mock_env, 1)

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -399,6 +399,49 @@ class TestShellFileOpsHelpers:
         assert result.content == "alpha\n"
 
 
+class TestReadStatProbeAborted:
+    """A killed ``wc -c`` stat probe must not masquerade as a missing file.
+
+    When a client disconnects mid-turn the in-flight stat subprocess is
+    killed with SIGINT (exit 130); a coreutils deadline is exit 124. Both
+    are read aborts, not deletions — see issue #63069.
+    """
+
+    def _stat_exit(self, mock_env, code):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": code}
+            return {"output": "", "returncode": 0}
+        mock_env.execute.side_effect = side_effect
+        return ShellFileOperations(mock_env)
+
+    def test_read_file_interrupt_reports_interrupted(self, mock_env):
+        ops = self._stat_exit(mock_env, 130)
+        result = ops.read_file("/tmp/test/present.md")
+        assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
+        assert result.similar_files == []
+
+    def test_read_file_timeout_reports_timed_out(self, mock_env):
+        ops = self._stat_exit(mock_env, 124)
+        result = ops.read_file("/tmp/test/present.md")
+        assert result.error == "Read timed out while checking file: /tmp/test/present.md"
+
+    def test_read_file_other_error_still_file_not_found(self, mock_env):
+        ops = self._stat_exit(mock_env, 1)
+        result = ops.read_file("/tmp/test/missing.md")
+        assert result.error == "File not found: /tmp/test/missing.md"
+
+    def test_read_file_raw_interrupt_reports_interrupted(self, mock_env):
+        ops = self._stat_exit(mock_env, 130)
+        result = ops.read_file_raw("/tmp/test/present.md")
+        assert result.error == "Read interrupted while checking file: /tmp/test/present.md"
+
+    def test_read_file_raw_other_error_still_file_not_found(self, mock_env):
+        ops = self._stat_exit(mock_env, 1)
+        result = ops.read_file_raw("/tmp/test/missing.md")
+        assert result.error == "File not found: /tmp/test/missing.md"
+
+
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -345,6 +345,28 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
+def _aborted_stat_read_result(path: str, exit_code: int) -> Optional["ReadResult"]:
+    """Map a killed ``wc -c`` stat probe to an explicit abort error.
+
+    The read path stats the file with ``wc -c`` before reading it. A non-zero
+    exit normally means the file is missing, but two exit codes mean the probe
+    itself was aborted, not that the file is gone:
+
+      * 130 — the subprocess was killed by SIGINT. This fires when a client
+        disconnects mid-turn and the in-flight read is interrupted; reporting
+        it as "File not found" makes agents believe a file was deleted.
+      * 124 — the probe hit a ``timeout``/coreutils deadline.
+
+    Returns a ``ReadResult`` carrying the accurate error for those cases, or
+    ``None`` so the caller falls through to the file-not-found suggestion path.
+    """
+    if exit_code == 130:
+        return ReadResult(error=f"Read interrupted while checking file: {path}")
+    if exit_code == 124:
+        return ReadResult(error=f"Read timed out while checking file: {path}")
+    return None
+
+
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
@@ -1104,9 +1126,13 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(stat_cmd)
         
         if stat_result.exit_code != 0:
+            # An interrupted/timed-out stat probe is not a missing file.
+            aborted = _aborted_stat_read_result(path, stat_result.exit_code)
+            if aborted is not None:
+                return aborted
             # File not found - try to suggest similar files
             return self._suggest_similar_files(path)
-        
+
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
             file_size = int(stat_output.strip())
@@ -1241,6 +1267,9 @@ class ShellFileOperations(FileOperations):
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:
+            aborted = _aborted_stat_read_result(path, stat_result.exit_code)
+            if aborted is not None:
+                return aborted
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -363,6 +363,28 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
+def _aborted_stat_read_result(path: str, exit_code: int) -> Optional["ReadResult"]:
+    """Map a killed ``wc -c`` stat probe to an explicit abort error.
+
+    The read path stats the file with ``wc -c`` before reading it. A non-zero
+    exit normally means the file is missing, but two exit codes mean the probe
+    itself was aborted, not that the file is gone:
+
+      * 130 — the subprocess was killed by SIGINT. This fires when a client
+        disconnects mid-turn and the in-flight read is interrupted; reporting
+        it as "File not found" makes agents believe a file was deleted.
+      * 124 — the probe hit a ``timeout``/coreutils deadline.
+
+    Returns a ``ReadResult`` carrying the accurate error for those cases, or
+    ``None`` so the caller falls through to the file-not-found suggestion path.
+    """
+    if exit_code == 130:
+        return ReadResult(error=f"Read interrupted while checking file: {path}")
+    if exit_code == 124:
+        return ReadResult(error=f"Read timed out while checking file: {path}")
+    return None
+
+
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
@@ -1371,6 +1393,12 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(self._size_probe_cmd(path))
 
         if stat_result.exit_code != 0:
+            # An interrupted/timed-out stat probe is not a missing file — a
+            # non-zero exit from an aborted probe must not masquerade as
+            # "File not found" (and must not trigger the fallbacks below).
+            aborted = _aborted_stat_read_result(path, stat_result.exit_code)
+            if aborted is not None:
+                return aborted
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
             # render identically in a terminal, so the model retyping a
@@ -1645,6 +1673,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
+            aborted = _aborted_stat_read_result(path, stat_result.exit_code)
+            if aborted is not None:
+                return aborted
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:


### PR DESCRIPTION
## What does this PR do?

`read_file` / `read_file_raw` in `tools/file_operations.py` stat the target with `wc -c` before reading it. **Any** non-zero exit fell straight through to `_suggest_similar_files()`, which returns `File not found: <path>`.

When a client disconnects mid-turn (`SSE client disconnected; interrupted agent task ...`), the interrupt kills the in-flight `wc -c` subprocess with exit code **130** (SIGINT). An existing, readable file is then misreported as *missing*. Agents that treat `read_file` failures as "file genuinely deleted" (e.g. governance/constitution files read at task start) can wrongly conclude a critical file vanished and escalate/block unnecessarily.

This branches on the stat probe's exit code **before** the not-found fallback:

- `130` → `Read interrupted while checking file: <path>`
- `124` (timeout) → `Read timed out while checking file: <path>`
- any other non-zero → unchanged `_suggest_similar_files()` path, so genuinely missing files still return `File not found`.

The mapping lives in a small `_aborted_stat_read_result()` helper, colocated with the existing `_search_stdout_and_limit()` that already special-cases exit `124` — matching the module's established exit-code-semantics pattern. The fix stays inside the shell abstraction (no host-side `os.path.exists`), so it holds for every backend (local, docker, ssh, modal, daytona).

## Related Issue

Fixes #63069

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: add `_aborted_stat_read_result(path, exit_code)` helper; call it in `read_file()` and `read_file_raw()` before falling back to `_suggest_similar_files()`.
- `tests/tools/test_file_operations.py`: add `TestReadStatProbeAborted` covering exit 130 (interrupted) and 124 (timeout) for both `read_file` and `read_file_raw`, plus a regression that other non-zero codes still return `File not found`.

## How to Test

```
scripts/run_tests.sh tests/tools/test_file_operations.py -q
```

Result: **95 passed** (5 new). The new cases mock the terminal env's `wc -c` probe to exit `130`/`124`/`1` and assert the surfaced error string.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — fix is exit-code branching inside the existing shell abstraction, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
