### PR TITLE
fix: warn in "hermes memory status" when a provider is configured but not activated

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -475,9 +475,26 @@ def cmd_status(args) -> None:
 
     if providers:
         print("\n  Installed plugins:")
-        for pname, desc, _ in providers:
-            active = " ← active" if pname == provider_name else ""
-            print(f"    • {pname}  ({desc}){active}")
+        for pname, desc, candidate in providers:
+            active = pname == provider_name
+            marker = " ← active" if active else ""
+            print(f"    • {pname}  ({desc}){marker}")
+            # A provider can be fully configured (its own config file has
+            # everything it needs) without being the activated one — e.g.
+            # honcho.json is present and enabled, but config.yaml's
+            # memory.provider was never set to "honcho". is_available()
+            # only checks the provider's own config, so this case reports
+            # no error anywhere; surface it here instead of leaving the
+            # user to notice a silently-unused config file on their own.
+            if not active:
+                try:
+                    if candidate.is_available():
+                        print(
+                            f"      ⚠ configured but not active — add "
+                            f"'memory.provider: {pname}' to config.yaml to enable"
+                        )
+                except Exception:
+                    pass
 
     print()
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -490,8 +490,8 @@ def cmd_status(args) -> None:
                 try:
                     if candidate.is_available():
                         print(
-                            f"      ⚠ configured but not active — add "
-                            f"'memory.provider: {pname}' to config.yaml to enable"
+                            f"      ⚠ configured but not active — run "
+                            f"'hermes config set memory.provider {pname}' to enable"
                         )
                 except Exception:
                     pass

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -165,6 +165,54 @@ def test_cmd_status_prefers_provider_status_config(monkeypatch, capsys):
     assert "http://stale.local" not in output
 
 
+def test_cmd_status_warns_when_inactive_provider_is_configured(monkeypatch, capsys):
+    """A provider can have its own config file fully populated (e.g. honcho.json
+    with enabled=true) without ever being activated via memory.provider in
+    config.yaml. is_available() only checks the provider's own config, so this
+    mismatch previously surfaced nowhere — cmd_status should flag it."""
+
+    class ConfiguredButInactiveProvider:
+        def is_available(self):
+            return True
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+    monkeypatch.setattr(
+        memory_setup,
+        "_get_available_providers",
+        lambda: [
+            ("honcho", "Memory with social cognition", ConfiguredButInactiveProvider())
+        ],
+    )
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    output = capsys.readouterr().out
+    assert "configured but not active" in output
+    assert "memory.provider: honcho" in output
+
+
+def test_cmd_status_silent_for_inactive_unconfigured_provider(monkeypatch, capsys):
+    """The common case — an installed plugin nobody has configured yet —
+    should not print the warning; only genuinely-configured-but-inactive
+    providers should."""
+
+    class UnconfiguredProvider:
+        def is_available(self):
+            return False
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+    monkeypatch.setattr(
+        memory_setup,
+        "_get_available_providers",
+        lambda: [("mem0", "Vector memory", UnconfiguredProvider())],
+    )
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    output = capsys.readouterr().out
+    assert "configured but not active" not in output
+
+
 def test_cmd_setup_generic_choice_cancel_writes_nothing(tmp_path, monkeypatch):
     class ChoiceProvider:
         def __init__(self):

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -188,7 +188,7 @@ def test_cmd_status_warns_when_inactive_provider_is_configured(monkeypatch, caps
 
     output = capsys.readouterr().out
     assert "configured but not active" in output
-    assert "memory.provider: honcho" in output
+    assert "hermes config set memory.provider honcho" in output
 
 
 def test_cmd_status_silent_for_inactive_unconfigured_provider(monkeypatch, capsys):


### PR DESCRIPTION
## What

A memory provider plugin can have its own config file fully populated
(e.g. `honcho.json` with `enabled=true` and a valid `baseUrl`) without
ever being the activated provider — that only happens if config.yaml's
`memory.provider` is also set to that provider's name. `is_available()`
checks only the provider's own config, independent of activation, so
this mismatch previously surfaced nowhere: `hermes memory status` would
just report "(none — built-in only)" with no hint that a fully
configured plugin was sitting there unused.

`cmd_status` now checks `is_available()` for each installed-but-inactive
provider and prints a one-line warning with the exact `config.yaml` fix
needed. Generic across all providers (no honcho-specific logic), since
every provider in this registry follows the same
is_available()-checks-own-config pattern.

## Why

Hit this directly setting up the honcho memory plugin for a self-hosted
instance — copied `honcho.json` into place, but `hermes memory status`
kept saying "(none — built-in only)" with no indication that the plugin
itself was fully configured and just needed one more line in
`config.yaml`.

## Testing

- Added two tests: one confirming the warning fires when an inactive
  provider reports `is_available() == True`, one confirming it stays
  silent for the common case (installed but genuinely unconfigured).
- `pytest tests/hermes_cli/test_memory_setup.py` — 11 passed.
- `ruff check` / `ruff format --check` clean on both changed files.