### PR TITLE
fix(skills): stabilize hashes and canonical bundle identity

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1150,11 +1150,16 @@ class TestCheckForSkillUpdates:
     def test_bundle_content_hash_matches_installed_content_hash(self, tmp_path):
         from tools.skills_guard import content_hash
 
+        # Nested references ensure the invariance holds across mixed-depth
+        # file layouts — same hash shape whether files live at the root or
+        # under subdirectories of subdirectories.
         bundle = SkillBundle(
             name="demo-skill",
             files={
                 "SKILL.md": "same content",
                 "references/checklist.md": "- [ ] security\n",
+                "references/styles.md": "style index\n",
+                "references/styles/minimal.md": "minimal style\n",
             },
             source="github",
             identifier="owner/repo/demo-skill",
@@ -1165,6 +1170,9 @@ class TestCheckForSkillUpdates:
         (skill_dir / "SKILL.md").write_text("same content")
         (skill_dir / "references").mkdir()
         (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "styles.md").write_text("style index\n")
+        (skill_dir / "references" / "styles").mkdir()
+        (skill_dir / "references" / "styles" / "minimal.md").write_text("minimal style\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
@@ -1817,6 +1825,61 @@ class TestSkillMetaToDict:
 
 
 class TestOptionalSkillSourceMetadata:
+    def test_fetch_uses_frontmatter_name_when_directory_slug_differs(self, tmp_path):
+        """Bundle identity must come from the installed SKILL.md frontmatter,
+        not the directory slug. ``scan_all()`` advertises the frontmatter
+        name; ``fetch()`` must produce the same identifier so installers and
+        updaters can correlate them.
+        """
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "training" / "trl-fine-tuning"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: fine-tuning-with-trl\ndescription: test\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        bundle = src.fetch("official/training/trl-fine-tuning")
+
+        assert bundle is not None
+        assert bundle.name == "fine-tuning-with-trl"
+
+    @pytest.mark.parametrize(
+        "skill_md",
+        [
+            None,
+            b"---\nname:\ndescription: test\n---\n",
+            b"---\nname: [not, a, string]\ndescription: test\n---\n",
+            b"\xff\xfe\x00not-utf8",
+        ],
+        ids=("missing", "empty-name", "non-string-name", "non-utf8"),
+    )
+    def test_fetch_falls_back_to_directory_slug_for_invalid_frontmatter_name(
+        self, tmp_path, skill_md
+    ):
+        """When the frontmatter name is missing, blank, non-string, or the
+        SKILL.md is unreadable bytes, ``fetch()`` must fall back to the
+        directory slug — never raise, never invent a bogus name.
+        """
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "training" / "directory-slug"
+        skill_dir.mkdir(parents=True)
+        if skill_md is None:
+            (skill_dir / "README.md").write_text("Body\n", encoding="utf-8")
+        else:
+            (skill_dir / "SKILL.md").write_bytes(skill_md)
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        bundle = src.fetch("official/training/directory-slug")
+
+        assert bundle is not None
+        assert bundle.name == "directory-slug"
+
     def test_scan_all_emits_repo_root_relative_metadata(self, tmp_path):
         optional_root = tmp_path / "optional-skills"
         skill_dir = optional_root / "finance" / "3-statement-model"

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -776,15 +776,20 @@ def content_hash(skill_path: Path) -> str:
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
-            if f.is_file():
-                try:
-                    rel = f.relative_to(skill_path).as_posix()
-                    h.update(rel.encode("utf-8"))
-                    h.update(b"\x00")
-                    h.update(f.read_bytes())
-                except OSError:
-                    continue
+        # Sort by relative POSIX path string — not by the Path objects
+        # directly — so the iteration order is identical across every OS and
+        # filesystem. Two skills with byte-identical contents must hash the
+        # same regardless of where the file lives on disk.
+        files = (f for f in skill_path.rglob("*") if f.is_file())
+        files = sorted(files, key=lambda f: f.relative_to(skill_path).as_posix())
+        for f in files:
+            try:
+                rel = f.relative_to(skill_path).as_posix()
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                h.update(f.read_bytes())
+            except OSError:
+                continue
     elif skill_path.is_file():
         h.update(skill_path.read_bytes())
     return f"sha256:{h.hexdigest()[:16]}"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3125,8 +3125,21 @@ class OptionalSkillSource(SkillSource):
         if not files:
             return None
 
-        # Determine category from directory structure
+        # Keep the bundle identity aligned with discovery and the installed
+        # SKILL.md. Directory slugs are source identifiers and may differ from
+        # the canonical frontmatter name; using ``skill_dir.name`` here would
+        # silently rename a skill between ``scan_all()`` and ``fetch()``.
         name = skill_dir.name
+        skill_md = files.get("SKILL.md")
+        if isinstance(skill_md, bytes):
+            try:
+                skill_md = skill_md.decode("utf-8")
+            except UnicodeDecodeError:
+                skill_md = None
+        if isinstance(skill_md, str):
+            frontmatter_name = self._parse_frontmatter(skill_md).get("name")
+            if isinstance(frontmatter_name, str) and frontmatter_name.strip():
+                name = frontmatter_name.strip()
 
         return SkillBundle(
             name=name,


### PR DESCRIPTION
## What does this PR do?

Fixes two integrity mismatches in optional skills: on-disk content hashing now uses a platform-independent relative POSIX ordering, and fetched bundles use the canonical `SKILL.md` frontmatter name consistently with discovery.

## Related Issue

N/A — reproduced during a local skill-integrity audit.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Sort on-disk skill files by relative POSIX path before hashing.
- Read a fetched optional skill's canonical name from `SKILL.md` frontmatter.
- Fall back safely to the directory slug for missing, blank, non-string, or non-UTF-8 frontmatter.
- Extend hash invariance tests to nested layouts and add canonical-name/fallback coverage.

## How to Test

1. Run `uv run --extra dev pytest -q tests/tools/test_skills_hub.py tests/tools/test_skills_guard.py`.
2. Confirm all 243 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and found no duplicate.
- [x] This PR contains only the skill hash/identity fix and its tests.
- [ ] I've run the entire `pytest tests/ -q` suite locally; repository-wide collection requires optional ACP/messaging dependencies not present in the minimal dev environment. The complete touched-file suite passes.
- [x] I've added tests for the changed behavior.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is documented in code and tests.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered; the change specifically normalizes path ordering across platforms.
- [x] Tool descriptions/schemas: N/A.
