### PR TITLE
fix(file): preserve interrupted read errors

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -577,6 +577,45 @@ class TestShellFileOpsHelpers:
         assert result.error is None
         assert result.content == "alpha\n"
 
+    @pytest.mark.parametrize("method_name", ["read_file", "read_file_raw"])
+    @pytest.mark.parametrize(
+        ("exit_code", "expected_error"),
+        [
+            (130, "Read interrupted while checking file: /tmp/test/a.txt"),
+            (124, "Read timed out while checking file: /tmp/test/a.txt"),
+        ],
+    )
+    def test_read_size_probe_reports_control_flow_failures(
+        self, mock_env, method_name, exit_code, expected_error
+    ):
+        mock_env.execute.return_value = {"output": "", "returncode": exit_code}
+        ops = ShellFileOperations(mock_env)
+
+        result = getattr(ops, method_name)("/tmp/test/a.txt")
+
+        assert result.error == expected_error
+        assert result.similar_files == []
+        mock_env.execute.assert_called_once()
+
+    @pytest.mark.parametrize("method_name", ["read_file", "read_file_raw"])
+    def test_read_size_probe_preserves_missing_file_suggestions(
+        self, mock_env, method_name
+    ):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            if command.startswith("ls -1"):
+                return {"output": "a.md\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+
+        result = getattr(ops, method_name)("/tmp/test/a.txt")
+
+        assert result.error == "File not found: /tmp/test/a.txt"
+        assert result.similar_files == ["/tmp/test/a.md"]
+
 
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1068,6 +1068,16 @@ class ShellFileOperations(FileOperations):
     # =========================================================================
     # READ Implementation
     # =========================================================================
+
+    def _read_size_probe_failure(
+        self, path: str, stat_result: ExecuteResult
+    ) -> ReadResult:
+        """Preserve control-flow failures from the initial ``wc`` probe."""
+        if stat_result.exit_code == 130:
+            return ReadResult(error=f"Read interrupted while checking file: {path}")
+        if stat_result.exit_code == 124:
+            return ReadResult(error=f"Read timed out while checking file: {path}")
+        return self._suggest_similar_files(path)
     
     def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
         """
@@ -1091,8 +1101,7 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(stat_cmd)
         
         if stat_result.exit_code != 0:
-            # File not found - try to suggest similar files
-            return self._suggest_similar_files(path)
+            return self._read_size_probe_failure(path, stat_result)
         
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
@@ -1228,7 +1237,7 @@ class ShellFileOperations(FileOperations):
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:
-            return self._suggest_similar_files(path)
+            return self._read_size_probe_failure(path, stat_result)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         try:
             file_size = int(stat_output.strip())


### PR DESCRIPTION
## Summary

- preserve exit code 130 from the initial file-size probe as an interrupted read
- preserve exit code 124 as a timed-out read
- keep the existing similar-file suggestions for ordinary missing-file failures
- cover both `read_file` and `read_file_raw`

## Root cause

Both shell-backed read paths treated every non-zero `wc -c` result as proof that the target did not exist. When session cancellation killed that probe with exit code 130, a real file was therefore reported as missing.

The shared failure helper now distinguishes cancellation and timeout control-flow statuses before falling back to the existing missing-file behavior. It intentionally avoids a local `os.path.exists` fallback because `ShellFileOperations` also serves remote terminal backends, where a local filesystem check would inspect the wrong machine.

## Validation

```text
scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py -q
131 passed
```

Closes #63069
