### PR TITLE
fix(mcp-oauth): preserve existing refresh_token on token refresh

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -366,6 +366,12 @@ class HermesTokenStorage:
                 # Mock tokens or unusual shapes: skip the expires_at write
                 # rather than fail persistence.
                 pass
+        # RFC 6749 §6: a refresh response MAY omit the new refresh_token.
+        # Preserve the existing one so the next refresh cycle still works.
+        if "refresh_token" not in payload:
+            existing = _read_json(self._tokens_path())
+            if existing and existing.get("refresh_token"):
+                payload["refresh_token"] = existing["refresh_token"]
         _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
 


### PR DESCRIPTION
Fixes #62333

## Problem
When an OAuth refresh response omits the `refresh_token` (allowed by RFC 6749 §6), `HermesTokenStorage.set_tokens` calls `model_dump(exclude_none=True)` which drops the `refresh_token` from the serialized payload. The next refresh cycle finds no `refresh_token` stored and fails.

## Fix
Before writing the token file, read the existing tokens and preserve the `refresh_token` when the new payload doesn't include one. This matches standard OAuth 2.0 behavior where the refresh_token is typically the same across refreshes.

## Testing
- All 7 existing MCP OAuth tests pass unchanged.