### PR TITLE
fix(copilot): include Copilot-Integration-Id in fallback headers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2829,6 +2829,7 @@ def copilot_default_headers(*, is_agent_turn: bool = True) -> dict[str, str]:
         return {
             "Editor-Version": COPILOT_EDITOR_VERSION,
             "User-Agent": "HermesAgent/1.0",
+            "Copilot-Integration-Id": "vscode-chat",
             "Openai-Intent": "conversation-edits",
             "x-initiator": "agent" if is_agent_turn else "user",
         }

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -348,3 +348,63 @@ def test_copilot_enterprise_base_url_applies_copilot_default_headers(mock_openai
     assert lc.get("copilot-integration-id") == "vscode-chat", (
         f"enterprise Copilot endpoint must carry Copilot-Integration-Id=vscode-chat; got {headers}"
     )
+
+
+@patch("run_agent.OpenAI")
+def test_copilot_codex_responses_path_carries_integration_id(mock_openai):
+    """Copilot requests via codex_responses api_mode must carry
+    Copilot-Integration-Id: vscode-chat on every outbound request.
+
+    Without this header, GitHub attributes the request to integrator
+    'copilot-language-server' (whose model whitelist is much smaller than
+    'vscode-chat') and rejects claude-opus-4.8, gpt-5.x-full, etc. with
+    HTTP 400. The header must be present in _client_kwargs so the per-request
+    client built by _create_request_openai_client inherits it for both
+    chat_completions and codex_responses paths.
+    """
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.githubcopilot.com",
+        model="gpt-5.4",
+        provider="copilot",
+        api_mode="codex_responses",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    headers = agent._client_kwargs.get("default_headers", {})
+    lc = {k.lower(): v for k, v in headers.items()}
+    assert lc.get("copilot-integration-id") == "vscode-chat", (
+        f"codex_responses path must carry Copilot-Integration-Id=vscode-chat; got {headers}"
+    )
+
+
+def test_copilot_default_headers_fallback_includes_integration_id():
+    """The copilot_default_headers() ImportError fallback must include
+    Copilot-Integration-Id: vscode-chat.
+
+    When hermes_cli.copilot_auth cannot be imported (partial install,
+    module load order), the fallback dict is used by agent_init.py and
+    run_agent.py to set default_headers. Omitting Copilot-Integration-Id
+    here causes the same HTTP 400 integrator attribution bug as missing
+    it in the primary path.
+    """
+    import builtins
+    real_import = builtins.__import__
+
+    def _block_copilot_auth(name, *args, **kwargs):
+        if name == "hermes_cli.copilot_auth":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    from hermes_cli.models import copilot_default_headers
+
+    with patch.object(builtins, "__import__", side_effect=_block_copilot_auth):
+        headers = copilot_default_headers()
+
+    lc = {k.lower(): v for k, v in headers.items()}
+    assert lc.get("copilot-integration-id") == "vscode-chat", (
+        f"fallback copilot_default_headers must include Copilot-Integration-Id; got {headers}"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds the missing `Copilot-Integration-Id: vscode-chat` header to the `ImportError` fallback of `copilot_default_headers()` in `hermes_cli/models.py`.

The primary path (`copilot_request_headers()` in `hermes_cli/copilot_auth.py`) already includes this header (added in `eaa21a827`). However, `copilot_default_headers()` — which wraps that function with a fallback dict — omits it in the fallback branch. When `hermes_cli.copilot_auth` cannot be imported (partial install, module load order, packaging edge cases), `agent_init.py` and `run_agent.py` use the fallback dict to set `default_headers` on the OpenAI client. Without `Copilot-Integration-Id`, GitHub attributes the request to integrator `copilot-language-server`, whose model whitelist is much smaller than `vscode-chat` — causing HTTP 400 for models like `claude-opus-4.8*` and `gpt-5.x-full`.

This affects all api_modes (`chat_completions` and `codex_responses`), since both paths share the same `_client_kwargs["default_headers"]` set at client-build time.

## Related Issue

Fixes #63188

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: Added `"Copilot-Integration-Id": "vscode-chat"` to the `ImportError` fallback of `copilot_default_headers()` (1 line)
- `tests/run_agent/test_provider_attribution_headers.py`: Added two regression tests:
  - `test_copilot_codex_responses_path_carries_integration_id` — verifies the header is present in `_client_kwargs` when `api_mode=codex_responses`
  - `test_copilot_default_headers_fallback_includes_integration_id` — verifies the fallback dict includes the header when `copilot_auth` import is blocked

## How to Test

1. Run the new regression tests:
   ```bash
   python -m pytest tests/run_agent/test_provider_attribution_headers.py::test_copilot_codex_responses_path_carries_integration_id tests/run_agent/test_provider_attribution_headers.py::test_copilot_default_headers_fallback_includes_integration_id -v
   ```
   Observed result: both tests pass.

2. Run the full attribution headers test suite to verify no regression:
   ```bash
   python -m pytest tests/run_agent/test_provider_attribution_headers.py -v
   ```
   Observed result: all 17 tests pass.

3. Run the copilot auth test suite:
   ```bash
   python -m pytest tests/hermes_cli/test_copilot_auth.py tests/test_copilot_initiator.py -v
   ```
   Observed result: all 43 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
