### PR TITLE
fix(update): skip Matrix E2EE refresh on macOS when CMake >= 4 blocks python-olm

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -376,6 +376,66 @@ class TestRefreshActiveFeatures:
 
         ld.ensure("platform.matrix", prompt=False)
 
+    def test_macos_cmake4_matrix_refresh_is_skipped_before_pip(self, monkeypatch):
+        """macOS + CMake ≥ 4 → Matrix E2EE refresh is skipped before reaching pip."""
+        monkeypatch.setattr(ld.sys, "platform", "darwin")
+        monkeypatch.setattr(ld, "_macos_cmake4_or_newer", lambda: True)
+        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix"])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail(
+                "pip must not be called when Matrix is unsupported on macOS+CMake4"
+            ),
+        )
+
+        result = ld.refresh_active_features()
+
+        assert result["platform.matrix"].startswith("skipped:")
+        assert "CMake" in result["platform.matrix"]
+
+    def test_macos_cmake4_matrix_ensure_fails_before_pip(self, monkeypatch):
+        """macOS + CMake ≥ 4 → ensure() raises FeatureUnavailable before pip."""
+        monkeypatch.setattr(ld.sys, "platform", "darwin")
+        monkeypatch.setattr(ld, "_macos_cmake4_or_newer", lambda: True)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail(
+                "pip must not be called when Matrix is unsupported on macOS+CMake4"
+            ),
+        )
+
+        with pytest.raises(ld.FeatureUnavailable, match="CMake"):
+            ld.ensure("platform.matrix", prompt=False)
+
+    def test_macos_no_cmake_matrix_refresh_succeeds(self, monkeypatch):
+        """macOS without CMake 4 → Matrix refresh proceeds normally."""
+        monkeypatch.setattr(ld.sys, "platform", "darwin")
+        monkeypatch.setattr(ld, "_macos_cmake4_or_newer", lambda: False)
+        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix"])
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        call_count = [0]
+
+        def fake_satisfied(spec):
+            call_count[0] += 1
+            return call_count[0] > 1  # first call: missing → triggers install
+
+        monkeypatch.setattr(ld, "_is_satisfied", fake_satisfied)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: ld._InstallResult(success=True, stdout="ok", stderr=""),
+        )
+
+        result = ld.refresh_active_features()
+
+        assert result["platform.matrix"] == "refreshed"
+
     def test_already_current_is_noop(self, monkeypatch):
         monkeypatch.setattr(ld, "active_features", lambda: ["test.feat"])
         monkeypatch.setitem(ld.LAZY_DEPS, "test.feat", ("zzzfake==1.0.0",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -468,7 +468,45 @@ def _unsupported_feature_reason(feature: str) -> Optional[str]:
             "which has no Windows wheel and requires make + libolm to build "
             "from sdist. Run Hermes under WSL to use Matrix on Windows."
         )
+    if sys.platform == "darwin" and feature == "platform.matrix" and _macos_cmake4_or_newer():
+        return (
+            "unsupported on this macOS: Matrix E2EE depends on python-olm, "
+            "which cannot build with CMake ≥ 4 (python-olm declares "
+            "cmake_minimum_required < 3.5, removed in CMake 4). Install "
+            "CMake 3.x (e.g. brew install cmake@3) and rerun hermes update."
+        )
     return None
+
+
+_cached_cmake4: bool | None = None
+
+
+def _macos_cmake4_or_newer() -> bool:
+    """Return True if cmake ≥ 4.0 is available on this macOS host.
+
+    Cached at module level — runs the subprocess check at most once.
+    """
+    global _cached_cmake4
+    if _cached_cmake4 is not None:
+        return _cached_cmake4
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        _cached_cmake4 = False
+        return False
+    try:
+        out = subprocess.run(
+            [cmake, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        _cached_cmake4 = False
+        return False
+    import re
+    m = re.search(r"cmake version (\d+)\.", out.stdout)
+    _cached_cmake4 = m is not None and int(m.group(1)) >= 4
+    return _cached_cmake4
 
 
 def _spec_is_safe(spec: str) -> bool:


### PR DESCRIPTION
fix(update): skip Matrix E2EE refresh on macOS when CMake >= 4 blocks python-olm

`hermes update` attempts to refresh all lazy-installed backends. On macOS
with CMake >= 4.0, the `platform.matrix` backend fails with a noisy 50-line
pip traceback because:

  platform.matrix -> mautrix[encryption] -> python-olm

python-olm's CMakeLists.txt declares `cmake_minimum_required(VERSION 2.8.12)`.
CMake 4 removed backward compatibility for < 3.5, so `cmake --build` fails.
Additionally, the vendored libolm C++ library fails to compile under Apple
Clang >= 21.0.0.

This extends the existing `_unsupported_feature_reason()` platform gate
(already used for Matrix on Windows) with a macOS + CMake version check.
`_macos_cmake4_or_newer()` runs a one-shot `cmake --version` subprocess
and caches the result at module level.  When detected:

- `hermes update` skips the doomed refresh with a clear message
- `ensure("platform.matrix")` raises FeatureUnavailable before pip

Before:
  platform.matrix failed to refresh: pip install failed:
  Compatibility with CMake < 3.5 has been removed from CMake.
  ... (50+ lines)

After:
  1 skipped (unsupported on this macOS: python-olm cannot build with
    CMake >= 4 ... Install CMake 3.x ...): platform.matrix

Already-installed Matrix deps continue to work.  The gate only applies
when CMake >= 4 is detected; macOS without CMake or with CMake < 4 is
unaffected.

Related upstream issues (not fixable in Hermes):
- poljar/python-olm: CMakeLists.txt needs bump + Clang 21.x C++ fixes
- tulir/mautrix-python: should migrate from python-olm to vodozemac
  (libolm was deprecated by the Matrix.org Foundation)