### PR TITLE
Fix user home path in local terminal prompt hint

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1096,7 +1096,10 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
-        host_lines.append(f"User home directory: {os.path.expanduser('~')}")
+        user_home = os.environ.get("HOME", "").strip()
+        if not user_home:
+            user_home = os.path.expanduser("~")
+        host_lines.append(f"User home directory: {user_home}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:


### PR DESCRIPTION
Closes #63093.

When building local environment hints, Hermes was using Python's xpanduser('~') for the User home directory line. In containerized setups where HOME can differ from the reported working directory, this can show /opt/data while $HOME is /opt/data/home.

This change uses os.environ['HOME'] when set, with a safe fallback to xpanduser('~') to preserve existing behavior when HOME is unavailable. The result is a prompt header that matches the runtime $HOME path and avoids confusion in local terminal contexts.