### PR TITLE
feat(web): advertise exact build identity in status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,9 @@ ignored/
 .worktrees/
 environments/benchmarks/evals/
 
-# Web UI build output
+# Build output
+/build/
+/dist/
 hermes_cli/web_dist/
 apps/desktop/build/
 apps/desktop/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,27 +227,16 @@ RUN mkdir -p /opt/hermes/bin && \
 # `s6-setuidgid hermes` in its run script. If HERMES_UID is unset, services
 # run as the default hermes user (UID 10000).
 
-# ---------- Bake build-time git revision ----------
-# .dockerignore excludes .git, so `git rev-parse HEAD` from inside the
-# container always returns nothing — meaning `hermes dump` reports
-# "(unknown)" and the startup banner drops its `· upstream <sha>` suffix.
-# That makes support triage from container bug reports impossible:
-# we can't tell which commit the user is actually running.
-#
-# Fix: write the commit SHA passed via the HERMES_GIT_SHA build-arg to
-# /opt/hermes/.hermes_build_sha at build time, and have
-# hermes_cli/build_info.py read it at runtime.  Both `hermes dump` and
-# banner.get_git_banner_state() try the baked SHA first, then fall back
-# to live `git rev-parse` for source installs (unchanged behaviour).
-#
-# The arg is optional — local `docker build` without --build-arg simply
-# omits the file, and the runtime falls back to live-git lookup.  CI
-# (.github/workflows/docker.yml) passes ${{ github.sha }} so
-# every published image has it.
+# ---------- Bake exact build identity ----------
+# .dockerignore excludes .git, so package-relative immutable metadata is the
+# only trustworthy source revision inside the image. CI passes github.sha;
+# local builds without the argument carry an explicit null rather than
+# guessing an identity. The same hermes_cli/_build_metadata.json path is used
+# by wheels, sdists, desktop artifacts, and other release builds.
 ARG HERMES_GIT_SHA=
-RUN if [ -n "${HERMES_GIT_SHA}" ]; then \
-        printf '%s\n' "${HERMES_GIT_SHA}" > /opt/hermes/.hermes_build_sha; \
-    fi
+RUN .venv/bin/python -c \
+    'import sys; from hermes_cli.build_info import write_build_metadata; write_build_metadata("/opt/hermes", sys.argv[1])' \
+    "${HERMES_GIT_SHA}"
 
 # ---------- s6-overlay service wiring ----------
 # Static services declared at build time: main-hermes + dashboard.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,7 +38,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.ts electron/hardening.test.ts electron/backend-env.test.ts electron/backend-probes.test.ts electron/backend-ready.test.ts electron/bootstrap-runner.test.ts electron/connection-config.test.ts electron/dashboard-token.test.ts electron/gateway-ws-probe.test.ts electron/oauth-net-request.test.ts electron/desktop-uninstall.test.ts electron/session-windows.test.ts electron/link-title-window.test.ts electron/workspace-cwd.test.ts electron/fs-read-dir.test.ts electron/git-root.test.ts electron/git-worktree-ops.test.ts electron/windows-child-process.test.ts electron/update-remote.test.ts electron/update-count.test.ts electron/update-rebuild.test.ts electron/update-marker.test.ts electron/update-relaunch.test.ts electron/windows-user-env.test.ts electron/wsl-clipboard-image.test.ts electron/titlebar-overlay-width.test.ts electron/window-state.test.ts electron/zoom.test.ts electron/windows-hermes-resolution.test.ts electron/oauth-session-request.test.ts",
+    "test:desktop:platforms": "node --test scripts/write-build-stamp.test.mjs electron/bootstrap-platform.test.ts electron/hardening.test.ts electron/backend-env.test.ts electron/backend-probes.test.ts electron/backend-ready.test.ts electron/bootstrap-runner.test.ts electron/connection-config.test.ts electron/dashboard-token.test.ts electron/gateway-ws-probe.test.ts electron/oauth-net-request.test.ts electron/desktop-uninstall.test.ts electron/session-windows.test.ts electron/link-title-window.test.ts electron/workspace-cwd.test.ts electron/fs-read-dir.test.ts electron/git-root.test.ts electron/git-worktree-ops.test.ts electron/windows-child-process.test.ts electron/update-remote.test.ts electron/update-count.test.ts electron/update-rebuild.test.ts electron/update-marker.test.ts electron/update-relaunch.test.ts electron/windows-user-env.test.ts electron/wsl-clipboard-image.test.ts electron/titlebar-overlay-width.test.ts electron/window-state.test.ts electron/zoom.test.ts electron/windows-hermes-resolution.test.ts electron/oauth-session-request.test.ts",
     "typecheck": "tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",
@@ -181,6 +181,10 @@
       {
         "from": "build/install-stamp.json",
         "to": "install-stamp.json"
+      },
+      {
+        "from": "build/hermes_cli/_build_metadata.json",
+        "to": "hermes_cli/_build_metadata.json"
       },
       {
         "from": "assets/icon.ico",

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -286,6 +286,8 @@ function launchFresh() {
 //   - The Hermes Agent Python payload is NOT shipped (it's fetched at first
 //     launch via install.ps1's stage protocol).
 //   - install-stamp.json IS shipped in resources/ with a valid commit + branch.
+//   - hermes_cli/_build_metadata.json carries the same exact source revision
+//     (or null for a deliberately dirty local package).
 //   - node-pty IS shipped inside app.asar.unpacked/dist/node_modules/node-pty
 //     with package.json + lib/ + at least one .node binary (the renderer's
 //     integrated terminal needs this; see Phase 1F.6).
@@ -322,6 +324,24 @@ function validateBundle() {
   }
   if (!stamp.branch || typeof stamp.branch !== 'string') {
     die(`install-stamp.json is missing the branch field: ${JSON.stringify(stamp)}`)
+  }
+
+  const metadataPath = path.join(APP.resourcesPath, 'hermes_cli', '_build_metadata.json')
+  if (!exists(metadataPath)) {
+    die(`Missing package-relative Hermes build metadata: ${metadataPath}`)
+  }
+  let buildMetadata
+  try {
+    buildMetadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+  } catch (err) {
+    die(`Hermes build metadata is not valid JSON: ${err.message}`)
+  }
+  const expectedRevision = stamp.dirty ? null : stamp.commit
+  if (buildMetadata.source_revision !== expectedRevision) {
+    die(
+      `Desktop build identity disagrees with install stamp: ` +
+        `${JSON.stringify(buildMetadata)} vs ${JSON.stringify(stamp)}`
+    )
   }
 
   // Positive assertion: node-pty native deps shipped

--- a/apps/desktop/scripts/write-build-stamp.mjs
+++ b/apps/desktop/scripts/write-build-stamp.mjs
@@ -26,7 +26,7 @@
  * bootstrap without a stamp.
  */
 
-import { mkdirSync, writeFileSync } from "fs"
+import { existsSync, mkdirSync, writeFileSync } from "fs"
 import { resolve, join, relative } from "path"
 import { execSync } from "child_process"
 
@@ -36,6 +36,9 @@ const DESKTOP_ROOT = resolve(import.meta.dirname, "..")
 const REPO_ROOT = resolve(DESKTOP_ROOT, "..", "..")
 const OUT_DIR = join(DESKTOP_ROOT, "build")
 const OUT_FILE = join(OUT_DIR, "install-stamp.json")
+const BUILD_METADATA_DIR = join(OUT_DIR, "hermes_cli")
+const BUILD_METADATA_FILE = join(BUILD_METADATA_DIR, "_build_metadata.json")
+const FULL_SOURCE_REVISION = /^[0-9a-f]{40}$/
 
 function tryExec(cmd, opts) {
   try {
@@ -49,10 +52,14 @@ function fromCI() {
   const sha = process.env.GITHUB_SHA
   if (!sha) return null
   const branch = process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || null
+  const hasGitMetadata = existsSync(join(REPO_ROOT, ".git"))
+  const local = hasGitMetadata ? fromLocalGit() : null
   return {
     commit: sha,
     branch: branch,
-    dirty: false, // CI builds from a checkout-of-ref by definition
+    dirty:
+      hasGitMetadata &&
+      (local === null || local.dirty || local.commit !== sha),
     source: "ci"
   }
 }
@@ -61,14 +68,11 @@ function fromLocalGit() {
   const sha = tryExec("git rev-parse HEAD", { cwd: REPO_ROOT })
   if (!sha) return null
   const branch = tryExec("git rev-parse --abbrev-ref HEAD", { cwd: REPO_ROOT })
-  // `git status --porcelain -uno` is empty iff tracked files match HEAD.
-  // We exclude untracked files (-uno) intentionally: a developer who's
-  // checked out an installer scratch dir alongside the repo shouldn't
-  // poison every local build with a [DIRTY] stamp.  We DO care about
-  // tracked-but-modified files because those mean the .exe content
-  // differs from the commit being pinned.
-  const status = tryExec("git status --porcelain -uno", { cwd: REPO_ROOT })
-  const dirty = status !== null && status.length > 0
+  // Exact build identity requires every non-ignored source path to match HEAD:
+  // an untracked module or asset can enter the packaged app just as easily as
+  // a tracked modification. Generated build outputs are covered by .gitignore.
+  const status = tryExec("git status --porcelain --untracked-files=normal", { cwd: REPO_ROOT })
+  const dirty = status === null || status.length > 0
   return {
     commit: sha,
     branch: branch === "HEAD" ? null : branch, // detached HEAD -> null
@@ -88,6 +92,12 @@ function main() {
         "\n" +
         "Packaged builds require a git ref to pin first-launch install.ps1\n" +
         "against. Run from a git checkout or set $GITHUB_SHA explicitly."
+    )
+    process.exit(1)
+  }
+  if (!FULL_SOURCE_REVISION.test(stamp.commit)) {
+    console.error(
+      "[write-build-stamp] ERROR: build revision must be a full lowercase 40-character Git SHA."
     )
     process.exit(1)
   }
@@ -113,6 +123,12 @@ function main() {
 
   mkdirSync(OUT_DIR, { recursive: true })
   writeFileSync(OUT_FILE, JSON.stringify(payload, null, 2) + "\n", "utf8")
+  mkdirSync(BUILD_METADATA_DIR, { recursive: true })
+  writeFileSync(
+    BUILD_METADATA_FILE,
+    JSON.stringify({ source_revision: stamp.dirty ? null : stamp.commit }) + "\n",
+    "utf8"
+  )
   console.log(
     "[write-build-stamp] wrote " +
       relative(REPO_ROOT, OUT_FILE) +
@@ -120,6 +136,12 @@ function main() {
       stamp.commit.slice(0, 12) +
       (stamp.branch ? " (" + stamp.branch + ")" : "") +
       (stamp.dirty ? " [DIRTY]" : "")
+  )
+  console.log(
+    "[write-build-stamp] wrote " +
+      relative(REPO_ROOT, BUILD_METADATA_FILE) +
+      " -> " +
+      (stamp.dirty ? "null [DIRTY]" : stamp.commit)
   )
 }
 

--- a/apps/desktop/scripts/write-build-stamp.test.mjs
+++ b/apps/desktop/scripts/write-build-stamp.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const DESKTOP_ROOT = resolve(import.meta.dirname, '..')
+const SCRIPT = join(DESKTOP_ROOT, 'scripts', 'write-build-stamp.mjs')
+const INSTALL_STAMP = join(DESKTOP_ROOT, 'build', 'install-stamp.json')
+const BUILD_METADATA = join(DESKTOP_ROOT, 'build', 'hermes_cli', '_build_metadata.json')
+
+function preserve(path) {
+  return existsSync(path) ? readFileSync(path) : null
+}
+
+function restore(path, original) {
+  if (original === null) {
+    rmSync(path, { force: true })
+    return
+  }
+  writeFileSync(path, original)
+}
+
+test('desktop build embeds the same exact revision as its install pin', () => {
+  const originalStamp = preserve(INSTALL_STAMP)
+  const originalMetadata = preserve(BUILD_METADATA)
+  const revision = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: DESKTOP_ROOT,
+    encoding: 'utf8'
+  }).stdout.trim()
+
+  try {
+    const run = spawnSync(process.execPath, [SCRIPT], {
+      cwd: DESKTOP_ROOT,
+      env: {
+        ...process.env,
+        GITHUB_SHA: revision,
+        GITHUB_REF_NAME: 'main'
+      },
+      encoding: 'utf8'
+    })
+    assert.equal(run.status, 0, run.stderr)
+
+    const installStamp = JSON.parse(readFileSync(INSTALL_STAMP, 'utf8'))
+    const buildMetadata = JSON.parse(readFileSync(BUILD_METADATA, 'utf8'))
+    assert.equal(installStamp.commit, revision)
+    assert.deepEqual(buildMetadata, { source_revision: revision })
+  } finally {
+    restore(INSTALL_STAMP, originalStamp)
+    restore(BUILD_METADATA, originalMetadata)
+  }
+})
+
+test('desktop build refuses exact identity when CI revision mismatches checkout', () => {
+  const originalStamp = preserve(INSTALL_STAMP)
+  const originalMetadata = preserve(BUILD_METADATA)
+  const revision = '0123456789abcdef0123456789abcdef01234567'
+
+  try {
+    const run = spawnSync(process.execPath, [SCRIPT], {
+      cwd: DESKTOP_ROOT,
+      env: {
+        ...process.env,
+        GITHUB_SHA: revision,
+        GITHUB_REF_NAME: 'main'
+      },
+      encoding: 'utf8'
+    })
+    assert.equal(run.status, 0, run.stderr)
+
+    const installStamp = JSON.parse(readFileSync(INSTALL_STAMP, 'utf8'))
+    const buildMetadata = JSON.parse(readFileSync(BUILD_METADATA, 'utf8'))
+    assert.equal(installStamp.dirty, true)
+    assert.deepEqual(buildMetadata, { source_revision: null })
+  } finally {
+    restore(INSTALL_STAMP, originalStamp)
+    restore(BUILD_METADATA, originalMetadata)
+  }
+})

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -802,6 +802,8 @@ export interface StatusResponse {
   hermes_home: string
   latest_config_version: number
   release_date: string
+  /** Full lowercase source SHA, null when unprovable, absent on older Hermes. */
+  source_revision?: string | null
   version: string
 }
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -407,7 +407,7 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
     For source installs and dev images this runs ``git rev-parse`` against
     the active checkout.  When no checkout is available — the canonical case
     is the published Docker image, which excludes ``.git`` from the build
-    context — we fall back to the baked-in build SHA (see
+    context — we fall back to package-relative exact build metadata (see
     ``hermes_cli/build_info.py``) and return it as a frozen
     ``upstream == local`` state with ``ahead=0``.  A built image is by
     definition pinned to one commit, so "ahead" is always zero and the

--- a/hermes_cli/build_info.py
+++ b/hermes_cli/build_info.py
@@ -1,50 +1,163 @@
-"""
-Baked-in build metadata for Hermes Agent.
+"""Exact, offline build identity for Hermes Agent.
 
-Source installs report their git revision live via ``git rev-parse`` (see
-``hermes_cli/dump.py`` and ``hermes_cli/banner.py``).  That doesn't work inside
-the published Docker image because ``.dockerignore`` excludes ``.git``, so
-those callsites fall back to ``"(unknown)"`` / drop the banner suffix entirely.
+Wheel, sdist, Docker, Desktop, and release artifacts carry one
+package-relative ``hermes_cli/_build_metadata.json`` file. Its optional
+``source_revision`` is authoritative only when it is a full lowercase
+40-character Git SHA. A source checkout without embedded metadata falls back
+to its full ``HEAD`` only while the working tree is clean. Resolution performs
+no network request or Git fetch.
 
-To make ``hermes dump`` and the startup banner identify the exact commit the
-image was built from, the Docker build writes the build-time ``$HERMES_GIT_SHA``
-arg into ``<project_root>/.hermes_build_sha``.  This module is the single
-read-side helper consumed by both callsites — keeping the lookup in one place
-so the file path and missing-file behaviour stay consistent.
-
-Behaviour:
-
-- Returns ``None`` when the file is absent.  Source installs and dev images
-  built without the ``HERMES_GIT_SHA`` build-arg fall through to live-git
-  resolution in the caller, so non-Docker installs are unaffected.
-- Returns ``None`` on any IO / decoding error.  The build-sha is a nice-to-have
-  for support triage; nothing in the CLI is allowed to crash because of it.
-- Truncates to ``short`` characters (default 8) to match the format used by
-  ``git rev-parse --short=8`` throughout the codebase.
+The old root-level ``.hermes_build_sha`` file remains a read-only compatibility
+fallback for short support displays from pre-migration Docker images; it never
+feeds the exact ``source_revision`` contract.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import re
+import subprocess
 from typing import Optional
 
 # Path is resolved relative to this module so it works regardless of cwd —
 # matches the pattern used by ``banner._resolve_repo_dir``.
 _BUILD_SHA_FILE = Path(__file__).parent.parent / ".hermes_build_sha"
+_PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+_BUILD_METADATA_RELATIVE_PATH = Path("hermes_cli") / "_build_metadata.json"
+_FULL_SOURCE_REVISION = re.compile(r"^[0-9a-f]{40}$")
 
 
-def get_build_sha(short: int = 8) -> Optional[str]:
-    """Return the baked-in build SHA, truncated to ``short`` chars, or None.
+def _read_embedded_source_revision(project_root: Path) -> tuple[bool, Optional[str]]:
+    metadata_file = project_root / _BUILD_METADATA_RELATIVE_PATH
+    if not metadata_file.is_file():
+        return False, None
+    try:
+        payload = json.loads(metadata_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return True, None
+    if not isinstance(payload, dict):
+        return True, None
+    revision = payload.get("source_revision")
+    if not isinstance(revision, str) or not _FULL_SOURCE_REVISION.fullmatch(revision):
+        return True, None
+    return True, revision
 
-    Reads ``<project_root>/.hermes_build_sha`` if present.  The file is
-    written by the Dockerfile's ``HERMES_GIT_SHA`` build-arg and contains
-    the full 40-character commit hash on a single line.
+
+def validate_source_revision(value: object) -> Optional[str]:
+    """Return ``value`` only when it is an exact lowercase Git SHA."""
+    if not isinstance(value, str) or not _FULL_SOURCE_REVISION.fullmatch(value):
+        return None
+    return value
+
+
+def write_build_metadata(
+    project_root: Path | str,
+    source_revision: object,
+) -> Path:
+    """Write the canonical package-relative build metadata file."""
+    metadata_file = Path(project_root) / _BUILD_METADATA_RELATIVE_PATH
+    metadata_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"source_revision": validate_source_revision(source_revision)}
+    metadata_file.write_text(
+        json.dumps(payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return metadata_file
+
+
+def _run_git(project_root: Path, *args: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def get_source_revision(project_root: Path | str | None = None) -> Optional[str]:
+    """Return the exact full revision for this Hermes artifact, if provable.
+
+    Packaged artifacts carry ``hermes_cli/_build_metadata.json``. A present
+    metadata file is authoritative and never falls through to Git when its
+    contents are malformed. Source checkouts without embedded metadata report
+    their full ``HEAD`` only while the checkout is clean.
     """
+    root = Path(project_root).resolve() if project_root is not None else _PROJECT_ROOT
+    metadata_present, embedded_revision = _read_embedded_source_revision(root)
+    if metadata_present:
+        return embedded_revision
+
+    status = _run_git(root, "status", "--porcelain", "--untracked-files=normal")
+    if status is None or status:
+        return None
+
+    revision = _run_git(root, "rev-parse", "--verify", "HEAD")
+    if revision is None or not _FULL_SOURCE_REVISION.fullmatch(revision):
+        return None
+    return revision
+
+
+def resolve_build_source_revision(
+    project_root: Path | str,
+    asserted_revision: object = None,
+) -> Optional[str]:
+    """Resolve the revision a build may safely embed in a new artifact.
+
+    Existing package metadata is immutable provenance and wins over all other
+    inputs. In a Git checkout, a builder assertion is accepted only when it
+    matches the checkout's clean full ``HEAD``. A source archive without Git or
+    embedded metadata may rely on a strictly validated builder assertion.
+    """
+    root = Path(project_root).resolve()
+    metadata_present, embedded_revision = _read_embedded_source_revision(root)
+    if metadata_present:
+        return embedded_revision
+
+    asserted = validate_source_revision(asserted_revision)
+    if asserted_revision is not None and asserted is None:
+        return None
+
+    if (root / ".git").exists():
+        checkout_revision = get_source_revision(root)
+        if asserted_revision is None:
+            return checkout_revision
+        return asserted if asserted == checkout_revision else None
+
+    return asserted
+
+
+def get_build_sha(
+    short: int = 8,
+    project_root: Path | str | None = None,
+) -> Optional[str]:
+    """Return the artifact SHA, truncated to ``short`` chars, or ``None``.
+
+    New artifacts use the canonical package-relative metadata consumed by
+    :func:`get_source_revision`. The root-level Docker stamp remains a
+    read-only fallback for artifacts built before that metadata existed.
+    """
+    root = Path(project_root).resolve() if project_root is not None else _PROJECT_ROOT
+    metadata_present, _ = _read_embedded_source_revision(root)
+    revision = get_source_revision(project_root)
+    if revision is not None:
+        return revision[:short] if short and short > 0 else revision
+    if metadata_present or project_root is not None:
+        return None
+
     try:
         if not _BUILD_SHA_FILE.is_file():
             return None
         sha = _BUILD_SHA_FILE.read_text(encoding="utf-8").strip()
-    except Exception:
+    except (OSError, UnicodeError):
         return None
     if not sha:
         return None

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -55,11 +55,10 @@ def _get_git_commit(project_root: Path) -> str:
     """Return short git commit hash, or '(unknown)'.
 
     Source installs and dev images resolve this live via ``git rev-parse``.
-    The published Docker image excludes ``.git`` from the build context, so
-    that lookup always fails — we fall back to the baked-in build SHA written
-    to ``<project_root>/.hermes_build_sha`` by the Dockerfile's
-    ``HERMES_GIT_SHA`` build-arg (see ``hermes_cli/build_info.py``).
-    The output format is identical regardless of source.
+    Packaged artifacts may not carry ``.git``, so that lookup can fail. We
+    then derive the short display from the package-relative exact build
+    metadata in ``hermes_cli/build_info.py``. The output format is identical
+    regardless of source.
     """
     try:
         result = subprocess.run(
@@ -74,9 +73,8 @@ def _get_git_commit(project_root: Path) -> str:
     except Exception:
         pass
 
-    # Fall back to the build-time baked SHA (populated in published Docker
-    # images, absent otherwise).  Defers the import so the dump module
-    # stays cheap on non-dump code paths.
+    # Fall back to package-relative build metadata. Defers the import so the
+    # dump module stays cheap on non-dump code paths.
     try:
         from hermes_cli.build_info import get_build_sha
         baked = get_build_sha(short=8)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -53,6 +53,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
+from hermes_cli.build_info import get_source_revision
 from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
@@ -120,6 +121,7 @@ except ImportError:
 
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
+_SOURCE_REVISION = get_source_revision()
 
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
@@ -2711,6 +2713,7 @@ async def get_status(profile: Optional[str] = None):
         # ``PUBLIC_API_PATHS`` documents this endpoint as serving.
         status = {
             "version": __version__,
+            "source_revision": _SOURCE_REVISION,
             "release_date": __release_date__,
             "config_version": current_ver,
             "latest_config_version": latest_ver,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,7 +336,7 @@ locales = ["locales/*.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
+hermes_cli = ["_build_metadata.json", "web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
 plugins = [
   "*/dashboard/manifest.json",

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,27 @@
 from __future__ import annotations
 
 from collections import defaultdict
+import importlib.util
+import os
 from pathlib import Path
 import tempfile
 
 from setuptools import setup
 from setuptools.command.build import build as _build
+from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.egg_info import egg_info as _egg_info
+from setuptools.command.sdist import sdist as _sdist
 
 
 REPO_ROOT = Path(__file__).parent.resolve()
+_BUILD_INFO_SPEC = importlib.util.spec_from_file_location(
+    "_hermes_build_info",
+    REPO_ROOT / "hermes_cli" / "build_info.py",
+)
+if _BUILD_INFO_SPEC is None or _BUILD_INFO_SPEC.loader is None:
+    raise RuntimeError("Unable to load Hermes build metadata helpers")
+_BUILD_INFO = importlib.util.module_from_spec(_BUILD_INFO_SPEC)
+_BUILD_INFO_SPEC.loader.exec_module(_BUILD_INFO)
 
 
 def _source_tree_is_writable() -> bool:
@@ -64,6 +76,27 @@ class ReadOnlySourceEggInfo(_egg_info):
         super().finalize_options()
 
 
+def _artifact_source_revision() -> str | None:
+    return _BUILD_INFO.resolve_build_source_revision(
+        REPO_ROOT,
+        os.environ.get("HERMES_GIT_SHA"),
+    )
+
+
+class BuildPythonWithMetadata(_build_py):
+    def run(self) -> None:
+        source_revision = _artifact_source_revision()
+        super().run()
+        _BUILD_INFO.write_build_metadata(self.build_lib, source_revision)
+
+
+class SourceDistributionWithMetadata(_sdist):
+    def make_release_tree(self, base_dir: str, files: list[str]) -> None:
+        source_revision = _artifact_source_revision()
+        super().make_release_tree(base_dir, files)
+        _BUILD_INFO.write_build_metadata(base_dir, source_revision)
+
+
 def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
     root = REPO_ROOT / root_name
     grouped: defaultdict[str, list[str]] = defaultdict(list)
@@ -78,7 +111,9 @@ def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
 setup(
     cmdclass={
         "build": ReadOnlySourceBuild,
+        "build_py": BuildPythonWithMetadata,
         "egg_info": ReadOnlySourceEggInfo,
+        "sdist": SourceDistributionWithMetadata,
     },
     data_files=[
         *_data_file_tree("skills"),

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -12,6 +12,7 @@ the repo's Dockerfile once per session.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import time
@@ -19,7 +20,10 @@ from collections.abc import Iterator
 
 import pytest
 
+from hermes_cli.build_info import get_source_revision
+
 IMAGE_TAG = os.environ.get("HERMES_TEST_IMAGE", "hermes-agent-harness:latest")
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _docker_available() -> bool:
@@ -49,7 +53,15 @@ def pytest_collection_modifyitems(config, items):  # noqa: D401 - pytest hook
 
 
 @pytest.fixture(scope="session")
-def built_image() -> str:
+def built_image_source_revision() -> str | None:
+    """Revision passed into locally built images, or ``None`` when unprovable."""
+    if os.environ.get("HERMES_TEST_IMAGE"):
+        return None
+    return get_source_revision(REPO_ROOT)
+
+
+@pytest.fixture(scope="session")
+def built_image(built_image_source_revision: str | None) -> str:
     """Build the image once per test session.
 
     Override with ``HERMES_TEST_IMAGE`` env var to point at a pre-built
@@ -57,11 +69,15 @@ def built_image() -> str:
     """
     if os.environ.get("HERMES_TEST_IMAGE"):
         return IMAGE_TAG
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", ".."),
-    )
+    command = ["docker", "build", "-t", IMAGE_TAG]
+    if built_image_source_revision is not None:
+        command.extend([
+            "--build-arg",
+            f"HERMES_GIT_SHA={built_image_source_revision}",
+        ])
+    command.append(str(REPO_ROOT))
     result = subprocess.run(
-        ["docker", "build", "-t", IMAGE_TAG, repo_root],
+        command,
         capture_output=True, text=True, timeout=1200,
     )
     assert result.returncode == 0, (

--- a/tests/docker/test_dump_build_sha.py
+++ b/tests/docker/test_dump_build_sha.py
@@ -1,27 +1,22 @@
-"""Regression test: ``hermes dump`` reports a real git SHA inside the container.
+"""Docker artifacts expose the same exact source revision everywhere.
 
-Background: ``.dockerignore`` excludes ``.git``, so ``git rev-parse HEAD``
-fails inside the published image and ``hermes dump`` used to report
-``version: ... [(unknown)]``.  The Dockerfile now writes the build-time
-``$HERMES_GIT_SHA`` build-arg to ``/opt/hermes/.hermes_build_sha`` and
-``hermes_cli/build_info.py`` reads it as a fallback.
+``.dockerignore`` excludes ``.git``, so the image must rely on immutable
+package-relative build metadata. CI passes ``$HERMES_GIT_SHA`` and the
+Dockerfile writes it to ``hermes_cli/_build_metadata.json``; local builds
+without the argument carry an explicit null revision.
 
 CI (``.github/workflows/docker.yml``) always sets the build-arg
-to ``${{ github.sha }}``.  Local ``docker build`` (the ``built_image``
-fixture in ``tests/docker/conftest.py``) does NOT — so locally the file
-is absent and ``hermes dump`` correctly falls back to ``(unknown)``.
+to ``${{ github.sha }}``. The local ``built_image`` fixture passes its clean
+checkout revision, or omits the argument when the checkout is dirty.
 
-This test handles both cases:
-
-* If ``/opt/hermes/.hermes_build_sha`` exists in the image, assert that
-  ``hermes dump`` surfaces its content as the version SHA (not
-  ``(unknown)``).
-* If the file is absent, assert the legacy behaviour (``(unknown)``)
-  still holds — defensive guard against the helper accidentally
-  reporting bogus data from somewhere else.
+The test reads the artifact file, resolves the public build-info API with no
+Git directory, and checks the legacy short ``hermes dump`` display derives
+from that same full revision.
 """
 from __future__ import annotations
 
+import json
+import os
 import re
 import subprocess
 
@@ -50,28 +45,51 @@ def _run_dump(image: str) -> str:
     return r.stdout
 
 
-def _read_baked_sha_from_image(image: str) -> str | None:
-    """Return the ``/opt/hermes/.hermes_build_sha`` content, or None if absent."""
+def _read_baked_metadata_from_image(image: str) -> dict:
     r = subprocess.run(
         [
             "docker", "run", "--rm", "--entrypoint", "cat", image,
-            "/opt/hermes/.hermes_build_sha",
+            "/opt/hermes/hermes_cli/_build_metadata.json",
         ],
         capture_output=True, text=True, timeout=30,
     )
-    if r.returncode != 0:
-        return None
-    return r.stdout.strip() or None
+    assert r.returncode == 0, r.stderr
+    return json.loads(r.stdout)
 
 
-def test_dump_reports_baked_sha_when_present(built_image: str) -> None:
+def _resolve_source_revision_in_image(image: str) -> str:
+    r = subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "--entrypoint", "/opt/hermes/.venv/bin/python", image,
+            "-c",
+            "from hermes_cli.build_info import get_source_revision; "
+            "print(get_source_revision())",
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+def test_docker_build_identity_matches_dump(
+    built_image: str,
+    built_image_source_revision: str | None,
+) -> None:
     """When the image was built with ``HERMES_GIT_SHA``, dump must surface it.
 
     Together with the smoke-test action (which exercises ``--help``), this
     closes the regression loop for the missing-sha bug: any future change
     that breaks the baked-file -> dump pipeline will fail CI here.
     """
-    baked = _read_baked_sha_from_image(built_image)
+    metadata = _read_baked_metadata_from_image(built_image)
+    assert set(metadata) == {"source_revision"}
+    baked = metadata["source_revision"]
+    assert baked is None or re.fullmatch(r"[0-9a-f]{40}", baked)
+    if not os.environ.get("HERMES_TEST_IMAGE"):
+        assert baked == built_image_source_revision
+
+    resolved = _resolve_source_revision_in_image(built_image)
     stdout = _run_dump(built_image)
 
     match = _VERSION_LINE.search(stdout)
@@ -83,22 +101,19 @@ def test_dump_reports_baked_sha_when_present(built_image: str) -> None:
     reported = sha_match.group("sha")
 
     if baked is None:
-        # Local-build path: no build-arg was passed.  Verify the legacy
-        # fallback ``(unknown)`` is intact — guards against the helper
-        # ever inventing a SHA from thin air.
+        assert resolved == "None"
         assert reported == "(unknown)", (
             f"expected '(unknown)' when no SHA baked, got {reported!r}"
         )
         return
 
-    # CI path: build-arg was set, baked file exists.  ``hermes dump``
-    # truncates to 8 chars via ``git rev-parse --short=8`` semantics.
+    assert resolved == baked
     assert reported != "(unknown)", (
-        "baked SHA file present in image but dump still reported "
+        "build metadata present in image but dump still reported "
         f"'(unknown)' — the build-info fallback is broken.  "
-        f"Baked file content: {baked!r}"
+        f"Metadata revision: {baked!r}"
     )
     assert reported == baked[:8], (
-        f"dump reported {reported!r} but baked file contained {baked!r} "
+        f"dump reported {reported!r} but metadata contained {baked!r} "
         f"(expected first 8 chars: {baked[:8]!r})"
     )

--- a/tests/hermes_cli/test_build_info.py
+++ b/tests/hermes_cli/test_build_info.py
@@ -1,12 +1,181 @@
-"""Tests for hermes_cli.build_info — baked-in build SHA resolution.
+"""Tests for exact Hermes source-revision resolution.
 
-The build SHA is written by the Dockerfile's ``HERMES_GIT_SHA`` build-arg
-into ``<project_root>/.hermes_build_sha``.  These tests cover the read-side
-helper: missing file, malformed file, truncation, and error tolerance.
+Release artifacts carry ``hermes_cli/_build_metadata.json``; source checkouts
+fall back to a clean full ``HEAD``. The legacy root-level Docker stamp remains
+covered at the bottom for compatibility with older artifacts.
 """
 
 from pathlib import Path
+import json
+import subprocess
 from unittest.mock import patch
+
+import pytest
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _clean_source_checkout(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "build-info@example.test")
+    _git(repo, "config", "user.name", "Build Info Test")
+    (repo / "tracked.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "tracked.py")
+    _git(repo, "commit", "-qm", "seed")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_clean_source_checkout_reports_full_head(tmp_path):
+    """A clean source artifact is identified by its exact committed HEAD."""
+    from hermes_cli import build_info
+
+    repo, revision = _clean_source_checkout(tmp_path)
+
+    assert build_info.get_source_revision(repo) == revision
+
+
+def test_dirty_source_checkout_does_not_claim_head(tmp_path):
+    """Tracked source changes make HEAD an inexact artifact identity."""
+    from hermes_cli import build_info
+
+    repo, _ = _clean_source_checkout(tmp_path)
+    (repo / "tracked.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    assert build_info.get_source_revision(repo) is None
+
+
+def test_untracked_source_checkout_does_not_claim_head(tmp_path):
+    """Untracked source can affect runtime behavior and is therefore dirty."""
+    from hermes_cli import build_info
+
+    repo, _ = _clean_source_checkout(tmp_path)
+    (repo / "untracked.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    assert build_info.get_source_revision(repo) is None
+
+
+def test_source_without_metadata_or_git_reports_none(tmp_path):
+    """An unpackaged tree cannot manufacture an exact source revision."""
+    from hermes_cli import build_info
+
+    assert build_info.get_source_revision(tmp_path) is None
+
+
+def test_embedded_revision_precedes_dirty_source_checkout(tmp_path):
+    """Immutable artifact metadata remains authoritative without clean Git."""
+    from hermes_cli import build_info
+
+    repo, _ = _clean_source_checkout(tmp_path)
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    metadata = repo / "hermes_cli" / "_build_metadata.json"
+    metadata.parent.mkdir()
+    metadata.write_text(
+        json.dumps({"source_revision": revision}) + "\n",
+        encoding="utf-8",
+    )
+    (repo / "tracked.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    assert build_info.get_source_revision(repo) == revision
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "",
+        "{",
+        "{}",
+        json.dumps({"source_revision": None}),
+        json.dumps({"source_revision": "a" * 39}),
+        json.dumps({"source_revision": "A" * 40}),
+        json.dumps({"source_revision": "g" * 40}),
+    ],
+)
+def test_malformed_embedded_revision_reports_none(tmp_path, payload):
+    """A malformed artifact stamp can never be promoted to exact identity."""
+    from hermes_cli import build_info
+
+    repo, _ = _clean_source_checkout(tmp_path)
+    metadata = repo / "hermes_cli" / "_build_metadata.json"
+    metadata.parent.mkdir()
+    metadata.write_text(payload, encoding="utf-8")
+
+    assert build_info.get_source_revision(repo) is None
+
+
+def test_build_assertion_cannot_override_embedded_revision(tmp_path):
+    """Rebuilding a packaged source preserves its immutable provenance."""
+    from hermes_cli import build_info
+
+    embedded = "0123456789abcdef0123456789abcdef01234567"
+    asserted = "89abcdef0123456789abcdef0123456789abcdef"
+    build_info.write_build_metadata(tmp_path, embedded)
+
+    assert build_info.resolve_build_source_revision(tmp_path, asserted) == embedded
+
+
+def test_build_assertion_must_match_clean_checkout(tmp_path):
+    """A builder variable cannot relabel a Git checkout as another commit."""
+    from hermes_cli import build_info
+
+    repo, revision = _clean_source_checkout(tmp_path)
+    other = "89abcdef0123456789abcdef0123456789abcdef"
+
+    assert build_info.resolve_build_source_revision(repo, revision) == revision
+    assert build_info.resolve_build_source_revision(repo, other) is None
+
+
+def test_build_assertion_cannot_bless_dirty_checkout(tmp_path):
+    """A dirty checkout remains inexact even with a valid asserted SHA."""
+    from hermes_cli import build_info
+
+    repo, revision = _clean_source_checkout(tmp_path)
+    (repo / "tracked.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    assert build_info.resolve_build_source_revision(repo, revision) is None
+
+
+def test_source_archive_may_use_validated_build_assertion(tmp_path):
+    """Git-free builders can attest the revision used to create an artifact."""
+    from hermes_cli import build_info
+
+    revision = "0123456789abcdef0123456789abcdef01234567"
+
+    assert build_info.resolve_build_source_revision(tmp_path, revision) == revision
+    assert build_info.resolve_build_source_revision(tmp_path, "a" * 39) is None
+
+
+def test_short_build_sha_comes_from_canonical_metadata(tmp_path):
+    """Legacy short displays derive from the same full artifact identity."""
+    from hermes_cli import build_info
+
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    build_info.write_build_metadata(tmp_path, revision)
+
+    assert build_info.get_build_sha(project_root=tmp_path) == revision[:8]
+
+
+def test_explicit_null_metadata_blocks_stale_legacy_fallback(tmp_path):
+    """A new artifact that declines identity cannot inherit an older stamp."""
+    from hermes_cli import build_info
+
+    build_info.write_build_metadata(tmp_path, None)
+    legacy = tmp_path / ".hermes_build_sha"
+    legacy.write_text("a" * 40 + "\n", encoding="utf-8")
+
+    with patch.object(build_info, "_PROJECT_ROOT", tmp_path), \
+         patch.object(build_info, "_BUILD_SHA_FILE", legacy):
+        assert build_info.get_build_sha() is None
 
 
 def test_get_build_sha_returns_none_when_file_absent(tmp_path):
@@ -15,7 +184,8 @@ def test_get_build_sha_returns_none_when_file_absent(tmp_path):
 
     missing = tmp_path / ".hermes_build_sha"  # never created
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", missing):
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", missing):
         assert build_info.get_build_sha() is None
 
 
@@ -26,7 +196,8 @@ def test_get_build_sha_reads_baked_file(tmp_path):
     sha_file = tmp_path / ".hermes_build_sha"
     sha_file.write_text("abcdef1234567890abcdef1234567890abcdef12\n")
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
         assert build_info.get_build_sha() == "abcdef12"
 
 
@@ -38,7 +209,8 @@ def test_get_build_sha_respects_short_argument(tmp_path):
     full_sha = "abcdef1234567890abcdef1234567890abcdef12"
     sha_file.write_text(full_sha + "\n")
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
         assert build_info.get_build_sha(short=12) == "abcdef123456"
         assert build_info.get_build_sha(short=0) == full_sha
         assert build_info.get_build_sha(short=-1) == full_sha
@@ -51,7 +223,8 @@ def test_get_build_sha_strips_whitespace(tmp_path):
     sha_file = tmp_path / ".hermes_build_sha"
     sha_file.write_text("  abcdef1234567890\n\n")
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
         assert build_info.get_build_sha() == "abcdef12"
 
 
@@ -62,7 +235,8 @@ def test_get_build_sha_returns_none_for_empty_file(tmp_path):
     sha_file = tmp_path / ".hermes_build_sha"
     sha_file.write_text("   \n\n")
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", sha_file):
         assert build_info.get_build_sha() is None
 
 
@@ -73,6 +247,7 @@ def test_get_build_sha_swallows_read_errors(tmp_path):
     sha_file = tmp_path / ".hermes_build_sha"
     sha_file.write_text("abcdef1234567890\n")
 
-    with patch.object(build_info, "_BUILD_SHA_FILE", sha_file), \
+    with patch.object(build_info, "get_source_revision", return_value=None), \
+         patch.object(build_info, "_BUILD_SHA_FILE", sha_file), \
          patch.object(Path, "read_text", side_effect=OSError("boom")):
         assert build_info.get_build_sha() is None

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -13,6 +13,8 @@ smoke test against staging Portal.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -92,6 +94,20 @@ def test_status_preserves_existing_fields(loopback_client):
     }
     missing = expected_keys - set(body.keys())
     assert not missing, f"/api/status dropped fields: {missing}"
+
+
+def test_status_reports_optional_exact_source_revision(loopback_client):
+    """The real HTTP response exposes only a full lowercase SHA or null."""
+    from hermes_cli.build_info import get_source_revision
+
+    response = loopback_client.get("/api/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "source_revision" in body
+    revision = body["source_revision"]
+    assert revision is None or re.fullmatch(r"[0-9a-f]{40}", revision)
+    assert revision == get_source_revision()
 
 
 # Host-local detail (absolute paths, PID, internal gateway URL) is deployment

--- a/tests/test_build_identity_packaging.py
+++ b/tests/test_build_identity_packaging.py
@@ -1,0 +1,125 @@
+"""Release artifacts retain an exact Hermes source revision without Git."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+METADATA_SUFFIX = "hermes_cli/_build_metadata.json"
+
+
+@pytest.mark.integration
+def test_wheel_and_sdist_embed_the_build_revision(tmp_path):
+    revision_result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    revision = revision_result.stdout.strip()
+    artifacts = tmp_path / "artifacts"
+    env = os.environ.copy()
+    env["HERMES_GIT_SHA"] = revision
+
+    build = subprocess.run(
+        [
+            "uv",
+            "build",
+            "--wheel",
+            "--sdist",
+            "--out-dir",
+            str(artifacts),
+            ".",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert build.returncode == 0, f"uv build failed:\n{build.stderr}"
+
+    wheels = glob.glob(str(artifacts / "*.whl"))
+    tarballs = glob.glob(str(artifacts / "*.tar.gz"))
+    assert len(wheels) == 1
+    assert len(tarballs) == 1
+
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        matches = [name for name in wheel.namelist() if name.endswith(METADATA_SUFFIX)]
+        assert len(matches) == 1
+        wheel_payload = json.loads(wheel.read(matches[0]))
+        extract_root = tmp_path / "wheel-root"
+        wheel.extractall(extract_root)
+
+    with tarfile.open(tarballs[0]) as sdist:
+        matches = [name for name in sdist.getnames() if name.endswith(METADATA_SUFFIX)]
+        assert len(matches) == 1
+        metadata = sdist.extractfile(matches[0])
+        assert metadata is not None
+        sdist_payload = json.load(metadata)
+        sdist_root = tmp_path / "sdist-root"
+        sdist.extractall(sdist_root, filter="data")
+
+    assert wheel_payload == {"source_revision": revision}
+    assert sdist_payload == wheel_payload
+
+    probe_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"PYTHONPATH", "HERMES_GIT_SHA"}
+    }
+    probe_env["PYTHONPATH"] = str(extract_root)
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.build_info import get_source_revision; "
+            "print(get_source_revision())",
+        ],
+        cwd=tmp_path,
+        env=probe_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.strip() == revision
+
+    extracted_sources = [path for path in sdist_root.iterdir() if path.is_dir()]
+    assert len(extracted_sources) == 1
+    downstream_artifacts = tmp_path / "downstream-artifacts"
+    downstream_env = os.environ.copy()
+    downstream_env["HERMES_GIT_SHA"] = "89abcdef0123456789abcdef0123456789abcdef"
+    downstream_build = subprocess.run(
+        [
+            "uv",
+            "build",
+            "--wheel",
+            "--out-dir",
+            str(downstream_artifacts),
+            ".",
+        ],
+        cwd=extracted_sources[0],
+        env=downstream_env,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert downstream_build.returncode == 0, downstream_build.stderr
+    downstream_wheels = glob.glob(str(downstream_artifacts / "*.whl"))
+    assert len(downstream_wheels) == 1
+    with zipfile.ZipFile(downstream_wheels[0]) as wheel:
+        matches = [name for name in wheel.namelist() if name.endswith(METADATA_SUFFIX)]
+        assert len(matches) == 1
+        assert json.loads(wheel.read(matches[0])) == {"source_revision": revision}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1779,6 +1779,9 @@ export interface StatusResponse {
   hermes_home: string;
   latest_config_version: number;
   release_date: string;
+  /** Full lowercase source SHA for the serving artifact, or null when the
+   * exact revision cannot be proven. Missing on older Hermes releases. */
+  source_revision?: string | null;
   version: string;
 }
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -412,7 +412,10 @@ a chat under the selected profile.
 
 ### GET /api/status
 
-Returns agent version, gateway status, platform states, and active session count.
+Returns the agent version, optional exact `source_revision` (a full lowercase
+40-character Git SHA or `null`), gateway status, platform states, and active
+session count. Packaged artifacts report their embedded build revision; a
+source checkout reports `HEAD` only while its working tree is clean.
 
 ### GET /api/sessions
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-dashboard.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-dashboard.md
@@ -198,7 +198,9 @@ Web Dashboard 暴露了一个供前端使用的 REST API。你也可以直接调
 
 ### GET /api/status
 
-返回 agent 版本、gateway 状态、平台状态和活跃会话数。
+返回 agent 版本、可选的精确 `source_revision`（完整的小写 40 字符 Git SHA，
+无法证明时为 `null`）、gateway 状态、平台状态和活跃会话数。打包产物会报告构建时嵌入的
+revision；源码 checkout 仅在工作树干净时报告其 `HEAD`。
 
 ### GET /api/sessions
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional exact source revision to the existing public `GET /api/status` response without changing its version field or authentication behavior.

`source_revision` is either a full lowercase 40-character Git SHA or `null`. Packaged artifacts prefer one package-relative `hermes_cli/_build_metadata.json` file; source checkouts fall back to their full `HEAD` only when the working tree is clean. Resolution is offline and never fetches from Git or the network.

## Related Issue

Related: https://github.com/ericlewis/cuttle/issues/12

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add strict, fail-closed source-revision resolution in `hermes_cli/build_info.py` and expose it from the real `/api/status` endpoint.
- Embed the same metadata path in wheel, sdist, Docker, and Desktop artifacts; preserve embedded provenance when rebuilding an sdist.
- Keep dirty, missing, malformed, short, uppercase, and non-hex identities explicit as `null`.
- Add backend/frontend response types plus English and Simplified Chinese API documentation.
- Add behavior, HTTP endpoint, real wheel/sdist, Desktop, and Docker artifact tests.

## How to Test

1. Run the focused status and compatibility suite:
   `scripts/run_tests.sh tests/hermes_cli/test_build_info.py tests/hermes_cli/test_dashboard_auth_status_endpoint.py tests/hermes_cli/test_banner.py tests/hermes_cli/test_dump_git_commit.py tests/test_setup_temporary_outputs.py tests/test_packaging_metadata.py tests/docker/test_dump_build_sha.py -q`
2. Build real release artifacts and verify the revision survives without `.git`:
   `scripts/run_tests.sh tests/test_build_identity_packaging.py -m integration -q`
3. Verify Desktop stamping and both TypeScript workspaces:
   `node --test apps/desktop/scripts/write-build-stamp.test.mjs`
   `npm run typecheck --workspace apps/desktop`
   `npm run typecheck --workspace web`
4. Run the portability scan:
   `.venv/bin/python scripts/check-windows-footguns.py --diff upstream/main`

Validated on macOS 27.0 with Python 3.12.13 and Node 26.0.0:

- 63 focused Python tests passed.
- Real wheel/sdist propagation test passed, including an sdist rebuild with a conflicting builder assertion.
- A default wheel built without `HERMES_GIT_SHA` embedded the clean checkout's exact `HEAD`.
- 2 Desktop build-stamp tests passed; Desktop and web TypeScript checks passed.
- Ruff, targeted ESLint, and the Windows-footgun scan passed.

The full suite was attempted but not completed because an unrelated macOS LSP e2e cleanup test intermittently trips the repository's live-system guard after its child process is reparented. Docker CLI is present but the local daemon is unavailable, so the real Docker test is left to CI; the test harness now builds from and asserts the clean checkout's exact revision.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Python 3.12.13, Node 26.0.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor instructions changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — portability scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

N/A — additive API and packaging metadata change.
