### PR TITLE
fix: exclude skill worktrees from discovery paths

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
+from agent.skill_utils import is_excluded_skill_path
 
 
 @dataclass
@@ -127,7 +128,7 @@ def build_skill_nodes(skill_roots: list[tuple[str, Path]]) -> dict[str, SkillNod
     nodes: dict[str, SkillNode] = {}
 
     for source, skill_md in _iter_skill_files(skill_roots):
-        if any(p in {".archive", ".hub", "node_modules", ".git"} for p in skill_md.parts):
+        if is_excluded_skill_path(skill_md):
             continue
         try:
             fm = _frontmatter(skill_md.read_text(encoding="utf-8")[:4000])

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -30,6 +30,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".worktrees",
         ".venv",
         "venv",
         "node_modules",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12759,6 +12759,7 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
     number of skills newly disabled.
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from agent.skill_utils import is_excluded_skill_path
     from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
 
     keep_set = {s.strip() for s in keep if s and s.strip()}
@@ -12769,7 +12770,8 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
         skills_root = profile_dir / "skills"
         if skills_root.is_dir():
             for md in skills_root.rglob("SKILL.md"):
-                installed.append(md.parent.name)
+                if not is_excluded_skill_path(md):
+                    installed.append(md.parent.name)
         cfg = load_config()
         disabled = get_disabled_skills(cfg)
         for name in installed:

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -66,6 +66,23 @@ def test_skill_node_timestamp_uses_iso_usage_activity(tmp_path, monkeypatch):
     assert nodes["iso-skill"].timestamp == 1_777_550_400
 
 
+def test_skill_nodes_exclude_archives_and_development_worktrees(tmp_path, monkeypatch):
+    skills_root = tmp_path / "skills"
+    paths = {
+        "active": skills_root / "active" / "SKILL.md",
+        "archived": skills_root / ".archive" / "old" / "SKILL.md",
+        "worktree": skills_root / ".worktrees" / "task-12" / "copy" / "SKILL.md",
+    }
+    for name, path in paths.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+    monkeypatch.setattr(learning_graph, "_load_usage", lambda: {})
+
+    nodes = learning_graph.build_skill_nodes([("profile", skills_root)])
+
+    assert set(nodes) == {"active"}
+
+
 def test_memory_is_cards_split_on_separator(tmp_path):
     home = tmp_path / ".hermes"
     (home / "memories").mkdir(parents=True)

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -218,6 +218,21 @@ def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):
     assert is_excluded_skill_path(package / "SKILL.md") is True
 
 
+def test_iter_skill_index_files_excludes_development_worktrees_and_archives(tmp_path):
+    active = tmp_path / "active" / "SKILL.md"
+    archived = tmp_path / ".archive" / "old" / "SKILL.md"
+    worktree = tmp_path / ".worktrees" / "plan001" / "duplicate" / "SKILL.md"
+    for path in (active, archived, worktree):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("---\nname: fixture\n---\n", encoding="utf-8")
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [active]
+    assert is_excluded_skill_path(archived) is True
+    assert is_excluded_skill_path(worktree) is True
+
+
 def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     """A category named scripts/templates/assets/references is still valid."""
     scripts_skill = tmp_path / "scripts" / "bash-helper"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -20,6 +20,27 @@ from hermes_cli.config import (
 )
 
 
+def test_profile_skill_selection_excludes_archives_and_worktree_copies(tmp_path):
+    from hermes_cli.web_server import _disable_unselected_skills
+
+    profile_dir = tmp_path / "profile"
+    skills_root = profile_dir / "skills"
+    for relative in (
+        Path("active") / "SKILL.md",
+        Path(".archive") / "old" / "SKILL.md",
+        Path(".worktrees") / "task-12" / "copy" / "SKILL.md",
+    ):
+        path = skills_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"---\nname: {path.parent.name}\n---\n", encoding="utf-8")
+
+    disabled_count = _disable_unselected_skills(profile_dir, keep=[])
+
+    assert disabled_count == 1
+    config = yaml.safe_load((profile_dir / "config.yaml").read_text(encoding="utf-8"))
+    assert config["skills"]["disabled"] == ["active"]
+
+
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- exclude `.worktrees` from shared skill discovery
- reuse the shared exclusion predicate in learning-graph discovery and profile onboarding
- add behavior regressions for all three discovery paths

## Verification
- 407 relevant tests passed
- Ruff passed
- exact staged tree `679dc5672a7d94fc97cfc28fcf07e65bf2f40d67` independently reviewed with no blockers