### PR TITLE
fix(kanban): enforce swarm review gates

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -80,11 +80,11 @@ _PROJECT_MARKERS = (
     "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts",
     "Gemfile", "composer.json", "mix.exs", "pubspec.yaml",
     "CMakeLists.txt", "Makefile", "Dockerfile",
-    "AGENTS.md", "CLAUDE.md", ".cursorrules",
+    ".hermes.md", "HERMES.md", "AGENTS.md", "CLAUDE.md", ".cursorrules",
 )
 
 # Agent-instruction files surfaced separately from manifests in the snapshot.
-_CONTEXT_FILES = ("AGENTS.md", "CLAUDE.md", ".cursorrules")
+_CONTEXT_FILES = (".hermes.md", "HERMES.md", "AGENTS.md", "CLAUDE.md", ".cursorrules")
 
 # Source-file extensions that make a git repo a *code* workspace even with no
 # manifest. Without this, `git init` on a notes/writing/research folder (a huge

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1894,13 +1894,19 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if not kb.complete_task(
-                conn, tid,
-                result=args.result,
-                summary=summary,
-                metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                completed = kb.complete_task(
+                    conn, tid,
+                    result=args.result,
+                    summary=summary,
+                    metadata=metadata,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.CompletionGateError as exc:
+                failed.append(tid)
+                print(f"cannot complete {tid}: {exc}", file=sys.stderr)
+                continue
+            if not completed:
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3121,6 +3121,17 @@ def _append_event(
     )
 
 
+def require_completion_gate(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    gate: str,
+) -> None:
+    """Attach an immutable, structured completion requirement to a task."""
+    with write_txn(conn):
+        _append_event(conn, task_id, "completion_gate_required", {"gate": gate})
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3975,6 +3986,18 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class CompletionGateError(ValueError):
+    """Raised when a task's durable completion gate was not satisfied."""
+
+    def __init__(self, task_id: str, required_gate: str):
+        self.task_id = task_id
+        self.required_gate = required_gate
+        super().__init__(
+            f"completion blocked: task requires metadata "
+            f'{{"gate": "{required_gate}"}}; review the evidence and retry'
+        )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4014,6 +4037,33 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+
+    # Completion requirements are immutable structured events, so normal task
+    # edits cannot remove or weaken a verifier gate.
+    gate_row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'completion_gate_required' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    required_gate = None
+    if gate_row is not None and gate_row["payload"]:
+        required_gate = json.loads(gate_row["payload"]).get("gate")
+    if (
+        required_gate
+        and (not isinstance(metadata, dict) or metadata.get("gate") != required_gate)
+    ):
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "completion_blocked_gate",
+                {
+                    "required_gate": required_gate,
+                    "provided_gate": metadata.get("gate") if isinstance(metadata, dict) else None,
+                },
+            )
+        raise CompletionGateError(task_id, required_gate)
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -191,6 +191,7 @@ def create_swarm(
         workspace_path=workspace_path,
         skills=["requesting-code-review"],
     )
+    kb.require_completion_gate(conn, verifier, gate="pass")
 
     synthesizer_body = (
         "Synthesize the verified worker outputs into the final deliverable. "

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -843,12 +843,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                except kanban_db.CompletionGateError as exc:
+                    raise HTTPException(status_code=409, detail=str(exc)) from exc
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -189,6 +189,20 @@ class TestProjectFacts:
         block = cc.build_coding_workspace_block(tmp_path)
         assert "Context files: AGENTS.md" in block
 
+    def test_hermes_context_file_marks_and_describes_non_git_workspace(self, tmp_path):
+        (tmp_path / ".hermes.md").write_text("# Hermes rules")
+
+        facts = cc.detect_project_facts(tmp_path)
+        block = cc.build_coding_workspace_block(tmp_path)
+
+        assert facts.context_files == [".hermes.md"]
+        assert "Context files: .hermes.md" in block
+        assert cc.is_coding_context(
+            platform="cli",
+            cwd=tmp_path,
+            config={"agent": {"coding_context": "auto"}},
+        )
+
     def test_worktree_detected_without_primary_path(self, tmp_path):
         # A linked worktree should be detected, but the output must NOT contain
         # the absolute path to the primary tree — exposing that path causes the

--- a/tests/hermes_cli/test_kanban_completion_gate_cli.py
+++ b/tests/hermes_cli/test_kanban_completion_gate_cli.py
@@ -1,0 +1,26 @@
+from argparse import Namespace
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban import _cmd_complete
+
+
+def test_complete_command_reports_unsatisfied_gate(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb.init_db()
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Review", created_by="test")
+        kb.require_completion_gate(conn, task_id, gate="pass")
+
+    exit_code = _cmd_complete(Namespace(
+        task_ids=[task_id],
+        result=None,
+        summary=None,
+        metadata=None,
+    ))
+
+    assert exit_code == 1
+    error = capsys.readouterr().err
+    assert f"cannot complete {task_id}" in error
+    assert "requires metadata" in error

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from hermes_cli import kanban_db as kb
 from hermes_cli.kanban_swarm import (
     SwarmWorkerSpec,
@@ -104,6 +106,37 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         kb.recompute_ready(conn)
         assert kb.get_task(conn, created.verifier_id).status == "ready"
         assert kb.get_task(conn, created.synthesizer_id).status == "todo"
+
+        with pytest.raises(kb.CompletionGateError, match='metadata.*gate.*pass'):
+            kb.complete_task(
+                conn,
+                created.verifier_id,
+                summary="Claimed verification without a gate",
+            )
+        assert kb.get_task(conn, created.verifier_id).status == "ready"
+        assert kb.get_task(conn, created.synthesizer_id).status == "todo"
+        blocked_events = [
+            event for event in kb.list_events(conn, created.verifier_id)
+            if event.kind == "completion_blocked_gate"
+        ]
+        assert len(blocked_events) == 1
+        assert blocked_events[0].payload == {
+            "required_gate": "pass",
+            "provided_gate": None,
+        }
+
+        # The requirement is structured immutable state, not editable prose.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET body = ? WHERE id = ?",
+                ("Body replaced through a supported edit surface", created.verifier_id),
+            )
+        with pytest.raises(kb.CompletionGateError):
+            kb.complete_task(
+                conn,
+                created.verifier_id,
+                metadata={"gate": "fail"},
+            )
 
         kb.complete_task(
             conn,

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -317,6 +317,36 @@ def test_patch_status_complete(client):
     assert any(x["id"] == t["id"] for x in done["tasks"])
 
 
+def test_patch_status_complete_returns_conflict_for_unsatisfied_gate(client):
+    task = client.post("/api/plugins/kanban/tasks", json={"title": "review"}).json()["task"]
+    with kb.connect_closing() as conn:
+        kb.require_completion_gate(conn, task["id"], gate="pass")
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "done", "metadata": {"gate": "fail"}},
+    )
+
+    assert response.status_code == 409
+    assert "requires metadata" in response.json()["detail"]
+
+
+def test_bulk_complete_reports_unsatisfied_gate_per_task(client):
+    task = client.post("/api/plugins/kanban/tasks", json={"title": "review"}).json()["task"]
+    with kb.connect_closing() as conn:
+        kb.require_completion_gate(conn, task["id"], gate="pass")
+
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [task["id"]], "status": "done"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["ok"] is False
+    assert "requires metadata" in result["error"]
+
+
 def test_patch_block_then_unblock(client):
     t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
     r = client.patch(


### PR DESCRIPTION
## Summary
- recognize `.hermes.md` / `HERMES.md` as coding workspace context files
- persist swarm verifier requirements as immutable structured Kanban events
- block verifier completion unless `metadata.gate` satisfies the required gate
- return actionable CLI, dashboard, and bulk-operation errors
- add bypass, audit-event, CLI, and dashboard regression coverage

## Test plan
- `python -m pytest -o "addopts=" -q tests/agent/test_coding_context.py tests/hermes_cli/test_kanban_swarm.py tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py` — 476 passed
- `python -m pytest -o "addopts=" -q tests/hermes_cli/test_kanban_completion_gate_cli.py tests/hermes_cli/test_kanban_swarm.py tests/plugins/test_kanban_dashboard_plugin.py tests/agent/test_coding_context.py` — 158 passed
- `git diff --check` — clean

## Risk / rollback
- Existing non-swarm tasks have no completion requirement and retain current behavior.
- Swarm verifier tasks now enforce the contract already present in their instructions.
- Revert commit `31b8e4e53` to roll back.

## Scope
Only Hermes Agent files changed; unrelated projects were untouched.