### PR TITLE
fix(desktop): keep node-pty spawn-helper executable on Darwin

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -34,6 +35,19 @@ function resolveNodePtyRoot() {
     paths: [projectRoot]
   })
   return dirname(pkgJsonPath)
+}
+
+/**
+ * node-pty's darwin prebuild ships a separate `spawn-helper` binary that
+ * lib/unixTerminal.js execs on every pty.spawn(). `cpSync` preserves source
+ * mode bits when available, but packaged/tarball/cache paths frequently
+ * land the helper as 0644. Without +x, Electron's first terminal open fails
+ * with `posix_spawnp failed` / Permission denied — so always re-assert the
+ * executable bit after copy.
+ */
+function copySpawnHelper(srcPath, destPath) {
+  cpSync(srcPath, destPath)
+  chmodSync(destPath, 0o755)
 }
 
 function copyGlobByExt(srcDir, destDir, extensions) {
@@ -71,7 +85,11 @@ function copyBuildRelease(srcDir, destDir) {
       cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
       continue
     }
-    if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
+    if (entry.name === 'spawn-helper') {
+      copySpawnHelper(join(srcDir, entry.name), join(destDir, entry.name))
+      continue
+    }
+    if (/\.(node|dll|exe)$/.test(entry.name)) {
       cpSync(join(srcDir, entry.name), join(destDir, entry.name))
     }
   }
@@ -114,7 +132,8 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        // Must be +x: without it darwin pty.spawn() dies with posix_spawnp failed.
+        copySpawnHelper(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
       }
     }
   } else {

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -349,13 +349,21 @@ function validateBundle() {
     die(`No .node native binaries found in: ${nativeBinaryDirs.join(', ')}`)
   }
   // Darwin requires a runtime-execed spawn-helper alongside pty.node; missing
-  // it manifests as "ENOENT: spawn-helper" on first pty.spawn() call.
+  // it manifests as "ENOENT: spawn-helper" on first pty.spawn() call. A helper
+  // that exists but lacks +x fails later with posix_spawnp / Permission denied.
   if (PLATFORM === 'darwin') {
     const spawnHelper = nativeBinaryDirs
       .map(dir => path.join(dir, 'spawn-helper'))
       .find(exists)
     if (!spawnHelper) {
       die(`Missing node-pty spawn-helper (required on darwin) in: ${nativeBinaryDirs.join(', ')}`)
+    }
+    try {
+      fs.accessSync(spawnHelper, fs.constants.X_OK)
+    } catch {
+      die(
+        `node-pty spawn-helper is not executable (chmod +x required on darwin): ${spawnHelper}`
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- Desktop embedded terminal was failing to start with `posix_spawnp failed` because packaged `node-pty` shipped Darwin `spawn-helper` without the executable bit.
- `stage-native-deps.mjs` now always `chmod 755` after copying `spawn-helper` from both prebuild and `build/Release` paths.
- Packaging smoke test now asserts `X_OK` on Darwin, not just file existence.

## Root cause
On macOS, `node-pty` execs a sibling `spawn-helper` binary for every `pty.spawn()`. After packaging/staging, that helper could land as `0644`. Hermes Desktop then surfaces:

`Terminal failed to start: Error invoking remote method 'hermes:terminal:start': Error: posix_spawnp failed.`

## Test plan
- [x] `node --check` on the two touched scripts
- [x] Locally reproduced: packaged `spawn-helper` was non-executable and caused Permission denied; `chmod +x` restored terminal start
- [ ] CI desktop packaging checks
- [ ] On a fresh Darwin package after this change, confirm `spawn-helper` is `0755` under `app.asar.unpacked/.../prebuilds/darwin-*/`
- [ ] Open Hermes Desktop embedded terminal and confirm shell starts without `posix_spawnp failed`
