### PR TITLE
fix(telegram): isolate busy group turns by user

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9170,7 +9170,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             self._queue_or_replace_pending_event(session_key, event)
             return True
-
         effective_mode = self._effective_busy_input_mode(event.source)
 
         # --- Draining case (gateway restarting/stopping) ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9034,6 +9034,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
 
+    def _telegram_group_busy_message_crosses_users(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        """Return whether a shared Telegram group turn belongs to another user."""
+        source = getattr(event, "source", None)
+        if (
+            source is None
+            or source.platform != Platform.TELEGRAM
+            or source.chat_type not in {"group", "supergroup"}
+        ):
+            return False
+
+        active_source = self._get_cached_session_source(session_key)
+        if active_source is None:
+            return False
+        if str(active_source.chat_id or "") != str(source.chat_id or ""):
+            return False
+
+        active_user_id = str(active_source.user_id or "").strip()
+        incoming_user_id = str(source.user_id or "").strip()
+        return bool(
+            active_user_id
+            and incoming_user_id
+            and active_user_id != incoming_user_id
+        )
+
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
@@ -9126,6 +9154,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
             )
             return True  # handled (silently dropped); do not fall through
+
+        # Telegram group sessions can be shared by multiple authorized users.
+        # A follow-up from a different user must not interrupt or steer the
+        # active user's turn. Own the enqueue here and return handled so the
+        # adapter fallback cannot merge multiple users' text into one event.
+        if self._telegram_group_busy_message_crosses_users(event, session_key):
+            active_source = self._get_cached_session_source(session_key)
+            logger.info(
+                "Queueing cross-user Telegram group follow-up for session %s "
+                "(active_user=%s incoming_user=%s)",
+                session_key,
+                getattr(active_source, "user_id", None),
+                event.source.user_id,
+            )
+            self._queue_or_replace_pending_event(session_key, event)
+            return True
 
         effective_mode = self._effective_busy_input_mode(event.source)
 
@@ -15443,6 +15487,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return await self._dispatch_busy_slash_command(
                     event, _cmd_def_inner, _quick_key, source,
                 )
+
+            # Most adapters consult _handle_active_session_busy_message before
+            # reaching this runner callback. Keep the same ownership boundary
+            # here for direct-dispatch adapters and tests: ordinary text from a
+            # second Telegram group user queues behind the active user's turn.
+            # Slash commands retain their dedicated control semantics above.
+            if (
+                not event.is_command()
+                and self._telegram_group_busy_message_crosses_users(
+                    event, _quick_key,
+                )
+            ):
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -98,7 +98,174 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
+    @pytest.mark.parametrize("chat_type", ["group", "supergroup"])
+    async def test_telegram_group_different_user_falls_back_to_queue(
+        self, busy_mode, chat_type,
+    ):
+        """A second group user must not redirect the active user's turn."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = busy_mode
+        adapter = _make_adapter()
 
+        active_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="group-123",
+            chat_type=chat_type,
+            user_id="active-user",
+        )
+        event = MessageEvent(
+            text="different user's follow-up",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="group-123",
+                chat_type=chat_type,
+                user_id="other-user",
+            ),
+            message_id="msg-other",
+        )
+        sk = build_session_key(active_source, group_sessions_per_user=False)
+        runner._session_sources = {sk: active_source}
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is False
+        agent.interrupt.assert_not_called()
+        agent.steer.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_telegram_group_different_user_is_queued_by_dispatch_path(self):
+        """The busy guard's fallthrough must retain the incoming message."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner.config.group_sessions_per_user = False
+        adapter = _make_adapter()
+
+        active_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="group-123",
+            chat_type="group",
+            user_id="active-user",
+        )
+        event = MessageEvent(
+            text="queue me after the active user's turn",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="group-123",
+                chat_type="group",
+                user_id="other-user",
+            ),
+            message_id="msg-other",
+        )
+        sk = build_session_key(active_source, group_sessions_per_user=False)
+        runner._session_sources = {sk: active_source}
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert adapter._pending_messages[sk] is event
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_telegram_group_same_user_still_interrupts(self):
+        """Per-user isolation must preserve the active user's interrupt control."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = MessageEvent(
+            text="redirect my active turn",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="group-123",
+                chat_type="group",
+                user_id="active-user",
+            ),
+            message_id="msg-active",
+        )
+        sk = build_session_key(event.source, group_sessions_per_user=False)
+        runner._session_sources = {sk: event.source}
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_called_once_with("redirect my active turn")
+
+    @pytest.mark.asyncio
+    async def test_telegram_dm_behavior_is_unchanged(self):
+        """The group-only guard must not alter existing DM busy semantics."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        active_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="dm-123",
+            chat_type="dm",
+            user_id="active-user",
+        )
+        event = MessageEvent(
+            text="normal dm follow-up",
+            message_type=MessageType.TEXT,
+            source=active_source,
+            message_id="msg-dm",
+        )
+        sk = build_session_key(active_source)
+        runner._session_sources = {sk: active_source}
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_called_once_with("normal dm follow-up")
+
+    @pytest.mark.asyncio
+    async def test_handle_message_queue_mode_queues_without_interrupt(self):
+        """Runner queue mode must not interrupt an active agent for text follow-ups."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="follow up in queue mode")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "queue"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk] is event
+        assert sk not in runner._pending_messages
+        running_agent.interrupt.assert_not_called()
     @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):
         """Rapid Telegram text follow-ups in queue mode must not merge."""
@@ -469,5 +636,4 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -3,6 +3,8 @@
 Verifies that users get an immediate status response instead of total silence
 when the agent is working on a task. See PR fix for the @Lonely__MH report.
 """
+
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,17 +27,20 @@ sys.modules.setdefault("telegram.constants", _tg.constants)
 sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
 
 from gateway.platforms.base import (
+    BasePlatformAdapter,
     MessageEvent,
     MessageType,
     Platform,
     SessionSource,
     build_session_key,
 )
+from gateway.config import PlatformConfig
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_event(text="hello", chat_id="123", platform_val="telegram"):
     """Build a minimal MessageEvent."""
@@ -91,9 +96,26 @@ def _make_adapter(platform_val="telegram"):
     return adapter
 
 
+class _AdapterPathStub(BasePlatformAdapter):
+    """Concrete adapter for exercising the active-session callback path."""
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, **kwargs):
+        return MagicMock(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
@@ -101,8 +123,10 @@ class TestBusySessionAck:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
     @pytest.mark.parametrize("chat_type", ["group", "supergroup"])
-    async def test_telegram_group_different_user_falls_back_to_queue(
-        self, busy_mode, chat_type,
+    async def test_telegram_group_different_user_is_queued_and_handled(
+        self,
+        busy_mode,
+        chat_type,
     ):
         """A second group user must not redirect the active user's turn."""
         runner, _sentinel = _make_runner()
@@ -136,18 +160,22 @@ class TestBusySessionAck:
 
         result = await runner._handle_active_session_busy_message(event, sk)
 
-        assert result is False
+        assert result is True
+        assert adapter._pending_messages[sk] is event
         agent.interrupt.assert_not_called()
         agent.steer.assert_not_called()
         adapter._send_with_retry.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_telegram_group_different_user_is_queued_by_dispatch_path(self):
+    @pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
+    async def test_telegram_group_different_user_is_queued_by_dispatch_path(
+        self, busy_mode
+    ):
         """The busy guard's fallthrough must retain the incoming message."""
         from gateway.run import GatewayRunner
 
         runner, _sentinel = _make_runner()
-        runner._busy_input_mode = "interrupt"
+        runner._busy_input_mode = busy_mode
         runner.config.group_sessions_per_user = False
         adapter = _make_adapter()
 
@@ -173,6 +201,7 @@ class TestBusySessionAck:
         runner.adapters[Platform.TELEGRAM] = adapter
 
         agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
         runner._running_agents[sk] = agent
 
         result = await GatewayRunner._handle_message(runner, event)
@@ -180,7 +209,59 @@ class TestBusySessionAck:
         assert result is None
         assert adapter._pending_messages[sk] is event
         agent.interrupt.assert_not_called()
+        agent.steer.assert_not_called()
         adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_telegram_group_cross_user_adapter_path_preserves_fifo_turns(self):
+        """Two callback-path messages stay as two ordered pending turns."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner.config.group_sessions_per_user = False
+
+        config = PlatformConfig(enabled=True, token="test-token")
+        config.extra["group_sessions_per_user"] = False
+        adapter = _AdapterPathStub(config, Platform.TELEGRAM)
+
+        async def unexpected_handler(_event):
+            pytest.fail("busy cross-user messages must not reach normal dispatch")
+
+        adapter.set_message_handler(unexpected_handler)
+        adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        active_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="group-123",
+            chat_type="group",
+            user_id="active-user",
+        )
+        sk = build_session_key(active_source, group_sessions_per_user=False)
+        runner._session_sources = {sk: active_source}
+        runner._running_agents[sk] = MagicMock()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        events = [
+            MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=SessionSource(
+                    platform=Platform.TELEGRAM,
+                    chat_id="group-123",
+                    chat_type="group",
+                    user_id="other-user",
+                ),
+                message_id=f"msg-{index}",
+            )
+            for index, text in enumerate(("first turn", "second turn"), start=1)
+        ]
+
+        for event in events:
+            await adapter.handle_message(event)
+
+        assert adapter._pending_messages[sk] is events[0]
+        assert runner._queued_events[sk] == [events[1]]
+        runner._running_agents[sk].interrupt.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_telegram_group_same_user_still_interrupts(self):
@@ -266,6 +347,7 @@ class TestBusySessionAck:
         assert adapter._pending_messages[sk] is event
         assert sk not in runner._pending_messages
         running_agent.interrupt.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):
         """Rapid Telegram text follow-ups in queue mode must not merge."""


### PR DESCRIPTION
## Summary

- keep a second authorized Telegram group user from interrupting or steering the active user's turn in a shared session
- enqueue the cross-user callback through the runner's bounded FIFO and return handled, preventing the base adapter from newline-merging separate messages
- enforce the same ownership boundary in the direct runner dispatch path for both interrupt and steer modes
- preserve authorization-first behavior, same-user controls, DMs, commands, media merging, and queue limits

Hardening follow-up to #49714.

## Root cause

Shared Telegram group sessions use one session key for multiple users. The gateway cached the source owning the active turn, but the busy callback returned to the base adapter after detecting another user. That fallback uses `merge_text=True`, so multiple cross-user messages could collapse into one pending event instead of remaining separate FIFO turns.

The callback now owns `_queue_or_replace_pending_event()` and returns handled. The direct-dispatch guard uses the same helper.

## Verification

- focused busy-session suite: 35 passed
- six-file FIFO, adapter, command, authorization, session-race, and subagent matrix: 129 passed
- real adapter-path regression sends two cross-user messages and proves head-plus-overflow FIFO order
- direct runner regression covers both interrupt and steer and proves neither reaches the active agent
- Ruff, `git diff --check`, contribution publish gate, and publish-range gitleaks: passed


