### PR TITLE
fix(telegram): honor HTTP timeout env vars in standalone send path

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1153,19 +1153,35 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
-        if _tg_proxy:
+
+        # Match the gateway adapter's HTTP timeouts (plugins/platforms/
+        # telegram/adapter.py). PTB's Bot() default is 5s read/write, which
+        # times out on full 4096-char chunks with many link entities, and
+        # timeouts are deliberately not retried to avoid double-sends — so
+        # the standalone path needs the same generous, env-tunable budget.
+        def _env_float(name: str, default: float) -> float:
             try:
-                from telegram.request import HTTPXRequest
-                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
-                bot = Bot(
-                    token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
-                )
-            except Exception as _proxy_err:
-                logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
-        else:
+                return float(os.getenv(name, str(default)))
+            except (TypeError, ValueError):
+                return default
+
+        _tg_request_kwargs = {
+            "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
+            "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
+            "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+        }
+        if _tg_proxy:
+            _tg_request_kwargs["proxy"] = _tg_proxy
+            logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
+        try:
+            from telegram.request import HTTPXRequest
+            bot = Bot(
+                token=token,
+                request=HTTPXRequest(**_tg_request_kwargs),
+                get_updates_request=HTTPXRequest(**_tg_request_kwargs),
+            )
+        except Exception as _req_err:
+            logger.warning("send_message: failed to build Telegram request with timeouts/proxy (%s), falling back to defaults", _req_err)
             bot = Bot(token=token)
         from plugins.platforms.telegram.telegram_ids import (
             normalize_telegram_chat_id,


### PR DESCRIPTION
## Problem

Long messages sent through the **standalone** Telegram path — cron job delivery, `hermes send`, and the `send_message` tool outside the gateway — fail with:

```
ERROR cron.scheduler: Job '…': delivery error: Telegram send failed: Timed out
```

Short messages deliver fine, which makes this look intermittent, but it reproduces reliably with full 4096-char chunks containing many link entities (e.g. a cited news briefing delivered by a cron job).

## Root cause

`_send_telegram` builds `Bot(token=token)` with python-telegram-bot's default `HTTPXRequest` timeouts (5s connect/read/write). A full-length, entity-heavy `sendMessage` routinely takes longer than 5s for Telegram to process. Since #3922, timeouts are deliberately **not retried** (to prevent duplicate sends), so a single slow chunk fails the whole delivery.

The gateway chat adapter already solved this class of problem: `plugins/platforms/telegram/adapter.py` uses env-tunable timeouts `HERMES_TELEGRAM_HTTP_{CONNECT,READ,WRITE}_TIMEOUT` with 10/20/20s defaults. The standalone path never got the same treatment.

## Fix

Build the standalone `Bot` with an `HTTPXRequest` wired to the same env vars and defaults as the adapter, folding the existing `TELEGRAM_PROXY` handling into the same construction (proxy + timeouts now compose instead of being either/or). Falls back to a bare `Bot(token)` if `HTTPXRequest` construction fails, preserving the old behavior.

## Testing

- Reproduced on a Hetzner VPS (direct connection, no proxy; `curl` to `api.telegram.org` connects in <100ms — this is not a network issue): a 13.8 KB markdown briefing with ~30 links consistently failed with `Timed out` before the patch (both via cron delivery and `hermes send --file`), while a 2.5 KB slice of the same content delivered fine.
- After the patch: the same 13.8 KB file delivers completely in one `hermes send` invocation (4 chunks), and scheduled cron delivery works.
- `python -m py_compile tools/send_message_tool.py` passes.

## Notes

- Duplicate search: no open issues/PRs on this; #3922 (closed) is related — it made timeouts non-retryable on this path, which is what turns the tight default timeout into a hard delivery failure.
- Opening as draft since I couldn't run the full test suite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)