### PR TITLE
fix(delegation): correlate async results to parent turns

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -143,6 +143,36 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_single_completion_event_carries_parent_turn_id():
+    """The async completion event remains correlated to its spawning turn."""
+    res = ad.dispatch_async_delegation(
+        goal="compute X", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", parent_turn_id="turn-single-123",
+        runner=lambda: {"status": "completed", "summary": "done"},
+        max_async_children=3,
+    )
+
+    assert res["status"] == "dispatched"
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["parent_turn_id"] == "turn-single-123"
+
+
+def test_batch_completion_event_carries_parent_turn_id():
+    """A consolidated async batch event keeps its spawning-turn correlation."""
+    res = ad.dispatch_async_delegation_batch(
+        goals=["compute X"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", parent_turn_id="turn-batch-456",
+        runner=lambda: {"results": [{"status": "completed", "summary": "done"}]},
+        max_async_children=3,
+    )
+
+    assert res["status"] == "dispatched"
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["parent_turn_id"] == "turn-batch-456"
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",
@@ -485,6 +515,38 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     text = format_process_notification(evt)
     assert text is not None
     assert "the real task" in text
+
+
+def test_delegate_task_background_forwards_parent_turn_id_to_batch_dispatcher(monkeypatch):
+    """Background delegation passes the parent agent's current turn to its dispatcher."""
+    import json
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent._current_turn_id = "turn-parent-789"
+    parent.session_id = "sess"
+    parent._active_children = []
+    parent._active_children_lock = None
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    dispatcher = MagicMock(return_value={
+        "status": "dispatched", "delegation_id": "deleg_parent_turn",
+    })
+
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "dispatch_async_delegation_batch", dispatcher)
+
+    out = dt.delegate_task(goal="track this turn", background=True, parent_agent=parent)
+
+    assert json.loads(out)["status"] == "dispatched"
+    assert dispatcher.call_args.kwargs["parent_turn_id"] == "turn-parent-789"
 
 
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -353,6 +353,64 @@ assert ad.mark_completion_delivered({delegation_id!r})
     assert probe.stdout.strip().splitlines()[-1] == "0"
 
 
+def test_real_process_restart_recovers_abandoned_batch_parent_turn_id(tmp_path):
+    """Owner-exit recovery retains the spawning turn on a durable batch event."""
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": repo}
+    producer = r'''
+import os
+import sys
+import threading
+from tools import async_delegation as ad
+gate = threading.Event()
+r = ad.dispatch_async_delegation_batch(
+    goals=["restart"], context=None, toolsets=None, role="leaf", model="m",
+    session_key="owner-session", parent_turn_id="turn-restart-901",
+    runner=lambda: (gate.wait(60), {"results": []})[1],
+)
+print(r["delegation_id"])
+sys.stdout.flush()
+os._exit(0)
+'''
+    first = subprocess.run(
+        [sys.executable, "-c", producer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    delegation_id = first.stdout.strip().splitlines()[-1]
+
+    consumer = r'''
+import json
+import os
+import queue
+import sqlite3
+import sys
+import types
+sys.modules["gateway.status"] = types.SimpleNamespace(
+    _pid_exists=lambda _pid: False,
+    get_process_start_time=lambda _pid: None,
+)
+from tools import async_delegation as ad
+task_json = sqlite3.connect(os.path.join(os.environ["HERMES_HOME"], "state.db")).execute(
+    "SELECT task_json FROM async_delegations"
+).fetchone()[0]
+recovered = queue.Queue()
+assert ad.restore_undelivered_completions(recovered) == 1
+evt = recovered.get_nowait()
+print(json.dumps({"event": evt, "task": json.loads(task_json)}, sort_keys=True))
+'''
+    second = subprocess.run(
+        [sys.executable, "-c", consumer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    payload = json.loads(second.stdout.strip().splitlines()[-1])
+    evt = payload["event"]
+    assert evt["delegation_id"] == delegation_id
+    assert evt["status"] == "unknown"
+    assert (
+        payload["task"].get("parent_turn_id"), evt.get("parent_turn_id")
+    ) == ("turn-restart-901", "turn-restart-901")
+
+
 def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -444,6 +444,7 @@ def dispatch_async_delegation(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    parent_turn_id: str = "",
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -466,6 +467,10 @@ def dispatch_async_delegation(
         the delegation. Carried on the completion event so the gateway can
         pin routing to the spawning session instead of recovering the latest
         ``ended_at IS NULL`` row for the peer tuple (#57498).
+    parent_turn_id
+        Optional stable id of the parent turn that initiated the delegation.
+        Carried on records and completion events for correlation only; it does
+        not contain prompt or task content.
     runner
         Zero-arg callable that builds + runs the child and returns the same
         result dict ``_run_single_child`` produces. Runs on the worker thread.
@@ -495,6 +500,7 @@ def dispatch_async_delegation(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "parent_turn_id": parent_turn_id,
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -615,6 +621,7 @@ def _push_completion_event(
         "session_key": record.get("session_key", ""),
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -651,6 +658,7 @@ def dispatch_async_delegation_batch(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    parent_turn_id: str = "",
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -694,6 +702,7 @@ def dispatch_async_delegation_batch(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "parent_turn_id": parent_turn_id,
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -794,6 +803,7 @@ def _finalize_batch(
         "session_key": event_record.get("session_key", ""),
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "parent_turn_id": event_record.get("parent_turn_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -136,6 +136,14 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch")
         if key in record
     }
+    # ``parent_turn_id`` is correlation metadata and is normally a string.
+    # Keep durable writes safe for legacy/mock parent agents that expose an
+    # arbitrary attribute instead of a concrete turn id.
+    parent_turn_id = record.get("parent_turn_id", "")
+    if not isinstance(parent_turn_id, str):
+        parent_turn_id = ""
+        record["parent_turn_id"] = parent_turn_id
+    task_payload["parent_turn_id"] = parent_turn_id
     with _DB_LOCK, _connect() as conn:
         conn.execute(
             """INSERT OR REPLACE INTO async_delegations
@@ -244,7 +252,9 @@ def recover_abandoned_delegations() -> int:
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
-                "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "parent_session_id": parent_id,
+                "parent_turn_id": task.get("parent_turn_id", ""),
+                "goal": task.get("goal", ""),
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2913,6 +2913,7 @@ def delegate_task(
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             parent_session_id=_parent_session_id,
+            parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),


### PR DESCRIPTION
## Summary

Preserves the optional parent turn ID across the background delegation lifecycle so consumers can correlate an async completion with the exact parent turn that created it.

- carries `parent_turn_id` from `delegate_task(background=True)` into async dispatch;
- includes it in in-memory records and live single/batch completion events;
- persists it in the durable dispatch payload and restores it on owner-exit/restart recovery;
- preserves compatibility with older durable records by defaulting a missing field to `""`;
- stores correlation metadata only — no prompt, goal, task arguments, credentials, or model-routing state.

No model/provider/profile selection, routing, fallback, config, or new tool surface is added.

## Validation

- RED: real cross-process owner-exit/restart regression failed before the durable payload/recovery fix because both values were absent.
- GREEN: real cross-process test now verifies `parent_turn_id` survives `task_json` and a recovered `unknown` completion event.
- Focused suites after latest rebase: `tests/tools/test_async_delegation.py`, `tests/tools/test_restored_delegation_ownership.py`, and `tests/agent/test_subagent_stop_hook.py` — **43 passed**.
- `git diff --check` passed.

## Full-suite note

The local canonical runner is not green in this environment. On the previous identical-base comparison, candidate and clean base both had unrelated environment/concurrency failures (including the Tavily URL-safety DNS symptom). A compression concurrency test also flaked symmetrically in alternating plain-pytest runs: **2 pass / 1 fail** on both candidate and clean base; its failing trace did not involve async delegation. The focused durable path is green.
