### PR TITLE
fix(gateway): add fail-safe continue in prune exception handler to prevent orphaning live background sessions (#63128)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2178,6 +2178,7 @@ class SessionStore:
                             "has_active_processes_fn raised during prune for %s: %s",
                             entry.session_key, exc,
                         )
+                        continue   # fail safe: can't confirm idle → don't orphan live work
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:


### PR DESCRIPTION
## Summary
`SessionStore.prune_old_entries` is supposed to keep any session that still has a live background process attached. When the `has_active_processes_fn` callback raises, the exception is swallowed at `debug` level but execution falls through to the age check — so the session gets pruned anyway, silently killing the record of live background work.

This directly contradicts the function's own docstring.

## Change
Added `continue` inside the `except` block so an indeterminate active-process check keeps the entry (fail-safe).

## Verification
Compilation/code review — 1 line change, no behavioral change on the happy path.