### PR TITLE
fix(simplex): key text batching per-sender so shared-chat messages aren't merged under one identity

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -671,8 +671,21 @@ class SimplexAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
-        return f"{event.source.platform.value}:{event.source.chat_id}"
+        """Session-scoped, per-sender key for text message batching.
+
+        Batching coalesces one participant's client-side message splits, so the
+        key must isolate senders. In a SimpleX *group* ``chat_id`` is the group
+        id while ``source.user_id`` is the member id (set from ``sender_id``
+        when the source is built) — without a sender component two members
+        posting inside the batch window would share a key and
+        ``_enqueue_text_event`` would concatenate their text into a single event
+        under the first sender's identity, dropping the second's authorship (and
+        letting their text ride the first sender through downstream
+        authorization). In a direct chat ``chat_id == sender_id``, so the extra
+        component is a no-op and a single sender's split chunks still batch.
+        """
+        sender = event.source.user_id or ""
+        return f"{event.source.platform.value}:{event.source.chat_id}:{sender}"
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer."""

--- a/tests/gateway/test_simplex_text_batching.py
+++ b/tests/gateway/test_simplex_text_batching.py
@@ -1,0 +1,97 @@
+"""Per-sender text batching for the SimpleX adapter.
+
+SimpleX batches a participant's rapid client-side message splits into one
+event before dispatch (mirroring Telegram/WhatsApp/Matrix). The batch key
+must isolate senders: in a SimpleX *group* ``chat_id`` is the group id while
+``source.user_id`` is the member id, so a chat-only key would fuse two
+members posting inside the batch window into a single event under the first
+sender's identity — dropping the second member's authorship and letting their
+text ride the first sender through downstream authorization.
+
+This is the SimpleX sibling of the Matrix fix (#63056); same class of bug,
+different platform, so a separate adapter and a separate PR.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+def _make_simplex_adapter():
+    """Minimal SimplexAdapter wired only for the text-batching path.
+
+    Built with ``object.__new__`` so no daemon/WebSocket state is required —
+    the batching helpers only touch the two pending dicts, the flush delay,
+    and ``handle_message`` (mirrors ``_make_matrix_adapter`` in
+    ``test_text_batching.py``).
+    """
+    from plugins.platforms.simplex.adapter import SimplexAdapter
+
+    adapter = object.__new__(SimplexAdapter)
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay = 0.1
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _group_event(text: str, user_id: str) -> MessageEvent:
+    """A text event in one shared SimpleX group from a given member."""
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform("simplex"),
+            chat_id="#team-group",
+            chat_type="group",
+            user_id=user_id,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_different_senders_in_group_not_merged():
+    """Two members of one group must not batch together under one identity."""
+    adapter = _make_simplex_adapter()
+
+    adapter._enqueue_text_event(_group_event("hi from alice", "alice-member-id"))
+    await asyncio.sleep(0.02)
+    adapter._enqueue_text_event(_group_event("hi from bob", "bob-member-id"))
+
+    await asyncio.sleep(0.3)
+
+    # Each sender is dispatched as its own event — never fused into one.
+    assert adapter.handle_message.call_count == 2
+    dispatched = {
+        call.args[0].source.user_id: call.args[0].text
+        for call in adapter.handle_message.call_args_list
+    }
+    assert dispatched == {
+        "alice-member-id": "hi from alice",
+        "bob-member-id": "hi from bob",
+    }
+    # No single dispatched event carries both senders' text.
+    for text in dispatched.values():
+        assert not ("alice" in text and "bob" in text)
+
+
+@pytest.mark.asyncio
+async def test_same_sender_split_chunks_still_batch():
+    """One member's split chunks in a group still aggregate into one event."""
+    adapter = _make_simplex_adapter()
+
+    adapter._enqueue_text_event(_group_event("first part", "alice-member-id"))
+    await asyncio.sleep(0.02)
+    adapter._enqueue_text_event(_group_event("second part", "alice-member-id"))
+
+    await asyncio.sleep(0.3)
+
+    adapter.handle_message.assert_called_once()
+    event = adapter.handle_message.call_args[0][0]
+    assert "first part" in event.text
+    assert "second part" in event.text
+    assert event.source.user_id == "alice-member-id"


### PR DESCRIPTION
## What does this PR do?

The SimpleX adapter batches a participant's rapid client-side message splits into one event before dispatch (mirroring Telegram/WhatsApp/Matrix). `_text_batch_key` keyed only on `platform:chat_id`, but in a SimpleX **group** `chat_id` is the group id while `source.user_id` is the member id (set from `sender_id` when the source is built at `adapter.py`). Two members posting inside the batch window therefore shared one key, and `_enqueue_text_event` concatenated their text into the first buffered event (it never updates `existing.source`).

Effect: the second member's message is fused into the first member's event — the second's authorship is dropped, and downstream authorization reads the **first** sender's identity for text the second sender wrote.

The fix appends the sender to the batch key: `platform:chat_id:user_id`. In a direct chat `chat_id == sender_id`, so the extra component is a no-op and a single sender's split chunks still batch exactly as before.

This is the SimpleX sibling of the Matrix fix in #63056 — the same class of bug on a different platform, so a separate atomic PR rather than a widening of that one.

## Related Issue

None — code-originated; sibling of #63056 (Matrix).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py` — `_text_batch_key` now appends `source.user_id`, isolating senders within a shared group; expanded the docstring to record the group-vs-DM invariant.
- `tests/gateway/test_simplex_text_batching.py` (new) — asserts two members of one group are dispatched as two separate events with their own authorship (not one fused event), and that a single sender's split chunks still batch into one event.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_simplex_text_batching.py -v` — both cases pass.
2. Regression guard: reverting only the `_text_batch_key` hunk makes `test_different_senders_in_group_not_merged` fail (`call_count == 1`, both members fused into one event); the same-sender batching case stays green.
3. `uv run --with pytest --with pytest-asyncio --with pytest-xdist python3 -m pytest tests/gateway/test_simplex_text_batching.py tests/gateway/test_simplex_plugin.py tests/gateway/test_text_batching.py -q` — 55 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — expanded the `_text_batch_key` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (platform-agnostic logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A