### PR TITLE
fix(windows): normalize native paths before bash file ops (supersedes #55481)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -467,6 +467,44 @@ class TestShellFileOpsHelpers:
         # Should be safely escaped
         assert result.count("'") >= 4  # wrapping + escaping
 
+    def test_escape_shell_arg_rewrites_windows_drive_paths_to_msys(self, monkeypatch, file_ops):
+        # bash eats backslashes and MSYS mangles ``C:\...``; the Git Bash
+        # ``/c/...`` form is the reliable one (reuses _windows_to_msys_path).
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_arg(r"C:\Users\alice\notes.txt") == "'/c/Users/alice/notes.txt'"
+        # Non-drive paths are untouched.
+        assert file_ops._escape_shell_arg("/tmp/foo") == "'/tmp/foo'"
+
+    def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if command.startswith("wc -c"):
+                return {"output": "5\n", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": "hello", "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": "hello\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "1\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file(r"C:\Users\alice\notes.txt")
+
+        assert result.error is None
+        assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[2] == "sed -n '1,500p' '/c/Users/alice/notes.txt'"
+        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
         assert file_ops._is_likely_binary("data.db") is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -958,7 +958,18 @@ class ShellFileOperations(FileOperations):
         return path
     
     def _escape_shell_arg(self, arg: str) -> str:
-        """Escape a string for safe use in shell commands."""
+        """Escape a string for safe use in shell commands.
+
+        On Windows a native drive path (``C:\\Users\\x``) is first rewritten to
+        the Git Bash / MSYS ``/c/Users/x`` form: bash eats the backslashes and
+        MSYS otherwise mangles ``C:\\...`` (the "Directory \\drivers\\etc does not
+        exist" class of failures). Reuses the env-layer translator so shell file
+        ops and the terminal ``cd`` agree on the path form. No-op off Windows and
+        for non-drive-qualified paths.
+        """
+        from tools.environments.local import _windows_to_msys_path
+
+        arg = _windows_to_msys_path(arg)
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 


### PR DESCRIPTION
## Summary

Supersedes #55481 (@konsisumer), scoped to the real gap and made consistent with the existing MSYS handling. This is the bash-side native→MSYS half of the Windows/Git-Bash path story (the `_msys_to_windows_path` PR #61915 covered the Python→native half).

`ShellFileOperations` builds bash commands with the target path as an argument (`wc`/`head`/`sed`/`cat`/`tee`…). On a Windows/Git-Bash host a native `C:\...` arg has its backslashes eaten by bash (and mangled by the msys runtime even when single-quoted) — the "Directory `\drivers\etc` does not exist; exiting — update your msys package" class of failures. `_escape_shell_arg` now rewrites a native drive path to forward slashes first.

## Changed from #55481
- **Reuse, don't duplicate.** Routes through the env layer's `_windows_to_msys_path` (the canonical helper `LocalEnvironment._quote_cwd_for_cd` already uses) instead of an inline conversion, so shell file ops and the terminal `cd` share one helper and one path form.
- **Emits `/c/…`, not `C:/…`.** Both forms fix the backslash bug — the MSYS coreutils resolve either via the POSIX API (this is *not* a reliability difference: `MSYS_NO_PATHCONV` governs POSIX→Windows conversion for **native** programs, not how msys coreutils resolve their args). `/c/…` is chosen purely for consistency with `_windows_to_msys_path`, which already produces it for `cd`.
- **Dropped the redundant `BaseEnvironment._quote_cwd_for_cd` change.** `LocalEnvironment` already overrides that method through `_windows_to_msys_path`, so on a real Windows host the base branch never ran (the cwd is already `/c/...` before it's reached).

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_local_env_windows_msys.py -q` → 118 passed (adds `_escape_shell_arg` + `read_file` `/c/`-form coverage)
- [x] `ruff check` clean

Credit: @konsisumer (original fix + diagnosis; `Co-authored-by`). Closes #55481.