### PR TITLE
fix(codex): throttle bursty Codex calls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1564,6 +1564,16 @@ def init_agent(
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+    try:
+        from agent.tool_output_hygiene import config_from_mapping as _tool_output_hygiene_config_from_mapping
+        _tool_output_cfg = _agent_cfg.get("tool_output", {})
+        agent._tool_output_hygiene_config = _tool_output_hygiene_config_from_mapping(
+            _tool_output_cfg if isinstance(_tool_output_cfg, dict) else {},
+            compression_protect_last_n=compression_protect_last,
+        )
+    except Exception as _toh_err:
+        _ra().logger.warning("Tool-output hygiene config ignored: %s", _toh_err)
+        agent._tool_output_hygiene_config = None
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
     # implicitly protected by the compressor).  Floor at 0 — a value of

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -842,6 +842,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     """
     import httpx as _httpx
 
+    # Burst limiter (HEMP 2026-07-12): pace codex Responses calls so a short
+    # burst cannot exhaust the provider's 5h rolling request window (the
+    # 2026-07-12 13:14 429 credential cascade).  The wait happens in the gateway
+    # event loop (never blocks it); it is a complete no-op when the throttle is
+    # disabled or when there is no gateway loop (CLI / cron / tests).
+    from agent.codex_throttle import throttle_codex_call_blocking
+    throttle_codex_call_blocking()
+
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
     # Accumulate streamed text so callers / compat shims can read it.

--- a/agent/codex_throttle.py
+++ b/agent/codex_throttle.py
@@ -1,0 +1,279 @@
+"""Codex outbound-call burst limiter (HEMP 2026-07-12).
+
+Proactively paces ``openai-codex`` Responses API calls so a short burst cannot
+exhaust the provider's 5-hour rolling request window — the failure mode behind
+the 2026-07-12 13:14 429 credential cascade (been-main-2/3 + tom -> luigi).
+
+The cap is a rolling-window request count: while the number of codex calls in
+the trailing ``window_seconds`` stays below ``calls_per_hour`` the limiter is a
+no-op; once at the cap the next call *waits* (never dropped, FIFO order
+preserved) until the window drains.  Same total work, spread over time.
+
+Async by construction
+---------------------
+The wait is ``await asyncio.sleep`` inside the gateway event loop, so a waiting
+codex call never blocks the loop — every other channel keeps flowing.
+
+The codex chokepoint (:func:`agent.codex_runtime.run_codex_stream`) runs
+*synchronously* inside a gateway executor thread (``max_workers=10``), below the
+event loop.  It reaches this async limiter through
+:func:`throttle_codex_call_blocking`, which hops onto the gateway loop via
+``asyncio.run_coroutine_threadsafe`` (the same cross-thread pattern already used
+in ``gateway/run.py``).  Because the *wait* happens in the loop rather than the
+thread, the loop is never blocked; the executor thread simply blocks on the
+future until admitted, which is the desired per-call back-pressure.
+
+Waiting in the loop (not spinning threads) is deliberate: blocking the 10 shared
+executor threads on ``time.sleep`` during a burst would wedge every channel —
+exactly the class of gateway freeze this project has fought before.
+
+Scope / off switch
+-------------------
+When no gateway loop is registered (CLI, cron, tests) the bridge is a no-op, so
+only the interactive gateway path is paced.  That matches the contract scope:
+cron / subagents get their own caps (out of scope here).
+
+``throttle.codex.enabled: false`` in config.yaml (or ``calls_per_hour <= 0``)
+makes both :meth:`CodexRateLimiter.acquire` and the bridge complete-through with
+zero interference.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import logging
+import time
+from typing import Any, Callable, Deque, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+# Code defaults for the two knobs that stay out of config.yaml (the contract
+# keeps the config surface to ``enabled`` + ``calls_per_hour`` only).
+_DEFAULT_WINDOW_SECONDS = 3600.0
+# Safety valve: bounds how long a single codex call may block its executor
+# thread under *pathological sustained* overload.  Never reached by normal
+# traffic (which stays under the cap and therefore never waits at all).
+_DEFAULT_MAX_WAIT_SECONDS = 120.0
+
+
+class CodexRateLimiter:
+    """Async rolling-window limiter for codex Responses API calls.
+
+    ``acquire`` admits immediately while under the cap; at the cap it awaits
+    (drop-free, FIFO) until the oldest in-window call ages out.  The internal
+    ``asyncio.Lock`` is held across the wait so admissions are strictly ordered
+    — the "queue" is just callers awaiting the lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        calls_per_hour: int,
+        enabled: bool = True,
+        window_seconds: float = _DEFAULT_WINDOW_SECONDS,
+        max_wait_seconds: Optional[float] = _DEFAULT_MAX_WAIT_SECONDS,
+        time_func: Optional[Callable[[], float]] = None,
+        sleep_func: Optional[Callable[[float], Any]] = None,
+    ) -> None:
+        self.enabled = bool(enabled)
+        self.calls_per_hour = int(calls_per_hour)
+        self.window_seconds = float(window_seconds)
+        self.max_wait_seconds = (
+            None if max_wait_seconds is None else float(max_wait_seconds)
+        )
+        # Injectable clock/sleep so the probe can drive deterministic bursts
+        # without real time.  Defaults: monotonic wall clock + asyncio.sleep.
+        self._time: Callable[[], float] = time_func or time.monotonic
+        self._sleep: Callable[[float], Any] = sleep_func or asyncio.sleep
+        self._events: Deque[float] = collections.deque()  # admitted call times
+        self._lock: Optional[asyncio.Lock] = None
+        self._waiting = 0  # callers currently trying to get through (queue depth)
+
+    @property
+    def active(self) -> bool:
+        """True when the limiter should actually gate (enabled + positive cap)."""
+        return self.enabled and self.calls_per_hour > 0
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self.window_seconds
+        events = self._events
+        while events and events[0] <= cutoff:
+            events.popleft()
+
+    def window_count(self, now: Optional[float] = None) -> int:
+        """Current number of admitted calls inside the rolling window."""
+        if now is None:
+            now = self._time()
+        self._prune(now)
+        return len(self._events)
+
+    async def acquire(self) -> None:
+        """Block (async) until this codex call may proceed.
+
+        No-op when the limiter is inactive (off switch / non-positive cap).
+        """
+        if not self.active:
+            return
+
+        # Lazily bind the lock to whatever loop is running now.  Safe without a
+        # guard: check-and-assign has no await between the two statements, so on
+        # a single-threaded event loop it cannot interleave.
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+
+        self._waiting += 1
+        try:
+            # Strict FIFO: waiters acquire the lock in arrival order, so
+            # admissions preserve call order (drop-free queueing).
+            async with self._lock:
+                waited = 0.0
+                while True:
+                    now = self._time()
+                    self._prune(now)
+                    if len(self._events) < self.calls_per_hour:
+                        self._events.append(now)
+                        return
+
+                    # At the cap: wait until the oldest in-window call ages out.
+                    wait = (self._events[0] + self.window_seconds) - now
+                    if wait <= 0:
+                        continue
+
+                    if self.max_wait_seconds is not None:
+                        remaining = self.max_wait_seconds - waited
+                        if remaining <= 0:
+                            # Safety valve: proceed drop-free rather than pin the
+                            # executor thread indefinitely.  Only reachable under
+                            # sustained > cap load; normal traffic never waits.
+                            logger.warning(
+                                "codex rate cap, waiting ~0.0s queue_depth=%d "
+                                "(max_wait %.0fs reached, proceeding drop-free)",
+                                self._waiting,
+                                self.max_wait_seconds,
+                            )
+                            self._events.append(self._time())
+                            return
+                        wait = min(wait, remaining)
+
+                    logger.info(
+                        "codex rate cap, waiting ~%.1fs queue_depth=%d",
+                        wait,
+                        self._waiting,
+                    )
+                    await self._sleep(wait)
+                    waited += wait
+        finally:
+            self._waiting -= 1
+
+
+# --------------------------------------------------------------------------- #
+# Process-wide singleton + gateway wiring
+# --------------------------------------------------------------------------- #
+
+_limiter: Optional[CodexRateLimiter] = None
+_gateway_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+def configure(
+    *,
+    enabled: bool,
+    calls_per_hour: int,
+    window_seconds: float = _DEFAULT_WINDOW_SECONDS,
+    max_wait_seconds: Optional[float] = _DEFAULT_MAX_WAIT_SECONDS,
+) -> CodexRateLimiter:
+    """Install the process-wide codex limiter and return it."""
+    global _limiter
+    _limiter = CodexRateLimiter(
+        calls_per_hour=calls_per_hour,
+        enabled=enabled,
+        window_seconds=window_seconds,
+        max_wait_seconds=max_wait_seconds,
+    )
+    logger.info(
+        "codex throttle configured: enabled=%s calls_per_hour=%s window=%.0fs "
+        "max_wait=%s",
+        _limiter.enabled,
+        _limiter.calls_per_hour,
+        _limiter.window_seconds,
+        _limiter.max_wait_seconds,
+    )
+    return _limiter
+
+
+def configure_from_config(cfg: Optional[Mapping[str, Any]]) -> CodexRateLimiter:
+    """Build the limiter from the raw config mapping's ``throttle.codex`` block.
+
+    Missing / malformed values fail safe to *disabled* so a config typo can
+    never wedge codex calls.
+    """
+    throttle = (cfg or {}).get("throttle") or {}
+    codex = throttle.get("codex") or {}
+
+    enabled = bool(codex.get("enabled", False))
+    try:
+        calls_per_hour = int(codex.get("calls_per_hour", 0) or 0)
+    except (TypeError, ValueError):
+        calls_per_hour = 0
+    try:
+        window_seconds = float(codex.get("window_seconds", _DEFAULT_WINDOW_SECONDS))
+    except (TypeError, ValueError):
+        window_seconds = _DEFAULT_WINDOW_SECONDS
+    raw_max_wait = codex.get("max_wait_seconds", _DEFAULT_MAX_WAIT_SECONDS)
+    try:
+        max_wait_seconds = None if raw_max_wait is None else float(raw_max_wait)
+    except (TypeError, ValueError):
+        max_wait_seconds = _DEFAULT_MAX_WAIT_SECONDS
+
+    return configure(
+        enabled=enabled,
+        calls_per_hour=calls_per_hour,
+        window_seconds=window_seconds,
+        max_wait_seconds=max_wait_seconds,
+    )
+
+
+def set_gateway_loop(loop: Optional[asyncio.AbstractEventLoop]) -> None:
+    """Register the gateway event loop the cross-thread bridge submits onto."""
+    global _gateway_loop
+    _gateway_loop = loop
+
+
+def get_limiter() -> Optional[CodexRateLimiter]:
+    return _limiter
+
+
+def _running_loop_is(loop: asyncio.AbstractEventLoop) -> bool:
+    try:
+        return asyncio.get_running_loop() is loop
+    except RuntimeError:
+        return False
+
+
+def throttle_codex_call_blocking(timeout: Optional[float] = None) -> None:
+    """Synchronous gate for the codex chokepoint (runs in an executor thread).
+
+    Hops onto the gateway loop and blocks the calling thread until the async
+    limiter admits the call.  No-op — completes through immediately — when:
+
+      * the limiter is unconfigured / disabled / non-positive cap,
+      * no gateway loop is registered (CLI, cron, tests), or
+      * we are already running on the gateway loop thread (avoids deadlock).
+
+    Fails open on any error: throttling must never break a real codex call.
+    """
+    limiter = _limiter
+    if limiter is None or not limiter.active:
+        return
+
+    loop = _gateway_loop
+    if loop is None or not loop.is_running():
+        return
+    if _running_loop_is(loop):
+        return
+
+    try:
+        future = asyncio.run_coroutine_threadsafe(limiter.acquire(), loop)
+        future.result(timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — fail-open by design
+        logger.debug("codex throttle bridge skipped (fail-open): %s", exc)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
+from agent.tool_output_hygiene import apply_api_tool_output_hygiene
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
@@ -955,6 +956,43 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Assembly-time tool-output hygiene (HEMP6 P0-1b): non-destructive
+        # pruning on the API copy only.  The canonical ``messages`` list and
+        # session DB rows keep full tool outputs.  Stale pruning is gated on
+        # the pre-hygiene request size so the decision is deterministic for a
+        # given assembled history; flag-off returns the exact same api_messages.
+        _hygiene_cfg = getattr(agent, "_tool_output_hygiene_config", None)
+        if getattr(_hygiene_cfg, "enabled", False):
+            _pre_hygiene_request_tokens = estimate_request_tokens_rough(
+                api_messages, tools=agent.tools or None
+            )
+            _hygiene_context_length = int(
+                getattr(getattr(agent, "context_compressor", None), "context_length", 0)
+                or getattr(agent, "context_length", 0)
+                or 0
+            )
+            api_messages, _hygiene_stats = apply_api_tool_output_hygiene(
+                api_messages,
+                config=_hygiene_cfg,
+                request_tokens=_pre_hygiene_request_tokens,
+                context_length=_hygiene_context_length,
+                session_id=agent.session_id or "",
+            )
+            if _hygiene_stats.total_pruned:
+                agent._touch_activity(
+                    f"context_hygiene pruned {_hygiene_stats.total_pruned} tool output(s)"
+                )
+                logger.info(
+                    "context_hygiene pruned %s tool output(s): dedup=%s failed=%s stale=%s saved_tokens~%s saved_chars=%s session=%s",
+                    _hygiene_stats.total_pruned,
+                    _hygiene_stats.dedup_pruned,
+                    _hygiene_stats.failed_pruned,
+                    _hygiene_stats.stale_pruned,
+                    _hygiene_stats.saved_tokens_rough,
+                    _hygiene_stats.saved_chars,
+                    agent.session_id or "",
+                )
 
         # Calculate approximate request size for logging and pressure checks.
         # estimate_messages_tokens_rough(api_messages) includes the system

--- a/agent/tool_output_hygiene.py
+++ b/agent/tool_output_hygiene.py
@@ -1,0 +1,371 @@
+"""Assembly-time tool-output hygiene for API request copies.
+
+This module is intentionally non-destructive: callers pass the per-request
+``api_messages`` copy, never the canonical session history.  Tool messages stay
+present with their original ``tool_call_id`` so provider replay invariants are
+preserved; only old/superseded/error tool *content* is replaced with stable
+one-line stubs when the feature flag is enabled.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PATH_RE = re.compile(
+    r"(?:(?:~|/Users|/Volumes|/tmp|/var|/private/var)/[^\s'\"`<>),;]+)"
+)
+
+
+@dataclass(frozen=True)
+class ToolCallInfo:
+    ordinal: int
+    name: str
+    args_text: str
+    args_sha: str
+
+
+@dataclass(frozen=True)
+class HygieneConfig:
+    enabled: bool = False
+    stale_context_ratio: float = 0.50
+    stale_protect_tail_tokens: int = 40_000
+    protect_last_n: int = 20
+    failed_after_user_turns: int = 3
+    max_stub_paths: int = 5
+
+
+@dataclass(frozen=True)
+class HygieneStats:
+    dedup_pruned: int = 0
+    failed_pruned: int = 0
+    stale_pruned: int = 0
+    saved_chars: int = 0
+
+    @property
+    def total_pruned(self) -> int:
+        return self.dedup_pruned + self.failed_pruned + self.stale_pruned
+
+    @property
+    def saved_tokens_rough(self) -> int:
+        return max(0, self.saved_chars // 4)
+
+
+def _is_truthy(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def config_from_mapping(mapping: Mapping[str, Any] | None, *, compression_protect_last_n: int = 20) -> HygieneConfig:
+    root = mapping if isinstance(mapping, Mapping) else {}
+    raw_hygiene = root.get("hygiene")
+    hygiene: Mapping[str, Any] = raw_hygiene if isinstance(raw_hygiene, Mapping) else {}
+
+    def _int(name: str, default: int, *, floor: int = 0) -> int:
+        try:
+            value = int(hygiene.get(name, default))
+        except (TypeError, ValueError):
+            return default
+        return max(floor, value)
+
+    def _float(name: str, default: float, *, floor: float = 0.0, ceiling: float = 1.0) -> float:
+        try:
+            value = float(hygiene.get(name, default))
+        except (TypeError, ValueError):
+            return default
+        return min(ceiling, max(floor, value))
+
+    return HygieneConfig(
+        enabled=_is_truthy(hygiene.get("enabled"), default=False),
+        stale_context_ratio=_float("stale_context_ratio", 0.50, floor=0.01, ceiling=0.99),
+        stale_protect_tail_tokens=_int("stale_protect_tail_tokens", 40_000, floor=1_000),
+        protect_last_n=_int("protect_last_n", compression_protect_last_n, floor=0),
+        failed_after_user_turns=_int("failed_after_user_turns", 3, floor=0),
+        max_stub_paths=_int("max_stub_paths", 5, floor=0),
+    )
+
+
+def _text_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, Mapping):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        if parts:
+            return "\n".join(parts)
+    return str(content)
+
+
+def _content_chars(content: Any) -> int:
+    return len(_text_content(content))
+
+
+def _message_tokens_rough(msg: Mapping[str, Any]) -> int:
+    # Keep deterministic and cheap.  The main loop does the authoritative rough
+    # token estimate separately; this only defines the protected tail window.
+    return max(1, len(str(msg)) // 4)
+
+
+def _normalize_args(args: Any) -> str:
+    if isinstance(args, str):
+        try:
+            parsed = json.loads(args)
+        except Exception:
+            return args.strip()
+        try:
+            return json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except Exception:
+            return args.strip()
+    try:
+        return json.dumps(args, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    except Exception:
+        return str(args)
+
+
+def _sha12(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def _iter_tool_calls(msg: Mapping[str, Any]) -> Iterable[Tuple[str, str, str]]:
+    tool_calls = msg.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        return []
+    rows: list[Tuple[str, str, str]] = []
+    for tc in tool_calls:
+        if not isinstance(tc, Mapping):
+            continue
+        call_id = str(tc.get("id") or tc.get("call_id") or "").strip()
+        fn = tc.get("function")
+        if not isinstance(fn, Mapping):
+            continue
+        name = str(fn.get("name") or "").strip()
+        args = _normalize_args(fn.get("arguments", ""))
+        if call_id and name:
+            rows.append((call_id, name, args))
+    return rows
+
+
+def _tool_call_index(messages: Sequence[Mapping[str, Any]]) -> Dict[str, ToolCallInfo]:
+    index: Dict[str, ToolCallInfo] = {}
+    ordinal = 0
+    for msg in messages:
+        if not isinstance(msg, Mapping) or msg.get("role") != "assistant":
+            continue
+        for call_id, name, args_text in _iter_tool_calls(msg):
+            ordinal += 1
+            index[call_id] = ToolCallInfo(
+                ordinal=ordinal,
+                name=name,
+                args_text=args_text,
+                args_sha=_sha12(args_text),
+            )
+    return index
+
+
+def _tool_name(msg: Mapping[str, Any], info: ToolCallInfo | None) -> str:
+    return str(
+        msg.get("name")
+        or msg.get("tool_name")
+        or (info.name if info else "")
+        or "unknown"
+    )
+
+
+def _extract_paths(text: str, *, limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+    seen: set[str] = set()
+    paths: list[str] = []
+    for match in _PATH_RE.finditer(text):
+        path = match.group(0).rstrip(".]")
+        if path not in seen:
+            seen.add(path)
+            paths.append(path)
+            if len(paths) >= limit:
+                break
+    return paths
+
+
+def _looks_failed(text: str) -> tuple[bool, str]:
+    lowered = text.lower()
+    if "error executing tool" in lowered:
+        return True, "execution_error"
+    if "traceback (most recent call last)" in lowered:
+        return True, "traceback"
+    if "permission denied" in lowered:
+        return True, "permission_denied"
+    if "timed out" in lowered or "timeout" in lowered:
+        return True, "timeout"
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = None
+    if isinstance(parsed, Mapping):
+        err = parsed.get("error")
+        if err:
+            return True, str(parsed.get("error_type") or parsed.get("type") or "error")[:80]
+        exit_code = parsed.get("exit_code", parsed.get("returncode"))
+        if isinstance(exit_code, int) and exit_code != 0:
+            return True, f"exit_code_{exit_code}"
+    if re.search(r"\b(error|failed|exception)\b", lowered):
+        return True, "error"
+    return False, ""
+
+
+def _user_turns_after(messages: Sequence[Mapping[str, Any]], idx: int) -> int:
+    return sum(1 for msg in messages[idx + 1 :] if isinstance(msg, Mapping) and msg.get("role") == "user")
+
+
+def _protected_tail_indices(messages: Sequence[Mapping[str, Any]], cfg: HygieneConfig) -> set[int]:
+    protected: set[int] = set()
+    if cfg.protect_last_n > 0:
+        start = max(0, len(messages) - cfg.protect_last_n)
+        protected.update(range(start, len(messages)))
+    remaining = cfg.stale_protect_tail_tokens
+    for idx in range(len(messages) - 1, -1, -1):
+        if remaining <= 0:
+            break
+        protected.add(idx)
+        remaining -= _message_tokens_rough(messages[idx])
+    return protected
+
+
+def _replace_content(msg: MutableMapping[str, Any], stub: str) -> int:
+    old_chars = _content_chars(msg.get("content"))
+    msg["content"] = stub
+    return max(0, old_chars - len(stub))
+
+
+def _dedup_stub(tool: str, info: ToolCallInfo | None, latest: ToolCallInfo | None, original_chars: int) -> str:
+    latest_ord = latest.ordinal if latest else "?"
+    args_sha = info.args_sha if info else "unknown"
+    return (
+        f"[pruned: superseded by call #{latest_ord}; tool={tool}; "
+        f"args_sha={args_sha}; original_chars={original_chars}]"
+    )
+
+
+def _failed_stub(tool: str, info: ToolCallInfo | None, error_type: str, original_chars: int) -> str:
+    ordinal = info.ordinal if info else "?"
+    return (
+        f"[pruned: old failed tool output; call=#{ordinal}; tool={tool}; "
+        f"error_type={error_type}; original_chars={original_chars}]"
+    )
+
+
+def _stale_stub(tool: str, info: ToolCallInfo | None, original_chars: int, paths: list[str]) -> str:
+    ordinal = info.ordinal if info else "?"
+    args_sha = info.args_sha if info else "unknown"
+    if paths:
+        pointer = " paths=" + ",".join(paths)
+    else:
+        pointer = " paths=none"
+    return (
+        f"[pruned: stale tool output; call=#{ordinal}; tool={tool}; args_sha={args_sha}; "
+        f"original_chars={original_chars}; requery=use the tool_call_id or rerun the tool if needed;{pointer}]"
+    )
+
+
+def apply_api_tool_output_hygiene(
+    messages: List[Dict[str, Any]],
+    *,
+    config: HygieneConfig,
+    request_tokens: int,
+    context_length: int,
+    session_id: str = "",
+) -> tuple[List[Dict[str, Any]], HygieneStats]:
+    """Return an API-message copy with old tool outputs replaced by stubs.
+
+    ``messages`` is expected to already be an API-call copy.  With
+    ``config.enabled`` false this returns the exact same list object and an empty
+    stats object, preserving flag-off equality for callers/tests.
+    """
+    if not config.enabled:
+        return messages, HygieneStats()
+
+    call_index = _tool_call_index(messages)
+    latest_by_key: Dict[Tuple[str, str], ToolCallInfo] = {}
+    for info in call_index.values():
+        latest_by_key[(info.name, info.args_text)] = info
+
+    context_ratio = (request_tokens / context_length) if context_length > 0 else 0.0
+    stale_enabled = context_ratio >= config.stale_context_ratio
+    protected_tail = _protected_tail_indices(messages, config) if stale_enabled else set()
+
+    # Copy lazily: once enabled, create new dicts so even tests cannot observe
+    # mutation of the API list passed by the caller.  Content lists are replaced
+    # wholesale only when pruned; otherwise shallow-copying message dicts is
+    # enough because this module never mutates nested structures.
+    out: List[Dict[str, Any]] = [dict(msg) if isinstance(msg, Mapping) else msg for msg in messages]
+
+    dedup = failed = stale = saved = 0
+    for idx, msg in enumerate(out):
+        if not isinstance(msg, MutableMapping) or msg.get("role") != "tool":
+            continue
+        call_id = str(msg.get("tool_call_id") or msg.get("id") or "").strip()
+        info = call_index.get(call_id)
+        tool = _tool_name(msg, info)
+        text = _text_content(msg.get("content"))
+        original_chars = len(text)
+
+        if info is not None:
+            latest = latest_by_key.get((info.name, info.args_text))
+            if latest is not None and latest.ordinal != info.ordinal:
+                saved += _replace_content(msg, _dedup_stub(tool, info, latest, original_chars))
+                dedup += 1
+                continue
+
+        is_failed, error_type = _looks_failed(text)
+        if is_failed and _user_turns_after(out, idx) >= config.failed_after_user_turns:
+            saved += _replace_content(msg, _failed_stub(tool, info, error_type, original_chars))
+            failed += 1
+            continue
+
+        if stale_enabled and idx not in protected_tail:
+            paths = _extract_paths(text, limit=config.max_stub_paths)
+            saved += _replace_content(msg, _stale_stub(tool, info, original_chars, paths))
+            stale += 1
+
+    stats = HygieneStats(
+        dedup_pruned=dedup,
+        failed_pruned=failed,
+        stale_pruned=stale,
+        saved_chars=saved,
+    )
+    if stats.total_pruned:
+        logger.info(
+            "context_hygiene session=%s pruned=%d dedup=%d failed=%d stale=%d saved_tokens=%d saved_chars=%d request_tokens=%d context_length=%d context_ratio=%.3f",
+            session_id or "-",
+            stats.total_pruned,
+            stats.dedup_pruned,
+            stats.failed_pruned,
+            stats.stale_pruned,
+            stats.saved_tokens_rough,
+            stats.saved_chars,
+            request_tokens,
+            context_length,
+            context_ratio,
+        )
+    return out, stats
+
+
+__all__ = [
+    "HygieneConfig",
+    "HygieneStats",
+    "apply_api_tool_output_hygiene",
+    "config_from_mapping",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6722,6 +6722,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._gateway_loop = asyncio.get_running_loop()
         except RuntimeError:
             self._gateway_loop = None
+
+        # Codex burst limiter (HEMP 2026-07-12): register the gateway loop for
+        # the cross-thread bridge and install the limiter from config.yaml
+        # (``throttle.codex``).  Best-effort — a config/import hiccup here must
+        # never block gateway startup, and the limiter fails open regardless.
+        try:
+            from agent import codex_throttle
+            from hermes_cli.config import read_raw_config
+
+            codex_throttle.set_gateway_loop(self._gateway_loop)
+            codex_throttle.configure_from_config(read_raw_config())
+        except Exception as _throttle_exc:  # noqa: BLE001 — never block startup
+            logger.warning("codex throttle setup skipped: %s", _throttle_exc)
+
         logger.info("Session storage: %s", self.config.sessions_dir)
 
         # Sanity-check that systemd's TimeoutStopSec covers our drain

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -10,10 +10,32 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
     so the endpoint's server default applies)
 """
 
+import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+
+def _is_ollama_endpoint(base_url: str | None) -> bool:
+    """True when base_url targets an Ollama server (its default port 11434).
+
+    Ollama is the one custom-lane backend known to reject Hermes' ``xhigh``
+    reasoning level (agent.log.1 2026-07-10: 400 "invalid reasoning value").
+    Keying off its signature port keeps the compat clamp scoped to Ollama and
+    leaves GLM-5.2/ARK, vLLM, and llama.cpp endpoints on the verbatim
+    passthrough so ``max``/``xhigh`` survive where the server accepts them.
+    """
+    if not base_url:
+        return False
+    try:
+        parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
+        return parsed.port == 11434
+    except Exception:
+        return False
 
 
 class CustomProfile(ProviderProfile):
@@ -55,6 +77,17 @@ class CustomProfile(ProviderProfile):
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
             elif _effort:
+                # Ollama validates reasoning_effort against
+                # {high, medium, low, max, none} and 400s on Hermes' ``xhigh``
+                # superset level. Downgrade xhigh->high for the Ollama lane only
+                # (default port 11434) so the free local last-resort fallback
+                # survives; other custom endpoints keep the verbatim passthrough.
+                if _effort == "xhigh" and _is_ollama_endpoint(ctx.get("base_url")):
+                    logger.info(
+                        "reasoning effort clamped xhigh->high for custom lane "
+                        "(ollama compat)"
+                    )
+                    _effort = "high"
                 top_level["reasoning_effort"] = _effort
 
         return extra_body, top_level

--- a/tests/agent/test_codex_throttle.py
+++ b/tests/agent/test_codex_throttle.py
@@ -1,0 +1,305 @@
+"""Unit tests for the Codex outbound-call burst limiter (``agent.codex_throttle``).
+
+Covers the four behaviours the HEMP 2026-07-12 contract pins for the limiter
+that paces ``openai-codex`` Responses API calls (the 13:14 429 credential
+cascade fix):
+
+1. **Rolling-window pacing** — under the cap ``acquire`` admits instantly; at
+   the cap it waits *exactly* until the oldest in-window call ages out, then
+   admits (drop-free). ``window_count`` prunes aged events.
+2. **Off / unregistered no-op** — ``enabled: false`` or ``calls_per_hour <= 0``
+   makes the limiter inert; the sync bridge is a no-op when unconfigured,
+   disabled, or when no gateway loop is registered (CLI / cron / tests).
+3. **Loop-thread guard** — ``throttle_codex_call_blocking`` returns immediately
+   when already running on the gateway loop (``_running_loop_is``), so it never
+   submits ``acquire`` back onto its own loop and deadlocks.
+4. **FIFO order** — queued callers are admitted in arrival order.
+
+The limiter takes injectable ``time_func`` / ``sleep_func`` so window maths can
+be driven deterministically without real wall-clock waits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+import agent.codex_throttle as ct
+from agent.codex_throttle import (
+    CodexRateLimiter,
+    configure,
+    configure_from_config,
+    get_limiter,
+    set_gateway_loop,
+    throttle_codex_call_blocking,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_codex_throttle_singletons(monkeypatch):
+    """Isolate the process-wide limiter / loop between tests in this file."""
+    monkeypatch.setattr(ct, "_limiter", None)
+    monkeypatch.setattr(ct, "_gateway_loop", None)
+    yield
+
+
+class _FakeClock:
+    """Injectable deterministic clock + async sleep that advances it.
+
+    Every ``await sleep(n)`` records ``n`` and moves the clock forward by ``n``,
+    so a burst past the cap is driven with zero real wall-clock time.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+        self.sleeps: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+# --------------------------------------------------------------------------- #
+# 1. Rolling-window pacing
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_under_cap_admits_immediately_without_waiting():
+    clock = _FakeClock()
+    lim = CodexRateLimiter(
+        calls_per_hour=3,
+        window_seconds=100.0,
+        max_wait_seconds=None,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+    for _ in range(3):
+        await lim.acquire()
+    assert lim.window_count() == 3
+    assert clock.sleeps == []  # never waited while under the cap
+
+
+@pytest.mark.asyncio
+async def test_at_cap_waits_exactly_until_oldest_ages_out():
+    clock = _FakeClock(start=1000.0)
+    lim = CodexRateLimiter(
+        calls_per_hour=3,
+        window_seconds=100.0,
+        max_wait_seconds=None,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+    for _ in range(3):  # fill the window at t=1000
+        await lim.acquire()
+
+    await lim.acquire()  # 4th: at the cap -> must wait one full window
+
+    # oldest in-window call was at t=1000; it ages out at 1000+100 -> wait == 100
+    assert clock.sleeps == [100.0]
+    assert clock.now == 1100.0
+    # the three t=1000 events aged out; only the freshly admitted 4th remains
+    assert lim.window_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_window_count_prunes_events_outside_window():
+    clock = _FakeClock(start=500.0)
+    lim = CodexRateLimiter(
+        calls_per_hour=10,
+        window_seconds=60.0,
+        max_wait_seconds=None,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+    await lim.acquire()
+    await lim.acquire()
+    assert lim.window_count() == 2
+
+    clock.now += 61.0  # both admitted calls now older than the 60s window
+    assert lim.window_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_max_wait_safety_valve_admits_drop_free_under_sustained_overload():
+    """Under sustained > cap load, a single call never blocks longer than
+    ``max_wait_seconds`` — it proceeds drop-free rather than pin its thread."""
+    clock = _FakeClock(start=0.0)
+    lim = CodexRateLimiter(
+        calls_per_hour=1,
+        window_seconds=1000.0,  # oldest call would otherwise block ~1000s
+        max_wait_seconds=5.0,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+    await lim.acquire()  # fills the single slot at t=0
+    await lim.acquire()  # at cap; wait capped at max_wait then admit drop-free
+
+    assert sum(clock.sleeps) == pytest.approx(5.0)  # never waited the full window
+    assert lim.window_count() == 2  # both admitted (drop-free), none dropped
+
+
+# --------------------------------------------------------------------------- #
+# 2. Off switch / no-op
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_disabled_by_zero_cap_is_noop():
+    lim = CodexRateLimiter(calls_per_hour=0)
+    assert lim.active is False
+    await lim.acquire()  # completes through instantly, records nothing
+    assert lim.window_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_enabled_false_is_noop():
+    lim = CodexRateLimiter(calls_per_hour=100, enabled=False)
+    assert lim.active is False
+    await lim.acquire()
+    assert lim.window_count() == 0
+
+
+def test_configure_from_config_missing_block_fails_safe_to_disabled():
+    lim = configure_from_config({})
+    assert lim.enabled is False
+    assert lim.active is False
+    assert get_limiter() is lim  # installed as the process-wide singleton
+
+
+def test_configure_from_config_enables_with_values():
+    lim = configure_from_config(
+        {"throttle": {"codex": {"enabled": True, "calls_per_hour": 40}}}
+    )
+    assert lim.active is True
+    assert lim.calls_per_hour == 40
+
+
+def test_configure_from_config_malformed_cap_fails_safe_to_disabled():
+    lim = configure_from_config(
+        {"throttle": {"codex": {"enabled": True, "calls_per_hour": "oops"}}}
+    )
+    # a config typo must never wedge codex: malformed cap -> 0 -> inactive
+    assert lim.calls_per_hour == 0
+    assert lim.active is False
+
+
+def test_bridge_noop_when_limiter_unconfigured():
+    # _limiter is None (reset fixture) -> return without touching any loop.
+    assert get_limiter() is None
+    throttle_codex_call_blocking()  # must not raise / hang
+
+
+def test_bridge_noop_when_limiter_disabled():
+    configure(enabled=False, calls_per_hour=0)
+    throttle_codex_call_blocking()  # inactive limiter -> no-op
+
+
+def test_bridge_noop_when_no_gateway_loop_registered():
+    configure(enabled=True, calls_per_hour=5)
+    set_gateway_loop(None)  # CLI / cron / tests: no loop -> bridge is a no-op
+    throttle_codex_call_blocking()
+
+
+# --------------------------------------------------------------------------- #
+# 3. Loop-thread guard (_running_loop_is)
+# --------------------------------------------------------------------------- #
+def test_running_loop_is_false_outside_event_loop():
+    other = asyncio.new_event_loop()
+    try:
+        # No loop is running in this sync test -> get_running_loop() raises ->
+        # guarded to False.
+        assert ct._running_loop_is(other) is False
+    finally:
+        other.close()
+
+
+@pytest.mark.asyncio
+async def test_running_loop_is_true_for_the_current_running_loop():
+    loop = asyncio.get_running_loop()
+    assert ct._running_loop_is(loop) is True
+
+
+@pytest.mark.asyncio
+async def test_bridge_returns_early_when_called_on_gateway_loop_thread(monkeypatch):
+    """If invoked from the gateway loop thread itself, the bridge must bail out
+    *before* submitting ``acquire`` onto that loop — otherwise it would block
+    the loop waiting on its own future (deadlock)."""
+    lim = configure(enabled=True, calls_per_hour=1)  # active
+
+    calls = {"n": 0}
+
+    async def _spy_acquire():
+        calls["n"] += 1
+
+    monkeypatch.setattr(lim, "acquire", _spy_acquire)
+
+    loop = asyncio.get_running_loop()
+    set_gateway_loop(loop)  # gateway loop == the loop we're running on now
+
+    throttle_codex_call_blocking(timeout=5)
+
+    # The _running_loop_is guard returned before acquire could be scheduled.
+    assert calls["n"] == 0
+
+
+def test_bridge_admits_via_gateway_loop_from_worker_thread():
+    """Happy path: called off-loop, the bridge hops onto the gateway loop and
+    completes once admitted — exercising the run_coroutine_threadsafe wiring."""
+    loop = asyncio.new_event_loop()
+
+    def _run_loop():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    t = threading.Thread(target=_run_loop, daemon=True)
+    t.start()
+    try:
+        deadline = time.time() + 5
+        while not loop.is_running() and time.time() < deadline:
+            time.sleep(0.005)
+        assert loop.is_running()
+
+        configure(enabled=True, calls_per_hour=5)  # under cap -> admit instantly
+        set_gateway_loop(loop)
+
+        # Called from THIS (worker) thread, not the loop thread.
+        throttle_codex_call_blocking(timeout=5)
+
+        # future.result() only returns after acquire() recorded the admission.
+        assert get_limiter().window_count() == 1
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=5)
+        loop.close()
+
+
+# --------------------------------------------------------------------------- #
+# 4. FIFO order under contention
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_acquire_preserves_fifo_order_under_contention():
+    """At the cap, queued callers are admitted strictly in arrival order."""
+    lim = CodexRateLimiter(
+        calls_per_hour=1, window_seconds=0.05, max_wait_seconds=None
+    )
+    admitted: list[str] = []
+
+    await lim.acquire()  # seed takes the single slot
+    admitted.append("seed")
+
+    async def worker(name: str) -> None:
+        await lim.acquire()
+        admitted.append(name)
+
+    tasks = []
+    for name in ("a", "b", "c", "d"):
+        tasks.append(asyncio.create_task(worker(name)))
+        # Yield so this worker reaches & queues on the internal lock (in order)
+        # before the next is created — pins deterministic arrival order.
+        await asyncio.sleep(0)
+
+    await asyncio.gather(*tasks)
+    assert admitted == ["seed", "a", "b", "c", "d"]

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -10,7 +10,9 @@ These tests pin the wire-shape contract:
   - disabled            → extra_body.think = False
   - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
                           format GLM/ARK expect), passed through verbatim
-                          including ``max``/``xhigh``
+                          including ``max``/``xhigh`` — except ``xhigh`` is
+                          clamped to ``high`` for the Ollama lane (port 11434),
+                          which rejects the superset level (TestOllamaXhighClamp)
   - enabled + no effort → nothing emitted (endpoint's server default applies)
   - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
 """
@@ -115,4 +117,70 @@ class TestCustomReasoningWithNumCtx:
             model="qwen3",
         )
         assert eb == {"options": {"num_ctx": 8192}}
+        assert tl == {"reasoning_effort": "high"}
+
+
+class TestOllamaXhighClamp:
+    """``xhigh`` is clamped to ``high`` for the Ollama lane only (port 11434).
+
+    Ollama's OpenAI-compatible endpoint validates reasoning_effort against
+    {high, medium, low, max, none} and 400s on Hermes' ``xhigh`` superset
+    level (agent.log.1 2026-07-10). The clamp is keyed on Ollama's signature
+    port so GLM-5.2/ARK, vLLM, and llama.cpp keep the verbatim passthrough
+    pinned by TestCustomReasoningWireShape — the free local last-resort
+    fallback survives instead of dying on a total-outage day.
+    """
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://127.0.0.1:11434/v1",
+            "http://localhost:11434/v1",
+            "http://100.85.75.123:11434/v1",  # ollama reached over Tailscale
+        ],
+    )
+    def test_xhigh_clamped_to_high_for_ollama(self, custom_profile, base_url):
+        """xhigh + ollama endpoint (:11434) → high, regardless of host form."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            base_url=base_url,
+            model="qwen3:14b",
+        )
+        assert tl == {"reasoning_effort": "high"}
+        assert "reasoning_effort" not in eb
+
+    def test_xhigh_passthrough_for_non_ollama_custom(self, custom_profile):
+        """xhigh on a non-ollama custom endpoint (GLM/ARK) is NOT clamped —
+        the verbatim-passthrough contract for those backends is preserved."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+            model="glm-5.2",
+        )
+        assert tl == {"reasoning_effort": "xhigh"}
+
+    def test_xhigh_passthrough_when_base_url_absent(self, custom_profile):
+        """No base_url (ollama can't be identified) → passthrough, not clamp."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.2",
+        )
+        assert tl == {"reasoning_effort": "xhigh"}
+
+    def test_max_not_clamped_for_ollama(self, custom_profile):
+        """``max`` is a valid ollama level — only xhigh is clamped."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="http://127.0.0.1:11434/v1",
+            model="qwen3:14b",
+        )
+        assert tl == {"reasoning_effort": "max"}
+
+    def test_high_unchanged_for_ollama(self, custom_profile):
+        """high + ollama is a no-op (already a valid level)."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="http://127.0.0.1:11434/v1",
+            model="qwen3:14b",
+        )
         assert tl == {"reasoning_effort": "high"}

--- a/tests/run_agent/test_tool_output_hygiene.py
+++ b/tests/run_agent/test_tool_output_hygiene.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from agent.tool_output_hygiene import HygieneConfig, apply_api_tool_output_hygiene
+
+
+def _assistant(call_id: str, name: str, args: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": call_id, "type": "function", "function": {"name": name, "arguments": args}}
+        ],
+    }
+
+
+def _tool(call_id: str, name: str, content: str) -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "name": name, "content": content}
+
+
+def test_flag_off_returns_exact_same_api_message_list() -> None:
+    messages = [
+        {"role": "user", "content": "keep me"},
+        _assistant("c1", "terminal", '{"command":"pwd"}'),
+        _tool("c1", "terminal", "x" * 1000),
+    ]
+
+    out, stats = apply_api_tool_output_hygiene(
+        messages,
+        config=HygieneConfig(enabled=False),
+        request_tokens=900,
+        context_length=1000,
+        session_id="s",
+    )
+
+    assert out is messages
+    assert stats.total_pruned == 0
+    assert messages[2]["content"] == "x" * 1000
+
+
+def test_dedup_prunes_superseded_tool_result_but_keeps_latest_raw() -> None:
+    old = "old-result" * 200
+    latest = "latest-result" * 200
+    messages = [
+        {"role": "user", "content": "run pwd"},
+        _assistant("c1", "terminal", '{"command":"pwd"}'),
+        _tool("c1", "terminal", old),
+        {"role": "user", "content": "run pwd again"},
+        _assistant("c2", "terminal", '{"command":"pwd"}'),
+        _tool("c2", "terminal", latest),
+    ]
+
+    out, stats = apply_api_tool_output_hygiene(
+        messages,
+        config=HygieneConfig(enabled=True, stale_context_ratio=0.99),
+        request_tokens=100,
+        context_length=1000,
+        session_id="s",
+    )
+
+    assert out is not messages
+    assert stats.dedup_pruned == 1
+    assert "[pruned: superseded by call #2" in out[2]["content"]
+    assert out[5]["content"] == latest
+    # Original session/API input copy is not mutated.
+    assert messages[2]["content"] == old
+
+
+def test_failed_tool_output_prunes_only_after_configured_user_turn_age() -> None:
+    error = '{"error":"boom","error_type":"RuntimeError","detail":"' + ("!" * 200) + '"}'
+    messages = [
+        {"role": "user", "content": "try"},
+        _assistant("c1", "terminal", '{"command":"bad"}'),
+        _tool("c1", "terminal", error),
+        {"role": "user", "content": "turn1"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "turn2"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "turn3"},
+    ]
+
+    out, stats = apply_api_tool_output_hygiene(
+        messages,
+        config=HygieneConfig(enabled=True, failed_after_user_turns=3, stale_context_ratio=0.99),
+        request_tokens=100,
+        context_length=1000,
+        session_id="s",
+    )
+
+    assert stats.failed_pruned == 1
+    assert "[pruned: old failed tool output" in out[2]["content"]
+    assert "error_type=RuntimeError" in out[2]["content"]
+
+    young, young_stats = apply_api_tool_output_hygiene(
+        messages[:-1],
+        config=HygieneConfig(enabled=True, failed_after_user_turns=3, stale_context_ratio=0.99),
+        request_tokens=100,
+        context_length=1000,
+        session_id="s",
+    )
+    assert young_stats.failed_pruned == 0
+    assert young[2]["content"] == error
+
+
+def test_stale_pruning_preserves_paths_and_respects_tail_window() -> None:
+    old = "see /Users/automation/project/results/out.txt\n" + ("A" * 2000)
+    recent = "recent tool result" * 100
+    messages = [
+        {"role": "user", "content": "old"},
+        _assistant("c1", "read_file", '{"path":"/Users/automation/project/results/out.txt"}'),
+        _tool("c1", "read_file", old),
+        {"role": "user", "content": "recent"},
+        _assistant("c2", "terminal", '{"command":"date"}'),
+        _tool("c2", "terminal", recent),
+    ]
+
+    out, stats = apply_api_tool_output_hygiene(
+        messages,
+        config=HygieneConfig(
+            enabled=True,
+            stale_context_ratio=0.50,
+            stale_protect_tail_tokens=1,
+            protect_last_n=2,
+        ),
+        request_tokens=600,
+        context_length=1000,
+        session_id="s",
+    )
+
+    assert stats.stale_pruned == 1
+    assert "[pruned: stale tool output" in out[2]["content"]
+    assert "/Users/automation/project/results/out.txt" in out[2]["content"]
+    assert out[5]["content"] == recent
+
+
+def test_hygiene_never_prunes_user_or_assistant_content() -> None:
+    user_text = "USER" * 1000
+    assistant_text = "ASSISTANT" * 1000
+    messages = [
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+        _assistant("c1", "terminal", '{"command":"date"}'),
+        _tool("c1", "terminal", "old" * 1000),
+        {"role": "user", "content": "tail"},
+    ]
+
+    out, stats = apply_api_tool_output_hygiene(
+        messages,
+        config=HygieneConfig(enabled=True, stale_context_ratio=0.1, stale_protect_tail_tokens=1, protect_last_n=1),
+        request_tokens=900,
+        context_length=1000,
+        session_id="s",
+    )
+
+    assert stats.total_pruned == 1
+    assert out[0]["content"] == user_text
+    assert out[1]["content"] == assistant_text

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -334,6 +334,20 @@ _MAX_BACKOFF_SECONDS = 60
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+# After this many consecutive park cycles a plain transport rebuild
+# (run()'s ``continue`` → _run_stdio) is presumed insufficient: the wedge is
+# surviving in-process state, not a transient transport drop. On every Nth
+# cycle the server does a full COLD recreate of its per-connection managed
+# objects (sampling/elicitation handlers, background refresh tasks, per-server
+# locks) plus an aggressive orphan reap — the same shape a fresh __init__ +
+# startup produces — instead of reusing the same corrupted state. Fail-open: a
+# cold recreate that raises falls back to the normal rebuild. (GBrain
+# permanent-wedge incident, 2026-07-12.)
+_COLD_RECREATE_AFTER_PARKS = 3
+# After this many consecutive park cycles with no recovery, emit a one-shot
+# CRIT log so a permanently wedged server is never silently parked. The
+# gateway's log watchers (doctor/guardian) surface CRIT lines.
+_PARK_ESCALATE_AFTER_CYCLES = 5
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 
 # Keepalive cadence for HTTP/SSE sessions. The MCP spec lets a server expire
@@ -1527,6 +1541,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries",
+        "_park_cycles", "_park_escalated",
     )
 
     def __init__(self, name: str):
@@ -1587,6 +1602,12 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        # Consecutive park cycles since the last healthy session. Drives the
+        # cold recreate (every _COLD_RECREATE_AFTER_PARKS cycles) and the
+        # one-shot escalation CRIT (_PARK_ESCALATE_AFTER_CYCLES). Both are
+        # cleared by _note_healthy_session on establishment.
+        self._park_cycles: int = 0
+        self._park_escalated: bool = False
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -2164,6 +2185,7 @@ class MCPServerTask:
                     # so transient prior failures do not accumulate toward
                     # permanent parking (#57604).
                     self._reconnect_retries = 0
+                    self._note_healthy_session()
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
@@ -2456,6 +2478,7 @@ class MCPServerTask:
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
                     self._reconnect_retries = 0
+                    self._note_healthy_session()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2513,6 +2536,7 @@ class MCPServerTask:
                         # isn't gated on a stale failure count (#16788).
                         _reset_server_error(self.name)
                         self._reconnect_retries = 0
+                        self._note_healthy_session()
                         reason = await self._wait_for_lifecycle_event()
                         if reason == "reconnect":
                             logger.info(
@@ -2545,6 +2569,7 @@ class MCPServerTask:
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
                     self._reconnect_retries = 0
+                    self._note_healthy_session()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2603,6 +2628,126 @@ class MCPServerTask:
             self.name, self, self._config
         )
 
+    def _note_healthy_session(self) -> None:
+        """Clear park-escalation bookkeeping after a session is established.
+
+        Called at every establishment site alongside the reconnect-retry
+        reset, so a server that recovers (whether via the normal reconnect
+        path or a cold recreate) starts the next outage from a clean slate.
+        """
+        self._park_cycles = 0
+        self._park_escalated = False
+
+    def _setup_handlers(self, config: dict) -> None:
+        """(Re)create the sampling and elicitation handlers from *config*.
+
+        Shared by :meth:`run` at startup and :meth:`_cold_recreate_state`, so a
+        cold rebuild reconstructs them through the exact same path a fresh
+        start uses. Elicitation lets servers ask the client for structured
+        input mid-tool-call (e.g. payment authorization); the handler routes
+        those through Hermes' approval system.
+        """
+        sampling_config = config.get("sampling", {})
+        if sampling_config.get("enabled", True) and _MCP_SAMPLING_TYPES:
+            self._sampling = SamplingHandler(self.name, sampling_config)
+        else:
+            self._sampling = None
+        elicitation_config = config.get("elicitation", {})
+        if elicitation_config.get("enabled", True) and _MCP_ELICITATION_TYPES:
+            self._elicitation = ElicitationHandler(
+                self.name, elicitation_config, owner=self
+            )
+        else:
+            self._elicitation = None
+
+    def _maybe_escalate_park(self, exc: Optional[BaseException] = None) -> None:
+        """Emit a one-shot CRIT when a server stays parked past the escalation
+        threshold, so a permanent wedge is never silently parked.
+
+        The gateway's log watchers (doctor/guardian) tail CRIT lines, so this
+        is the in-process surfacing path. Latched via ``_park_escalated`` and
+        reset by :meth:`_note_healthy_session` on recovery, so it fires at most
+        once per wedge episode.
+        """
+        if self._park_escalated or self._park_cycles < _PARK_ESCALATE_AFTER_CYCLES:
+            return
+        self._park_escalated = True
+        logger.critical(
+            "MCP server '%s' has been parked for %d consecutive cycles "
+            "(~%.0f min) without recovering via automatic rebuild — the "
+            "server may be permanently wedged and need manual intervention: %s",
+            self.name, self._park_cycles,
+            (self._park_cycles * _PARKED_RETRY_INTERVAL) / 60.0,
+            exc if exc is not None else "(no error captured)",
+        )
+
+    async def _cold_recreate_state(self) -> bool:
+        """Fully rebuild this server's in-process managed state (fail-open).
+
+        A plain transport rebuild (run()'s ``continue`` → _run_stdio / _run_http)
+        makes a fresh transport but REUSES the long-lived per-server objects on
+        ``self``: the sampling/elicitation handlers, the background refresh
+        tasks, and the per-server RPC/refresh locks. If any of those is wedged —
+        a refresh task pinned on a dead stream, a lock still held by a cancelled
+        RPC, a handler bound to a torn-down session — every rebuild inherits the
+        corruption and the server stays parked even though its binary is healthy
+        (GBrain incident, 2026-07-12: each rebuild died ~145 ms before the child
+        banner). This discards and re-creates that state to the same shape a
+        fresh __init__ + startup produces, and aggressively reaps any lingering
+        child process tree so the next spawn starts from a clean slate.
+
+        Returns True when the cold rebuild ran, False when it was skipped or
+        failed. On failure the caller falls through to the normal rebuild, so a
+        healthy server can never be harmed by this recovery attempt.
+        """
+        try:
+            logger.warning(
+                "MCP server '%s': cold-recreating in-process state after %d "
+                "park cycles (plain transport rebuild is not recovering it).",
+                self.name, self._park_cycles,
+            )
+            # Cancel and drop background refresh tasks that may be pinned on the
+            # dead session's streams (mirrors shutdown()'s teardown).
+            if self._pending_refresh_tasks:
+                for task in list(self._pending_refresh_tasks):
+                    task.cancel()
+                await asyncio.gather(
+                    *self._pending_refresh_tasks, return_exceptions=True
+                )
+                self._pending_refresh_tasks.clear()
+            # Reap any orphaned child tree for THIS server so a stale child
+            # can't keep holding a singleton resource (lock file, socket,
+            # pidfile) that a fresh spawn needs — a plausible cause of the
+            # child dying before its banner on every rebuild.
+            try:
+                await asyncio.to_thread(
+                    _kill_orphaned_mcp_children, False, self.name
+                )
+            except Exception:
+                pass
+            # Reset per-connection scalars to __init__ defaults.
+            self.session = None
+            self.initialize_result = None
+            self._ping_unsupported = False
+            self._pending_call_context = None
+            self._recycled_reason = None
+            # Recreate the per-server locks so one held by a cancelled RPC
+            # can't deadlock every future call. Safe here: parking deregistered
+            # the tools, so no live RPC is holding them.
+            self._rpc_lock = asyncio.Lock()
+            self._refresh_lock = asyncio.Lock()
+            # Rebuild the sampling/elicitation handlers through the same path a
+            # fresh startup uses, discarding any handler bound to the dead
+            # session.
+            self._setup_handlers(self._config)
+            return True
+        except Exception as exc:
+            logger.warning(
+                "MCP server '%s': cold recreate failed (%s) — falling back to "
+                "the normal rebuild path.", self.name, exc,
+            )
+            return False
+
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
 
@@ -2615,22 +2760,10 @@ class MCPServerTask:
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
         self._max_lifetime_seconds = _get_lifecycle_seconds(config, "max_lifetime_seconds")
 
-        # Set up sampling handler if enabled and SDK types are available
-        sampling_config = config.get("sampling", {})
-        if sampling_config.get("enabled", True) and _MCP_SAMPLING_TYPES:
-            self._sampling = SamplingHandler(self.name, sampling_config)
-        else:
-            self._sampling = None
-
-        # Set up elicitation handler if enabled and SDK types are available.
-        # Servers use elicitation/create to ask the client for structured
-        # input mid-tool-call (e.g. payment authorization). The handler
-        # routes those requests through Hermes' approval system.
-        elicitation_config = config.get("elicitation", {})
-        if elicitation_config.get("enabled", True) and _MCP_ELICITATION_TYPES:
-            self._elicitation = ElicitationHandler(self.name, elicitation_config, owner=self)
-        else:
-            self._elicitation = None
+        # Set up the sampling and elicitation handlers (when enabled and the
+        # SDK types are available). Shared with _cold_recreate_state so a cold
+        # rebuild reconstructs them identically.
+        self._setup_handlers(config)
 
         # Validate: warn if both url and command are present
         if "url" in config and "command" in config:
@@ -2780,11 +2913,20 @@ class MCPServerTask:
                         self._ready.set()
                         self._deregister_tools()
                         self._reconnect_event.clear()
+                        self._park_cycles += 1
+                        self._maybe_escalate_park(exc)
                         parked = await self._wait_for_reconnect_or_shutdown(
                             timeout=_PARKED_RETRY_INTERVAL
                         )
                         if parked == "shutdown":
                             return
+                        # A plain rebuild has not cleared the wedge for this
+                        # many cycles: fully re-create the per-server managed
+                        # state before retrying. Fail-open — the cold path
+                        # swallows its own errors, so we always fall through to
+                        # the normal rebuild below.
+                        if self._park_cycles % _COLD_RECREATE_AFTER_PARKS == 0:
+                            await self._cold_recreate_state()
                         logger.info(
                             "MCP server '%s': attempting revival after initial "
                             "connection failures (self-probe or explicit "
@@ -2843,11 +2985,20 @@ class MCPServerTask:
                     # manual /mcp refresh) still wakes us immediately.
                     self._deregister_tools()
                     self._reconnect_event.clear()
+                    self._park_cycles += 1
+                    self._maybe_escalate_park(exc)
                     parked = await self._wait_for_reconnect_or_shutdown(
                         timeout=_PARKED_RETRY_INTERVAL
                     )
                     if parked == "shutdown":
                         return
+                    # A plain rebuild has not cleared the wedge for this many
+                    # cycles: fully re-create the per-server managed state
+                    # before the next transport attempt. Fail-open — the cold
+                    # path swallows its own errors, so we always fall through
+                    # to the normal rebuild below.
+                    if self._park_cycles % _COLD_RECREATE_AFTER_PARKS == 0:
+                        await self._cold_recreate_state()
                     logger.info(
                         "MCP server '%s': attempting revival from parked state "
                         "(self-probe or explicit reconnect request); "


### PR DESCRIPTION
## Summary

- add a configurable Codex call-rate limiter for bursty Codex/OpenAI-OAuth traffic
- wire throttle configuration at agent/gateway startup and before Codex runtime calls
- add tool-output hygiene to avoid replaying provider/tool failure traces as user context
- harden MCP parked-server recovery and custom/Ollama reasoning compatibility in the same 429-prevention pass

## Why

Long gateway sessions can hit provider-side 429/usage-limit failures when repeated tool-heavy turns, compaction/retry loops, and Codex transport calls cluster too tightly. This patch keeps the primary model route unchanged while adding a local rate cap and context hygiene guardrails.

## Verification

Passed on a clean worktree based on current `origin/main`:

```bash
python -m py_compile \
  agent/codex_throttle.py agent/tool_output_hygiene.py \
  agent/agent_init.py agent/codex_runtime.py agent/conversation_loop.py \
  gateway/run.py tools/mcp_tool.py \
  plugins/model-providers/custom/__init__.py

python -m pytest \
  tests/agent/test_codex_throttle.py \
  tests/run_agent/test_tool_output_hygiene.py \
  tests/plugins/model_providers/test_custom_profile.py \
  -q -o 'addopts='
# 42 passed

python -m pytest \
  tests/tools/test_mcp_tool.py \
  tests/tools/test_mcp_parked_self_probe.py \
  tests/tools/test_mcp_circuit_breaker.py \
  tests/tools/test_mcp_empty_error_message.py \
  tests/tools/test_mcp_tool_session_expired.py \
  tests/tools/test_mcp_loop_profile_override.py \
  -q -o 'addopts='
# 249 passed, 1 warning
```

I also tried a broader local full-suite run. It is not currently a useful patch-specific signal in this local gateway environment: the same unrelated groups fail on a pristine `origin/main` baseline (`19 failed, 294 passed` for the compared failing groups), while the patch-specific and MCP-focused suites above pass.

## Notes

- The limiter is config-driven and does not downshift the user's model/provider.
- Local deployment used `throttle.codex.enabled: true` and `calls_per_hour: 300`; defaults can remain conservative for upstream review.
