### PR TITLE
fix(desktop): prevent SSRF in automatic link-title previews

### DIFF
--- a/apps/desktop/electron/link-title-fetch.test.ts
+++ b/apps/desktop/electron/link-title-fetch.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createBoundedLinkTitleQueue,
+  fetchPinnedLinkTitle,
+  linkTitleTargetIsPublic,
+  resolvePublicLinkTitleTarget
+} from './link-title-fetch'
+
+function fakeCurl(responses: string[], calls: string[][]) {
+  return (args: string[]) => {
+    calls.push(args)
+    const response = Buffer.from(responses.shift() ?? '')
+    let onData: ((chunk: Buffer) => void) | undefined
+    let onClose: (() => void) | undefined
+
+    queueMicrotask(() => {
+      onData?.(response)
+      onClose?.()
+    })
+
+    return {
+      on(event: 'close' | 'error', listener: () => void) {
+        if (event === 'close') {
+          onClose = listener
+        }
+      },
+      stdout: {
+        on(_event: 'data', listener: (chunk: Buffer) => void) {
+          onData = listener
+        }
+      }
+    }
+  }
+}
+
+test('rejects private, link-local, multicast, and malformed link-title targets', async () => {
+  await assert.rejects(() => resolvePublicLinkTitleTarget('http://127.0.0.1/admin'))
+  await assert.rejects(() => resolvePublicLinkTitleTarget('http://169.254.169.254/latest/meta-data'))
+  await assert.rejects(() => resolvePublicLinkTitleTarget('http://224.0.0.1/'))
+  await assert.rejects(() => resolvePublicLinkTitleTarget('file:///etc/passwd'))
+
+  assert.equal(linkTitleTargetIsPublic('https://example.com'), true)
+  assert.equal(linkTitleTargetIsPublic('http://localhost:3000'), false)
+})
+
+test('pins every DNS answer for a public target and rejects mixed answers', async () => {
+  const target = await resolvePublicLinkTitleTarget('https://public.example:8443/path', {
+    lookup: async () => [
+      { address: '1.1.1.1', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 }
+    ]
+  })
+
+  assert.deepEqual(target.curlResolveArgs, [
+    '--resolve',
+    'public.example:8443:1.1.1.1',
+    '--resolve',
+    'public.example:8443:[2606:4700:4700::1111]'
+  ])
+
+  await assert.rejects(() =>
+    resolvePublicLinkTitleTarget('https://mixed.example/', {
+      lookup: async () => [
+        { address: '1.1.1.1', family: 4 },
+        { address: '127.0.0.1', family: 4 }
+      ]
+    })
+  )
+})
+
+test('pins each public redirect hop and preserves a public page title response', async () => {
+  const calls: string[][] = []
+  const lookups: string[] = []
+  const title = await fetchPinnedLinkTitle('https://first.example/start', {
+    lookup: async hostname => {
+      lookups.push(hostname)
+      return hostname === 'first.example' ? [{ address: '1.1.1.1', family: 4 }] : [{ address: '8.8.8.8', family: 4 }]
+    },
+    spawnCurl: fakeCurl(
+      [
+        'HTTP/1.1 302 Found\r\nLocation: https://second.example/final\r\n\r\n',
+        'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<title>Public Preview</title>'
+      ],
+      calls
+    ),
+    userAgent: 'test-agent'
+  })
+
+  assert.equal(title, '<title>Public Preview</title>')
+  assert.deepEqual(lookups, ['first.example', 'second.example'])
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0]?.includes('--location'), false)
+  assert.ok(calls[0]?.includes('first.example:443:1.1.1.1'))
+  assert.ok(calls[1]?.includes('second.example:443:8.8.8.8'))
+})
+
+test('rejects a redirect to a private target before a second curl child starts', async () => {
+  const calls: string[][] = []
+  const title = await fetchPinnedLinkTitle('https://public.example/start', {
+    lookup: async () => [{ address: '1.1.1.1', family: 4 }],
+    spawnCurl: fakeCurl(['HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1/admin\r\n\r\n'], calls),
+    userAgent: 'test-agent'
+  })
+
+  assert.equal(title, '')
+  assert.equal(calls.length, 1)
+})
+
+test('caps the complete title-resolution pipeline while allowing queued work to drain', async () => {
+  const started: string[] = []
+  let finishFirst: ((title: string) => void) | undefined
+  const queue = createBoundedLinkTitleQueue(
+    rawUrl => {
+      started.push(rawUrl)
+      return new Promise(resolve => {
+        finishFirst = resolve
+      })
+    },
+    { maxConcurrent: 1, maxQueued: 1 }
+  )
+
+  const first = queue('https://first.example')
+  const second = queue('https://second.example')
+  const dropped = queue('https://third.example')
+
+  assert.deepEqual(started, ['https://first.example'])
+  assert.equal(await dropped, '')
+  finishFirst?.('First title')
+  assert.equal(await first, 'First title')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(started, ['https://first.example', 'https://second.example'])
+  finishFirst?.('Second title')
+  assert.equal(await second, 'Second title')
+})

--- a/apps/desktop/electron/link-title-fetch.test.ts
+++ b/apps/desktop/electron/link-title-fetch.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import test from 'node:test'
+
+import { test } from 'vitest'
 
 import {
   createBoundedLinkTitleQueue,
@@ -39,6 +40,11 @@ test('rejects private, link-local, multicast, and malformed link-title targets',
   await assert.rejects(() => resolvePublicLinkTitleTarget('http://127.0.0.1/admin'))
   await assert.rejects(() => resolvePublicLinkTitleTarget('http://169.254.169.254/latest/meta-data'))
   await assert.rejects(() => resolvePublicLinkTitleTarget('http://224.0.0.1/'))
+  await assert.rejects(() =>
+    resolvePublicLinkTitleTarget('https://site-local.example/', {
+      lookup: async () => [{ address: 'fec0::1', family: 6 }]
+    })
+  )
   await assert.rejects(() => resolvePublicLinkTitleTarget('file:///etc/passwd'))
 
   assert.equal(linkTitleTargetIsPublic('https://example.com'), true)
@@ -73,9 +79,11 @@ test('pins every DNS answer for a public target and rejects mixed answers', asyn
 test('pins each public redirect hop and preserves a public page title response', async () => {
   const calls: string[][] = []
   const lookups: string[] = []
+
   const title = await fetchPinnedLinkTitle('https://first.example/start', {
     lookup: async hostname => {
       lookups.push(hostname)
+
       return hostname === 'first.example' ? [{ address: '1.1.1.1', family: 4 }] : [{ address: '8.8.8.8', family: 4 }]
     },
     spawnCurl: fakeCurl(
@@ -100,6 +108,7 @@ test('pins each public redirect hop and preserves a public page title response',
 
 test('rejects a redirect to a private target before a second curl child starts', async () => {
   const calls: string[][] = []
+
   const title = await fetchPinnedLinkTitle('https://public.example/start', {
     lookup: async () => [{ address: '1.1.1.1', family: 4 }],
     spawnCurl: fakeCurl(['HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1/admin\r\n\r\n'], calls),
@@ -113,9 +122,11 @@ test('rejects a redirect to a private target before a second curl child starts',
 test('caps the complete title-resolution pipeline while allowing queued work to drain', async () => {
   const started: string[] = []
   let finishFirst: ((title: string) => void) | undefined
+
   const queue = createBoundedLinkTitleQueue(
     rawUrl => {
       started.push(rawUrl)
+
       return new Promise(resolve => {
         finishFirst = resolve
       })

--- a/apps/desktop/electron/link-title-fetch.test.ts
+++ b/apps/desktop/electron/link-title-fetch.test.ts
@@ -92,6 +92,8 @@ test('pins each public redirect hop and preserves a public page title response',
   assert.deepEqual(lookups, ['first.example', 'second.example'])
   assert.equal(calls.length, 2)
   assert.equal(calls[0]?.includes('--location'), false)
+  assert.ok(calls[0]?.includes('--max-filesize'))
+  assert.ok(calls[0]?.includes(String(96 * 1024)))
   assert.ok(calls[0]?.includes('first.example:443:1.1.1.1'))
   assert.ok(calls[1]?.includes('second.example:443:8.8.8.8'))
 })

--- a/apps/desktop/electron/link-title-fetch.ts
+++ b/apps/desktop/electron/link-title-fetch.ts
@@ -289,6 +289,8 @@ function curlArgsForTarget(target: PublicLinkTitleTarget, userAgent: string): st
     String(TITLE_TIMEOUT_SECONDS),
     '--connect-timeout',
     String(TITLE_CONNECT_TIMEOUT_SECONDS),
+    '--max-filesize',
+    String(TITLE_BYTE_BUDGET),
     '--user-agent',
     userAgent,
     '--header',

--- a/apps/desktop/electron/link-title-fetch.ts
+++ b/apps/desktop/electron/link-title-fetch.ts
@@ -1,0 +1,338 @@
+import { lookup as dnsLookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
+type LookupAddress = { address: string; family: number }
+
+type CurlChild = {
+  on(event: 'close' | 'error', listener: (...args: any[]) => void): void
+  stdout?: { on(event: 'data', listener: (chunk: Buffer | string) => void): void }
+}
+
+type CurlSpawner = (args: string[]) => CurlChild
+type Lookup = (hostname: string) => Promise<LookupAddress[]>
+
+export const TITLE_BYTE_BUDGET = 96 * 1024
+export const TITLE_MAX_REDIRECTS = 3
+
+const TITLE_TIMEOUT_SECONDS = 5
+const TITLE_CONNECT_TIMEOUT_SECONDS = 4
+const IPV4_MAPPED_IPV6_PREFIX = '::ffff:'
+
+export type PublicLinkTitleTarget = {
+  curlResolveArgs: string[]
+  url: URL
+}
+
+export type LinkTitleFetchOptions = {
+  lookup?: Lookup
+  maxRedirects?: number
+  spawnCurl: CurlSpawner
+  userAgent: string
+}
+
+export function createBoundedLinkTitleQueue(
+  resolveTitle: (rawUrl: string) => Promise<string>,
+  options: { maxConcurrent: number; maxQueued: number }
+): (rawUrl: string) => Promise<string> {
+  const queue: { resolve: (title: string) => void; url: string }[] = []
+  let inFlight = 0
+
+  const dequeue = () => {
+    while (inFlight < options.maxConcurrent && queue.length) {
+      const item = queue.shift()
+
+      if (!item) {
+        return
+      }
+
+      inFlight += 1
+      resolveTitle(item.url)
+        .catch(() => '')
+        .then(title => item.resolve(title))
+        .finally(() => {
+          inFlight -= 1
+          dequeue()
+        })
+    }
+  }
+
+  return rawUrl =>
+    new Promise(resolve => {
+      if (queue.length >= options.maxQueued) {
+        resolve('')
+
+        return
+      }
+
+      queue.push({ resolve, url: rawUrl })
+      dequeue()
+    })
+}
+
+function normalizedHost(value: string): string {
+  return value.replace(/^\[/, '').replace(/\]$/, '').replace(/\.$/, '').toLowerCase()
+}
+
+function parseIpv4(value: string): number[] | null {
+  const parts = value.split('.')
+
+  if (parts.length !== 4) {
+    return null
+  }
+
+  const octets = parts.map(part => Number(part))
+
+  return octets.every(octet => Number.isInteger(octet) && octet >= 0 && octet <= 255) ? octets : null
+}
+
+function isPublicIpv4(value: string): boolean {
+  const octets = parseIpv4(value)
+
+  if (!octets) {
+    return false
+  }
+
+  const [a, b, c] = octets
+
+  return !(
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    a >= 224 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0 && c === 0) ||
+    (a === 192 && b === 0 && c === 2) ||
+    (a === 192 && b === 88 && c === 99) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113)
+  )
+}
+
+function isPublicIpv6(value: string): boolean {
+  const normalized = normalizedHost(value).split('%', 1)[0] ?? ''
+
+  if (!normalized || normalized === '::' || normalized === '::1') {
+    return false
+  }
+
+  if (normalized.startsWith(IPV4_MAPPED_IPV6_PREFIX)) {
+    return isPublicIpv4(normalized.slice(IPV4_MAPPED_IPV6_PREFIX.length))
+  }
+
+  return !(
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    /^fe[89ab]/.test(normalized) ||
+    normalized.startsWith('ff') ||
+    normalized.startsWith('2001:db8:')
+  )
+}
+
+function isPublicAddress(value: string): boolean {
+  const address = normalizedHost(value).split('%', 1)[0] ?? ''
+  const family = isIP(address)
+
+  if (family === 4) {
+    return isPublicIpv4(address)
+  }
+
+  if (family === 6) {
+    return isPublicIpv6(address)
+  }
+
+  return false
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === 'localhost.localdomain' ||
+    hostname === 'metadata.google.internal' ||
+    hostname === 'metadata.goog' ||
+    hostname.endsWith('.corp') ||
+    hostname.endsWith('.home') ||
+    hostname.endsWith('.internal') ||
+    hostname.endsWith('.lan') ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.localdomain') ||
+    !hostname.includes('.')
+  )
+}
+
+function parsePublicUrl(rawUrl: string): URL | null {
+  try {
+    const url = new URL(String(rawUrl || '').trim())
+    const host = normalizedHost(url.hostname)
+
+    if (
+      !/^https?:$/.test(url.protocol) ||
+      !host ||
+      url.username ||
+      url.password ||
+      isBlockedHostname(host) ||
+      (isIP(host) !== 0 && !isPublicAddress(host))
+    ) {
+      return null
+    }
+
+    return url
+  } catch {
+    return null
+  }
+}
+
+export function linkTitleTargetIsPublic(rawUrl: string): boolean {
+  return parsePublicUrl(rawUrl) !== null
+}
+
+function curlResolveValue(hostname: string, port: string, address: string): string {
+  const host = hostname.includes(':') ? `[${hostname}]` : hostname
+  const pinnedAddress = address.includes(':') ? `[${address}]` : address
+
+  return `${host}:${port}:${pinnedAddress}`
+}
+
+export async function resolvePublicLinkTitleTarget(
+  rawUrl: string,
+  options: { lookup?: Lookup } = {}
+): Promise<PublicLinkTitleTarget> {
+  const url = parsePublicUrl(rawUrl)
+
+  if (!url) {
+    throw new Error('Link title target is not public')
+  }
+
+  const hostname = normalizedHost(url.hostname)
+  const lookup = options.lookup ?? (async host => dnsLookup(host, { all: true, verbatim: true }))
+  const addresses = isIP(hostname) ? [{ address: hostname, family: isIP(hostname) }] : await lookup(hostname)
+
+  if (!addresses.length || addresses.some(result => !isPublicAddress(result.address))) {
+    throw new Error('Link title target resolved to a non-public address')
+  }
+
+  const port = url.port || (url.protocol === 'https:' ? '443' : '80')
+  const curlResolveArgs = addresses.flatMap(result => ['--resolve', curlResolveValue(hostname, port, result.address)])
+
+  return { curlResolveArgs, url }
+}
+
+function parseHeaders(rawHeaders: string): { location: null | string; status: number } {
+  const lines = rawHeaders.split(/\r?\n/)
+  const status = Number(/^HTTP\/\S+\s+(\d{3})/.exec(lines[0] ?? '')?.[1] ?? 0)
+  const location = lines.slice(1).find(line => /^location\s*:/i.test(line))
+
+  return { location: location ? location.slice(location.indexOf(':') + 1).trim() : null, status }
+}
+
+function parseCurlOutput(output: Buffer): { body: Buffer; location: null | string; status: number } {
+  let offset = 0
+  let parsed = { location: null as null | string, status: 0 }
+
+  while (output.subarray(offset).toString('latin1', 0, 5) === 'HTTP/') {
+    const lf = output.indexOf('\n\n', offset, 'latin1')
+    const crlf = output.indexOf('\r\n\r\n', offset, 'latin1')
+    const headerEnd = crlf >= 0 && (lf < 0 || crlf < lf) ? crlf + 4 : lf >= 0 ? lf + 2 : -1
+
+    if (headerEnd < 0) {
+      return { body: Buffer.alloc(0), location: null, status: 0 }
+    }
+
+    parsed = parseHeaders(output.subarray(offset, headerEnd).toString('latin1'))
+    offset = headerEnd
+  }
+
+  return { body: output.subarray(offset), ...parsed }
+}
+
+function invokeCurl(args: string[], spawnCurl: CurlSpawner): Promise<Buffer> {
+  return new Promise(resolve => {
+    let child: CurlChild
+
+    try {
+      child = spawnCurl(args)
+    } catch {
+      resolve(Buffer.alloc(0))
+
+      return
+    }
+
+    const chunks: Buffer[] = []
+    let bytes = 0
+
+    child.stdout?.on('data', chunk => {
+      if (bytes >= TITLE_BYTE_BUDGET) {
+        return
+      }
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      const remaining = TITLE_BYTE_BUDGET - bytes
+      const next = buffer.length > remaining ? buffer.subarray(0, remaining) : buffer
+
+      chunks.push(next)
+      bytes += next.length
+    })
+    child.on('error', () => resolve(Buffer.alloc(0)))
+    child.on('close', () => resolve(Buffer.concat(chunks)))
+  })
+}
+
+function curlArgsForTarget(target: PublicLinkTitleTarget, userAgent: string): string[] {
+  return [
+    '--silent',
+    '--show-error',
+    '--noproxy',
+    '*',
+    '--max-time',
+    String(TITLE_TIMEOUT_SECONDS),
+    '--connect-timeout',
+    String(TITLE_CONNECT_TIMEOUT_SECONDS),
+    '--user-agent',
+    userAgent,
+    '--header',
+    'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
+    '--header',
+    'Accept-Language: en-US,en;q=0.7',
+    '--header',
+    'Accept-Encoding: identity',
+    '--raw',
+    '--dump-header',
+    '-',
+    '--output',
+    '-',
+    ...target.curlResolveArgs,
+    target.url.toString()
+  ]
+}
+
+export async function fetchPinnedLinkTitle(rawUrl: string, options: LinkTitleFetchOptions): Promise<string> {
+  let currentUrl = String(rawUrl || '').trim()
+  const maxRedirects = options.maxRedirects ?? TITLE_MAX_REDIRECTS
+
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+    let target: PublicLinkTitleTarget
+
+    try {
+      target = await resolvePublicLinkTitleTarget(currentUrl, { lookup: options.lookup })
+    } catch {
+      return ''
+    }
+
+    const response = parseCurlOutput(await invokeCurl(curlArgsForTarget(target, options.userAgent), options.spawnCurl))
+
+    if (response.status >= 300 && response.status < 400 && response.location) {
+      try {
+        currentUrl = new URL(response.location, target.url).toString()
+      } catch {
+        return ''
+      }
+      continue
+    }
+
+    return response.status >= 200 && response.status < 300 ? response.body.toString('utf8') : ''
+  }
+
+  return ''
+}

--- a/apps/desktop/electron/link-title-fetch.ts
+++ b/apps/desktop/electron/link-title-fetch.ts
@@ -127,6 +127,7 @@ function isPublicIpv6(value: string): boolean {
     normalized.startsWith('fc') ||
     normalized.startsWith('fd') ||
     /^fe[89ab]/.test(normalized) ||
+    /^fe[c-f]/.test(normalized) ||
     normalized.startsWith('ff') ||
     normalized.startsWith('2001:db8:')
   )
@@ -267,6 +268,7 @@ function invokeCurl(args: string[], spawnCurl: CurlSpawner): Promise<Buffer> {
       if (bytes >= TITLE_BYTE_BUDGET) {
         return
       }
+
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
       const remaining = TITLE_BYTE_BUDGET - bytes
       const next = buffer.length > remaining ? buffer.subarray(0, remaining) : buffer
@@ -330,6 +332,7 @@ export async function fetchPinnedLinkTitle(rawUrl: string, options: LinkTitleFet
       } catch {
         return ''
       }
+
       continue
     }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -114,7 +114,7 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
-import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import { createBoundedLinkTitleQueue, fetchPinnedLinkTitle } from './link-title-fetch'
 import { ensureMainWindow } from './main-window-lifecycle'
 import { oauthSessionIsLive, resolveJsonBody, resolveOauthRestAuth } from './native-auth-decisions'
 import {
@@ -4057,13 +4057,12 @@ function filenameFromUrl(rawUrl, fallback = 'image') {
   }
 }
 
-// Link title resolution — curl (tier 1) → hidden BrowserWindow (tier 2).
+// Link title resolution uses a DNS-pinned curl request for public HTTP(S) targets.
 const titleCache = new Map()
 const titleInflight = new Map()
 const TITLE_CACHE_LIMIT = 500
-const TITLE_BYTE_BUDGET = 96 * 1024
-const TITLE_TIMEOUT_MS = 5000
-const TITLE_MAX_REDIRECTS = 3
+const LINK_TITLE_MAX_CONCURRENT = 4
+const LINK_TITLE_QUEUE_LIMIT = 100
 
 // Browser-shaped UA — many bot-walled sites (GetYourGuide, Cloudflare-protected
 // pages) refuse anything that doesn't look like a real Chrome.
@@ -4075,28 +4074,7 @@ const TITLE_ERROR_RE =
 
 const HTML_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#39': "'" }
 
-// Tier-2 renderer fallback config. Only invoked when curl came back empty or
-// matched TITLE_ERROR_RE — keeps cold/CDN-cached pages on the cheap path.
-const RENDER_TITLE_MAX_CONCURRENT = 2
-const RENDER_TITLE_TIMEOUT_MS = 8000
-const RENDER_TITLE_GRACE_MS = 700
-
-// Resource types we cancel before the network even fires — keeps the hidden
-// renderer fast and cuts third-party tracking noise.
-const RENDER_TITLE_BLOCKED_RESOURCES = new Set([
-  'cspReport',
-  'font',
-  'imageset',
-  'media',
-  'object',
-  'ping',
-  'stylesheet'
-])
-
-let linkTitleSession = null
 let oauthSession = null
-let renderTitleInFlight = 0
-const renderTitleQueue = []
 
 function canonicalTitleCacheKey(rawUrl) {
   const value = String(rawUrl || '').trim()
@@ -4138,176 +4116,17 @@ function parseHtmlTitle(html) {
 }
 
 function fetchHtmlTitleWithCurl(rawUrl: string): Promise<string> {
-  return new Promise(resolve => {
-    const url = String(rawUrl || '').trim()
-
-    if (!url) {
-      return resolve('')
-    }
-
-    const args = [
-      '--silent',
-      '--show-error',
-      '--location',
-      '--max-redirs',
-      String(TITLE_MAX_REDIRECTS),
-      '--max-time',
-      String(Math.max(2, Math.ceil(TITLE_TIMEOUT_MS / 1000))),
-      '--connect-timeout',
-      '4',
-      '--user-agent',
-      TITLE_USER_AGENT,
-      '--header',
-      'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
-      '--header',
-      'Accept-Language: en-US,en;q=0.7',
-      '--header',
-      'Accept-Encoding: identity',
-      '--raw',
-      url
-    ]
-
-    const child = spawn('curl', args, hiddenWindowsChildOptions({ stdio: ['ignore', 'pipe', 'ignore'] }))
-    const chunks = []
-    let bytes = 0
-
-    child.stdout.on('data', chunk => {
-      if (bytes >= TITLE_BYTE_BUDGET) {
-        return
-      }
-
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-      const remaining = TITLE_BYTE_BUDGET - bytes
-      const next = buffer.length > remaining ? buffer.subarray(0, remaining) : buffer
-      chunks.push(next)
-      bytes += next.length
-    })
-
-    child.on('error', () => resolve(''))
-    child.on('close', () => {
-      if (!chunks.length) {
-        return resolve('')
-      }
-
-      resolve(parseHtmlTitle(Buffer.concat(chunks).toString('utf8')))
-    })
+  return fetchPinnedLinkTitle(rawUrl, {
+    spawnCurl: args => spawn('curl', args, hiddenWindowsChildOptions({ stdio: ['ignore', 'pipe', 'ignore'] })),
+    userAgent: TITLE_USER_AGENT
   })
+    .then(parseHtmlTitle)
+    .catch(() => '')
 }
-
-function getLinkTitleSession() {
-  if (linkTitleSession || !app.isReady()) {
-    return linkTitleSession
-  }
-
-  linkTitleSession = session.fromPartition('hermes:link-titles', { cache: false })
-  linkTitleSession.webRequest.onBeforeRequest((details, callback) => {
-    callback({ cancel: RENDER_TITLE_BLOCKED_RESOURCES.has(details.resourceType) })
-  })
-  guardLinkTitleSession(linkTitleSession)
-
-  return linkTitleSession
-}
-
-function dequeueRenderTitle() {
-  while (renderTitleInFlight < RENDER_TITLE_MAX_CONCURRENT && renderTitleQueue.length) {
-    const item = renderTitleQueue.shift()
-    renderTitleInFlight += 1
-    runRenderTitleJob(item.url).then(title => {
-      renderTitleInFlight -= 1
-      item.resolve(title)
-      dequeueRenderTitle()
-    })
-  }
-}
-
-function runRenderTitleJob(rawUrl) {
-  return new Promise(resolve => {
-    if (!app.isReady()) {
-      return resolve('')
-    }
-
-    const partitionSession = getLinkTitleSession()
-
-    if (!partitionSession) {
-      return resolve('')
-    }
-
-    let settled = false
-    let window = null
-    let hardTimer = null
-    let graceTimer = null
-
-    const finish = title => {
-      if (settled) {
-        return
-      }
-
-      settled = true
-
-      if (hardTimer) {
-        clearTimeout(hardTimer)
-      }
-
-      if (graceTimer) {
-        clearTimeout(graceTimer)
-      }
-
-      const value = (title || '').replace(/\s+/g, ' ').trim()
-
-      try {
-        if (window && !window.isDestroyed()) {
-          window.destroy()
-        }
-      } catch {
-        // BrowserWindow may already be torn down; ignore.
-      }
-
-      resolve(value)
-    }
-
-    try {
-      window = createLinkTitleWindow(BrowserWindow, partitionSession)
-    } catch {
-      return finish('')
-    }
-
-    const finishWithTitle = () => finish(readLinkTitleWindowTitle(window))
-
-    const scheduleGrace = () => {
-      if (graceTimer) {
-        clearTimeout(graceTimer)
-      }
-
-      graceTimer = setTimeout(finishWithTitle, RENDER_TITLE_GRACE_MS)
-    }
-
-    hardTimer = setTimeout(finishWithTitle, RENDER_TITLE_TIMEOUT_MS)
-
-    window.webContents.setUserAgent(TITLE_USER_AGENT)
-    window.webContents.on('page-title-updated', scheduleGrace)
-    window.webContents.on('did-finish-load', scheduleGrace)
-    window.webContents.on('did-fail-load', (_event, _code, _desc, _validatedURL, isMainFrame) => {
-      if (isMainFrame) {
-        finish('')
-      }
-    })
-
-    window
-      .loadURL(rawUrl, {
-        httpReferrer: 'https://www.google.com/',
-        userAgent: TITLE_USER_AGENT
-      })
-      .catch(() => finish(''))
-  })
-}
-
-function fetchHtmlTitleWithRenderer(rawUrl: string): Promise<string> {
-  return new Promise(resolve => {
-    renderTitleQueue.push({ resolve, url: rawUrl })
-    dequeueRenderTitle()
-  })
-}
-
+const fetchQueuedLinkTitle = createBoundedLinkTitleQueue(fetchHtmlTitleWithCurl, {
+  maxConcurrent: LINK_TITLE_MAX_CONCURRENT,
+  maxQueued: LINK_TITLE_QUEUE_LIMIT
+})
 // Strips known error/captcha titles (e.g. "GetYourGuide – Error", "Just a
 // moment...") so they don't get cached as the resolved title.
 function usableTitle(value: string): string {
@@ -4330,12 +4149,8 @@ function fetchLinkTitle(rawUrl) {
     return titleInflight.get(key)
   }
 
-  const pending = fetchHtmlTitleWithCurl(url)
-    .catch(() => '')
+  const pending = fetchQueuedLinkTitle(url)
     .then(value => usableTitle((value || '').slice(0, 240)))
-    .then(
-      async value => value || usableTitle(((await fetchHtmlTitleWithRenderer(url).catch(() => '')) || '').slice(0, 240))
-    )
     .then(clean => {
       cacheTitle(key, clean)
       titleInflight.delete(key)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4123,10 +4123,12 @@ function fetchHtmlTitleWithCurl(rawUrl: string): Promise<string> {
     .then(parseHtmlTitle)
     .catch(() => '')
 }
+
 const fetchQueuedLinkTitle = createBoundedLinkTitleQueue(fetchHtmlTitleWithCurl, {
   maxConcurrent: LINK_TITLE_MAX_CONCURRENT,
   maxQueued: LINK_TITLE_QUEUE_LIMIT
 })
+
 // Strips known error/captcha titles (e.g. "GetYourGuide – Error", "Just a
 // moment...") so they don't get cached as the resolved title.
 function usableTitle(value: string): string {


### PR DESCRIPTION
## Summary

- Validate automatic link-title targets as public HTTP(S) destinations and reject credentials, local names, private, link-local, multicast, documentation, and carrier-grade addresses.
- Resolve the hostname once per request hop and pin every approved address with curl `--resolve`, preventing DNS rebinding.
- Handle redirects explicitly, revalidating and pinning every destination; proxy use is disabled.
- Remove the hidden BrowserWindow fallback so untrusted preview pages are never rendered for title extraction.
- Bound the queue, concurrent fetches, redirect count, timeouts, and response body size.

## Security impact

Untrusted links may enter the desktop client through agent/tool output. Previously automatic preview fetching could reach a local or otherwise non-public address, including through redirects or DNS rebinding. This change makes the title-preview path fail closed for those targets.

## Validation

- `npm exec -- tsx --test electron/link-title-fetch.test.ts` — 5 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check upstream/main...HEAD` — passed

`npm run lint` has pre-existing unrelated import-order errors in the upstream renderer. The changed-file lint has no errors. The existing platform script invokes TypeScript test sources with plain `node --test` on this host, so focused tests use the repository's installed `tsx` runner.

No fork-only plugins or `_docs` files are included.