### PR TITLE
fix(plugins): AI-8222 support persistent Firecrawl browser profiles

### DIFF
--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -22,6 +22,7 @@ Auth env vars::
     FIRECRAWL_API_KEY=...           # https://firecrawl.dev
     FIRECRAWL_API_URL=...           # optional override (default https://api.firecrawl.dev)
     FIRECRAWL_BROWSER_TTL=...       # optional, default 300 seconds
+    FIRECRAWL_BROWSER_PROFILE=...   # optional, persistent profile name
 """
 
 from __future__ import annotations
@@ -77,6 +78,25 @@ class FirecrawlBrowserProvider(BrowserProvider):
             "Authorization": f"Bearer {api_key}",
         }
 
+    def _resolve_profile(self) -> str | None:
+        """Resolve Firecrawl persistent profile name from env or config."""
+        profile = os.environ.get("FIRECRAWL_BROWSER_PROFILE", "").strip()
+        if profile:
+            return profile
+
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            profile = (cfg.get("browser", {}).get("firecrawl", {}).get("profile") or 
+                       cfg.get("browser", {}).get("profile") or "")
+            profile = str(profile).strip()
+            if profile:
+                return profile
+        except Exception:
+            pass
+
+        return None
+
     def create_session(self, task_id: str) -> Dict[str, object]:
         try:
             ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
@@ -84,6 +104,13 @@ class FirecrawlBrowserProvider(BrowserProvider):
             ttl = 300
 
         body: Dict[str, object] = {"ttl": ttl}
+
+        profile_name = self._resolve_profile()
+        if profile_name:
+            body["profile"] = {
+                "name": profile_name,
+                "saveChanges": True
+            }
 
         try:
             response = requests.post(
@@ -106,13 +133,16 @@ class FirecrawlBrowserProvider(BrowserProvider):
         data = response.json()
         session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
 
-        logger.info("Created Firecrawl browser session %s", session_name)
+        if profile_name:
+            logger.info("Created Firecrawl browser session %s with profile %s", session_name, profile_name)
+        else:
+            logger.info("Created Firecrawl browser session %s", session_name)
 
         return {
             "session_name": session_name,
             "bb_session_id": data["id"],
             "cdp_url": data["cdpUrl"],
-            "features": {"firecrawl": True},
+            "features": {"firecrawl": True, "persistent_profile": bool(profile_name)},
         }
 
     def close_session(self, session_id: str) -> bool:

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -377,3 +377,64 @@ class TestPickerIntegration:
 
         for row in _plugin_browser_providers():
             assert row.get("browser_plugin_name") == row.get("browser_provider")
+
+
+# ---------------------------------------------------------------------------
+# Firecrawl persistent profile
+# ---------------------------------------------------------------------------
+
+
+class TestFirecrawlProfile:
+    """Firecrawl persistent profile resolution and creation tests."""
+
+    def test_resolve_profile_default_none(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.browser_registry import get_provider
+
+        p = get_provider("firecrawl")
+        assert p is not None
+        assert p._resolve_profile() is None
+
+    def test_resolve_profile_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.browser_registry import get_provider
+
+        p = get_provider("firecrawl")
+        assert p is not None
+        monkeypatch.setenv("FIRECRAWL_BROWSER_PROFILE", "test-profile-123")
+        assert p._resolve_profile() == "test-profile-123"
+
+    def test_create_session_includes_profile(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.browser_registry import get_provider
+
+        p = get_provider("firecrawl")
+        assert p is not None
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "test-key")
+        monkeypatch.setenv("FIRECRAWL_BROWSER_PROFILE", "my-pers-profile")
+
+        class MockResponse:
+            ok = True
+            status_code = 200
+            def json(self):
+                return {"id": "session-123", "cdpUrl": "ws://test-cdp"}
+
+        posted_json = None
+        def mock_post(url, headers, json, timeout):
+            nonlocal posted_json
+            posted_json = json
+            return MockResponse()
+
+        monkeypatch.setattr("requests.post", mock_post)
+
+        session = p.create_session("task-999")
+        assert session["bb_session_id"] == "session-123"
+        assert session["features"].get("persistent_profile") is True
+        assert posted_json is not None
+        assert posted_json.get("profile") == {
+            "name": "my-pers-profile",
+            "saveChanges": True,
+        }


### PR DESCRIPTION
Implements persistent browser profile support for the Firecrawl provider. Resolves AI-8222 by allowing persistent browser states (cookies, logins, passwords) across browser sessions.