### PR TITLE
Fix prompt home directory hint for subprocess environments

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ import contextvars
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_hermes_home, get_skills_dir, get_subprocess_home, is_wsl
 from typing import Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
@@ -1096,7 +1096,8 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
-        host_lines.append(f"User home directory: {os.path.expanduser('~')}")
+        home_dir = get_subprocess_home() or os.path.expanduser("~")
+        host_lines.append(f"User home directory: {home_dir}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1169,6 +1169,21 @@ class TestEnvironmentHints:
         assert "hostname" not in result
         assert "WSL" not in result
 
+    def test_build_environment_hints_prefers_subprocess_home(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import sys, platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.setattr(_pb, "get_subprocess_home", lambda: "/opt/data/home")
+        monkeypatch.setattr(_pb.os.path, "expanduser", lambda _path: "/opt/data")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "User home directory: /opt/data/home" in result
+        assert "User home directory: /opt/data\n" not in result
+
     def test_build_environment_hints_on_windows_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys
@@ -1644,5 +1659,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
## Summary
- use the subprocess home helper when rendering environment hints
- add a regression test for environments where the controller home differs from the tool subprocess home

Fixes #63093.

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_prompt_builder.py -q`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile agent/prompt_builder.py tests/agent/test_prompt_builder.py`
- `git diff --check HEAD~1 HEAD`
