### PR TITLE
fix(cron): forward provider_routing.data_collection and require_parameters to cron AIAgent

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3060,6 +3060,8 @@ def run_job(
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
+            provider_require_parameters=pr.get("require_parameters", False),
+            provider_data_collection=pr.get("data_collection"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),

--- a/tests/cron/test_cron_provider_data_collection.py
+++ b/tests/cron/test_cron_provider_data_collection.py
@@ -1,0 +1,121 @@
+"""Regression test: cron jobs must forward provider_routing.data_collection
+and provider_routing.require_parameters to AIAgent, the same way they already
+forward only/ignore/order/sort.
+
+Found 2026-07-12: cron/scheduler.py::run_job built the per-job AIAgent with
+providers_allowed/providers_ignored/providers_order/provider_sort taken from
+config.yaml's provider_routing block, but silently dropped data_collection and
+require_parameters — both fully supported by AIAgent (agent/agent_init.py) and
+already correctly forwarded to delegated subagents (tools/delegate_tool.py).
+
+Net effect before the fix: a user who set provider_routing.data_collection:
+"deny" to stop OpenRouter/Nous Portal from routing to data-training providers
+got that protection on their main chat and on delegate_task subagents, but
+NOT on any scheduled cron job — every cron run silently ignored the setting.
+"""
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import run_job
+
+
+def _base_job(**overrides):
+    job = {
+        "id": "dc-test",
+        "name": "data collection test",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": "openrouter",
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _run_job_capturing_agent_kwargs(job, provider_routing_cfg, tmp_path):
+    """Drive run_job with a given provider_routing config block and capture
+    the exact kwargs AIAgent was constructed with."""
+    fake_db = MagicMock()
+    fake_cfg = {"provider_routing": provider_routing_cfg} if provider_routing_cfg is not None else {}
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+
+        # scheduler.py loads config.yaml straight off disk (yaml.safe_load),
+        # so write a real file into the patched _hermes_home rather than
+        # mocking the loader.
+        import yaml
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.safe_dump(fake_cfg))
+
+        success, output, final_response, error = run_job(job)
+        assert mock_agent_cls.called, f"AIAgent never constructed: {error}\n{output}"
+        _, kwargs = mock_agent_cls.call_args
+
+    return kwargs
+
+
+class TestCronForwardsDataCollectionAndRequireParameters:
+    def test_data_collection_deny_is_forwarded(self, tmp_path):
+        job = _base_job()
+        kwargs = _run_job_capturing_agent_kwargs(
+            job, {"data_collection": "deny"}, tmp_path
+        )
+        assert kwargs.get("provider_data_collection") == "deny", (
+            "provider_routing.data_collection was not forwarded to AIAgent — "
+            "cron jobs would silently ignore the user's data-collection privacy setting"
+        )
+
+    def test_require_parameters_true_is_forwarded(self, tmp_path):
+        job = _base_job()
+        kwargs = _run_job_capturing_agent_kwargs(
+            job, {"require_parameters": True}, tmp_path
+        )
+        assert kwargs.get("provider_require_parameters") is True
+
+    def test_no_provider_routing_block_defaults_safely(self, tmp_path):
+        """Back-compat: no provider_routing section at all must not crash and
+        must default to no data-collection restriction (None) and
+        require_parameters=False, matching pre-fix behavior for users who
+        never configured this."""
+        job = _base_job()
+        kwargs = _run_job_capturing_agent_kwargs(job, None, tmp_path)
+        assert kwargs.get("provider_data_collection") is None
+        assert kwargs.get("provider_require_parameters") is False
+
+    def test_existing_only_ignore_order_sort_still_forwarded(self, tmp_path):
+        """Guard against regressing the four routing keys that already worked
+        while adding the two that didn't."""
+        job = _base_job()
+        kwargs = _run_job_capturing_agent_kwargs(
+            job,
+            {
+                "only": ["anthropic"],
+                "ignore": ["together"],
+                "order": ["anthropic", "google"],
+                "sort": "price",
+                "data_collection": "deny",
+            },
+            tmp_path,
+        )
+        assert kwargs.get("providers_allowed") == ["anthropic"]
+        assert kwargs.get("providers_ignored") == ["together"]
+        assert kwargs.get("providers_order") == ["anthropic", "google"]
+        assert kwargs.get("provider_sort") == "price"
+        assert kwargs.get("provider_data_collection") == "deny"


### PR DESCRIPTION
## Summary

`cron/scheduler.py::run_job()` builds each scheduled job's `AIAgent` from the `provider_routing` config block, but only forwards `only`/`ignore`/`order`/`sort`. `data_collection` and `require_parameters` are silently dropped — not defaulted, just absent from the constructor call entirely.

Both are fully supported `AIAgent` parameters (`agent/agent_init.py`) and are already correctly forwarded on the main chat path (`gateway/run.py`) and to delegated subagents (`tools/delegate_tool.py` has 36 references to `provider_data_collection` alone). Cron is the one call path that drops them, with no error, warning, or log line.

**Impact:** a user who sets `provider_routing.data_collection: "deny"` — specifically to stop OpenRouter/Nous Portal from routing to providers that train on submitted data — gets that protection on interactive chat and `delegate_task` subagents, but **not on a single scheduled cron job**. Same for `require_parameters: true`. Nothing fails or logs anything; `cronjob list` / job status shows everything running "ok" regardless.

## Root cause

```python
# cron/scheduler.py, current call site (~line 3046)
agent = AIAgent(
    ...
    providers_allowed=pr.get("only"),
    providers_ignored=pr.get("ignore"),
    providers_order=pr.get("order"),
    provider_sort=pr.get("sort"),
    # provider_require_parameters / provider_data_collection missing here
    openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
    ...
)
```

## Fix

Two-line addition mirroring the four keys already forwarded correctly, using the same defaults `AIAgent`'s own constructor uses (`require_parameters=False`, `data_collection=None`) so back-compat for users with no `provider_routing` configured is unchanged:

```python
provider_require_parameters=pr.get("require_parameters", False),
provider_data_collection=pr.get("data_collection"),
```

## Testing

Added `tests/cron/test_cron_provider_data_collection.py`, following the existing mock pattern in `test_cron_provider_pin.py` (patches `run_agent.AIAgent` + `resolve_runtime_provider`, writes a real `config.yaml` into a `tmp_path`-scoped `HERMES_HOME`, asserts the exact kwargs `AIAgent` was constructed with).

- Confirmed the new tests **fail** on unfixed `main` (`AssertionError: assert None == 'deny'`) and **pass** with this fix (checked out both ways locally before opening this PR).
- Full `tests/cron/` suite: **683 passed**, no regressions.
- Ran everything in a sandboxed `HOME`/`HERMES_HOME` (not the ambient one) to avoid the known test-isolation issue described in #60014 while validating — more on that below.

## Related / prior art (not part of this PR)

While testing this fix I ran into the already-reported, well-documented cron test-isolation bug (#60014, open; duplicate #61673, closed) where running `pytest tests/cron/` against a real profile's `HERMES_HOME` leaks fixture jobs (`w`/`claim job`/`oneshot`/`paused job`) into the live `jobs.json` because `cron/jobs.py` binds its storage path at import time. I hit this twice firsthand while validating the change above (real jobs.json needed manual cleanup both times). Not re-filing or fixing that here since it's an unrelated root cause already under active discussion with competing fix PRs (#61674, #60393, #60824) — just flagging the connection since both surfaced in the same investigation, and noting for anyone landing this PR: **run the suite with an explicit sandboxed `HOME`** (see repro in #61673) until that one lands, rather than against a real profile.

## Willing to fix further

Happy to adjust the approach (e.g. if you'd rather thread `provider_routing` through differently, or want the two new kwargs named/ordered differently for consistency) — just let me know.