### PR TITLE
fix(desktop): preserve lane session recency order

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -594,6 +594,50 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
   })
 
+  it('preserves backend recency order when live sessions overlay a lane', () => {
+    const recentlyActive = makeSession('/www/app', {
+      id: 'recently-active',
+      git_branch: 'main',
+      started_at: 1,
+      last_active: 3
+    })
+
+    const newlyCreated = makeSession('/www/app', {
+      id: 'newly-created',
+      git_branch: 'main',
+      started_at: 2,
+      last_active: 2
+    })
+
+    const project = projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 2,
+          groups: [
+            lane({
+              id: '/www/app::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/www/app',
+              sessions: [recentlyActive, newlyCreated]
+            })
+          ]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [recentlyActive, newlyCreated])
+
+    expect(overlaid.repos[0].groups[0].sessions.map(session => session.id)).toEqual([
+      'recently-active',
+      'newly-created'
+    ])
+  })
+
   it('adds a new session to an existing worktree lane keyed by a divergent id (matches by path)', () => {
     // Backend keyed the worktree lane off a branch-style id (no live git probe),
     // but the lane PATH is the worktree dir. A new session under that worktree

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -397,7 +397,7 @@ export function liveSessionProjectId(session: SessionInfo, explicitProjects: Pro
 }
 
 const upsertSession = (rows: SessionInfo[], session: SessionInfo): SessionInfo[] =>
-  [session, ...rows.filter(row => row.id !== session.id)].sort((a, b) => b.started_at - a.started_at)
+  [session, ...rows.filter(row => row.id !== session.id)].sort((a, b) => sessionRecency(b) - sessionRecency(a))
 
 /**
  * The lane a live session belongs to WITHIN a known repo root, by path — the


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent session ordering in the desktop Projects sidebar.

The backend orders sessions by their latest activity, falling back to when they were created. The desktop’s live-session update was sorting them by creation time only, so an older session could remain below a newer session even after it was used more recently.

The live update now uses the same session recency logic as the backend.

## Related Issue

No related issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Updated the live session ordering in `workspace-groups.ts`.
- Added a regression test for an older session that was used more recently than a newer session.

## How to Test

1. Create two sessions in the same project lane.
2. Return to the session created first and send another message.
3. Confirm that it moves above the newer inactive session.
4. Leave and reopen the project and confirm the order remains the same.

I also ran the focused test suite, typecheck, and ESLint. All 40 focused tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs
- [x] This PR contains only changes related to this fix
- [ ] I've run the full Python test suite
- [x] I've added a regression test
- [x] I've tested on Windows 11 with WSL2

### Documentation & Housekeeping

- [x] Documentation changes are not needed
- [x] Config example changes are not needed
- [x] Contributor guide changes are not needed
- [x] I've considered cross-platform impact
- [x] Tool description and schema changes are not needed

## Test Results

```text
Test Files  1 passed
Tests       40 passed