### PR TITLE
fix(responses): emit output_text for plain-string assistant content in codex_responses adapter

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -500,14 +500,14 @@ def _chat_messages_to_responses_input(
                 elif content_parts:
                     items.append({"role": "assistant", "content": content_parts})
                 elif content_text.strip():
-                    items.append({"role": "assistant", "content": content_text})
+                    items.append({"role": "assistant", "content": [{"type": "output_text", "text": content_text}]})
                 elif has_codex_reasoning:
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
                     # content, emit an empty assistant message as the required
                     # following item.
-                    items.append({"role": "assistant", "content": ""})
+                    items.append({"role": "assistant", "content": [{"type": "output_text", "text": ""}]})
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -429,3 +429,80 @@ def test_normalize_codex_response_failed_with_message_only():
     )
     with pytest.raises(RuntimeError, match=r"^model error$"):
         _normalize_codex_response(response)
+
+
+def test_chat_messages_to_responses_input_plain_string_assistant_content():
+    """Regression: plain-string assistant content must be emitted as output_text,
+    not bare string (which the OpenAI SDK expands to input_text).
+
+    The Responses API rejects input_text inside assistant messages with
+    HTTP 400 Invalid value: 'input_text'.
+
+    This test covers the tool-call-followed-by-model-turn scenario where
+    the assistant's plain-string response is replayed as history.
+    """
+    messages = [
+        {"role": "user", "content": "Write test file"},
+        {
+            "role": "assistant",
+            "content": "I'll write the test file.",
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": '{"path": "/tmp/test.txt", "content": "test"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_abc",
+            "content": "File written successfully",
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    # The assistant message should be formatted as a message item
+    assistant_items = [item for item in items if item.get("role") == "assistant"]
+    assert len(assistant_items) == 1
+
+    # Content must be explicitly typed as output_text, not a bare string
+    assert assistant_items[0]["content"] == [{"type": "output_text", "text": "I'll write the test file."}]
+
+
+def test_chat_messages_to_responses_input_reasoning_only_empty_output_text():
+    """When assistant produced only reasoning with no visible content,
+    emit an empty assistant message as a following item.
+
+    The empty content must be explicitly typed as output_text, not a bare
+    empty string (which the OpenAI SDK expands to input_text).
+    """
+    messages = [
+        {"role": "user", "content": "Think about it"},
+        {
+            "role": "assistant",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "encrypted_content": "opaque-reasoning",
+                    "summary": [{"type": "summary_text", "text": "thinking"}],
+                }
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    # Should have both reasoning item and following assistant message
+    reasoning_items = [item for item in items if item.get("type") == "reasoning"]
+    assistant_items = [item for item in items if item.get("role") == "assistant"]
+    assert len(reasoning_items) == 1
+    assert len(assistant_items) == 1
+
+    # Assistant content must be explicitly typed as empty output_text
+    assert assistant_items[0]["content"] == [{"type": "output_text", "text": ""}]

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -918,7 +918,7 @@ class TestChatMessagesToResponsesInputMessageItems:
                             base_url="https://chatgpt.com/backend-api/codex")
         messages = [{"role": "assistant", "content": "Hello world"}]
         items = _chat_messages_to_responses_input(messages)
-        assert items == [{"role": "assistant", "content": "Hello world"}]
+        assert items == [{"role": "assistant", "content": [{"type": "output_text", "text": "Hello world"}]}]
 
     def test_skips_invalid_message_items(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
@@ -936,7 +936,7 @@ class TestChatMessagesToResponsesInputMessageItems:
         ]
         items = _chat_messages_to_responses_input(messages)
         # All invalid — falls back to plain text reconstruction
-        assert items == [{"role": "assistant", "content": "fallback text"}]
+        assert items == [{"role": "assistant", "content": [{"type": "output_text", "text": "fallback text"}]}]
 
 
 # ── Chat completions response handling (OpenRouter/Nous) ─────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where plain-string assistant content in `codex_responses` mode was emitted as a bare string instead of explicitly typed `output_text` content. The OpenAI SDK expands bare assistant strings to `input_text`, which the Responses API rejects with HTTP 400 `Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'`.

This is the plain-string counterpart to #15687, which fixed list-form assistant content but left the plain-string path unaddressed. Any workflow requiring a post-tool model turn fails when the assistant message has plain-string content (the default for Hermes-generated messages).

## Related Issue

Fixes #63135

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py`: Emit `[{type: "output_text", text: content_text}]` instead of bare string for plain-string assistant content in `_chat_messages_to_responses_input()` (line 503)
- `agent/codex_responses_adapter.py`: Emit `[{type: "output_text", text: ""}]` instead of bare empty string for reasoning-only fallback (line 510)
- `tests/agent/test_codex_responses_adapter.py`: Added regression test for plain-string assistant content followed by tool calls
- `tests/agent/test_codex_responses_adapter.py`: Added regression test for reasoning-only empty output_text fallback

## How to Test

1. Run the new regression tests:
   ```
   python -m pytest tests/agent/test_codex_responses_adapter.py::test_chat_messages_to_responses_input_plain_string_assistant_content -xvs
   python -m pytest tests/agent/test_codex_responses_adapter.py::test_chat_messages_to_responses_input_reasoning_only_empty_output_text -xvs
   ```
   Both should pass.

2. Run the full test file to confirm no regression:
   ```
   python -m pytest tests/agent/test_codex_responses_adapter.py -x --tb=short
   ```
   All 24 tests should pass.

3. Observed result: All 24 tests passed, including the 2 new regression tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
