### PR TITLE
fix(gateway): stop standing-goal loop after a failed provider turn (#63180)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3240,6 +3240,28 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return True
 
 
+def _should_continue_goal_after_turn(agent_result, final_text) -> bool:
+    """Return True only when a standing goal may be continued after this turn.
+
+    A continuation must be gated on *real* progress. ``final_text`` alone is not
+    enough: ``_normalize_empty_agent_response()`` deliberately returns non-empty,
+    user-facing text for ``failed``/``partial``/interrupted/errored results, so a
+    provider failure still yields a non-empty final response. Feeding that to the
+    goal judge makes it answer "continue", which re-enqueues the same synthetic
+    ``[Continuing toward your standing goal]`` prompt and loops on the failure.
+
+    Require non-empty text *and* the same success semantics used by
+    ``_should_clear_resume_pending_after_turn`` so only genuinely completed turns
+    advance the goal. Non-dict results (bare string replies) are treated as
+    successful, matching the legacy text-only behaviour.
+    """
+    if not str(final_text or "").strip():
+        return False
+    if not isinstance(agent_result, dict):
+        return True
+    return _should_clear_resume_pending_after_turn(agent_result)
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
@@ -12680,10 +12702,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
-                # Skip for empty responses (interrupted / errored) — the
-                # judge would almost always say "continue" and we'd loop
-                # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                # Skip for empty, failed, partial, or interrupted turns — a
+                # provider failure is normalized into non-empty user-facing
+                # text, and the judge would almost always say "continue", so
+                # we'd loop on the error and append duplicate continuation
+                # prompts. Require a genuinely successful turn instead; let the
+                # user drive the next one otherwise.
+                if _should_continue_goal_after_turn(_agent_result, _final_text):
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3122,6 +3122,29 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return agent_result.get("completed") is not False
 
 
+def _should_continue_goal_after_turn(agent_result, final_text) -> bool:
+    """Return True only when a standing goal may be continued after this turn.
+
+    A continuation must be gated on *real* progress. ``final_text`` alone is not
+    enough: the post-turn text deliberately stays non-empty for
+    ``failed``/``partial``/interrupted/errored results (user-facing error text),
+    so a provider failure still yields a non-empty final response. Feeding that
+    to the goal judge makes it answer "continue", which re-enqueues the same
+    synthetic ``[Continuing toward your standing goal]`` prompt and loops on the
+    failure.
+
+    Require non-empty text *and* the same success semantics used by
+    ``_should_clear_resume_pending_after_turn`` so only genuinely completed turns
+    advance the goal. Non-dict results (bare string replies) are treated as
+    successful, matching the legacy text-only behaviour.
+    """
+    if not str(final_text or "").strip():
+        return False
+    if not isinstance(agent_result, dict):
+        return True
+    return _should_clear_resume_pending_after_turn(agent_result)
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict, followup_result: dict) -> dict:
     """Carry the outer history offset through queued follow-up drains.

--- a/gateway/run_goals.py
+++ b/gateway/run_goals.py
@@ -318,10 +318,14 @@ class GatewayGoalsMixin:
         except Exception as exc:
             logger.debug("post-turn session resolution failed: %s", exc)
             return
-        # Empty interrupted/errored responses must not drive /goal, but an in-flight /loop tick
-        # still needs to be released and rescheduled.
+        # A standing /goal may only continue after a genuinely successful turn. A provider failure is
+        # normalized into non-empty user-facing text, so gating on text alone would let the goal judge
+        # answer "continue" and loop on the error; require real success semantics. The /loop tick still
+        # runs on every path so an in-flight tick is released and rescheduled even when the goal is held.
         hooks = [("loop completion", self._post_turn_loop_completion)]
-        if final_text.strip():
+        from gateway.run import _should_continue_goal_after_turn  # lazy: gateway.run import cycle
+
+        if _should_continue_goal_after_turn(agent_result, final_text):
             hooks.insert(0, ("goal continuation", self._post_turn_goal_continuation))
         for label, hook in hooks:
             try:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -41,6 +41,7 @@ from gateway.run import (
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
     _should_clear_resume_pending_after_turn,
+    _should_continue_goal_after_turn,
     build_resume_recovery_note,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -70,6 +71,33 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_goal_continuation_requires_successful_turn():
+    """Only genuinely successful turns may enqueue a goal continuation.
+
+    Regression for the standing-goal loop after a provider failure: an empty,
+    failed, partial, interrupted, or ``completed=False`` result is normalized
+    into non-empty user-facing text, and gating continuation on that text alone
+    let the goal judge re-enqueue the same synthetic continuation until the
+    session grew without bound.
+    """
+    # Successful turns continue the goal.
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "done") is True
+    assert _should_continue_goal_after_turn({"completed": True}, "done") is True
+    # Bare string results (no dict envelope) keep the legacy text-only behaviour.
+    assert _should_continue_goal_after_turn("done", "done") is True
+
+    # Empty / whitespace-only text never continues.
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "") is False
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "   ") is False
+
+    # Unsuccessful results must not continue even with non-empty normalized text.
+    assert _should_continue_goal_after_turn({"failed": True}, "Provider error") is False
+    assert _should_continue_goal_after_turn({"partial": True}, "Partial output") is False
+    assert _should_continue_goal_after_turn({"interrupted": True}, "Interrupted") is False
+    assert _should_continue_goal_after_turn({"error": "boom"}, "boom") is False
+    assert _should_continue_goal_after_turn({"completed": False}, "incomplete") is False
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -43,6 +43,7 @@ from gateway.run import (
     _last_transcript_timestamp,
     _prepare_resume_pending_message,
     _should_clear_resume_pending_after_turn,
+    _should_continue_goal_after_turn,
     build_resume_recovery_note,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -72,6 +73,31 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_goal_continuation_requires_successful_turn():
+    """Only genuinely successful turns may enqueue a goal continuation.
+
+    Regression for the standing-goal loop after a provider failure: an empty,
+    failed, partial, interrupted, or ``completed=False`` result is normalized
+    into non-empty user-facing text, and gating continuation on that text alone
+    let the goal judge re-enqueue the same synthetic continuation until the
+    session grew without bound.
+    """
+    # Successful turns continue the goal.
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "done") is True
+    assert _should_continue_goal_after_turn({"completed": True}, "done") is True
+    # Bare string results (no dict envelope) keep the legacy text-only behaviour.
+    assert _should_continue_goal_after_turn("done", "done") is True
+    # No user-facing text: nothing to continue on.
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "") is False
+    assert _should_continue_goal_after_turn({"final_response": "done"}, "   ") is False
+    # Non-empty text but a failed/partial/interrupted/incomplete turn must not continue.
+    assert _should_continue_goal_after_turn({"interrupted": True}, "err") is False
+    assert _should_continue_goal_after_turn({"failed": True}, "err") is False
+    assert _should_continue_goal_after_turn({"partial": True}, "err") is False
+    assert _should_continue_goal_after_turn({"error": "boom"}, "err") is False
+    assert _should_continue_goal_after_turn({"completed": False}, "err") is False
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):


### PR DESCRIPTION
## What does this PR do?

Stops a self-sustaining standing-goal continuation loop that a provider/model
failure could trigger in the gateway.

When a gateway session has an active `/goal`, `_normalize_empty_agent_response()`
deliberately turns a `failed`/`partial`/interrupted/errored agent result into
**non-empty** user-facing text. The post-turn goal-continuation hook in
`gateway/run.py` gated the continuation only on `if _final_text.strip():`, so
that normalized error text passed the gate. The goal judge then answered
"continue" and re-enqueued the same synthetic `[Continuing toward your standing
goal]` prompt. Each repeated failure appended another identical continuation
block, growing the session without bound (the reporter observed 10 msgs /
~46,600 tokens with duplicate blocks merged into one user message) and
eventually corrupting the shape the model prompt template expects.

The fix reuses the success semantics the gateway already defines. A new helper
`_should_continue_goal_after_turn(agent_result, final_text)` requires non-empty
text **and** applies `_should_clear_resume_pending_after_turn` (which already
rejects `interrupted`/`failed`/`partial`/`error`/`completed=False`), so only a
genuinely successful turn advances the goal. Bare string results keep the legacy
text-only behaviour.

This is distinct from #34197 (compression/session-split resurrecting stale goal
state) and #27585 (the goal judge's own API call failing after a *successful*
agent turn); here the primary agent turn itself fails but its normalized error
text still reached the continuation path.

## Related Issue

Fixes #63180

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: add `_should_continue_goal_after_turn(agent_result, final_text)` next to `_should_clear_resume_pending_after_turn`, and gate the post-turn goal continuation on it instead of `_final_text.strip()`.
- `tests/gateway/test_restart_resume_pending.py`: add `test_goal_continuation_requires_successful_turn` covering success, empty/whitespace text, bare-string results, and `failed`/`partial`/`interrupted`/`error`/`completed=False`.

## How to Test

```
scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py
```

Result: `82 tests passed, 0 failed`. Goal-adjacent suites also pass:

```
scripts/run_tests.sh tests/gateway/test_goal_max_turns_config.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_verdict_send.py
```

Result: `9 tests passed, 0 failed`.

Behaviourally: with an active `/goal`, force the model request to fail (e.g. an
OpenAI-compatible/LM Studio provider returning a jinja-template render error).
Before this change the gateway enqueues a fresh `[Continuing toward your
standing goal]` prompt after each failure; after it, the failed turn does not
run the judge and the loop waits for a real user message.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected gateway tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behaviour-only fix; new helper is documented in its docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python control flow)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
