### PR TITLE
fix: detect macOS system gateway LaunchDaemon

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1242,7 +1242,11 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     """
     for line in output.splitlines():
         stripped = line.strip()
-        if stripped.startswith('"PID"') or stripped.startswith("PID"):
+        if (
+            stripped.startswith('"PID"')
+            or stripped.startswith("PID")
+            or stripped.startswith("pid")
+        ):
             parts = stripped.split("=", 1)
             if len(parts) == 2:
                 val = parts[1].strip().rstrip(";").strip('"')
@@ -1257,25 +1261,43 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
 def _probe_launchd_service_running() -> bool:
     """Return True when launchd is actively supervising the gateway process.
 
-    ``launchctl list <label>`` returns exit 0 whenever the service definition is
+    ``launchctl list <label>`` returns exit 0 whenever a user LaunchAgent is
     registered with launchd — even when ``state = not running`` (macOS 26+).
     We additionally require a PID in the output to confirm launchd is actually
     managing a live process, not just holding a static definition.
+
+    Also recognize the system LaunchDaemon layout used by always-on macOS hosts
+    (``/Library/LaunchDaemons/com.nousresearch.hermes-gateway*.plist``), where
+    the reliable probe is ``launchctl print system/<label>``.
     """
-    if not get_launchd_plist_path().exists():
-        return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    if result.returncode != 0:
-        return False
-    return _parse_launchd_pid_from_list_output(result.stdout) is not None
+    if get_launchd_plist_path().exists():
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", get_launchd_label()],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            result = None
+        if result is not None and result.returncode == 0:
+            if _parse_launchd_pid_from_list_output(result.stdout) is not None:
+                return True
+
+    if get_launchd_system_plist_path().exists():
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", f"system/{get_launchd_system_label()}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            result = None
+        if result is not None and result.returncode == 0:
+            return _parse_launchd_pid_from_list_output(result.stdout) is not None
+
+    return False
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -1340,7 +1362,7 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
     if is_macos():
         return GatewayRuntimeSnapshot(
             manager="launchd",
-            service_installed=get_launchd_plist_path().exists(),
+            service_installed=_launchd_service_definition_exists(),
             service_running=_probe_launchd_service_running(),
             gateway_pids=gateway_pids,
             service_scope="launchd",
@@ -2467,6 +2489,28 @@ def get_launchd_plist_path() -> Path:
     suffix = _profile_suffix()
     name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
     return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+
+
+def get_launchd_system_label() -> str:
+    """Return the macOS system LaunchDaemon label, scoped per profile.
+
+    ``hermes gateway install`` historically installs a per-user LaunchAgent on
+    macOS, but some always-on hosts intentionally run the gateway as a system
+    LaunchDaemon so it starts at boot before any GUI login. Detect that layout
+    too so ``hermes gateway status`` does not misreport the process as manual.
+    """
+    suffix = _profile_suffix()
+    return f"com.nousresearch.hermes-gateway-{suffix}" if suffix else "com.nousresearch.hermes-gateway"
+
+
+def get_launchd_system_plist_path() -> Path:
+    """Return the macOS system LaunchDaemon plist path for the active profile."""
+    return Path("/Library/LaunchDaemons") / f"{get_launchd_system_label()}.plist"
+
+
+def _launchd_service_definition_exists() -> bool:
+    """True when either the user LaunchAgent or system LaunchDaemon exists."""
+    return get_launchd_plist_path().exists() or get_launchd_system_plist_path().exists()
 
 
 def _detect_venv_dir() -> Path | None:
@@ -4391,6 +4435,55 @@ def launchd_restart():
 
 
 def launchd_status(deep: bool = False):
+    system_plist_path = get_launchd_system_plist_path()
+    if system_plist_path.exists():
+        label = get_launchd_system_label()
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", f"system/{label}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            service_listed = result.returncode == 0
+            list_output = result.stdout
+        except subprocess.TimeoutExpired:
+            service_listed = False
+            list_output = ""
+
+        launchd_pid = _parse_launchd_pid_from_list_output(list_output) if service_listed else None
+
+        from gateway.status import get_running_pid
+        fallback_pid = get_running_pid(cleanup_stale=False)
+        if launchd_pid is not None and fallback_pid == launchd_pid:
+            fallback_pid = None
+
+        print(f"Launchd plist: {system_plist_path}")
+        print("✓ System LaunchDaemon definition exists")
+        if service_listed:
+            if launchd_pid is not None:
+                print(f"✓ Gateway is supervised by system launchd (PID {launchd_pid})")
+                print("  Auto-start at boot and auto-restart on crash are available.")
+            else:
+                print("✓ Gateway system service is registered with launchd")
+                print(list_output)
+                if fallback_pid:
+                    print(f"  Detached gateway process is running (PID {fallback_pid})")
+        else:
+            print("✗ Gateway system service is not loaded")
+            print("  Service definition exists locally but launchd has not loaded it.")
+            print(f"  Run: sudo launchctl bootstrap system {system_plist_path}")
+            if fallback_pid:
+                print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
+
+        if deep:
+            log_file = get_hermes_home() / "logs" / "gateway.log"
+            if log_file.exists():
+                print()
+                print("Recent logs:")
+                subprocess.run(["tail", "-20", str(log_file)], timeout=10)
+        return
+
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
     try:
@@ -5456,7 +5549,7 @@ def _is_service_installed() -> bool:
             or get_systemd_unit_path(system=True).exists()
         )
     elif is_macos():
-        return get_launchd_plist_path().exists()
+        return _launchd_service_definition_exists()
     elif is_windows():
         from hermes_cli import gateway_windows
 
@@ -5499,17 +5592,8 @@ def _is_service_running() -> bool:
                 pass
 
         return False
-    elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+    elif is_macos():
+        return _probe_launchd_service_running()
     elif is_windows():
         from hermes_cli import gateway_windows
 
@@ -7041,7 +7125,7 @@ def _gateway_command_inner(args):
         ):
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)
-        elif is_macos() and get_launchd_plist_path().exists():
+        elif is_macos() and _launchd_service_definition_exists():
             launchd_status(deep)
             _print_gateway_process_mismatch(snapshot)
         elif _windows_service_installed:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -958,6 +958,11 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
         monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_plist_path",
+            lambda: tmp_path / "missing-system-daemon.plist",
+        )
+        monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
             lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
@@ -1213,6 +1218,16 @@ class TestLaunchdServiceRecovery:
         output = "{\n    PID = 99999;\n}"
         assert gateway_cli._parse_launchd_pid_from_list_output(output) == 99999
 
+    def test_parse_launchd_pid_from_launchctl_print_output_lowercase_pid(self):
+        """`launchctl print system/<label>` emits lowercase pid fields."""
+        output = """
+system/com.nousresearch.hermes-gateway = {
+    state = running
+    pid = 48417
+}
+"""
+        assert gateway_cli._parse_launchd_pid_from_list_output(output) == 48417
+
     def test_parse_launchd_pid_from_list_output_negative_pid_returns_none(self):
         """PID = -1 (recently-crashed service sentinel) must return None."""
         output = '{\n    "PID" = -1;\n    "Label" = "ai.hermes.gateway";\n}'
@@ -1252,6 +1267,47 @@ class TestLaunchdServiceRecovery:
         )
         assert gateway_cli._probe_launchd_service_running() is True
 
+    def test_probe_launchd_service_running_true_for_system_launchdaemon(
+        self, tmp_path, monkeypatch
+    ):
+        """System LaunchDaemons are probed via `launchctl print system/<label>`."""
+        system_plist_path = tmp_path / "com.nousresearch.hermes-gateway.plist"
+        system_plist_path.write_text("<plist/>", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_plist_path",
+            lambda: tmp_path / "missing-user-agent.plist",
+        )
+        monkeypatch.setattr(
+            gateway_cli, "get_launchd_system_plist_path", lambda: system_plist_path
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_label",
+            lambda: "com.nousresearch.hermes-gateway",
+        )
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "print", "system/com.nousresearch.hermes-gateway"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="""
+system/com.nousresearch.hermes-gateway = {
+    state = running
+    pid = 48417
+}
+""",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+        assert calls == [["launchctl", "print", "system/com.nousresearch.hermes-gateway"]]
+
     # ── Unsupport marker lifecycle ───────────────────────────────────────
 
     def test_launchd_unsupported_marker_write_and_clear(self, tmp_path, monkeypatch):
@@ -1290,6 +1346,11 @@ class TestLaunchdServiceRecovery:
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_plist_path",
+            lambda: tmp_path / "missing-system-daemon.plist",
+        )
 
         def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
             if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:
@@ -1310,11 +1371,57 @@ class TestLaunchdServiceRecovery:
         assert "supervised by launchd" in out
         assert "Auto-start at login" in out
 
+    def test_launchd_status_reports_system_launchdaemon(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Status should not call a running system LaunchDaemon a manual process."""
+        system_plist_path = tmp_path / "com.nousresearch.hermes-gateway.plist"
+        system_plist_path.write_text("<plist/>", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_plist_path",
+            lambda: system_plist_path,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_label",
+            lambda: "com.nousresearch.hermes-gateway",
+        )
+
+        def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
+            if cmd == ["launchctl", "print", "system/com.nousresearch.hermes-gateway"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="""
+system/com.nousresearch.hermes-gateway = {
+    state = running
+    pid = 48417
+}
+""",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda cleanup_stale=False: 48417)
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "System LaunchDaemon definition exists" in out
+        assert "Gateway is supervised by system launchd (PID 48417)" in out
+        assert "Auto-start at boot" in out
+
     def test_launchd_status_reports_fallback_when_unsupported_and_pid_running(self, tmp_path, monkeypatch, capsys):
         """When the unsupported marker exists and a fallback PID is running."""
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_plist_path",
+            lambda: tmp_path / "missing-system-daemon.plist",
+        )
 
         def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
             if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:
@@ -1343,6 +1450,11 @@ class TestLaunchdServiceRecovery:
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_system_plist_path",
+            lambda: tmp_path / "missing-system-daemon.plist",
+        )
 
         def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
             if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:


### PR DESCRIPTION
## Summary
- recognize macOS system LaunchDaemon gateway installs under /Library/LaunchDaemons
- parse lowercase pid output from launchctl print system/<label>
- report system launchd supervision/boot auto-start accurately in gateway status
- add regression coverage for system LaunchDaemon probes and status output

## Test Plan
- scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k 'launchd_status or probe_launchd_service_running or parse_launchd_pid' -q
- python3 -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py
- hermes gateway status