### PR TITLE
feat(gateway): persist mobile mutation receipts

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -728,6 +728,12 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    # Gateway-only receipt proof tags copied onto the next user message. The
+    # underscore-prefixed field never leaves the process or persists to SQLite;
+    # it binds the in-memory `_db_persisted` proof to an exact mobile mutation.
+    agent._pending_mobile_mutation_receipt_tags: list[str] = []
+    agent._durable_mobile_mutation_receipt_tags: set[str] = set()
+    agent._mobile_mutation_receipt_condition = None
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -545,6 +545,32 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                     if prev_content and new_content
                     else (prev_content or new_content)
                 )
+                # The gateway binds a mobile receipt to the exact new user
+                # dict that SessionDB successfully persisted. Repair discards
+                # that dict after merging its text into ``prev``. Preserve an
+                # explicit proof-only tag without marking the merged content as
+                # wholly DB-persisted (``prev`` itself may still need a flush).
+                persisted_receipt_tags = list(
+                    msg.get("_mobile_mutation_persisted_receipt_tags") or ()
+                )
+                if msg.get("_db_persisted"):
+                    for tag in msg.get(
+                        "_mobile_mutation_receipt_tags",
+                        (),
+                    ) or ():
+                        if tag not in persisted_receipt_tags:
+                            persisted_receipt_tags.append(tag)
+                if persisted_receipt_tags:
+                    existing_receipt_tags = list(
+                        prev.get("_mobile_mutation_persisted_receipt_tags")
+                        or ()
+                    )
+                    for tag in persisted_receipt_tags:
+                        if tag not in existing_receipt_tags:
+                            existing_receipt_tags.append(tag)
+                    prev["_mobile_mutation_persisted_receipt_tags"] = (
+                        existing_receipt_tags
+                    )
                 repairs += 1
                 continue
         merged.append(msg)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -313,8 +313,19 @@ def build_turn_context(
             should_review_memory = True
             agent._turns_since_memory = 0
 
-    # Add user message.
+    # Add user message. Gateway mobile receipt tags are process-private proof
+    # tags: transport sanitizers strip underscore-prefixed fields and SessionDB
+    # stores only the canonical message columns, while `_db_persisted` remains
+    # on this exact dict after a successful append for receipt finalization.
     user_msg = {"role": "user", "content": user_message}
+    mobile_mutation_receipt_tags = list(
+        getattr(agent, "_pending_mobile_mutation_receipt_tags", ()) or ()
+    )
+    agent._pending_mobile_mutation_receipt_tags = []
+    if mobile_mutation_receipt_tags:
+        user_msg["_mobile_mutation_receipt_tags"] = (
+            mobile_mutation_receipt_tags
+        )
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
@@ -360,6 +371,36 @@ def build_turn_context(
             agent.session_id or "none",
             exc_info=True,
         )
+    if user_msg.get("_db_persisted") and mobile_mutation_receipt_tags:
+        receipt_condition = getattr(
+            agent,
+            "_mobile_mutation_receipt_condition",
+            None,
+        )
+        if receipt_condition is not None:
+            with receipt_condition:
+                durable_tags = set(
+                    getattr(
+                        agent,
+                        "_durable_mobile_mutation_receipt_tags",
+                        set(),
+                    )
+                    or set()
+                )
+                durable_tags.update(mobile_mutation_receipt_tags)
+                agent._durable_mobile_mutation_receipt_tags = durable_tags
+                receipt_condition.notify_all()
+        else:
+            durable_tags = set(
+                getattr(
+                    agent,
+                    "_durable_mobile_mutation_receipt_tags",
+                    set(),
+                )
+                or set()
+            )
+            durable_tags.update(mobile_mutation_receipt_tags)
+            agent._durable_mobile_mutation_receipt_tags = durable_tags
 
     # ── Preflight context compression ──
     # Gate the (expensive) full token estimate behind a cheap pre-check.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,6 +15,7 @@ The routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -621,7 +622,9 @@ async def api_auth_ws_ticket(request: Request):
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the
-    expected pattern.
+    expected pattern. A bodyless request intentionally retains the dashboard's
+    full legacy authority. A mobile audience requests a narrower grant for one
+    WebSocket connection; it is not a persistent device credential.
     """
     sess = getattr(request.state, "session", None)
     if sess is None:
@@ -632,11 +635,58 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    body = await request.body()
+    requested = {}
+    if body:
+        try:
+            requested = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+        if not isinstance(requested, dict):
+            raise HTTPException(status_code=400, detail="Expected a JSON object")
+
+    audience = str(requested.get("audience") or "").strip()
+    if "scopes" in requested and not audience:
+        raise HTTPException(
+            status_code=400,
+            detail="audience is required when scopes are requested",
+        )
+    if audience:
+        from tui_gateway.mobile_contract import (
+            MOBILE_AUDIENCE,
+            normalize_mobile_scopes,
+        )
+
+        if audience != MOBILE_AUDIENCE:
+            raise HTTPException(status_code=400, detail="Unsupported WebSocket audience")
+        raw_scopes = requested.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise HTTPException(status_code=400, detail="scopes must be an array")
+        try:
+            granted_scopes = normalize_mobile_scopes(raw_scopes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        ticket = mint_ticket(
+            user_id=sess.user_id,
+            provider=sess.provider,
+            audience=audience,
+            scopes=granted_scopes,
+        )
+    else:
+        # Preserve the existing dashboard contract exactly for bodyless calls.
+        ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,
         user_id=sess.user_id,
         ip=_client_ip(request),
     )
-    return {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    response = {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    if audience:
+        response.update(
+            {
+                "audience": audience,
+                "granted_scopes": list(granted_scopes),
+            }
+        )
+    return response

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -646,11 +646,13 @@ async def api_auth_ws_ticket(request: Request):
             raise HTTPException(status_code=400, detail="Expected a JSON object")
 
     audience = str(requested.get("audience") or "").strip()
-    if "scopes" in requested and not audience:
-        raise HTTPException(
-            status_code=400,
-            detail="audience is required when scopes are requested",
+    if body and not audience:
+        detail = (
+            "audience is required when scopes are requested"
+            if "scopes" in requested
+            else "audience is required for a non-empty ticket request"
         )
+        raise HTTPException(status_code=400, detail=detail)
     if audience:
         from tui_gateway.mobile_contract import (
             MOBILE_AUDIENCE,

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -5,10 +5,13 @@ mode the legacy ``?token=<_SESSION_TOKEN>`` query param works because the
 token is injected into the SPA bundle. In gated mode there is no injected
 token — so this module provides two credential shapes:
 
-1. **Single-use browser tickets** (``mint_ticket`` / ``consume_ticket``).
-   The SPA gets a fresh ticket via the authenticated REST endpoint
-   ``POST /api/auth/ws-ticket`` and passes it as ``?ticket=`` on the WS
-   upgrade. Single-use, TTL = 30 seconds — a leaked ticket is uninteresting.
+1. **Single-use client tickets** (``mint_ticket`` / ``consume_ticket``).
+   The SPA gets a full-authority legacy ticket from a bodyless authenticated
+   ``POST /api/auth/ws-ticket``. A native client can request a mobile audience
+   and explicit scopes instead. Both pass ``?ticket=`` on the WS upgrade and
+   are single-use with TTL = 30 seconds. The scoped ticket narrows one socket;
+   it is not a persistent device credential or a replacement for the legacy
+   compatibility path.
 
 2. **A process-lifetime internal credential** (``internal_ws_credential`` /
    ``consume_internal_credential``). This authenticates *server-spawned*
@@ -53,13 +56,21 @@ _internal_credential: Optional[str] = None
 #: credential, so audit logs distinguish them from browser-initiated tickets.
 INTERNAL_USER_ID = "server-internal"
 INTERNAL_PROVIDER = "server-internal"
+LEGACY_AUDIENCE = "dashboard"
+LEGACY_SCOPES = ("*",)
 
 
 class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(
+    *,
+    user_id: str,
+    provider: str,
+    audience: str = LEGACY_AUDIENCE,
+    scopes: tuple[str, ...] = LEGACY_SCOPES,
+) -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -70,6 +81,8 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     info = {
         "user_id": user_id,
         "provider": provider,
+        "audience": audience,
+        "scopes": tuple(scopes),
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -132,10 +145,10 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     Unlike :func:`consume_ticket` this is **not** single-use — the value is
     not removed on success, so a server-spawned child can present it on every
     (re)connect. Returns the fixed server-internal identity ``info`` dict
-    (``{user_id, provider}``), mirroring the ``info`` shape ``consume_ticket``
-    returns, so a caller that wants to record the connecting identity can; the
-    current ``_ws_auth_ok`` caller validates for the boolean outcome only and
-    discards the dict.
+    (identity plus legacy audience/scopes), mirroring the ``info`` shape
+    ``consume_ticket`` returns so the gateway can carry one effective grant
+    shape through its transport. Non-gateway callers may validate only the
+    boolean outcome and discard the dict.
 
     A constant-time compare against the (lazily-minted) credential avoids
     leaking length / prefix information on mismatch. If no internal
@@ -150,6 +163,8 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     return {
         "user_id": INTERNAL_USER_ID,
         "provider": INTERNAL_PROVIDER,
+        "audience": LEGACY_AUDIENCE,
+        "scopes": LEGACY_SCOPES,
     }
 
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -77,12 +77,20 @@ def mint_ticket(
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
     """
+    scope_tuple = tuple(scopes)
+    if audience == "hermes.mobile":
+        from tui_gateway.mobile_contract import normalize_mobile_scopes
+
+        scope_tuple = normalize_mobile_scopes(scope_tuple)
+    elif audience != LEGACY_AUDIENCE or scope_tuple != LEGACY_SCOPES:
+        raise ValueError(f"unsupported WebSocket audience or grant: {audience}")
+
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
         "audience": audience,
-        "scopes": tuple(scopes),
+        "scopes": scope_tuple,
         "minted_at": int(time.time()),
     }
     with _lock:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14442,8 +14442,10 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_result(
+    ws: "WebSocket",
+) -> tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Validate WS-upgrade auth and return its effective authorization grant.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -14451,15 +14453,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``authorization`` is the server-derived grant carried by an accepted
+    credential; it is ``None`` for every rejected request.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
 
     Gated (public bind, no ``--insecure``): one of two credentials —
 
-    * ``?ticket=<single-use>`` — a browser-minted, single-use, 30s-TTL ticket
-      consumed against the dashboard-auth ticket store. This is what the SPA
-      (and native clients) use.
+    * ``?ticket=<single-use>`` — a client-minted, single-use, 30s-TTL ticket
+      consumed against the dashboard-auth ticket store. The bodyless SPA flow
+      retains legacy dashboard authority. A native mobile ticket is restricted
+      to ``/api/ws`` and carries explicit scopes into its dispatcher.
     * ``?internal=<process-credential>`` — the process-lifetime internal
       credential, used only by WS clients the server spawns itself (the
       embedded-TUI PTY child attaching to ``/api/ws`` and ``/api/pub``). It
@@ -14491,8 +14496,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                grant = consume_internal_credential(internal)
+                return None, "internal", grant
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14500,15 +14505,26 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            grant = consume_ticket(ticket)
+            if (
+                grant.get("audience") == "hermes.mobile"
+                and ws.url.path != "/api/ws"
+            ):
+                audit_log(
+                    AuditEvent.WS_TICKET_REJECTED,
+                    reason="mobile ticket used outside /api/ws",
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return "ticket_audience_mismatch", "ticket", None
+            return None, "ticket", grant
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14516,14 +14532,29 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return (
+            None,
+            "token",
+            {
+                "user_id": "loopback",
+                "provider": "loopback",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            },
+        )
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Compatibility view of :func:`_ws_auth_result` for non-gateway sockets."""
+    reason, credential, _authorization = _ws_auth_result(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -15613,7 +15644,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, authorization = _ws_auth_result(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -15623,7 +15655,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, authorization=authorization)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -175,6 +175,30 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_mobile_mutation_receipt_tags_bind_exactly_one_user_turn():
+    agent = _FakeAgent()
+    agent._pending_mobile_mutation_receipt_tags = ["proof-a", "proof-b"]
+
+    def persist(messages, *_args, **_kwargs):
+        messages[-1]["_db_persisted"] = True
+
+    agent._persist_session = persist
+
+    tagged = _build(agent)
+    following = _build(agent, user_message="later")
+
+    assert tagged.messages[-1]["_mobile_mutation_receipt_tags"] == [
+        "proof-a",
+        "proof-b",
+    ]
+    assert "_mobile_mutation_receipt_tags" not in following.messages[-1]
+    assert agent._pending_mobile_mutation_receipt_tags == []
+    assert agent._durable_mobile_mutation_receipt_tags == {
+        "proof-a",
+        "proof-b",
+    }
+
+
 def test_applies_agent_side_effects():
     agent = _FakeAgent()
     _build(agent)
@@ -363,4 +387,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -13,6 +13,8 @@ pre-existing regression unrelated to dashboard-auth.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -20,14 +22,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
+from hermes_cli import mcp_startup
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
+    consume_ticket,
     consume_internal_credential,
     internal_ws_credential,
     mint_ticket,
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tui_gateway import server as tui_server
+from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +122,13 @@ class TestWsTicketEndpoint:
         r = gated_app.post("/api/auth/ws-ticket")
         assert r.status_code == 200
         body = r.json()
-        assert "ticket" in body
+        assert set(body) == {"ticket", "ttl_seconds"}
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "dashboard"
+        assert grant["scopes"] == ("*",)
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -132,6 +141,58 @@ class TestWsTicketEndpoint:
         tickets = {gated_app.post("/api/auth/ws-ticket").json()["ticket"]
                    for _ in range(5)}
         assert len(tickets) == 5
+
+    def test_mobile_ticket_returns_and_preserves_the_granted_scopes(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.read", "conversation.write"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["audience"] == "hermes.mobile"
+        assert body["granted_scopes"] == [
+            "conversation.read",
+            "conversation.write",
+        ]
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "hermes.mobile"
+        assert grant["scopes"] == ("conversation.read", "conversation.write")
+
+    @pytest.mark.parametrize("scope", ["approval.respond", "shell.exec"])
+    def test_mobile_ticket_rejects_scopes_not_enforced_by_this_contract(
+        self,
+        gated_app,
+        scope,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"audience": "hermes.mobile", "scopes": [scope]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"unsupported mobile scope: {scope}"
+
+    def test_scopes_without_a_mobile_audience_do_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"scopes": ["conversation.read"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "audience is required when scopes are requested"
 
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
@@ -150,6 +211,54 @@ class TestWsTicketEndpoint:
             f"GET /api/auth/ws-ticket leaked a ticket (status={r.status_code}, "
             f"body[:200]={body[:200]!r})"
         )
+
+
+def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
+    sent = []
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
+    ticket = mint_ticket(
+        user_id="mobile-user",
+        provider="stub",
+        audience="hermes.mobile",
+        scopes=("conversation.read",),
+    )
+
+    class QueryParams:
+        def get(self, key, default=""):
+            return {"ticket": ticket}.get(key, default)
+
+    class FakeWS:
+        query_params = QueryParams()
+        client = SimpleNamespace(host="203.0.113.10")
+        url = SimpleNamespace(path="/api/ws")
+        headers = {
+            "host": "fly-app.fly.dev",
+            "origin": "https://fly-app.fly.dev",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise tui_ws._WebSocketDisconnect()
+
+        async def close(self, code=None):
+            pass
+
+    asyncio.run(web_server.gateway_ws(FakeWS()))
+
+    authorization = sent[0]["params"]["payload"]["authorization"]
+    assert authorization == {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ["conversation.read"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +337,26 @@ class TestWsAuthOkGated:
         ticket = mint_ticket(user_id="u1", provider="stub")
         ws = _fake_ws(query={"ticket": ticket})
         assert web_server._ws_auth_ok(ws) is True
+
+    @pytest.mark.parametrize("path", ["/api/pty", "/api/console", "/api/pub", "/api/events"])
+    def test_mobile_ticket_cannot_authenticate_non_gateway_websockets(
+        self,
+        gated_app,
+        path,
+    ):
+        ticket = mint_ticket(
+            user_id="mobile-user",
+            provider="stub",
+            audience="hermes.mobile",
+            scopes=("conversation.read",),
+        )
+        ws = _fake_ws(query={"ticket": ticket}, path=path)
+
+        reason, credential, authorization = web_server._ws_auth_result(ws)
+
+        assert reason == "ticket_audience_mismatch"
+        assert credential == "ticket"
+        assert authorization is None
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -5,16 +5,14 @@ The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
-These tests exercise the helper at the unit level (no actual WS upgrade)
-plus the ticket-mint endpoint under realistic gated-mode setup. We don't
-test the full WS upgrade because the starlette TestClient WS path has a
-pre-existing regression unrelated to dashboard-auth.
+These tests exercise the helper at the unit level, the ticket-mint endpoint
+under realistic gated-mode setup, and one public mint-to-upgrade-to-dispatch
+round trip. The full upgrade supplies explicit Host/Origin headers because
+Starlette's WebSocket TestClient does not inherit the HTTP ``base_url`` host.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -33,7 +31,6 @@ from hermes_cli.dashboard_auth.ws_tickets import (
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 from tui_gateway import server as tui_server
-from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +191,35 @@ class TestWsTicketEndpoint:
         assert response.status_code == 400
         assert response.json()["detail"] == "audience is required when scopes are requested"
 
+    def test_nonempty_request_without_an_audience_does_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post("/api/auth/ws-ticket", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "audience is required for a non-empty ticket request"
+        )
+
+    def test_mobile_write_grant_requires_read_scope(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.write"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "conversation.read is required for every mobile WebSocket grant"
+        )
+
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
         r = gated_app.get("/api/auth/ws-ticket", follow_redirects=False)
@@ -213,52 +239,47 @@ class TestWsTicketEndpoint:
         )
 
 
-def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
-    sent = []
+def test_scoped_ticket_grant_reaches_gateway_ready_and_dispatch(gated_app, monkeypatch):
     monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
     monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
-    ticket = mint_ticket(
-        user_id="mobile-user",
-        provider="stub",
-        audience="hermes.mobile",
-        scopes=("conversation.read",),
+
+    _logged_in(gated_app)
+    minted = gated_app.post(
+        "/api/auth/ws-ticket",
+        json={
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
+        },
     )
+    assert minted.status_code == 200
 
-    class QueryParams:
-        def get(self, key, default=""):
-            return {"ticket": ticket}.get(key, default)
-
-    class FakeWS:
-        query_params = QueryParams()
-        client = SimpleNamespace(host="203.0.113.10")
-        url = SimpleNamespace(path="/api/ws")
-        headers = {
-            "host": "fly-app.fly.dev",
-            "origin": "https://fly-app.fly.dev",
+    with gated_app.websocket_connect(
+        f"/api/ws?ticket={minted.json()['ticket']}",
+        headers={
+            "Host": "fly-app.fly.dev",
+            "Origin": "https://fly-app.fly.dev",
+        },
+    ) as socket:
+        ready = socket.receive_json()
+        authorization = ready["params"]["payload"]["authorization"]
+        assert authorization == {
+            "subject": "stub-user-1",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
         }
 
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            sent.append(json.loads(line))
-
-        async def receive_text(self):
-            raise tui_ws._WebSocketDisconnect()
-
-        async def close(self, code=None):
-            pass
-
-    asyncio.run(web_server.gateway_ws(FakeWS()))
-
-    authorization = sent[0]["params"]["payload"]["authorization"]
-    assert authorization == {
-        "subject": "mobile-user",
-        "provider": "stub",
-        "audience": "hermes.mobile",
-        "scopes": ["conversation.read"],
-    }
+        socket.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": "denied-write",
+                "method": "prompt.submit",
+                "params": {},
+            }
+        )
+        denied = socket.receive_json()
+        assert denied["error"]["data"]["required_scope"] == "conversation.write"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,18 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_scoped_ticket_can_explicitly_grant_conversation_deletion(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.delete"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["scopes"] == ("conversation.read", "conversation.delete")
+
     def test_ticket_store_rejects_unknown_audiences(self):
         with pytest.raises(ValueError, match="unsupported WebSocket audience"):
             mint_ticket(

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,27 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_ticket_store_rejects_unknown_audiences(self):
+        with pytest.raises(ValueError, match="unsupported WebSocket audience"):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.future",
+                scopes=("*",),
+            )
+
+    def test_ticket_store_rejects_mobile_grants_without_read_scope(self):
+        with pytest.raises(
+            ValueError,
+            match="conversation.read is required for every mobile WebSocket grant",
+        ):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.mobile",
+                scopes=("conversation.write",),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -51,6 +51,19 @@ class TestMintAndConsume:
         seen = {mint_ticket(user_id="u1", provider="x") for _ in range(50)}
         assert len(seen) == 50
 
+    def test_scoped_ticket_preserves_its_authorization_grant(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.write"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["audience"] == "hermes.mobile"
+        assert info["scopes"] == ("conversation.read", "conversation.write")
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -105,6 +105,43 @@ def test_repair_preserves_user_content_when_one_side_empty():
     assert messages == [{"role": "user", "content": "real message"}]
 
 
+def test_repair_preserves_persisted_mobile_receipt_proof_on_user_merge():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "mobile retry",
+            "_db_persisted": True,
+            "_mobile_mutation_receipt_tags": ["proof-1"],
+        },
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 1
+    assert messages[0]["_mobile_mutation_persisted_receipt_tags"] == [
+        "proof-1"
+    ]
+
+
+def test_repair_does_not_promote_unpersisted_mobile_receipt_proof():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "failed write",
+            "_mobile_mutation_receipt_tags": ["proof-1"],
+        },
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 1
+    assert "_mobile_mutation_persisted_receipt_tags" not in messages[0]
+
+
 def test_repair_does_not_rewind_ongoing_dialog_tool_pair():
     """assistant(tool_calls) + tool + user is a VALID pattern (user redirect
     before the model gets its continuation turn). Repair must not touch it —

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -55,12 +55,24 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                 },
                 "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
                 "contract": {"name": "hermes.mobile", "major": 1},
-                "schemas": {
-                    "gateway.ready": 1,
-                    "authorization.grant": 1,
-                    "authorization.error": 1,
-                },
-                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                    "schemas": {
+                        "gateway.ready": 1,
+                        "authorization.grant": 1,
+                        "authorization.error": 1,
+                        "mutation.receipt": 1,
+                    },
+                    "capabilities": {
+                        "auth.ws_scopes": {"version": 1},
+                        "mutation.idempotency": {
+                            "version": 1,
+                            "methods": [
+                                "prompt.submit",
+                                "session.interrupt",
+                                "session.delete",
+                            ],
+                            "status_method": "mutation.status",
+                        },
+                    },
                 "authorization": {
                     "subject": "user-1",
                     "provider": "stub",

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -121,8 +121,11 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "not.a.mobile.method",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read"],
+            "grantable": False,
         },
     }
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,10 +1,130 @@
 import asyncio
+import json
 import threading
 import time
 
 from hermes_cli import mcp_startup
+from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+
+
+def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
+    monkeypatch,
+):
+    sent = []
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(mobile_contract, "SERVER_VERSION", "test-version")
+    monkeypatch.setattr(mobile_contract, "SERVER_RELEASE_DATE", "test-release")
+    monkeypatch.setattr(mobile_contract, "SERVER_INSTANCE_ID", "test-instance")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "user-1",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ("conversation.read", "conversation.write"),
+    }
+
+    asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+
+    assert sent[0] == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": "test-skin",
+                "server": {
+                    "version": "test-version",
+                    "release_date": "test-release",
+                    "instance_id": "test-instance",
+                },
+                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
+                "contract": {"name": "hermes.mobile", "major": 1},
+                "schemas": {
+                    "gateway.ready": 1,
+                    "authorization.grant": 1,
+                    "authorization.error": 1,
+                },
+                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "authorization": {
+                    "subject": "user-1",
+                    "provider": "stub",
+                    "audience": "hermes.mobile",
+                    "scopes": ["conversation.read", "conversation.write"],
+                },
+            },
+        },
+    }
+
+
+def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
+    monkeypatch,
+):
+    sent = []
+    received = False
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "mobile-request",
+                        "method": "not.a.mobile.method",
+                        "params": {},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(
+        ws_mod.handle_ws(
+            FakeWS(),
+            authorization={
+                "subject": "user-1",
+                "provider": "stub",
+                "audience": "hermes.mobile",
+                "scopes": ("conversation.read",),
+            },
+        )
+    )
+
+    assert sent[1]["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "not.a.mobile.method",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read"],
+        },
+    }
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,0 +1,217 @@
+"""Public JSON-RPC conformance tests for the mobile authorization contract."""
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self, authorization=None):
+        self.authorization = authorization
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "prompt.submit",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-1",
+        "error": {
+            "code": 4030,
+            "message": "insufficient authorization scope",
+            "data": {
+                "reason": "missing_scope",
+                "method": "prompt.submit",
+                "required_scope": "conversation.write",
+                "granted_scopes": ["conversation.read"],
+            },
+        },
+    }
+
+
+def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-2",
+            "method": "shell.exec",
+            "params": {"command": "true"},
+        },
+        transport,
+    )
+
+    assert response["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "shell.exec",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read", "conversation.write"],
+        },
+    }
+
+
+def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-request",
+            "method": "approval.respond",
+            "params": {"choice": "once"},
+        },
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "method_not_available_to_mobile",
+        "method": "approval.respond",
+        "required_scope": None,
+        "granted_scopes": ["conversation.read", "conversation.write"],
+    }
+
+
+def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+    server._sessions.clear()
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-3",
+            "method": "session.active_list",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-3",
+        "result": {"sessions": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "required_scope"),
+    [
+        ("session.list", "conversation.read"),
+        ("session.active_list", "conversation.read"),
+        ("session.activate", "conversation.read"),
+        ("session.history", "conversation.read"),
+        ("session.status", "conversation.read"),
+        ("session.usage", "conversation.read"),
+        ("session.create", "conversation.write"),
+        ("session.resume", "conversation.write"),
+        ("prompt.submit", "conversation.write"),
+        ("session.interrupt", "conversation.control"),
+        ("session.steer", "conversation.control"),
+    ],
+)
+def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
+    method,
+    required_scope,
+):
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (),
+        }
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": method,
+        "required_scope": required_scope,
+        "granted_scopes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        {
+            "subject": "server-internal",
+            "provider": "server-internal",
+            "audience": "dashboard",
+            "scopes": ("*",),
+        },
+    ],
+)
+def test_legacy_and_internal_dispatch_keep_the_existing_behavior(authorization):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-request",
+            "method": "not.a.real.method",
+            "params": {},
+        },
+        RecordingTransport(authorization),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "legacy-request",
+        "error": {
+            "code": -32601,
+            "message": "unknown method: not.a.real.method",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -220,25 +220,28 @@ def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(metho
     assert response["error"]["data"]["grantable"] is False
 
 
-def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
-    authorization = _mobile_authorization(
-        "conversation.read",
-        "conversation.write",
-        "conversation.control",
+def test_mobile_dispatch_rejects_hidden_history_deletion():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "hidden-delete",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "known",
+                "text": "replace",
+                "truncate_before_user_ordinal": 1,
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
     )
 
-    delete_denial = mobile_contract.mobile_method_denial(
-        "prompt.submit",
-        authorization,
-        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
-    )
-    profile_denial = mobile_contract.mobile_method_denial(
-        "session.create",
-        authorization,
-        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
-    )
-
-    assert delete_denial == {
+    assert response["error"]["data"] == {
         "reason": "parameter_not_available_to_mobile",
         "method": "prompt.submit",
         "parameter": "truncate_before_user_ordinal",
@@ -252,10 +255,55 @@ def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters(
         ],
         "grantable": False,
     }
-    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
-    assert profile_denial["parameter"] == "messages"
-    assert profile_denial["required_scope"] == "mobile.unavailable"
-    assert profile_denial["grantable"] is False
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("close_on_disconnect", True),
+        ("cwd", "/tmp/outside"),
+        ("fast", True),
+        ("messages", [{"role": "system", "content": "override"}]),
+        ("model", "provider/model"),
+        ("parent_session_id", "parent"),
+        ("profile", "../../outside"),
+        ("provider", "custom"),
+        ("reasoning_effort", "high"),
+        ("source", "spoofed-platform"),
+    ],
+)
+def test_mobile_dispatch_rejects_each_privileged_create_parameter(
+    monkeypatch,
+    parameter,
+    value,
+):
+    def fail_if_handler_runs(_profile):
+        raise AssertionError("session.create handler ran before mobile authorization")
+
+    monkeypatch.setattr(server, "_profile_home", fail_if_handler_runs)
+    server._sessions.clear()
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "privileged-create",
+            "method": "session.create",
+            "params": {parameter: value},
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == parameter
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
+    assert server._sessions == {}
 
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
@@ -268,12 +316,13 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             self.interrupted = True
 
     agent = Agent()
+    original_transport = RecordingTransport()
     session = {
         "agent": agent,
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
-        "transport": None,
+        "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
@@ -294,7 +343,9 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     assert response["result"] == {"status": "queued"}
     assert agent.interrupted is False
+    assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
+    assert session["queued_prompt"]["transport"] is transport
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,7 +1,10 @@
 """Public JSON-RPC conformance tests for the mobile authorization contract."""
 
+import threading
+
 import pytest
 
+from tui_gateway import mobile_contract
 from tui_gateway import server
 
 
@@ -18,15 +21,17 @@ class RecordingTransport:
         pass
 
 
+def _mobile_authorization(*scopes):
+    return {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": scopes,
+    }
+
+
 def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
 
     response = server.dispatch(
         {
@@ -48,7 +53,10 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
                 "reason": "missing_scope",
                 "method": "prompt.submit",
                 "required_scope": "conversation.write",
+                "required_scopes": ["conversation.write"],
+                "missing_scopes": ["conversation.write"],
                 "granted_scopes": ["conversation.read"],
+                "grantable": True,
             },
         },
     }
@@ -56,12 +64,7 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
 
 def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -80,20 +83,18 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "shell.exec",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read", "conversation.write"],
+            "grantable": False,
         },
     }
 
 
 def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -109,20 +110,16 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     assert response["error"]["data"] == {
         "reason": "method_not_available_to_mobile",
         "method": "approval.respond",
-        "required_scope": None,
+        "required_scope": "mobile.unavailable",
+        "required_scopes": ["mobile.unavailable"],
+        "missing_scopes": ["mobile.unavailable"],
         "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": False,
     }
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
     server._sessions.clear()
 
     response = server.dispatch(
@@ -147,29 +144,19 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
     [
         ("session.list", "conversation.read"),
         ("session.active_list", "conversation.read"),
-        ("session.activate", "conversation.read"),
+        ("session.activate", "conversation.control"),
         ("session.history", "conversation.read"),
-        ("session.status", "conversation.read"),
-        ("session.usage", "conversation.read"),
         ("session.create", "conversation.write"),
-        ("session.resume", "conversation.write"),
+        ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
-        ("session.steer", "conversation.control"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
     method,
     required_scope,
 ):
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": (),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization())
 
     response = server.dispatch(
         {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
@@ -180,8 +167,142 @@ def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
         "reason": "missing_scope",
         "method": method,
         "required_scope": required_scope,
+        "required_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
+        "missing_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
         "granted_scopes": [],
+        "grantable": True,
     }
+
+
+def test_mobile_create_requires_write_and_control():
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": "session.create",
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.write", "conversation.control"],
+        "missing_scopes": ["conversation.control"],
+        "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": True,
+    }
+
+
+@pytest.mark.parametrize("method", ["session.status", "session.usage", "session.steer"])
+def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(method):
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "unavailable", "method": method, "params": {}},
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    assert response["error"]["data"]["required_scope"] == "mobile.unavailable"
+    assert response["error"]["data"]["grantable"] is False
+
+
+def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
+    authorization = _mobile_authorization(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+
+    delete_denial = mobile_contract.mobile_method_denial(
+        "prompt.submit",
+        authorization,
+        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
+    )
+    profile_denial = mobile_contract.mobile_method_denial(
+        "session.create",
+        authorization,
+        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
+    )
+
+    assert delete_denial == {
+        "reason": "parameter_not_available_to_mobile",
+        "method": "prompt.submit",
+        "parameter": "truncate_before_user_ordinal",
+        "required_scope": "conversation.delete",
+        "required_scopes": ["conversation.delete"],
+        "missing_scopes": ["conversation.delete"],
+        "granted_scopes": [
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ],
+        "grantable": False,
+    }
+    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
+    assert profile_denial["parameter"] == "messages"
+    assert profile_denial["required_scope"] == "mobile.unavailable"
+    assert profile_denial["grantable"] is False
+
+
+def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
+    monkeypatch,
+):
+    class Agent:
+        interrupted = False
+
+        def interrupt(self):
+            self.interrupted = True
+
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["busy"] = session
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "busy-write",
+            "method": "prompt.submit",
+            "params": {"session_id": "busy", "text": "next"},
+        },
+        transport,
+    )
+
+    assert response["result"] == {"status": "queued"}
+    assert agent.interrupted is False
+    assert session["queued_prompt"]["text"] == "next"
+
+
+def test_mobile_scope_grants_require_read_access():
+    with pytest.raises(
+        ValueError,
+        match="conversation.read is required for every mobile WebSocket grant",
+    ):
+        mobile_contract.normalize_mobile_scopes(["conversation.write"])
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -150,6 +150,8 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
         ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
+        ("session.delete", "conversation.delete"),
+        ("mutation.status", "conversation.read"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
@@ -308,7 +310,10 @@ def test_mobile_dispatch_rejects_each_privileged_create_parameter(
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
     monkeypatch,
+    tmp_path,
 ):
+    from tui_gateway.mobile_mutations import MobileMutationStore
+
     class Agent:
         interrupted = False
 
@@ -322,11 +327,14 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
+        "session_key": "stored-busy",
         "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
     transport = RecordingTransport(
         _mobile_authorization("conversation.read", "conversation.write")
     )
@@ -336,12 +344,24 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             "jsonrpc": "2.0",
             "id": "busy-write",
             "method": "prompt.submit",
-            "params": {"session_id": "busy", "text": "next"},
+            "params": {
+                "client_request_id": "busy-write-1",
+                "expected_stored_session_id": "stored-busy",
+                "session_id": "busy",
+                "text": "next",
+            },
         },
         transport,
     )
 
-    assert response["result"] == {"status": "queued"}
+    assert response["result"] == {
+        "mutation": {
+            "client_request_id": "busy-write-1",
+            "deduplicated": False,
+            "state": "completed",
+        },
+        "status": "queued",
+    }
     assert agent.interrupted is False
     assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -322,19 +322,52 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     agent = Agent()
     original_transport = RecordingTransport()
+    release_turn = threading.Event()
+    receipt_completed = threading.Event()
     session = {
         "agent": agent,
+        "history": [],
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
         "session_key": "stored-busy",
         "transport": original_transport,
     }
+
+    def finish_turn():
+        assert release_turn.wait(timeout=2)
+        with session["history_lock"]:
+            queued = session["queued_prompt"]
+            assert queued is not None
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": queued["text"],
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": list(
+                        queued["mobile_mutation_receipt_tags"]
+                    ),
+                }
+            )
+            session["queued_prompt"] = None
+            session["running"] = False
+
+    run_thread = threading.Thread(target=finish_turn)
+    session["_run_thread"] = run_thread
+    run_thread.start()
     server._sessions.clear()
     server._sessions["busy"] = session
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
     store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
     monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    original_complete = store.complete
+
+    def complete_receipt(claim, outcome):
+        completed = original_complete(claim, outcome)
+        receipt_completed.set()
+        return completed
+
+    monkeypatch.setattr(store, "complete", complete_receipt)
     transport = RecordingTransport(
         _mobile_authorization("conversation.read", "conversation.write")
     )
@@ -358,7 +391,7 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
         "mutation": {
             "client_request_id": "busy-write-1",
             "deduplicated": False,
-            "state": "completed",
+            "state": "in_progress",
         },
         "status": "queued",
     }
@@ -366,6 +399,11 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
     assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
     assert session["queued_prompt"]["transport"] is transport
+    release_turn.set()
+    run_thread.join(timeout=1)
+    assert not run_thread.is_alive()
+    assert receipt_completed.wait(timeout=1)
+    store.close()
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -177,6 +177,102 @@ def test_transient_lineage_failure_releases_receipt_for_identical_retry(
     }
 
 
+def test_waiting_duplicate_re_reserves_after_preflight_release(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    first_preflight = threading.Event()
+    release_first_preflight = threading.Event()
+    duplicate_waiting = threading.Event()
+    preflight_calls = 0
+    preflight_lock = threading.Lock()
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root", "conversation-tip"]
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        nonlocal preflight_calls
+        with preflight_lock:
+            preflight_calls += 1
+            call = preflight_calls
+        if call == 1:
+            first_preflight.set()
+            assert release_first_preflight.wait(timeout=2)
+            raise sqlite3.OperationalError("lineage store unavailable")
+        yield Db()
+
+    original_wait = _isolated_gateway_mutation_store.wait_for_outcome
+
+    def observed_wait(claim, *, timeout):
+        duplicate_waiting.set()
+        return original_wait(claim, timeout=timeout)
+
+    class Agent:
+        session_id = "conversation-tip"
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "wait_for_outcome",
+        observed_wait,
+    )
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-tip",
+    }
+    request = {
+        "jsonrpc": "2.0",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "waiter-after-release",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    responses = {}
+
+    def dispatch(name, correlation):
+        responses[name] = server.dispatch(
+            {**request, "id": correlation},
+            transport,
+        )
+
+    owner = threading.Thread(target=dispatch, args=("owner", "owner-request"))
+    duplicate = threading.Thread(
+        target=dispatch,
+        args=("duplicate", "duplicate-request"),
+    )
+    owner.start()
+    assert first_preflight.wait(timeout=2)
+    duplicate.start()
+    assert duplicate_waiting.wait(timeout=2)
+    release_first_preflight.set()
+    owner.join(timeout=2)
+    duplicate.join(timeout=2)
+
+    assert not owner.is_alive()
+    assert not duplicate.is_alive()
+    assert responses["owner"]["error"]["code"] == 5037
+    assert responses["duplicate"]["result"]["status"] == "interrupted"
+    assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is False
+    assert agent.interrupt_calls == 1
+
+
 def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path):
     path = tmp_path / "mobile-mutations.sqlite3"
     first = MobileMutationStore(path, owner_instance_id="process-a")
@@ -200,6 +296,57 @@ def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path
         subject="mobile-user",
         client_request_id="request-1",
     )["state"] == "completed"
+
+
+def test_corrupt_completed_outcome_is_store_unavailable_not_invalid_request(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    from tui_gateway import server
+
+    path = tmp_path / "corrupt-mobile-mutations.sqlite3"
+    first = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = first.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="corrupt-outcome-1",
+        method="session.interrupt",
+        resource_id="conversation-root",
+        semantic_parameters={},
+    )
+    assert first.complete(claim, {"result": {"status": "interrupted"}}) is True
+    first.close()
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE mobile_mutations SET outcome_json = ?",
+            ("{not-json",),
+        )
+
+    reopened = MobileMutationStore(path, owner_instance_id="process-b")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: reopened)
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "corrupt-outcome-retry",
+                "method": "session.interrupt",
+                "params": {
+                    "client_request_id": "corrupt-outcome-1",
+                    "expected_stored_session_id": "conversation-root",
+                    "session_id": "no-live-session-needed-for-replay",
+                },
+            },
+            _MobileTransport("conversation.read", "conversation.control"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+    reopened.close()
 
 
 def test_same_request_identity_with_different_semantics_conflicts(tmp_path):
@@ -550,6 +697,157 @@ def test_receipt_completion_failures_become_structured_unknown_outcomes(
 
     assert retry["error"]["code"] == 4091
     assert agent.interrupt_calls == 1
+
+
+def test_completion_and_terminalization_failures_recycle_to_unknown(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+
+    def fail_write(*_args, **_kwargs):
+        raise sqlite3.OperationalError("receipt connection unhealthy")
+
+    monkeypatch.setattr(_isolated_gateway_mutation_store, "complete", fail_write)
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "mark_outcome_unknown",
+        fail_write,
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "double-write-failure",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "double-write-failure-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(request, transport)
+
+    assert response["error"]["code"] == 5037
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="double-write-failure-1",
+    )["state"] == "outcome_unknown"
+    assert agent.interrupt_calls == 1
+    assert any(record.exc_info is not None for record in caplog.records)
+
+    request["id"] = "double-write-failure-retry"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert agent.interrupt_calls == 1
+
+
+def test_failed_recycle_is_retried_after_storage_recovers(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+
+    def fail_write(*_args, **_kwargs):
+        raise sqlite3.OperationalError("receipt connection unhealthy")
+
+    original_open = _isolated_gateway_mutation_store._open_connection
+    recycle_attempts = 0
+
+    def fail_first_recycle(owner_instance_id):
+        nonlocal recycle_attempts
+        recycle_attempts += 1
+        if recycle_attempts == 1:
+            raise sqlite3.OperationalError("storage still unavailable")
+        return original_open(owner_instance_id)
+
+    original_wait = _isolated_gateway_mutation_store.wait_for_outcome
+
+    def no_slow_wait(claim, *, timeout):
+        assert timeout == 30.0
+        return original_wait(claim, timeout=0.0)
+
+    monkeypatch.setattr(_isolated_gateway_mutation_store, "complete", fail_write)
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "mark_outcome_unknown",
+        fail_write,
+    )
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "_open_connection",
+        fail_first_recycle,
+    )
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "wait_for_outcome",
+        no_slow_wait,
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "recycle-still-down",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "recycle-recovery-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    unavailable = server.dispatch(request, transport)
+
+    assert unavailable["error"]["code"] == 5037
+    assert recycle_attempts == 1
+    assert agent.interrupt_calls == 1
+
+    request["id"] = "recycle-storage-recovered"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert recycle_attempts == 2
+    assert agent.interrupt_calls == 1
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="recycle-recovery-1",
+    )["state"] == "outcome_unknown"
 
 
 def test_unexpected_handler_failure_returns_structured_unknown_outcome(

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import logging
+import sqlite3
 import threading
 
 import pytest
@@ -27,6 +29,21 @@ class _MobileTransport:
         return True
 
 
+@pytest.fixture(autouse=True)
+def _isolated_gateway_mutation_store(tmp_path, monkeypatch):
+    """Keep every dispatch in this module off the user's Hermes home."""
+    from tui_gateway import server
+
+    store = MobileMutationStore(tmp_path / "gateway-mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    try:
+        yield store
+    finally:
+        server._sessions.clear()
+        store.close()
+        assert store._closed is True
+
+
 def _reserve(
     store: MobileMutationStore,
     *,
@@ -41,6 +58,123 @@ def _reserve(
         resource_id="conversation-root",
         semantic_parameters={"text": text},
     )
+
+
+def test_owned_pre_execution_reservation_can_be_released_and_retried(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    first = _reserve(store)
+    duplicate = _reserve(store)
+
+    assert duplicate.disposition is MutationDisposition.IN_PROGRESS
+    assert store.release_before_execution(duplicate) is False
+    assert store.release_before_execution(first) is True
+    assert store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    ) is None
+    assert _reserve(store).disposition is MutationDisposition.EXECUTE
+    store.close()
+
+
+def test_advertised_mutations_share_one_policy_and_resource_authority():
+    from tui_gateway import mobile_contract
+
+    payload = mobile_contract.gateway_ready_payload(skin="default")
+    advertised = set(
+        payload["capabilities"]["mutation.idempotency"]["methods"]
+    )
+    described = {
+        method
+        for method, policy in mobile_contract.MOBILE_METHOD_POLICIES.items()
+        if policy.mutation is not None
+    }
+
+    assert advertised == set(mobile_contract.MOBILE_MUTATION_METHODS)
+    assert advertised == described
+    for method in advertised:
+        policy = mobile_contract.MOBILE_METHOD_POLICIES[method]
+        descriptor = policy.mutation
+        assert descriptor is not None
+        assert descriptor.resource_parameter in policy.allowed_parameters
+        assert set(descriptor.semantic_parameters) <= policy.allowed_parameters
+
+
+def test_transient_lineage_failure_releases_receipt_for_identical_retry(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    outage = {"active": True}
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root", "conversation-tip"]
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        if outage["active"]:
+            raise sqlite3.OperationalError("lineage store unavailable")
+        yield Db()
+
+    class Agent:
+        session_id = "conversation-tip"
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-tip",
+    }
+    request = {
+        "jsonrpc": "2.0",
+        "id": "first-correlation",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "retry-after-lineage-outage",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    unavailable = server.dispatch(request, transport)
+
+    assert unavailable["error"] == {
+        "code": 5037,
+        "message": "mobile mutation preflight is temporarily unavailable",
+        "data": {
+            "client_request_id": "retry-after-lineage-outage",
+            "reason": "mutation_preflight_unavailable",
+        },
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="retry-after-lineage-outage",
+    ) is None
+
+    outage["active"] = False
+    request["id"] = "retry-correlation"
+    retry = server.dispatch(request, transport)
+
+    assert agent.interrupt_calls == 1
+    assert retry["result"]["status"] == "interrupted"
+    assert retry["result"]["mutation"] == {
+        "client_request_id": "retry-after-lineage-outage",
+        "deduplicated": False,
+        "state": "completed",
+    }
 
 
 def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path):
@@ -207,6 +341,272 @@ def test_mobile_mutation_rejects_an_oversized_request_identity():
     assert response["error"]["data"] == {
         "reason": "invalid_client_request_id"
     }
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_reservation_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    def fail_reservation(**_kwargs):
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "reserve",
+        fail_reservation,
+    )
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "store-outage",
+                "method": "session.interrupt",
+                "params": {
+                    "client_request_id": "store-outage-1",
+                    "expected_stored_session_id": "conversation-root",
+                    "session_id": "live-1",
+                },
+            },
+            _MobileTransport("conversation.read", "conversation.control"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_wait_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    original = _isolated_gateway_mutation_store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="wait-outage-1",
+        method="session.interrupt",
+        resource_id="conversation-root",
+        semantic_parameters={},
+    )
+    assert original.disposition is MutationDisposition.EXECUTE
+
+    def fail_wait(_claim, *, timeout):
+        assert timeout == 30.0
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "wait_for_outcome",
+        fail_wait,
+    )
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "wait-outage",
+                "method": "session.interrupt",
+                "params": {
+                    "client_request_id": "wait-outage-1",
+                    "expected_stored_session_id": "conversation-root",
+                    "session_id": "live-1",
+                },
+            },
+            _MobileTransport("conversation.read", "conversation.control"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_status_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    def fail_status(**_kwargs):
+        raise failure
+
+    monkeypatch.setattr(_isolated_gateway_mutation_store, "status", fail_status)
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "status-outage",
+                "method": "mutation.status",
+                "params": {"client_request_id": "status-outage-1"},
+            },
+            _MobileTransport("conversation.read"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_completion_failures_become_structured_unknown_outcomes(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    original_complete = _isolated_gateway_mutation_store.complete
+
+    def fail_completion(_claim, _outcome):
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "complete",
+        fail_completion,
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "completion-outage",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "completion-outage-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(request, transport)
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "mutation outcome could not be recorded durably",
+        "data": {"reason": "mutation_outcome_unknown"},
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="completion-outage-1",
+    )["state"] == "outcome_unknown"
+    assert agent.interrupt_calls == 1
+    assert any(record.exc_info is not None for record in caplog.records)
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "complete",
+        original_complete,
+    )
+    request["id"] = "completion-outage-retry"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert agent.interrupt_calls == 1
+
+
+def test_unexpected_handler_failure_returns_structured_unknown_outcome(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+            raise RuntimeError("interrupt transport failed")
+
+    agent = Agent()
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    request = {
+        "jsonrpc": "2.0",
+        "id": "handler-failure",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "handler-failure-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    with caplog.at_level(logging.ERROR, logger="tui_gateway.server"):
+        response = server.dispatch(request, transport)
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "mutation handler failed before a durable outcome was available",
+        "data": {"reason": "mutation_outcome_unknown"},
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="handler-failure-1",
+    )["state"] == "outcome_unknown"
+    assert agent.interrupt_calls == 1
+    assert any(record.exc_info is not None for record in caplog.records)
+
+    request["id"] = "handler-failure-retry"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert agent.interrupt_calls == 1
 
 
 

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -1,0 +1,650 @@
+"""Durable receipt behavior for consequential mobile JSON-RPC mutations."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+
+import pytest
+
+from tui_gateway.mobile_mutations import (
+    MobileMutationStore,
+    MutationConflict,
+    MutationDisposition,
+)
+
+
+class _MobileTransport:
+    def __init__(self, *scopes: str, subject: str = "mobile-user"):
+        self.authorization = {
+            "audience": "hermes.mobile",
+            "provider": "password",
+            "scopes": scopes,
+            "subject": subject,
+        }
+
+    def write(self, _obj):
+        return True
+
+
+def _reserve(
+    store: MobileMutationStore,
+    *,
+    request_id: str = "request-1",
+    text: str = "hello",
+):
+    return store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id=request_id,
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": text},
+    )
+
+
+def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path):
+    path = tmp_path / "mobile-mutations.sqlite3"
+    first = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = _reserve(first)
+    assert claim.disposition is MutationDisposition.EXECUTE
+    outcome = {
+        "jsonrpc": "2.0",
+        "id": "original-correlation",
+        "result": {"status": "streaming"},
+    }
+    assert first.complete(claim, outcome) is True
+    first.close()
+
+    reopened = MobileMutationStore(path, owner_instance_id="process-b")
+    replay = _reserve(reopened)
+
+    assert replay.disposition is MutationDisposition.REPLAY
+    assert replay.outcome == outcome
+    assert reopened.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )["state"] == "completed"
+
+
+def test_same_request_identity_with_different_semantics_conflicts(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    claim = _reserve(store, text="first")
+    store.complete(claim, {"result": {"status": "streaming"}})
+
+    with pytest.raises(MutationConflict):
+        _reserve(store, text="different")
+
+
+def test_abandoned_in_progress_mutation_becomes_outcome_unknown_after_reopen(
+    tmp_path,
+):
+    path = tmp_path / "mobile-mutations.sqlite3"
+    first = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = _reserve(first)
+    assert claim.disposition is MutationDisposition.EXECUTE
+    first.close()
+
+    reopened = MobileMutationStore(path, owner_instance_id="process-b")
+    uncertain = _reserve(reopened)
+
+    assert uncertain.disposition is MutationDisposition.OUTCOME_UNKNOWN
+    status = reopened.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )
+    assert status["state"] == "outcome_unknown"
+    assert status["outcome"] is None
+
+
+def test_principals_do_not_share_request_identity_namespaces(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    first = _reserve(store)
+    store.complete(first, {"result": {"status": "streaming"}})
+
+    other = store.reserve(
+        provider="password",
+        subject="different-user",
+        client_request_id="request-1",
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": "hello"},
+    )
+
+    assert other.disposition is MutationDisposition.EXECUTE
+
+
+def test_same_process_duplicate_waits_for_one_authoritative_outcome(tmp_path):
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    original = _reserve(store)
+    duplicate = _reserve(store)
+    assert duplicate.disposition is MutationDisposition.IN_PROGRESS
+
+    completed = threading.Event()
+
+    def finish_original():
+        store.complete(original, {"result": {"status": "interrupted"}})
+        completed.set()
+
+    thread = threading.Thread(target=finish_original)
+    thread.start()
+    replay = store.wait_for_outcome(duplicate, timeout=2)
+    thread.join(timeout=2)
+
+    assert completed.is_set()
+    assert replay.disposition is MutationDisposition.REPLAY
+    assert replay.outcome == {"result": {"status": "interrupted"}}
+
+
+def test_status_lookup_does_not_require_a_live_conversation(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    claim = _reserve(store)
+    store.complete(claim, {"result": {"deleted": "conversation-root"}})
+
+    status = store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )
+
+    assert status == {
+        "client_request_id": "request-1",
+        "method": "prompt.submit",
+        "outcome": {"result": {"deleted": "conversation-root"}},
+        "state": "completed",
+    }
+
+
+def test_mobile_interrupt_requires_a_client_request_identity(monkeypatch):
+    from tui_gateway import server
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "missing-id",
+            "method": "session.interrupt",
+            "params": {
+                "session_id": "live-1",
+                "expected_stored_session_id": "conversation-root",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"] == {
+        "code": -32602,
+        "message": "client_request_id is required for mobile mutation",
+        "data": {
+            "method": "session.interrupt",
+            "reason": "client_request_id_required",
+        },
+    }
+
+
+def test_mobile_mutation_rejects_an_oversized_request_identity():
+    from tui_gateway import server
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "invalid-id",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "x" * 257,
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"]["code"] == -32602
+    assert response["error"]["data"] == {
+        "reason": "invalid_client_request_id"
+    }
+
+
+
+def test_mobile_interrupt_retry_executes_once_and_status_survives_session_removal(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    class RunThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    agent = Agent()
+    session = {
+        "_run_thread": RunThread(),
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    server._sessions.clear()
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    params = {
+        "session_id": "live-1",
+        "expected_stored_session_id": "conversation-root",
+        "client_request_id": "interrupt-1",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "first-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "retry-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert agent.interrupt_calls == 1
+    assert first == {
+        "jsonrpc": "2.0",
+        "id": "first-correlation",
+        "result": {
+            "mutation": {
+                "client_request_id": "interrupt-1",
+                "deduplicated": False,
+                "state": "completed",
+            },
+            "status": "interrupted",
+        },
+    }
+    assert retry == {
+        "jsonrpc": "2.0",
+        "id": "retry-correlation",
+        "result": {
+            "mutation": {
+                "client_request_id": "interrupt-1",
+                "deduplicated": True,
+                "state": "completed",
+            },
+            "status": "interrupted",
+        },
+    }
+
+    server._sessions.clear()
+    replay_without_live_session = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "post-removal-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+    assert replay_without_live_session["result"]["status"] == "interrupted"
+    assert (
+        replay_without_live_session["result"]["mutation"]["deduplicated"] is True
+    )
+
+    status = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "status-correlation",
+            "method": "mutation.status",
+            "params": {"client_request_id": "interrupt-1"},
+        },
+        transport,
+    )
+
+    assert status["result"]["client_request_id"] == "interrupt-1"
+    assert status["result"]["method"] == "session.interrupt"
+    assert status["result"]["outcome"] == {
+        "result": {"status": "interrupted"}
+    }
+    assert status["result"]["state"] == "completed"
+
+
+def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkeypatch):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    counts = {"inflight": 0, "turn": 0}
+    monkeypatch.setattr(
+        server,
+        "_start_inflight_turn",
+        lambda *_args: counts.__setitem__("inflight", counts["inflight"] + 1),
+    )
+
+    def run_turn(_rid, _sid, session, _text):
+        counts["turn"] += 1
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["live-1"] = session
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    params = {
+        "client_request_id": "prompt-1",
+        "expected_stored_session_id": "conversation-root",
+        "session_id": "live-1",
+        "text": "run exactly once",
+    }
+
+    original_complete = store.complete
+    first_at_completion = threading.Event()
+    release_completion = threading.Event()
+
+    def blocking_complete(claim, outcome):
+        first_at_completion.set()
+        assert release_completion.wait(timeout=2)
+        return original_complete(claim, outcome)
+
+    monkeypatch.setattr(store, "complete", blocking_complete)
+    responses = {}
+
+    def dispatch(name, correlation):
+        responses[name] = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": correlation,
+                "method": "prompt.submit",
+                "params": params,
+            },
+            transport,
+        )
+
+    first = threading.Thread(target=dispatch, args=("first", "correlation-1"))
+    duplicate = threading.Thread(
+        target=dispatch,
+        args=("duplicate", "correlation-2"),
+    )
+    first.start()
+    assert first_at_completion.wait(timeout=2)
+    duplicate.start()
+    release_completion.set()
+    first.join(timeout=2)
+    duplicate.join(timeout=2)
+
+    assert counts == {"inflight": 1, "turn": 1}
+    assert responses["first"]["result"]["mutation"]["deduplicated"] is False
+    assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is True
+    assert responses["first"]["result"]["status"] == "streaming"
+    assert responses["duplicate"]["result"]["status"] == "streaming"
+
+
+def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_state import SessionDB
+    from tui_gateway import server
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("conversation-delete", source="tui")
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    server._sessions.clear()
+    calls = 0
+    original_delete = db.delete_session
+
+    def counted_delete(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_delete(*args, **kwargs)
+
+    monkeypatch.setattr(db, "delete_session", counted_delete)
+    transport = _MobileTransport("conversation.read", "conversation.delete")
+    params = {
+        "client_request_id": "delete-1",
+        "session_id": "conversation-delete",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "delete-correlation-1",
+            "method": "session.delete",
+            "params": params,
+        },
+        transport,
+    )
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "delete-correlation-2",
+            "method": "session.delete",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert calls == 1
+    assert db.get_session("conversation-delete") is None
+    assert first["result"]["deleted"] == "conversation-delete"
+    assert first["result"]["mutation"]["deduplicated"] is False
+    assert retry["result"]["deleted"] == "conversation-delete"
+    assert retry["result"]["mutation"]["deduplicated"] is True
+    db.close()
+
+
+def test_mobile_prompt_retry_uses_durable_identity_after_live_id_rotation(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def resolve_resume_session_id(session_id):
+            return "conversation-tip" if session_id == "conversation-root" else session_id
+
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root", "conversation-tip"]
+
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    turns = 0
+    turn_done = threading.Event()
+
+    def run_turn(_rid, _sid, session, _text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+
+    def live_session(stored_id):
+        return {
+            "agent": type("Agent", (), {"session_id": stored_id})(),
+            "history": [],
+            "history_lock": threading.Lock(),
+            "profile_home": str(tmp_path),
+            "queued_prompt": None,
+            "running": False,
+            "session_key": stored_id,
+            "transport": None,
+        }
+
+    server._sessions.clear()
+    server._sessions["live-before"] = live_session("conversation-root")
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    base_params = {
+        "client_request_id": "prompt-rotation-1",
+        "expected_stored_session_id": "conversation-root",
+        "text": "continue exactly once",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "before-rotation",
+            "method": "prompt.submit",
+            "params": {**base_params, "session_id": "live-before"},
+        },
+        transport,
+    )
+    assert turn_done.wait(timeout=2)
+    server._sessions.clear()
+    server._sessions["live-after"] = live_session("conversation-tip")
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "after-rotation",
+            "method": "prompt.submit",
+            "params": {**base_params, "session_id": "live-after"},
+        },
+        transport,
+    )
+
+    assert turns == 1
+    assert first["result"]["mutation"]["deduplicated"] is False
+    assert retry["result"]["mutation"]["deduplicated"] is True
+
+
+def test_mobile_abandoned_interrupt_is_outcome_unknown_and_never_reexecuted(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    path = tmp_path / "mobile-mutations.sqlite3"
+    before_restart = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = before_restart.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="interrupt-unknown",
+        method="session.interrupt",
+        resource_id="conversation-root",
+        semantic_parameters={},
+    )
+    assert claim.disposition is MutationDisposition.EXECUTE
+    before_restart.close()
+    after_restart = MobileMutationStore(path, owner_instance_id="process-b")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: after_restart)
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    server._sessions.clear()
+    server._sessions["live-unknown"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "unknown-correlation",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "interrupt-unknown",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-unknown",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert agent.interrupt_calls == 0
+    assert response["error"] == {
+        "code": 4091,
+        "message": "the prior mutation outcome is unknown and will not be re-executed",
+        "data": {
+            "client_request_id": "interrupt-unknown",
+            "reason": "mutation_outcome_unknown",
+            "state": "outcome_unknown",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import sqlite3
 import threading
+import time
 
 import pytest
 
@@ -1051,16 +1052,43 @@ def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkey
     monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
     monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
     counts = {"inflight": 0, "turn": 0}
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    inner_workers = []
     monkeypatch.setattr(
         server,
         "_start_inflight_turn",
         lambda *_args: counts.__setitem__("inflight", counts["inflight"] + 1),
     )
 
-    def run_turn(_rid, _sid, session, _text):
+    def run_turn(_rid, _sid, session, text):
         counts["turn"] += 1
-        with session["history_lock"]:
-            session["running"] = False
+
+        def persist_turn():
+            worker_started.set()
+            assert release_worker.wait(timeout=2)
+            with session["history_lock"]:
+                receipt_tags = list(
+                    session.get("_pending_mobile_mutation_receipt_tags") or ()
+                )
+                assert len(receipt_tags) == 1
+                session["history"].append(
+                    {
+                        "role": "user",
+                        "content": text,
+                        "_db_persisted": True,
+                        "_mobile_mutation_receipt_tags": receipt_tags,
+                    }
+                )
+                session["running"] = False
+
+        # Match the production topology: prompt.submit first runs an agent-ready
+        # wrapper, then _run_prompt_submit replaces its handle with the real turn
+        # worker. Receipt monitoring must follow that live handle replacement.
+        worker = threading.Thread(target=persist_turn)
+        inner_workers.append(worker)
+        session["_run_thread"] = worker
+        worker.start()
 
     monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
     session = {
@@ -1116,17 +1144,846 @@ def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkey
         args=("duplicate", "correlation-2"),
     )
     first.start()
+    assert worker_started.wait(timeout=2)
+    first.join(timeout=2)
+    assert not first.is_alive()
+    assert store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="prompt-1",
+    )["state"] == "in_progress"
+
+    release_worker.set()
     assert first_at_completion.wait(timeout=2)
     duplicate.start()
     release_completion.set()
-    first.join(timeout=2)
     duplicate.join(timeout=2)
+    inner_workers[0].join(timeout=2)
 
     assert counts == {"inflight": 1, "turn": 1}
     assert responses["first"]["result"]["mutation"]["deduplicated"] is False
+    assert responses["first"]["result"]["mutation"]["state"] == "in_progress"
     assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is True
+    assert responses["duplicate"]["result"]["mutation"]["state"] == "completed"
     assert responses["first"]["result"]["status"] == "streaming"
     assert responses["duplicate"]["result"]["status"] == "streaming"
+
+
+def test_mobile_prompt_proof_tag_is_scoped_to_authenticated_principal(tmp_path):
+    from tui_gateway import server
+
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    shared = {
+        "client_request_id": "same-request-id",
+        "method": "prompt.submit",
+        "resource_id": "conversation-root",
+        "semantic_parameters": {"text": "same text"},
+    }
+    alice = store.reserve(provider="password", subject="alice", **shared)
+    bob = store.reserve(provider="password", subject="bob", **shared)
+    session = {
+        "agent": object(),
+        "history": [
+            {
+                "role": "user",
+                "content": "same text",
+                "_db_persisted": True,
+                "_mobile_mutation_receipt_tags": [alice.proof_tag],
+            }
+        ],
+        "history_lock": threading.Lock(),
+    }
+
+    assert alice.proof_tag != bob.proof_tag
+    assert server._mobile_prompt_turn_is_durable(
+        ("live-1", session, alice.proof_tag)
+    )
+    assert not server._mobile_prompt_turn_is_durable(
+        ("live-1", session, bob.proof_tag)
+    )
+    store.close()
+
+
+def test_mobile_prompt_durable_proof_survives_user_sequence_repair():
+    from run_agent import AIAgent
+    from tui_gateway import server
+
+    proof_tag = "principal-scoped-proof"
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "mobile send",
+            "_db_persisted": True,
+            "_mobile_mutation_receipt_tags": [proof_tag],
+        },
+    ]
+    session = {
+        "agent": object(),
+        "history": messages,
+        "history_lock": threading.Lock(),
+    }
+    context = ("live-1", session, proof_tag)
+
+    assert server._mobile_prompt_turn_is_durable(context)
+    AIAgent._repair_message_sequence(AIAgent.__new__(AIAgent), messages)
+    assert len(messages) == 1
+    assert server._mobile_prompt_turn_is_durable(context)
+
+
+def test_mobile_prompt_receipt_rechecks_proof_after_worker_exit_race(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    claim = _isolated_gateway_mutation_store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="persist-at-exit-1",
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": "persist at exit"},
+    )
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+    }
+    context = ("live-1", session, claim.proof_tag)
+
+    def persist_while_observing_worker_exit(_context):
+        with session["history_lock"]:
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": "persist at exit",
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": [claim.proof_tag],
+                }
+            )
+            session["running"] = False
+        return False
+
+    monkeypatch.setattr(
+        server,
+        "_mobile_prompt_turn_is_pending",
+        persist_while_observing_worker_exit,
+    )
+    assert server._defer_mobile_prompt_receipt(
+        store=_isolated_gateway_mutation_store,
+        claim=claim,
+        outcome={"result": {"status": "streaming"}},
+        context=context,
+    )
+
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="persist-at-exit-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "completed"
+
+
+def test_mobile_prompt_receipts_share_one_constant_time_session_monitor(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    claims = [
+        _isolated_gateway_mutation_store.reserve(
+            provider="password",
+            subject="mobile-user",
+            client_request_id=f"shared-monitor-{index}",
+            method="prompt.submit",
+            resource_id="conversation-root",
+            semantic_parameters={"text": f"prompt {index}"},
+        )
+        for index in (1, 2)
+    ]
+
+    class WorkThread:
+        alive = True
+
+        def is_alive(self):
+            return self.alive
+
+    work_thread = WorkThread()
+    proof_tags = [claim.proof_tag for claim in claims]
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "_pending_mobile_mutation_receipt_tags": proof_tags,
+        "_live_mobile_mutation_receipt_tags": set(proof_tags),
+        "_run_thread": work_thread,
+    }
+    contexts = [("live-1", session, tag) for tag in proof_tags]
+    original_durable_check = server._mobile_prompt_turn_is_durable
+    hot_path_scans = 0
+
+    def count_hot_path_scan(context):
+        nonlocal hot_path_scans
+        hot_path_scans += 1
+        return original_durable_check(context)
+
+    monkeypatch.setattr(
+        server,
+        "_mobile_prompt_turn_is_durable",
+        count_hot_path_scan,
+    )
+    for claim, context in zip(claims, contexts):
+        assert server._defer_mobile_prompt_receipt(
+            store=_isolated_gateway_mutation_store,
+            claim=claim,
+            outcome={"result": {"status": "queued"}},
+            context=context,
+        )
+
+    monitor = session["_mobile_prompt_receipt_monitor_thread"]
+    time.sleep(0.3)
+    assert session["_mobile_prompt_receipt_monitor_thread"] is monitor
+    assert len(session["_mobile_prompt_receipt_entries"]) == 2
+    assert hot_path_scans == 0
+
+    with session["history_lock"]:
+        work_thread.alive = False
+        session["running"] = False
+        session.pop("_pending_mobile_mutation_receipt_tags", None)
+    server._notify_mobile_prompt_receipt_change(session)
+
+    deadline = time.monotonic() + 1
+    statuses = []
+    while time.monotonic() < deadline:
+        statuses = [
+            _isolated_gateway_mutation_store.status(
+                provider="password",
+                subject="mobile-user",
+                client_request_id=f"shared-monitor-{index}",
+            )
+            for index in (1, 2)
+        ]
+        if all(status and status["state"] == "outcome_unknown" for status in statuses):
+            break
+        time.sleep(0.01)
+    assert all(
+        status is not None and status["state"] == "outcome_unknown"
+        for status in statuses
+    )
+    assert hot_path_scans == 2
+
+
+def test_mobile_prompt_receipt_follows_real_turn_context_and_session_db(
+    _isolated_gateway_mutation_store,
+    tmp_path,
+    monkeypatch,
+):
+    from agent.turn_context import build_turn_context
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+    from tui_gateway import server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        session_db=db,
+        session_id="conversation-root",
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cached_system_prompt = "SYSTEM"
+    agent.compression_enabled = False
+    agent._skip_mcp_refresh = True
+    turn_done = threading.Event()
+    turns = 0
+
+    class RuntimeAdapter:
+        @staticmethod
+        def _set_interrupt(_value, _thread_id):
+            return None
+
+    def run_turn(_rid, _sid, session, text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            receipt_tags = list(
+                session.pop("_pending_mobile_mutation_receipt_tags", ()) or ()
+            )
+            session["_active_mobile_mutation_receipt_tags"] = receipt_tags
+            history = list(session["history"])
+        agent._pending_mobile_mutation_receipt_tags = receipt_tags
+        context = build_turn_context(
+            agent=agent,
+            user_message=text,
+            system_message=None,
+            conversation_history=history,
+            task_id=None,
+            stream_callback=None,
+            persist_user_message=None,
+            restore_or_build_system_prompt=lambda *_args, **_kwargs: None,
+            install_safe_stdio=lambda: None,
+            sanitize_surrogates=lambda value: value,
+            summarize_user_message_for_log=lambda value: value,
+            set_session_context=lambda _session_id: None,
+            set_current_write_origin=lambda _origin: None,
+            ra=lambda: RuntimeAdapter,
+        )
+        agent._session_messages = context.messages
+        with session["history_lock"]:
+            session["history"] = context.messages
+            session.pop("_active_mobile_mutation_receipt_tags", None)
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    session = {
+        "agent": agent,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.write")
+    request = {
+        "jsonrpc": "2.0",
+        "id": "real-path-first",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "real-path-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "persist through the real path",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    assert turn_done.wait(timeout=2)
+    deadline = time.monotonic() + 2
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="real-path-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+
+    assert status is not None and status["state"] == "completed"
+    rows = db.get_messages("conversation-root")
+    assert [(row["role"], row["content"]) for row in rows] == [
+        ("user", "persist through the real path")
+    ]
+    assert session["history"][-1]["_db_persisted"] is True
+    assert session["history"][-1]["_mobile_mutation_receipt_tags"]
+
+    request["id"] = "real-path-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["result"]["mutation"]["deduplicated"] is True
+    assert turns == 1
+    db.close()
+
+
+def test_mobile_prompt_receipt_completes_only_after_durable_turn(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    class Agent:
+        @staticmethod
+        def steer(_text):
+            raise AssertionError("durable mobile prompts must queue, not steer")
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "steer")
+    entered = threading.Event()
+    release = threading.Event()
+    delivered = 0
+    session = {
+        "agent": Agent(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+
+    def finish_active_turn():
+        nonlocal delivered
+        entered.set()
+        assert release.wait(timeout=2)
+        with session["history_lock"]:
+            queued = session["queued_prompt"]
+            assert queued is not None
+            delivered += 1
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": queued["text"],
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": list(
+                        queued["mobile_mutation_receipt_tags"]
+                    ),
+                }
+            )
+            session["queued_prompt"] = None
+            session["running"] = False
+
+    active_turn = threading.Thread(target=finish_active_turn)
+    session["_run_thread"] = active_turn
+    server._sessions["live-1"] = session
+    active_turn.start()
+    assert entered.wait(timeout=1)
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "prompt-first",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "prompt-durable-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "persist this once",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["status"] == "queued"
+    assert first["result"]["mutation"] == {
+        "client_request_id": "prompt-durable-1",
+        "deduplicated": False,
+        "state": "in_progress",
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="prompt-durable-1",
+    )["state"] == "in_progress"
+
+    release.set()
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="prompt-durable-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "completed"
+
+    request["id"] = "prompt-retry"
+    retry = server.dispatch(request, transport)
+    assert delivered == 1
+    assert retry["result"]["status"] == "queued"
+    assert retry["result"]["mutation"]["deduplicated"] is True
+
+
+def test_interrupting_queued_mobile_prompt_terminalizes_its_receipt(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    class Agent:
+        interrupted = 0
+
+        def interrupt(self):
+            self.interrupted += 1
+
+    class LiveThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "transport": None,
+        "_run_thread": LiveThread(),
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    prompt = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "queued-prompt",
+            "method": "prompt.submit",
+            "params": {
+                "client_request_id": "queued-prompt-1",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+                "text": "cancel before delivery",
+            },
+        },
+        transport,
+    )
+    assert prompt["result"]["status"] == "queued"
+    assert prompt["result"]["mutation"]["state"] == "in_progress"
+    assert session["queued_prompt"] is not None
+
+    interrupted = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "interrupt-queued-prompt",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "interrupt-queued-prompt-1",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        transport,
+    )
+    assert interrupted["result"]["status"] == "interrupted"
+    assert interrupted["result"]["mutation"]["state"] == "completed"
+    assert agent.interrupted == 1
+    assert session["queued_prompt"] is None
+
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="queued-prompt-1",
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "outcome_unknown"
+    assert "_live_mobile_mutation_receipt_tags" not in session
+
+
+def test_mobile_prompt_without_durable_history_becomes_outcome_unknown(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    turn_done = threading.Event()
+    turns = 0
+
+    def run_turn(_rid, _sid, session, _text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": "banana",
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": ["different-proof"],
+                }
+            )
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    server._sessions["live-1"] = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "prompt-undurable",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "prompt-undurable-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "a",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert turn_done.wait(timeout=1)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="prompt-undurable-1",
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "outcome_unknown"
+
+    request["id"] = "prompt-undurable-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["error"]["code"] == 4091
+    assert turns == 1
+
+
+@pytest.mark.parametrize(
+    "exit_mode",
+    ["agent_init_failure", "pre_worker_cancel", "worker_setup_failure"],
+)
+def test_mobile_prompt_pre_worker_exit_terminalizes_receipt(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    exit_mode,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    def wait_agent(session, *_args):
+        if exit_mode == "pre_worker_cancel":
+            session["_turn_cancel_requested"] = True
+            return None
+        if exit_mode == "agent_init_failure":
+            return {"error": {"message": "agent initialization failed"}}
+        return None
+
+    monkeypatch.setattr(server, "_wait_agent", wait_agent)
+    if exit_mode == "worker_setup_failure":
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("transport closed before worker start")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            server,
+            "_run_prompt_submit",
+            lambda *_args: pytest.fail("turn worker must not start"),
+        )
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.write")
+    client_request_id = f"prompt-{exit_mode}-1"
+    request = {
+        "jsonrpc": "2.0",
+        "id": f"prompt-{exit_mode}",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": client_request_id,
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "never started",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id=client_request_id,
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+
+    assert status is not None and status["state"] == "outcome_unknown"
+    assert "_pending_mobile_mutation_receipt_tags" not in session
+    request["id"] = f"prompt-{exit_mode}-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["error"]["code"] == 4091
+
+
+def test_blocked_context_clears_unconsumed_mobile_receipt_tag(
+    tmp_path,
+    monkeypatch,
+):
+    from agent import context_references, model_metadata
+    from tui_gateway import server
+
+    class Agent:
+        api_key = "test-key"
+        api_mode = "openai_chat"
+        base_url = ""
+        model = "test/model"
+        provider = "test"
+        _config_context_length = None
+        _pending_mobile_mutation_receipt_tags = []
+
+        @staticmethod
+        def run_conversation(*_args, **_kwargs):
+            raise AssertionError("blocked context must not reach the agent")
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        @staticmethod
+        def is_alive():
+            return False
+
+    monkeypatch.setattr(server.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(
+        server,
+        "_sync_agent_model_with_config",
+        lambda _sid, _session: None,
+    )
+    monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(
+        model_metadata,
+        "get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    monkeypatch.setattr(
+        context_references,
+        "preprocess_context_references",
+        lambda *_args, **_kwargs: type(
+            "BlockedContext",
+            (),
+            {
+                "blocked": True,
+                "message": "",
+                "warnings": ["Context injection refused."],
+            },
+        )(),
+    )
+    agent = Agent()
+    proof_tag = "principal-scoped-proof"
+    session = {
+        "agent": agent,
+        "attached_images": [],
+        "cols": 80,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "_pending_mobile_mutation_receipt_tags": [proof_tag],
+    }
+
+    server._run_prompt_submit("rid", "live-1", session, "@blocked")
+
+    assert session["running"] is False
+    assert "_pending_mobile_mutation_receipt_tags" not in session
+    assert "_active_mobile_mutation_receipt_tags" not in session
+    assert agent._pending_mobile_mutation_receipt_tags == []
+    assert not server._mobile_prompt_turn_is_pending(
+        ("live-1", session, proof_tag)
+    )
 
 
 def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
@@ -1215,10 +2072,22 @@ def test_mobile_prompt_retry_uses_durable_identity_after_live_id_rotation(
     turns = 0
     turn_done = threading.Event()
 
-    def run_turn(_rid, _sid, session, _text):
+    def run_turn(_rid, _sid, session, text):
         nonlocal turns
         turns += 1
         with session["history_lock"]:
+            receipt_tags = list(
+                session.get("_pending_mobile_mutation_receipt_tags") or ()
+            )
+            assert len(receipt_tags) == 1
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": text,
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": receipt_tags,
+                }
+            )
             session["running"] = False
         turn_done.set()
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -58,12 +58,23 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
+
+@dataclass(frozen=True)
+class MobileMutationDescriptor:
+    """Durable identity and pre-execution checks for an idempotent mutation."""
+
+    resource_parameter: str
+    semantic_parameters: tuple[str, ...] = ()
+    requires_live_lineage_validation: bool = False
+
+
 @dataclass(frozen=True)
 class MobileMethodPolicy:
-    """Scopes and parameters that make one existing gateway method mobile-safe."""
+    """Authorization and mutation policy for one mobile-safe gateway method."""
 
     required_scopes: tuple[str, ...]
     allowed_parameters: frozenset[str]
+    mutation: MobileMutationDescriptor | None = None
 
 
 MOBILE_METHOD_POLICIES = {
@@ -106,6 +117,11 @@ MOBILE_METHOD_POLICIES = {
                 "text",
             }
         ),
+        mutation=MobileMutationDescriptor(
+            resource_parameter="expected_stored_session_id",
+            semantic_parameters=("text",),
+            requires_live_lineage_validation=True,
+        ),
     ),
     "session.interrupt": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
@@ -116,16 +132,28 @@ MOBILE_METHOD_POLICIES = {
                 "session_id",
             }
         ),
+        mutation=MobileMutationDescriptor(
+            resource_parameter="expected_stored_session_id",
+            requires_live_lineage_validation=True,
+        ),
     ),
     "session.delete": MobileMethodPolicy(
         (CONVERSATION_DELETE_SCOPE,),
         frozenset({"client_request_id", "session_id"}),
+        mutation=MobileMutationDescriptor(resource_parameter="session_id"),
     ),
     "mutation.status": MobileMethodPolicy(
         (CONVERSATION_READ_SCOPE,),
         frozenset({"client_request_id"}),
     ),
 }
+
+MOBILE_MUTATION_POLICIES = {
+    method: policy.mutation
+    for method, policy in MOBILE_METHOD_POLICIES.items()
+    if policy.mutation is not None
+}
+MOBILE_MUTATION_METHODS = frozenset(MOBILE_MUTATION_POLICIES)
 
 
 def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
@@ -179,11 +207,7 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
             "auth.ws_scopes": {"version": 1},
             "mutation.idempotency": {
                 "version": 1,
-                "methods": [
-                    "prompt.submit",
-                    "session.interrupt",
-                    "session.delete",
-                ],
+                "methods": list(MOBILE_MUTATION_POLICIES),
                 "status_method": "mutation.status",
             },
         },

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -27,20 +27,21 @@ SERVER_RELEASE_DATE = __release_date__
 # durable deployment identity remains outside this first contract slice.
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
-# Advertise only schemas this slice actually defines.  Conversation snapshots,
-# replay, mutation idempotency, and recoverable approvals land in later slices
-# and must not be inferred from Mobile Client Contract v1 alone.
+# Advertise only schemas implemented at this stacked branch. Conversation
+# snapshots/replay and recoverable approvals remain separate capabilities and
+# must not be inferred from Mobile Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
     "authorization.error": 1,
+    "mutation.receipt": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
 CONVERSATION_WRITE_SCOPE = "conversation.write"
-# This scope is an authorization boundary only.  It does not claim durable
-# mutation idempotency; clients must wait for that separately advertised
-# capability before treating retries as safe.
+# This scope is an authorization boundary only. Clients must still intersect it
+# with the separately advertised mutation capability before treating retries as
+# safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
 CONVERSATION_DELETE_SCOPE = "conversation.delete"
 # Error-only marker for a method or parameter that has no grantable mobile
@@ -53,6 +54,7 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
         CONVERSATION_READ_SCOPE,
         CONVERSATION_WRITE_SCOPE,
         CONVERSATION_CONTROL_SCOPE,
+        CONVERSATION_DELETE_SCOPE,
     }
 )
 
@@ -96,11 +98,32 @@ MOBILE_METHOD_POLICIES = {
     ),
     "prompt.submit": MobileMethodPolicy(
         (CONVERSATION_WRITE_SCOPE,),
-        frozenset({"session_id", "text"}),
+        frozenset(
+            {
+                "client_request_id",
+                "expected_stored_session_id",
+                "session_id",
+                "text",
+            }
+        ),
     ),
     "session.interrupt": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
-        frozenset({"session_id"}),
+        frozenset(
+            {
+                "client_request_id",
+                "expected_stored_session_id",
+                "session_id",
+            }
+        ),
+    ),
+    "session.delete": MobileMethodPolicy(
+        (CONVERSATION_DELETE_SCOPE,),
+        frozenset({"client_request_id", "session_id"}),
+    ),
+    "mutation.status": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"client_request_id"}),
     ),
 }
 
@@ -152,7 +175,18 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
             "major": MOBILE_CONTRACT_MAJOR,
         },
         "schemas": dict(CLIENT_SCHEMA_MAJORS),
-        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "capabilities": {
+            "auth.ws_scopes": {"version": 1},
+            "mutation.idempotency": {
+                "version": 1,
+                "methods": [
+                    "prompt.submit",
+                    "session.interrupt",
+                    "session.delete",
+                ],
+                "status_method": "mutation.status",
+            },
+        },
         "authorization": effective_authorization(authorization),
     }
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
 
@@ -41,6 +42,11 @@ CONVERSATION_WRITE_SCOPE = "conversation.write"
 # mutation idempotency; clients must wait for that separately advertised
 # capability before treating retries as safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
+CONVERSATION_DELETE_SCOPE = "conversation.delete"
+# Error-only marker for a method or parameter that has no grantable mobile
+# scope in this contract version.  It is deliberately absent from
+# SUPPORTED_MOBILE_SCOPES; clients must also inspect ``grantable``.
+MOBILE_UNAVAILABLE_SCOPE = "mobile.unavailable"
 
 SUPPORTED_MOBILE_SCOPES = frozenset(
     {
@@ -50,18 +56,52 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
-MOBILE_METHOD_SCOPES = {
-    "session.list": CONVERSATION_READ_SCOPE,
-    "prompt.submit": CONVERSATION_WRITE_SCOPE,
-    "session.active_list": CONVERSATION_READ_SCOPE,
-    "session.activate": CONVERSATION_READ_SCOPE,
-    "session.history": CONVERSATION_READ_SCOPE,
-    "session.status": CONVERSATION_READ_SCOPE,
-    "session.usage": CONVERSATION_READ_SCOPE,
-    "session.create": CONVERSATION_WRITE_SCOPE,
-    "session.resume": CONVERSATION_WRITE_SCOPE,
-    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
-    "session.steer": CONVERSATION_CONTROL_SCOPE,
+@dataclass(frozen=True)
+class MobileMethodPolicy:
+    """Scopes and parameters that make one existing gateway method mobile-safe."""
+
+    required_scopes: tuple[str, ...]
+    allowed_parameters: frozenset[str]
+
+
+MOBILE_METHOD_POLICIES = {
+    "session.list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset(),
+    ),
+    "session.active_list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"current_session_id"}),
+    ),
+    # Activating or resuming rebinds the live transport, so read access alone
+    # is intentionally insufficient even though both responses contain history.
+    "session.activate": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    "session.history": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    # Creating a live session starts Hermes-owned workers and hooks.  It is both
+    # a conversation write and a runtime-control action, with server-derived
+    # profile/source/model/cwd rather than client-selected privileged knobs.
+    "session.create": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE, CONVERSATION_CONTROL_SCOPE),
+        frozenset({"cols", "title"}),
+    ),
+    "session.resume": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"cols", "session_id"}),
+    ),
+    "prompt.submit": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE,),
+        frozenset({"session_id", "text"}),
+    ),
+    "session.interrupt": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
 }
 
 
@@ -76,6 +116,10 @@ def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
             granted.append(scope)
     if not granted:
         raise ValueError("at least one mobile scope is required")
+    if CONVERSATION_READ_SCOPE not in granted:
+        raise ValueError(
+            "conversation.read is required for every mobile WebSocket grant"
+        )
     return tuple(granted)
 
 
@@ -113,25 +157,85 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
     }
 
 
-def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+def authorization_allows_scope(authorization: dict | None, scope: str) -> bool:
+    """Return whether a connection may perform a scope-gated side effect."""
+    grant = effective_authorization(authorization)
+    return grant["audience"] != MOBILE_AUDIENCE or scope in grant["scopes"]
+
+
+def _denial(
+    *,
+    reason: str,
+    method: str,
+    grant: dict,
+    required_scopes: tuple[str, ...],
+    grantable: bool,
+    parameter: str | None = None,
+) -> dict:
+    missing = (
+        list(required_scopes)
+        if not grantable
+        else [scope for scope in required_scopes if scope not in grant["scopes"]]
+    )
+    data = {
+        "reason": reason,
+        "method": method,
+        "required_scope": missing[0] if missing else required_scopes[0],
+        "required_scopes": list(required_scopes),
+        "missing_scopes": missing,
+        "granted_scopes": grant["scopes"],
+        "grantable": grantable,
+    }
+    if parameter is not None:
+        data["parameter"] = parameter
+    return data
+
+
+def mobile_method_denial(
+    method: str,
+    authorization: dict | None,
+    params: dict | None = None,
+) -> dict | None:
     """Describe why a mobile grant cannot call *method*, or return ``None``."""
     grant = effective_authorization(authorization)
     if grant["audience"] != MOBILE_AUDIENCE:
         return None
 
-    required_scope = MOBILE_METHOD_SCOPES.get(method)
-    if required_scope is None:
-        return {
-            "reason": "method_not_available_to_mobile",
-            "method": method,
-            "required_scope": None,
-            "granted_scopes": grant["scopes"],
-        }
-    if required_scope not in grant["scopes"]:
-        return {
-            "reason": "missing_scope",
-            "method": method,
-            "required_scope": required_scope,
-            "granted_scopes": grant["scopes"],
-        }
+    policy = MOBILE_METHOD_POLICIES.get(method)
+    if policy is None:
+        return _denial(
+            reason="method_not_available_to_mobile",
+            method=method,
+            grant=grant,
+            required_scopes=(MOBILE_UNAVAILABLE_SCOPE,),
+            grantable=False,
+        )
+
+    params = params or {}
+    unsupported_parameters = sorted(set(params) - policy.allowed_parameters)
+    if unsupported_parameters:
+        parameter = unsupported_parameters[0]
+        required_scope = (
+            CONVERSATION_DELETE_SCOPE
+            if method == "prompt.submit"
+            and parameter == "truncate_before_user_ordinal"
+            else MOBILE_UNAVAILABLE_SCOPE
+        )
+        return _denial(
+            reason="parameter_not_available_to_mobile",
+            method=method,
+            parameter=parameter,
+            grant=grant,
+            required_scopes=(required_scope,),
+            grantable=False,
+        )
+
+    if any(scope not in grant["scopes"] for scope in policy.required_scopes):
+        return _denial(
+            reason="missing_scope",
+            method=method,
+            grant=grant,
+            required_scopes=policy.required_scopes,
+            grantable=True,
+        )
     return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -1,0 +1,137 @@
+"""Versioned authorization contract for native/mobile gateway clients.
+
+This module is deliberately transport-only: it defines what a scoped client
+may ask the existing TUI JSON-RPC gateway to do. It does not introduce a new
+runtime or duplicate any Hermes-owned session state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from hermes_cli import __release_date__, __version__
+
+MOBILE_AUDIENCE = "hermes.mobile"
+LEGACY_AUDIENCE = "dashboard"
+PROTOCOL_NAME = "hermes.tui.jsonrpc"
+PROTOCOL_MAJOR = 1
+MOBILE_CONTRACT_NAME = "hermes.mobile"
+MOBILE_CONTRACT_MAJOR = 1
+
+SERVER_VERSION = __version__
+SERVER_RELEASE_DATE = __release_date__
+# A new server process is a new event-stream authority.  This identity is
+# intentionally stable across connections but changes after process restart;
+# durable deployment identity remains outside this first contract slice.
+SERVER_INSTANCE_ID = str(uuid.uuid4())
+
+# Advertise only schemas this slice actually defines.  Conversation snapshots,
+# replay, mutation idempotency, and recoverable approvals land in later slices
+# and must not be inferred from Mobile Client Contract v1 alone.
+CLIENT_SCHEMA_MAJORS = {
+    "gateway.ready": 1,
+    "authorization.grant": 1,
+    "authorization.error": 1,
+}
+
+CONVERSATION_READ_SCOPE = "conversation.read"
+CONVERSATION_WRITE_SCOPE = "conversation.write"
+# This scope is an authorization boundary only.  It does not claim durable
+# mutation idempotency; clients must wait for that separately advertised
+# capability before treating retries as safe.
+CONVERSATION_CONTROL_SCOPE = "conversation.control"
+
+SUPPORTED_MOBILE_SCOPES = frozenset(
+    {
+        CONVERSATION_READ_SCOPE,
+        CONVERSATION_WRITE_SCOPE,
+        CONVERSATION_CONTROL_SCOPE,
+    }
+)
+
+MOBILE_METHOD_SCOPES = {
+    "session.list": CONVERSATION_READ_SCOPE,
+    "prompt.submit": CONVERSATION_WRITE_SCOPE,
+    "session.active_list": CONVERSATION_READ_SCOPE,
+    "session.activate": CONVERSATION_READ_SCOPE,
+    "session.history": CONVERSATION_READ_SCOPE,
+    "session.status": CONVERSATION_READ_SCOPE,
+    "session.usage": CONVERSATION_READ_SCOPE,
+    "session.create": CONVERSATION_WRITE_SCOPE,
+    "session.resume": CONVERSATION_WRITE_SCOPE,
+    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
+    "session.steer": CONVERSATION_CONTROL_SCOPE,
+}
+
+
+def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested mobile authorization grant."""
+    granted: list[str] = []
+    for raw in scopes:
+        scope = str(raw or "").strip()
+        if not scope or scope not in SUPPORTED_MOBILE_SCOPES:
+            raise ValueError(f"unsupported mobile scope: {scope or '<empty>'}")
+        if scope not in granted:
+            granted.append(scope)
+    if not granted:
+        raise ValueError("at least one mobile scope is required")
+    return tuple(granted)
+
+
+def effective_authorization(raw: dict | None = None) -> dict:
+    """Return the stable, JSON-safe authorization grant exposed to a client."""
+    raw = raw or {}
+    scopes = raw.get("scopes", ("*",))
+    if not isinstance(scopes, (list, tuple)):
+        scopes = (str(scopes),)
+    return {
+        "subject": str(raw.get("subject") or raw.get("user_id") or "legacy"),
+        "provider": str(raw.get("provider") or "legacy"),
+        "audience": str(raw.get("audience") or LEGACY_AUDIENCE),
+        "scopes": [str(scope) for scope in scopes],
+    }
+
+
+def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> dict:
+    """Build the additive first-frame contract for every WebSocket client."""
+    return {
+        "skin": skin,
+        "server": {
+            "version": SERVER_VERSION,
+            "release_date": SERVER_RELEASE_DATE,
+            "instance_id": SERVER_INSTANCE_ID,
+        },
+        "protocol": {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR},
+        "contract": {
+            "name": MOBILE_CONTRACT_NAME,
+            "major": MOBILE_CONTRACT_MAJOR,
+        },
+        "schemas": dict(CLIENT_SCHEMA_MAJORS),
+        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "authorization": effective_authorization(authorization),
+    }
+
+
+def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+    """Describe why a mobile grant cannot call *method*, or return ``None``."""
+    grant = effective_authorization(authorization)
+    if grant["audience"] != MOBILE_AUDIENCE:
+        return None
+
+    required_scope = MOBILE_METHOD_SCOPES.get(method)
+    if required_scope is None:
+        return {
+            "reason": "method_not_available_to_mobile",
+            "method": method,
+            "required_scope": None,
+            "granted_scopes": grant["scopes"],
+        }
+    if required_scope not in grant["scopes"]:
+        return {
+            "reason": "missing_scope",
+            "method": method,
+            "required_scope": required_scope,
+            "granted_scopes": grant["scopes"],
+        }
+    return None

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -49,6 +49,19 @@ class MutationClaim:
     _fingerprint: str = ""
     _owner_instance_id: str = ""
 
+    @property
+    def proof_tag(self) -> str:
+        """Opaque identity for binding an in-memory effect to this receipt."""
+        if not (
+            self._principal_digest
+            and self._request_digest
+            and self._fingerprint
+        ):
+            return ""
+        return _digest(
+            [self._principal_digest, self._request_digest, self._fingerprint]
+        )
+
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -1,0 +1,389 @@
+"""Durable at-most-once receipts for consequential mobile mutations.
+
+The store is deliberately independent of any live TUI session.  A receipt is
+scoped to the authenticated principal plus a client-generated request identity,
+while its fingerprint binds the durable Hermes resource and semantic request
+parameters.  An unfinished receipt owned by another process is never released
+for automatic execution: it becomes ``outcome_unknown`` and stays queryable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_MAX_REQUEST_ID_CHARS = 256
+
+
+class MutationConflict(ValueError):
+    """One client request identity was reused for different semantics."""
+
+
+class MutationDisposition(str, Enum):
+    EXECUTE = "execute"
+    IN_PROGRESS = "in_progress"
+    REPLAY = "replay"
+    OUTCOME_UNKNOWN = "outcome_unknown"
+
+
+@dataclass(frozen=True)
+class MutationClaim:
+    disposition: MutationDisposition
+    outcome: dict[str, Any] | None = None
+    _principal_digest: str = ""
+    _request_digest: str = ""
+    _fingerprint: str = ""
+    _owner_instance_id: str = ""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+class MobileMutationStore:
+    """SQLite-backed mutation receipts shared across reconnects and restarts."""
+
+    def __init__(
+        self,
+        db_path: str | os.PathLike[str],
+        *,
+        owner_instance_id: str | None = None,
+    ) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.close(fd)
+        elif os.name != "nt":
+            os.chmod(self._path, 0o600)
+
+        self._owner_instance_id = owner_instance_id or str(uuid.uuid4())
+        self._lock = threading.RLock()
+        self._changed = threading.Condition(self._lock)
+        self._closed = False
+        self._conn = sqlite3.connect(
+            self._path,
+            check_same_thread=False,
+            isolation_level=None,
+            timeout=5.0,
+        )
+        self._conn.execute("PRAGMA busy_timeout = 5000")
+        # Import lazily so loading the gateway does not freeze SessionDB's
+        # profile path before reload-style tests and embedded callers install
+        # their Hermes-home override. The receipt store itself is lazy too.
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(
+            self._conn,
+            db_label=f"mobile mutations ({self._path.name})",
+        )
+        self._conn.execute("PRAGMA synchronous = FULL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mobile_mutations (
+                principal_digest TEXT NOT NULL,
+                request_digest TEXT NOT NULL,
+                method TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                state TEXT NOT NULL,
+                owner_instance_id TEXT,
+                outcome_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY (principal_digest, request_digest)
+            )
+            """
+        )
+        # A process that disappeared after reservation may already have caused
+        # side effects.  Preserve that uncertainty durably instead of making a
+        # new process guess that the request is safe to execute again.
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE mobile_mutations
+            SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
+            WHERE state = 'in_progress' AND owner_instance_id <> ?
+            """,
+            (now, self._owner_instance_id),
+        )
+
+    @staticmethod
+    def _key(
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+    ) -> tuple[str, str, str]:
+        request_id = str(client_request_id or "").strip()
+        if not request_id or len(request_id) > _MAX_REQUEST_ID_CHARS:
+            raise ValueError(
+                "client_request_id must contain 1 to 256 non-whitespace characters"
+            )
+        principal = [str(provider or ""), str(subject or "")]
+        return _digest(principal), _digest(request_id), request_id
+
+    @staticmethod
+    def _fingerprint(
+        *,
+        method: str,
+        resource_id: str,
+        semantic_parameters: dict[str, Any],
+    ) -> str:
+        return _digest(
+            {
+                "method": str(method),
+                "resource_id": str(resource_id),
+                "semantic_parameters": semantic_parameters,
+            }
+        )
+
+    def reserve(
+        self,
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+        method: str,
+        resource_id: str,
+        semantic_parameters: dict[str, Any],
+    ) -> MutationClaim:
+        principal_digest, request_digest, _ = self._key(
+            provider=provider,
+            subject=subject,
+            client_request_id=client_request_id,
+        )
+        fingerprint = self._fingerprint(
+            method=method,
+            resource_id=resource_id,
+            semantic_parameters=semantic_parameters,
+        )
+        now = time.time()
+
+        with self._changed:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    """
+                    SELECT method, fingerprint, state, owner_instance_id, outcome_json
+                    FROM mobile_mutations
+                    WHERE principal_digest = ? AND request_digest = ?
+                    """,
+                    (principal_digest, request_digest),
+                ).fetchone()
+                if row is None:
+                    self._conn.execute(
+                        """
+                        INSERT INTO mobile_mutations (
+                            principal_digest, request_digest, method, fingerprint,
+                            state, owner_instance_id, outcome_json, created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, 'in_progress', ?, NULL, ?, ?)
+                        """,
+                        (
+                            principal_digest,
+                            request_digest,
+                            str(method),
+                            fingerprint,
+                            self._owner_instance_id,
+                            now,
+                            now,
+                        ),
+                    )
+                    disposition = MutationDisposition.EXECUTE
+                    outcome = None
+                else:
+                    _, existing_fingerprint, state, owner, outcome_json = row
+                    if existing_fingerprint != fingerprint:
+                        raise MutationConflict(
+                            "client_request_id was already used for different semantics"
+                        )
+                    if state == "completed":
+                        disposition = MutationDisposition.REPLAY
+                        outcome = json.loads(outcome_json) if outcome_json else None
+                    elif state == "outcome_unknown":
+                        disposition = MutationDisposition.OUTCOME_UNKNOWN
+                        outcome = None
+                    elif owner == self._owner_instance_id:
+                        disposition = MutationDisposition.IN_PROGRESS
+                        outcome = None
+                    else:
+                        self._conn.execute(
+                            """
+                            UPDATE mobile_mutations
+                            SET state = 'outcome_unknown', owner_instance_id = NULL,
+                                updated_at = ?
+                            WHERE principal_digest = ? AND request_digest = ?
+                              AND state = 'in_progress' AND owner_instance_id = ?
+                            """,
+                            (now, principal_digest, request_digest, owner),
+                        )
+                        disposition = MutationDisposition.OUTCOME_UNKNOWN
+                        outcome = None
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+            return MutationClaim(
+                disposition=disposition,
+                outcome=outcome,
+                _principal_digest=principal_digest,
+                _request_digest=request_digest,
+                _fingerprint=fingerprint,
+                _owner_instance_id=self._owner_instance_id,
+            )
+
+    def complete(self, claim: MutationClaim, outcome: dict[str, Any]) -> bool:
+        if claim.disposition is not MutationDisposition.EXECUTE:
+            return False
+        encoded = _canonical_json(outcome)
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'completed', outcome_json = ?, updated_at = ?
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    encoded,
+                    time.time(),
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            completed = cursor.rowcount == 1
+            self._changed.notify_all()
+            return completed
+
+    def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
+        """Terminalize a reserved request after an unexpected execution failure."""
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'outcome_unknown', owner_instance_id = NULL,
+                    outcome_json = NULL, updated_at = ?
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    time.time(),
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            changed = cursor.rowcount == 1
+            self._changed.notify_all()
+            return changed
+
+    def wait_for_outcome(
+        self,
+        claim: MutationClaim,
+        *,
+        timeout: float,
+    ) -> MutationClaim:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._changed:
+            while True:
+                row = self._conn.execute(
+                    """
+                    SELECT state, outcome_json
+                    FROM mobile_mutations
+                    WHERE principal_digest = ? AND request_digest = ?
+                      AND fingerprint = ?
+                    """,
+                    (
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                    ),
+                ).fetchone()
+                if row is None:
+                    return claim
+                state, outcome_json = row
+                if state == "completed":
+                    return MutationClaim(
+                        MutationDisposition.REPLAY,
+                        json.loads(outcome_json) if outcome_json else None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
+                if state == "outcome_unknown":
+                    return MutationClaim(
+                        MutationDisposition.OUTCOME_UNKNOWN,
+                        None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return claim
+                self._changed.wait(remaining)
+
+    def status(
+        self,
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+    ) -> dict[str, Any] | None:
+        principal_digest, request_digest, request_id = self._key(
+            provider=provider,
+            subject=subject,
+            client_request_id=client_request_id,
+        )
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT method, state, outcome_json
+                FROM mobile_mutations
+                WHERE principal_digest = ? AND request_digest = ?
+                """,
+                (principal_digest, request_digest),
+            ).fetchone()
+        if row is None:
+            return None
+        method, state, outcome_json = row
+        return {
+            "client_request_id": request_id,
+            "method": method,
+            "outcome": json.loads(outcome_json) if outcome_json else None,
+            "state": state,
+        }
+
+    def close(self) -> None:
+        with self._changed:
+            if self._closed:
+                return
+            self._closed = True
+            self._conn.close()
+            self._changed.notify_all()

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -277,6 +277,29 @@ class MobileMutationStore:
             self._changed.notify_all()
             return completed
 
+    def release_before_execution(self, claim: MutationClaim) -> bool:
+        """Remove this process's reservation before any side effect can run."""
+        if claim.disposition is not MutationDisposition.EXECUTE:
+            return False
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                DELETE FROM mobile_mutations
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            released = cursor.rowcount == 1
+            self._changed.notify_all()
+            return released
+
     def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
         """Terminalize a reserved request after an unexpected execution failure."""
         with self._changed:

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -28,9 +28,14 @@ class MutationConflict(ValueError):
     """One client request identity was reused for different semantics."""
 
 
+class InvalidMutationRequestIdentity(ValueError):
+    """A client request identity is empty or exceeds the wire contract."""
+
+
 class MutationDisposition(str, Enum):
     EXECUTE = "execute"
     IN_PROGRESS = "in_progress"
+    RETRY = "retry"
     REPLAY = "replay"
     OUTCOME_UNKNOWN = "outcome_unknown"
 
@@ -80,51 +85,84 @@ class MobileMutationStore:
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._closed = False
-        self._conn = sqlite3.connect(
+        self._recycle_required = False
+        self._conn = self._open_connection(self._owner_instance_id)
+
+    def _open_connection(self, owner_instance_id: str) -> sqlite3.Connection:
+        connection = sqlite3.connect(
             self._path,
             check_same_thread=False,
             isolation_level=None,
             timeout=5.0,
         )
-        self._conn.execute("PRAGMA busy_timeout = 5000")
-        # Import lazily so loading the gateway does not freeze SessionDB's
-        # profile path before reload-style tests and embedded callers install
-        # their Hermes-home override. The receipt store itself is lazy too.
-        from hermes_state import apply_wal_with_fallback
+        try:
+            connection.execute("PRAGMA busy_timeout = 5000")
+            # Import lazily so loading the gateway does not freeze SessionDB's
+            # profile path before reload-style tests and embedded callers install
+            # their Hermes-home override. The receipt store itself is lazy too.
+            from hermes_state import apply_wal_with_fallback
 
-        apply_wal_with_fallback(
-            self._conn,
-            db_label=f"mobile mutations ({self._path.name})",
-        )
-        self._conn.execute("PRAGMA synchronous = FULL")
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS mobile_mutations (
-                principal_digest TEXT NOT NULL,
-                request_digest TEXT NOT NULL,
-                method TEXT NOT NULL,
-                fingerprint TEXT NOT NULL,
-                state TEXT NOT NULL,
-                owner_instance_id TEXT,
-                outcome_json TEXT,
-                created_at REAL NOT NULL,
-                updated_at REAL NOT NULL,
-                PRIMARY KEY (principal_digest, request_digest)
+            apply_wal_with_fallback(
+                connection,
+                db_label=f"mobile mutations ({self._path.name})",
             )
-            """
-        )
-        # A process that disappeared after reservation may already have caused
-        # side effects.  Preserve that uncertainty durably instead of making a
-        # new process guess that the request is safe to execute again.
-        now = time.time()
-        self._conn.execute(
-            """
-            UPDATE mobile_mutations
-            SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
-            WHERE state = 'in_progress' AND owner_instance_id <> ?
-            """,
-            (now, self._owner_instance_id),
-        )
+            connection.execute("PRAGMA synchronous = FULL")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mobile_mutations (
+                    principal_digest TEXT NOT NULL,
+                    request_digest TEXT NOT NULL,
+                    method TEXT NOT NULL,
+                    fingerprint TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    owner_instance_id TEXT,
+                    outcome_json TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (principal_digest, request_digest)
+                )
+                """
+            )
+            # A process that disappeared after reservation may already have caused
+            # side effects. Preserve that uncertainty durably instead of making a
+            # new process guess that the request is safe to execute again.
+            connection.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
+                WHERE state = 'in_progress' AND owner_instance_id <> ?
+                """,
+                (time.time(), owner_instance_id),
+            )
+        except Exception:
+            connection.close()
+            raise
+        return connection
+
+    def _recycle_connection_locked(self) -> None:
+        if self._closed:
+            raise sqlite3.ProgrammingError("mobile mutation store is closed")
+        replacement_owner = str(uuid.uuid4())
+        replacement = self._open_connection(replacement_owner)
+        previous = self._conn
+        self._conn = replacement
+        self._owner_instance_id = replacement_owner
+        self._recycle_required = False
+        try:
+            previous.close()
+        except sqlite3.Error:
+            pass
+        self._changed.notify_all()
+
+    def _ensure_connection_locked(self) -> None:
+        if self._recycle_required:
+            self._recycle_connection_locked()
+
+    def recycle_after_storage_failure(self) -> None:
+        """Poison and replace the connection, terminalizing all open claims."""
+        with self._changed:
+            self._recycle_required = True
+            self._recycle_connection_locked()
 
     @staticmethod
     def _key(
@@ -135,7 +173,7 @@ class MobileMutationStore:
     ) -> tuple[str, str, str]:
         request_id = str(client_request_id or "").strip()
         if not request_id or len(request_id) > _MAX_REQUEST_ID_CHARS:
-            raise ValueError(
+            raise InvalidMutationRequestIdentity(
                 "client_request_id must contain 1 to 256 non-whitespace characters"
             )
         principal = [str(provider or ""), str(subject or "")]
@@ -179,6 +217,7 @@ class MobileMutationStore:
         now = time.time()
 
         with self._changed:
+            self._ensure_connection_locked()
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 row = self._conn.execute(
@@ -256,6 +295,7 @@ class MobileMutationStore:
             return False
         encoded = _canonical_json(outcome)
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 UPDATE mobile_mutations
@@ -282,6 +322,7 @@ class MobileMutationStore:
         if claim.disposition is not MutationDisposition.EXECUTE:
             return False
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 DELETE FROM mobile_mutations
@@ -303,6 +344,7 @@ class MobileMutationStore:
     def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
         """Terminalize a reserved request after an unexpected execution failure."""
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 UPDATE mobile_mutations
@@ -333,6 +375,7 @@ class MobileMutationStore:
         deadline = time.monotonic() + max(0.0, timeout)
         with self._changed:
             while True:
+                self._ensure_connection_locked()
                 row = self._conn.execute(
                     """
                     SELECT state, outcome_json
@@ -347,7 +390,14 @@ class MobileMutationStore:
                     ),
                 ).fetchone()
                 if row is None:
-                    return claim
+                    return MutationClaim(
+                        MutationDisposition.RETRY,
+                        None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
                 state, outcome_json = row
                 if state == "completed":
                     return MutationClaim(
@@ -385,6 +435,7 @@ class MobileMutationStore:
             client_request_id=client_request_id,
         )
         with self._lock:
+            self._ensure_connection_locked()
             row = self._conn.execute(
                 """
                 SELECT method, state, outcome_json

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -28,6 +28,11 @@ from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
+from tui_gateway.mobile_mutations import (
+    MobileMutationStore,
+    MutationConflict,
+    MutationDisposition,
+)
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -846,6 +851,32 @@ except (TypeError, ValueError):
 _SESSION_TTL_S = max(0.0, _SESSION_TTL_S)
 _REAPER_SCAN_S = 300.0
 
+_mobile_mutation_store_instance: MobileMutationStore | None = None
+_mobile_mutation_store_lock = threading.Lock()
+
+
+def _mobile_mutation_store() -> MobileMutationStore:
+    """Return the gateway-profile receipt store, opening it only when needed."""
+    global _mobile_mutation_store_instance
+    with _mobile_mutation_store_lock:
+        if _mobile_mutation_store_instance is None:
+            _mobile_mutation_store_instance = MobileMutationStore(
+                Path(_hermes_home) / "state" / "mobile_mutations.sqlite3"
+            )
+        return _mobile_mutation_store_instance
+
+
+def _close_mobile_mutation_store() -> None:
+    global _mobile_mutation_store_instance
+    with _mobile_mutation_store_lock:
+        store = _mobile_mutation_store_instance
+        _mobile_mutation_store_instance = None
+    if store is not None:
+        store.close()
+
+
+atexit.register(_close_mobile_mutation_store)
+
 
 def _transport_is_dead(transport) -> bool:
     # _detached_ws_transport is the post-WS-disconnect drop sentinel; a session
@@ -1251,6 +1282,258 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
+_MOBILE_MUTATION_METHODS = frozenset(
+    {"prompt.submit", "session.interrupt", "session.delete"}
+)
+_NOT_A_MOBILE_MUTATION = object()
+
+
+def _mobile_mutation_resource(
+    method: str,
+    params: dict,
+    rid: Any,
+) -> tuple[str, dict[str, Any]] | dict:
+    """Resolve client-supplied durable semantics without consulting live state."""
+    if method in {"prompt.submit", "session.interrupt"}:
+        expected = str(params.get("expected_stored_session_id") or "").strip()
+        if not expected:
+            return _err(
+                rid,
+                -32602,
+                "expected_stored_session_id is required for mobile mutation",
+                data={
+                    "method": method,
+                    "reason": "durable_resource_id_required",
+                },
+            )
+        semantics = {"text": params.get("text")} if method == "prompt.submit" else {}
+        # Cuttle keeps this server-issued Conversation identity stable while the
+        # process-local live session id and compression tip can rotate. Binding
+        # the receipt to the live id would turn a valid reconnect retry into a
+        # different mutation. The execute path validates this identity against
+        # current Hermes state before the handler can mutate anything.
+        return expected, semantics
+
+    target = str(params.get("session_id") or "").strip()
+    if not target:
+        return _err(rid, -32602, "session_id is required")
+    # A stored session id is itself the durable resource being deleted. Do not
+    # normalize it through a compression lineage: after successful deletion
+    # that lineage is intentionally gone, while a retry must still fingerprint
+    # to the same tombstoned target and replay the original outcome.
+    return target, {}
+
+
+def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | None:
+    """Validate live routing only for a newly reserved mutation, not a replay."""
+    if method not in {"prompt.submit", "session.interrupt"}:
+        return None
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    assert session is not None
+
+    expected = str(params.get("expected_stored_session_id") or "").strip()
+    runtime_id = str(params.get("session_id") or "").strip()
+    current_ids = {
+        str(session.get("session_key") or "").strip(),
+        str(session.get("resume_session_id") or "").strip(),
+        _session_lookup_key(session, fallback=runtime_id).strip(),
+    }
+    current_ids.discard("")
+    if expected in current_ids:
+        return None
+
+    lazy_watch = bool(session.get("lazy") and session.get("agent") is None)
+    if not lazy_watch:
+        try:
+            with _session_db(session) as db:
+                lineage = getattr(db, "get_compression_lineage", None)
+                if callable(lineage):
+                    expected_lineage = lineage(expected)
+                    expected_root = str(expected_lineage[0]) if expected_lineage else ""
+                    for current in current_ids:
+                        current_lineage = lineage(current)
+                        if (
+                            expected_root
+                            and current_lineage
+                            and str(current_lineage[0]) == expected_root
+                        ):
+                            return None
+        except Exception:
+            logger.debug(
+                "failed to validate mobile mutation conversation identity",
+                exc_info=True,
+            )
+
+    live = ", ".join(sorted(current_ids)) or "unknown"
+    return _err(
+        rid,
+        4019,
+        f"stored session mismatch: expected {expected!r}; live session is {live}",
+    )
+
+
+def _mutation_outcome(response: dict) -> dict[str, Any]:
+    if "result" in response:
+        return {"result": copy.deepcopy(response["result"])}
+    return {"error": copy.deepcopy(response.get("error") or {})}
+
+
+def _mutation_response(
+    rid: Any,
+    outcome: dict[str, Any],
+    *,
+    client_request_id: str,
+    deduplicated: bool,
+) -> dict:
+    receipt = {
+        "client_request_id": client_request_id,
+        "deduplicated": deduplicated,
+        "state": "completed",
+    }
+    if "result" in outcome:
+        result = copy.deepcopy(outcome["result"])
+        if not isinstance(result, dict):
+            result = {"value": result}
+        result["mutation"] = receipt
+        return _ok(rid, result)
+
+    error = copy.deepcopy(outcome.get("error") or {})
+    data = error.get("data")
+    if not isinstance(data, dict):
+        data = {}
+    data["mutation"] = receipt
+    error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
+
+
+def _dispatch_mobile_mutation(
+    req: dict,
+    *,
+    rid: Any,
+    method: str,
+    params: dict,
+    transport: Transport,
+) -> object:
+    from tui_gateway.mobile_contract import (
+        MOBILE_AUDIENCE,
+        effective_authorization,
+    )
+
+    grant = effective_authorization(getattr(transport, "authorization", None))
+    if grant["audience"] != MOBILE_AUDIENCE or method not in _MOBILE_MUTATION_METHODS:
+        return _NOT_A_MOBILE_MUTATION
+
+    client_request_id = str(params.get("client_request_id") or "").strip()
+    if not client_request_id:
+        return _err(
+            rid,
+            -32602,
+            "client_request_id is required for mobile mutation",
+            data={"method": method, "reason": "client_request_id_required"},
+        )
+
+    resource = _mobile_mutation_resource(method, params, rid)
+    if isinstance(resource, dict):
+        return resource
+    resource_id, semantic_parameters = resource
+    try:
+        store = _mobile_mutation_store()
+        claim = store.reserve(
+            provider=grant["provider"],
+            subject=grant["subject"],
+            client_request_id=client_request_id,
+            method=method,
+            resource_id=resource_id,
+            semantic_parameters=semantic_parameters,
+        )
+    except MutationConflict:
+        return _err(
+            rid,
+            4090,
+            "client_request_id was already used for different semantics",
+            data={"reason": "mutation_conflict"},
+        )
+    except ValueError as exc:
+        return _err(
+            rid,
+            -32602,
+            str(exc),
+            data={"reason": "invalid_client_request_id"},
+        )
+    except (OSError, sqlite3.Error):
+        logger.warning("mobile mutation receipt reservation failed", exc_info=True)
+        return _err(
+            rid,
+            5037,
+            "durable mutation receipt is temporarily unavailable",
+            data={"reason": "mutation_store_unavailable"},
+        )
+
+    if claim.disposition is MutationDisposition.IN_PROGRESS:
+        claim = store.wait_for_outcome(claim, timeout=30.0)
+    if claim.disposition is MutationDisposition.REPLAY:
+        return _mutation_response(
+            rid,
+            claim.outcome or {},
+            client_request_id=client_request_id,
+            deduplicated=True,
+        )
+    if claim.disposition is MutationDisposition.OUTCOME_UNKNOWN:
+        return _err(
+            rid,
+            4091,
+            "the prior mutation outcome is unknown and will not be re-executed",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_outcome_unknown",
+                "state": "outcome_unknown",
+            },
+        )
+    if claim.disposition is MutationDisposition.IN_PROGRESS:
+        return _err(
+            rid,
+            4092,
+            "the mutation is still in progress",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_in_progress",
+                "state": "in_progress",
+            },
+        )
+
+    try:
+        response = _mobile_mutation_preflight(method, params, rid)
+        if response is None:
+            response = handle_request(req)
+    except Exception:
+        store.mark_outcome_unknown(claim)
+        raise
+    if response is None:
+        store.mark_outcome_unknown(claim)
+        return _err(
+            rid,
+            5037,
+            "mutation handler did not produce a durable outcome",
+            data={"reason": "mutation_outcome_unknown"},
+        )
+    outcome = _mutation_outcome(response)
+    if not store.complete(claim, outcome):
+        return _err(
+            rid,
+            5037,
+            "mutation outcome could not be recorded durably",
+            data={"reason": "mutation_outcome_unknown"},
+        )
+    return _mutation_response(
+        rid,
+        outcome,
+        client_request_id=client_request_id,
+        deduplicated=False,
+    )
+
+
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     """Route inbound RPCs — long handlers to the pool, everything else inline.
 
@@ -1285,6 +1568,15 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
                 "insufficient authorization scope",
                 data=denial,
             )
+        mutation_response = _dispatch_mobile_mutation(
+            req,
+            rid=_rid,
+            method=method,
+            params=_params,
+            transport=t,
+        )
+        if mutation_response is not _NOT_A_MOBILE_MUTATION:
+            return mutation_response
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 
@@ -6213,6 +6505,40 @@ def _(rid, params: dict) -> dict:
     if not deleted:
         return _err(rid, 4007, "session not found")
     return _ok(rid, {"deleted": target})
+
+
+@method("mutation.status")
+def _(rid, params: dict) -> dict:
+    """Return the authenticated principal's durable mutation outcome."""
+    from tui_gateway.mobile_contract import effective_authorization
+
+    client_request_id = str(params.get("client_request_id") or "").strip()
+    if not client_request_id:
+        return _err(rid, -32602, "client_request_id is required")
+    transport = current_transport()
+    grant = effective_authorization(getattr(transport, "authorization", None))
+    try:
+        status = _mobile_mutation_store().status(
+            provider=grant["provider"],
+            subject=grant["subject"],
+            client_request_id=client_request_id,
+        )
+    except (OSError, sqlite3.Error, ValueError):
+        logger.warning("mobile mutation status lookup failed", exc_info=True)
+        return _err(
+            rid,
+            5037,
+            "durable mutation receipt is temporarily unavailable",
+            data={"reason": "mutation_store_unavailable"},
+        )
+    if status is None:
+        return _err(
+            rid,
+            4040,
+            "mutation receipt not found",
+            data={"reason": "mutation_not_found"},
+        )
+    return _ok(rid, status)
 
 
 @method("session.title")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -30,6 +30,7 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.mobile_mutations import (
+    InvalidMutationRequestIdentity,
     MobileMutationStore,
     MutationClaim,
     MutationConflict,
@@ -1481,6 +1482,41 @@ def _mark_mobile_mutation_outcome_unknown(
     return changed
 
 
+def _recover_mobile_mutation_outcome_unknown(
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    *,
+    context: str,
+) -> bool:
+    """Terminalize an uncertain claim, recycling a failed SQLite connection."""
+    if _mark_mobile_mutation_outcome_unknown(store, claim, context=context):
+        return True
+    try:
+        store.recycle_after_storage_failure()
+        recovered = store.wait_for_outcome(claim, timeout=0.0)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile mutation receipt recovery failed after %s",
+            context,
+            exc_info=True,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "unexpected mobile mutation receipt recovery failure after %s",
+            context,
+        )
+        return False
+    if recovered.disposition is MutationDisposition.OUTCOME_UNKNOWN:
+        return True
+    logger.error(
+        "mobile mutation receipt remained %s after recovery from %s",
+        recovered.disposition.value,
+        context,
+    )
+    return False
+
+
 def _dispatch_mobile_mutation(
     req: dict,
     *,
@@ -1512,46 +1548,50 @@ def _dispatch_mobile_mutation(
     if isinstance(resource, dict):
         return resource
     resource_id, semantic_parameters = resource
-    try:
-        store = _mobile_mutation_store()
-        claim = store.reserve(
-            provider=grant["provider"],
-            subject=grant["subject"],
-            client_request_id=client_request_id,
-            method=method,
-            resource_id=resource_id,
-            semantic_parameters=semantic_parameters,
-        )
-    except MutationConflict:
-        return _err(
-            rid,
-            4090,
-            "client_request_id was already used for different semantics",
-            data={"reason": "mutation_conflict"},
-        )
-    except ValueError as exc:
-        return _err(
-            rid,
-            -32602,
-            str(exc),
-            data={"reason": "invalid_client_request_id"},
-        )
-    except (OSError, sqlite3.Error):
-        logger.warning("mobile mutation receipt reservation failed", exc_info=True)
-        return _mobile_mutation_store_unavailable(rid)
-    except Exception:
-        logger.exception("unexpected mobile mutation receipt reservation failure")
-        return _mobile_mutation_store_unavailable(rid)
-
-    if claim.disposition is MutationDisposition.IN_PROGRESS:
+    while True:
         try:
-            claim = store.wait_for_outcome(claim, timeout=30.0)
-        except (OSError, sqlite3.Error):
-            logger.warning("mobile mutation receipt wait failed", exc_info=True)
+            store = _mobile_mutation_store()
+            claim = store.reserve(
+                provider=grant["provider"],
+                subject=grant["subject"],
+                client_request_id=client_request_id,
+                method=method,
+                resource_id=resource_id,
+                semantic_parameters=semantic_parameters,
+            )
+        except MutationConflict:
+            return _err(
+                rid,
+                4090,
+                "client_request_id was already used for different semantics",
+                data={"reason": "mutation_conflict"},
+            )
+        except InvalidMutationRequestIdentity as exc:
+            return _err(
+                rid,
+                -32602,
+                str(exc),
+                data={"reason": "invalid_client_request_id"},
+            )
+        except (OSError, sqlite3.Error, ValueError):
+            logger.warning("mobile mutation receipt reservation failed", exc_info=True)
             return _mobile_mutation_store_unavailable(rid)
         except Exception:
-            logger.exception("unexpected mobile mutation receipt wait failure")
+            logger.exception("unexpected mobile mutation receipt reservation failure")
             return _mobile_mutation_store_unavailable(rid)
+
+        if claim.disposition is MutationDisposition.IN_PROGRESS:
+            try:
+                claim = store.wait_for_outcome(claim, timeout=30.0)
+            except (OSError, sqlite3.Error):
+                logger.warning("mobile mutation receipt wait failed", exc_info=True)
+                return _mobile_mutation_store_unavailable(rid)
+            except Exception:
+                logger.exception("unexpected mobile mutation receipt wait failure")
+                return _mobile_mutation_store_unavailable(rid)
+        if claim.disposition is not MutationDisposition.RETRY:
+            break
+
     if claim.disposition is MutationDisposition.REPLAY:
         return _mutation_response(
             rid,
@@ -1618,11 +1658,13 @@ def _dispatch_mobile_mutation(
             response = handle_request(req)
     except Exception:
         logger.exception("mobile mutation handler failed")
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="handler failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         return _err(
             rid,
             5037,
@@ -1630,11 +1672,13 @@ def _dispatch_mobile_mutation(
             data={"reason": "mutation_outcome_unknown"},
         )
     if response is None:
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="empty handler response",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         return _err(
             rid,
             5037,
@@ -1646,19 +1690,23 @@ def _dispatch_mobile_mutation(
         completed = store.complete(claim, outcome)
     except (OSError, sqlite3.Error):
         logger.warning("mobile mutation receipt completion failed", exc_info=True)
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="receipt completion failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         completed = False
     except Exception:
         logger.exception("unexpected mobile mutation receipt completion failure")
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="unexpected receipt completion failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         completed = False
     if not completed:
         return _err(
@@ -6663,6 +6711,13 @@ def _(rid, params: dict) -> dict:
             provider=grant["provider"],
             subject=grant["subject"],
             client_request_id=client_request_id,
+        )
+    except InvalidMutationRequestIdentity as exc:
+        return _err(
+            rid,
+            -32602,
+            str(exc),
+            data={"reason": "invalid_client_request_id"},
         )
     except (OSError, sqlite3.Error, ValueError):
         logger.warning("mobile mutation status lookup failed", exc_info=True)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1205,8 +1205,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, *, data: dict | None = None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):
@@ -1268,6 +1271,16 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        from tui_gateway.mobile_contract import mobile_method_denial
+
+        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        if denial is not None:
+            return _err(
+                _rid,
+                4030,
+                "insufficient authorization scope",
+                data=denial,
+            )
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1273,7 +1273,11 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
         _rid, method, _params = normalized
         from tui_gateway.mobile_contract import mobile_method_denial
 
-        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        denial = mobile_method_denial(
+            method,
+            getattr(t, "authorization", None),
+            _params,
+        )
         if denial is not None:
             return _err(
                 _rid,
@@ -5101,7 +5105,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     session["queued_prompt"] = {"text": text, "transport": transport}
 
 
-def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any) -> dict:
+def _handle_busy_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    allow_control: bool = True,
+) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
 
@@ -5116,6 +5128,14 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
     without interrupting; ``steer`` → inject into the live turn if accepted,
     else queue.
     """
+    # A scoped writer may enqueue the next user turn, but must not inherit the
+    # dashboard's interrupt/steer preference unless its connection also holds
+    # conversation.control.
+    if not allow_control:
+        _enqueue_prompt(session, text, transport)
+        session["last_active"] = time.time()
+        return _ok(rid, {"status": "queued"})
+
     mode = _load_busy_input_mode()
     agent = session.get("agent")
     if mode == "steer" and agent is not None and hasattr(agent, "steer"):
@@ -8137,7 +8157,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.interrupt")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Interrupting a deferred/lazy session must not build the very agent the
+    # caller is trying to stop. Operate on live state only.
+    session, err = _sess_nowait(params, rid)
     if err:
         return err
     # Safety net: if the turn's run thread is already gone but `running` stayed
@@ -8459,7 +8481,23 @@ def _(rid, params: dict) -> dict:
             # interrupt the live turn) so it runs as the next turn. See
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
-            return _handle_busy_submit(rid, sid, session, text, t or session.get("transport"))
+            active_transport = t or session.get("transport")
+            from tui_gateway.mobile_contract import (
+                CONVERSATION_CONTROL_SCOPE,
+                authorization_allows_scope,
+            )
+
+            return _handle_busy_submit(
+                rid,
+                sid,
+                session,
+                text,
+                active_transport,
+                allow_control=authorization_allows_scope(
+                    getattr(active_transport, "authorization", None),
+                    CONVERSATION_CONTROL_SCOPE,
+                ),
+            )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1430,11 +1430,12 @@ def _mutation_response(
     *,
     client_request_id: str,
     deduplicated: bool,
+    state: str = "completed",
 ) -> dict:
     receipt = {
         "client_request_id": client_request_id,
         "deduplicated": deduplicated,
-        "state": "completed",
+        "state": state,
     }
     if "result" in outcome:
         result = copy.deepcopy(outcome["result"])
@@ -1515,6 +1516,374 @@ def _recover_mobile_mutation_outcome_unknown(
         context,
     )
     return False
+
+
+def _capture_mobile_prompt_receipt_context(
+    params: dict,
+    *,
+    proof_tag: str,
+) -> tuple | None:
+    """Capture the exact receipt identity expected on the user row."""
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None or not proof_tag:
+        return None
+    return sid, session, proof_tag
+
+
+def _mobile_prompt_turn_is_durable(context: tuple) -> bool:
+    _, session, proof_tag = context
+    agent = session.get("agent")
+    if proof_tag in (
+        getattr(agent, "_durable_mobile_mutation_receipt_tags", set()) or set()
+    ):
+        return True
+    with session.setdefault("history_lock", threading.RLock()):
+        history = list(session.get("history") or ())
+    agent_messages = list(getattr(agent, "_session_messages", ()) or ())
+    # ``_db_persisted`` is stamped only after SessionDB.append_message succeeds.
+    # The turn-context tag binds that proof to this exact receipt, so an older,
+    # substring-matching, or later queued user turn cannot satisfy it. Sequence
+    # repair may merge away that exact dict; in that case it carries only the
+    # receipt's already-persisted proof, never a blanket DB marker for the
+    # merged content.
+    return any(
+        isinstance(message, dict)
+        and message.get("role") == "user"
+        and (
+            (
+                message.get("_db_persisted")
+                and proof_tag
+                in (message.get("_mobile_mutation_receipt_tags") or ())
+            )
+            or proof_tag
+            in (
+                message.get("_mobile_mutation_persisted_receipt_tags")
+                or ()
+            )
+        )
+        for message in [*history, *agent_messages]
+    )
+
+
+def _mobile_prompt_turn_is_pending(context: tuple) -> bool:
+    _, session, proof_tag = context
+    with session.setdefault("history_lock", threading.RLock()):
+        live_tags = session.get("_live_mobile_mutation_receipt_tags")
+        starting_tags = set(
+            session.get("_starting_mobile_mutation_receipt_tags") or ()
+        )
+        run_thread = session.get("_run_thread")
+        if isinstance(live_tags, set):
+            tag_owned = proof_tag in live_tags
+        else:
+            # Compatibility for legacy/synthetic session dictionaries. New
+            # gateway paths maintain the O(1) live-tag set below.
+            queued_tags = (
+                (session.get("queued_prompt") or {}).get(
+                    "mobile_mutation_receipt_tags"
+                )
+                or ()
+            )
+            pending_tags = (
+                session.get("_pending_mobile_mutation_receipt_tags") or ()
+            )
+            active_tags = (
+                session.get("_active_mobile_mutation_receipt_tags") or ()
+            )
+            agent_pending_tags = (
+                getattr(
+                    session.get("agent"),
+                    "_pending_mobile_mutation_receipt_tags",
+                    (),
+                )
+                or ()
+            )
+            tag_owned = any(
+                proof_tag in tags
+                for tags in (
+                    queued_tags,
+                    pending_tags,
+                    active_tags,
+                    starting_tags,
+                    agent_pending_tags,
+                )
+            )
+    is_alive = getattr(run_thread, "is_alive", None)
+    thread_alive = bool(callable(is_alive) and is_alive())
+    # ``Thread.is_alive()`` is briefly false between assigning a replacement
+    # worker handle and starting it. An explicit starting tag covers only that
+    # handoff; generic ``running`` cannot let orphan tags survive a dead worker.
+    execution_live = thread_alive or proof_tag in starting_tags
+    return tag_owned and execution_live
+
+
+def _mobile_prompt_receipt_condition(session: dict) -> threading.Condition:
+    with session.setdefault("history_lock", threading.RLock()):
+        condition = session.get("_mobile_prompt_receipt_condition")
+        if condition is None:
+            condition = threading.Condition()
+            session["_mobile_prompt_receipt_condition"] = condition
+        agent = session.get("agent")
+        if agent is not None:
+            try:
+                agent._mobile_mutation_receipt_condition = condition
+            except (AttributeError, TypeError):
+                pass
+    return condition
+
+
+def _notify_mobile_prompt_receipt_change(session: dict) -> None:
+    condition = session.get("_mobile_prompt_receipt_condition")
+    if condition is None:
+        return
+    with condition:
+        condition.notify_all()
+
+
+def _track_mobile_prompt_receipt_tags_locked(
+    session: dict,
+    proof_tags: list[str] | tuple[str, ...],
+) -> None:
+    live_tags = set(session.get("_live_mobile_mutation_receipt_tags") or ())
+    live_tags.update(tag for tag in proof_tags if tag)
+    if live_tags:
+        session["_live_mobile_mutation_receipt_tags"] = live_tags
+
+
+def _discard_mobile_prompt_receipt_tags_locked(
+    session: dict,
+    proof_tags: list[str] | tuple[str, ...],
+    *,
+    agent: Any = None,
+) -> None:
+    """Remove only the named receipt identities from live handoff state."""
+    remove = {tag for tag in proof_tags if tag}
+    if not remove:
+        return
+    for key in (
+        "_pending_mobile_mutation_receipt_tags",
+        "_active_mobile_mutation_receipt_tags",
+        "_starting_mobile_mutation_receipt_tags",
+        "_live_mobile_mutation_receipt_tags",
+    ):
+        current = session.get(key) or ()
+        remaining = type(current)(
+            tag for tag in current if tag not in remove
+        )
+        if remaining:
+            session[key] = remaining
+        else:
+            session.pop(key, None)
+    if agent is not None:
+        remaining = [
+            tag
+            for tag in (
+                getattr(agent, "_pending_mobile_mutation_receipt_tags", ())
+                or ()
+            )
+            if tag not in remove
+        ]
+        if remaining or hasattr(
+            agent,
+            "_pending_mobile_mutation_receipt_tags",
+        ):
+            agent._pending_mobile_mutation_receipt_tags = remaining
+    _notify_mobile_prompt_receipt_change(session)
+
+
+def _complete_mobile_prompt_receipt(
+    *,
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    outcome: dict[str, Any],
+) -> None:
+    try:
+        completed = store.complete(claim, outcome)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile prompt receipt completion failed",
+            exc_info=True,
+        )
+        completed = False
+    except Exception:
+        logger.exception("unexpected mobile prompt receipt completion failure")
+        completed = False
+    if not completed:
+        _recover_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="prompt receipt completion failure",
+        )
+
+
+def _forget_mobile_prompt_durable_tag(context: tuple) -> None:
+    _, session, proof_tag = context
+    agent = session.get("agent")
+    condition = session.get("_mobile_prompt_receipt_condition")
+
+    def discard() -> None:
+        durable = getattr(
+            agent,
+            "_durable_mobile_mutation_receipt_tags",
+            None,
+        )
+        if isinstance(durable, set):
+            durable.discard(proof_tag)
+
+    if condition is None:
+        discard()
+    else:
+        with condition:
+            discard()
+
+
+def _run_mobile_prompt_receipt_monitor(
+    session: dict,
+    condition: threading.Condition,
+) -> None:
+    """Resolve all deferred prompt receipts for one live session."""
+    try:
+        while True:
+            with condition:
+                entries = dict(
+                    session.get("_mobile_prompt_receipt_entries") or {}
+                )
+                if not entries:
+                    current = session.get(
+                        "_mobile_prompt_receipt_monitor_thread"
+                    )
+                    if current is threading.current_thread():
+                        session.pop(
+                            "_mobile_prompt_receipt_monitor_thread",
+                            None,
+                        )
+                    condition.notify_all()
+                    return
+
+            terminal: list[tuple[str, dict[str, Any]]] = []
+            for proof_tag, entry in entries.items():
+                context = entry["context"]
+                _, entry_session, _ = context
+                agent = entry_session.get("agent")
+                durable_tags = (
+                    getattr(
+                        agent,
+                        "_durable_mobile_mutation_receipt_tags",
+                        set(),
+                    )
+                    or set()
+                )
+                durable = proof_tag in durable_tags
+                try:
+                    if not durable and _mobile_prompt_turn_is_pending(context):
+                        continue
+                    # One transcript scan at the terminal edge supports legacy
+                    # and test paths that predate the O(1) durable-tag signal,
+                    # while the queued hot path remains constant-time.
+                    if not durable:
+                        durable = _mobile_prompt_turn_is_durable(context)
+                    if durable:
+                        _complete_mobile_prompt_receipt(
+                            store=entry["store"],
+                            claim=entry["claim"],
+                            outcome=entry["outcome"],
+                        )
+                    else:
+                        _recover_mobile_mutation_outcome_unknown(
+                            entry["store"],
+                            entry["claim"],
+                            context="prompt turn lacked durable history",
+                        )
+                except Exception:
+                    logger.exception("mobile prompt receipt monitor failed")
+                    _recover_mobile_mutation_outcome_unknown(
+                        entry["store"],
+                        entry["claim"],
+                        context="unexpected prompt receipt monitor failure",
+                    )
+                terminal.append((proof_tag, entry))
+
+            if terminal:
+                with condition:
+                    live_entries = session.get(
+                        "_mobile_prompt_receipt_entries"
+                    ) or {}
+                    for proof_tag, entry in terminal:
+                        if live_entries.get(proof_tag) is entry:
+                            live_entries.pop(proof_tag, None)
+                    condition.notify_all()
+                for _, entry in terminal:
+                    _forget_mobile_prompt_durable_tag(entry["context"])
+                continue
+
+            with condition:
+                condition.wait(timeout=0.25)
+    finally:
+        stranded: list[dict[str, Any]] = []
+        with condition:
+            current = session.get("_mobile_prompt_receipt_monitor_thread")
+            if current is threading.current_thread():
+                session.pop("_mobile_prompt_receipt_monitor_thread", None)
+                live_entries = session.get(
+                    "_mobile_prompt_receipt_entries"
+                ) or {}
+                stranded = list(live_entries.values())
+                live_entries.clear()
+            condition.notify_all()
+        for entry in stranded:
+            _recover_mobile_mutation_outcome_unknown(
+                entry["store"],
+                entry["claim"],
+                context="prompt receipt coordinator stopped unexpectedly",
+            )
+            _forget_mobile_prompt_durable_tag(entry["context"])
+
+
+def _defer_mobile_prompt_receipt(
+    *,
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    outcome: dict[str, Any],
+    context: tuple | None,
+) -> bool:
+    """Register a prompt receipt with the session's bounded monitor."""
+    if context is None:
+        return False
+    _, session, proof_tag = context
+    condition = _mobile_prompt_receipt_condition(session)
+    entry = {
+        "claim": claim,
+        "context": context,
+        "outcome": outcome,
+        "store": store,
+    }
+    monitor = None
+    try:
+        with condition:
+            entries = session.setdefault("_mobile_prompt_receipt_entries", {})
+            entries[proof_tag] = entry
+            monitor = session.get("_mobile_prompt_receipt_monitor_thread")
+            is_alive = getattr(monitor, "is_alive", None)
+            if not (callable(is_alive) and is_alive()):
+                monitor = threading.Thread(
+                    target=_run_mobile_prompt_receipt_monitor,
+                    args=(session, condition),
+                    daemon=True,
+                )
+                session["_mobile_prompt_receipt_monitor_thread"] = monitor
+                monitor.start()
+            condition.notify_all()
+    except Exception:
+        logger.exception("mobile prompt receipt monitor failed to start")
+        with condition:
+            entries = session.get("_mobile_prompt_receipt_entries") or {}
+            if entries.get(proof_tag) is entry:
+                entries.pop(proof_tag, None)
+            if session.get("_mobile_prompt_receipt_monitor_thread") is monitor:
+                session.pop("_mobile_prompt_receipt_monitor_thread", None)
+        return False
+    return True
 
 
 def _dispatch_mobile_mutation(
@@ -1653,6 +2022,16 @@ def _dispatch_mobile_mutation(
             },
         )
 
+    prompt_receipt_context = None
+    if method == "prompt.submit" and response is None:
+        proof_tag = claim.proof_tag
+        if proof_tag:
+            params["_mobile_mutation_receipt_tag"] = proof_tag
+            prompt_receipt_context = _capture_mobile_prompt_receipt_context(
+                params,
+                proof_tag=proof_tag,
+            )
+
     try:
         if response is None:
             response = handle_request(req)
@@ -1671,6 +2050,8 @@ def _dispatch_mobile_mutation(
             "mutation handler failed before a durable outcome was available",
             data={"reason": "mutation_outcome_unknown"},
         )
+    finally:
+        params.pop("_mobile_mutation_receipt_tag", None)
     if response is None:
         recovered = _recover_mobile_mutation_outcome_unknown(
             store,
@@ -1686,6 +2067,42 @@ def _dispatch_mobile_mutation(
             data={"reason": "mutation_outcome_unknown"},
         )
     outcome = _mutation_outcome(response)
+    prompt_status = (
+        str((outcome.get("result") or {}).get("status") or "")
+        if isinstance(outcome.get("result"), dict)
+        else ""
+    )
+    if method == "prompt.submit" and prompt_status in {
+        "queued",
+        "steered",
+        "streaming",
+    }:
+        if not _defer_mobile_prompt_receipt(
+            store=store,
+            claim=claim,
+            outcome=outcome,
+            context=prompt_receipt_context,
+        ):
+            recovered = _recover_mobile_mutation_outcome_unknown(
+                store,
+                claim,
+                context="prompt receipt monitor startup failure",
+            )
+            if not recovered:
+                return _mobile_mutation_store_unavailable(rid)
+            return _err(
+                rid,
+                5037,
+                "prompt mutation outcome could not be monitored durably",
+                data={"reason": "mutation_outcome_unknown"},
+            )
+        return _mutation_response(
+            rid,
+            outcome,
+            client_request_id=client_request_id,
+            deduplicated=False,
+            state="in_progress",
+        )
     try:
         completed = store.complete(claim, outcome)
     except (OSError, sqlite3.Error):
@@ -5566,7 +5983,13 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
-def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
+def _enqueue_prompt(
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    mobile_mutation_receipt_tag: str = "",
+) -> None:
     """Stash a message to run as the very next turn once the live one ends.
 
     Used when a prompt arrives mid-turn (see ``_handle_busy_submit``). A single
@@ -5576,6 +5999,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     the client that sent it even if the session transport is rebound meanwhile.
     """
     existing = session.get("queued_prompt")
+    receipt_tags = list(
+        (existing or {}).get("mobile_mutation_receipt_tags") or ()
+    )
+    if (
+        mobile_mutation_receipt_tag
+        and mobile_mutation_receipt_tag not in receipt_tags
+    ):
+        receipt_tags.append(mobile_mutation_receipt_tag)
+    _track_mobile_prompt_receipt_tags_locked(session, receipt_tags)
     if (
         existing
         and isinstance(existing.get("text"), str)
@@ -5583,7 +6015,11 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     ):
         prev = existing["text"]
         text = f"{prev}\n\n{text}" if prev and text else (prev or text)
-    session["queued_prompt"] = {"text": text, "transport": transport}
+    session["queued_prompt"] = {
+        "text": text,
+        "transport": transport,
+        "mobile_mutation_receipt_tags": receipt_tags,
+    }
 
 
 def _handle_busy_submit(
@@ -5594,6 +6030,7 @@ def _handle_busy_submit(
     transport: Any,
     *,
     allow_control: bool = True,
+    mobile_mutation_receipt_tag: str = "",
 ) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -5613,7 +6050,12 @@ def _handle_busy_submit(
     # dashboard's interrupt/steer preference unless its connection also holds
     # conversation.control.
     if not allow_control:
-        _enqueue_prompt(session, text, transport)
+        _enqueue_prompt(
+            session,
+            text,
+            transport,
+            mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
+        )
         session["last_active"] = time.time()
         return _ok(rid, {"status": "queued"})
 
@@ -5631,7 +6073,12 @@ def _handle_busy_submit(
             agent.interrupt()
         except Exception:
             pass
-    _enqueue_prompt(session, text, transport)
+    _enqueue_prompt(
+        session,
+        text,
+        transport,
+        mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
+    )
     session["last_active"] = time.time()
     return _ok(rid, {"status": "queued"})
 
@@ -5649,6 +6096,14 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             return False
         session["queued_prompt"] = None
         session["running"] = True
+        receipt_tags = list(
+            queued.get("mobile_mutation_receipt_tags") or ()
+        )
+        if receipt_tags:
+            session["_pending_mobile_mutation_receipt_tags"] = receipt_tags
+            _track_mobile_prompt_receipt_tags_locked(session, receipt_tags)
+        else:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
         if queued.get("transport") is not None:
             session["transport"] = queued["transport"]
     try:
@@ -5660,7 +6115,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             file=sys.stderr,
         )
         with session["history_lock"]:
+            _discard_mobile_prompt_receipt_tags_locked(
+                session,
+                receipt_tags,
+                agent=session.get("agent"),
+            )
             session["running"] = False
+            _clear_inflight_turn(session)
     return True
 
 
@@ -8696,7 +9157,18 @@ def _(rid, params: dict) -> dict:
         session["agent"].interrupt()
     with session["history_lock"]:
         session["_turn_cancel_requested"] = True
+        queued_receipt_tags = list(
+            (session.get("queued_prompt") or {}).get(
+                "mobile_mutation_receipt_tags"
+            )
+            or ()
+        )
         session["queued_prompt"] = None
+        _discard_mobile_prompt_receipt_tags_locked(
+            session,
+            queued_receipt_tags,
+            agent=session.get("agent"),
+        )
     if not run_thread_alive:
         with session["history_lock"]:
             if session.get("running"):
@@ -8994,6 +9466,23 @@ def _(rid, params: dict) -> dict:
     # without conversation.control queues its next turn on this transport but
     # must not seize the in-flight turn from the currently attached client.
     t = current_transport()
+    active_authorization = getattr(t, "authorization", None)
+    from tui_gateway.mobile_contract import (
+        CONVERSATION_CONTROL_SCOPE,
+        MOBILE_AUDIENCE,
+        authorization_allows_scope,
+        effective_authorization,
+    )
+
+    mobile_mutation_receipt_tag = str(
+        params.get("_mobile_mutation_receipt_tag") or ""
+    ).strip()
+    durable_mobile_prompt = bool(mobile_mutation_receipt_tag) and (
+        effective_authorization(active_authorization)["audience"]
+        == MOBILE_AUDIENCE
+    )
+    if not durable_mobile_prompt:
+        mobile_mutation_receipt_tag = ""
     with session["history_lock"]:
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
@@ -9001,13 +9490,13 @@ def _(rid, params: dict) -> dict:
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
             active_transport = t or session.get("transport")
-            from tui_gateway.mobile_contract import (
-                CONVERSATION_CONTROL_SCOPE,
-                authorization_allows_scope,
-            )
-
-            allow_control = authorization_allows_scope(
-                getattr(active_transport, "authorization", None),
+            authorization = getattr(active_transport, "authorization", None)
+            # A durable mobile send always becomes its own next user turn.
+            # Interrupt/steer are separate idempotent control operations; using
+            # either implicit busy-input policy here would make persistence of
+            # this prompt identity impossible to prove after an uncertain ACK.
+            allow_control = not durable_mobile_prompt and authorization_allows_scope(
+                authorization,
                 CONVERSATION_CONTROL_SCOPE,
             )
             if t is not None and allow_control:
@@ -9019,6 +9508,7 @@ def _(rid, params: dict) -> dict:
                 text,
                 active_transport,
                 allow_control=allow_control,
+                mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
             )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -9051,6 +9541,16 @@ def _(rid, params: dict) -> dict:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+        if mobile_mutation_receipt_tag:
+            session["_pending_mobile_mutation_receipt_tags"] = [
+                mobile_mutation_receipt_tag
+            ]
+            _track_mobile_prompt_receipt_tags_locked(
+                session,
+                [mobile_mutation_receipt_tag],
+            )
+        else:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
@@ -9076,15 +9576,37 @@ def _(rid, params: dict) -> dict:
                 },
             )
             with session["history_lock"]:
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
                 session["running"] = False
                 _clear_inflight_turn(session)
             return
         with session["history_lock"]:
             if session.get("_turn_cancel_requested") or not session.get("running"):
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
                 session["running"] = False
                 _clear_inflight_turn(session)
                 return
-        _run_prompt_submit(rid, sid, session, text)
+        try:
+            _run_prompt_submit(rid, sid, session, text)
+        except Exception as exc:
+            logger.exception("mobile prompt worker setup failed")
+            with session["history_lock"]:
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
+                session["running"] = False
+                _clear_inflight_turn(session)
+            _emit("error", sid, {"message": str(exc)})
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck
@@ -9480,13 +10002,59 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session["attached_images"] = []
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
-    agent = session["agent"]
+        mobile_mutation_receipt_tags = list(
+            session.get("_pending_mobile_mutation_receipt_tags") or ()
+        )
+        _track_mobile_prompt_receipt_tags_locked(
+            session,
+            mobile_mutation_receipt_tags,
+        )
+        agent = session.get("agent")
+        if agent is None:
+            _discard_mobile_prompt_receipt_tags_locked(
+                session,
+                mobile_mutation_receipt_tags,
+            )
+            session["running"] = False
+            _clear_inflight_turn(session)
+            raise RuntimeError("prompt agent is unavailable")
+        receipt_condition = session.get("_mobile_prompt_receipt_condition")
+        if receipt_condition is not None:
+            try:
+                agent._mobile_mutation_receipt_condition = receipt_condition
+            except (AttributeError, TypeError):
+                pass
+        active_receipt_tags = list(
+            session.get("_active_mobile_mutation_receipt_tags") or ()
+        )
+        for tag in mobile_mutation_receipt_tags:
+            if tag not in active_receipt_tags:
+                active_receipt_tags.append(tag)
+        if active_receipt_tags:
+            session["_active_mobile_mutation_receipt_tags"] = (
+                active_receipt_tags
+            )
+
+    def discard_mobile_receipt_tags_locked() -> None:
+        _discard_mobile_prompt_receipt_tags_locked(
+            session,
+            mobile_mutation_receipt_tags,
+            agent=agent,
+        )
+
     if hasattr(agent, "clear_interrupt"):
         try:
             agent.clear_interrupt()
         except Exception:
             pass
-    _emit("message.start", sid)
+    try:
+        _emit("message.start", sid)
+    except Exception:
+        with session["history_lock"]:
+            discard_mobile_receipt_tags_locked()
+            session["running"] = False
+            _clear_inflight_turn(session)
+        raise
 
     def run():
         approval_token = None
@@ -9626,6 +10194,39 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
+            if mobile_mutation_receipt_tags:
+                with session["history_lock"]:
+                    pending = [
+                        tag
+                        for tag in (
+                            session.get(
+                                "_pending_mobile_mutation_receipt_tags"
+                            )
+                            or ()
+                        )
+                        if tag not in set(mobile_mutation_receipt_tags)
+                    ]
+                    if pending:
+                        session["_pending_mobile_mutation_receipt_tags"] = (
+                            pending
+                        )
+                    else:
+                        session.pop(
+                            "_pending_mobile_mutation_receipt_tags",
+                            None,
+                        )
+                    agent_pending = list(
+                        getattr(
+                            agent,
+                            "_pending_mobile_mutation_receipt_tags",
+                            (),
+                        )
+                        or ()
+                    )
+                    for tag in mobile_mutation_receipt_tags:
+                        if tag not in agent_pending:
+                            agent_pending.append(tag)
+                    agent._pending_mobile_mutation_receipt_tags = agent_pending
             result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
@@ -9894,6 +10495,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 reset_hermes_home_override(home_token)
             _clear_session_context(session_tokens)
             with session["history_lock"]:
+                discard_mobile_receipt_tags_locked()
                 session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
@@ -9968,9 +10570,41 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 file=sys.stderr,
             )
 
-    run_thread = threading.Thread(target=run, daemon=True)
-    session["_run_thread"] = run_thread
-    run_thread.start()
+    try:
+        run_thread = threading.Thread(target=run, daemon=True)
+        with session["history_lock"]:
+            starting_tags = list(
+                session.get("_starting_mobile_mutation_receipt_tags") or ()
+            )
+            for tag in mobile_mutation_receipt_tags:
+                if tag not in starting_tags:
+                    starting_tags.append(tag)
+            if starting_tags:
+                session["_starting_mobile_mutation_receipt_tags"] = (
+                    starting_tags
+                )
+            session["_run_thread"] = run_thread
+        run_thread.start()
+        with session["history_lock"]:
+            remove = set(mobile_mutation_receipt_tags)
+            remaining = [
+                tag
+                for tag in (
+                    session.get("_starting_mobile_mutation_receipt_tags")
+                    or ()
+                )
+                if tag not in remove
+            ]
+            if remaining:
+                session["_starting_mobile_mutation_receipt_tags"] = remaining
+            else:
+                session.pop("_starting_mobile_mutation_receipt_tags", None)
+    except Exception:
+        with session["history_lock"]:
+            discard_mobile_receipt_tags_locked()
+            session["running"] = False
+            _clear_inflight_turn(session)
+        raise
 
 
 @method("clipboard.paste")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8470,11 +8470,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    # Re-bind accepted idle work to the current client. A busy scoped writer
+    # without conversation.control queues its next turn on this transport but
+    # must not seize the in-flight turn from the currently attached client.
+    t = current_transport()
     with session["history_lock"]:
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
@@ -8487,16 +8486,19 @@ def _(rid, params: dict) -> dict:
                 authorization_allows_scope,
             )
 
+            allow_control = authorization_allows_scope(
+                getattr(active_transport, "authorization", None),
+                CONVERSATION_CONTROL_SCOPE,
+            )
+            if t is not None and allow_control:
+                session["transport"] = t
             return _handle_busy_submit(
                 rid,
                 sid,
                 session,
                 text,
                 active_transport,
-                allow_control=authorization_allows_scope(
-                    getattr(active_transport, "authorization", None),
-                    CONVERSATION_CONTROL_SCOPE,
-                ),
+                allow_control=allow_control,
             )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -8505,6 +8507,8 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if t is not None:
+            session["transport"] = t
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -30,6 +31,7 @@ from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.mobile_mutations import (
     MobileMutationStore,
+    MutationClaim,
     MutationConflict,
     MutationDisposition,
 )
@@ -1282,10 +1284,20 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
-_MOBILE_MUTATION_METHODS = frozenset(
-    {"prompt.submit", "session.interrupt", "session.delete"}
-)
 _NOT_A_MOBILE_MUTATION = object()
+
+
+class _MobileMutationPreflightUnavailable(RuntimeError):
+    """Live lineage validation could not safely authorize execution."""
+
+
+def _mobile_mutation_store_unavailable(rid: Any) -> dict:
+    return _err(
+        rid,
+        5037,
+        "durable mutation receipt is temporarily unavailable",
+        data={"reason": "mutation_store_unavailable"},
+    )
 
 
 def _mobile_mutation_resource(
@@ -1294,9 +1306,20 @@ def _mobile_mutation_resource(
     rid: Any,
 ) -> tuple[str, dict[str, Any]] | dict:
     """Resolve client-supplied durable semantics without consulting live state."""
-    if method in {"prompt.submit", "session.interrupt"}:
-        expected = str(params.get("expected_stored_session_id") or "").strip()
-        if not expected:
+    from tui_gateway.mobile_contract import MOBILE_MUTATION_POLICIES
+
+    descriptor = MOBILE_MUTATION_POLICIES.get(method)
+    if descriptor is None:
+        return _err(
+            rid,
+            -32601,
+            f"unknown mobile mutation: {method}",
+            data={"method": method, "reason": "unknown_mobile_mutation"},
+        )
+
+    resource_id = str(params.get(descriptor.resource_parameter) or "").strip()
+    if not resource_id:
+        if descriptor.resource_parameter == "expected_stored_session_id":
             return _err(
                 rid,
                 -32602,
@@ -1306,34 +1329,48 @@ def _mobile_mutation_resource(
                     "reason": "durable_resource_id_required",
                 },
             )
-        semantics = {"text": params.get("text")} if method == "prompt.submit" else {}
+        return _err(rid, -32602, f"{descriptor.resource_parameter} is required")
+
+    semantics = {
+        parameter: params.get(parameter)
+        for parameter in descriptor.semantic_parameters
+    }
+    if descriptor.resource_parameter == "expected_stored_session_id":
         # Cuttle keeps this server-issued Conversation identity stable while the
         # process-local live session id and compression tip can rotate. Binding
         # the receipt to the live id would turn a valid reconnect retry into a
         # different mutation. The execute path validates this identity against
         # current Hermes state before the handler can mutate anything.
-        return expected, semantics
+        return resource_id, semantics
 
-    target = str(params.get("session_id") or "").strip()
-    if not target:
-        return _err(rid, -32602, "session_id is required")
-    # A stored session id is itself the durable resource being deleted. Do not
-    # normalize it through a compression lineage: after successful deletion
-    # that lineage is intentionally gone, while a retry must still fingerprint
-    # to the same tombstoned target and replay the original outcome.
-    return target, {}
+    if descriptor.resource_parameter == "session_id":
+        # A stored session id is itself the durable resource being deleted. Do not
+        # normalize it through a compression lineage: after successful deletion
+        # that lineage is intentionally gone, while a retry must still fingerprint
+        # to the same tombstoned target and replay the original outcome.
+        return resource_id, semantics
+
+    return _err(
+        rid,
+        5037,
+        "mobile mutation resource policy is unavailable",
+        data={"method": method, "reason": "mutation_policy_unavailable"},
+    )
 
 
 def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | None:
     """Validate live routing only for a newly reserved mutation, not a replay."""
-    if method not in {"prompt.submit", "session.interrupt"}:
+    from tui_gateway.mobile_contract import MOBILE_MUTATION_POLICIES
+
+    descriptor = MOBILE_MUTATION_POLICIES.get(method)
+    if descriptor is None or not descriptor.requires_live_lineage_validation:
         return None
     session, err = _sess_nowait(params, rid)
     if err:
         return err
     assert session is not None
 
-    expected = str(params.get("expected_stored_session_id") or "").strip()
+    expected = str(params.get(descriptor.resource_parameter) or "").strip()
     runtime_id = str(params.get("session_id") or "").strip()
     current_ids = {
         str(session.get("session_key") or "").strip(),
@@ -1360,11 +1397,17 @@ def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | No
                             and str(current_lineage[0]) == expected_root
                         ):
                             return None
-        except Exception:
-            logger.debug(
+        except (OSError, sqlite3.Error) as exc:
+            logger.warning(
                 "failed to validate mobile mutation conversation identity",
                 exc_info=True,
             )
+            raise _MobileMutationPreflightUnavailable from exc
+        except Exception as exc:
+            logger.exception(
+                "unexpected failure validating mobile mutation conversation identity"
+            )
+            raise _MobileMutationPreflightUnavailable from exc
 
     live = ", ".join(sorted(current_ids)) or "unknown"
     return _err(
@@ -1408,6 +1451,36 @@ def _mutation_response(
     return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
+def _mark_mobile_mutation_outcome_unknown(
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    *,
+    context: str,
+) -> bool:
+    """Best-effort terminalization after execution may have begun."""
+    try:
+        changed = store.mark_outcome_unknown(claim)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile mutation outcome-unknown update failed after %s",
+            context,
+            exc_info=True,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "unexpected mobile mutation outcome-unknown update failure after %s",
+            context,
+        )
+        return False
+    if not changed:
+        logger.error(
+            "mobile mutation receipt was not owned while marking outcome unknown after %s",
+            context,
+        )
+    return changed
+
+
 def _dispatch_mobile_mutation(
     req: dict,
     *,
@@ -1418,11 +1491,12 @@ def _dispatch_mobile_mutation(
 ) -> object:
     from tui_gateway.mobile_contract import (
         MOBILE_AUDIENCE,
+        MOBILE_MUTATION_METHODS,
         effective_authorization,
     )
 
     grant = effective_authorization(getattr(transport, "authorization", None))
-    if grant["audience"] != MOBILE_AUDIENCE or method not in _MOBILE_MUTATION_METHODS:
+    if grant["audience"] != MOBILE_AUDIENCE or method not in MOBILE_MUTATION_METHODS:
         return _NOT_A_MOBILE_MUTATION
 
     client_request_id = str(params.get("client_request_id") or "").strip()
@@ -1464,15 +1538,20 @@ def _dispatch_mobile_mutation(
         )
     except (OSError, sqlite3.Error):
         logger.warning("mobile mutation receipt reservation failed", exc_info=True)
-        return _err(
-            rid,
-            5037,
-            "durable mutation receipt is temporarily unavailable",
-            data={"reason": "mutation_store_unavailable"},
-        )
+        return _mobile_mutation_store_unavailable(rid)
+    except Exception:
+        logger.exception("unexpected mobile mutation receipt reservation failure")
+        return _mobile_mutation_store_unavailable(rid)
 
     if claim.disposition is MutationDisposition.IN_PROGRESS:
-        claim = store.wait_for_outcome(claim, timeout=30.0)
+        try:
+            claim = store.wait_for_outcome(claim, timeout=30.0)
+        except (OSError, sqlite3.Error):
+            logger.warning("mobile mutation receipt wait failed", exc_info=True)
+            return _mobile_mutation_store_unavailable(rid)
+        except Exception:
+            logger.exception("unexpected mobile mutation receipt wait failure")
+            return _mobile_mutation_store_unavailable(rid)
     if claim.disposition is MutationDisposition.REPLAY:
         return _mutation_response(
             rid,
@@ -1505,13 +1584,57 @@ def _dispatch_mobile_mutation(
 
     try:
         response = _mobile_mutation_preflight(method, params, rid)
+    except _MobileMutationPreflightUnavailable:
+        try:
+            released = store.release_before_execution(claim)
+        except (OSError, sqlite3.Error):
+            logger.warning(
+                "mobile mutation receipt release failed after preflight outage",
+                exc_info=True,
+            )
+            released = False
+        except Exception:
+            logger.exception(
+                "unexpected mobile mutation receipt release failure after preflight outage"
+            )
+            released = False
+        if not released:
+            logger.error(
+                "mobile mutation receipt could not be released after preflight outage"
+            )
+            return _mobile_mutation_store_unavailable(rid)
+        return _err(
+            rid,
+            5037,
+            "mobile mutation preflight is temporarily unavailable",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_preflight_unavailable",
+            },
+        )
+
+    try:
         if response is None:
             response = handle_request(req)
     except Exception:
-        store.mark_outcome_unknown(claim)
-        raise
+        logger.exception("mobile mutation handler failed")
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="handler failure",
+        )
+        return _err(
+            rid,
+            5037,
+            "mutation handler failed before a durable outcome was available",
+            data={"reason": "mutation_outcome_unknown"},
+        )
     if response is None:
-        store.mark_outcome_unknown(claim)
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="empty handler response",
+        )
         return _err(
             rid,
             5037,
@@ -1519,7 +1642,25 @@ def _dispatch_mobile_mutation(
             data={"reason": "mutation_outcome_unknown"},
         )
     outcome = _mutation_outcome(response)
-    if not store.complete(claim, outcome):
+    try:
+        completed = store.complete(claim, outcome)
+    except (OSError, sqlite3.Error):
+        logger.warning("mobile mutation receipt completion failed", exc_info=True)
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="receipt completion failure",
+        )
+        completed = False
+    except Exception:
+        logger.exception("unexpected mobile mutation receipt completion failure")
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="unexpected receipt completion failure",
+        )
+        completed = False
+    if not completed:
         return _err(
             rid,
             5037,
@@ -6525,12 +6666,10 @@ def _(rid, params: dict) -> dict:
         )
     except (OSError, sqlite3.Error, ValueError):
         logger.warning("mobile mutation status lookup failed", exc_info=True)
-        return _err(
-            rid,
-            5037,
-            "durable mutation receipt is temporarily unavailable",
-            data={"reason": "mutation_store_unavailable"},
-        )
+        return _mobile_mutation_store_unavailable(rid)
+    except Exception:
+        logger.exception("unexpected mobile mutation status lookup failure")
+        return _mobile_mutation_store_unavailable(rid)
     if status is None:
         return _err(
             rid,

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,6 +81,10 @@ class WSTransport:
     the loop we're currently blocking. We detect that case and fire-and-
     forget instead. Callers that need to know when the bytes are on the wire
     should use :meth:`write_async` from the loop thread.
+
+    ``authorization`` is the server-derived grant for this connection. The
+    dispatcher reads it before resolving any method; clients cannot mutate it
+    through JSON-RPC input.
     """
 
     def __init__(
@@ -89,10 +93,12 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        authorization: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        self.authorization = authorization
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -280,7 +286,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, authorization: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -298,7 +304,12 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            authorization=authorization,
+        )
 
         # The desktop app and dashboard chat reach the agent through this WS
         # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
@@ -316,13 +327,18 @@ async def handle_ws(ws: Any) -> None:
             thread_name="tui-ws-mcp-discovery",
         )
 
+        from tui_gateway.mobile_contract import gateway_ready_payload
+
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    "payload": {"skin": server.resolve_skin()},
+                    "payload": gateway_ready_payload(
+                        skin=server.resolve_skin(),
+                        authorization=authorization,
+                    ),
                 },
             }
         )


### PR DESCRIPTION
## Stack

This draft is **stacked on #62858** (`feat/mobile-contract-hello-scopes`). It intentionally includes that PR's commits until #62858 merges; rebase this branch onto `main` after the parent lands.

- Parent head used: `d8bc3bc9b1277b54d72b097c7a5d0328ecb62348`
- Parent base: `f67aae323010e32c592a185984d36b20e9fa474a`
- This foundation implements the non-approval durable-mutation work tracked in `ericlewis/cuttle#4`.

## Summary

- persist mobile mutation receipts in a private SQLite store keyed by authenticated principal plus client request identity
- fingerprint durable Hermes conversation identity and semantic parameters rather than replaceable live session IDs
- require `client_request_id` for mobile prompt submission, interruption, and deletion while preserving legacy ID-less transports
- replay identical completed requests with `deduplicated: true`, reject semantic ID reuse deterministically, and expose authoritative `mutation.status`
- retain replay after process restart, live-session rotation, and conversation deletion; abandoned ownership becomes fail-closed `outcome_unknown`
- complete prompt receipts only after the exact principal-scoped user turn is proven persisted by the real SessionDB path
- coordinate deferred prompt receipts with one condition-driven monitor per live session, O(1) live/durable proof sets, exact handoff cleanup, and terminal-only transcript fallback
- preserve durable proof through Hermes consecutive-user repair without falsely promoting an unpersisted row
- terminalize queued mobile prompts canceled by interrupt rather than leaving an in-progress receipt or live-tag residue

Existing dashboard, stdio, messaging, and other legacy callers keep their current wire behavior. The capability advertises only the mutation methods implemented in this slice.

## Validation

Clean commit `cc535c21eb6c98a778d88f27d8d76cad096fa964`:

- all 30 `tests/tui_gateway/test_*.py` files in fresh process isolation: **420 passed**
- `tests/test_tui_gateway_server.py`: **316 passed**
- dashboard auth WebSocket: **61 passed**
- dashboard ticket WebSocket: **23 passed**
- root gateway WebSocket: **6 passed**
- console WebSocket: **5 passed**
- PTY keepalive WebSocket: **1 passed**
- `tests/run_agent/test_run_agent.py`: **416 passed**
- chat-completions transport: **88 passed**
- turn context: **15 passed**
- message-sequence repair: **39 passed**
- total distinct coverage: **1,390 passed, 0 failed**
- two independent final reviews: **no findings**
- Ruff on all changed Python files: passed
- `git diff --check`: passed
- added-line cross-platform footgun scan: clean

The `tests/tui_gateway` files are intentionally invoked in fresh processes because current upstream `test_inline_rpc_gil_starvation.py` replaces the global `prompt.submit` handler without restoring it; file-scoped isolation avoids that unrelated cross-file test leak.

## Deliberate limit / next stack

`approval.respond` is intentionally not advertised by this foundation branch. Stable approval identity, recoverable lifecycle events, and durable approval-response fingerprinting are integrated together on the next #5 stack; `ericlewis/cuttle#4` remains open until that integration is published and validated.
