### PR TITLE
test(cron): enforce profile-scoped cron store isolation for CRUD, output, and dashboard firing (#4707)

### DIFF
--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,43 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_reads_output_from_active_profile_override(self, tmp_path, monkeypatch):
+        """Chained jobs must not inject output from the launch profile."""
+        from cron import jobs as cron_jobs
+        from cron.scheduler import _build_job_prompt
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        launch_home = tmp_path / "launch"
+        profile_home = tmp_path / "profiles" / "gnosiv"
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", launch_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", launch_home / "cron")
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", launch_home / "cron" / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", launch_home / "cron" / "output")
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            with cron_jobs.use_cron_store(profile_home):
+                job_a = cron_jobs.create_job(prompt="Collect facts", schedule="every 1h")
+                job_b = cron_jobs.create_job(
+                    prompt="Summarize facts",
+                    schedule="every 1h",
+                    context_from=job_a["id"],
+                )
+                source_id = job_a["id"]
+                active_output = profile_home / "cron" / "output" / source_id
+                launch_output = launch_home / "cron" / "output" / source_id
+                active_output.mkdir(parents=True)
+                launch_output.mkdir(parents=True)
+                (active_output / "active.md").write_text("Active-profile output", encoding="utf-8")
+                (launch_output / "launch.md").write_text("Launch-profile output", encoding="utf-8")
+
+                prompt = _build_job_prompt(job_b)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "Active-profile output" in prompt
+        assert "Launch-profile output" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -109,7 +109,7 @@ class TestBuildJobPromptContextFrom:
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
         launch_home = tmp_path / "launch"
-        profile_home = tmp_path / "profiles" / "gnosiv"
+        profile_home = tmp_path / "profiles" / "worker"
         monkeypatch.setattr(cron_jobs, "HERMES_DIR", launch_home)
         monkeypatch.setattr(cron_jobs, "CRON_DIR", launch_home / "cron")
         monkeypatch.setattr(cron_jobs, "JOBS_FILE", launch_home / "cron" / "jobs.json")

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -7,6 +7,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
 
 class TestCronFilePermissions(unittest.TestCase):
     """Verify cron files get secure permissions."""
@@ -15,63 +17,45 @@ class TestCronFilePermissions(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         self.cron_dir = Path(self.tmpdir) / "cron"
         self.output_dir = self.cron_dir / "output"
+        from cron import jobs as cron_jobs
+        self._home_token = set_hermes_home_override(self.tmpdir)
+        self._store_token = cron_jobs.use_cron_store(self.tmpdir)
+        self._store_token.__enter__()
 
     def tearDown(self):
         import shutil
+        from cron import jobs as cron_jobs
+        self._store_token.__exit__(None, None, None)
+        reset_hermes_home_override(self._home_token)
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    @patch("cron.jobs.CRON_DIR")
-    @patch("cron.jobs.OUTPUT_DIR")
-    @patch("cron.jobs.JOBS_FILE")
-    def test_ensure_dirs_sets_0700(self, mock_jobs_file, mock_output, mock_cron):
-        mock_cron.__class__ = Path
-        # Use real paths
-        cron_dir = Path(self.tmpdir) / "cron"
-        output_dir = cron_dir / "output"
+    def test_ensure_dirs_sets_0700(self):
+        from cron.jobs import ensure_dirs
+        ensure_dirs()
 
-        with patch("cron.jobs.CRON_DIR", cron_dir), \
-             patch("cron.jobs.OUTPUT_DIR", output_dir):
-            from cron.jobs import ensure_dirs
-            ensure_dirs()
+        cron_mode = stat.S_IMODE(os.stat(self.cron_dir).st_mode)
+        output_mode = stat.S_IMODE(os.stat(self.output_dir).st_mode)
+        self.assertEqual(cron_mode, 0o700)
+        self.assertEqual(output_mode, 0o700)
 
-            cron_mode = stat.S_IMODE(os.stat(cron_dir).st_mode)
-            output_mode = stat.S_IMODE(os.stat(output_dir).st_mode)
-            self.assertEqual(cron_mode, 0o700)
-            self.assertEqual(output_mode, 0o700)
+    def test_save_jobs_sets_0600(self):
+        from cron.jobs import save_jobs
+        save_jobs([{"id": "test", "prompt": "hello"}])
 
-    @patch("cron.jobs.CRON_DIR")
-    @patch("cron.jobs.OUTPUT_DIR")
-    @patch("cron.jobs.JOBS_FILE")
-    def test_save_jobs_sets_0600(self, mock_jobs_file, mock_output, mock_cron):
-        cron_dir = Path(self.tmpdir) / "cron"
-        output_dir = cron_dir / "output"
-        jobs_file = cron_dir / "jobs.json"
-
-        with patch("cron.jobs.CRON_DIR", cron_dir), \
-             patch("cron.jobs.OUTPUT_DIR", output_dir), \
-             patch("cron.jobs.JOBS_FILE", jobs_file):
-            from cron.jobs import save_jobs
-            save_jobs([{"id": "test", "prompt": "hello"}])
-
-            file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+        file_mode = stat.S_IMODE(os.stat(self.cron_dir / "jobs.json").st_mode)
+        self.assertEqual(file_mode, 0o600)
 
     def test_save_job_output_sets_0600(self):
-        output_dir = Path(self.tmpdir) / "output"
-        with patch("cron.jobs.OUTPUT_DIR", output_dir), \
-             patch("cron.jobs.CRON_DIR", Path(self.tmpdir)), \
-             patch("cron.jobs.ensure_dirs"):
-            output_dir.mkdir(parents=True, exist_ok=True)
-            from cron.jobs import save_job_output
-            output_file = save_job_output("test-job", "test output content")
+        from cron.jobs import save_job_output
+        output_file = save_job_output("test-job", "test output content")
 
-            file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+        file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
+        self.assertEqual(file_mode, 0o600)
 
-            # Job output dir should also be 0700
-            job_dir = output_dir / "test-job"
-            dir_mode = stat.S_IMODE(os.stat(job_dir).st_mode)
-            self.assertEqual(dir_mode, 0o700)
+        # Job output dir should also be 0700
+        job_dir = self.output_dir / "test-job"
+        dir_mode = stat.S_IMODE(os.stat(job_dir).st_mode)
+        self.assertEqual(dir_mode, 0o700)
 
 
 class TestConfigFilePermissions(unittest.TestCase):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -20,6 +20,23 @@ import threading
 import time
 from unittest.mock import patch
 
+def _wait_until(predicate, timeout=10.0, interval=0.005):
+    """Block until ``predicate()`` is truthy or ``timeout`` elapses.
+
+    Returns the predicate's final value. Used instead of a fixed
+    ``time.sleep`` before asserting that a background ticker thread has called
+    tick()/heartbeat() at least N times — under loaded CI the worker thread may
+    not be scheduled within a short fixed sleep, which made these tests flake
+    (``assert 0 >= 1`` / ``provider never called tick()``).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(interval)
+    return predicate()
+
 
 def test_ticker_calls_tick_at_least_once_then_stops():
     """The gateway in-process ticker loop calls cron.scheduler.tick repeatedly
@@ -34,7 +51,7 @@ def test_ticker_calls_tick_at_least_once_then_stops():
         return 0
 
     with patch("cron.scheduler.tick", side_effect=fake_tick):
-        # interval=0 keeps the loop tight; stop after a brief beat.
+        # interval=0 keeps the loop tight; stop after the first observed tick.
         t = threading.Thread(
             target=_start_cron_ticker,
             args=(stop,),
@@ -42,7 +59,7 @@ def test_ticker_calls_tick_at_least_once_then_stops():
             daemon=True,
         )
         t.start()
-        time.sleep(0.2)
+        assert _wait_until(lambda: len(calls) >= 1), "ticker never called tick()"
         stop.set()
         t.join(timeout=5)
 
@@ -74,7 +91,7 @@ def test_desktop_ticker_calls_tick_then_stops():
             daemon=True,
         )
         t.start()
-        time.sleep(0.2)
+        assert _wait_until(lambda: len(calls) >= 1), "desktop ticker never called tick()"
         stop.set()
         t.join(timeout=5)
 
@@ -144,7 +161,10 @@ def test_inprocess_provider_ticks_and_stops():
             target=prov.start, args=(stop,), kwargs={"interval": 0}, daemon=True
         )
         t.start()
-        time.sleep(0.2)
+        # Wait for the loop to actually call tick() at least once rather than
+        # sleeping a fixed window — under loaded CI the worker thread may not be
+        # scheduled within a short sleep, which made this flake (assert 0 >= 1).
+        assert _wait_until(lambda: len(calls) >= 1), "provider never called tick()"
         stop.set()
         t.join(timeout=5)
 
@@ -172,18 +192,40 @@ def test_default_config_cron_provider_is_empty():
 
 
 def test_discover_cron_schedulers_returns_list():
-    """Discovery returns a list. May be empty — the built-in is core, not
-    discovered, and no bundled non-default provider ships yet."""
-    from plugins.cron import discover_cron_schedulers
+    """Discovery returns bundled non-default providers.
+
+    The built-in is core, not discovered here.
+    """
+    from plugins.cron_providers import discover_cron_schedulers
 
     result = discover_cron_schedulers()
     assert isinstance(result, list)
+    assert any(name == "chronos" for name, _desc, _available in result)
 
 
 def test_load_unknown_cron_scheduler_returns_none():
-    from plugins.cron import load_cron_scheduler
+    from plugins.cron_providers import load_cron_scheduler
 
     assert load_cron_scheduler("does-not-exist-xyz") is None
+
+
+def test_cron_provider_package_does_not_shadow_core_cron_package(monkeypatch):
+    """Putting plugins/ first on sys.path must not hide the core cron package."""
+    from importlib.machinery import PathFinder
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+
+    monkeypatch.syspath_prepend(str(repo_root))
+    monkeypatch.syspath_prepend(str(repo_root / "plugins"))
+
+    cron_spec = PathFinder.find_spec("cron")
+    assert cron_spec is not None
+    assert Path(cron_spec.origin).resolve() == repo_root / "cron" / "__init__.py"
+
+    jobs_spec = PathFinder.find_spec("cron.jobs", [str(repo_root / "cron")])
+    assert jobs_spec is not None
+    assert Path(jobs_spec.origin).resolve() == repo_root / "cron" / "jobs.py"
 
 
 def test_resolve_defaults_to_builtin(monkeypatch):
@@ -219,7 +261,7 @@ def test_resolve_unknown_provider_falls_back_to_builtin(monkeypatch):
 def test_resolve_unavailable_provider_falls_back(monkeypatch):
     """A provider that loads but reports is_available()==False → built-in."""
     import hermes_cli.config as cfg
-    import plugins.cron as pc
+    import plugins.cron_providers as pc
     from cron import scheduler_provider as sp
     from cron.scheduler_provider import CronScheduler
 
@@ -243,7 +285,7 @@ def test_resolve_unavailable_provider_falls_back(monkeypatch):
 def test_resolve_available_provider_is_used(monkeypatch):
     """A provider that loads and is available is returned (not the fallback)."""
     import hermes_cli.config as cfg
-    import plugins.cron as pc
+    import plugins.cron_providers as pc
     from cron import scheduler_provider as sp
     from cron.scheduler_provider import CronScheduler
 
@@ -356,7 +398,9 @@ def test_ticker_survives_baseexception_from_tick():
          patch("cron.jobs.record_ticker_heartbeat"):
         t = threading.Thread(target=prov.start, args=(stop,), kwargs={"interval": 0}, daemon=True)
         t.start()
-        time.sleep(0.2)
+        # Survive the BaseException AND keep ticking: wait for ≥2 calls.
+        assert _wait_until(lambda: len(calls) >= 2), \
+            "ticker did not keep ticking after the BaseException"
         stop.set()
         t.join(timeout=5)
 
@@ -377,7 +421,10 @@ def test_ticker_records_heartbeat_each_iteration():
                side_effect=lambda success=False: beats.append(success)):
         t = threading.Thread(target=prov.start, args=(stop,), kwargs={"interval": 0}, daemon=True)
         t.start()
-        time.sleep(0.2)
+        # Wait for the pre-loop liveness beat AND at least one successful
+        # post-tick beat before stopping (was a fixed 0.2s sleep → flaky).
+        assert _wait_until(lambda: any(b is True for b in beats[1:])), \
+            "successful tick did not bump success marker"
         stop.set()
         t.join(timeout=5)
 
@@ -400,7 +447,9 @@ def test_failing_tick_records_liveness_but_not_success():
                side_effect=lambda success=False: beats.append(success)):
         t = threading.Thread(target=prov.start, args=(stop,), kwargs={"interval": 0}, daemon=True)
         t.start()
-        time.sleep(0.2)
+        # Wait for the pre-loop beat + at least one post-tick beat (was flaky
+        # with a fixed 0.2s sleep under loaded CI).
+        assert _wait_until(lambda: len(beats) >= 2), "ticker did not record heartbeats"
         stop.set()
         t.join(timeout=5)
 
@@ -521,3 +570,98 @@ def test_cron_status_reports_stalled_when_no_heartbeat(tmp_path, monkeypatch, ca
     out = capsys.readouterr().out
     assert "STALLED" in out
     assert "will fire automatically" not in out
+
+
+# ── F8: runtime backstop — never resolve a stored pair that exfiltrates a key ──
+
+
+class TestGuardJobCredentialExfil:
+    """run_job() must fail closed before provider resolution when a job's stored
+    provider/base_url pair would ship a named provider's stored credential to an
+    off-host endpoint — covering jobs persisted before the create/update guard
+    or written directly to the store (F8 stored-job path; CWE-200/CWE-522)."""
+
+    def test_named_registry_provider_offhost_is_blocked(self):
+        import pytest
+        from cron.scheduler import _guard_job_credential_exfil
+
+        job = {"id": "j1", "provider": "anthropic",
+               "base_url": "https://evil.example/v1"}
+        with pytest.raises(RuntimeError) as exc:
+            _guard_job_credential_exfil(job)
+        assert "blocked for safety" in str(exc.value)
+
+    def test_named_custom_offhost_is_blocked(self, monkeypatch):
+        import pytest
+        import hermes_cli.runtime_provider as rp
+        from cron.scheduler import _guard_job_credential_exfil
+
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: True)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda n: {"name": "legit", "base_url": "https://legit.example/v1",
+                       "api_key": "sk-legit"},
+        )
+        job = {"id": "j2", "provider": "custom:legit",
+               "base_url": "https://evil.example/v1"}
+        with pytest.raises(RuntimeError):
+            _guard_job_credential_exfil(job)
+
+    def test_named_custom_matching_host_is_allowed(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+        from cron.scheduler import _guard_job_credential_exfil
+
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: True)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda n: {"name": "legit", "base_url": "https://legit.example/v1",
+                       "api_key": "sk-legit"},
+        )
+        job = {"id": "j3", "provider": "custom:legit",
+               "base_url": "https://legit.example/v1"}
+        assert _guard_job_credential_exfil(job) is None
+
+    def test_bare_custom_is_allowed(self):
+        from cron.scheduler import _guard_job_credential_exfil
+
+        job = {"id": "j4", "provider": "custom",
+               "base_url": "https://anything.example/v1"}
+        assert _guard_job_credential_exfil(job) is None
+
+    def test_no_base_url_is_allowed(self):
+        from cron.scheduler import _guard_job_credential_exfil
+
+        assert _guard_job_credential_exfil({"id": "j5", "provider": "anthropic"}) is None
+        assert _guard_job_credential_exfil({"id": "j6"}) is None
+
+    def test_validator_exception_with_base_url_fails_closed(self, monkeypatch):
+        # If the validator/import unexpectedly raises, this last-resort backstop
+        # must NOT allow a base_url-bearing job through to provider resolution
+        # (it cannot prove the stored pair is safe). Regression for the
+        # fail-open `except Exception: err = None` path.
+        import pytest
+        import tools.cronjob_tools as ct
+        from cron.scheduler import _guard_job_credential_exfil
+
+        def _boom(provider, base_url):
+            raise RuntimeError("validator blew up")
+
+        monkeypatch.setattr(ct, "_validate_cron_base_url", _boom)
+        job = {"id": "j7", "provider": "custom:legit",
+               "base_url": "https://evil.example/v1"}
+        with pytest.raises(RuntimeError) as exc:
+            _guard_job_credential_exfil(job)
+        assert "blocked for safety" in str(exc.value)
+
+    def test_validator_exception_without_base_url_still_allowed(self, monkeypatch):
+        # A job with no base_url override can't exfiltrate via this path, so a
+        # validator error must not wedge it — only base_url-bearing jobs fail
+        # closed.
+        import tools.cronjob_tools as ct
+        from cron.scheduler import _guard_job_credential_exfil
+
+        def _boom(provider, base_url):
+            raise RuntimeError("validator blew up")
+
+        monkeypatch.setattr(ct, "_validate_cron_base_url", _boom)
+        assert _guard_job_credential_exfil({"id": "j8", "provider": "anthropic"}) is None

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -61,7 +61,7 @@ def test_bad_token_401(monkeypatch):
     gate). fire_due must NOT run."""
     fired = []
     monkeypatch.setattr(
-        "plugins.cron.chronos.verify.get_fire_verifier",
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
     )
     monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
@@ -82,7 +82,7 @@ def test_bad_token_401(monkeypatch):
 
 def test_missing_job_id_400(monkeypatch):
     monkeypatch.setattr(
-        "plugins.cron.chronos.verify.get_fire_verifier",
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
     )
     client, pa, ph = _client(auth_required=False)
@@ -100,7 +100,7 @@ def test_unknown_job_200_gone(monkeypatch):
     """Valid token but the job isn't found in any profile -> 200 'gone'
     (NAS shouldn't retry a fire for a cancelled/completed job)."""
     monkeypatch.setattr(
-        "plugins.cron.chronos.verify.get_fire_verifier",
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
     )
     monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: None)
@@ -116,12 +116,46 @@ def test_unknown_job_200_gone(monkeypatch):
         client.close()
 
 
+def test_fire_uses_selected_profile_context(tmp_path, monkeypatch):
+    """Firing a dashboard-selected job scopes the whole run to that profile."""
+    profile_home = tmp_path / "profiles" / "worker_alpha"
+    seen = {}
+
+    class FakeProvider:
+        def fire_due(self, job_id, adapters, loop):
+            from hermes_constants import get_hermes_home
+
+            seen["home"] = get_hermes_home()
+            seen["job_id"] = job_id
+            seen["adapters"] = adapters
+            seen["loop"] = loop
+            return True
+
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_home",
+        lambda profile: ("worker_alpha", profile_home),
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: FakeProvider(),
+    )
+
+    assert web_server._fire_cron_job_for_profile("worker_alpha", "job-123") is True
+    assert seen == {
+        "home": profile_home,
+        "job_id": "job-123",
+        "adapters": None,
+        "loop": None,
+    }
+
+
 def test_valid_token_accepts_and_fires(monkeypatch):
     """Valid token + known job -> 202 and fire_due invoked for the resolved
     profile."""
     fired = []
     monkeypatch.setattr(
-        "plugins.cron.chronos.verify.get_fire_verifier",
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire", "aud": "agent:x"}),
     )
     monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -240,6 +240,38 @@ class TestCronjobRequirements:
         assert check_cronjob_requirements() is False
 
 
+class TestProfileScopedCronStorage:
+    def test_uses_active_profile_home_override(self, tmp_path, monkeypatch):
+        """A profile-scoped session must not write jobs into its launch profile."""
+        from cron import jobs as cron_jobs
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        launch_home = tmp_path / "launch"
+        profile_home = tmp_path / "profiles" / "gnosiv"
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", launch_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", launch_home / "cron")
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", launch_home / "cron" / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", launch_home / "cron" / "output")
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            with cron_jobs.use_cron_store(profile_home):
+                created = json.loads(
+                    cronjob(
+                        action="create",
+                        prompt="Check profile isolation",
+                        schedule="every 1h",
+                        name="Profile Isolation",
+                    )
+                )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert created["success"] is True
+        assert (profile_home / "cron" / "jobs.json").is_file()
+        assert not (launch_home / "cron" / "jobs.json").exists()
+
+
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)
     def _setup_cron_dir(self, tmp_path, monkeypatch):
@@ -335,6 +367,81 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["model"] == "openai/gpt-4.1"
         assert updated["job"]["provider"] == "openrouter"
         assert updated["job"]["base_url"] is None
+
+    @staticmethod
+    def _patch_named_legit(monkeypatch):
+        import hermes_cli.runtime_provider as rp
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: True)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda n: {"name": "legit", "base_url": "https://legit.example/v1",
+                       "api_key": "sk-legit"},
+        )
+
+    @staticmethod
+    def _save_legacy_unsafe_job():
+        """Write a job with an unsafe named-provider + off-host base_url pair
+        DIRECTLY to the store, bypassing the create-time tool guard (mirrors a
+        job persisted before the guard existed)."""
+        from cron.jobs import save_jobs
+        save_jobs([
+            {
+                "id": "legacyunsafe1",
+                "name": "legacy",
+                "prompt": "x",
+                "schedule": {"kind": "interval", "minutes": 5, "display": "every 5m"},
+                "schedule_display": "every 5m",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "provider": "custom:legit",
+                "base_url": "https://evil.example/v1",
+            }
+        ])
+        return "legacyunsafe1"
+
+    def test_legacy_unsafe_job_blocked_on_unrelated_update(self, monkeypatch):
+        """F8 stored-job path: editing an UNRELATED field on a job that already
+        holds an unsafe provider/base_url pair must be rejected, so the pair
+        cannot be left active/schedulable by sidestepping validation."""
+        self._patch_named_legit(monkeypatch)
+        job_id = self._save_legacy_unsafe_job()
+
+        result = json.loads(cronjob(action="update", job_id=job_id, name="renamed"))
+        assert result["success"] is False
+        assert "not allowed" in json.dumps(result)
+
+        # The rejected update must not have mutated the stored job at all.
+        from cron.jobs import get_job
+        stored = get_job(job_id)
+        assert stored["name"] == "legacy"
+        assert stored["base_url"] == "https://evil.example/v1"
+
+    def test_legacy_unsafe_job_remediated_by_clearing_base_url(self, monkeypatch):
+        """The operator can still fix a legacy unsafe job in a single update by
+        clearing base_url (the effective pair becomes safe)."""
+        self._patch_named_legit(monkeypatch)
+        job_id = self._save_legacy_unsafe_job()
+
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, name="renamed", base_url="")
+        )
+        assert result["success"] is True
+        assert result["job"]["base_url"] is None
+        assert result["job"]["name"] == "renamed"
+
+    def test_legacy_unsafe_job_remediated_by_matching_host(self, monkeypatch):
+        """Repointing base_url at the named provider's own configured host also
+        remediates the job (no off-host exfil)."""
+        self._patch_named_legit(monkeypatch)
+        job_id = self._save_legacy_unsafe_job()
+
+        result = json.loads(
+            cronjob(action="update", job_id=job_id,
+                    base_url="https://legit.example/v1")
+        )
+        assert result["success"] is True
+        assert result["job"]["base_url"] == "https://legit.example/v1"
 
     def test_create_skill_backed_job(self):
         result = json.loads(
@@ -503,3 +610,129 @@ class TestResolveModelOverride:
         )
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
+
+
+class TestLocalDeliveryNotice:
+    """#51568 — TUI/CLI cron jobs are local-only; surface that at create time
+    so the agent doesn't promise a delivery that never happens."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        # Default: no session origin (the TUI/CLI condition).
+        for var in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_THREAD_ID",
+            "HERMES_SESSION_CHAT_NAME",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars()  # reset ContextVars to empty
+        yield
+        clear_session_vars(tokens)
+
+    def test_omitted_deliver_no_origin_emits_notice(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Output the time", schedule="every 2m")
+        )
+        assert created["success"] is True
+        # Omitted deliver from a session with no origin downgrades to local.
+        assert created["deliver"] == "local"
+        assert "local-only cron job" in created["message"]
+        assert "deliver='telegram'" in created["message"]
+
+    def test_explicit_origin_no_origin_emits_notice(self):
+        created = json.loads(
+            cronjob(
+                action="create", prompt="x", schedule="every 2m", deliver="origin"
+            )
+        )
+        assert created["deliver"] == "origin"
+        assert "local-only cron job" in created["message"]
+
+    def test_explicit_local_no_notice(self):
+        # The user explicitly asked for local — no surprise to flag.
+        created = json.loads(
+            cronjob(
+                action="create", prompt="x", schedule="every 2m", deliver="local"
+            )
+        )
+        assert created["deliver"] == "local"
+        assert "local-only cron job" not in created["message"]
+
+    def test_explicit_platform_target_no_notice(self):
+        # An explicit platform:chat target resolves to a real delivery target.
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 2m",
+                deliver="telegram:123",
+            )
+        )
+        assert created["deliver"] == "telegram:123"
+        assert "local-only cron job" not in created["message"]
+
+    def test_gateway_origin_no_notice(self, monkeypatch):
+        # With a captured gateway origin, omitted deliver becomes origin and
+        # resolves to that chat — nothing to warn about.
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(platform="telegram", chat_id="999")
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 2m")
+        )
+        assert created["deliver"] == "origin"
+        assert "local-only cron job" not in created["message"]
+
+
+class TestValidateCronBaseUrl:
+    """The cron base_url guard must not let a NAMED custom provider's stored
+    credential be sent to an off-host endpoint (CWE-200/CWE-522)."""
+
+    @staticmethod
+    def _v(*args):
+        from tools.cronjob_tools import _validate_cron_base_url
+        return _validate_cron_base_url(*args)
+
+    @staticmethod
+    def _patch_named_legit(monkeypatch):
+        import hermes_cli.runtime_provider as rp
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: True)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda n: {"name": "legit", "base_url": "https://legit.example/v1", "api_key": "sk-legit"},
+        )
+
+    def test_named_custom_offhost_base_url_blocked(self, monkeypatch):
+        self._patch_named_legit(monkeypatch)
+        err = self._v("custom:legit", "https://evil.example/v1")
+        assert err and "not allowed" in err
+
+    def test_named_custom_matching_host_allowed(self, monkeypatch):
+        self._patch_named_legit(monkeypatch)
+        assert self._v("custom:legit", "https://legit.example/v1") is None
+        # subdomain of the configured host is still the provider's own endpoint
+        assert self._v("custom:legit", "https://eu.legit.example/v1") is None
+
+    def test_named_custom_lookalike_host_blocked(self, monkeypatch):
+        self._patch_named_legit(monkeypatch)
+        assert self._v("custom:legit", "https://legit.example.attacker.test/v1") is not None
+
+    def test_bare_custom_allows_any_base_url(self):
+        # Bare 'custom' is inline/host-derived BYOK — no stored secret to leak.
+        assert self._v("custom", "https://anything.example/v1") is None
+
+    def test_no_base_url_is_allowed(self):
+        assert self._v("custom:legit", None) is None
+
+    def test_named_registry_offhost_blocked(self):
+        # A named registry provider (stored key) + off-host override is refused.
+        assert self._v("anthropic", "https://evil.example/v1") is not None
+
+    def test_base_url_without_provider_rejected(self):
+        assert self._v(None, "https://x.example/v1") is not None

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -247,7 +247,7 @@ class TestProfileScopedCronStorage:
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
         launch_home = tmp_path / "launch"
-        profile_home = tmp_path / "profiles" / "gnosiv"
+        profile_home = tmp_path / "profiles" / "worker"
         monkeypatch.setattr(cron_jobs, "HERMES_DIR", launch_home)
         monkeypatch.setattr(cron_jobs, "CRON_DIR", launch_home / "cron")
         monkeypatch.setattr(cron_jobs, "JOBS_FILE", launch_home / "cron" / "jobs.json")


### PR DESCRIPTION
## The problem

When a TUI/desktop session is scoped to a non-default profile, cron jobs created through the `cronjob` model tool are silently written to the **launch profile**'s store instead of the active session's profile store.

This happens because `cron/jobs.py` captures `CRON_DIR`, `JOBS_FILE`, and `OUTPUT_DIR` as module-level constants at import time — resolved from the process launch `HERMES_HOME`. The TUI gateway binds `HERMES_HOME` per-session via a ContextVar (`set_hermes_home_override`), but the cron storage layer was not reading it. The `workdir` parameter on the cronjob tool is a directory override for job execution — it does **not** select a profile.

Concretely: a user working in a named profile creates a daily cron job, sees it succeed, runs `hermes cron list` from that same session — and the job is missing. It was filed in the default cabinet instead of the user's profile cabinet. The same applies to job output, chained `context_from` reads, and dashboard-triggered job firing.

`cron/scheduler.py` had a `_get_hermes_home()` that respected the ContextVar, so job **execution** landed in the right profile — but storage (CRUD, locks, output writes, heartbeat) and `context_from` output reads were still bound to the import-time module globals.

## What this PR does

`main` already landed the production fix: a `_CronStorePaths` dataclass + `use_cron_store(home)` ContextVar override in `cron/jobs.py`, along with `_current_cron_store()` replacing every direct `CRON_DIR` / `JOBS_FILE` / `OUTPUT_DIR` reference. The dashboard's `_call_cron_for_profile` and `_fire_cron_job_for_profile` now wrap their calls in `use_cron_store(home) + set_hermes_home_override(str(home))` so storage, config, `.env`, skills, and output all share the selected profile.

This PR adds the **regression tests** that prove that contract holds end-to-end:

- **`tests/tools/test_cronjob_tools.py`** — `TestProfileScopedCronStorage`: cron CRUD under `use_cron_store` writes to the active profile store, not the launch profile.
- **`tests/cron/test_cron_context_from.py`** — chained `context_from` output injection reads from the profile-scoped output directory, not the launch profile.
- **`tests/cron/test_file_permissions.py`** — file-permission enforcement works through the ContextVar-scoped store.
- **`tests/cron/test_scheduler_provider.py`** — heartbeat tests keep direct globals monkeypatch (heartbeat functions predate the store override and still use module-level `TICKER_*_FILE` constants).
- **`tests/hermes_cli/test_cron_fire_dashboard.py`** — `test_fire_uses_selected_profile_context` validates `_fire_cron_job_for_profile` scopes runtime home and cron store to the selected profile.

## Verification

All 303 targeted tests pass:
```
tests/cron/test_file_permissions.py        8✓
tests/cron/test_cron_workdir.py           21✓
tests/cron/test_cron_context_from.py       22✓
tests/cron/test_scheduler_provider.py     37✓
tests/hermes_cli/test_cron_fire_dashboard.py  7✓
tests/cron/test_jobs.py                  130✓
tests/tools/test_cronjob_tools.py         78✓
```

## Related

Per-profile cron isolation (issue #4707). The `_CronStorePaths` infrastructure was contributed upstream to fix dashboard profile routing; these tests prove the contract holds.