### PR TITLE
feat(desktop): add workspace path status action (supersedes #59241)

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -8,15 +8,18 @@ import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
-import { Activity, AlertCircle, Clock, Command, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
+import { Activity, AlertCircle, Clock, Command, CopyIcon, FolderOpen, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { setGlobalYolo, setSessionYolo } from '@/lib/yolo-session'
+import { copyFilePath, revealFile } from '@/store/file-actions'
+import { revealFileInTree } from '@/store/layout'
 import {
   $activeSessionId,
   $busy,
   $connection,
+  $currentCwd,
   $currentUsage,
   $sessionStartedAt,
   $turnStartedAt,
@@ -37,6 +40,13 @@ import type { StatusResponse } from '@/types/hermes'
 
 import { CRON_ROUTE } from '../../routes'
 import type { StatusbarItem, StatusbarSelectModifiers } from '../statusbar-controls'
+
+function workspaceLabel(cwd: string): string {
+  const normalized = cwd.replace(/[\\/]+$/, '')
+  const leaf = normalized.split(/[\\/]/).filter(Boolean).pop()
+
+  return leaf || cwd
+}
 
 interface StatusbarItemsOptions {
   agentsOpen: boolean
@@ -71,10 +81,12 @@ export function useStatusbarItems({
 }: StatusbarItemsOptions) {
   const { t } = useI18n()
   const copy = t.shell.statusbar
+  const fileMenu = t.fileMenu
   const activeSessionId = useStore($activeSessionId)
   const terminalTakeover = useStore($terminalTakeover)
   const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
+  const currentCwd = useStore($currentCwd)
   const currentUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const sessionStartedAt = useStore($sessionStartedAt)
@@ -300,6 +312,39 @@ export function useStatusbarItems({
         variant: 'menu'
       },
       {
+        hidden: !currentCwd,
+        icon: <FolderOpen className="size-3" />,
+        id: 'workspace-cwd',
+        label: currentCwd ? workspaceLabel(currentCwd) : undefined,
+        menuItems: currentCwd
+          ? [
+              {
+                icon: <CopyIcon className="size-4" />,
+                id: 'copy-workspace-path',
+                label: fileMenu.copyPath,
+                onSelect: () => void copyFilePath(currentCwd),
+                title: currentCwd
+              },
+              {
+                icon: <FolderOpen className="size-4" />,
+                id: 'reveal-workspace-finder',
+                label: fileMenu.revealFileManager,
+                onSelect: () => void revealFile(currentCwd),
+                title: currentCwd
+              },
+              {
+                icon: <Codicon name="go-to-file" size="1rem" />,
+                id: 'reveal-workspace-sidebar',
+                label: fileMenu.revealInSidebar,
+                onSelect: () => revealFileInTree(currentCwd),
+                title: currentCwd
+              }
+            ]
+          : undefined,
+        title: currentCwd || undefined,
+        variant: 'menu'
+      },
+      {
         className: cn(
           agentsOpen && 'bg-accent/55 text-foreground',
           subagentsFailed > 0 && 'text-destructive hover:text-destructive'
@@ -337,6 +382,10 @@ export function useStatusbarItems({
       agentsOpen,
       commandCenterOpen,
       copy,
+      currentCwd,
+      fileMenu.copyPath,
+      fileMenu.revealFileManager,
+      fileMenu.revealInSidebar,
       gatewayMenuContent,
       gatewayClassName,
       gatewayDetail,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -8,7 +8,7 @@ import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
-import { Activity, AlertCircle, Clock, Command, CopyIcon, FolderOpen, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
+import { Activity, AlertCircle, Clock, Command, FolderOpen, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
@@ -319,21 +319,18 @@ export function useStatusbarItems({
         menuItems: currentCwd
           ? [
               {
-                icon: <CopyIcon className="size-4" />,
                 id: 'copy-workspace-path',
                 label: fileMenu.copyPath,
                 onSelect: () => void copyFilePath(currentCwd),
                 title: currentCwd
               },
               {
-                icon: <FolderOpen className="size-4" />,
                 id: 'reveal-workspace-finder',
                 label: fileMenu.revealFileManager,
                 onSelect: () => void revealFile(currentCwd),
                 title: currentCwd
               },
               {
-                icon: <Codicon name="go-to-file" size="1rem" />,
                 id: 'reveal-workspace-sidebar',
                 label: fileMenu.revealInSidebar,
                 onSelect: () => revealFileInTree(currentCwd),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "true@supersynergy.de": "Supersynergy",  # PR #59241 salvage (desktop: workspace path status-bar action)
     "esthon@gmail.com": "esthonjr",  # PR #61950 salvage (desktop: legacy non-git workspace grouping + Windows path identity)
     "iganapolsky@gmail.com": "IgorGanapolsky",  # PR #62125 salvage (compaction anti-thrash threshold verification)
     "tturney1@gmail.com": "TheTom",  # PR #62696 salvage (gateway: expand @ context references under runtime/session model resolution)


### PR DESCRIPTION
## Summary

Supersedes #59241 (@Supersynergy) — his commit is preserved intact. Adds a workspace-path item to the desktop status bar (hidden when no cwd) with copy / reveal-in-file-manager / reveal-in-tree, reusing the existing `copyFilePath` / `revealFile` / `revealFileInTree` actions and `fileMenu` i18n.

### Changed from #59241
Aligned the dropdown with the rest of the status bar:
- **Dropped the per-item icons.** They mixed a lucide `size-4` glyph with a Codicon `1rem` glyph, and this was the only status-bar menu carrying item icons. It's now text-only items on the shared `DropdownMenuItem` primitive with default typography — consistent sizing with every other menu.
- The status-bar **trigger** keeps its `FolderOpen` glyph, matching sibling items (`Hash`, `Clock`, `Terminal`, …).

## Test plan
- [x] `npm --workspace apps/desktop run typecheck` (app + electron) clean
- [x] `eslint` on the changed file clean
- [x] Ran the desktop dev app: item appears when a cwd is attached, hidden otherwise; menu actions work

Credit: @Supersynergy (original feature, commit preserved). Closes #59241.