### PR TITLE
fix(prompt): use HOME env var over expanduser for system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1096,7 +1096,7 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
-        host_lines.append(f"User home directory: {os.path.expanduser('~')}")
+        host_lines.append(f"User home directory: {os.environ.get('HOME', os.path.expanduser('~'))}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1243,6 +1243,19 @@ class TestEnvironmentHints:
         _pb._clear_backend_probe_cache()
         assert f"Current working directory: {tmp_path}" in _pb.build_environment_hints()
 
+    def test_build_environment_hints_uses_home_env_over_expanduser(self, monkeypatch, tmp_path):
+        """Fix for #63093: HOME env var should take precedence over expanduser(~)."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        # Set HOME to a different path than what expanduser would return
+        custom_home = tmp_path / "custom_home"
+        custom_home.mkdir()
+        monkeypatch.setenv("HOME", str(custom_home))
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert f"User home directory: {custom_home}" in result
+
     def test_build_environment_hints_uses_live_probe_when_available(self, monkeypatch):
         """When the probe succeeds, its output must appear in the hint block."""
         import agent.prompt_builder as _pb


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the system prompt reported an incorrect "User home directory" value in container environments. The prompt displayed `/opt/data` (the CWD) instead of the actual `$HOME` value `/opt/data/home`.

The root cause: `os.path.expanduser('~')` may return incorrect paths in some container setups where the `$HOME` environment variable is the authoritative source. This PR prioritizes `$HOME` over `os.path.expanduser('~')`.

## Related Issue

Fixes #63093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: Changed `User home directory: {os.path.expanduser('~')}` to `User home directory: {os.environ.get('HOME', os.path.expanduser('~'))}` (1 line)
- `tests/agent/test_prompt_builder.py`: Added regression test `test_build_environment_hints_uses_home_env_over_expanduser` (13 lines)

## How to Test

1. In a container environment where `$HOME` differs from CWD (e.g., `HOME=/opt/data/home`, CWD=/opt/data)
2. Run Hermes with `local` terminal backend
3. Observe the system prompt header — it should now correctly report `User home directory: /opt/data/home` (matching `$HOME`) instead of `/opt/data`

Test coverage: `pytest tests/agent/test_prompt_builder.py -k "uses_home_env"` should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A