### PR TITLE
fix(62146): bug: clarify tool fails when LLM emits choices with 'value' field

### DIFF
--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -43,7 +43,7 @@ def _flatten_choice(c) -> str:
     if isinstance(c, str):
         return c.strip()
     if isinstance(c, dict):
-        for key in ("label", "description", "text", "title"):
+        for key in ("label", "description", "text", "title", "value"):
             v = c.get(key)
             if isinstance(v, str) and v.strip():
                 return v.strip()


### PR DESCRIPTION
Fixes #62146

## Changes

```
tools/clarify_tool.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Auto-generated by Hermes Harness — reviewed by AI gate before submission.