### PR TITLE
fix(gateway): never prune sessions when active-process check fails

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2178,6 +2178,10 @@ class SessionStore:
                             "has_active_processes_fn raised during prune for %s: %s",
                             entry.session_key, exc,
                         )
+                        # Fail safe: if we can't tell whether a background
+                        # process is attached, keep the entry rather than
+                        # risk orphaning live work.
+                        continue
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -165,6 +165,37 @@ class TestPruneBasics:
         assert removed == 1
         assert "active" not in store._entries
 
+    def test_prune_keeps_entry_when_active_check_raises(self, tmp_path):
+        """A failing active-process check must fail safe, not fail open.
+
+        If has_active_processes_fn raises, we can't tell whether a live
+        background process is attached — so the entry must be kept.
+        Previously the except block logged and fell through to the age
+        check, pruning the session anyway.
+        """
+        def _broken(session_key: str) -> bool:
+            raise RuntimeError("process registry unavailable")
+
+        store = _make_store(tmp_path, has_active_processes_fn=_broken)
+        store._entries["old"] = _entry("old", age_days=1000)
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        assert removed == 0
+        assert "old" in store._entries
+
+    def test_prune_removes_old_entry_when_active_check_returns_false(self, tmp_path):
+        """Sibling guard: a callback that cleanly reports no active process
+        must still allow the old entry to be pruned.
+        """
+        store = _make_store(tmp_path, has_active_processes_fn=lambda key: False)
+        store._entries["old"] = _entry("old", age_days=1000)
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        assert removed == 1
+        assert "old" not in store._entries
+
     def test_prune_does_not_write_disk_when_no_removals(self, tmp_path):
         """If nothing is evictable, _save() should NOT be called."""
         store = _make_store(tmp_path)


### PR DESCRIPTION
Fixes #63128. Supersedes #44854 (re-cut onto current `main`).

## Problem
`SessionStore.prune_old_entries` promises (in its own docstring) to keep any session that still has a live background process attached. But when the `has_active_processes_fn` callback **raises**, the exception is swallowed at `debug` level and execution falls through to the age check — so the session is pruned anyway, silently orphaning running background work. The hourly sweep is on by default (`session_store_max_age_days` defaults to 90), so this runs for essentially every install.

## Fix
Add a fail-safe `continue` inside the `except` so an indeterminate active-process check keeps the entry (`gateway/session.py`).

## Verification
- **Dynamic repro (red→green):** the new test `test_prune_keeps_entry_when_active_check_raises` fails on unfixed `main` with `assert 1 == 0` (session wrongly pruned) and passes with this fix.
- New tests cover both paths (raise → kept; returns `False` → pruned).
- Full local suite (per-file isolation, 1976 files) run against this branch and against the pristine base `889533545`: **this change introduces zero new failures** — every pre-existing failure is identical to baseline.

## Impact
Data-loss class: orphans live background work, no workaround, and the sweep is on by default. Priority left to triage — see #63128.
