### PR TITLE
fix(cli): resolve session ID prefixes for resume

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1286,16 +1286,17 @@ def _exec_in_container(container_info: dict, cli_args: list):
 
 
 def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
-    """Resolve a session name (title) or ID to a session ID.
+    """Resolve a session title, exact ID, or unique ID prefix.
 
-    - If it looks like a session ID (contains underscore + hex), try direct lookup first.
-    - Otherwise, treat it as a title and use resolve_session_by_title (auto-latest).
-    - Falls back to the other method if the first doesn't match.
-    - If the resolved session is a compression root, follow the chain forward
-      to the latest continuation. Users who remember the old root ID (e.g.
-      from an exit summary printed before the bug fix, or from notes) get
-      resumed at the live tip instead of a stale parent with no messages.
+    Resolution precedence is exact session ID, exact title (including the
+    latest numbered lineage), then unique session ID prefix. If the resolved
+    session is a compression root, follow the chain forward to the latest
+    continuation so resumes land on the live tip.
     """
+    if not name_or_id.strip():
+        return None
+
+    db = None
     try:
         from hermes_state import SessionDB
 
@@ -1307,8 +1308,10 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
         if session:
             resolved_id = session["id"]
         else:
-            # Try as title (with auto-latest for lineage)
+            # Preserve exact-title precedence over session ID prefixes.
             resolved_id = db.resolve_session_by_title(name_or_id)
+            if not resolved_id:
+                resolved_id = db.resolve_session_id(name_or_id)
 
         if resolved_id:
             # Project forward through compression chain so resumes land on
@@ -1318,11 +1321,15 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
             except Exception:
                 pass
 
-        db.close()
         return resolved_id
     except Exception:
-        pass
-    return None
+        return None
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
 
 
 def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -29,6 +29,21 @@ def main_mod(monkeypatch):
     return mod
 
 
+@pytest.fixture
+def resume_db_factory(monkeypatch, tmp_path):
+    import hermes_state
+
+    db_path = tmp_path / "state.db"
+    session_db_cls = hermes_state.SessionDB
+
+    class ResumeSessionDB(session_db_cls):
+        def __init__(self):
+            super().__init__(db_path=db_path)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", ResumeSessionDB)
+    return ResumeSessionDB
+
+
 def test_cmd_chat_tui_continue_uses_latest_tui_session(monkeypatch, main_mod):
     calls = []
     captured = {}
@@ -116,6 +131,104 @@ def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod)
         main_mod.cmd_chat(_args(resume="my t0p session"))
 
     assert captured["resume"] == "20260409_000000_aa11bb"
+
+
+def test_cmd_chat_tui_resume_resolves_unique_id_prefix(
+    monkeypatch, resume_db_factory, main_mod
+):
+    full_id = "20260712_101010_abc123"
+    seed_db = resume_db_factory()
+    seed_db.create_session(full_id, "cli")
+    seed_db.close()
+    captured = {}
+
+    def fake_launch(resume_session_id=None, **_kwargs):
+        captured["resume"] = resume_session_id
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(resume="20260712_101010_abc"))
+
+    assert captured["resume"] == full_id
+
+
+def test_resolve_session_by_name_or_id_rejects_blank_prefix(
+    resume_db_factory, main_mod
+):
+    seed_db = resume_db_factory()
+    seed_db.create_session("20260712_101010_abc123", "cli")
+    seed_db.close()
+
+    assert main_mod._resolve_session_by_name_or_id("") is None
+
+
+def test_resolve_session_by_name_or_id_prefers_exact_title_over_id_prefix(
+    resume_db_factory, main_mod
+):
+    prefix = "20260712_101010_abc"
+    titled_session_id = "20260712_111111_def456"
+    seed_db = resume_db_factory()
+    seed_db.create_session(f"{prefix}123", "cli")
+    seed_db.create_session(titled_session_id, "cli")
+    seed_db.set_session_title(titled_session_id, prefix)
+    seed_db.close()
+
+    assert main_mod._resolve_session_by_name_or_id(prefix) == titled_session_id
+
+
+def test_resolve_session_by_name_or_id_rejects_ambiguous_id_prefix(
+    resume_db_factory, main_mod
+):
+    prefix = "20260712_101010_abc"
+    seed_db = resume_db_factory()
+    seed_db.create_session(f"{prefix}123", "cli")
+    seed_db.create_session(f"{prefix}456", "cli")
+    seed_db.close()
+
+    assert main_mod._resolve_session_by_name_or_id(prefix) is None
+
+
+def test_resolve_session_by_name_or_id_projects_prefix_to_compression_tip(
+    resume_db_factory, main_mod
+):
+    root_id = "20260712_101010_abc123"
+    child_id = "20260712_111111_def456"
+    seed_db = resume_db_factory()
+    seed_db.create_session(root_id, "cli")
+    seed_db.end_session(root_id, "compression")
+    seed_db.create_session(child_id, "cli", parent_session_id=root_id)
+    seed_db.close()
+
+    assert main_mod._resolve_session_by_name_or_id("20260712_101010_abc") == child_id
+
+
+def test_resolve_session_by_name_or_id_closes_db_after_prefix_error(
+    monkeypatch, main_mod
+):
+    import hermes_state
+
+    class FailingSessionDB:
+        closed = False
+
+        def get_session(self, _value):
+            return None
+
+        def resolve_session_by_title(self, _value):
+            return None
+
+        def resolve_session_id(self, _value):
+            raise RuntimeError("prefix lookup failed")
+
+        def close(self):
+            self.closed = True
+
+    db = FailingSessionDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+
+    assert main_mod._resolve_session_by_name_or_id("20260712_101010_abc") is None
+    assert db.closed is True
 
 
 def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):


### PR DESCRIPTION
## Related Issue

N/A — no exact issue or open PR was found for startup `--resume` session ID prefix resolution.

## Changes

- Reuse the existing `SessionDB.resolve_session_id()` resolver when exact-ID and title resolution do not match.
- Preserve resolution precedence: exact session ID → exact title/latest lineage → unique session ID prefix.
- Reject blank prefixes before lookup so an empty value cannot resolve a sole session.
- Keep compression-tip projection for sessions resolved from prefixes.
- Close `SessionDB` in a `finally` block on both successful and failed lookups.
- Add a real temporary SQLite DB regression test through `cmd_chat(... --resume <prefix>)`, plus coverage for title precedence, ambiguous prefixes, blank input, compression continuations, and DB cleanup.

## Rationale

`SessionDB.resolve_session_id()` already provides exact-or-unique-prefix semantics and is used by other session actions. Startup `hermes --resume <value>` currently stops after exact-ID and title lookup, so a unique session ID prefix is rejected even though the shared resolver can resolve it safely.

This is a CLI/TUI wiring fix only. It does not add new SQL, change the session schema, or alter gateway `/resume` authorization or lookup behavior.

This is also distinct from #14411, which concerns truncated **title** prefixes; this PR handles unique **session ID** prefixes.

## Testing

- Before the production change, the new startup prefix regression failed because `_resolve_session_by_name_or_id()` returned `None`.
- After the change:
  - `423 passed`:
    - `tests/hermes_cli/test_tui_resume_flow.py`
    - `tests/cli/test_cli_resume_command.py`
    - `tests/test_hermes_state.py`
  - `ruff check .` — passed
  - `git diff --check origin/main...HEAD` — passed

The canonical full suite was also run locally on macOS. It reported 39 failures across 10 unrelated files plus one collection error; no failure was reported in either changed file. Representative local failures included `/tmp` versus `/private/tmp` path normalization and platform/service-specific tests. GitHub CI remains the authoritative clean-environment run.

## Checklist

- [x] The change is focused and reuses the existing session ID resolver.
- [x] Existing exact-ID and title behavior is preserved.
- [x] Ambiguous prefixes fail closed.
- [x] Regression tests fail before the fix and pass after it.
- [x] No unrelated generated or desktop files are included.
