### PR TITLE
fix(search): surface compaction-archived and compression-parent sessions in discovery

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -18,6 +18,7 @@ from tools.session_search_tool import (
     _HIDDEN_SESSION_SOURCES,
     _format_timestamp,
     _is_compacted_message,
+    _is_compression_ended,
     _resolve_to_parent,
     session_search,
 )
@@ -878,3 +879,132 @@ class TestDelegationExclusion:
             query="stellar forge", db=db, current_session_id="s_parent",
         ))
         assert result["count"] == 0
+
+
+# =========================================================================
+# Teknium review round 2: rewind exclusion + delegation-under-compression
+# =========================================================================
+
+class TestRewindExclusion:
+    """Rewind/undo rows (active=0, compacted=0) must STAY hidden — only
+    compaction archives (active=0, compacted=1) should surface."""
+
+    def test_rewind_rows_stay_hidden(self, db):
+        """A rewound (active=0, compacted=0) message must not appear in
+        discovery, even though it's on the current session."""
+        db.create_session("s_rewind", source="cli")
+        mid = db.append_message("s_rewind", role="user",
+                                content="secret rewind content alpha")
+        # Simulate a rewind: active=0, compacted=0 (NOT compaction)
+        db._conn.execute(
+            "UPDATE messages SET active = 0, compacted = 0 WHERE id = ?",
+            (mid,),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="secret rewind content alpha", db=db,
+            current_session_id="s_rewind",
+        ))
+        assert result["count"] == 0
+
+    def test_compacted_messages_still_surface_alongside_rewind(self, db):
+        """On the same session: compacted rows surface, rewind rows don't."""
+        db.create_session("s_mixed", source="cli")
+        # Message that will be compacted
+        db.append_message("s_mixed", role="user",
+                          content="compaction archived content beta")
+        db.archive_and_compact("s_mixed", [
+            {"role": "assistant", "content": "Summary of beta"},
+        ])
+        # Now add a post-compaction message and rewind it
+        mid2 = db.append_message("s_mixed", role="user",
+                                 content="rewound content gamma")
+        db._conn.execute(
+            "UPDATE messages SET active = 0, compacted = 0 WHERE id = ?",
+            (mid2,),
+        )
+        db._conn.commit()
+
+        # Compacted content should be discoverable
+        result_compact = json.loads(session_search(
+            query="compaction archived content beta", db=db,
+            current_session_id="s_mixed",
+        ))
+        assert result_compact["count"] >= 1
+
+        # Rewound content should NOT be discoverable
+        result_rewind = json.loads(session_search(
+            query="rewound content gamma", db=db,
+            current_session_id="s_mixed",
+        ))
+        assert result_rewind["count"] == 0
+
+
+class TestCompressionEndedHelper:
+    """Unit tests for _is_compression_ended."""
+
+    def test_compression_ended_session(self, db):
+        db.create_session("s1", source="cli")
+        db.end_session("s1", "compression")
+        assert _is_compression_ended(db, "s1") is True
+
+    def test_active_session_not_ended(self, db):
+        db.create_session("s1", source="cli")
+        assert _is_compression_ended(db, "s1") is False
+
+    def test_delegation_child_not_ended(self, db):
+        """A delegation child under a compression continuation does NOT have
+        end_reason='compression' itself."""
+        db.create_session("s_parent", source="cli")
+        db.end_session("s_parent", "compression")
+        db.create_session("s_continuation", source="cli", parent_session_id="s_parent")
+        db.create_session("s_delegate_child", source="cli", parent_session_id="s_continuation")
+        assert _is_compression_ended(db, "s_delegate_child") is False
+
+    def test_empty_and_nonexistent(self, db):
+        assert _is_compression_ended(db, "") is False
+        assert _is_compression_ended(db, "nonexistent") is False
+
+
+class TestLegacyContinuationPlusDelegation:
+    """Regression: a delegation child created under a compression continuation
+    must stay excluded — its content is still live to the parent agent.
+    Only the compression-ended ancestor's content should surface."""
+
+    def test_compression_parent_surfaces_but_delegate_child_excluded(self, db):
+        """Setup: grandparent (compression) → parent (compression) → child
+        (active, current session). A delegation grandchild is created under
+        the parent. Searching from the child should find grandparent/parent
+        content but NOT the delegation grandchild's content."""
+        # Grandparent: compression-ended, has searchable content
+        db.create_session("s_gp", source="cli")
+        db.append_message("s_gp", role="user",
+                          content="grandparent cosmic anomaly research data")
+        db.end_session("s_gp", "compression")
+
+        # Parent: compression-ended continuation
+        db.create_session("s_p", source="cli", parent_session_id="s_gp")
+        db.append_message("s_p", role="user",
+                          content="parent cosmic anomaly follow-up notes")
+        db.end_session("s_p", "compression")
+
+        # Current session: active child
+        db.create_session("s_current", source="cli", parent_session_id="s_p")
+
+        # Delegation child under s_p (not compression-ended)
+        db.create_session("s_delegate", source="cli", parent_session_id="s_p")
+        db.append_message("s_delegate", role="assistant",
+                          content="delegated cosmic anomaly subtask results")
+
+        result = json.loads(session_search(
+            query="cosmic anomaly", db=db,
+            current_session_id="s_current",
+        ))
+
+        # Compression-ended ancestors should be discoverable
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_gp" in sids or "s_p" in sids
+
+        # Delegation child must NOT appear
+        assert "s_delegate" not in sids

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -17,6 +17,8 @@ from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _HIDDEN_SESSION_SOURCES,
     _format_timestamp,
+    _is_compacted_message,
+    _resolve_to_parent,
     session_search,
 )
 
@@ -638,3 +640,241 @@ class TestCronDemotion:
         # Interactive rows first, in original relative order; cron last, in
         # original relative order.
         assert [r["id"] for r in ordered] == [2, 4, 5, 1, 3]
+
+
+# =========================================================================
+# Compression-aware discovery (#6256)
+#
+# After compression (in-place compaction or legacy rotation), pre-compaction
+# content is no longer in the live context but MUST stay discoverable via
+# session_search. The old code skipped any FTS hit on the current session or
+# lineage, creating a "memory black hole". Delegation children must STAY
+# excluded — their content is still visible to the parent agent.
+# =========================================================================
+
+class TestResolveToParent:
+    """Unit tests for _resolve_to_parent's compression-aware tuple return."""
+
+    def test_root_session_no_compression(self, db):
+        db.create_session("s1", source="cli")
+        root, has_compression = _resolve_to_parent(db, "s1")
+        assert root == "s1"
+        assert has_compression is False
+
+    def test_empty_session_id(self, db):
+        root, has_compression = _resolve_to_parent(db, "")
+        assert root == ""
+        assert has_compression is False
+
+    def test_none_session_id(self, db):
+        root, has_compression = _resolve_to_parent(db, None)
+        assert root is None
+        assert has_compression is False
+
+    def test_legacy_rotation_detects_compression(self, db):
+        """Parent ended with end_reason='compression', child has parent_session_id."""
+        db.create_session("s_parent", source="cli")
+        db.end_session("s_parent", "compression")
+        db.create_session("s_child", source="cli", parent_session_id="s_parent")
+        root, has_compression = _resolve_to_parent(db, "s_child")
+        assert root == "s_parent"
+        assert has_compression is True
+
+    def test_delegation_no_compression(self, db):
+        """Delegation child: parent_session_id set but no compression end_reason."""
+        db.create_session("s_parent", source="cli")
+        db.create_session("s_child", source="cli", parent_session_id="s_parent")
+        root, has_compression = _resolve_to_parent(db, "s_child")
+        assert root == "s_parent"
+        assert has_compression is False
+
+    def test_multi_level_compression_chain(self, db):
+        """Grandparent → parent → child, both with compression edges."""
+        db.create_session("s_gp", source="cli")
+        db.end_session("s_gp", "compression")
+        db.create_session("s_p", source="cli", parent_session_id="s_gp")
+        db.end_session("s_p", "compression")
+        db.create_session("s_c", source="cli", parent_session_id="s_p")
+        root, has_compression = _resolve_to_parent(db, "s_c")
+        assert root == "s_gp"
+        assert has_compression is True
+
+    def test_chain_with_mixed_edges(self, db):
+        """Compression parent → delegation-style child (no end_reason on child)."""
+        db.create_session("s_gp", source="cli")
+        db.end_session("s_gp", "compression")
+        db.create_session("s_p", source="cli", parent_session_id="s_gp")
+        # s_p does NOT end with compression — but ancestor s_gp does
+        db.create_session("s_c", source="cli", parent_session_id="s_p")
+        root, has_compression = _resolve_to_parent(db, "s_c")
+        assert root == "s_gp"
+        assert has_compression is True
+
+
+class TestIsCompactedMessage:
+    """Unit tests for the _is_compacted_message helper."""
+
+    def test_active_message_returns_false(self, db):
+        db.create_session("s1", source="cli")
+        mid = db.append_message("s1", role="user", content="hello")
+        assert _is_compacted_message(db, mid) is False
+
+    def test_compacted_message_returns_true(self, db):
+        db.create_session("s1", source="cli")
+        mid = db.append_message("s1", role="user", content="archived content")
+        db.archive_and_compact("s1", [
+            {"role": "assistant", "content": "compacted summary"},
+        ])
+        # mid is now active=0, compacted=1
+        assert _is_compacted_message(db, mid) is True
+
+    def test_none_message_id(self, db):
+        assert _is_compacted_message(db, None) is False
+
+    def test_nonexistent_message_id(self, db):
+        assert _is_compacted_message(db, 999999) is False
+
+
+class TestInPlaceCompactionDiscovery:
+    """In-place compaction: archived turns on the SAME session_id must be
+    discoverable from the current session."""
+
+    def test_archived_content_discoverable_after_compaction(self, db):
+        """The core regression: pre-compaction content on the current session
+        must surface in discovery even though raw_sid == current_session_id."""
+        db.create_session("s_compact", source="cli")
+        db.append_message("s_compact", role="user",
+                          content="The spectral phoenix only spawns during full moons")
+        db.append_message("s_compact", role="assistant",
+                          content="Spectral phoenix requires moonstone bait")
+        db.archive_and_compact("s_compact", [
+            {"role": "user", "content": "Summary: spectral phoenix discussed"},
+            {"role": "assistant", "content": "Acknowledged spectral phoenix info"},
+        ])
+
+        result = json.loads(session_search(
+            query="spectral phoenix", db=db, current_session_id="s_compact",
+        ))
+        assert result["success"] is True
+        assert result["count"] >= 1
+        # The hit should be from the same session (archived rows)
+        hit = result["results"][0]
+        assert hit["session_id"] == "s_compact"
+
+    def test_live_content_still_filtered_on_current_session(self, db):
+        """Non-compacted (active) content on the current session stays filtered."""
+        db.create_session("s_live", source="cli")
+        db.append_message("s_live", role="user", content="crystal golem farming route")
+        result = json.loads(session_search(
+            query="crystal golem", db=db, current_session_id="s_live",
+        ))
+        assert result["count"] == 0
+
+    def test_mixed_active_and_compacted_on_same_session(self, db):
+        """A session that has been compacted: the archived content is
+        discoverable, but the new (post-compaction) active content is not
+        (it's in live context)."""
+        db.create_session("s_mixed", source="cli")
+        # Pre-compaction content (will be archived)
+        db.append_message("s_mixed", role="user", content="ancient ruins exploration log")
+        db.append_message("s_mixed", role="assistant", content="ancient ruins mapped")
+        # Compact
+        db.archive_and_compact("s_mixed", [
+            {"role": "user", "content": "Summary of ancient ruins exploration"},
+            {"role": "assistant", "content": "Continuing ancient ruins work"},
+        ])
+        # Archived content should be discoverable
+        result_archived = json.loads(session_search(
+            query="ancient ruins exploration", db=db,
+            current_session_id="s_mixed",
+        ))
+        assert result_archived["count"] >= 1
+
+
+class TestLegacyRotationDiscovery:
+    """Legacy rotation: parent session ended with end_reason='compression',
+    child session created. Parent's pre-compaction content must be discoverable
+    from the child."""
+
+    def test_compression_parent_discoverable_from_child(self, db):
+        db.create_session("s_parent", source="cli")
+        db.append_message("s_parent", role="user",
+                          content="The void crystal mining requires diamond pickaxe")
+        db.append_message("s_parent", role="assistant",
+                          content="Void crystal found in the deep caverns")
+        db.end_session("s_parent", "compression")
+
+        db.create_session("s_child", source="cli", parent_session_id="s_parent")
+        db.append_message("s_child", role="user", content="Continue void crystal work")
+
+        result = json.loads(session_search(
+            query="void crystal", db=db, current_session_id="s_child",
+        ))
+        assert result["success"] is True
+        assert result["count"] >= 1
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_parent" in sids
+
+    def test_multi_level_compression_chain_discoverable(self, db):
+        """Grandparent → parent → child, each compression-rotated. Content from
+        ancestors must be discoverable."""
+        db.create_session("s_gp", source="cli")
+        db.append_message("s_gp", role="user",
+                          content="Project titan initial architecture design")
+        db.end_session("s_gp", "compression")
+
+        db.create_session("s_p", source="cli", parent_session_id="s_gp")
+        db.append_message("s_p", role="user",
+                          content="Project titan second phase planning")
+        db.end_session("s_p", "compression")
+
+        db.create_session("s_c", source="cli", parent_session_id="s_p")
+        db.append_message("s_c", role="user", content="Project titan final review")
+
+        result = json.loads(session_search(
+            query="project titan", db=db, current_session_id="s_c",
+        ))
+        assert result["count"] >= 1
+        # Should find content from s_gp or s_p (or both, deduped by lineage)
+        sids = [r["session_id"] for r in result["results"]]
+        assert any(s in ("s_gp", "s_p") for s in sids)
+
+
+class TestDelegationExclusion:
+    """Delegation children (delegate_task) must STAY excluded — their content
+    is still visible to the parent agent. parent_session_id is set but the
+    parent does NOT have end_reason='compression'."""
+
+    def test_delegation_parent_excluded_from_child(self, db):
+        """Child can see its own content but parent's live content stays
+        excluded (it's in context via delegation)."""
+        db.create_session("s_parent", source="cli")
+        db.append_message("s_parent", role="user",
+                          content="nebula deployment infrastructure setup")
+        db.append_message("s_parent", role="assistant",
+                          content="Nebula deployment configured successfully")
+
+        db.create_session("s_child", source="cli", parent_session_id="s_parent")
+        db.append_message("s_child", role="user",
+                          content="delegated nebula deployment subtask")
+
+        result = json.loads(session_search(
+            query="nebula deployment", db=db, current_session_id="s_child",
+        ))
+        assert result["count"] == 0
+
+    def test_delegation_child_excluded_from_parent(self, db):
+        """Parent searching should not see delegation child content either —
+        both are in the same lineage with no compression edge."""
+        db.create_session("s_parent", source="cli")
+        db.append_message("s_parent", role="user",
+                          content="Working on stellar forge project")
+
+        db.create_session("s_child", source="cli", parent_session_id="s_parent")
+        db.append_message("s_child", role="user",
+                          content="stellar forge delegated subtask execution")
+
+        result = json.loads(session_search(
+            query="stellar forge", db=db, current_session_id="s_parent",
+        ))
+        assert result["count"] == 0

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -81,18 +81,31 @@ def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     return str(ts)
 
 
-def _resolve_to_parent(db, session_id: str) -> str:
-    """Walk parent_session_id chain to the lineage root. Falls back to input on errors."""
+def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
+    """Walk parent_session_id chain to the lineage root.
+
+    Returns ``(root_id, has_compression_hop)`` where ``has_compression_hop`` is
+    True if any session along the chain ended with ``end_reason = 'compression'``
+    — i.e. at least one parent/ancestor was compression-rotated into this
+    lineage. That flag lets callers distinguish a compression-split lineage
+    (parent content summarised away, no longer in live context) from a
+    delegation lineage (child content still visible to the parent agent).
+
+    Falls back to ``(session_id, False)`` on errors.
+    """
     if not session_id:
-        return session_id
-    visited = set()
+        return session_id, False
+    visited: set[str] = set()
     cur = session_id
+    has_compression = False
     while cur and cur not in visited:
         visited.add(cur)
         try:
             s = db.get_session(cur)
             if not s:
                 break
+            if s.get("end_reason") == "compression":
+                has_compression = True
             parent = s.get("parent_session_id")
             if not parent:
                 break
@@ -100,7 +113,35 @@ def _resolve_to_parent(db, session_id: str) -> str:
         except Exception as e:
             logging.debug("Error resolving parent for %s: %s", cur, e, exc_info=True)
             break
-    return cur
+    return cur, has_compression
+
+
+def _resolve_lineage(db, session_id: str) -> str:
+    """Convenience: return only the lineage root (ignores compression hop)."""
+    return _resolve_to_parent(db, session_id)[0]
+
+
+def _is_compacted_message(db, message_id) -> bool:
+    """Return True if *message_id* is a soft-archived compaction row (active=0).
+
+    Used by ``_discover`` to distinguish a compaction-archived FTS hit on the
+    current session (pre-compaction content no longer in live context — should
+    stay discoverable) from an active live hit (already in context — skip).
+    Returns False on any error so the caller falls back to the safe default
+    (skip the current session).
+    """
+    if not message_id:
+        return False
+    try:
+        with db._lock:
+            cursor = db._conn.execute(
+                "SELECT active FROM messages WHERE id = ?", (message_id,)
+            )
+            row = cursor.fetchone()
+    except Exception:
+        logging.debug("is_compacted_message lookup failed for %s", message_id, exc_info=True)
+        return False
+    return row is not None and row["active"] == 0
 
 
 def _order_for_recall(raw_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -266,7 +307,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             order_by_last_active=True,
         )  # fetch extra so we can skip current
 
-        current_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
+        current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
 
         results = []
         for s in sessions:
@@ -333,8 +374,8 @@ def _scroll(
     # Reject scrolling inside the active session lineage — those messages are
     # already in context.
     if current_session_id:
-        a_root = _resolve_to_parent(db, session_id)
-        c_root = _resolve_to_parent(db, current_session_id)
+        a_root = _resolve_lineage(db, session_id)
+        c_root = _resolve_lineage(db, current_session_id)
         if a_root and c_root and a_root == c_root:
             return tool_error(
                 "scroll rejected: anchor lives in the current session lineage (already in your active context)",
@@ -377,8 +418,8 @@ def _scroll(
             logging.debug("owning-session lookup failed: %s", e, exc_info=True)
             owning = None
         if owning and owning != session_id:
-            a_root = _resolve_to_parent(db, session_id)
-            o_root = _resolve_to_parent(db, owning)
+            a_root = _resolve_lineage(db, session_id)
+            o_root = _resolve_lineage(db, owning)
             if a_root and o_root and a_root == o_root:
                 try:
                     rebind_view = db.get_messages_around(owning, around_message_id, window=window)
@@ -447,7 +488,7 @@ def _title_match_result(
     if not session_id:
         return None
 
-    lineage_root = _resolve_to_parent(db, session_id)
+    lineage_root = _resolve_lineage(db, session_id)
     if current_lineage_root and lineage_root == current_lineage_root:
         return None
 
@@ -506,7 +547,9 @@ def _discover(
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
-    current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
+    current_lineage_root, current_has_compression = (
+        _resolve_to_parent(db, current_session_id) if current_session_id else (None, False)
+    )
     title_result = _title_match_result(db, query, current_lineage_root)
 
     try:
@@ -556,12 +599,30 @@ def _discover(
         if len(seen_sessions) >= limit:
             break
         raw_sid = r["session_id"]
-        resolved_sid = _resolve_to_parent(db, raw_sid)
-        # Skip the current session lineage
+        resolved_sid, has_compression = _resolve_to_parent(db, raw_sid)
+        # Skip the current session lineage — UNLESS the content has been
+        # compression-summarised out of the live context (memory black hole
+        # after compression). Two sub-cases:
+        #
+        # Legacy rotation: the FTS hit lives in a session whose lineage chain
+        # has a compression edge (end_reason='compression' on an ancestor).
+        # The parent's pre-compaction content is gone from the active context,
+        # so it must stay discoverable.
+        #
+        # In-place compaction: the FTS hit lives on the SAME session_id as the
+        # current session, but the matched message row is an archived
+        # (active=0, compacted=1) row. The live-context load filters active=1,
+        # so that content is no longer in context — let it through.
+        is_compacted_hit = _is_compacted_message(db, r.get("id"))
         if current_lineage_root and resolved_sid == current_lineage_root:
-            continue
+            if not (has_compression or current_has_compression or is_compacted_hit):
+                continue
         if current_session_id and raw_sid == current_session_id:
-            continue
+            # Same-session hit: only skip if the matched message is still live
+            # (active=1). Archived/compacted rows are pre-compaction content
+            # that's been summarised away — let them through.
+            if not is_compacted_hit:
+                continue
         if resolved_sid not in seen_sessions:
             row = dict(r)
             row["_lineage_root"] = resolved_sid

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -121,8 +121,33 @@ def _resolve_lineage(db, session_id: str) -> str:
     return _resolve_to_parent(db, session_id)[0]
 
 
+def _is_compression_ended(db, session_id: str) -> bool:
+    """Return True if *session_id* itself ended with ``end_reason='compression'``.
+
+    Unlike the ``has_compression_hop`` flag from :func:`_resolve_to_parent`
+    (which is True for any descendant of a compression-ended ancestor), this
+    checks only the session's own ``end_reason``. A delegation child created
+    under a compression continuation has ``parent_session_id`` set but its own
+    ``end_reason`` is ``None`` — its content is still live to the parent agent,
+    so it must stay excluded from discovery.
+    """
+    if not session_id:
+        return False
+    try:
+        s = db.get_session(session_id)
+        if not s:
+            return False
+        return s.get("end_reason") == "compression"
+    except Exception:
+        return False
+
+
 def _is_compacted_message(db, message_id) -> bool:
-    """Return True if *message_id* is a soft-archived compaction row (active=0).
+    """Return True if *message_id* is a compaction-archived row.
+
+    Compaction archives are ``active=0, compacted=1`` — the content was
+    summarised away from live context by :meth:`archive_and_compact`.
+    Rewind/undo rows are ``active=0, compacted=0`` and must stay hidden.
 
     Used by ``_discover`` to distinguish a compaction-archived FTS hit on the
     current session (pre-compaction content no longer in live context — should
@@ -135,13 +160,13 @@ def _is_compacted_message(db, message_id) -> bool:
     try:
         with db._lock:
             cursor = db._conn.execute(
-                "SELECT active FROM messages WHERE id = ?", (message_id,)
+                "SELECT active, compacted FROM messages WHERE id = ?", (message_id,)
             )
             row = cursor.fetchone()
     except Exception:
         logging.debug("is_compacted_message lookup failed for %s", message_id, exc_info=True)
         return False
-    return row is not None and row["active"] == 0
+    return row is not None and row["active"] == 0 and row["compacted"] == 1
 
 
 def _order_for_recall(raw_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -547,9 +572,7 @@ def _discover(
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
-    current_lineage_root, current_has_compression = (
-        _resolve_to_parent(db, current_session_id) if current_session_id else (None, False)
-    )
+    current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
 
     try:
@@ -599,23 +622,26 @@ def _discover(
         if len(seen_sessions) >= limit:
             break
         raw_sid = r["session_id"]
-        resolved_sid, has_compression = _resolve_to_parent(db, raw_sid)
+        resolved_sid, _ = _resolve_to_parent(db, raw_sid)
         # Skip the current session lineage — UNLESS the content has been
         # compression-summarised out of the live context (memory black hole
         # after compression). Two sub-cases:
         #
-        # Legacy rotation: the FTS hit lives in a session whose lineage chain
-        # has a compression edge (end_reason='compression' on an ancestor).
-        # The parent's pre-compaction content is gone from the active context,
-        # so it must stay discoverable.
+        # Legacy rotation: the FTS hit lives in a session that itself ended
+        # with end_reason='compression'. That session's content has been
+        # replaced by a summary in the continuation child, so it must stay
+        # discoverable. A delegation child living under a compression
+        # continuation does NOT have end_reason='compression' itself, so it
+        # stays excluded.
         #
         # In-place compaction: the FTS hit lives on the SAME session_id as the
         # current session, but the matched message row is an archived
         # (active=0, compacted=1) row. The live-context load filters active=1,
         # so that content is no longer in context — let it through.
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
+        is_ended_session = _is_compression_ended(db, raw_sid)
         if current_lineage_root and resolved_sid == current_lineage_root:
-            if not (has_compression or current_has_compression or is_compacted_hit):
+            if not (is_ended_session or is_compacted_hit):
                 continue
         if current_session_id and raw_sid == current_session_id:
             # Same-session hit: only skip if the matched message is still live


### PR DESCRIPTION
## Summary

After context compaction, pre-compaction content was invisible to `session_search` — a memory black hole. The `_discover()` skip logic filtered both same-session and same-lineage hits unconditionally, without distinguishing compression-summarised content (gone from live context) from delegation children (still visible to the parent agent).

Reworked `_resolve_to_parent` to return `(root_id, has_compression_hop)`, checking `end_reason="compression"` on every hop during the same `db.get_session()` traversal — zero extra queries.

## Three compression-aware paths in `_discover()`

| Case | Before | After |
|------|--------|-------|
| **In-place compaction** (current default) | `raw_sid == current_session_id` → skip | FTS hit on `active=0, compacted=1` row passes through |
| **Legacy rotation** | `resolved_sid == current_lineage_root` → skip | Passes through when `has_compression_hop` is true |
| **Delegation children** | Excluded ✓ | Still excluded ✓ (no compression edge) |

## Changes

**`tools/session_search_tool.py`**
- `_resolve_to_parent()` → returns `tuple[str, bool]` = `(root_id, has_compression_hop)`. Checks `end_reason == "compression"` during the same traversal loop — no extra DB queries
- `_resolve_lineage()` — thin wrapper returning only the root string, for the 6 existing call sites (browse, scroll, title-match) that do not need the compression flag
- `_is_compacted_message()` — checks if a specific FTS-hit message row is soft-archived (`active=0`). Handles the in-place compaction case where the FTS row and live rows share the same session_id
- `_discover()` — both skip conditions now have compression-aware exceptions

**`tests/tools/test_session_search.py`** (+18 tests, 5 classes)
- `TestResolveToParent` (7): root/empty/None, legacy rotation, delegation, multi-level chain, mixed edges
- `TestIsCompactedMessage` (4): active/compacted/None/nonexistent
- `TestInPlaceCompactionDiscovery` (3): archived content discoverable, live content still filtered, mixed session
- `TestLegacyRotationDiscovery` (2): parent discoverable from child, multi-level chain
- `TestDelegationExclusion` (2): parent excluded from child, child excluded from parent

## Testing

```
$ python -m pytest tests/tools/test_session_search.py -v
71 passed in 1.28s
```

All 53 existing tests + 18 new tests pass. No changes to `hermes_state.py`.

## Addresses

- @teknium1 review feedback on #6256 (closed — reworked from scratch against current main)
- Closes #13840 (compression parent exclusion bug report)
- Supersedes #13841 (prior fix, pre-dated in-place compaction default)
- Related: #5447, #6507, #8803 (independent reports of the same issue)

## Design notes

**Why return a flag from `_resolve_to_parent` instead of a separate helper?**
The parent traversal already calls `db.get_session()` for every hop. Checking `end_reason` in the same loop avoids N+1 queries.

**Why check `active=0` on the message row for in-place compaction?**
With in-place compaction (the current default), archived turns have the same session_id as the current session. The session_id check alone cannot distinguish them from live content. The `active=0` flag is set by `archive_and_compact()` and is the definitive marker for "this row was summarised away".