### PR TITLE
feat(desktop): soft-wrap code blocks in chat responses

### DIFF
--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -97,14 +97,14 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   const chunks = useMemo(() => chunkByLines(code, CHUNK_LINES), [code])
 
   if (chunks.length === 1) {
-    return <code className="block whitespace-pre">{code}</code>
+    return <code className="block whitespace-pre-wrap wrap-anywhere">{code}</code>
   }
 
   return (
     <>
       {chunks.map((chunk, index) => (
         <code
-          className="block whitespace-pre [content-visibility:auto]"
+          className="block whitespace-pre-wrap wrap-anywhere [content-visibility:auto]"
           key={index}
           style={{ containIntrinsicSize: `auto ${chunk.lines * EST_LINE_PX}px` }}
         >
@@ -157,7 +157,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
       </CodeCardHeader>
       <CodeCardBody>
         <ExpandableBlock>
-          <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
+          <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0 whitespace-pre-wrap wrap-anywhere [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap">
             {plain ? (
               <PlainCode code={trimmed} />
             ) : (


### PR DESCRIPTION
## Problem

Fenced code blocks in assistant responses render with `whitespace-pre`, so long lines scroll horizontally and get clipped off the right edge — you can't read the full line without scrolling.

## Change

Switch the chat `SyntaxHighlighter` code paths (both the plain/`text` fallback and the Shiki-highlighted path) from `whitespace-pre` to `whitespace-pre-wrap` + `wrap-anywhere`, so long lines wrap to the next line instead of overflowing.

## Why it's safe

These blocks use `content-visibility:auto` (a paint optimization that measures the real element size when it scrolls on screen) — **not** fixed-row virtualization. So taller wrapped lines don't desync any row math. Only the chat `SyntaxHighlighter` is touched; terminal/log-tail surfaces keep horizontal scrolling.

## Notes

Consistent with the existing prose-fence and mermaid-embed rendering in the same file, which already use `whitespace-pre-wrap wrap-anywhere`. Could be gated behind a setting if a toggle is preferred.