### PR TITLE
fix(cli): preserve YAML comments and formatting in set_config_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8138,16 +8138,29 @@ def set_config_value(key: str, value: str):
     
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
+    # dumping all default values back to the file.
+    # Use ruamel.yaml round-trip mode so comments, blank lines, key ordering,
+    # quoting, and Unicode are preserved through the write (issue #63039).
+    # ``_set_nested`` works on the resulting CommentedMap because it subclasses
+    # dict and CommentedSeq subclasses list.
     config_path = get_config_path()
     require_readable_config_before_write(config_path)
-    user_config = {}
+    from ruamel.yaml import YAML as _RuamelYAML
+    from ruamel.yaml.comments import CommentedMap as _CM
+    _yaml_rt = _RuamelYAML(typ="rt")
+    _yaml_rt.preserve_quotes = True
+    _yaml_rt.allow_unicode = True
+    _yaml_rt.default_flow_style = False
+    _yaml_rt.indent(mapping=2, sequence=4, offset=2)
+    user_config = _CM()
     if config_path.exists():
         try:
             with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
+                _loaded = _yaml_rt.load(f)
+                if _loaded is not None:
+                    user_config = _loaded if isinstance(_loaded, _CM) else _CM(_loaded)
         except Exception:
-            user_config = {}
+            user_config = _CM()
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -8171,13 +8184,33 @@ def set_config_value(key: str, value: str):
     # ignored. Mirrors the load-time migration in _normalize_root_model_keys.
     _alias_norm = key.strip().lower()
     if _alias_norm in ("model.api_base", "api_base"):
-        user_config = _normalize_root_model_keys(user_config)
+        # _normalize_root_model_keys returns a plain dict, which drops comments.
+        # Wrap the result back into CommentedMap so the round-trip write below
+        # still preserves top-level formatting as much as possible.
+        _normed = _normalize_root_model_keys(user_config)
+        user_config = _CM(_normed)
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+    # Write only user config back (not the full merged defaults), preserving
+    # comments and formatting via ruamel.yaml round-trip (issue #63039).
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    import tempfile
+    from utils import atomic_replace
+    _fd, _tmp = tempfile.mkstemp(
+        dir=str(config_path.parent), prefix=f".{config_path.stem}_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(_fd, "w", encoding="utf-8") as f:
+            _yaml_rt.dump(user_config, f)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(_tmp, config_path)
+    except BaseException:
+        try:
+            os.unlink(_tmp)
+        except OSError:
+            pass
+        raise
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -301,3 +301,61 @@ class TestSecretRedactionInDisplay:
 
         captured = capsys.readouterr()
         assert "Set model.reasoning_effort = high" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Comment / formatting preservation — regression tests for #63039
+# ---------------------------------------------------------------------------
+
+class TestCommentPreservation:
+    """set_config_value must preserve YAML comments and key ordering (#63039)."""
+
+    def test_top_level_comment_preserved(self, _isolated_hermes_home):
+        """A comment on a key that is NOT modified must survive the write."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "# My model configuration\n"
+            "model: gpt-4o\n"
+            "# Terminal settings\n"
+            "terminal:\n"
+            "  backend: local\n"
+        )
+        set_config_value("verbose", "true")
+        config_text = _read_config(_isolated_hermes_home)
+        assert "# My model configuration" in config_text
+        assert "# Terminal settings" in config_text
+
+    def test_inline_comment_preserved_on_unchanged_key(self, _isolated_hermes_home):
+        """Inline comment on an unmodified sibling key must survive."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "model: gpt-4o  # primary model\n"
+            "terminal:\n"
+            "  backend: local\n"
+        )
+        set_config_value("verbose", "true")
+        config_text = _read_config(_isolated_hermes_home)
+        assert "# primary model" in config_text
+
+    def test_key_order_preserved(self, _isolated_hermes_home):
+        """Keys should retain their original order, not be re-sorted."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "zebra: first\n"
+            "alpha: second\n"
+            "middle: third\n"
+        )
+        set_config_value("verbose", "true")
+        config_text = _read_config(_isolated_hermes_home)
+        lines = [l.strip() for l in config_text.splitlines() if l.strip() and not l.strip().startswith("#")]
+        keys = [l.split(":")[0] for l in lines if ":" in l]
+        assert keys.index("zebra") < keys.index("alpha") < keys.index("middle")
+
+    def test_blank_lines_preserved(self, _isolated_hermes_home):
+        """Blank lines between sections should be kept."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "model: gpt-4o\n"
+            "\n"
+            "terminal:\n"
+            "  backend: local\n"
+        )
+        set_config_value("verbose", "true")
+        config_text = _read_config(_isolated_hermes_home)
+        assert "\n\n" in config_text


### PR DESCRIPTION
## What does this PR do?

`hermes config set` silently strips all YAML comments, blank lines, and key ordering from `config.yaml` on every write. This PR fixes that by switching `set_config_value` from PyYAML (`fast_safe_load` + `atomic_yaml_write`) to `ruamel.yaml` round-trip mode, matching the approach already used by `cli.py:save_config_value` (which was updated in commit `85383c636` but never ported to `set_config_value`).

The existing `_set_nested` helper works unchanged on the ruamel `CommentedMap` because `CommentedMap` subclasses `dict` and `CommentedSeq` subclasses `list`, so all `isinstance` checks and dict/list operations behave identically.

## Related Issue

Fixes #63039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py:set_config_value` — replaced `fast_safe_load` read + `atomic_yaml_write` write with `ruamel.yaml` round-trip (`typ="rt"`) read + dump, preserving comments, blank lines, key ordering, quoting, and Unicode
- `hermes_cli/config.py:set_config_value` — the `api_base` alias branch wraps `_normalize_root_model_keys` output back in `CommentedMap` to retain as much formatting as possible (the normalizer returns a plain dict)
- `tests/hermes_cli/test_set_config_value.py` — added `TestCommentPreservation` class with 4 regression tests covering top-level comments, inline comments, key ordering, and blank line preservation

## How to Test

1. Create a `config.yaml` with comments:
   ```yaml
   # My model configuration
   model: gpt-4o
   # Terminal settings
   terminal:
     backend: local
   ```
2. Run `hermes config set verbose true`
3. Inspect `config.yaml` — the comments and key ordering should be preserved

Observed result: all 4 new tests in `TestCommentPreservation` pass, plus the existing 37 tests in `test_set_config_value.py` and 151 tests in `test_config.py` continue to pass.

```bash
$ python -m pytest tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py -q
192 passed in 4.6s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A