### PR TITLE
feat(gateway): add revisioned conversation sync

### DIFF
--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -27,9 +27,10 @@ from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
 Synchronization state and replay retention begin when an authorized mobile
-transport attaches to a live session. Legacy stdio and Desktop transports keep
-their original response and event shapes and do not pay the per-delta replay
-copying cost.
+transport first attaches to a live session. A session that has never negotiated
+sync does not pay the per-delta replay copying cost. If a legacy transport later
+attaches to a previously negotiated session, retention continues for the next
+mobile reconnect, but the legacy response and event shapes remain unchanged.
 
 ## Snapshot and event barrier
 

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -26,6 +26,11 @@ limits. `gap` means an event needed after the supplied cursor was evicted.
 from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
+Synchronization state and replay retention begin when an authorized mobile
+transport attaches to a live session. Legacy stdio and Desktop transports keep
+their original response and event shapes and do not pay the per-delta replay
+copying cost.
+
 ## Snapshot and event barrier
 
 Hermes serializes snapshot-visible live state, event sequence allocation,

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -1,0 +1,55 @@
+# Mobile Client Contract
+
+Hermes exposes its additive Mobile Client Contract on the existing
+authenticated `/api/ws` JSON-RPC transport. Clients must negotiate features
+from `gateway.ready`; a contract major or server version alone does not imply a
+capability.
+
+## Revisioned conversation synchronization
+
+When `conversation.sync` version 1 is advertised, `session.create` and
+`session.resume` include the same `synchronization` envelope:
+
+- `snapshot` is authoritative conversation state. It identifies the server
+  process, live event stream, stable conversation lineage, current stored
+  session tip, and process-local live session. It also includes a revision,
+  event watermark, messages, inflight turn, active tool descriptors, pending
+  interactions, and runtime status.
+- `recovery` reports `complete`, `gap`, or `reset`, the cursor at the snapshot
+  watermark, and any replayable events after the supplied cursor.
+- Every session event carries `schema_major`, `stream_id`, and a monotonically
+  increasing `sequence` within that stream.
+
+The replay store is bounded in memory by both the advertised event and byte
+limits. `gap` means an event needed after the supplied cursor was evicted.
+`reset` means the cursor is absent, invalid, from another server process, or
+from another reconstructed live stream. Clients must never treat either
+outcome as complete replay.
+
+## Snapshot and event barrier
+
+Hermes serializes snapshot-visible live state, event sequence allocation,
+replay retention, and event transport enqueueing at one per-stream boundary.
+Snapshot capture takes the conversation history lock before that stream
+boundary. The returned watermark therefore covers every state transition
+published before the snapshot.
+
+A client should:
+
+1. Buffer events for the returned `stream_id` while create or resume is in
+   flight.
+2. Install the complete snapshot at its `watermark`.
+3. Discard buffered or replayed events at or below the watermark.
+4. Apply only events for the same server and stream whose sequence is greater
+   than the watermark, in sequence order.
+5. Replace local state from the snapshot whenever recovery is `gap` or
+   `reset`.
+
+Assistant `message.delta` events additionally carry one `turn_id` and an
+absolute `offset`. The `conversation.sync.delta_offsets.unit` capability names
+the unit as `utf8_bytes`. Clients can therefore ignore an overlapping prefix
+instead of duplicating text after replay or transport coalescing.
+
+This slice does not claim durable mutation idempotency or addressable,
+recoverable approvals. Those features require separately advertised
+capabilities.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,6 +15,7 @@ The routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -621,7 +622,9 @@ async def api_auth_ws_ticket(request: Request):
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the
-    expected pattern.
+    expected pattern. A bodyless request intentionally retains the dashboard's
+    full legacy authority. A mobile audience requests a narrower grant for one
+    WebSocket connection; it is not a persistent device credential.
     """
     sess = getattr(request.state, "session", None)
     if sess is None:
@@ -632,11 +635,58 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    body = await request.body()
+    requested = {}
+    if body:
+        try:
+            requested = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+        if not isinstance(requested, dict):
+            raise HTTPException(status_code=400, detail="Expected a JSON object")
+
+    audience = str(requested.get("audience") or "").strip()
+    if "scopes" in requested and not audience:
+        raise HTTPException(
+            status_code=400,
+            detail="audience is required when scopes are requested",
+        )
+    if audience:
+        from tui_gateway.mobile_contract import (
+            MOBILE_AUDIENCE,
+            normalize_mobile_scopes,
+        )
+
+        if audience != MOBILE_AUDIENCE:
+            raise HTTPException(status_code=400, detail="Unsupported WebSocket audience")
+        raw_scopes = requested.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise HTTPException(status_code=400, detail="scopes must be an array")
+        try:
+            granted_scopes = normalize_mobile_scopes(raw_scopes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        ticket = mint_ticket(
+            user_id=sess.user_id,
+            provider=sess.provider,
+            audience=audience,
+            scopes=granted_scopes,
+        )
+    else:
+        # Preserve the existing dashboard contract exactly for bodyless calls.
+        ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,
         user_id=sess.user_id,
         ip=_client_ip(request),
     )
-    return {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    response = {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    if audience:
+        response.update(
+            {
+                "audience": audience,
+                "granted_scopes": list(granted_scopes),
+            }
+        )
+    return response

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -646,11 +646,13 @@ async def api_auth_ws_ticket(request: Request):
             raise HTTPException(status_code=400, detail="Expected a JSON object")
 
     audience = str(requested.get("audience") or "").strip()
-    if "scopes" in requested and not audience:
-        raise HTTPException(
-            status_code=400,
-            detail="audience is required when scopes are requested",
+    if body and not audience:
+        detail = (
+            "audience is required when scopes are requested"
+            if "scopes" in requested
+            else "audience is required for a non-empty ticket request"
         )
+        raise HTTPException(status_code=400, detail=detail)
     if audience:
         from tui_gateway.mobile_contract import (
             MOBILE_AUDIENCE,

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -5,10 +5,13 @@ mode the legacy ``?token=<_SESSION_TOKEN>`` query param works because the
 token is injected into the SPA bundle. In gated mode there is no injected
 token — so this module provides two credential shapes:
 
-1. **Single-use browser tickets** (``mint_ticket`` / ``consume_ticket``).
-   The SPA gets a fresh ticket via the authenticated REST endpoint
-   ``POST /api/auth/ws-ticket`` and passes it as ``?ticket=`` on the WS
-   upgrade. Single-use, TTL = 30 seconds — a leaked ticket is uninteresting.
+1. **Single-use client tickets** (``mint_ticket`` / ``consume_ticket``).
+   The SPA gets a full-authority legacy ticket from a bodyless authenticated
+   ``POST /api/auth/ws-ticket``. A native client can request a mobile audience
+   and explicit scopes instead. Both pass ``?ticket=`` on the WS upgrade and
+   are single-use with TTL = 30 seconds. The scoped ticket narrows one socket;
+   it is not a persistent device credential or a replacement for the legacy
+   compatibility path.
 
 2. **A process-lifetime internal credential** (``internal_ws_credential`` /
    ``consume_internal_credential``). This authenticates *server-spawned*
@@ -53,13 +56,21 @@ _internal_credential: Optional[str] = None
 #: credential, so audit logs distinguish them from browser-initiated tickets.
 INTERNAL_USER_ID = "server-internal"
 INTERNAL_PROVIDER = "server-internal"
+LEGACY_AUDIENCE = "dashboard"
+LEGACY_SCOPES = ("*",)
 
 
 class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(
+    *,
+    user_id: str,
+    provider: str,
+    audience: str = LEGACY_AUDIENCE,
+    scopes: tuple[str, ...] = LEGACY_SCOPES,
+) -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -70,6 +81,8 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     info = {
         "user_id": user_id,
         "provider": provider,
+        "audience": audience,
+        "scopes": tuple(scopes),
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -132,10 +145,10 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     Unlike :func:`consume_ticket` this is **not** single-use — the value is
     not removed on success, so a server-spawned child can present it on every
     (re)connect. Returns the fixed server-internal identity ``info`` dict
-    (``{user_id, provider}``), mirroring the ``info`` shape ``consume_ticket``
-    returns, so a caller that wants to record the connecting identity can; the
-    current ``_ws_auth_ok`` caller validates for the boolean outcome only and
-    discards the dict.
+    (identity plus legacy audience/scopes), mirroring the ``info`` shape
+    ``consume_ticket`` returns so the gateway can carry one effective grant
+    shape through its transport. Non-gateway callers may validate only the
+    boolean outcome and discard the dict.
 
     A constant-time compare against the (lazily-minted) credential avoids
     leaking length / prefix information on mismatch. If no internal
@@ -150,6 +163,8 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     return {
         "user_id": INTERNAL_USER_ID,
         "provider": INTERNAL_PROVIDER,
+        "audience": LEGACY_AUDIENCE,
+        "scopes": LEGACY_SCOPES,
     }
 
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -77,12 +77,20 @@ def mint_ticket(
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
     """
+    scope_tuple = tuple(scopes)
+    if audience == "hermes.mobile":
+        from tui_gateway.mobile_contract import normalize_mobile_scopes
+
+        scope_tuple = normalize_mobile_scopes(scope_tuple)
+    elif audience != LEGACY_AUDIENCE or scope_tuple != LEGACY_SCOPES:
+        raise ValueError(f"unsupported WebSocket audience or grant: {audience}")
+
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
         "audience": audience,
-        "scopes": tuple(scopes),
+        "scopes": scope_tuple,
         "minted_at": int(time.time()),
     }
     with _lock:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14442,8 +14442,10 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_result(
+    ws: "WebSocket",
+) -> tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Validate WS-upgrade auth and return its effective authorization grant.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -14451,15 +14453,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``authorization`` is the server-derived grant carried by an accepted
+    credential; it is ``None`` for every rejected request.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
 
     Gated (public bind, no ``--insecure``): one of two credentials —
 
-    * ``?ticket=<single-use>`` — a browser-minted, single-use, 30s-TTL ticket
-      consumed against the dashboard-auth ticket store. This is what the SPA
-      (and native clients) use.
+    * ``?ticket=<single-use>`` — a client-minted, single-use, 30s-TTL ticket
+      consumed against the dashboard-auth ticket store. The bodyless SPA flow
+      retains legacy dashboard authority. A native mobile ticket is restricted
+      to ``/api/ws`` and carries explicit scopes into its dispatcher.
     * ``?internal=<process-credential>`` — the process-lifetime internal
       credential, used only by WS clients the server spawns itself (the
       embedded-TUI PTY child attaching to ``/api/ws`` and ``/api/pub``). It
@@ -14491,8 +14496,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                grant = consume_internal_credential(internal)
+                return None, "internal", grant
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14500,15 +14505,26 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            grant = consume_ticket(ticket)
+            if (
+                grant.get("audience") == "hermes.mobile"
+                and ws.url.path != "/api/ws"
+            ):
+                audit_log(
+                    AuditEvent.WS_TICKET_REJECTED,
+                    reason="mobile ticket used outside /api/ws",
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return "ticket_audience_mismatch", "ticket", None
+            return None, "ticket", grant
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14516,14 +14532,29 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return (
+            None,
+            "token",
+            {
+                "user_id": "loopback",
+                "provider": "loopback",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            },
+        )
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Compatibility view of :func:`_ws_auth_result` for non-gateway sockets."""
+    reason, credential, _authorization = _ws_auth_result(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -15613,7 +15644,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, authorization = _ws_auth_result(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -15623,7 +15655,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, authorization=authorization)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -13,6 +13,8 @@ pre-existing regression unrelated to dashboard-auth.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -20,14 +22,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
+from hermes_cli import mcp_startup
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
+    consume_ticket,
     consume_internal_credential,
     internal_ws_credential,
     mint_ticket,
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tui_gateway import server as tui_server
+from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +122,13 @@ class TestWsTicketEndpoint:
         r = gated_app.post("/api/auth/ws-ticket")
         assert r.status_code == 200
         body = r.json()
-        assert "ticket" in body
+        assert set(body) == {"ticket", "ttl_seconds"}
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "dashboard"
+        assert grant["scopes"] == ("*",)
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -132,6 +141,58 @@ class TestWsTicketEndpoint:
         tickets = {gated_app.post("/api/auth/ws-ticket").json()["ticket"]
                    for _ in range(5)}
         assert len(tickets) == 5
+
+    def test_mobile_ticket_returns_and_preserves_the_granted_scopes(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.read", "conversation.write"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["audience"] == "hermes.mobile"
+        assert body["granted_scopes"] == [
+            "conversation.read",
+            "conversation.write",
+        ]
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "hermes.mobile"
+        assert grant["scopes"] == ("conversation.read", "conversation.write")
+
+    @pytest.mark.parametrize("scope", ["approval.respond", "shell.exec"])
+    def test_mobile_ticket_rejects_scopes_not_enforced_by_this_contract(
+        self,
+        gated_app,
+        scope,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"audience": "hermes.mobile", "scopes": [scope]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"unsupported mobile scope: {scope}"
+
+    def test_scopes_without_a_mobile_audience_do_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"scopes": ["conversation.read"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "audience is required when scopes are requested"
 
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
@@ -150,6 +211,54 @@ class TestWsTicketEndpoint:
             f"GET /api/auth/ws-ticket leaked a ticket (status={r.status_code}, "
             f"body[:200]={body[:200]!r})"
         )
+
+
+def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
+    sent = []
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
+    ticket = mint_ticket(
+        user_id="mobile-user",
+        provider="stub",
+        audience="hermes.mobile",
+        scopes=("conversation.read",),
+    )
+
+    class QueryParams:
+        def get(self, key, default=""):
+            return {"ticket": ticket}.get(key, default)
+
+    class FakeWS:
+        query_params = QueryParams()
+        client = SimpleNamespace(host="203.0.113.10")
+        url = SimpleNamespace(path="/api/ws")
+        headers = {
+            "host": "fly-app.fly.dev",
+            "origin": "https://fly-app.fly.dev",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise tui_ws._WebSocketDisconnect()
+
+        async def close(self, code=None):
+            pass
+
+    asyncio.run(web_server.gateway_ws(FakeWS()))
+
+    authorization = sent[0]["params"]["payload"]["authorization"]
+    assert authorization == {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ["conversation.read"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +337,26 @@ class TestWsAuthOkGated:
         ticket = mint_ticket(user_id="u1", provider="stub")
         ws = _fake_ws(query={"ticket": ticket})
         assert web_server._ws_auth_ok(ws) is True
+
+    @pytest.mark.parametrize("path", ["/api/pty", "/api/console", "/api/pub", "/api/events"])
+    def test_mobile_ticket_cannot_authenticate_non_gateway_websockets(
+        self,
+        gated_app,
+        path,
+    ):
+        ticket = mint_ticket(
+            user_id="mobile-user",
+            provider="stub",
+            audience="hermes.mobile",
+            scopes=("conversation.read",),
+        )
+        ws = _fake_ws(query={"ticket": ticket}, path=path)
+
+        reason, credential, authorization = web_server._ws_auth_result(ws)
+
+        assert reason == "ticket_audience_mismatch"
+        assert credential == "ticket"
+        assert authorization is None
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -5,16 +5,14 @@ The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
-These tests exercise the helper at the unit level (no actual WS upgrade)
-plus the ticket-mint endpoint under realistic gated-mode setup. We don't
-test the full WS upgrade because the starlette TestClient WS path has a
-pre-existing regression unrelated to dashboard-auth.
+These tests exercise the helper at the unit level, the ticket-mint endpoint
+under realistic gated-mode setup, and one public mint-to-upgrade-to-dispatch
+round trip. The full upgrade supplies explicit Host/Origin headers because
+Starlette's WebSocket TestClient does not inherit the HTTP ``base_url`` host.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -33,7 +31,6 @@ from hermes_cli.dashboard_auth.ws_tickets import (
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 from tui_gateway import server as tui_server
-from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +191,35 @@ class TestWsTicketEndpoint:
         assert response.status_code == 400
         assert response.json()["detail"] == "audience is required when scopes are requested"
 
+    def test_nonempty_request_without_an_audience_does_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post("/api/auth/ws-ticket", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "audience is required for a non-empty ticket request"
+        )
+
+    def test_mobile_write_grant_requires_read_scope(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.write"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "conversation.read is required for every mobile WebSocket grant"
+        )
+
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
         r = gated_app.get("/api/auth/ws-ticket", follow_redirects=False)
@@ -213,52 +239,47 @@ class TestWsTicketEndpoint:
         )
 
 
-def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
-    sent = []
+def test_scoped_ticket_grant_reaches_gateway_ready_and_dispatch(gated_app, monkeypatch):
     monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
     monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
-    ticket = mint_ticket(
-        user_id="mobile-user",
-        provider="stub",
-        audience="hermes.mobile",
-        scopes=("conversation.read",),
+
+    _logged_in(gated_app)
+    minted = gated_app.post(
+        "/api/auth/ws-ticket",
+        json={
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
+        },
     )
+    assert minted.status_code == 200
 
-    class QueryParams:
-        def get(self, key, default=""):
-            return {"ticket": ticket}.get(key, default)
-
-    class FakeWS:
-        query_params = QueryParams()
-        client = SimpleNamespace(host="203.0.113.10")
-        url = SimpleNamespace(path="/api/ws")
-        headers = {
-            "host": "fly-app.fly.dev",
-            "origin": "https://fly-app.fly.dev",
+    with gated_app.websocket_connect(
+        f"/api/ws?ticket={minted.json()['ticket']}",
+        headers={
+            "Host": "fly-app.fly.dev",
+            "Origin": "https://fly-app.fly.dev",
+        },
+    ) as socket:
+        ready = socket.receive_json()
+        authorization = ready["params"]["payload"]["authorization"]
+        assert authorization == {
+            "subject": "stub-user-1",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
         }
 
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            sent.append(json.loads(line))
-
-        async def receive_text(self):
-            raise tui_ws._WebSocketDisconnect()
-
-        async def close(self, code=None):
-            pass
-
-    asyncio.run(web_server.gateway_ws(FakeWS()))
-
-    authorization = sent[0]["params"]["payload"]["authorization"]
-    assert authorization == {
-        "subject": "mobile-user",
-        "provider": "stub",
-        "audience": "hermes.mobile",
-        "scopes": ["conversation.read"],
-    }
+        socket.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": "denied-write",
+                "method": "prompt.submit",
+                "params": {},
+            }
+        )
+        denied = socket.receive_json()
+        assert denied["error"]["data"]["required_scope"] == "conversation.write"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,27 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_ticket_store_rejects_unknown_audiences(self):
+        with pytest.raises(ValueError, match="unsupported WebSocket audience"):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.future",
+                scopes=("*",),
+            )
+
+    def test_ticket_store_rejects_mobile_grants_without_read_scope(self):
+        with pytest.raises(
+            ValueError,
+            match="conversation.read is required for every mobile WebSocket grant",
+        ):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.mobile",
+                scopes=("conversation.write",),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -51,6 +51,19 @@ class TestMintAndConsume:
         seen = {mint_ticket(user_id="u1", provider="x") for _ in range(50)}
         assert len(seen) == 50
 
+    def test_scoped_ticket_preserves_its_authorization_grant(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.write"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["audience"] == "hermes.mobile"
+        assert info["scopes"] == ("conversation.read", "conversation.write")
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8383,8 +8383,9 @@ def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason: seen.append((session, end_reason)),
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
     # outlives the test; grace=0 short-circuits it so no thread lingers.
@@ -8394,8 +8395,10 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     server._sessions["a"] = {"transport": transport, "close_on_disconnect": True}
     server._sessions["b"] = {"transport": transport, "close_on_disconnect": False}
     try:
+        flagged = server._sessions["a"]
         server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
-        assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
+        assert seen == [(flagged, "ws_disconnect")]  # only the flagged one closed
+        assert "a" not in server._sessions  # claimed before teardown can race resume
         assert server._sessions["b"]["transport"] is server._detached_ws_transport  # re-pointed
     finally:
         server._sessions.clear()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -59,8 +59,20 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                     "gateway.ready": 1,
                     "authorization.grant": 1,
                     "authorization.error": 1,
+                    "session.synchronization": 1,
+                    "session.event": 1,
                 },
-                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "capabilities": {
+                    "auth.ws_scopes": {"version": 1},
+                    "conversation.sync": {
+                        "version": 1,
+                        "delta_offsets": {"unit": "utf8_bytes"},
+                        "replay": {
+                            "max_events": 512,
+                            "max_bytes": 1048576,
+                        },
+                    },
+                },
                 "authorization": {
                     "subject": "user-1",
                     "provider": "stub",
@@ -128,6 +140,147 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
             "grantable": False,
         },
     }
+
+
+def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
+    monkeypatch,
+):
+    """Exercise synchronization through the real handle_ws transport boundary."""
+    sent = []
+    receive_index = 0
+    state = {}
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id, "cwd": server.os.getcwd()}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+
+    async def wait_for_response(request_id):
+        deadline = asyncio.get_running_loop().time() + 2
+        while asyncio.get_running_loop().time() < deadline:
+            match = next(
+                (frame for frame in sent if frame.get("id") == request_id), None
+            )
+            if match is not None:
+                return match
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"missing WebSocket response {request_id}")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "create-sync",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await wait_for_response("create-sync"))["result"]
+                state["created"] = created
+                sid = created["session_id"]
+                session = server._sessions[sid]
+
+                def emit_deltas():
+                    with session["history_lock"]:
+                        server._start_inflight_turn(session, "question")
+                    server._emit_inflight_delta(sid, session, "A💡")
+                    server._emit_inflight_delta(sid, session, "B")
+
+                await asyncio.to_thread(emit_deltas)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "resume-sync",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": created["synchronization"]["recovery"]["cursor"],
+                        },
+                    }
+                )
+            await wait_for_response("resume-sync")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": (
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ),
+    }
+
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+    finally:
+        server._sessions.clear()
+
+    created = state["created"]
+    resumed = next(frame for frame in sent if frame.get("id") == "resume-sync")[
+        "result"
+    ]
+    deltas = [
+        frame["params"]
+        for frame in sent
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [params["payload"]["offset"] for params in deltas] == [0, 5]
+    assert len({params["payload"]["turn_id"] for params in deltas}) == 1
+    assert [params["sequence"] for params in deltas] == [1, 2]
+    assert resumed["session_id"] == created["session_id"]
+    assert (
+        resumed["synchronization"]["snapshot"]["stream_id"]
+        == created["synchronization"]["snapshot"]["stream_id"]
+    )
+    assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
+    assert len(resumed["synchronization"]["recovery"]["events"]) == 2
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -7,6 +7,7 @@ from hermes_cli import mcp_startup
 from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+from tui_gateway.mobile_sync import SessionEventStream
 
 
 def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
@@ -281,6 +282,305 @@ def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
     )
     assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
     assert len(resumed["synchronization"]["recovery"]["events"]) == 2
+
+
+def _isolate_mobile_ws_gateway(monkeypatch, db):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+
+class _MobileSessionDB:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+_MOBILE_AUTHORIZATION = {
+    "subject": "mobile-user",
+    "provider": "stub",
+    "audience": "hermes.mobile",
+    "scopes": (
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    ),
+}
+
+
+async def _wait_for_ws_response(sent, request_id):
+    deadline = asyncio.get_running_loop().time() + 2
+    while asyncio.get_running_loop().time() < deadline:
+        match = next((frame for frame in sent if frame.get("id") == request_id), None)
+        if match is not None:
+            return match
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"missing WebSocket response {request_id}")
+
+
+def test_mobile_socket_cold_resume_reports_stream_reset(monkeypatch):
+    sent = []
+    received = False
+    stored_id = "stored-cold"
+    _isolate_mobile_ws_gateway(
+        monkeypatch,
+        _MobileSessionDB(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "cold-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": stored_id,
+                            "cols": 100,
+                            "cursor": {
+                                "server_instance_id": (
+                                    mobile_contract.SERVER_INSTANCE_ID
+                                ),
+                                "stream_id": "retired-stream",
+                                "sequence": 12,
+                            },
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "cold-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "cold-resume")[
+        "result"
+    ]
+    synchronization = result["synchronization"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+    assert synchronization["recovery"]["snapshot_required"] is True
+    assert synchronization["recovery"]["events"] == []
+
+
+def test_mobile_socket_resume_reports_gap_after_replay_eviction(monkeypatch):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await _wait_for_ws_response(sent, "gap-create"))["result"]
+                sid = created["session_id"]
+                db.session_id = created["stored_session_id"]
+                stream = SessionEventStream(
+                    mobile_contract.SERVER_INSTANCE_ID,
+                    max_events=2,
+                    max_bytes=1024 * 1024,
+                )
+                server._sessions[sid]["mobile_sync"] = stream
+                cursor = stream.cursor()
+
+                def fill_replay():
+                    for index in range(3):
+                        server._emit(
+                            "status.update",
+                            sid,
+                            {"kind": "step", "text": str(index)},
+                        )
+
+                await asyncio.to_thread(fill_replay)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": cursor,
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "gap-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "gap-resume")[
+        "result"
+    ]
+    recovery = result["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["available_after"] == 1
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_mobile_socket_concurrent_events_have_monotonic_wire_sequences(
+    monkeypatch,
+):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "concurrent-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+
+            created = (await _wait_for_ws_response(sent, "concurrent-create"))[
+                "result"
+            ]
+            sid = created["session_id"]
+            start = threading.Barrier(9)
+
+            def publish(index):
+                start.wait()
+                server._emit(
+                    "status.update",
+                    sid,
+                    {"kind": "worker", "text": str(index)},
+                )
+
+            def publish_concurrently():
+                threads = [
+                    threading.Thread(target=publish, args=(index,))
+                    for index in range(8)
+                ]
+                for thread in threads:
+                    thread.start()
+                start.wait()
+                for thread in threads:
+                    thread.join(timeout=1)
+                    assert not thread.is_alive()
+
+            await asyncio.to_thread(publish_concurrently)
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    events = [
+        frame
+        for frame in sent
+        if frame.get("params", {}).get("type") == "status.update"
+    ]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -703,6 +703,53 @@ def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch)
         server._sessions.clear()
 
 
+def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    cleanup_reached_session = threading.Event()
+    allow_cleanup = threading.Event()
+    scheduled = []
+
+    class GateLock:
+        def __enter__(self):
+            cleanup_reached_session.set()
+            assert allow_cleanup.wait(timeout=2)
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    server._sessions.clear()
+    server._sessions["raced"] = {
+        "transport": old_transport,
+        "close_on_disconnect": False,
+        "history_lock": GateLock(),
+        "session_key": "stored",
+    }
+    monkeypatch.setattr(
+        server,
+        "_schedule_ws_orphan_reap",
+        lambda sid: scheduled.append(sid),
+    )
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert cleanup_reached_session.wait(timeout=1)
+    server._sessions["raced"]["transport"] = new_transport
+    allow_cleanup.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+
+    assert result["counts"] == (0, 0)
+    assert server._sessions["raced"]["transport"] is new_transport
+    assert scheduled == []
+    server._sessions.clear()
+
+
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     """A write that times out because the event loop is stalled (GIL-heavy
     agent turn) must NOT latch the transport closed — the frame is already

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -750,6 +750,55 @@ def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch)
     server._sessions.clear()
 
 
+def test_close_on_disconnect_claim_blocks_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    teardown_entered = threading.Event()
+    release_teardown = threading.Event()
+    session = {
+        "agent": None,
+        "close_on_disconnect": True,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "session_key": "stored",
+        "transport": old_transport,
+    }
+    server._sessions.clear()
+    server._sessions["flagged"] = session
+
+    def blocked_teardown(claimed, *, end_reason):
+        assert claimed is session
+        assert end_reason == "ws_disconnect"
+        teardown_entered.set()
+        assert release_teardown.wait(timeout=2)
+
+    monkeypatch.setattr(server, "_teardown_session", blocked_teardown)
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert teardown_entered.wait(timeout=1)
+    assert "flagged" not in server._sessions
+
+    payload = server._live_session_payload(
+        "flagged",
+        session,
+        transport=new_transport,
+    )
+    assert payload is None
+    assert session["transport"] is old_transport
+
+    release_teardown.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+    assert result["counts"] == (1, 0)
+    server._sessions.clear()
+
+
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     """A write that times out because the event loop is stalled (GIL-heavy
     agent turn) must NOT latch the transport closed — the frame is already

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -121,8 +121,11 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "not.a.mobile.method",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read"],
+            "grantable": False,
         },
     }
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,10 +1,130 @@
 import asyncio
+import json
 import threading
 import time
 
 from hermes_cli import mcp_startup
+from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+
+
+def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
+    monkeypatch,
+):
+    sent = []
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(mobile_contract, "SERVER_VERSION", "test-version")
+    monkeypatch.setattr(mobile_contract, "SERVER_RELEASE_DATE", "test-release")
+    monkeypatch.setattr(mobile_contract, "SERVER_INSTANCE_ID", "test-instance")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "user-1",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ("conversation.read", "conversation.write"),
+    }
+
+    asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+
+    assert sent[0] == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": "test-skin",
+                "server": {
+                    "version": "test-version",
+                    "release_date": "test-release",
+                    "instance_id": "test-instance",
+                },
+                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
+                "contract": {"name": "hermes.mobile", "major": 1},
+                "schemas": {
+                    "gateway.ready": 1,
+                    "authorization.grant": 1,
+                    "authorization.error": 1,
+                },
+                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "authorization": {
+                    "subject": "user-1",
+                    "provider": "stub",
+                    "audience": "hermes.mobile",
+                    "scopes": ["conversation.read", "conversation.write"],
+                },
+            },
+        },
+    }
+
+
+def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
+    monkeypatch,
+):
+    sent = []
+    received = False
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "mobile-request",
+                        "method": "not.a.mobile.method",
+                        "params": {},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(
+        ws_mod.handle_ws(
+            FakeWS(),
+            authorization={
+                "subject": "user-1",
+                "provider": "stub",
+                "audience": "hermes.mobile",
+                "scopes": ("conversation.read",),
+            },
+        )
+    )
+
+    assert sent[1]["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "not.a.mobile.method",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read"],
+        },
+    }
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,0 +1,217 @@
+"""Public JSON-RPC conformance tests for the mobile authorization contract."""
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self, authorization=None):
+        self.authorization = authorization
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "prompt.submit",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-1",
+        "error": {
+            "code": 4030,
+            "message": "insufficient authorization scope",
+            "data": {
+                "reason": "missing_scope",
+                "method": "prompt.submit",
+                "required_scope": "conversation.write",
+                "granted_scopes": ["conversation.read"],
+            },
+        },
+    }
+
+
+def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-2",
+            "method": "shell.exec",
+            "params": {"command": "true"},
+        },
+        transport,
+    )
+
+    assert response["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "shell.exec",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read", "conversation.write"],
+        },
+    }
+
+
+def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-request",
+            "method": "approval.respond",
+            "params": {"choice": "once"},
+        },
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "method_not_available_to_mobile",
+        "method": "approval.respond",
+        "required_scope": None,
+        "granted_scopes": ["conversation.read", "conversation.write"],
+    }
+
+
+def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+    server._sessions.clear()
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-3",
+            "method": "session.active_list",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-3",
+        "result": {"sessions": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "required_scope"),
+    [
+        ("session.list", "conversation.read"),
+        ("session.active_list", "conversation.read"),
+        ("session.activate", "conversation.read"),
+        ("session.history", "conversation.read"),
+        ("session.status", "conversation.read"),
+        ("session.usage", "conversation.read"),
+        ("session.create", "conversation.write"),
+        ("session.resume", "conversation.write"),
+        ("prompt.submit", "conversation.write"),
+        ("session.interrupt", "conversation.control"),
+        ("session.steer", "conversation.control"),
+    ],
+)
+def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
+    method,
+    required_scope,
+):
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (),
+        }
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": method,
+        "required_scope": required_scope,
+        "granted_scopes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        {
+            "subject": "server-internal",
+            "provider": "server-internal",
+            "audience": "dashboard",
+            "scopes": ("*",),
+        },
+    ],
+)
+def test_legacy_and_internal_dispatch_keep_the_existing_behavior(authorization):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-request",
+            "method": "not.a.real.method",
+            "params": {},
+        },
+        RecordingTransport(authorization),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "legacy-request",
+        "error": {
+            "code": -32601,
+            "message": "unknown method: not.a.real.method",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -220,25 +220,28 @@ def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(metho
     assert response["error"]["data"]["grantable"] is False
 
 
-def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
-    authorization = _mobile_authorization(
-        "conversation.read",
-        "conversation.write",
-        "conversation.control",
+def test_mobile_dispatch_rejects_hidden_history_deletion():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "hidden-delete",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "known",
+                "text": "replace",
+                "truncate_before_user_ordinal": 1,
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
     )
 
-    delete_denial = mobile_contract.mobile_method_denial(
-        "prompt.submit",
-        authorization,
-        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
-    )
-    profile_denial = mobile_contract.mobile_method_denial(
-        "session.create",
-        authorization,
-        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
-    )
-
-    assert delete_denial == {
+    assert response["error"]["data"] == {
         "reason": "parameter_not_available_to_mobile",
         "method": "prompt.submit",
         "parameter": "truncate_before_user_ordinal",
@@ -252,10 +255,55 @@ def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters(
         ],
         "grantable": False,
     }
-    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
-    assert profile_denial["parameter"] == "messages"
-    assert profile_denial["required_scope"] == "mobile.unavailable"
-    assert profile_denial["grantable"] is False
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("close_on_disconnect", True),
+        ("cwd", "/tmp/outside"),
+        ("fast", True),
+        ("messages", [{"role": "system", "content": "override"}]),
+        ("model", "provider/model"),
+        ("parent_session_id", "parent"),
+        ("profile", "../../outside"),
+        ("provider", "custom"),
+        ("reasoning_effort", "high"),
+        ("source", "spoofed-platform"),
+    ],
+)
+def test_mobile_dispatch_rejects_each_privileged_create_parameter(
+    monkeypatch,
+    parameter,
+    value,
+):
+    def fail_if_handler_runs(_profile):
+        raise AssertionError("session.create handler ran before mobile authorization")
+
+    monkeypatch.setattr(server, "_profile_home", fail_if_handler_runs)
+    server._sessions.clear()
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "privileged-create",
+            "method": "session.create",
+            "params": {parameter: value},
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == parameter
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
+    assert server._sessions == {}
 
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
@@ -268,12 +316,13 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             self.interrupted = True
 
     agent = Agent()
+    original_transport = RecordingTransport()
     session = {
         "agent": agent,
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
-        "transport": None,
+        "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
@@ -294,7 +343,9 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     assert response["result"] == {"status": "queued"}
     assert agent.interrupted is False
+    assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
+    assert session["queued_prompt"]["transport"] is transport
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,7 +1,10 @@
 """Public JSON-RPC conformance tests for the mobile authorization contract."""
 
+import threading
+
 import pytest
 
+from tui_gateway import mobile_contract
 from tui_gateway import server
 
 
@@ -18,15 +21,17 @@ class RecordingTransport:
         pass
 
 
+def _mobile_authorization(*scopes):
+    return {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": scopes,
+    }
+
+
 def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
 
     response = server.dispatch(
         {
@@ -48,7 +53,10 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
                 "reason": "missing_scope",
                 "method": "prompt.submit",
                 "required_scope": "conversation.write",
+                "required_scopes": ["conversation.write"],
+                "missing_scopes": ["conversation.write"],
                 "granted_scopes": ["conversation.read"],
+                "grantable": True,
             },
         },
     }
@@ -56,12 +64,7 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
 
 def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -80,20 +83,18 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "shell.exec",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read", "conversation.write"],
+            "grantable": False,
         },
     }
 
 
 def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -109,20 +110,16 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     assert response["error"]["data"] == {
         "reason": "method_not_available_to_mobile",
         "method": "approval.respond",
-        "required_scope": None,
+        "required_scope": "mobile.unavailable",
+        "required_scopes": ["mobile.unavailable"],
+        "missing_scopes": ["mobile.unavailable"],
         "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": False,
     }
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
     server._sessions.clear()
 
     response = server.dispatch(
@@ -147,29 +144,19 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
     [
         ("session.list", "conversation.read"),
         ("session.active_list", "conversation.read"),
-        ("session.activate", "conversation.read"),
+        ("session.activate", "conversation.control"),
         ("session.history", "conversation.read"),
-        ("session.status", "conversation.read"),
-        ("session.usage", "conversation.read"),
         ("session.create", "conversation.write"),
-        ("session.resume", "conversation.write"),
+        ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
-        ("session.steer", "conversation.control"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
     method,
     required_scope,
 ):
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": (),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization())
 
     response = server.dispatch(
         {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
@@ -180,8 +167,142 @@ def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
         "reason": "missing_scope",
         "method": method,
         "required_scope": required_scope,
+        "required_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
+        "missing_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
         "granted_scopes": [],
+        "grantable": True,
     }
+
+
+def test_mobile_create_requires_write_and_control():
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": "session.create",
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.write", "conversation.control"],
+        "missing_scopes": ["conversation.control"],
+        "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": True,
+    }
+
+
+@pytest.mark.parametrize("method", ["session.status", "session.usage", "session.steer"])
+def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(method):
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "unavailable", "method": method, "params": {}},
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    assert response["error"]["data"]["required_scope"] == "mobile.unavailable"
+    assert response["error"]["data"]["grantable"] is False
+
+
+def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
+    authorization = _mobile_authorization(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+
+    delete_denial = mobile_contract.mobile_method_denial(
+        "prompt.submit",
+        authorization,
+        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
+    )
+    profile_denial = mobile_contract.mobile_method_denial(
+        "session.create",
+        authorization,
+        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
+    )
+
+    assert delete_denial == {
+        "reason": "parameter_not_available_to_mobile",
+        "method": "prompt.submit",
+        "parameter": "truncate_before_user_ordinal",
+        "required_scope": "conversation.delete",
+        "required_scopes": ["conversation.delete"],
+        "missing_scopes": ["conversation.delete"],
+        "granted_scopes": [
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ],
+        "grantable": False,
+    }
+    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
+    assert profile_denial["parameter"] == "messages"
+    assert profile_denial["required_scope"] == "mobile.unavailable"
+    assert profile_denial["grantable"] is False
+
+
+def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
+    monkeypatch,
+):
+    class Agent:
+        interrupted = False
+
+        def interrupt(self):
+            self.interrupted = True
+
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["busy"] = session
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "busy-write",
+            "method": "prompt.submit",
+            "params": {"session_id": "busy", "text": "next"},
+        },
+        transport,
+    )
+
+    assert response["result"] == {"status": "queued"}
+    assert agent.interrupted is False
+    assert session["queued_prompt"]["text"] == "next"
+
+
+def test_mobile_scope_grants_require_read_access():
+    with pytest.raises(
+        ValueError,
+        match="conversation.read is required for every mobile WebSocket grant",
+    ):
+        mobile_contract.normalize_mobile_scopes(["conversation.write"])
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -479,6 +479,94 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     assert "mobile_sync" not in server._sessions[sid]
 
 
+def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    legacy_payload = server._live_session_payload(
+        sid,
+        session,
+        transport=legacy,
+        cursor=cursor,
+    )
+    assert "synchronization" not in legacy_payload
+
+    server._emit("status.update", sid, {"kind": "legacy", "text": "Still here"})
+    legacy_event = legacy.frames[-1]
+    assert "sequence" not in legacy_event["params"]
+    assert "stream_id" not in legacy_event["params"]
+
+    reconnected = resume_session(mobile, stored_id, cursor)
+    recovery = reconnected["synchronization"]["recovery"]
+    assert recovery["outcome"] == "complete"
+    assert [event["params"]["type"] for event in recovery["events"]] == [
+        "status.update"
+    ]
+    assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():
+    transport = RecordingTransport()
+    sid = "first-attach"
+    session = {
+        "agent": None,
+        "conversation_id": "first-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "running": False,
+        "session_key": "first-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    start = threading.Barrier(3)
+    attached = {}
+
+    def attach():
+        start.wait()
+        attached["payload"] = server._attach_synchronization({}, sid, session)
+
+    def publish():
+        start.wait()
+        server._emit("status.update", sid, {"kind": "race", "text": "Ready"})
+
+    attach_thread = threading.Thread(target=attach)
+    publish_thread = threading.Thread(target=publish)
+    attach_thread.start()
+    publish_thread.start()
+    start.wait()
+    attach_thread.join(timeout=1)
+    publish_thread.join(timeout=1)
+    assert not attach_thread.is_alive()
+    assert not publish_thread.is_alive()
+
+    snapshot = attached["payload"]["synchronization"]["snapshot"]
+    event = next(
+        frame
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "status.update"
+    )
+    assert snapshot["stream_id"] == event["params"]["stream_id"]
+    assert session["mobile_sync"].stream_id == snapshot["stream_id"]
+
+
 def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
     transport = RecordingTransport()
     sid = "barrier-live"
@@ -491,7 +579,7 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         "history_version": 0,
         "inflight_turn": None,
         "mobile_sync": stream,
-        "mobile_sync_enabled": True,
+        "mobile_sync_retention": True,
         "running": True,
         "session_key": "barrier-stored",
         "transport": transport,
@@ -558,6 +646,53 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         event["params"]["type"]
         for event in synchronization["recovery"]["events"]
     ] == ["message.complete"]
+
+
+def test_deferred_prompt_start_advances_revision_before_agent_ready(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    entered_wait = threading.Event()
+    release_wait = threading.Event()
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+
+    def blocked_wait(_session, rid):
+        entered_wait.set()
+        assert release_wait.wait(timeout=2)
+        return server._err(rid, 5000, "test build stopped")
+
+    monkeypatch.setattr(server, "_wait_agent", blocked_wait)
+    try:
+        submitted = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "deferred-submit",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "question"},
+            },
+            transport,
+        )
+        assert submitted["result"] == {"status": "streaming"}
+        assert entered_wait.wait(timeout=1)
+
+        resumed = resume_session(transport, stored_id, cursor)
+        synchronization = resumed["synchronization"]
+        assert synchronization["snapshot"]["revision"] == initial_revision + 1
+        assert synchronization["snapshot"]["watermark"] == cursor["sequence"]
+        assert synchronization["snapshot"]["inflight_turn"]["user"] == "question"
+        assert synchronization["recovery"]["outcome"] == "complete"
+        assert synchronization["recovery"]["events"] == []
+    finally:
+        release_wait.set()
+        run_thread = server._sessions.get(sid, {}).get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(timeout=1)
 
 
 def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
@@ -649,5 +784,21 @@ def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
     assert settled["active_tools"] == []
     assert settled["messages"][-1] == {
         "role": "assistant",
-        "text": "goal\nanswer",
+        "text": "answer",
     }
+    complete = next(
+        frame
+        for frame in reversed(transport.frames)
+        if frame.get("params", {}).get("type") == "message.complete"
+    )
+    assert complete["params"]["payload"]["text"] == "answer"
+
+
+def test_conversation_root_does_not_hide_callable_attribute_errors():
+    class BrokenLineageDB:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            raise AttributeError("lineage implementation bug")
+
+    with pytest.raises(AttributeError, match="lineage implementation bug"):
+        server._conversation_root(BrokenLineageDB(), "stored")

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -444,3 +444,210 @@ def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
 
     settled = resume_session(transport, stored_id)
     assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+
+
+def test_legacy_session_keeps_original_response_and_event_shape():
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    transport = LegacyTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+
+    assert "synchronization" not in created
+    assert "mobile_sync" not in server._sessions[sid]
+
+    server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
+
+    event = transport.frames[-1]
+    assert event == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "status.update",
+            "session_id": sid,
+            "payload": {"kind": "idle", "text": "Ready"},
+        },
+    }
+    assert "mobile_sync" not in server._sessions[sid]
+
+
+def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
+    transport = RecordingTransport()
+    sid = "barrier-live"
+    stream = SessionEventStream(mobile_contract.SERVER_INSTANCE_ID)
+    session = {
+        "agent": None,
+        "conversation_id": "barrier-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "mobile_sync": stream,
+        "mobile_sync_enabled": True,
+        "running": True,
+        "session_key": "barrier-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+    cursor = stream.cursor()
+
+    entered_completion = threading.Event()
+    release_completion = threading.Event()
+    original_clear = server._clear_inflight_turn
+
+    def blocking_clear(target):
+        entered_completion.set()
+        assert release_completion.wait(timeout=2)
+        original_clear(target)
+
+    monkeypatch.setattr(server, "_clear_inflight_turn", blocking_clear)
+    completion = threading.Thread(
+        target=server._commit_prompt_completion,
+        kwargs={
+            "sid": sid,
+            "session": session,
+            "expected_history_version": 0,
+            "result_messages": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+            "payload": {"text": "answer", "status": "complete", "usage": {}},
+        },
+    )
+    completion.start()
+    assert entered_completion.wait(timeout=1)
+
+    captured = {}
+    snapshot_started = threading.Event()
+    snapshot_done = threading.Event()
+
+    def capture_snapshot():
+        snapshot_started.set()
+        captured["value"] = server._session_synchronization(sid, session, cursor)
+        snapshot_done.set()
+
+    snapshot_thread = threading.Thread(target=capture_snapshot)
+    snapshot_thread.start()
+    assert snapshot_started.wait(timeout=1)
+    assert not snapshot_done.wait(timeout=0.05)
+
+    release_completion.set()
+    completion.join(timeout=1)
+    snapshot_thread.join(timeout=1)
+    assert not completion.is_alive()
+    assert not snapshot_thread.is_alive()
+
+    synchronization = captured["value"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "question"},
+        {"role": "assistant", "text": "answer"},
+    ]
+    assert synchronization["snapshot"]["inflight_turn"] is None
+    assert synchronization["snapshot"]["watermark"] == 1
+    assert [
+        event["params"]["type"]
+        for event in synchronization["recovery"]["events"]
+    ] == ["message.complete"]
+
+
+def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    session["agent"] = object()
+    session["history"] = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    initial_watermark = created["synchronization"]["snapshot"]["watermark"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+
+    result = server._methods["session.undo"]("undo", {"session_id": sid})
+    resumed = resume_session(transport, stored_id)
+
+    assert result["result"] == {"removed": 2}
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["messages"] == []
+    assert snapshot["revision"] == initial_revision + 1
+    assert snapshot["watermark"] == initial_watermark
+
+
+def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+
+    server._mirror_subagent_to_child(
+        "subagent.start",
+        {"child_session_id": stored_id, "text": "goal"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.text",
+        {"child_session_id": stored_id, "text": "answer"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.tool",
+        {
+            "child_session_id": stored_id,
+            "tool_name": "terminal",
+            "tool_preview": "workspace command",
+        },
+    )
+
+    running = resume_session(transport, stored_id)
+    snapshot = running["synchronization"]["snapshot"]
+    assert snapshot["status"] == "working"
+    assert snapshot["inflight_turn"]["assistant"] == "goal\nanswer"
+    assert snapshot["inflight_turn"]["streaming"] is True
+    assert snapshot["active_tools"] == [
+        {
+            "tool_id": snapshot["active_tools"][0]["tool_id"],
+            "name": "terminal",
+            "started_at": snapshot["active_tools"][0]["started_at"],
+        }
+    ]
+    assert isinstance(snapshot["active_tools"][0]["started_at"], float)
+    assert "preview" not in snapshot["active_tools"][0]
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [delta["offset"] for delta in deltas] == [0, 5]
+    assert len({delta["turn_id"] for delta in deltas}) == 1
+
+    server._mirror_subagent_to_child(
+        "subagent.complete",
+        {
+            "child_session_id": stored_id,
+            "summary": "done",
+        },
+    )
+    completed = resume_session(transport, stored_id)
+    settled = completed["synchronization"]["snapshot"]
+    assert settled["status"] == "idle"
+    assert settled["inflight_turn"] is None
+    assert settled["active_tools"] == []
+    assert settled["messages"][-1] == {
+        "role": "assistant",
+        "text": "goal\nanswer",
+    }

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -1,0 +1,446 @@
+"""Public JSON-RPC conformance tests for revisioned conversation sync."""
+
+import threading
+import time
+
+import pytest
+
+from tui_gateway import mobile_contract
+from tui_gateway import server
+from tui_gateway.mobile_sync import SessionEventStream
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.authorization = {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            ),
+        }
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+class SessionDBStub:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": self.session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+@pytest.fixture(autouse=True)
+def isolated_gateway(monkeypatch):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    yield
+    server._sessions.clear()
+
+
+def create_session(transport):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "create",
+            "method": "session.create",
+            "params": {"cols": 100},
+        },
+        transport,
+    )
+    assert response is not None
+    return response["result"]
+
+
+def resume_session(transport, stored_session_id, cursor=None):
+    params = {"session_id": stored_session_id, "cols": 100}
+    if cursor is not None:
+        params["cursor"] = cursor
+    request_id = f"resume-{len(transport.frames)}"
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "session.resume",
+            "params": params,
+        },
+        transport,
+    )
+    if response is not None:
+        return response["result"]
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        responses = [
+            frame for frame in transport.frames if frame.get("id") == request_id
+        ]
+        if responses:
+            assert "error" not in responses[-1]
+            return responses[-1]["result"]
+        time.sleep(0.01)
+    raise AssertionError("session.resume response was not delivered")
+
+
+def test_create_returns_revisioned_authoritative_sync_snapshot():
+    transport = RecordingTransport()
+
+    result = create_session(transport)
+
+    synchronization = result["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert synchronization["schema_major"] == 1
+    assert snapshot == {
+        "schema_major": 1,
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": snapshot["stream_id"],
+        "revision": 1,
+        "watermark": 0,
+        "conversation_id": result["stored_session_id"],
+        "stored_session_id": result["stored_session_id"],
+        "live_session_id": result["session_id"],
+        "messages": [],
+        "inflight_turn": None,
+        "active_tools": [],
+        "pending_interactions": [],
+        "status": "idle",
+    }
+    assert synchronization["recovery"] == {
+        "outcome": "reset",
+        "reason": "cursor_missing",
+        "snapshot_required": True,
+        "events": [],
+        "cursor": {
+            "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+            "stream_id": snapshot["stream_id"],
+            "sequence": 0,
+        },
+    }
+
+
+def test_live_resume_replays_every_event_after_a_matching_cursor(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    sid = created["session_id"]
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "working", "text": "Working"})
+    server._emit("session.info", sid, {"running": True})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    synchronization = resumed["synchronization"]
+    assert resumed["session_id"] == sid
+    assert synchronization["snapshot"]["stream_id"] == cursor["stream_id"]
+    assert synchronization["snapshot"]["watermark"] == 2
+    assert synchronization["snapshot"]["revision"] == 3
+    assert synchronization["recovery"]["outcome"] == "complete"
+    assert synchronization["recovery"]["snapshot_required"] is False
+    assert [
+        event["params"]["type"] for event in synchronization["recovery"]["events"]
+    ] == ["status.update", "session.info"]
+    assert [
+        event["params"]["sequence"] for event in synchronization["recovery"]["events"]
+    ] == [1, 2]
+
+
+def test_cold_resume_has_the_same_shape_and_requires_stream_reset(monkeypatch):
+    stored_id = "stored-cold"
+    transport = RecordingTransport()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+    prior_cursor = {
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": "retired-stream",
+        "sequence": 12,
+    }
+
+    resumed = resume_session(transport, stored_id, prior_cursor)
+
+    synchronization = resumed["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert set(snapshot) == {
+        "schema_major",
+        "server_instance_id",
+        "stream_id",
+        "revision",
+        "watermark",
+        "conversation_id",
+        "stored_session_id",
+        "live_session_id",
+        "messages",
+        "inflight_turn",
+        "active_tools",
+        "pending_interactions",
+        "status",
+    }
+    assert snapshot["conversation_id"] == stored_id
+    assert snapshot["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+
+
+def test_resume_preserves_conversation_lineage_while_exposing_current_ids(
+    monkeypatch,
+):
+    class LineageDB(SessionDBStub):
+        def get_compression_lineage(self, _session_id):
+            return ["conversation-root", self.session_id]
+
+    stored_id = "compression-tip"
+    transport = RecordingTransport()
+    monkeypatch.setattr(server, "_get_db", lambda: LineageDB(stored_id))
+
+    resumed = resume_session(transport, stored_id)
+
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["conversation_id"] == "conversation-root"
+    assert snapshot["stored_session_id"] == stored_id
+    assert snapshot["live_session_id"] == resumed["session_id"]
+
+
+def test_replay_overflow_is_an_explicit_gap(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=2,
+        max_bytes=1024 * 1024,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    for index in range(3):
+        server._emit("status.update", sid, {"kind": "step", "text": str(index)})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_oversized_event_is_delivered_live_but_not_claimed_as_replayable(
+    monkeypatch,
+):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=20,
+        max_bytes=128,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "large", "text": "x" * 256})
+    assert transport.frames[-1]["params"]["sequence"] == 1
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_concurrent_session_events_are_monotonic_in_wire_order():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    start = threading.Barrier(9)
+
+    def publish(index):
+        start.wait()
+        server._emit("status.update", sid, {"kind": "worker", "text": str(index)})
+
+    threads = [threading.Thread(target=publish, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    events = [frame for frame in transport.frames if frame.get("method") == "event"]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
+
+
+def test_coalesced_deltas_carry_one_turn_identity_and_absolute_utf8_offsets():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+        turn_id = session["inflight_turn"]["turn_id"]
+    server._emit_inflight_delta(sid, session, "A💡")
+    server._emit_inflight_delta(sid, session, "B")
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert deltas == [
+        {"text": "A💡", "turn_id": turn_id, "offset": 0},
+        {"text": "B", "turn_id": turn_id, "offset": 5},
+    ]
+
+
+def test_snapshot_tracks_only_sanitized_active_tool_descriptors(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+    monkeypatch.setattr(server, "_tool_ctx", lambda _name, _args: "workspace file")
+
+    server._on_tool_start(
+        sid,
+        "tool-1",
+        "terminal",
+        {"command": "printf super-secret"},
+    )
+    running = resume_session(transport, stored_id)
+
+    descriptor = running["synchronization"]["snapshot"]["active_tools"][0]
+    assert descriptor["tool_id"] == "tool-1"
+    assert descriptor["name"] == "terminal"
+    assert isinstance(descriptor["started_at"], float)
+    assert "context" not in descriptor
+    assert "args" not in descriptor
+    assert "command" not in descriptor
+
+    server._on_tool_complete(sid, "tool-1", "terminal", {}, "{}")
+    finished = resume_session(transport, stored_id)
+    assert finished["synchronization"]["snapshot"]["active_tools"] == []
+
+
+def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    answer = {}
+
+    def ask():
+        answer["value"] = server._block(
+            "clarify.request",
+            sid,
+            {"question": "Pick one", "choices": ["A", "B"]},
+            timeout=2,
+        )
+
+    thread = threading.Thread(target=ask)
+    thread.start()
+    deadline = time.monotonic() + 1
+    request = None
+    while time.monotonic() < deadline:
+        request = next(
+            (
+                frame
+                for frame in transport.frames
+                if frame.get("params", {}).get("type") == "clarify.request"
+            ),
+            None,
+        )
+        if request is not None:
+            break
+        time.sleep(0.01)
+    assert request is not None
+    request_id = request["params"]["payload"]["request_id"]
+
+    waiting = resume_session(transport, stored_id)
+    snapshot = waiting["synchronization"]["snapshot"]
+    assert snapshot["status"] == "waiting"
+    assert snapshot["pending_interactions"] == [
+        {
+            "request_id": request_id,
+            "kind": "clarify",
+            "payload": {
+                "request_id": request_id,
+                "question": "Pick one",
+                "choices": ["A", "B"],
+            },
+        }
+    ]
+
+    response = server._methods["clarify.respond"](
+        "answer",
+        {"request_id": request_id, "answer": "A"},
+    )
+    assert response["result"] == {"status": "ok"}
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert answer == {"value": "A"}
+
+    settled = resume_session(transport, stored_id)
+    assert settled["synchronization"]["snapshot"]["pending_interactions"] == []

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -462,7 +462,7 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     sid = created["session_id"]
 
     assert "synchronization" not in created
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
 
     server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
 
@@ -476,7 +476,8 @@ def test_legacy_session_keeps_original_response_and_event_shape():
             "payload": {"kind": "idle", "text": "Ready"},
         },
     }
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
+    assert server._sessions[sid]["mobile_sync"].cursor()["sequence"] == 0
 
 
 def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
@@ -519,6 +520,116 @@ def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
         "status.update"
     ]
     assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_transport_handoffs_serialize_audience_snapshot_and_delivery(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    class BlockingWriteMobile(RecordingTransport):
+        def __init__(self, entered, release):
+            super().__init__()
+            self._entered = entered
+            self._release = release
+
+        def write(self, obj):
+            self._entered.set()
+            assert self._release.wait(timeout=2)
+            return super().write(obj)
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    blocking_mobile = BlockingWriteMobile(write_entered, release_write)
+    with session["history_lock"]:
+        server._set_session_transport_locked(session, blocking_mobile)
+
+    emitted = threading.Thread(
+        target=server._emit,
+        args=("status.update", sid, {"kind": "race", "text": "mobile"}),
+    )
+    legacy_result = {}
+
+    def attach_legacy():
+        legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    emitted.start()
+    assert write_entered.wait(timeout=1)
+    legacy_handoff = threading.Thread(target=attach_legacy)
+    legacy_handoff.start()
+    assert legacy_handoff.is_alive()
+    release_write.set()
+    emitted.join(timeout=1)
+    legacy_handoff.join(timeout=1)
+    assert not emitted.is_alive()
+    assert not legacy_handoff.is_alive()
+    mobile_event = blocking_mobile.frames[-1]
+    assert mobile_event["params"]["sequence"] == 1
+    assert "synchronization" not in legacy_result["payload"]
+
+    auth_entered = threading.Event()
+    release_auth = threading.Event()
+
+    class BlockingAuthMobile(RecordingTransport):
+        def __init__(self):
+            self._authorization = dict(RecordingTransport().authorization)
+            self.frames = []
+
+        @property
+        def authorization(self):
+            auth_entered.set()
+            assert release_auth.wait(timeout=2)
+            return self._authorization
+
+    blocking_auth_mobile = BlockingAuthMobile()
+    mobile_result = {}
+    final_legacy_result = {}
+
+    def attach_mobile():
+        mobile_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=blocking_auth_mobile,
+        )
+
+    def attach_final_legacy():
+        final_legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    mobile_handoff = threading.Thread(target=attach_mobile)
+    mobile_handoff.start()
+    assert auth_entered.wait(timeout=1)
+    final_legacy_handoff = threading.Thread(target=attach_final_legacy)
+    final_legacy_handoff.start()
+    assert final_legacy_handoff.is_alive()
+    release_auth.set()
+    mobile_handoff.join(timeout=1)
+    final_legacy_handoff.join(timeout=1)
+    assert not mobile_handoff.is_alive()
+    assert not final_legacy_handoff.is_alive()
+    assert "synchronization" in mobile_result["payload"]
+    assert "synchronization" not in final_legacy_result["payload"]
 
 
 def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -107,7 +107,8 @@ def test_live_child_session_gets_native_stream(server, emits):
     assert child[2][1] == {"text": "hmm"}
     # The rotated-out tool closes with the same id it opened with.
     assert child[3][1]["tool_id"] == first_tool["tool_id"]
-    assert child[6][1] == {"text": "done deal"}
+    assert child[6][1]["text"] == "done deal"
+    assert child[6][1]["turn_id"] == child[0][1]["turn_id"]
 
     # Parent relay is untouched alongside the mirror.
     assert [e for e, s, _ in emits if s == "parent-sid"] == [
@@ -212,9 +213,17 @@ def test_start_mirrors_as_immediate_header_line(server, emits):
     _relay(server, "subagent.progress", preview="step 1/3", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "starting child branch\n"}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {
+                "text": "starting child branch\n",
+                "turn_id": turn_id,
+                "offset": 0,
+            },
+        ),
     ]
 
 
@@ -228,10 +237,17 @@ def test_text_mirrors_as_message_delta(server, emits):
     _relay(server, "subagent.text", preview="the answer.", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "Here is "}),
-        ("message.delta", {"text": "the answer."}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {"text": "Here is ", "turn_id": turn_id, "offset": 0},
+        ),
+        (
+            "message.delta",
+            {"text": "the answer.", "turn_id": turn_id, "offset": 8},
+        ),
     ]
 
 
@@ -267,5 +283,9 @@ def test_text_routes_to_watch_transport_without_contextvar(server, monkeypatch):
         for f in frames
         if f.get("method") == "event" and f["params"]["session_id"] == "live-1"
     ]
-    assert ("message.start", "live-1", None) in routed
-    assert ("message.delta", "live-1", {"text": "streamed reply"}) in routed
+    start = next(payload for event, sid, payload in routed if event == "message.start")
+    assert (
+        "message.delta",
+        "live-1",
+        {"text": "streamed reply", "turn_id": start["turn_id"], "offset": 0},
+    ) in routed

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -12,6 +12,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
+from tui_gateway.mobile_sync import (
+    DEFAULT_REPLAY_MAX_BYTES,
+    DEFAULT_REPLAY_MAX_EVENTS,
+)
 
 MOBILE_AUDIENCE = "hermes.mobile"
 LEGACY_AUDIENCE = "dashboard"
@@ -27,13 +31,15 @@ SERVER_RELEASE_DATE = __release_date__
 # durable deployment identity remains outside this first contract slice.
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
-# Advertise only schemas this slice actually defines.  Conversation snapshots,
-# replay, mutation idempotency, and recoverable approvals land in later slices
-# and must not be inferred from Mobile Client Contract v1 alone.
+# Advertise only schemas implemented by the stacked contract slices. Mutation
+# idempotency and recoverable approvals still land later and must not be
+# inferred from Mobile Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
     "authorization.error": 1,
+    "session.synchronization": 1,
+    "session.event": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
@@ -92,7 +98,7 @@ MOBILE_METHOD_POLICIES = {
     ),
     "session.resume": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
-        frozenset({"cols", "session_id"}),
+        frozenset({"cols", "cursor", "session_id"}),
     ),
     "prompt.submit": MobileMethodPolicy(
         (CONVERSATION_WRITE_SCOPE,),
@@ -152,7 +158,17 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
             "major": MOBILE_CONTRACT_MAJOR,
         },
         "schemas": dict(CLIENT_SCHEMA_MAJORS),
-        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "capabilities": {
+            "auth.ws_scopes": {"version": 1},
+            "conversation.sync": {
+                "version": 1,
+                "delta_offsets": {"unit": "utf8_bytes"},
+                "replay": {
+                    "max_events": DEFAULT_REPLAY_MAX_EVENTS,
+                    "max_bytes": DEFAULT_REPLAY_MAX_BYTES,
+                },
+            },
+        },
         "authorization": effective_authorization(authorization),
     }
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
 
@@ -41,6 +42,11 @@ CONVERSATION_WRITE_SCOPE = "conversation.write"
 # mutation idempotency; clients must wait for that separately advertised
 # capability before treating retries as safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
+CONVERSATION_DELETE_SCOPE = "conversation.delete"
+# Error-only marker for a method or parameter that has no grantable mobile
+# scope in this contract version.  It is deliberately absent from
+# SUPPORTED_MOBILE_SCOPES; clients must also inspect ``grantable``.
+MOBILE_UNAVAILABLE_SCOPE = "mobile.unavailable"
 
 SUPPORTED_MOBILE_SCOPES = frozenset(
     {
@@ -50,18 +56,52 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
-MOBILE_METHOD_SCOPES = {
-    "session.list": CONVERSATION_READ_SCOPE,
-    "prompt.submit": CONVERSATION_WRITE_SCOPE,
-    "session.active_list": CONVERSATION_READ_SCOPE,
-    "session.activate": CONVERSATION_READ_SCOPE,
-    "session.history": CONVERSATION_READ_SCOPE,
-    "session.status": CONVERSATION_READ_SCOPE,
-    "session.usage": CONVERSATION_READ_SCOPE,
-    "session.create": CONVERSATION_WRITE_SCOPE,
-    "session.resume": CONVERSATION_WRITE_SCOPE,
-    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
-    "session.steer": CONVERSATION_CONTROL_SCOPE,
+@dataclass(frozen=True)
+class MobileMethodPolicy:
+    """Scopes and parameters that make one existing gateway method mobile-safe."""
+
+    required_scopes: tuple[str, ...]
+    allowed_parameters: frozenset[str]
+
+
+MOBILE_METHOD_POLICIES = {
+    "session.list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset(),
+    ),
+    "session.active_list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"current_session_id"}),
+    ),
+    # Activating or resuming rebinds the live transport, so read access alone
+    # is intentionally insufficient even though both responses contain history.
+    "session.activate": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    "session.history": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    # Creating a live session starts Hermes-owned workers and hooks.  It is both
+    # a conversation write and a runtime-control action, with server-derived
+    # profile/source/model/cwd rather than client-selected privileged knobs.
+    "session.create": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE, CONVERSATION_CONTROL_SCOPE),
+        frozenset({"cols", "title"}),
+    ),
+    "session.resume": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"cols", "session_id"}),
+    ),
+    "prompt.submit": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE,),
+        frozenset({"session_id", "text"}),
+    ),
+    "session.interrupt": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
 }
 
 
@@ -76,6 +116,10 @@ def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
             granted.append(scope)
     if not granted:
         raise ValueError("at least one mobile scope is required")
+    if CONVERSATION_READ_SCOPE not in granted:
+        raise ValueError(
+            "conversation.read is required for every mobile WebSocket grant"
+        )
     return tuple(granted)
 
 
@@ -113,25 +157,85 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
     }
 
 
-def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+def authorization_allows_scope(authorization: dict | None, scope: str) -> bool:
+    """Return whether a connection may perform a scope-gated side effect."""
+    grant = effective_authorization(authorization)
+    return grant["audience"] != MOBILE_AUDIENCE or scope in grant["scopes"]
+
+
+def _denial(
+    *,
+    reason: str,
+    method: str,
+    grant: dict,
+    required_scopes: tuple[str, ...],
+    grantable: bool,
+    parameter: str | None = None,
+) -> dict:
+    missing = (
+        list(required_scopes)
+        if not grantable
+        else [scope for scope in required_scopes if scope not in grant["scopes"]]
+    )
+    data = {
+        "reason": reason,
+        "method": method,
+        "required_scope": missing[0] if missing else required_scopes[0],
+        "required_scopes": list(required_scopes),
+        "missing_scopes": missing,
+        "granted_scopes": grant["scopes"],
+        "grantable": grantable,
+    }
+    if parameter is not None:
+        data["parameter"] = parameter
+    return data
+
+
+def mobile_method_denial(
+    method: str,
+    authorization: dict | None,
+    params: dict | None = None,
+) -> dict | None:
     """Describe why a mobile grant cannot call *method*, or return ``None``."""
     grant = effective_authorization(authorization)
     if grant["audience"] != MOBILE_AUDIENCE:
         return None
 
-    required_scope = MOBILE_METHOD_SCOPES.get(method)
-    if required_scope is None:
-        return {
-            "reason": "method_not_available_to_mobile",
-            "method": method,
-            "required_scope": None,
-            "granted_scopes": grant["scopes"],
-        }
-    if required_scope not in grant["scopes"]:
-        return {
-            "reason": "missing_scope",
-            "method": method,
-            "required_scope": required_scope,
-            "granted_scopes": grant["scopes"],
-        }
+    policy = MOBILE_METHOD_POLICIES.get(method)
+    if policy is None:
+        return _denial(
+            reason="method_not_available_to_mobile",
+            method=method,
+            grant=grant,
+            required_scopes=(MOBILE_UNAVAILABLE_SCOPE,),
+            grantable=False,
+        )
+
+    params = params or {}
+    unsupported_parameters = sorted(set(params) - policy.allowed_parameters)
+    if unsupported_parameters:
+        parameter = unsupported_parameters[0]
+        required_scope = (
+            CONVERSATION_DELETE_SCOPE
+            if method == "prompt.submit"
+            and parameter == "truncate_before_user_ordinal"
+            else MOBILE_UNAVAILABLE_SCOPE
+        )
+        return _denial(
+            reason="parameter_not_available_to_mobile",
+            method=method,
+            parameter=parameter,
+            grant=grant,
+            required_scopes=(required_scope,),
+            grantable=False,
+        )
+
+    if any(scope not in grant["scopes"] for scope in policy.required_scopes):
+        return _denial(
+            reason="missing_scope",
+            method=method,
+            grant=grant,
+            required_scopes=policy.required_scopes,
+            grantable=True,
+        )
     return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -1,0 +1,137 @@
+"""Versioned authorization contract for native/mobile gateway clients.
+
+This module is deliberately transport-only: it defines what a scoped client
+may ask the existing TUI JSON-RPC gateway to do. It does not introduce a new
+runtime or duplicate any Hermes-owned session state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from hermes_cli import __release_date__, __version__
+
+MOBILE_AUDIENCE = "hermes.mobile"
+LEGACY_AUDIENCE = "dashboard"
+PROTOCOL_NAME = "hermes.tui.jsonrpc"
+PROTOCOL_MAJOR = 1
+MOBILE_CONTRACT_NAME = "hermes.mobile"
+MOBILE_CONTRACT_MAJOR = 1
+
+SERVER_VERSION = __version__
+SERVER_RELEASE_DATE = __release_date__
+# A new server process is a new event-stream authority.  This identity is
+# intentionally stable across connections but changes after process restart;
+# durable deployment identity remains outside this first contract slice.
+SERVER_INSTANCE_ID = str(uuid.uuid4())
+
+# Advertise only schemas this slice actually defines.  Conversation snapshots,
+# replay, mutation idempotency, and recoverable approvals land in later slices
+# and must not be inferred from Mobile Client Contract v1 alone.
+CLIENT_SCHEMA_MAJORS = {
+    "gateway.ready": 1,
+    "authorization.grant": 1,
+    "authorization.error": 1,
+}
+
+CONVERSATION_READ_SCOPE = "conversation.read"
+CONVERSATION_WRITE_SCOPE = "conversation.write"
+# This scope is an authorization boundary only.  It does not claim durable
+# mutation idempotency; clients must wait for that separately advertised
+# capability before treating retries as safe.
+CONVERSATION_CONTROL_SCOPE = "conversation.control"
+
+SUPPORTED_MOBILE_SCOPES = frozenset(
+    {
+        CONVERSATION_READ_SCOPE,
+        CONVERSATION_WRITE_SCOPE,
+        CONVERSATION_CONTROL_SCOPE,
+    }
+)
+
+MOBILE_METHOD_SCOPES = {
+    "session.list": CONVERSATION_READ_SCOPE,
+    "prompt.submit": CONVERSATION_WRITE_SCOPE,
+    "session.active_list": CONVERSATION_READ_SCOPE,
+    "session.activate": CONVERSATION_READ_SCOPE,
+    "session.history": CONVERSATION_READ_SCOPE,
+    "session.status": CONVERSATION_READ_SCOPE,
+    "session.usage": CONVERSATION_READ_SCOPE,
+    "session.create": CONVERSATION_WRITE_SCOPE,
+    "session.resume": CONVERSATION_WRITE_SCOPE,
+    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
+    "session.steer": CONVERSATION_CONTROL_SCOPE,
+}
+
+
+def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested mobile authorization grant."""
+    granted: list[str] = []
+    for raw in scopes:
+        scope = str(raw or "").strip()
+        if not scope or scope not in SUPPORTED_MOBILE_SCOPES:
+            raise ValueError(f"unsupported mobile scope: {scope or '<empty>'}")
+        if scope not in granted:
+            granted.append(scope)
+    if not granted:
+        raise ValueError("at least one mobile scope is required")
+    return tuple(granted)
+
+
+def effective_authorization(raw: dict | None = None) -> dict:
+    """Return the stable, JSON-safe authorization grant exposed to a client."""
+    raw = raw or {}
+    scopes = raw.get("scopes", ("*",))
+    if not isinstance(scopes, (list, tuple)):
+        scopes = (str(scopes),)
+    return {
+        "subject": str(raw.get("subject") or raw.get("user_id") or "legacy"),
+        "provider": str(raw.get("provider") or "legacy"),
+        "audience": str(raw.get("audience") or LEGACY_AUDIENCE),
+        "scopes": [str(scope) for scope in scopes],
+    }
+
+
+def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> dict:
+    """Build the additive first-frame contract for every WebSocket client."""
+    return {
+        "skin": skin,
+        "server": {
+            "version": SERVER_VERSION,
+            "release_date": SERVER_RELEASE_DATE,
+            "instance_id": SERVER_INSTANCE_ID,
+        },
+        "protocol": {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR},
+        "contract": {
+            "name": MOBILE_CONTRACT_NAME,
+            "major": MOBILE_CONTRACT_MAJOR,
+        },
+        "schemas": dict(CLIENT_SCHEMA_MAJORS),
+        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "authorization": effective_authorization(authorization),
+    }
+
+
+def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+    """Describe why a mobile grant cannot call *method*, or return ``None``."""
+    grant = effective_authorization(authorization)
+    if grant["audience"] != MOBILE_AUDIENCE:
+        return None
+
+    required_scope = MOBILE_METHOD_SCOPES.get(method)
+    if required_scope is None:
+        return {
+            "reason": "method_not_available_to_mobile",
+            "method": method,
+            "required_scope": None,
+            "granted_scopes": grant["scopes"],
+        }
+    if required_scope not in grant["scopes"]:
+        return {
+            "reason": "missing_scope",
+            "method": method,
+            "required_scope": required_scope,
+            "granted_scopes": grant["scopes"],
+        }
+    return None

--- a/tui_gateway/mobile_sync.py
+++ b/tui_gateway/mobile_sync.py
@@ -1,0 +1,241 @@
+"""Revisioned conversation snapshots and bounded session-event replay.
+
+The synchronization boundary is one lock per live session stream.  Callers
+mutate snapshot-visible state, allocate the matching event sequence, and queue
+that event for transport while this lock is held.  Snapshot capture takes the
+conversation history lock first and this stream lock second.  A snapshot's
+``watermark`` therefore covers every state transition published before it;
+clients install the snapshot at that watermark and apply only events with a
+larger sequence.
+
+Replay is intentionally process-local and bounded.  A process restart changes
+``server_instance_id`` and rebuilding a live session changes ``stream_id``;
+either condition produces an explicit reset instead of pretending replay is
+complete.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import uuid
+from collections import deque
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+SYNC_SCHEMA_MAJOR = 1
+EVENT_SCHEMA_MAJOR = 1
+DEFAULT_REPLAY_MAX_EVENTS = 512
+DEFAULT_REPLAY_MAX_BYTES = 1024 * 1024
+
+
+class SessionEventStream:
+    """Thread-safe synchronization authority for one live Hermes session."""
+
+    def __init__(
+        self,
+        server_instance_id: str,
+        *,
+        max_events: int = DEFAULT_REPLAY_MAX_EVENTS,
+        max_bytes: int = DEFAULT_REPLAY_MAX_BYTES,
+    ) -> None:
+        self.server_instance_id = str(server_instance_id)
+        self.stream_id = str(uuid.uuid4())
+        self.max_events = max(1, int(max_events))
+        self.max_bytes = max(1, int(max_bytes))
+        self._lock = threading.RLock()
+        self._sequence = 0
+        self._revision = 1
+        self._discarded_through = 0
+        self._replay_bytes = 0
+        self._replay: deque[tuple[int, int, dict[str, Any]]] = deque()
+        self._active_tools: dict[str, dict[str, Any]] = {}
+        self._pending_interactions: dict[str, dict[str, Any]] = {}
+
+    def track_tool(self, descriptor: dict[str, Any]) -> None:
+        tool_id = str(descriptor.get("tool_id") or "")
+        if tool_id:
+            self._active_tools[tool_id] = copy.deepcopy(descriptor)
+
+    def finish_tool(self, tool_id: str) -> None:
+        self._active_tools.pop(str(tool_id), None)
+
+    def track_pending_interaction(self, descriptor: dict[str, Any]) -> None:
+        request_id = str(descriptor.get("request_id") or "")
+        if request_id:
+            self._pending_interactions[request_id] = copy.deepcopy(descriptor)
+
+    def finish_pending_interaction(self, request_id: str) -> None:
+        """Remove state that has no legacy completion event.
+
+        The revision changes so the next authoritative snapshot cannot compare
+        equal to one that still contained the interaction.  The future
+        addressable-approval slice can replace this with an explicit lifecycle
+        event without changing the synchronization envelope.
+        """
+        with self._lock:
+            if self._pending_interactions.pop(str(request_id), None) is not None:
+                self._revision += 1
+
+    def mutate(self, update: Callable[[SessionEventStream], None]) -> None:
+        """Apply snapshot-only state when the legacy protocol emits no event."""
+        with self._lock:
+            update(self)
+            self._revision += 1
+
+    @contextmanager
+    def transition(self, update: Callable[[SessionEventStream], None]):
+        """Keep a state update and the caller's event publication atomic."""
+        with self._lock:
+            update(self)
+            yield
+
+    def publish(
+        self,
+        event: str,
+        session_id: str,
+        payload: dict[str, Any] | None,
+        deliver: Callable[[dict[str, Any]], Any],
+        *,
+        update: Callable[[SessionEventStream], None] | None = None,
+    ) -> dict[str, Any]:
+        """Allocate, retain, and deliver one event in monotonic wire order."""
+        with self._lock:
+            retained_payload = copy.deepcopy(payload) if payload is not None else None
+            if update is not None:
+                update(self)
+            self._sequence += 1
+            self._revision += 1
+            params: dict[str, Any] = {
+                "type": event,
+                "session_id": session_id,
+                "schema_major": EVENT_SCHEMA_MAJOR,
+                "stream_id": self.stream_id,
+                "sequence": self._sequence,
+            }
+            if retained_payload is not None:
+                params["payload"] = retained_payload
+            frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+            retained = copy.deepcopy(frame)
+            try:
+                size = len(
+                    json.dumps(
+                        retained,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+            except (TypeError, ValueError):
+                # A malformed event cannot be replayed. Preserve the explicit
+                # gap invariant even if its producer catches serialization.
+                self._discard_all_through(self._sequence)
+                raise
+            self._retain(self._sequence, size, retained)
+            # Keep delivery under the stream lock so concurrent publishers
+            # cannot put sequence N+1 on the transport before sequence N.
+            deliver(frame)
+            return copy.deepcopy(frame)
+
+    def synchronization(
+        self,
+        snapshot_factory: Callable[[dict[str, Any]], dict[str, Any]],
+        cursor: object = None,
+    ) -> dict[str, Any]:
+        """Capture one authoritative snapshot and classify cursor recovery."""
+        with self._lock:
+            watermark = self._sequence
+            snapshot = snapshot_factory({
+                "active_tools": copy.deepcopy(list(self._active_tools.values())),
+                "pending_interactions": copy.deepcopy(
+                    list(self._pending_interactions.values())
+                ),
+            })
+            snapshot.update({
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "server_instance_id": self.server_instance_id,
+                "stream_id": self.stream_id,
+                "revision": self._revision,
+                "watermark": watermark,
+            })
+            recovery = self._recovery(cursor, watermark)
+            return {
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "snapshot": snapshot,
+                "recovery": recovery,
+            }
+
+    def cursor(self) -> dict[str, Any]:
+        with self._lock:
+            return self._cursor(self._sequence)
+
+    def _retain(self, sequence: int, size: int, frame: dict[str, Any]) -> None:
+        if size > self.max_bytes:
+            self._discard_all_through(sequence)
+            return
+        self._replay.append((sequence, size, frame))
+        self._replay_bytes += size
+        while (
+            len(self._replay) > self.max_events or self._replay_bytes > self.max_bytes
+        ):
+            evicted_sequence, evicted_size, _ = self._replay.popleft()
+            self._replay_bytes -= evicted_size
+            self._discarded_through = max(
+                self._discarded_through,
+                evicted_sequence,
+            )
+
+    def _discard_all_through(self, sequence: int) -> None:
+        self._replay.clear()
+        self._replay_bytes = 0
+        self._discarded_through = max(self._discarded_through, sequence)
+
+    def _cursor(self, sequence: int) -> dict[str, Any]:
+        return {
+            "server_instance_id": self.server_instance_id,
+            "stream_id": self.stream_id,
+            "sequence": sequence,
+        }
+
+    def _recovery(self, cursor: object, watermark: int) -> dict[str, Any]:
+        current = self._cursor(watermark)
+        base: dict[str, Any] = {
+            "cursor": current,
+            "events": [],
+            "snapshot_required": True,
+        }
+        if not isinstance(cursor, dict):
+            return {**base, "outcome": "reset", "reason": "cursor_missing"}
+        if cursor.get("server_instance_id") != self.server_instance_id:
+            return {
+                **base,
+                "outcome": "reset",
+                "reason": "server_instance_changed",
+            }
+        if cursor.get("stream_id") != self.stream_id:
+            return {**base, "outcome": "reset", "reason": "stream_changed"}
+        raw_sequence = cursor.get("sequence")
+        if isinstance(raw_sequence, bool) or not isinstance(raw_sequence, int):
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        sequence = raw_sequence
+        if sequence < 0 or sequence > watermark:
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        if sequence < self._discarded_through:
+            return {
+                **base,
+                "outcome": "gap",
+                "reason": "replay_evicted",
+                "available_after": self._discarded_through,
+            }
+        events = [
+            copy.deepcopy(frame)
+            for event_sequence, _size, frame in self._replay
+            if sequence < event_sequence <= watermark
+        ]
+        return {
+            **base,
+            "outcome": "complete",
+            "events": events,
+            "snapshot_required": False,
+        }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1205,8 +1205,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, *, data: dict | None = None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):
@@ -1268,6 +1271,16 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        from tui_gateway.mobile_contract import mobile_method_denial
+
+        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        if denial is not None:
+            return _err(
+                _rid,
+                4030,
+                "insufficient authorization scope",
+                data=denial,
+            )
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1273,7 +1273,11 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
         _rid, method, _params = normalized
         from tui_gateway.mobile_contract import mobile_method_denial
 
-        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        denial = mobile_method_denial(
+            method,
+            getattr(t, "authorization", None),
+            _params,
+        )
         if denial is not None:
             return _err(
                 _rid,
@@ -5101,7 +5105,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     session["queued_prompt"] = {"text": text, "transport": transport}
 
 
-def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any) -> dict:
+def _handle_busy_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    allow_control: bool = True,
+) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
 
@@ -5116,6 +5128,14 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
     without interrupting; ``steer`` → inject into the live turn if accepted,
     else queue.
     """
+    # A scoped writer may enqueue the next user turn, but must not inherit the
+    # dashboard's interrupt/steer preference unless its connection also holds
+    # conversation.control.
+    if not allow_control:
+        _enqueue_prompt(session, text, transport)
+        session["last_active"] = time.time()
+        return _ok(rid, {"status": "queued"})
+
     mode = _load_busy_input_mode()
     agent = session.get("agent")
     if mode == "steer" and agent is not None and hasattr(agent, "steer"):
@@ -8137,7 +8157,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.interrupt")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Interrupting a deferred/lazy session must not build the very agent the
+    # caller is trying to stop. Operate on live state only.
+    session, err = _sess_nowait(params, rid)
     if err:
         return err
     # Safety net: if the turn's run thread is already gone but `running` stayed
@@ -8459,7 +8481,23 @@ def _(rid, params: dict) -> dict:
             # interrupt the live turn) so it runs as the next turn. See
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
-            return _handle_busy_submit(rid, sid, session, text, t or session.get("transport"))
+            active_transport = t or session.get("transport")
+            from tui_gateway.mobile_contract import (
+                CONVERSATION_CONTROL_SCOPE,
+                authorization_allows_scope,
+            )
+
+            return _handle_busy_submit(
+                rid,
+                sid,
+                session,
+                text,
+                active_transport,
+                allow_control=authorization_allows_scope(
+                    getattr(active_transport, "authorization", None),
+                    CONVERSATION_CONTROL_SCOPE,
+                ),
+            )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1149,13 +1149,35 @@ def _session_event_stream(session: dict) -> SessionEventStream:
     return stream
 
 
+def _session_sync_enabled(session: dict) -> bool:
+    """Return whether this live session negotiated revisioned mobile sync.
+
+    Legacy stdio and Desktop clients retain the original response/event shape
+    and avoid replay copies.  Once a mobile transport attaches, keep retention
+    enabled for the rest of the live stream so a later reconnect can replay
+    events emitted while the socket was detached.
+    """
+    if session.get("mobile_sync_enabled"):
+        return True
+    transport = session.get("transport") or current_transport()
+    authorization = getattr(transport, "authorization", None)
+    if not isinstance(authorization, dict):
+        return False
+    from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
+
+    if effective_authorization(authorization)["audience"] != MOBILE_AUDIENCE:
+        return False
+    session["mobile_sync_enabled"] = True
+    return True
+
+
 def _emit(
     event: str,
     sid: str,
     payload: dict | None = None,
 ):
     session = _sessions.get(sid)
-    if session is not None:
+    if session is not None and _session_sync_enabled(session):
         return _session_event_stream(session).publish(
             event,
             sid,
@@ -1176,6 +1198,15 @@ def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
         return _emit(event, sid, payload)
     with _session_event_stream(session).transition(update):
         return _emit(event, sid, payload)
+
+
+def _mark_snapshot_mutation(session: dict) -> None:
+    """Advance the snapshot revision for a state change with no wire event.
+
+    Callers hold ``history_lock`` first, preserving the same history -> stream
+    lock order used by snapshot capture and event publication.
+    """
+    _session_event_stream(session).mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -2513,6 +2544,7 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         with lock:
             session.setdefault("history", []).append(entry)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     else:
         session.setdefault("history", []).append(entry)
         session["history_version"] = int(session.get("history_version", 0)) + 1
@@ -3170,6 +3202,7 @@ def _compress_session_history(
             return 0, usage
         session["history"] = compressed
         session["history_version"] = history_version + 1
+        _mark_snapshot_mutation(session)
     usage = _get_usage(agent)
     return len(history) - len(compressed), usage
 
@@ -3913,12 +3946,36 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         with _child_mirrors_lock:
             _child_mirrors.pop(child_key, None)
         return
-    csid = live[0]
+    csid, child_session = live
+    history_lock = child_session.setdefault("history_lock", threading.RLock())
+    child_session.setdefault("history", [])
+    child_session.setdefault("history_version", 0)
+    child_session.setdefault("inflight_turn", None)
+    child_session.setdefault("running", False)
+
+    def finish_open_tool(tool: dict | None) -> None:
+        if not tool:
+            return
+        tool_id = str(tool.get("tool_id") or "")
+        _emit_with_sync_update(
+            "tool.complete",
+            csid,
+            tool,
+            lambda stream: stream.finish_tool(tool_id),
+        )
+
     with _child_mirrors_lock:
         st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
         if not st["started"]:
             st["started"] = True
-            _emit("message.start", csid)
+            with history_lock:
+                child_session["running"] = True
+                if not isinstance(child_session.get("inflight_turn"), dict):
+                    _start_inflight_turn(child_session, "")
+                turn_id = str(
+                    (child_session.get("inflight_turn") or {}).get("turn_id") or ""
+                )
+                _emit("message.start", csid, {"turn_id": turn_id})
         if event_type == "subagent.thinking":
             if text := str(payload.get("text") or ""):
                 _emit("reasoning.delta", csid, {"text": text})
@@ -3927,15 +3984,14 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             # Relayed token-by-token from the child's run_conversation
             # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": text})
+                _emit_inflight_delta(csid, child_session, text)
         elif event_type == "subagent.start":
             # One-time header line (the child's goal) so a freshly opened window
             # shows immediate context before the first reply token streams.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": f"{text}\n"})
+                _emit_inflight_delta(csid, child_session, f"{text}\n")
         elif event_type == "subagent.tool":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
             st["seq"] += 1
             tool = {
                 "name": str(payload.get("tool_name") or "tool"),
@@ -3945,12 +4001,43 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             if preview := str(payload.get("tool_preview") or payload.get("text") or ""):
                 tool["preview"] = preview
             st["open_tool"] = tool
-            _emit("tool.start", csid, tool)
+            descriptor = {
+                "tool_id": tool["tool_id"],
+                "name": tool["name"],
+                "started_at": time.time(),
+            }
+            _emit_with_sync_update(
+                "tool.start",
+                csid,
+                tool,
+                lambda stream: stream.track_tool(descriptor),
+            )
         elif event_type == "subagent.complete":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
+            st["open_tool"] = None
             summary = str(payload.get("summary") or payload.get("text") or "")
-            _emit("message.complete", csid, {"text": summary})
+            with history_lock:
+                turn = child_session.get("inflight_turn") or {}
+                turn_id = str(turn.get("turn_id") or "")
+                assistant = str(turn.get("assistant") or "")
+                final_text = assistant or summary
+                history = child_session.setdefault("history", [])
+                if final_text and not (
+                    history
+                    and history[-1].get("role") == "assistant"
+                    and history[-1].get("content") == final_text
+                ):
+                    history.append({"role": "assistant", "content": final_text})
+                    child_session["history_version"] = int(
+                        child_session.get("history_version", 0)
+                    ) + 1
+                child_session["running"] = False
+                _clear_inflight_turn(child_session)
+                _emit(
+                    "message.complete",
+                    csid,
+                    {"text": summary or final_text, "turn_id": turn_id},
+                )
             _child_mirrors.pop(child_key, None)
 
 
@@ -4194,6 +4281,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         info = _session_info(agent)
         _emit("session.info", sid, info)
         return False, info
@@ -4445,6 +4533,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
+        _mark_snapshot_mutation(session)
     info = _session_info(new_agent, session)
     _emit("session.info", sid, info)
     _restart_slash_worker(sid, session)
@@ -4754,7 +4843,6 @@ def _init_session(
             "history_version": 0,
             "inflight_turn": None,
             "conversation_id": key,
-            "mobile_sync": _new_session_event_stream(),
             "created_at": now,
             "last_active": now,
             "running": False,
@@ -5313,17 +5401,21 @@ def _inflight_snapshot(
     return snapshot
 
 
-def _new_session_event_stream() -> SessionEventStream:
-    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
-
-    return SessionEventStream(SERVER_INSTANCE_ID)
-
-
 def _conversation_root(db, session_id: str) -> str:
     try:
         lineage = db.get_compression_lineage(session_id)
-    except Exception:
+    except AttributeError:
+        # Compatibility with old/embedded SessionDB stubs that predate
+        # compression lineage. Unexpected database failures must not silently
+        # change a conversation's supposedly stable identity to its current tip.
         lineage = []
+    except Exception:
+        logger.warning(
+            "failed to resolve stable conversation lineage for %s",
+            session_id,
+            exc_info=True,
+        )
+        raise
     return str(
         lineage[0]
         if isinstance(lineage, (list, tuple)) and lineage
@@ -5373,6 +5465,8 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
+    if not _session_sync_enabled(session):
+        return payload
     payload["synchronization"] = _session_synchronization(sid, session, cursor)
     return payload
 
@@ -5463,7 +5557,6 @@ def _(rid, params: dict) -> dict:
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
-            "mobile_sync": _new_session_event_stream(),
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id,
@@ -5720,7 +5813,6 @@ def _deferred_session_record(
         "last_active": now,
         "lazy": lazy,
         "model_override": model_override,
-        "mobile_sync": _new_session_event_stream(),
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
         "resume_runtime_overrides": resume_runtime_overrides,
@@ -6148,7 +6240,6 @@ def _(rid, params: dict) -> dict:
                 "history": history,
                 "history_lock": threading.Lock(),
                 "inflight_turn": None,
-                "mobile_sync": _new_session_event_stream(),
                 "running": False,
                 "session_key": target,
             }
@@ -6157,7 +6248,6 @@ def _(rid, params: dict) -> dict:
             session.setdefault("history", history)
             session.setdefault("history_lock", threading.Lock())
             session.setdefault("inflight_turn", None)
-            session.setdefault("mobile_sync", _new_session_event_stream())
             session.setdefault("running", False)
         session["conversation_id"] = conversation_id
     payload = {
@@ -8135,6 +8225,7 @@ def _(rid, params: dict) -> dict:
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     return _ok(rid, {"removed": removed})
 
 
@@ -8412,6 +8503,7 @@ def _(rid, params: dict) -> dict:
             if session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
 
     # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
     # foreground subprocess). Background processes the agent started (dev servers,
@@ -8705,6 +8797,13 @@ def _(rid, params: dict) -> dict:
     # must not seize the in-flight turn from the currently attached client.
     t = current_transport()
     with session["history_lock"]:
+        # A watch session's run lives in the PARENT turn. Reject before the
+        # ordinary busy/queue path: queuing onto a lazy mirror would otherwise
+        # build a second agent against the child's still-running transcript.
+        if session.get("lazy") and _child_run_active(
+            str(session.get("session_key") or "")
+        ):
+            return _err(rid, 4009, "subagent still running — wait for it to finish")
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
             # interrupt the live turn) so it runs as the next turn. See
@@ -8730,13 +8829,6 @@ def _(rid, params: dict) -> dict:
                 active_transport,
                 allow_control=allow_control,
             )
-        # A watch session's run lives in the PARENT turn, so its own running
-        # flag is False — without this, typing mid-run builds a second agent
-        # racing the in-flight child on the same stored session (interleaved
-        # transcript, stale fork). After the run completes, submitting is fine:
-        # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
-            return _err(rid, 4009, "subagent still running — wait for it to finish")
         if t is not None:
             session["transport"] = t
         if truncate_user_ordinal is not None:
@@ -8756,6 +8848,7 @@ def _(rid, params: dict) -> dict:
             truncated = history[: user_indices[ordinal]]
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
             if (db := _get_db()) is not None:
                 try:
                     db.replace_messages(session["session_key"], truncated)
@@ -8788,11 +8881,13 @@ def _(rid, params: dict) -> dict:
             with session["history_lock"]:
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             return
         with session["history_lock"]:
             if session.get("_turn_cancel_requested") or not session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
                 return
         _run_prompt_submit(rid, sid, session, text)
 
@@ -9182,6 +9277,49 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _commit_prompt_completion(
+    sid: str,
+    session: dict,
+    *,
+    expected_history_version: int,
+    result_messages: list | None,
+    payload: dict[str, Any],
+) -> str | None:
+    """Publish final history and completion at one snapshot/event barrier."""
+    status_note = None
+    with session["history_lock"]:
+        if result_messages is not None:
+            current_version = int(session.get("history_version", 0))
+            if current_version == expected_history_version:
+                session["history"] = result_messages
+                session["history_version"] = expected_history_version + 1
+            else:
+                # History mutated externally during the turn
+                # (undo/compress/retry/rollback guard on session.running, but
+                # this is the defensive backstop for any path that slips past).
+                # Surface the desync rather than silently dropping output.
+                print(
+                    f"[tui_gateway] prompt.submit: history_version mismatch "
+                    f"(expected={expected_history_version} current={current_version}) — "
+                    f"agent output NOT written to session history",
+                    file=sys.stderr,
+                )
+                status_note = (
+                    "History changed during this turn — the response above is visible "
+                    "but was not saved to session history."
+                )
+                payload["warning"] = status_note
+
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        payload["turn_id"] = turn_id
+        _clear_inflight_turn(session)
+        # _emit allocates the stream sequence while history_lock is still held.
+        # Snapshot capture takes the same locks in this order, so it can observe
+        # either the streaming turn or the completed history, never a mixture.
+        _emit("message.complete", sid, payload)
+    return status_note
+
+
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
         history = list(session["history"])
@@ -9381,33 +9519,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     session["model_override"] = _restore
 
             last_reasoning = None
-            status_note = None
+            result_messages = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
-                    with session["history_lock"]:
-                        current_version = int(session.get("history_version", 0))
-                        if current_version == history_version:
-                            session["history"] = result["messages"]
-                            session["history_version"] = history_version + 1
-                        else:
-                            # History mutated externally during the turn
-                            # (undo/compress/retry/rollback now guard on
-                            # session.running, but this is the defensive
-                            # backstop for any path that slips past).
-                            # Surface the desync rather than silently
-                            # dropping the agent's output — the UI can
-                            # show the response and warn that it was
-                            # not persisted.
-                            print(
-                                f"[tui_gateway] prompt.submit: history_version mismatch "
-                                f"(expected={history_version} current={current_version}) — "
-                                f"agent output NOT written to session history",
-                                file=sys.stderr,
-                            )
-                            status_note = (
-                                "History changed during this turn — the response above is visible "
-                                "but was not saved to session history."
-                            )
+                    result_messages = result["messages"]
 
                 # If auto-compression fired inside run_conversation(), agent.session_id
                 # may have rotated. Sync session_key before downstream title/goal/finalize
@@ -9447,18 +9562,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
-            if status_note:
-                payload["warning"] = status_note
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
-            with session["history_lock"]:
-                turn_id = str(
-                    (session.get("inflight_turn") or {}).get("turn_id") or ""
-                )
-                payload["turn_id"] = turn_id
-                _clear_inflight_turn(session)
-                _emit("message.complete", sid, payload)
+            _commit_prompt_completion(
+                sid,
+                session,
+                expected_history_version=history_version,
+                result_messages=result_messages,
+                payload=payload,
+            )
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge
@@ -9612,6 +9725,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             _emit("session.info", sid, _session_info(agent, session))
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
@@ -12371,6 +12485,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = history[:last_user_idx]
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         return _ok(rid, {"type": "send", "message": content})
 
     if name == "steer":
@@ -12517,6 +12632,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = list(active)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         # Notify memory providers — same hook /branch fires, plus the
         # rewound flag so providers caching per-turn document state
         # know to invalidate. See #6672 + #21910.
@@ -13900,6 +14016,7 @@ def _(rid, params: dict) -> dict:
                         session["history_version"] = (
                             int(session.get("history_version", 0)) + 1
                         )
+                        _mark_snapshot_mutation(session)
                 result["history_removed"] = removed
             return result
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -815,6 +815,7 @@ def _close_sessions_for_transport(
     detached = 0
     for sid, session in owned:
         claimed = False
+        close_claim = False
         with session.setdefault("history_lock", threading.RLock()):
             stream = _session_event_stream(session)
             with stream.transition(lambda _stream: None):
@@ -822,13 +823,23 @@ def _close_sessions_for_transport(
                 # socket may detach only if it still owns the session at this
                 # exact handoff boundary.
                 if session.get("transport") is transport:
-                    claimed = True
-                    if not session.get("close_on_disconnect"):
+                    if session.get("close_on_disconnect"):
+                        # Pop while the transport handoff boundary is still
+                        # held. A resume/activate that already captured this
+                        # record will recheck membership before rebinding.
+                        with _sessions_lock:
+                            if _sessions.get(sid) is session:
+                                _sessions.pop(sid, None)
+                                session["_sid"] = sid
+                                claimed = True
+                                close_claim = True
+                    else:
                         session["transport"] = _detached_ws_transport
+                        claimed = True
         if not claimed:
             continue
-        if session.get("close_on_disconnect"):
-            _close_session_by_id(sid, end_reason=end_reason)
+        if close_claim:
+            _teardown_session(session, end_reason=end_reason)
             reaped += 1
         else:
             # Point detached sessions at the drop sentinel (NOT real stdio) so
@@ -6001,7 +6012,7 @@ def _(rid, params: dict) -> dict:
     )
     conversation_id = _conversation_root(db, target)
 
-    def _reuse_live_payload(sid: str, session: dict) -> dict:
+    def _reuse_live_payload(sid: str, session: dict) -> dict | None:
         payload = _live_session_payload(
             sid,
             session,
@@ -6010,6 +6021,8 @@ def _(rid, params: dict) -> dict:
             transport=current_transport() or _stdio_transport,
             cursor=params.get("cursor"),
         )
+        if payload is None:
+            return None
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
         # flag is always False — overlay the child-run registry so a reconnecting
@@ -6023,7 +6036,9 @@ def _(rid, params: dict) -> dict:
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
-            return _ok(rid, _reuse_live_payload(*live))
+            payload = _reuse_live_payload(*live)
+            if payload is not None:
+                return _ok(rid, payload)
 
     # Lazy/watch resume: register the live session WITHOUT building an agent.
     # Used by the desktop's subagent windows — the child runs inside the
@@ -6245,13 +6260,6 @@ def _(rid, params: dict) -> dict:
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
-            try:
-                if hasattr(agent, "close"):
-                    agent.close()
-            except Exception:
-                pass
-            if lease is not None:
-                lease.release()
             other_sid, other_session = live
             payload = _live_session_payload(
                 other_sid,
@@ -6261,8 +6269,16 @@ def _(rid, params: dict) -> dict:
                 transport=current_transport() or _stdio_transport,
                 cursor=params.get("cursor"),
             )
-            payload["resumed"] = target
-            return _ok(rid, payload)
+            if payload is not None:
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                if lease is not None:
+                    lease.release()
+                payload["resumed"] = target
+                return _ok(rid, payload)
         try:
             init_home_token = (
                 set_hermes_home_override(str(profile_home))
@@ -6473,11 +6489,14 @@ def _live_session_payload(
     touch: bool = False,
     transport: Transport | None = None,
     cursor: object = None,
-) -> dict:
+) -> dict | None:
     info = _fallback_session_info(session)
     with session["history_lock"]:
         stream = _session_event_stream(session)
         with stream.transition(lambda _stream: None):
+            with _sessions_lock:
+                if _sessions.get(sid) is not session:
+                    return None
             if cols is not None:
                 session["cols"] = cols
             if transport is not None:
@@ -6563,15 +6582,15 @@ def _(rid, params: dict) -> dict:
         return err
     assert session is not None
 
-    return _ok(
-        rid,
-        _live_session_payload(
-            sid,
-            session,
-            touch=True,
-            transport=current_transport() or _stdio_transport,
-        ),
+    payload = _live_session_payload(
+        sid,
+        session,
+        touch=True,
+        transport=current_transport() or _stdio_transport,
     )
+    if payload is None:
+        return _err(rid, 4001, "session closed during transport handoff")
+    return _ok(rid, payload)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -28,6 +28,7 @@ from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
+from tui_gateway.mobile_sync import SessionEventStream
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -1137,11 +1138,44 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
+def _session_event_stream(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    stream = SessionEventStream(SERVER_INSTANCE_ID)
+    session["mobile_sync"] = stream
+    return stream
+
+
+def _emit(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+):
+    session = _sessions.get(sid)
+    if session is not None:
+        return _session_event_stream(session).publish(
+            event,
+            sid,
+            payload,
+            write_json,
+        )
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+    write_json(frame)
+    return frame
+
+
+def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
+    session = _sessions.get(sid)
+    if session is None:
+        return _emit(event, sid, payload)
+    with _session_event_stream(session).transition(update):
+        return _emit(event, sid, payload)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -2056,7 +2090,17 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
     answer = ""
     answer_present = False
     try:
-        _emit(event, sid, payload)
+        descriptor = {
+            "request_id": rid,
+            "kind": event.removesuffix(".request"),
+            "payload": dict(payload),
+        }
+        _emit_with_sync_update(
+            event,
+            sid,
+            payload,
+            lambda stream: stream.track_pending_interaction(descriptor),
+        )
         answered = ev.wait(timeout=timeout)
     finally:
         with _prompt_lock:
@@ -2064,6 +2108,9 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
             _pending_prompt_payloads.pop(rid, None)
             answer_present = rid in _answers
             answer = _answers.pop(rid, "")
+        session = _sessions.get(sid)
+        if session is not None:
+            _session_event_stream(session).finish_pending_interaction(rid)
 
     if not answered and not answer_present and event in {"secret.request", "sudo.request"}:
         _emit(
@@ -3617,6 +3664,11 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         except Exception:
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+    descriptor = {
+        "tool_id": tool_call_id,
+        "name": name,
+        "started_at": time.time(),
+    }
     if _tool_progress_enabled(sid):
         payload = {
             "tool_id": tool_call_id,
@@ -3629,7 +3681,16 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 payload["args_text"] = args_text
         # tool.complete is the source of truth for todos (full list from the
         # tool result). args.todos here may be a partial merge update.
-        _emit("tool.start", sid, payload)
+        _emit_with_sync_update(
+            "tool.start",
+            sid,
+            payload,
+            lambda stream: stream.track_tool(descriptor),
+        )
+    elif session is not None:
+        _session_event_stream(session).mutate(
+            lambda stream: stream.track_tool(descriptor)
+        )
 
 
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
@@ -3676,7 +3737,16 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     except Exception:
         pass
     if _tool_progress_enabled(sid) or payload.get("inline_diff"):
-        _emit("tool.complete", sid, payload)
+        _emit_with_sync_update(
+            "tool.complete",
+            sid,
+            payload,
+            lambda stream: stream.finish_tool(tool_call_id),
+        )
+    elif session is not None:
+        _session_event_stream(session).mutate(
+            lambda stream: stream.finish_tool(tool_call_id)
+        )
 
 
 def _on_tool_progress(
@@ -4683,6 +4753,8 @@ def _init_session(
             "history_lock": threading.Lock(),
             "history_version": 0,
             "inflight_turn": None,
+            "conversation_id": key,
+            "mobile_sync": _new_session_event_stream(),
             "created_at": now,
             "last_active": now,
             "running": False,
@@ -5063,22 +5135,57 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
         "assistant": "",
         "started_at": now,
         "streaming": True,
+        "turn_id": str(uuid.uuid4()),
         "updated_at": now,
         "user": _inflight_text(text),
     }
 
 
-def _append_inflight_delta(session: dict, delta: Any) -> None:
+def _append_inflight_delta(session: dict, delta: Any) -> int:
     text = "" if delta is None else str(delta)
-    if not text:
-        return
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
-        turn = {"assistant": "", "streaming": True, "user": ""}
+        turn = {
+            "assistant": "",
+            "streaming": True,
+            "turn_id": str(uuid.uuid4()),
+            "user": "",
+        }
+    offset = len(str(turn.get("assistant") or "").encode("utf-8"))
+    if not text:
+        return offset
     turn["assistant"] = f"{turn.get('assistant') or ''}{text}"
     turn["streaming"] = True
     turn["updated_at"] = time.time()
     session["inflight_turn"] = turn
+    return offset
+
+
+def _emit_inflight_delta(
+    sid: str,
+    session: dict,
+    delta: Any,
+    *,
+    rendered: Any = None,
+) -> None:
+    """Append and publish a delta with its absolute UTF-8 byte offset.
+
+    UTF-8 bytes give clients a language-neutral overlap key even when one
+    streamed chunk contains extended grapheme clusters.
+    """
+    with session["history_lock"]:
+        offset = _append_inflight_delta(session, delta)
+        turn_id = str(
+            (session.get("inflight_turn") or {}).get("turn_id") or ""
+        )
+        payload = {
+            "text": delta,
+            "turn_id": turn_id,
+            "offset": offset,
+        }
+        if rendered is not None:
+            payload["rendered"] = rendered
+        _emit("message.delta", sid, payload)
 
 
 def _clear_inflight_turn(session: dict) -> None:
@@ -5183,7 +5290,11 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
-def _inflight_snapshot(session: dict) -> dict | None:
+def _inflight_snapshot(
+    session: dict,
+    *,
+    include_turn_id: bool = False,
+) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
         return None
@@ -5192,11 +5303,78 @@ def _inflight_snapshot(session: dict) -> dict | None:
     streaming = bool(turn.get("streaming"))
     if not user and not assistant and not streaming:
         return None
-    return {
+    snapshot = {
         "assistant": assistant,
         "streaming": streaming,
         "user": user,
     }
+    if include_turn_id:
+        snapshot["turn_id"] = str(turn.get("turn_id") or "")
+    return snapshot
+
+
+def _new_session_event_stream() -> SessionEventStream:
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    return SessionEventStream(SERVER_INSTANCE_ID)
+
+
+def _conversation_root(db, session_id: str) -> str:
+    try:
+        lineage = db.get_compression_lineage(session_id)
+    except Exception:
+        lineage = []
+    return str(
+        lineage[0]
+        if isinstance(lineage, (list, tuple)) and lineage
+        else session_id
+    )
+
+
+def _session_synchronization(
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    """Capture history then the stream watermark using the documented lock order."""
+    with session["history_lock"]:
+        history = list(session.get("display_history_prefix") or []) + list(
+            session.get("history") or []
+        )
+        messages = _history_to_messages(history)
+        inflight = _inflight_snapshot(session, include_turn_id=True)
+        stored_session_id = _session_lookup_key(session, fallback=sid)
+        conversation_id = str(
+            session.get("conversation_id") or stored_session_id or sid
+        )
+        running = bool(session.get("running"))
+
+        def snapshot(state: dict) -> dict:
+            status = "waiting" if state["pending_interactions"] else (
+                "working" if running else "idle"
+            )
+            return {
+                "conversation_id": conversation_id,
+                "stored_session_id": stored_session_id,
+                "live_session_id": sid,
+                "messages": messages,
+                "inflight_turn": inflight,
+                "active_tools": state["active_tools"],
+                "pending_interactions": state["pending_interactions"],
+                "status": status,
+            }
+
+        return _session_event_stream(session).synchronization(snapshot, cursor)
+
+
+def _attach_synchronization(
+    payload: dict,
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    payload["synchronization"] = _session_synchronization(sid, session, cursor)
+    return payload
 
 
 # ── Methods: session ─────────────────────────────────────────────────
@@ -5273,6 +5451,7 @@ def _(rid, params: dict) -> dict:
             "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
             "active_session_lease": lease,
             "cols": cols,
+            "conversation_id": key,
             "created_at": now,
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
@@ -5284,6 +5463,7 @@ def _(rid, params: dict) -> dict:
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
+            "mobile_sync": _new_session_event_stream(),
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id,
@@ -5314,37 +5494,38 @@ def _(rid, params: dict) -> dict:
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
+    payload = {
+        "session_id": sid,
+        "stored_session_id": key,
+        "message_count": len(history),
+        "messages": _history_to_messages(history),
+        "info": {
+            # Reflect the per-session model override (desktop composer pick)
+            # in the immediate response so the client doesn't briefly clobber
+            # its sticky pick with the global default before the deferred
+            # build's session.info lands.
+            "model": (
+                session_model_override.get("model")
+                if session_model_override
+                else _resolve_model()
+            ),
+            **(
+                {"provider": session_model_override["provider"]}
+                if session_model_override and session_model_override.get("provider")
+                else {}
+            ),
+            "tools": {},
+            "skills": {},
+            "cwd": _sessions[sid]["cwd"],
+            "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
+            "lazy": True,
+            "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+            "profile_name": _current_profile_name(),
+        },
+    }
     return _ok(
         rid,
-        {
-            "session_id": sid,
-            "stored_session_id": key,
-            "message_count": len(history),
-            "messages": _history_to_messages(history),
-            "info": {
-                # Reflect the per-session model override (desktop composer pick)
-                # in the immediate response so the client doesn't briefly clobber
-                # its sticky pick with the global default before the deferred
-                # build's session.info lands.
-                "model": (
-                    session_model_override.get("model")
-                    if session_model_override
-                    else _resolve_model()
-                ),
-                **(
-                    {"provider": session_model_override["provider"]}
-                    if session_model_override and session_model_override.get("provider")
-                    else {}
-                ),
-                "tools": {},
-                "skills": {},
-                "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
-                "lazy": True,
-                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _current_profile_name(),
-            },
-        },
+        _attach_synchronization(payload, sid, _sessions[sid]),
     )
 
 
@@ -5512,6 +5693,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    conversation_id: str | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -5524,6 +5706,7 @@ def _deferred_session_record(
         "close_on_disconnect": close_on_disconnect,
         "active_session_lease": lease,
         "cols": cols,
+        "conversation_id": conversation_id or session_key,
         "created_at": now,
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
@@ -5537,6 +5720,7 @@ def _deferred_session_record(
         "last_active": now,
         "lazy": lazy,
         "model_override": model_override,
+        "mobile_sync": _new_session_event_stream(),
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
         "resume_runtime_overrides": resume_runtime_overrides,
@@ -5653,6 +5837,7 @@ def _(rid, params: dict) -> dict:
     profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
         profile_home
     )
+    conversation_id = _conversation_root(db, target)
 
     def _reuse_live_payload(sid: str, session: dict) -> dict:
         payload = _live_session_payload(
@@ -5661,6 +5846,7 @@ def _(rid, params: dict) -> dict:
             cols=cols,
             touch=True,
             transport=current_transport() or _stdio_transport,
+            cursor=params.get("cursor"),
         )
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
@@ -5712,6 +5898,7 @@ def _(rid, params: dict) -> dict:
             close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
             profile_home=profile_home,
             lazy=True,
+            conversation_id=conversation_id,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -5719,20 +5906,26 @@ def _(rid, params: dict) -> dict:
         # its liveness from the relay registry so the window shows a busy turn.
         child_running = _child_run_active(target)
         messages = _history_to_messages(history)
+        payload = {
+            "session_id": sid,
+            "resumed": target,
+            "message_count": len(messages),
+            "messages": messages,
+            "info": _lazy_resume_info(cwd),
+            "inflight": None,
+            "running": child_running,
+            "session_key": target,
+            "started_at": record["created_at"],
+            "status": "streaming" if child_running else "idle",
+        }
         return _ok(
             rid,
-            {
-                "session_id": sid,
-                "resumed": target,
-                "message_count": len(messages),
-                "messages": messages,
-                "info": _lazy_resume_info(cwd),
-                "inflight": None,
-                "running": child_running,
-                "session_key": target,
-                "started_at": record["created_at"],
-                "status": "streaming" if child_running else "idle",
-            },
+            _attach_synchronization(
+                payload,
+                sid,
+                record,
+                params.get("cursor"),
+            ),
         )
 
     # Cold resume default: register the live session and read its stored
@@ -5790,6 +5983,7 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
+            conversation_id=conversation_id,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -5798,24 +5992,30 @@ def _(rid, params: dict) -> dict:
         _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
         messages = _history_to_messages(display_history)
+        payload = {
+            "session_id": sid,
+            "resumed": target,
+            "message_count": len(messages),
+            "messages": messages,
+            "info": _lazy_resume_info(
+                cwd,
+                model=model_override.get("model") or "",
+                provider=overrides.get("provider_override") or "",
+            ),
+            "inflight": None,
+            "running": False,
+            "session_key": target,
+            "started_at": record["created_at"],
+            "status": "idle",
+        }
         return _ok(
             rid,
-            {
-                "session_id": sid,
-                "resumed": target,
-                "message_count": len(messages),
-                "messages": messages,
-                "info": _lazy_resume_info(
-                    cwd,
-                    model=model_override.get("model") or "",
-                    provider=overrides.get("provider_override") or "",
-                ),
-                "inflight": None,
-                "running": False,
-                "session_key": target,
-                "started_at": record["created_at"],
-                "status": "idle",
-            },
+            _attach_synchronization(
+                payload,
+                sid,
+                record,
+                params.get("cursor"),
+            ),
         )
 
     # Build the agent OUTSIDE the lock — _make_agent can block for seconds
@@ -5897,6 +6097,7 @@ def _(rid, params: dict) -> dict:
                 cols=cols,
                 touch=True,
                 transport=current_transport() or _stdio_transport,
+                cursor=params.get("cursor"),
             )
             payload["resumed"] = target
             return _ok(rid, payload)
@@ -5936,21 +6137,49 @@ def _(rid, params: dict) -> dict:
             if lease is not None:
                 lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
-        session = _sessions.get(sid) or {}
+        session = _sessions.get(sid)
+        if session is None:
+            # Keep the response contract robust for embedders/tests that
+            # replace _init_session with an external session owner.
+            session = {
+                "agent": agent,
+                "conversation_id": conversation_id,
+                "display_history_prefix": display_history_prefix,
+                "history": history,
+                "history_lock": threading.Lock(),
+                "inflight_turn": None,
+                "mobile_sync": _new_session_event_stream(),
+                "running": False,
+                "session_key": target,
+            }
+        else:
+            session.setdefault("display_history_prefix", display_history_prefix)
+            session.setdefault("history", history)
+            session.setdefault("history_lock", threading.Lock())
+            session.setdefault("inflight_turn", None)
+            session.setdefault("mobile_sync", _new_session_event_stream())
+            session.setdefault("running", False)
+        session["conversation_id"] = conversation_id
+    payload = {
+        "session_id": sid,
+        "resumed": target,
+        "message_count": len(messages),
+        "messages": messages,
+        "info": _session_info(agent, session),
+        "inflight": None,
+        "running": False,
+        "session_key": target,
+        "started_at": float(session.get("created_at") or time.time()),
+        "status": "idle",
+    }
     return _ok(
         rid,
-        {
-            "session_id": sid,
-            "resumed": target,
-            "message_count": len(messages),
-            "messages": messages,
-            "info": _session_info(agent, session),
-            "inflight": None,
-            "running": False,
-            "session_key": target,
-            "started_at": float(session.get("created_at") or time.time()),
-            "status": "idle",
-        },
+        _attach_synchronization(
+            payload,
+            sid,
+            session,
+            params.get("cursor"),
+        ),
     )
 
 
@@ -6083,6 +6312,7 @@ def _live_session_payload(
     cols: int | None = None,
     touch: bool = False,
     transport: Transport | None = None,
+    cursor: object = None,
 ) -> dict:
     with session["history_lock"]:
         if cols is not None:
@@ -6108,7 +6338,7 @@ def _live_session_payload(
     }
     if inflight:
         payload["inflight"] = inflight
-    return payload
+    return _attach_synchronization(payload, sid, session, cursor)
 
 
 @method("session.active_list")
@@ -8960,14 +9190,14 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session["attached_images"] = []
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        _emit("message.start", sid, {"turn_id": turn_id})
     agent = session["agent"]
     if hasattr(agent, "clear_interrupt"):
         try:
             agent.clear_interrupt()
         except Exception:
             pass
-    _emit("message.start", sid)
-
     def run():
         approval_token = None
         session_tokens = []
@@ -9090,12 +9320,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_message = _enrich_with_attached_images(prompt, images)
 
             def _stream(delta):
-                with session["history_lock"]:
-                    _append_inflight_delta(session, delta)
-                payload = {"text": delta}
-                if streamer and (r := streamer.feed(delta)) is not None:
-                    payload["rendered"] = r
-                _emit("message.delta", sid, payload)
+                rendered_delta = streamer.feed(delta) if streamer else None
+                _emit_inflight_delta(
+                    sid,
+                    session,
+                    delta,
+                    rendered=rendered_delta,
+                )
 
             run_kwargs = {
                 "conversation_history": list(history),
@@ -9222,8 +9453,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             if rendered:
                 payload["rendered"] = rendered
             with session["history_lock"]:
+                turn_id = str(
+                    (session.get("inflight_turn") or {}).get("turn_id") or ""
+                )
+                payload["turn_id"] = turn_id
                 _clear_inflight_turn(session)
-            _emit("message.complete", sid, payload)
+                _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -814,6 +814,19 @@ def _close_sessions_for_transport(
     reaped = 0
     detached = 0
     for sid, session in owned:
+        claimed = False
+        with session.setdefault("history_lock", threading.RLock()):
+            stream = _session_event_stream(session)
+            with stream.transition(lambda _stream: None):
+                # The ownership snapshot above can race a reconnect. The old
+                # socket may detach only if it still owns the session at this
+                # exact handoff boundary.
+                if session.get("transport") is transport:
+                    claimed = True
+                    if not session.get("close_on_disconnect"):
+                        session["transport"] = _detached_ws_transport
+        if not claimed:
+            continue
         if session.get("close_on_disconnect"):
             _close_session_by_id(sid, end_reason=end_reason)
             reaped += 1
@@ -821,8 +834,6 @@ def _close_sessions_for_transport(
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            with session.setdefault("history_lock", threading.RLock()):
-                _set_session_transport_locked(session, _detached_ws_transport)
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8470,11 +8470,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    # Re-bind accepted idle work to the current client. A busy scoped writer
+    # without conversation.control queues its next turn on this transport but
+    # must not seize the in-flight turn from the currently attached client.
+    t = current_transport()
     with session["history_lock"]:
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
@@ -8487,16 +8486,19 @@ def _(rid, params: dict) -> dict:
                 authorization_allows_scope,
             )
 
+            allow_control = authorization_allows_scope(
+                getattr(active_transport, "authorization", None),
+                CONVERSATION_CONTROL_SCOPE,
+            )
+            if t is not None and allow_control:
+                session["transport"] = t
             return _handle_busy_submit(
                 rid,
                 sid,
                 session,
                 text,
                 active_transport,
-                allow_control=authorization_allows_scope(
-                    getattr(active_transport, "authorization", None),
-                    CONVERSATION_CONTROL_SCOPE,
-                ),
+                allow_control=allow_control,
             )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -8505,6 +8507,8 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if t is not None:
+            session["transport"] = t
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -821,7 +821,8 @@ def _close_sessions_for_transport(
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            session["transport"] = _detached_ws_transport
+            with session.setdefault("history_lock", threading.RLock()):
+                _set_session_transport_locked(session, _detached_ws_transport)
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)
@@ -1160,38 +1161,24 @@ def _session_event_stream(session: dict) -> SessionEventStream:
         return _session_event_stream_locked(session)
 
 
-def _session_transport_requests_sync(session: dict) -> bool:
-    transport = session.get("transport") or current_transport()
+def _transport_requests_sync(transport: Any) -> bool:
     authorization = getattr(transport, "authorization", None)
     if not isinstance(authorization, dict):
         return False
     from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
 
-
     return effective_authorization(authorization)["audience"] == MOBILE_AUDIENCE
 
 
-def _enable_session_sync_retention(session: dict) -> SessionEventStream:
-    """Atomically enable replay retention and return its single stream."""
-    with _session_event_stream_init_lock:
-        stream = _session_event_stream_locked(session)
-        session["mobile_sync_retention"] = True
-        return stream
+def _captured_session_transport(session: dict) -> Transport:
+    return session.get("transport") or current_transport() or _stdio_transport
 
 
-def _session_retains_sync(session: dict) -> bool:
-    """Keep replay after mobile disconnect without changing legacy wire shape.
-
-    Legacy stdio and Desktop clients retain the original response/event shape
-    even after a mobile client previously attached. The sticky bit controls
-    replay retention only; the current transport audience controls envelopes.
-    """
-    if session.get("mobile_sync_retention"):
-        return True
-    if _session_transport_requests_sync(session):
-        _enable_session_sync_retention(session)
-        return True
-    return False
+def _set_session_transport_locked(session: dict, transport: Transport) -> None:
+    """Replace the event recipient while holding history then stream locks."""
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        session["transport"] = transport
 
 
 def _emit(
@@ -1204,24 +1191,34 @@ def _emit(
     if payload is not None:
         params["payload"] = payload
     legacy_frame = {"jsonrpc": "2.0", "method": "event", "params": params}
-    if session is None or not _session_retains_sync(session):
+    if session is None:
         write_json(legacy_frame)
         return legacy_frame
 
-    mobile_recipient = _session_transport_requests_sync(session)
     stream = _session_event_stream(session)
-    if mobile_recipient:
-        return stream.publish(event, sid, payload, write_json)
+    with stream.transition(lambda _stream: None):
+        # Capture the recipient once under the same boundary used by transport
+        # handoff. Never classify one transport and then let write_json re-read
+        # a different transport before delivery.
+        recipient = _captured_session_transport(session)
+        mobile_recipient = _transport_requests_sync(recipient)
+        if mobile_recipient:
+            session["mobile_sync_retention"] = True
+        if not session.get("mobile_sync_retention"):
+            recipient.write(legacy_frame)
+            return legacy_frame
+        if mobile_recipient:
+            return stream.publish(event, sid, payload, recipient.write)
 
-    # Retain a sequenced copy for a future mobile reconnect, but preserve the
-    # original unsequenced event shape on the currently attached legacy wire.
-    stream.publish(
-        event,
-        sid,
-        payload,
-        lambda _sequenced: write_json(legacy_frame),
-    )
-    return legacy_frame
+        # Retain a sequenced copy for a future mobile reconnect, but preserve
+        # the original event shape on the currently attached legacy wire.
+        stream.publish(
+            event,
+            sid,
+            payload,
+            lambda _sequenced: recipient.write(legacy_frame),
+        )
+        return legacy_frame
 
 
 def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
@@ -1238,8 +1235,12 @@ def _mark_snapshot_mutation(session: dict) -> None:
     Callers hold ``history_lock`` first, preserving the same history -> stream
     lock order used by snapshot capture and event publication.
     """
-    if _session_retains_sync(session):
-        _session_event_stream(session).mutate(lambda _stream: None)
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        if _transport_requests_sync(_captured_session_transport(session)):
+            session["mobile_sync_retention"] = True
+        if session.get("mobile_sync_retention"):
+            stream.mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -5402,7 +5403,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         session["queued_prompt"] = None
         session["running"] = True
         if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+            _set_session_transport_locked(session, queued["transport"])
     try:
         _run_prompt_submit(rid, sid, session, queued["text"])
     except Exception as exc:
@@ -5459,6 +5460,42 @@ def _conversation_root(db, session_id: str) -> str:
     )
 
 
+def _session_synchronization_locked(
+    sid: str,
+    session: dict,
+    stream: SessionEventStream,
+    cursor: object = None,
+) -> dict:
+    """Capture synchronization while history and stream boundaries are held."""
+    history = list(session.get("display_history_prefix") or []) + list(
+        session.get("history") or []
+    )
+    messages = _history_to_messages(history)
+    inflight = _inflight_snapshot(session, include_turn_id=True)
+    stored_session_id = _session_lookup_key(session, fallback=sid)
+    conversation_id = str(
+        session.get("conversation_id") or stored_session_id or sid
+    )
+    running = bool(session.get("running"))
+
+    def snapshot(state: dict) -> dict:
+        status = "waiting" if state["pending_interactions"] else (
+            "working" if running else "idle"
+        )
+        return {
+            "conversation_id": conversation_id,
+            "stored_session_id": stored_session_id,
+            "live_session_id": sid,
+            "messages": messages,
+            "inflight_turn": inflight,
+            "active_tools": state["active_tools"],
+            "pending_interactions": state["pending_interactions"],
+            "status": status,
+        }
+
+    return stream.synchronization(snapshot, cursor)
+
+
 def _session_synchronization(
     sid: str,
     session: dict,
@@ -5466,33 +5503,10 @@ def _session_synchronization(
 ) -> dict:
     """Capture history then the stream watermark using the documented lock order."""
     with session["history_lock"]:
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        messages = _history_to_messages(history)
-        inflight = _inflight_snapshot(session, include_turn_id=True)
-        stored_session_id = _session_lookup_key(session, fallback=sid)
-        conversation_id = str(
-            session.get("conversation_id") or stored_session_id or sid
-        )
-        running = bool(session.get("running"))
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            return _session_synchronization_locked(sid, session, stream, cursor)
 
-        def snapshot(state: dict) -> dict:
-            status = "waiting" if state["pending_interactions"] else (
-                "working" if running else "idle"
-            )
-            return {
-                "conversation_id": conversation_id,
-                "stored_session_id": stored_session_id,
-                "live_session_id": sid,
-                "messages": messages,
-                "inflight_turn": inflight,
-                "active_tools": state["active_tools"],
-                "pending_interactions": state["pending_interactions"],
-                "status": status,
-            }
-
-        return _session_event_stream(session).synchronization(snapshot, cursor)
 
 
 def _attach_synchronization(
@@ -5501,11 +5515,19 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
-    if not _session_transport_requests_sync(session):
-        return payload
-    _enable_session_sync_retention(session)
-    payload["synchronization"] = _session_synchronization(sid, session, cursor)
-    return payload
+    with session["history_lock"]:
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            if not _transport_requests_sync(_captured_session_transport(session)):
+                return payload
+            session["mobile_sync_retention"] = True
+            payload["synchronization"] = _session_synchronization_locked(
+                sid,
+                session,
+                stream,
+                cursor,
+            )
+            return payload
 
 
 # ── Methods: session ─────────────────────────────────────────────────
@@ -6441,31 +6463,42 @@ def _live_session_payload(
     transport: Transport | None = None,
     cursor: object = None,
 ) -> dict:
+    info = _fallback_session_info(session)
     with session["history_lock"]:
-        if cols is not None:
-            session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
-        if touch:
-            session["last_active"] = time.time()
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        inflight = _inflight_snapshot(session)
-        running = bool(session.get("running"))
-    payload = {
-        "info": _fallback_session_info(session),
-        "message_count": len(history),
-        "messages": _history_to_messages(history),
-        "running": running,
-        "session_id": sid,
-        "session_key": _session_lookup_key(session, fallback=sid),
-        "started_at": float(session.get("created_at") or time.time()),
-        "status": _session_live_status(sid, session),
-    }
-    if inflight:
-        payload["inflight"] = inflight
-    return _attach_synchronization(payload, sid, session, cursor)
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            if cols is not None:
+                session["cols"] = cols
+            if transport is not None:
+                session["transport"] = transport
+            if touch:
+                session["last_active"] = time.time()
+            history = list(session.get("display_history_prefix") or []) + list(
+                session.get("history") or []
+            )
+            inflight = _inflight_snapshot(session)
+            running = bool(session.get("running"))
+            payload = {
+                "info": info,
+                "message_count": len(history),
+                "messages": _history_to_messages(history),
+                "running": running,
+                "session_id": sid,
+                "session_key": _session_lookup_key(session, fallback=sid),
+                "started_at": float(session.get("created_at") or time.time()),
+                "status": _session_live_status(sid, session),
+            }
+            if inflight:
+                payload["inflight"] = inflight
+            if _transport_requests_sync(_captured_session_transport(session)):
+                session["mobile_sync_retention"] = True
+                payload["synchronization"] = _session_synchronization_locked(
+                    sid,
+                    session,
+                    stream,
+                    cursor,
+                )
+            return payload
 
 
 @method("session.active_list")
@@ -8857,7 +8890,7 @@ def _(rid, params: dict) -> dict:
                 CONVERSATION_CONTROL_SCOPE,
             )
             if t is not None and allow_control:
-                session["transport"] = t
+                _set_session_transport_locked(session, t)
             return _handle_busy_submit(
                 rid,
                 sid,
@@ -8867,7 +8900,7 @@ def _(rid, params: dict) -> dict:
                 allow_control=allow_control,
             )
         if t is not None:
-            session["transport"] = t
+            _set_session_transport_locked(session, t)
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1138,7 +1138,10 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _session_event_stream(session: dict) -> SessionEventStream:
+_session_event_stream_init_lock = threading.RLock()
+
+
+def _session_event_stream_locked(session: dict) -> SessionEventStream:
     stream = session.get("mobile_sync")
     if isinstance(stream, SessionEventStream):
         return stream
@@ -1149,26 +1152,46 @@ def _session_event_stream(session: dict) -> SessionEventStream:
     return stream
 
 
-def _session_sync_enabled(session: dict) -> bool:
-    """Return whether this live session negotiated revisioned mobile sync.
+def _session_event_stream(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    with _session_event_stream_init_lock:
+        return _session_event_stream_locked(session)
 
-    Legacy stdio and Desktop clients retain the original response/event shape
-    and avoid replay copies.  Once a mobile transport attaches, keep retention
-    enabled for the rest of the live stream so a later reconnect can replay
-    events emitted while the socket was detached.
-    """
-    if session.get("mobile_sync_enabled"):
-        return True
+
+def _session_transport_requests_sync(session: dict) -> bool:
     transport = session.get("transport") or current_transport()
     authorization = getattr(transport, "authorization", None)
     if not isinstance(authorization, dict):
         return False
     from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
 
-    if effective_authorization(authorization)["audience"] != MOBILE_AUDIENCE:
-        return False
-    session["mobile_sync_enabled"] = True
-    return True
+
+    return effective_authorization(authorization)["audience"] == MOBILE_AUDIENCE
+
+
+def _enable_session_sync_retention(session: dict) -> SessionEventStream:
+    """Atomically enable replay retention and return its single stream."""
+    with _session_event_stream_init_lock:
+        stream = _session_event_stream_locked(session)
+        session["mobile_sync_retention"] = True
+        return stream
+
+
+def _session_retains_sync(session: dict) -> bool:
+    """Keep replay after mobile disconnect without changing legacy wire shape.
+
+    Legacy stdio and Desktop clients retain the original response/event shape
+    even after a mobile client previously attached. The sticky bit controls
+    replay retention only; the current transport audience controls envelopes.
+    """
+    if session.get("mobile_sync_retention"):
+        return True
+    if _session_transport_requests_sync(session):
+        _enable_session_sync_retention(session)
+        return True
+    return False
 
 
 def _emit(
@@ -1177,19 +1200,28 @@ def _emit(
     payload: dict | None = None,
 ):
     session = _sessions.get(sid)
-    if session is not None and _session_sync_enabled(session):
-        return _session_event_stream(session).publish(
-            event,
-            sid,
-            payload,
-            write_json,
-        )
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    frame = {"jsonrpc": "2.0", "method": "event", "params": params}
-    write_json(frame)
-    return frame
+    legacy_frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+    if session is None or not _session_retains_sync(session):
+        write_json(legacy_frame)
+        return legacy_frame
+
+    mobile_recipient = _session_transport_requests_sync(session)
+    stream = _session_event_stream(session)
+    if mobile_recipient:
+        return stream.publish(event, sid, payload, write_json)
+
+    # Retain a sequenced copy for a future mobile reconnect, but preserve the
+    # original unsequenced event shape on the currently attached legacy wire.
+    stream.publish(
+        event,
+        sid,
+        payload,
+        lambda _sequenced: write_json(legacy_frame),
+    )
+    return legacy_frame
 
 
 def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
@@ -1206,7 +1238,8 @@ def _mark_snapshot_mutation(session: dict) -> None:
     Callers hold ``history_lock`` first, preserving the same history -> stream
     lock order used by snapshot capture and event publication.
     """
-    _session_event_stream(session).mutate(lambda _stream: None)
+    if _session_retains_sync(session):
+        _session_event_stream(session).mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -3965,7 +3998,11 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         )
 
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_key,
+            {"seq": 0, "open_tool": None, "reply_text": "", "started": False},
+        )
+        st.setdefault("reply_text", "")
         if not st["started"]:
             st["started"] = True
             with history_lock:
@@ -3984,6 +4021,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             # Relayed token-by-token from the child's run_conversation
             # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
+                st["reply_text"] = f"{st['reply_text']}{text}"
                 _emit_inflight_delta(csid, child_session, text)
         elif event_type == "subagent.start":
             # One-time header line (the child's goal) so a freshly opened window
@@ -4020,7 +4058,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
                 turn = child_session.get("inflight_turn") or {}
                 turn_id = str(turn.get("turn_id") or "")
                 assistant = str(turn.get("assistant") or "")
-                final_text = assistant or summary
+                final_text = str(st.get("reply_text") or "") or summary or assistant
                 history = child_session.setdefault("history", [])
                 if final_text and not (
                     history
@@ -4036,7 +4074,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
                 _emit(
                     "message.complete",
                     csid,
-                    {"text": summary or final_text, "turn_id": turn_id},
+                    {"text": final_text, "turn_id": turn_id},
                 )
             _child_mirrors.pop(child_key, None)
 
@@ -5402,13 +5440,11 @@ def _inflight_snapshot(
 
 
 def _conversation_root(db, session_id: str) -> str:
+    lineage_reader = getattr(db, "get_compression_lineage", None)
+    if not callable(lineage_reader):
+        return str(session_id)
     try:
-        lineage = db.get_compression_lineage(session_id)
-    except AttributeError:
-        # Compatibility with old/embedded SessionDB stubs that predate
-        # compression lineage. Unexpected database failures must not silently
-        # change a conversation's supposedly stable identity to its current tip.
-        lineage = []
+        lineage = lineage_reader(session_id)
     except Exception:
         logger.warning(
             "failed to resolve stable conversation lineage for %s",
@@ -5465,8 +5501,9 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
-    if not _session_sync_enabled(session):
+    if not _session_transport_requests_sync(session):
         return payload
+    _enable_session_sync_retention(session)
     payload["synchronization"] = _session_synchronization(sid, session, cursor)
     return payload
 
@@ -8858,6 +8895,7 @@ def _(rid, params: dict) -> dict:
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
+        _mark_snapshot_mutation(session)
 
     # Persist the DB row lazily, now that the user has actually sent a message.
     _ensure_session_db_row(session)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,6 +81,10 @@ class WSTransport:
     the loop we're currently blocking. We detect that case and fire-and-
     forget instead. Callers that need to know when the bytes are on the wire
     should use :meth:`write_async` from the loop thread.
+
+    ``authorization`` is the server-derived grant for this connection. The
+    dispatcher reads it before resolving any method; clients cannot mutate it
+    through JSON-RPC input.
     """
 
     def __init__(
@@ -89,10 +93,12 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        authorization: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        self.authorization = authorization
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -280,7 +286,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, authorization: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -298,7 +304,12 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            authorization=authorization,
+        )
 
         # The desktop app and dashboard chat reach the agent through this WS
         # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
@@ -316,13 +327,18 @@ async def handle_ws(ws: Any) -> None:
             thread_name="tui-ws-mcp-discovery",
         )
 
+        from tui_gateway.mobile_contract import gateway_ready_payload
+
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    "payload": {"skin": server.resolve_skin()},
+                    "payload": gateway_ready_payload(
+                        skin=server.resolve_skin(),
+                        authorization=authorization,
+                    ),
                 },
             }
         )


### PR DESCRIPTION
## Stack

This draft is **stacked on #62858** (`feat/mobile-contract-hello-scopes`). It intentionally includes that PR's commits until #62858 merges; rebase this branch onto `main` after the parent lands.

- Parent head used: `d8bc3bc9b1277b54d72b097c7a5d0328ecb62348`
- Parent base: `f67aae323010e32c592a185984d36b20e9fa474a`
- This slice implements the revisioned synchronization work tracked in `ericlewis/cuttle#3`.

## Summary

- add one per-live-session stream identity, snapshot revision, event watermark, and stable conversation-lineage identity to the existing create/resume payloads
- sequence every live session event and retain a bounded in-memory replay by event count and serialized byte count
- classify resume cursors as `complete`, `gap`, or `reset` without claiming evicted events are recoverable
- expose inflight turn identity, sanitized active tools, and pending interactions in authoritative snapshots
- add turn IDs plus absolute UTF-8 byte offsets to streamed message deltas
- serialize history, event publication, transport handoff, resume, activation, and disconnect teardown so snapshots and replay cannot cross ownership generations
- atomically claim close-on-disconnect sessions before teardown, while reconnectable sessions retain the newly attached transport
- document the history-lock -> stream-lock synchronization barrier and client installation algorithm
- advertise the implemented schema/capability parameters additively in `gateway.ready`

Existing clients keep their existing fields and legacy wire behavior; sync retention is activated only after a mobile-capable transport requests it.

## Validation

Post-rebase validation against parent head `d8bc3bc9b`:

- all 30 `tests/tui_gateway/test_*.py` files in fresh process isolation: **396 passed**
- `tests/test_tui_gateway_server.py`: **316 passed**
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: **61 passed**
- `tests/hermes_cli/test_dashboard_auth_ws_tickets.py`: **22 passed**
- `tests/test_tui_gateway_ws.py`: **12 passed**
- `tests/hermes_cli/test_web_server_console_ws.py`: **5 passed**
- total distinct coverage: **812 passed across 35 files**
- final independent race/protocol review: **124 focused tests passed, no findings**
- Ruff on every changed Python file: passed
- `git diff --check`: passed
- added-line cross-platform footgun scan: clean

The `tests/tui_gateway` files are intentionally invoked in fresh processes because the current upstream `test_inline_rpc_gil_starvation.py` replaces the global `prompt.submit` handler without restoring it; file-scoped isolation avoids that unrelated cross-file test leak.

## Deliberate limits / risks

- Replay is process-local and bounded; restart/reconstruction requires snapshot replacement by design.
- This slice does not advertise durable mutation idempotency or addressable/recoverable approvals; those remain separate stacked work.
- Event delivery is serialized under the per-stream lock to preserve wire sequence. Slow non-streaming transports can delay snapshot capture for that session, favoring correctness over concurrent reordering.
