### PR TITLE
fix(pty): guard keep-alive ring-buffer replay against a closed socket

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -90,7 +90,20 @@ class PtySession:
         self.last_detached_at = None
         snap = self.buffer.snapshot()
         if snap:
-            await ws.send_bytes(snap)
+            # Replaying the ring buffer can fail if the client socket died
+            # between the WS upgrade and this send (browser closed, half-open
+            # socket). Mirror the defensive send in ``_drain``: roll the
+            # session back to detached so a dead socket never looks live
+            # (which would block the reaper), then re-raise so the caller can
+            # tear the socket down. Without this, the WebSocketDisconnect
+            # propagates out of the ASGI handler and spews a traceback.
+            try:
+                await ws.send_bytes(snap)
+            except Exception:
+                self._ws = None
+                self.attached = False
+                self.last_detached_at = time.monotonic()
+                raise
 
     def detach(self, ws) -> None:
         # Only the currently-attached socket may mark the session detached.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15556,7 +15556,14 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    await session.attach(ws)
+    try:
+        await session.attach(ws)
+    except WebSocketDisconnect:
+        # Client disconnected before/during buffer replay — the PTY is
+        # still alive; mark the session detached so the reaper can
+        # clean it up when the process exits or TTL expires.
+        PTY_REGISTRY.detach(attach_token, ws)
+        return
 
     # --- writer loop: WebSocket → PTY master ----------------------------
     # No reader task here: the session's drain task (spawned once per PTY,

--- a/tests/test_pty_attach_disconnect_repro.py
+++ b/tests/test_pty_attach_disconnect_repro.py
@@ -1,0 +1,181 @@
+"""Regression: a browser closing while a keep-alive PTY replays its ring
+buffer must not crash the ASGI handler.
+
+Root cause (pre-fix): PtySession.attach() calls ``await ws.send_bytes(snap)``
+to replay buffered output on (re)attach, with NO exception guard — unlike the
+two sibling send sites (PtySession._drain and web_server._legacy_pump) which
+both wrap send_bytes in try/except. When the client socket is already gone,
+starlette raises WebSocketDisconnect, which propagated uncaught out of
+web_server.pty_ws and up the uvicorn/starlette stack, spewing a traceback and
+leaving the operator's terminal needing Ctrl-C.
+
+Two layers are asserted here:
+  1. attach() surfaces the disconnect (documents current behavior / the site).
+  2. pty_ws swallows it and detaches cleanly (the fix contract).
+"""
+import asyncio
+
+import pytest
+
+from hermes_cli.pty_session import PtySession
+from starlette.websockets import WebSocketDisconnect
+
+
+class _FakeBridge:
+    def __init__(self):
+        self.alive = True
+
+    def read(self, timeout):
+        return b""
+
+    def write(self, data):
+        pass
+
+    def resize(self, cols, rows):
+        pass
+
+    def close(self):
+        self.alive = False
+
+
+class _DeadSocket:
+    """Stub whose send_bytes fails exactly like a closed peer."""
+
+    async def send_bytes(self, data):
+        raise WebSocketDisconnect(code=1006)
+
+    async def close(self, code=1000):
+        pass
+
+
+class _CountingSocket:
+    """Records replayed bytes; used to prove the happy path still replays."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send_bytes(self, data):
+        self.sent.append(bytes(data))
+
+    async def close(self, code=1000):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_attach_replays_buffer_on_live_socket():
+    """Sanity: with buffered output and a live socket, attach() replays it.
+
+    This is the precondition that makes the bug reachable — attach() only
+    calls send_bytes when the ring buffer is non-empty.
+    """
+    session = PtySession("K", _FakeBridge(), buffer_cap=4096, read_timeout=0.05)
+    session.buffer.append(b"buffered agent output\r\n")
+    ws = _CountingSocket()
+
+    await session.attach(ws)
+
+    assert ws.sent == [b"buffered agent output\r\n"]
+    assert session.attached is True
+
+
+@pytest.mark.asyncio
+async def test_attach_raises_on_dead_socket_during_replay():
+    """attach() re-raises when the ring-buffer replay hits a dead socket, but
+    first rolls the session back to a detached, reapable state — a dead socket
+    must never be left looking live (that would block the reaper).
+    """
+    session = PtySession("K", _FakeBridge(), buffer_cap=4096, read_timeout=0.05)
+    session.buffer.append(b"buffered agent output\r\n")
+    ws = _DeadSocket()
+
+    with pytest.raises(WebSocketDisconnect):
+        await session.attach(ws)
+
+    # Rolled back: not attached, no live socket, timestamped for the reaper.
+    assert session.attached is False
+    assert session._ws is None
+    assert session.last_detached_at is not None
+    # Buffer preserved so a genuine reattach still replays history.
+    assert session.buffer.snapshot() == b"buffered agent output\r\n"
+
+
+@pytest.mark.asyncio
+async def test_pty_ws_attach_site_swallows_disconnect(monkeypatch):
+    """The fix contract: web_server.pty_ws must NOT propagate a
+    WebSocketDisconnect raised during session.attach(). It detaches cleanly.
+
+    We exercise the real pty_ws handler up to the attach call by stubbing the
+    auth/allow gates and the argv resolver, and forcing the spawned session's
+    attach() to raise (dead-socket replay). A green result requires the
+    try/except around ``await session.attach(ws)`` in pty_ws.
+    """
+    from hermes_cli import web_server as ws_mod
+
+    # --- open the gates -------------------------------------------------
+    monkeypatch.setattr(ws_mod, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(ws_mod, "_PTY_BRIDGE_AVAILABLE", True)
+    monkeypatch.setattr(ws_mod, "_ws_auth_reason", lambda ws: (None, "test"))
+    monkeypatch.setattr(ws_mod, "_ws_host_origin_reason", lambda ws: None)
+    monkeypatch.setattr(ws_mod, "_ws_client_reason", lambda ws: None)
+    monkeypatch.setattr(ws_mod, "_channel_or_close_code", lambda ws: None)
+
+    async def fake_argv(**kw):
+        return (["/bin/true"], None, {})
+
+    monkeypatch.setattr(ws_mod, "_resolve_chat_argv_async", fake_argv)
+
+    # A session whose attach() blows up like a dead-socket replay.
+    class _ExplodingSession:
+        def __init__(self):
+            self.bridge = _FakeBridge()
+            self.detached_with = None
+
+        async def attach(self, ws):
+            raise WebSocketDisconnect(code=1006)
+
+    exploding = _ExplodingSession()
+
+    async def fake_attach_or_spawn(token, *, spawn):
+        return exploding, True
+
+    detach_calls = []
+    monkeypatch.setattr(
+        ws_mod.PTY_REGISTRY, "attach_or_spawn", fake_attach_or_spawn
+    )
+    monkeypatch.setattr(
+        ws_mod.PTY_REGISTRY,
+        "detach",
+        lambda token, ws: detach_calls.append((token, ws)),
+    )
+
+    # Minimal WebSocket double covering everything pty_ws touches pre/at attach.
+    class _WS:
+        def __init__(self):
+            self.client = type("C", (), {"host": "127.0.0.1"})()
+            self.query_params = {"attach": "TOK"}
+            self.app = ws_mod.app
+            self.accepted = False
+            self.closed_with = None
+
+        async def accept(self):
+            self.accepted = True
+
+        async def send_text(self, text):
+            pass
+
+        async def close(self, code=1000, reason=None):
+            self.closed_with = code
+
+        async def receive(self):
+            return {"type": "websocket.disconnect"}
+
+    ws = _WS()
+
+    # The whole point: this call must return without raising.
+    await ws_mod.pty_ws(ws)
+
+    assert ws.accepted is True
+    assert detach_calls == [("TOK", ws)], (
+        "pty_ws must detach the token after a failed attach so the reaper can "
+        "reclaim the PTY; instead the disconnect escaped or detach was skipped."
+    )


### PR DESCRIPTION
## Summary

The dashboard's keep-alive PTY terminal crashes its ASGI handler with an uncaught `WebSocketDisconnect` when the browser is closed while buffered output is being replayed on (re)attach. The operator sees a full uvicorn/starlette traceback printed to the terminal running `hermes dashboard`.

### Symptom (real report)

Closing the browser tab mid-session produced this on the `hermes dashboard` terminal:

```
ERROR:    Exception in ASGI application
...
  File ".../hermes_cli/web_server.py", line 15559, in pty_ws
    await session.attach(ws)
  File ".../hermes_cli/pty_session.py", line 93, in attach
    await ws.send_bytes(snap)
  File ".../starlette/websockets.py", line 169, in send_bytes
    await self.send({"type": "websocket.send", "bytes": data})
  ...
starlette.websockets.WebSocketDisconnect
```

## Root cause

`PtySession.attach()` replays the `RingBuffer` to the socket via `await ws.send_bytes(snap)` when a keep-alive terminal (`?attach=<token>`) attaches. That send had **no exception guard** — unlike the two sibling send sites in the same subsystem, both of which already wrap `send_bytes` in `try/except`:

- `PtySession._drain()` — `except Exception: pass` (keep buffering)
- `web_server._legacy_pump()` — `except Exception: return`

When the client socket is already gone by replay time (browser closed, half-open socket), starlette raises `WebSocketDisconnect`, which propagates uncaught out of `web_server.pty_ws` and up the ASGI stack.

Introduced in the keep-alive PTY feature (`e10e4bca8`). The test shipped with that feature never caught it: its `FakeBridge.read()` returns empty bytes, so the ring buffer is always empty and `send_bytes(snap)` is never called. Buffered output only exists in real use.

## Fix

Fixes the whole bug class at the source, plus a defensive guard at the call site:

- **`PtySession.attach()`** — wrap the replay send. On failure, roll the session back to a detached, reapable state (a dead socket must never look live and block the reaper) and re-raise so the caller can tear it down.
- **`web_server.pty_ws()`** — catch `WebSocketDisconnect` around `session.attach()` and detach the token cleanly instead of letting it escape the handler.

## Test plan

Adds `tests/test_pty_attach_disconnect_repro.py`:

- `test_pty_ws_attach_site_swallows_disconnect` — drives the **real** `pty_ws` handler; **fails on current `main`** with an uncaught `WebSocketDisconnect`, passes with the fix.
- `test_attach_raises_on_dead_socket_during_replay` — locks in the rollback-on-failure invariant (not attached, no live socket, buffer preserved).
- `test_attach_replays_buffer_on_live_socket` — happy-path replay still works.

Verified:

- [x] New repro test fails on clean `main`, passes with the fix (confirmed by stash/pop).
- [x] Existing PTY suite green: `tests/test_pty_session.py`, `tests/test_pty_keepalive_ws.py`, `tests/hermes_cli/test_web_server_pty_reconnect.py`, `tests/hermes_cli/test_web_server_pty_import.py` — 17 passed, 1 skipped (Windows-only).
- [x] The 3 pre-existing `TestPtyWebSocket` env failures (real PTY spawn under TestClient) fail identically with and without this change — untouched.

Note: the secondary Ctrl-C `KeyboardInterrupt` traceback in the original report is standard `asyncio.run` interrupt chaining and is intentionally left out of this focused fix.
