### PR TITLE
fix(web): map thinking-off (false/disabled) reasoning_effort to none in dashboard picker

### DIFF
--- a/web/src/lib/reasoning-effort.test.ts
+++ b/web/src/lib/reasoning-effort.test.ts
@@ -28,6 +28,17 @@ describe("normalizeEffort", () => {
     expect(normalizeEffort("turbo")).toBe("medium");
     expect(normalizeEffort(42)).toBe("medium");
   });
+
+  it("maps thinking-off (false/disabled) to none, not medium", () => {
+    // #57330 fixed this everywhere but web/; a config `reasoning_effort: false`
+    // arrives as the boolean false / "false" and must resolve to Off, never
+    // fall through to the medium default (which would re-enable thinking for a
+    // user who explicitly turned it off).
+    expect(normalizeEffort(false)).toBe("none");
+    expect(normalizeEffort("false")).toBe("none");
+    expect(normalizeEffort("FALSE")).toBe("none");
+    expect(normalizeEffort("  disabled  ")).toBe("none");
+  });
 });
 
 describe("EFFORT_OPTIONS", () => {

--- a/web/src/lib/reasoning-effort.ts
+++ b/web/src/lib/reasoning-effort.ts
@@ -30,9 +30,17 @@ export const VALID_EFFORTS: ReadonlySet<string> = new Set(
 );
 
 /** Normalize a raw `agent.reasoning_effort` config value to a selectable
- *  option. Empty/unknown → `medium` (Hermes' default when unset). */
+ *  option. Empty/unset → `medium` (Hermes' default); thinking-off
+ *  (`false`/`disabled`) → `none`; any other unknown → `medium`. */
 export function normalizeEffort(raw: unknown): string {
   const value = String(raw ?? "").trim().toLowerCase();
   if (!value) return "medium";
+  // A hand-written `reasoning_effort: false`/`off`/`no` reaches config as a
+  // YAML boolean (String(false) === "false"), and `disabled` is the
+  // spelled-out form — both mean thinking OFF. Mirror #57330, which fixed this
+  // class in the Python resolvers and desktop (use-hermes-config.ts /
+  // model-settings.tsx) but did not touch web/: map them to `none`, not the
+  // medium fallback that would silently re-enable thinking.
+  if (value === "false" || value === "disabled") return "none";
   return VALID_EFFORTS.has(value) ? value : "medium";
 }


### PR DESCRIPTION
## This is a sibling follow-up to #57330

- **#57330 covered:** the Python resolvers (`cli.py`, `cron/scheduler.py`, `gateway/run.py`, `hermes_constants.py`) and the desktop app (`use-hermes-config.ts`, `model-settings.tsx`) — a thinking-off config (`reasoning_effort: false`/`off`/`no`/`disabled`) now resolves to `none` there instead of reverting to `medium`.
- **#57330 did NOT touch `web/`:** the dashboard reasoning picker's `normalizeEffort` still fell `false`/`disabled` through to its unknown-value `medium` fallback, silently re-enabling thinking for a user who set `reasoning_effort: false`.
- **This PR** adds the same `false`/`disabled` → `none` mapping to `web/src/lib/reasoning-effort.ts`, matching the desktop `model-settings.tsx` string check, with a vitest case.

## What does this PR do?

The dashboard `ReasoningPicker` reads `agent.reasoning_effort` and passes it through `normalizeEffort()`. A hand-written `reasoning_effort: false` (or `off`/`no`, which YAML also parses to boolean false, or the spelled-out `disabled`) reaches the config as a boolean — `String(false) === "false"` — which was not in `VALID_EFFORTS`, so it hit the `medium` fallback. The picker therefore showed **Medium**, silently re-enabling thinking for a user who explicitly turned it off.

This maps `false`/`disabled` to `none` before the fallback, so the picker shows **Off (no thinking)**. Empty/unset still resolves to `medium` (Hermes' default), and every valid level still passes through unchanged. The file is deliberately DOM-free, so the fix is covered by the node-environment vitest harness.

## Related Issue

None — code-originated; sibling of merged #57330.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/reasoning-effort.ts` — `normalizeEffort()` now maps `false`/`disabled` (thinking-off) to `none` before the `medium` unknown-value fallback; updated the docstring accordingly.
- `web/src/lib/reasoning-effort.test.ts` — added a case asserting `false` / `"false"` / `"FALSE"` / `"disabled"` all resolve to `none`.

## How to Test

1. `cd web && npm test -- reasoning-effort` — the new case passes; reverting only the prod hunk makes exactly that case fail (`normalizeEffort(false)` → `"medium"`), the other cases stay green.
2. `cd web && npx tsc -p . --noEmit` — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests (`npm test -- reasoning-effort`) and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `normalizeEffort` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure TS logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A