### PR TITLE
fix(cron): classify no-agent failures as script errors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -59,6 +59,15 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # Script-only jobs never invoke an LLM provider or fallback chain. Keep
+    # their failures source-accurate even when the script output contains
+    # provider-like tokens such as "timeout", "429", or "authentication".
+    if job.get("no_agent"):
+        cleaned = re.sub(r"\s+", " ", text[:2000]).strip()
+        if len(cleaned) > 180:
+            cleaned = cleaned[:177].rstrip() + "..."
+        return f"⚠️ Cron '{job_name}' script failed: {cleaned}"
+
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
         reason = "rate limit"

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -210,6 +210,28 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        "Script exited with code 1\nstdout:\nTimeoutError: timed out",
+        "HTTP 429 rate limit",
+        "authentication failed with 403",
+    ],
+)
+def test_no_agent_failure_summary_does_not_claim_provider_fallback(hermes_env, error):
+    """Script-only failures must not be mislabeled as LLM provider failures."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    summary = _summarize_cron_failure_for_delivery(
+        {"id": "watchdog", "name": "Local watchdog", "no_agent": True},
+        error,
+    )
+
+    assert summary.startswith("⚠️ Cron 'Local watchdog' script failed:")
+    assert "provider" not in summary.lower()
+    assert "fallback chain" not in summary.lower()
+
+
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
     from cron.jobs import create_job


### PR DESCRIPTION
## Summary
- classify `no_agent=True` cron failures before provider/API heuristics
- keep timeout, rate-limit, and auth-like script output source-accurate
- add regression coverage proving script-only failures never claim a provider fallback

## Problem
A script-only watchdog timeout was delivered as `provider timeout` with `Fallback chain was exhausted`, even though `no_agent=True` skips the LLM and provider path entirely.

## Verification
- `python -m pytest tests/cron/test_cron_no_agent.py -q -o addopts=` — 21 passed
- `python -m ruff check cron/scheduler.py tests/cron/test_cron_no_agent.py` — passed
- `git diff --check` — passed

Assisted-by: Hermes:gpt-5.6-sol