### PR TITLE
fix(build): remove --link from COPY to restore Podman/Buildah compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,13 +193,13 @@ RUN cd web && npm run build && \
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.
-# --link decouples this layer from parents for cache purposes; --chmod bakes
-# the final read-only permissions at copy time so we skip the separate
-# `chmod -R` pass that previously walked ~30k files across the venv +
-# node_modules + source (21s amd64 / 222s arm64 — #49113).  `a+rX,go-w`
-# gives the non-root hermes user read + traverse but no write; root retains
-# write so the build steps below don't need chmod u+w dances.
-COPY --link --chmod=a+rX,go-w . .
+# --chmod bakes the final read-only permissions at copy time so we skip the
+# separate `chmod -R` pass that previously walked ~30k files across the
+# venv + node_modules + source (21s amd64 / 222s arm64 — #49113).
+# `a+rX,go-w` gives the non-root hermes user read + traverse but no write;
+# root retains write so the build steps below don't need chmod u+w dances.
+# NOTE: --link omitted intentionally; Buildah/Podman does not support it.
+COPY --chmod=a+rX,go-w . .
 
 # ---------- Permissions ----------
 # Link hermes-agent itself (editable). Deps are already installed in the


### PR DESCRIPTION
Fixes #62849

Buildah (used by Podman) does not support the `--link` flag in COPY
instructions. Remove `--link` while keeping `--chmod`, which Buildah
does support, to maintain the permission-baking optimization.