### PR TITLE
test(cron): isolate regression stores from live jobs

### DIFF
--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -12,6 +12,13 @@ import pytest
 @pytest.fixture
 def temp_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import cron.jobs as jobs_mod
+
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", tmp_path)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", cron_dir / "output")
     yield tmp_path
 
 

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -45,6 +45,18 @@ except ImportError:  # pragma: no cover - non-POSIX
 pytestmark = pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
 
 
+@pytest.fixture(autouse=True)
+def isolated_cron_store(tmp_path, monkeypatch):
+    """Never let these lock/claim regressions touch a user's live cron store."""
+    hermes_home = tmp_path / ".hermes"
+    cron_dir = hermes_home / "cron"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", cron_dir / "output")
+
+
 def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):
     """Hold an exclusive flock on *path* from a separate fd until released.
 


### PR DESCRIPTION
## Summary

Ensure two cron regression-test modules never read or mutate a user's live Hermes cron store:

- add an autouse isolated `cron.jobs` fixture to `test_ticker_stall_60703.py`;
- make the existing `temp_home` fixture in `test_jobs_changed_notify.py` patch the already-imported module-level cron paths, not only `HERMES_HOME`.

Without this, running `pytest tests/cron` from a machine with a real Hermes profile can create live jobs such as `claim job`, `paused job`, or the provider-notify test job.

## Verification

- Focused modules: **14 passed**
- Full cron suite: **679 passed**
- SHA-256 of the live `$HERMES_HOME/cron/jobs.json` was identical before and after both runs

## Scope

Tests only. No scheduler/runtime behavior changes.
