### PR TITLE
fix(tools): bridge terminal.backend config to TERMINAL_ENV in serve process

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17001,6 +17001,16 @@ def start_server(
     """
     import uvicorn
 
+    # Bridge terminal.* config into the process env so that terminal tool calls
+    # running inside this serve process (not just child processes) respect the
+    # configured backend (e.g. docker sandbox). Without this, the serve process
+    # always runs terminal commands locally regardless of config.yaml settings.
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env()
+    except Exception:
+        _log.debug("Failed to apply terminal config bridge for serve process", exc_info=True)
+
     try:
         from hermes_cli.nous_auth_keepalive import start_nous_auth_keepalive
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -210,3 +210,31 @@ def test_start_server_keeps_bare_asyncio_run_on_posix(monkeypatch):
     assert runner_called["hit"] is False, (
         "POSIX must not take the Windows loop-factory branch"
     )
+
+
+def test_start_server_bridges_terminal_config_to_env(monkeypatch):
+    """start_server must call apply_terminal_config_to_env() so that terminal
+    tool calls running inside the serve process itself (not just child
+    processes) respect the configured backend.
+
+    Without this bridge, a serve process with terminal.backend: docker in
+    config.yaml still runs terminal commands locally, bypassing the sandbox.
+    """
+    _stub_uvicorn(monkeypatch)
+
+    called = {"hit": False}
+
+    import hermes_cli.config as _cfg
+
+    def _fake_apply(*, env=None, config=None, override=None):
+        called["hit"] = True
+        return env or {}
+
+    monkeypatch.setattr(_cfg, "apply_terminal_config_to_env", _fake_apply)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert called["hit"] is True, (
+        "start_server must call apply_terminal_config_to_env() to bridge "
+        "terminal.* config into the serve process environment"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a security-relevant bug where `hermes serve` (the headless backend used by the Desktop app) never bridges `terminal.backend` config from `config.yaml` to the `TERMINAL_ENV` environment variable for its own process. This means all terminal tool calls inside the serve process run in local mode regardless of the configured Docker sandbox backend, completely bypassing sandbox isolation.

The `apply_terminal_config_to_env()` function was already called for child processes (TUI launch, dashboard PTY), but the serve process itself was never bridged. Adding the call at the start of `start_server()` ensures the terminal tool respects the configured backend (docker, local, etc.).

## Related Issue

Fixes #63141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Added `apply_terminal_config_to_env()` call at the beginning of `start_server()` (before uvicorn starts accepting tool calls), with try/except to match the existing child-process pattern
- `tests/test_web_server.py`: Added regression test verifying `start_server()` calls `apply_terminal_config_to_env()`

## How to Test

1. Run the new regression test:
   ```
   python -m pytest tests/test_web_server.py::test_start_server_bridges_terminal_config_to_env -xvs
   ```
   Should pass.

2. Run the full test file to confirm no regression:
   ```
   python -m pytest tests/test_web_server.py -x --tb=short
   ```
   All 5 tests should pass.

3. Observed result: All 5 tests passed, including the new regression test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
