### PR TITLE
feat(gateway): add recoverable mobile approvals

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -728,6 +728,12 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    # Gateway-only receipt proof tags copied onto the next user message. The
+    # underscore-prefixed field never leaves the process or persists to SQLite;
+    # it binds the in-memory `_db_persisted` proof to an exact mobile mutation.
+    agent._pending_mobile_mutation_receipt_tags: list[str] = []
+    agent._durable_mobile_mutation_receipt_tags: set[str] = set()
+    agent._mobile_mutation_receipt_condition = None
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -545,6 +545,32 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                     if prev_content and new_content
                     else (prev_content or new_content)
                 )
+                # The gateway binds a mobile receipt to the exact new user
+                # dict that SessionDB successfully persisted. Repair discards
+                # that dict after merging its text into ``prev``. Preserve an
+                # explicit proof-only tag without marking the merged content as
+                # wholly DB-persisted (``prev`` itself may still need a flush).
+                persisted_receipt_tags = list(
+                    msg.get("_mobile_mutation_persisted_receipt_tags") or ()
+                )
+                if msg.get("_db_persisted"):
+                    for tag in msg.get(
+                        "_mobile_mutation_receipt_tags",
+                        (),
+                    ) or ():
+                        if tag not in persisted_receipt_tags:
+                            persisted_receipt_tags.append(tag)
+                if persisted_receipt_tags:
+                    existing_receipt_tags = list(
+                        prev.get("_mobile_mutation_persisted_receipt_tags")
+                        or ()
+                    )
+                    for tag in persisted_receipt_tags:
+                        if tag not in existing_receipt_tags:
+                            existing_receipt_tags.append(tag)
+                    prev["_mobile_mutation_persisted_receipt_tags"] = (
+                        existing_receipt_tags
+                    )
                 repairs += 1
                 continue
         merged.append(msg)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -313,8 +313,19 @@ def build_turn_context(
             should_review_memory = True
             agent._turns_since_memory = 0
 
-    # Add user message.
+    # Add user message. Gateway mobile receipt tags are process-private proof
+    # tags: transport sanitizers strip underscore-prefixed fields and SessionDB
+    # stores only the canonical message columns, while `_db_persisted` remains
+    # on this exact dict after a successful append for receipt finalization.
     user_msg = {"role": "user", "content": user_message}
+    mobile_mutation_receipt_tags = list(
+        getattr(agent, "_pending_mobile_mutation_receipt_tags", ()) or ()
+    )
+    agent._pending_mobile_mutation_receipt_tags = []
+    if mobile_mutation_receipt_tags:
+        user_msg["_mobile_mutation_receipt_tags"] = (
+            mobile_mutation_receipt_tags
+        )
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
@@ -360,6 +371,36 @@ def build_turn_context(
             agent.session_id or "none",
             exc_info=True,
         )
+    if user_msg.get("_db_persisted") and mobile_mutation_receipt_tags:
+        receipt_condition = getattr(
+            agent,
+            "_mobile_mutation_receipt_condition",
+            None,
+        )
+        if receipt_condition is not None:
+            with receipt_condition:
+                durable_tags = set(
+                    getattr(
+                        agent,
+                        "_durable_mobile_mutation_receipt_tags",
+                        set(),
+                    )
+                    or set()
+                )
+                durable_tags.update(mobile_mutation_receipt_tags)
+                agent._durable_mobile_mutation_receipt_tags = durable_tags
+                receipt_condition.notify_all()
+        else:
+            durable_tags = set(
+                getattr(
+                    agent,
+                    "_durable_mobile_mutation_receipt_tags",
+                    set(),
+                )
+                or set()
+            )
+            durable_tags.update(mobile_mutation_receipt_tags)
+            agent._durable_mobile_mutation_receipt_tags = durable_tags
 
     # ── Preflight context compression ──
     # Gate the (expensive) full token estimate behind a cheap pre-check.

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -27,9 +27,10 @@ from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
 Synchronization state and replay retention begin when an authorized mobile
-transport attaches to a live session. Legacy stdio and Desktop transports keep
-their original response and event shapes and do not pay the per-delta replay
-copying cost.
+transport first attaches to a live session. A session that has never negotiated
+sync does not pay the per-delta replay copying cost. If a legacy transport later
+attaches to a previously negotiated session, retention continues for the next
+mobile reconnect, but the legacy response and event shapes remain unchanged.
 
 ## Snapshot and event barrier
 

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -26,6 +26,11 @@ limits. `gap` means an event needed after the supplied cursor was evicted.
 from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
+Synchronization state and replay retention begin when an authorized mobile
+transport attaches to a live session. Legacy stdio and Desktop transports keep
+their original response and event shapes and do not pay the per-delta replay
+copying cost.
+
 ## Snapshot and event barrier
 
 Hermes serializes snapshot-visible live state, event sequence allocation,

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -1,0 +1,55 @@
+# Mobile Client Contract
+
+Hermes exposes its additive Mobile Client Contract on the existing
+authenticated `/api/ws` JSON-RPC transport. Clients must negotiate features
+from `gateway.ready`; a contract major or server version alone does not imply a
+capability.
+
+## Revisioned conversation synchronization
+
+When `conversation.sync` version 1 is advertised, `session.create` and
+`session.resume` include the same `synchronization` envelope:
+
+- `snapshot` is authoritative conversation state. It identifies the server
+  process, live event stream, stable conversation lineage, current stored
+  session tip, and process-local live session. It also includes a revision,
+  event watermark, messages, inflight turn, active tool descriptors, pending
+  interactions, and runtime status.
+- `recovery` reports `complete`, `gap`, or `reset`, the cursor at the snapshot
+  watermark, and any replayable events after the supplied cursor.
+- Every session event carries `schema_major`, `stream_id`, and a monotonically
+  increasing `sequence` within that stream.
+
+The replay store is bounded in memory by both the advertised event and byte
+limits. `gap` means an event needed after the supplied cursor was evicted.
+`reset` means the cursor is absent, invalid, from another server process, or
+from another reconstructed live stream. Clients must never treat either
+outcome as complete replay.
+
+## Snapshot and event barrier
+
+Hermes serializes snapshot-visible live state, event sequence allocation,
+replay retention, and event transport enqueueing at one per-stream boundary.
+Snapshot capture takes the conversation history lock before that stream
+boundary. The returned watermark therefore covers every state transition
+published before the snapshot.
+
+A client should:
+
+1. Buffer events for the returned `stream_id` while create or resume is in
+   flight.
+2. Install the complete snapshot at its `watermark`.
+3. Discard buffered or replayed events at or below the watermark.
+4. Apply only events for the same server and stream whose sequence is greater
+   than the watermark, in sequence order.
+5. Replace local state from the snapshot whenever recovery is `gap` or
+   `reset`.
+
+Assistant `message.delta` events additionally carry one `turn_id` and an
+absolute `offset`. The `conversation.sync.delta_offsets.unit` capability names
+the unit as `utf8_bytes`. Clients can therefore ignore an overlapping prefix
+instead of duplicating text after replay or transport coalescing.
+
+This slice does not claim durable mutation idempotency or addressable,
+recoverable approvals. Those features require separately advertised
+capabilities.

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -56,6 +56,49 @@ absolute `offset`. The `conversation.sync.delta_offsets.unit` capability names
 the unit as `utf8_bytes`. Clients can therefore ignore an overlapping prefix
 instead of duplicating text after replay or transport coalescing.
 
-This slice does not claim durable mutation idempotency or addressable,
-recoverable approvals. Those features require separately advertised
-capabilities.
+## Durable consequential mutations
+
+When `mutation.idempotency` version 1 is advertised, its `methods` list is the
+complete set of mobile methods covered by durable receipts. Each covered
+request requires a non-empty `client_request_id`. Prompt submission,
+interruption, and approval response additionally require the stable
+`expected_stored_session_id`; approval response also requires the
+Hermes-issued `approval_id`.
+
+Receipts are scoped to the authenticated provider and subject. Repeating the
+same request identity with equivalent normalized semantics returns the stored
+result with `mutation.deduplicated` set to `true`. Reusing it with different
+semantics returns `mutation_conflict`. A request abandoned after execution may
+have begun is reported as `mutation_outcome_unknown` and is never executed
+again automatically. Clients can inspect a known receipt with the advertised
+`mutation.status` method.
+
+This guarantee applies only to the methods named by the capability on a
+mobile-scoped connection. Existing legacy transports retain their prior
+request shapes and behavior.
+
+## Recoverable approval lifecycle
+
+When `interaction.lifecycle` version 1 names `approval` in `kinds` and
+`approval.respond` in `response_methods`, approval requests use the
+`approval.lifecycle` version 1 schema. Each request carries a stable
+Hermes-owned `approval_id`, server-redacted presentation fields, creation and
+expiry times, current state, and resolution metadata. Pending descriptors are
+part of the authoritative synchronization snapshot and remain addressable
+after reconnect.
+
+Hermes emits `approval.request` for creation and one of `approval.resolved`,
+`approval.expired`, or `approval.stale` for a terminal transition. Every event
+and snapshot descriptor carries the same `approval_id`. A mobile response must
+name that identity, the stable conversation lineage, a choice, and a durable
+client request identity. Identical retries replay the stored mutation result;
+changed semantics conflict. Short-lived terminal tombstones distinguish
+`already_resolved`, `expired`, `stale`, and `not_found` outcomes without
+consuming another pending approval.
+
+Approval payload and resolution metadata redaction is server-owned. Mobile
+clients must not infer authorization from presentation fields: the response is
+available only when the lifecycle capability, mutation coverage,
+`conversation.control` grant, live reconciled state, and valid Hermes resource
+identities all agree. ID-less legacy desktop and stdin responses retain their
+existing FIFO behavior.

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -260,6 +260,9 @@ class QQAdapter(BasePlatformAdapter):
         # box; callers can override with set_interaction_callback(None) or
         # register a custom handler.
         self._interaction_callback = self._default_interaction_dispatch
+        # Hermes approval_id → session key. Button payloads carry only the
+        # stable identity so a delayed click cannot consume another FIFO item.
+        self._approval_state: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -1118,7 +1121,7 @@ class QQAdapter(BasePlatformAdapter):
     ) -> None:
         """Route ``INTERACTION_CREATE`` button clicks to the right subsystem.
 
-        - ``approve:<session_key>:<decision>`` →
+        - ``approve:<approval_id>:<decision>`` →
           :func:`tools.approval.resolve_gateway_approval`
           (unblocks the agent thread waiting on a dangerous-command approval).
         - ``update_prompt:<answer>`` →
@@ -1137,7 +1140,14 @@ class QQAdapter(BasePlatformAdapter):
 
         approval = parse_approval_button_data(button_data)
         if approval is not None:
-            session_key, decision = approval
+            approval_id, decision = approval
+            session_key = self._approval_state.get(approval_id)
+            if not session_key:
+                logger.info(
+                    "[%s] Approval %s is already resolved, expired, or unknown",
+                    self._log_tag, approval_id,
+                )
+                return
             choice = self._APPROVAL_BUTTON_TO_CHOICE.get(decision)
             if choice is None:
                 logger.warning(
@@ -1156,11 +1166,16 @@ class QQAdapter(BasePlatformAdapter):
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(session_key, choice)
+                count = resolve_gateway_approval(
+                    session_key,
+                    choice,
+                    approval_id=approval_id,
+                )
+                self._approval_state.pop(approval_id, None)
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s "
-                    "(choice=%s, operator=%s)",
-                    self._log_tag, count, session_key, choice,
+                    "(approval_id=%s, choice=%s, operator=%s)",
+                    self._log_tag, count, session_key, approval_id, choice,
                     event.operator_openid,
                 )
             except Exception as exc:
@@ -2648,7 +2663,7 @@ class QQAdapter(BasePlatformAdapter):
         return await self.send_with_keyboard(
             chat_id,
             build_approval_text(req),
-            build_approval_keyboard(req.session_key),
+            build_approval_keyboard(req.approval_id or req.session_key),
             reply_to=reply_to,
         )
 
@@ -2676,7 +2691,11 @@ class QQAdapter(BasePlatformAdapter):
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
-        del metadata  # QQ doesn't have thread_id / DM targeting overrides.
+        from agent.redact import redact_sensitive_text
+
+        approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
+        command = redact_sensitive_text(command, force=True)
+        description = redact_sensitive_text(description, force=True)
 
         # Use the reply-to message for passive-message context when we have one.
         # QQ requires a msg_id on outbound messages to a user we've never
@@ -2686,13 +2705,17 @@ class QQAdapter(BasePlatformAdapter):
         req = ApprovalRequest(
             session_key=session_key,
             title="Execute this command?",
+            approval_id=approval_id,
             description=description,
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )
-        return await self.send_approval_request(
+        result = await self.send_approval_request(
             chat_id, req, reply_to=msg_id,
         )
+        if result.success:
+            self._approval_state[approval_id] = session_key
+        return result
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout
 

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -20,7 +20,7 @@ This module provides:
 
 ``button_data`` formats::
 
-    approve:<session_key>:<decision>      # decision = allow-once|allow-always|deny
+    approve:<approval_id>:<decision>      # decision = allow-once|allow-always|deny
     update_prompt:<answer>                # answer = y|n
 
 Ported from WideLee's qqbot-agent-sdk v1.2.2 (``approval.py`` + ``dto.py``
@@ -41,9 +41,8 @@ logger = logging.getLogger(__name__)
 APPROVAL_BUTTON_PREFIX = "approve:"
 UPDATE_PROMPT_PREFIX = "update_prompt:"
 
-# Pattern: approve:<session_key>:<decision>
-# session_key may itself contain colons (e.g. agent:main:qqbot:c2c:OPENID),
-# so the session_key group is greedy but trails the decision.
+# Pattern: approve:<approval_id>:<decision>. The identifier group remains
+# greedy for backward-compatible parsing of previously-issued keyboards.
 _APPROVAL_DATA_RE = re.compile(
     r"^approve:(.+):(allow-once|allow-always|deny)$"
 )
@@ -159,11 +158,11 @@ class InlineKeyboard:
 # ── INTERACTION_CREATE parsing ───────────────────────────────────────
 
 def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str]]:
-    """Parse approval ``button_data`` into ``(session_key, decision)``.
+    """Parse approval ``button_data`` into ``(approval_id, decision)``.
 
     :param button_data: Raw ``data.resolved.button_data`` from
         ``INTERACTION_CREATE``.
-    :returns: ``(session_key, decision)`` or ``None`` if not an approval button.
+    :returns: ``(approval_id, decision)`` or ``None`` if not an approval button.
     """
     m = _APPROVAL_DATA_RE.match(button_data or "")
     if not m:
@@ -201,14 +200,14 @@ def _make_callback_button(
     )
 
 
-def build_approval_keyboard(session_key: str) -> InlineKeyboard:
+def build_approval_keyboard(approval_id: str) -> InlineKeyboard:
     """Build the 3-button approval keyboard.
 
     Layout: ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` — all three share
     ``group_id='approval'`` so clicking one greys out the rest.
 
-    :param session_key: Embedded into ``button_data`` so the decision
-        routes back to the right pending approval.
+    :param approval_id: Embedded into ``button_data`` so the decision targets
+        exactly one Hermes-owned pending approval.
     """
     return InlineKeyboard(
         content=KeyboardContent(
@@ -218,7 +217,7 @@ def build_approval_keyboard(session_key: str) -> InlineKeyboard:
                         btn_id="allow",
                         label="✅ 允许一次",
                         visited_label="已允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{approval_id}:allow-once",
                         style=1,
                         group_id="approval",
                     ),
@@ -226,7 +225,7 @@ def build_approval_keyboard(session_key: str) -> InlineKeyboard:
                         btn_id="always",
                         label="⭐ 始终允许",
                         visited_label="已始终允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{approval_id}:allow-always",
                         style=1,
                         group_id="approval",
                     ),
@@ -234,7 +233,7 @@ def build_approval_keyboard(session_key: str) -> InlineKeyboard:
                         btn_id="deny",
                         label="❌ 拒绝",
                         visited_label="已拒绝",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{approval_id}:deny",
                         style=0,
                         group_id="approval",
                     ),
@@ -289,6 +288,7 @@ class ApprovalRequest:
     """
     session_key: str
     title: str
+    approval_id: str = ""
     description: str = ""
     command_preview: str = ""
     cwd: str = ""
@@ -380,7 +380,7 @@ class ApprovalSender:
         :returns: ``True`` on success, ``False`` on failure.
         """
         text = build_approval_text(req)
-        keyboard = build_approval_keyboard(req.session_key)
+        keyboard = build_approval_keyboard(req.approval_id or req.session_key)
 
         logger.info(
             "[%s] Sending approval request to %s:%s (session=%.20s…)",

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -311,12 +311,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # fallback path, same as after a gateway restart).
         #   _clarify_state:        clarify_id → session_key (resolves via
         #                          tools.clarify_gateway.resolve_gateway_clarify)
-        #   _exec_approval_state:  approval_id → session_key (resolves via
-        #                          tools.approval.resolve_gateway_approval)
+        #   _exec_approval_state:  approval_id → {session_key, chat_id}
+        #                          (resolves via tools.approval)
         #   _slash_confirm_state:  confirm_id → session_key (resolves via
         #                          tools.slash_confirm.resolve)
         self._clarify_state: "OrderedDict[str, str]" = OrderedDict()
-        self._exec_approval_state: "OrderedDict[str, str]" = OrderedDict()
+        self._exec_approval_state: "OrderedDict[str, Dict[str, str]]" = OrderedDict()
         self._slash_confirm_state: "OrderedDict[str, str]" = OrderedDict()
 
         # Runtime
@@ -816,6 +816,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if self._http_client is None:
             return SendResult(success=False, error="Not connected")
 
+        from agent.redact import redact_sensitive_text
+
+        command = redact_sensitive_text(command, force=True)
+        description = redact_sensitive_text(description, force=True)
         # WhatsApp body caps at 1024 chars; reserve room for the
         # framing prose around the command.
         cmd = command or ""
@@ -826,7 +830,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             f"Reason: {description}"
         )
 
-        approval_id = uuid.uuid4().hex[:12]
+        approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
         reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
 
         interactive = {
@@ -848,7 +852,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         result = await self._post_interactive(chat_id, interactive, reply_to=reply_to)
         if result.success:
-            self._bounded_put(self._exec_approval_state, approval_id, session_key)
+            self._bounded_put(
+                self._exec_approval_state,
+                approval_id,
+                {"session_key": session_key, "chat_id": str(chat_id)},
+            )
         return result
 
     async def send_slash_confirm(
@@ -1732,18 +1740,30 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             parts = button_id.split(":", 2)
             if len(parts) != 3:
                 return False
-            _, approval_id, choice = parts
-            session_key = self._exec_approval_state.pop(approval_id, None)
-            if not session_key:
+            _, approval_id, button_choice = parts
+            approval_state = self._exec_approval_state.get(approval_id)
+            if not approval_state:
                 logger.info(
                     "[whatsapp_cloud] approval tap with no matching state "
                     "(approval_id=%s) — likely stale; falling back to text",
                     approval_id,
                 )
                 return False
-            if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
+            sender_id = str(raw_message.get("from") or "").strip()
+            expected_chat_id = str(approval_state.get("chat_id") or "").strip()
+            if not sender_id or sender_id != expected_chat_id:
+                logger.warning(
+                    "[whatsapp_cloud] rejected approval tap from unexpected "
+                    "sender (approval_id=%s)",
+                    approval_id,
+                )
+                # Consume the forged/stale button event instead of degrading
+                # it into normal user text for the agent.
+                return True
+            session_key = approval_state["session_key"]
+            if button_choice not in ("approve", "deny"):
                 return False
+            choice = "once" if button_choice == "approve" else "deny"
             try:
                 from tools.approval import resolve_gateway_approval
             except ImportError:
@@ -1751,7 +1771,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[whatsapp_cloud] approval resolver unavailable"
                 )
                 return False
-            count = resolve_gateway_approval(session_key, choice)
+            count = resolve_gateway_approval(
+                session_key,
+                choice,
+                approval_id=approval_id,
+            )
+            self._exec_approval_state.pop(approval_id, None)
             if not count:
                 logger.info(
                     "[whatsapp_cloud] approval resolver reported no waiter "
@@ -1761,7 +1786,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Send confirmation message — paralleling Telegram's UX.
             try:
                 confirm_text = (
-                    "✅ Approved." if choice == "approve" else "❌ Denied."
+                    ("✅ Approved." if choice == "once" else "❌ Denied.")
+                    if count
+                    else "⚠️ Approval is no longer pending."
                 )
                 await self.send(str(raw_message.get("from") or ""), confirm_text)
             except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18620,6 +18620,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_meta = dict(_status_thread_metadata or {})
+                approval_id = approval_data.get("approval_id")
+                if approval_id:
+                    approval_meta["approval_id"] = approval_id
 
                 # Redact credentials from the command before displaying it in
                 # the approval prompt — Tirith's findings are already redacted,
@@ -18640,7 +18644,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_meta or None,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,6 +15,7 @@ The routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -621,7 +622,9 @@ async def api_auth_ws_ticket(request: Request):
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the
-    expected pattern.
+    expected pattern. A bodyless request intentionally retains the dashboard's
+    full legacy authority. A mobile audience requests a narrower grant for one
+    WebSocket connection; it is not a persistent device credential.
     """
     sess = getattr(request.state, "session", None)
     if sess is None:
@@ -632,11 +635,58 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    body = await request.body()
+    requested = {}
+    if body:
+        try:
+            requested = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+        if not isinstance(requested, dict):
+            raise HTTPException(status_code=400, detail="Expected a JSON object")
+
+    audience = str(requested.get("audience") or "").strip()
+    if "scopes" in requested and not audience:
+        raise HTTPException(
+            status_code=400,
+            detail="audience is required when scopes are requested",
+        )
+    if audience:
+        from tui_gateway.mobile_contract import (
+            MOBILE_AUDIENCE,
+            normalize_mobile_scopes,
+        )
+
+        if audience != MOBILE_AUDIENCE:
+            raise HTTPException(status_code=400, detail="Unsupported WebSocket audience")
+        raw_scopes = requested.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise HTTPException(status_code=400, detail="scopes must be an array")
+        try:
+            granted_scopes = normalize_mobile_scopes(raw_scopes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        ticket = mint_ticket(
+            user_id=sess.user_id,
+            provider=sess.provider,
+            audience=audience,
+            scopes=granted_scopes,
+        )
+    else:
+        # Preserve the existing dashboard contract exactly for bodyless calls.
+        ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,
         user_id=sess.user_id,
         ip=_client_ip(request),
     )
-    return {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    response = {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    if audience:
+        response.update(
+            {
+                "audience": audience,
+                "granted_scopes": list(granted_scopes),
+            }
+        )
+    return response

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -646,11 +646,13 @@ async def api_auth_ws_ticket(request: Request):
             raise HTTPException(status_code=400, detail="Expected a JSON object")
 
     audience = str(requested.get("audience") or "").strip()
-    if "scopes" in requested and not audience:
-        raise HTTPException(
-            status_code=400,
-            detail="audience is required when scopes are requested",
+    if body and not audience:
+        detail = (
+            "audience is required when scopes are requested"
+            if "scopes" in requested
+            else "audience is required for a non-empty ticket request"
         )
+        raise HTTPException(status_code=400, detail=detail)
     if audience:
         from tui_gateway.mobile_contract import (
             MOBILE_AUDIENCE,

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -5,10 +5,13 @@ mode the legacy ``?token=<_SESSION_TOKEN>`` query param works because the
 token is injected into the SPA bundle. In gated mode there is no injected
 token — so this module provides two credential shapes:
 
-1. **Single-use browser tickets** (``mint_ticket`` / ``consume_ticket``).
-   The SPA gets a fresh ticket via the authenticated REST endpoint
-   ``POST /api/auth/ws-ticket`` and passes it as ``?ticket=`` on the WS
-   upgrade. Single-use, TTL = 30 seconds — a leaked ticket is uninteresting.
+1. **Single-use client tickets** (``mint_ticket`` / ``consume_ticket``).
+   The SPA gets a full-authority legacy ticket from a bodyless authenticated
+   ``POST /api/auth/ws-ticket``. A native client can request a mobile audience
+   and explicit scopes instead. Both pass ``?ticket=`` on the WS upgrade and
+   are single-use with TTL = 30 seconds. The scoped ticket narrows one socket;
+   it is not a persistent device credential or a replacement for the legacy
+   compatibility path.
 
 2. **A process-lifetime internal credential** (``internal_ws_credential`` /
    ``consume_internal_credential``). This authenticates *server-spawned*
@@ -53,13 +56,21 @@ _internal_credential: Optional[str] = None
 #: credential, so audit logs distinguish them from browser-initiated tickets.
 INTERNAL_USER_ID = "server-internal"
 INTERNAL_PROVIDER = "server-internal"
+LEGACY_AUDIENCE = "dashboard"
+LEGACY_SCOPES = ("*",)
 
 
 class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(
+    *,
+    user_id: str,
+    provider: str,
+    audience: str = LEGACY_AUDIENCE,
+    scopes: tuple[str, ...] = LEGACY_SCOPES,
+) -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -70,6 +81,8 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     info = {
         "user_id": user_id,
         "provider": provider,
+        "audience": audience,
+        "scopes": tuple(scopes),
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -132,10 +145,10 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     Unlike :func:`consume_ticket` this is **not** single-use — the value is
     not removed on success, so a server-spawned child can present it on every
     (re)connect. Returns the fixed server-internal identity ``info`` dict
-    (``{user_id, provider}``), mirroring the ``info`` shape ``consume_ticket``
-    returns, so a caller that wants to record the connecting identity can; the
-    current ``_ws_auth_ok`` caller validates for the boolean outcome only and
-    discards the dict.
+    (identity plus legacy audience/scopes), mirroring the ``info`` shape
+    ``consume_ticket`` returns so the gateway can carry one effective grant
+    shape through its transport. Non-gateway callers may validate only the
+    boolean outcome and discard the dict.
 
     A constant-time compare against the (lazily-minted) credential avoids
     leaking length / prefix information on mismatch. If no internal
@@ -150,6 +163,8 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     return {
         "user_id": INTERNAL_USER_ID,
         "provider": INTERNAL_PROVIDER,
+        "audience": LEGACY_AUDIENCE,
+        "scopes": LEGACY_SCOPES,
     }
 
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -77,12 +77,20 @@ def mint_ticket(
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
     """
+    scope_tuple = tuple(scopes)
+    if audience == "hermes.mobile":
+        from tui_gateway.mobile_contract import normalize_mobile_scopes
+
+        scope_tuple = normalize_mobile_scopes(scope_tuple)
+    elif audience != LEGACY_AUDIENCE or scope_tuple != LEGACY_SCOPES:
+        raise ValueError(f"unsupported WebSocket audience or grant: {audience}")
+
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
         "audience": audience,
-        "scopes": tuple(scopes),
+        "scopes": scope_tuple,
         "minted_at": int(time.time()),
     }
     with _lock:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14442,8 +14442,10 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_result(
+    ws: "WebSocket",
+) -> tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Validate WS-upgrade auth and return its effective authorization grant.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -14451,15 +14453,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``authorization`` is the server-derived grant carried by an accepted
+    credential; it is ``None`` for every rejected request.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
 
     Gated (public bind, no ``--insecure``): one of two credentials —
 
-    * ``?ticket=<single-use>`` — a browser-minted, single-use, 30s-TTL ticket
-      consumed against the dashboard-auth ticket store. This is what the SPA
-      (and native clients) use.
+    * ``?ticket=<single-use>`` — a client-minted, single-use, 30s-TTL ticket
+      consumed against the dashboard-auth ticket store. The bodyless SPA flow
+      retains legacy dashboard authority. A native mobile ticket is restricted
+      to ``/api/ws`` and carries explicit scopes into its dispatcher.
     * ``?internal=<process-credential>`` — the process-lifetime internal
       credential, used only by WS clients the server spawns itself (the
       embedded-TUI PTY child attaching to ``/api/ws`` and ``/api/pub``). It
@@ -14491,8 +14496,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                grant = consume_internal_credential(internal)
+                return None, "internal", grant
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14500,15 +14505,26 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            grant = consume_ticket(ticket)
+            if (
+                grant.get("audience") == "hermes.mobile"
+                and ws.url.path != "/api/ws"
+            ):
+                audit_log(
+                    AuditEvent.WS_TICKET_REJECTED,
+                    reason="mobile ticket used outside /api/ws",
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return "ticket_audience_mismatch", "ticket", None
+            return None, "ticket", grant
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14516,14 +14532,29 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return (
+            None,
+            "token",
+            {
+                "user_id": "loopback",
+                "provider": "loopback",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            },
+        )
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Compatibility view of :func:`_ws_auth_result` for non-gateway sockets."""
+    reason, credential, _authorization = _ws_auth_result(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -15613,7 +15644,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, authorization = _ws_auth_result(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -15623,7 +15655,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, authorization=authorization)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -21,6 +21,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import uuid
 from collections import defaultdict
 from contextlib import suppress
 from typing import Callable, Dict, List, Optional, Any, Tuple
@@ -5582,6 +5583,11 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from agent.redact import redact_sensitive_text
+
+            command = redact_sensitive_text(command, force=True)
+            description = redact_sensitive_text(description, force=True)
+            approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
             # Resolve channel — use thread_id from metadata if present
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
@@ -5638,6 +5644,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             view = ExecApprovalView(
                 session_key=session_key,
+                approval_id=approval_id,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
@@ -6836,9 +6843,11 @@ def _define_discord_view_classes() -> None:
             allowed_role_ids: Optional[set] = None,
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
+            approval_id: Optional[str] = None,
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
+            self.approval_id = str(approval_id or uuid.uuid4().hex)
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             # Opt-in admin gate for exec approval (default off → user-scope,
@@ -6900,7 +6909,32 @@ def _define_discord_view_classes() -> None:
                 )
                 return
 
+            # Resolve the Hermes-owned identity before committing the UI. If
+            # the resolver itself fails, leave the buttons retryable.
+            try:
+                from tools.approval import resolve_gateway_approval
+                count = resolve_gateway_approval(
+                    self.session_key,
+                    choice,
+                    approval_id=self.approval_id,
+                )
+                logger.info(
+                    "Discord button resolved %d approval(s) for session %s "
+                    "(approval_id=%s, choice=%s, user=%s)",
+                    count, self.session_key, self.approval_id, choice,
+                    interaction.user.display_name,
+                )
+            except Exception as exc:
+                logger.error("Failed to resolve gateway approval from button: %s", exc)
+                await interaction.response.send_message(
+                    "Approval resolution failed. Please retry~", ephemeral=True
+                )
+                return
+
             self.resolved = True
+            if not count:
+                color = discord.Color.greyple()
+                label = "Approval is no longer pending"
 
             # Update the embed with the decision
             embed = interaction.message.embeds[0] if interaction.message.embeds else None
@@ -6913,17 +6947,6 @@ def _define_discord_view_classes() -> None:
                 child.disabled = True
 
             await interaction.response.edit_message(embed=embed, view=self)
-
-            # Unblock the waiting agent thread via the gateway approval queue
-            try:
-                from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
-                logger.info(
-                    "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                    count, self.session_key, choice, interaction.user.display_name,
-                )
-            except Exception as exc:
-                logger.error("Failed to resolve gateway approval from button: %s", exc)
 
         @discord.ui.button(label="Allow Once", style=discord.ButtonStyle.green)
         async def allow_once(

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1490,8 +1490,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
-        self._approval_state: Dict[int, Dict[str, str]] = {}
-        self._approval_counter = itertools.count(1)
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
@@ -1991,7 +1990,11 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            approval_id = next(self._approval_counter)
+            from agent.redact import redact_sensitive_text
+
+            command = redact_sensitive_text(command, force=True)
+            description = redact_sensitive_text(description, force=True)
+            approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
             cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
@@ -2040,6 +2043,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "approval_id": approval_id,
                 }
             return result
         except Exception as exc:
@@ -2129,6 +2133,26 @@ class FeishuAdapter(BasePlatformAdapter):
                 {
                     "tag": "markdown",
                     "content": f"{icon} **{label}** by {user_name}",
+                },
+            ],
+        }
+
+    @staticmethod
+    def _build_unavailable_approval_card() -> Dict[str, Any]:
+        """Build a truthful terminal card for late or duplicate decisions."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {
+                    "content": "⚠️ Approval no longer pending",
+                    "tag": "plain_text",
+                },
+                "template": "grey",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "This approval was already resolved or expired.",
                 },
             ],
         }
@@ -2634,9 +2658,9 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_card_action_trigger(self, data: Any) -> Any:
         """Handle card-action callback from the Feishu SDK (synchronous).
 
-        For approval actions: parses the event once, returns the resolved card
-        inline (the only reliable way to sync all clients), and schedules a
-        lightweight async method to actually unblock the agent.
+        For approval actions: parses and resolves the event synchronously,
+        then returns the authoritative terminal card inline (the only reliable
+        way to sync all clients).
 
         For other card actions: delegates to ``_handle_card_action_event``.
         """
@@ -2655,7 +2679,10 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
         if hermes_action:
-            return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
+            return self._handle_approval_card_action(
+                event=event,
+                action_value=action_value,
+            )
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
                 event=event,
@@ -2697,10 +2724,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return True
         return "*" in allowed_ids or normalized in allowed_ids
 
-    def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
-        """Schedule approval resolution and build the synchronous callback response."""
-        approval_id = action_value.get("approval_id")
-        if approval_id is None:
+    def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any]) -> Any:
+        """Resolve an approval and build the synchronous callback response."""
+        approval_id = str(action_value.get("approval_id") or "")
+        if not approval_id:
             logger.debug("[Feishu] Card action missing approval_id, ignoring")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
         state = self._approval_state.get(approval_id)
@@ -2728,20 +2755,37 @@ class FeishuAdapter(BasePlatformAdapter):
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
         user_name = self._get_cached_sender_name(open_id) or open_id
-
-        chat_context = getattr(event, "context", None)
-        chat_id = str(getattr(chat_context, "open_chat_id", "") or "")
-        if not self._submit_on_loop(
-            loop,
-            self._resolve_approval(
-                approval_id=approval_id,
-                choice=choice,
-                user_name=user_name,
-                open_id=open_id,
-                chat_id=chat_id,
-            ),
-        ):
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning(
+                "[Feishu] Unauthorized approval click by %s for approval %s",
+                open_id or "<unknown>",
+                approval_id,
+            )
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        # The core resolver is synchronous and lock-bounded, so resolve here
+        # before returning Feishu's inline replacement card. This ensures a
+        # late or losing concurrent tap cannot be rendered as approved.
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(
+                state["session_key"],
+                choice,
+                approval_id=approval_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to resolve gateway approval from Feishu button: %s",
+                exc,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        self._approval_state.pop(approval_id, None)
+        logger.info(
+            "Feishu button resolved %d approval(s) for session %s "
+            "(approval_id=%s, choice=%s, user=%s)",
+            count, state["session_key"], approval_id, choice, user_name,
+        )
 
         if P2CardActionTriggerResponse is None:
             return None
@@ -2749,7 +2793,14 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = (
+                self._build_resolved_approval_card(
+                    choice=choice,
+                    user_name=user_name,
+                )
+                if count
+                else self._build_unavailable_approval_card()
+            )
             response.card = card
         return response
 
@@ -2834,16 +2885,18 @@ class FeishuAdapter(BasePlatformAdapter):
                 approval_id, expected_chat_id, chat_id,
             )
             return
-        state = self._approval_state.pop(approval_id, None)
-        if not state:
-            logger.debug("[Feishu] Approval %s already resolved while validating callback", approval_id)
-            return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            count = resolve_gateway_approval(
+                state["session_key"],
+                choice,
+                approval_id=approval_id,
+            )
+            self._approval_state.pop(approval_id, None)
             logger.info(
-                "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                count, state["session_key"], choice, user_name,
+                "Feishu button resolved %d approval(s) for session %s "
+                "(approval_id=%s, choice=%s, user=%s)",
+                count, state["session_key"], approval_id, choice, user_name,
             )
         except Exception as exc:
             logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -56,6 +56,7 @@ import logging
 import mimetypes
 import os
 import re
+import uuid
 import time
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
@@ -309,11 +310,13 @@ class _MatrixApprovalPrompt:
         session_key: str,
         chat_id: str,
         message_id: str,
+        approval_id: str | None = None,
         resolved: bool = False,
         requester_user_id: str | None = None,
         expires_at: float | None = None,
     ):
         self.session_key = session_key
+        self.approval_id = str(approval_id or uuid.uuid4().hex)
         self.chat_id = chat_id
         self.message_id = message_id
         self.resolved = resolved
@@ -2005,6 +2008,11 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        from agent.redact import redact_sensitive_text
+
+        command = redact_sensitive_text(command, force=True)
+        description = redact_sensitive_text(description, force=True)
+        approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
         text = (
@@ -2026,12 +2034,10 @@ class MatrixAdapter(BasePlatformAdapter):
             session_key=session_key,
             chat_id=chat_id,
             message_id=result.message_id,
+            approval_id=approval_id,
             requester_user_id=requester_user_id,
             expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
         )
-        old_event = self._approval_prompt_by_session.get(session_key)
-        if old_event:
-            self._approval_prompts_by_event.pop(old_event, None)
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
@@ -3265,18 +3271,27 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import resolve_gateway_approval
 
-                    count = resolve_gateway_approval(prompt.session_key, choice)
+                    count = resolve_gateway_approval(
+                        prompt.session_key,
+                        choice,
+                        approval_id=prompt.approval_id,
+                    )
                     if count:
                         prompt.resolved = True
                         self._approval_prompts_by_event.pop(reacts_to, None)
-                        self._approval_prompt_by_session.pop(prompt.session_key, None)
+                        if self._approval_prompt_by_session.get(prompt.session_key) == reacts_to:
+                            self._approval_prompt_by_session.pop(prompt.session_key, None)
                         logger.info(
                             "Matrix reaction resolved %d approval(s) for session %s "
-                            "(choice=%s, user=%s)",
-                            count, prompt.session_key, choice, sender,
+                            "(approval_id=%s, choice=%s, user=%s)",
+                            count, prompt.session_key, prompt.approval_id, choice, sender,
                         )
                         # Redact bot's seed reactions, leaving only the user's
                         await self._redact_bot_approval_reactions(room_id, prompt)
+                    else:
+                        await self._expire_matrix_approval_prompt(
+                            room_id, reacts_to, prompt
+                        )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Matrix reaction: %s", exc)
                 return
@@ -3384,7 +3399,8 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         prompt.resolved = True
         self._approval_prompts_by_event.pop(target_event_id, None)
-        self._approval_prompt_by_session.pop(prompt.session_key, None)
+        if self._approval_prompt_by_session.get(prompt.session_key) == target_event_id:
+            self._approval_prompt_by_session.pop(prompt.session_key, None)
         await self._redact_bot_approval_reactions(room_id, prompt)
         await self._send_invalid_reaction_feedback(
             room_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -452,6 +453,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        # Hermes approval_id → session metadata.  Button values never carry a
+        # session key, so one delayed click cannot consume another FIFO item.
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -3254,7 +3258,12 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from agent.redact import redact_sensitive_text
+
+            command = redact_sensitive_text(command, force=True)
+            description = redact_sensitive_text(description, force=True)
             thread_ts = self._resolve_thread_ts(None, metadata)
+            approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
 
             # Slack hard-caps a section block's text at 3000 chars; an
             # oversized block fails the whole send with ``invalid_blocks``
@@ -3284,26 +3293,26 @@ class SlackAdapter(BasePlatformAdapter):
                             "text": {"type": "plain_text", "text": "Allow Once"},
                             "style": "primary",
                             "action_id": "hermes_approve_once",
-                            "value": session_key,
+                            "value": approval_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Allow Session"},
                             "action_id": "hermes_approve_session",
-                            "value": session_key,
+                            "value": approval_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Always Allow"},
                             "action_id": "hermes_approve_always",
-                            "value": session_key,
+                            "value": approval_id,
                         },
                         {
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Deny"},
                             "style": "danger",
                             "action_id": "hermes_deny",
-                            "value": session_key,
+                            "value": approval_id,
                         },
                     ],
                 },
@@ -3321,6 +3330,7 @@ class SlackAdapter(BasePlatformAdapter):
             msg_ts = result.get("ts", "")
             if msg_ts:
                 self._approval_resolved[msg_ts] = False
+                self._approval_state[approval_id] = {"session_key": session_key}
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
@@ -3575,7 +3585,7 @@ class SlackAdapter(BasePlatformAdapter):
         await ack()
 
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        approval_id = str(action.get("value", "") or "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -3592,6 +3602,15 @@ class SlackAdapter(BasePlatformAdapter):
                 user_name, user_id,
             )
             return
+
+        approval_state = self._approval_state.get(approval_id)
+        if approval_state is None:
+            logger.info(
+                "Slack approval %s is already resolved, expired, or unknown",
+                approval_id,
+            )
+            return
+        session_key = approval_state["session_key"]
 
         # Only authorized users may click approval buttons.  Button clicks
         # bypass the normal message auth flow in gateway/run.py, so we must
@@ -3620,14 +3639,46 @@ class SlackAdapter(BasePlatformAdapter):
         if self._approval_resolved.pop(msg_ts, True):
             return
 
-        # Update the message to show the decision and remove buttons
+        # Resolve the exact approval before updating the message.  A late
+        # callback must never fall back to the session's oldest FIFO entry.
+        count = 0
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(
+                session_key,
+                choice,
+                approval_id=approval_id,
+            )
+            logger.info(
+                "Slack button resolved %d approval(s) for session %s "
+                "(approval_id=%s, choice=%s, user=%s)",
+                count,
+                session_key,
+                approval_id,
+                choice,
+                user_name,
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to resolve gateway approval from Slack button: %s", exc
+            )
+            self._approval_resolved[msg_ts] = False
+            return
+        self._approval_state.pop(approval_id, None)
+
+        # Update the message to show the decision and remove buttons.
         label_map = {
             "once": f"✅ Approved once by {user_name}",
             "session": f"✅ Approved for session by {user_name}",
             "always": f"✅ Approved permanently by {user_name}",
             "deny": f"❌ Denied by {user_name}",
         }
-        decision_text = label_map.get(choice, f"Resolved by {user_name}")
+        decision_text = (
+            label_map.get(choice, f"Resolved by {user_name}")
+            if count
+            else "⚠️ Approval is no longer pending"
+        )
 
         # Get original text from the section block
         original_text = ""
@@ -3662,24 +3713,7 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[Slack] Failed to update approval message: %s", e)
 
-        # Resolve the approval — this unblocks the agent thread
-        try:
-            from tools.approval import resolve_gateway_approval
-
-            count = resolve_gateway_approval(session_key, choice)
-            logger.info(
-                "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                count,
-                session_key,
-                choice,
-                user_name,
-            )
-        except Exception as exc:
-            logger.error(
-                "Failed to resolve gateway approval from Slack button: %s", exc
-            )
-
-        # (approval state already consumed by atomic pop above)
+        # (approval state already consumed above)
 
     # ----- Thread context fetching -----
 

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,6 +27,7 @@ import html
 import json
 import logging
 import os
+import uuid
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
@@ -711,6 +712,9 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Hermes approval_id → server-owned prompt/session data. Adaptive Card
+        # actions carry only the opaque ID, never a mutable session key.
+        self._approval_state: Dict[str, Dict[str, str]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -1000,18 +1004,29 @@ class TeamsAdapter(BasePlatformAdapter):
         self, ctx: "ActivityContext[AdaptiveCardInvokeActivity]"
     ) -> "InvokeResponse[AdaptiveCardActionMessageResponse]":
         """Handle an Adaptive Card Action.Execute button click."""
-        from tools.approval import resolve_gateway_approval, has_blocking_approval
+        from tools.approval import resolve_gateway_approval
 
         action = ctx.activity.value.action
         data = action.data or {}
         hermes_action = data.get("hermes_action", "")
-        session_key = data.get("session_key", "")
+        approval_id = str(data.get("approval_id") or "")
+        approval_state = self._approval_state.get(approval_id)
 
-        if not hermes_action or not session_key:
+        if not hermes_action or not approval_id:
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
             )
+        if not approval_state:
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionCardResponse(
+                    value=AdaptiveCard()
+                    .with_version("1.4")
+                    .with_body([TextBlock(text="⚠️ Approval already resolved or expired.", wrap=True)])
+                ),
+            )
+        session_key = approval_state["session_key"]
 
         # Only authorized users may click approval buttons.
         # Default-deny: require either TEAMS_ALLOWED_USERS or an explicit
@@ -1056,7 +1071,13 @@ class TeamsAdapter(BasePlatformAdapter):
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
             )
 
-        if not has_blocking_approval(session_key):
+        count = resolve_gateway_approval(
+            session_key,
+            choice,
+            approval_id=approval_id,
+        )
+        self._approval_state.pop(approval_id, None)
+        if not count:
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionCardResponse(
@@ -1066,16 +1087,14 @@ class TeamsAdapter(BasePlatformAdapter):
                 ),
             )
 
-        resolve_gateway_approval(session_key, choice)
-
         label_map = {
             "once": "✅ Allowed (once)",
             "session": "✅ Allowed (session)",
             "always": "✅ Always allowed",
             "deny": "❌ Denied",
         }
-        cmd = data.get("cmd", "")
-        desc = data.get("desc", "")
+        cmd = approval_state.get("cmd", "")
+        desc = approval_state.get("desc", "")
         body = []
         if cmd:
             body.append(TextBlock(text="⚠️ Command Approval Required", wrap=True, weight="Bolder"))
@@ -1103,13 +1122,13 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
 
+        from agent.redact import redact_sensitive_text
+
+        command = redact_sensitive_text(command, force=True)
+        description = redact_sensitive_text(description, force=True)
+        approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
-        # Truncated for button data payload — just enough to reconstruct the card body.
-        btn_data_base = {
-            "session_key": session_key,
-            "cmd": command[:200] + "..." if len(command) > 200 else command,
-            "desc": description,
-        }
+        btn_data_base = {"approval_id": approval_id}
 
         card = (
             AdaptiveCard()
@@ -1148,6 +1167,11 @@ class TeamsAdapter(BasePlatformAdapter):
         try:
             result = await self._send_card(chat_id, card)
             message_id = getattr(result, "id", None) if result else None
+            self._approval_state[approval_id] = {
+                "session_key": session_key,
+                "cmd": command[:200] + "..." if len(command) > 200 else command,
+                "desc": description,
+            }
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[teams] send_exec_approval failed: %s", e, exc_info=True)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,7 @@ import os
 import html as _html
 import re
 import threading
+import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -643,8 +644,9 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        # Hermes approval_id → session metadata.  Callback data never embeds a
+        # session key, so late clicks cannot consume a different FIFO request.
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -4578,6 +4580,10 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from agent.redact import redact_sensitive_text
+
+            command = redact_sensitive_text(command, force=True)
+            description = redact_sensitive_text(description, force=True)
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
@@ -4588,13 +4594,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
-            # We'll use the message_id as part of callback_data to look up session_key
-            # Send a placeholder first, then update — or use a counter.
-            # Simpler: use a monotonic counter to generate short IDs.
-            import itertools
-            if not hasattr(self, "_approval_counter"):
-                self._approval_counter = itertools.count(1)
-            approval_id = next(self._approval_counter)
+            approval_id = str((metadata or {}).get("approval_id") or uuid.uuid4().hex)
 
             keyboard = InlineKeyboardMarkup([
                 [
@@ -4628,8 +4628,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            self._approval_state[approval_id] = {"session_key": session_key}
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -5352,9 +5351,8 @@ class TelegramAdapter(BasePlatformAdapter):
             parts = data.split(":", 2)
             if len(parts) == 3:
                 choice = parts[1]  # once, session, always, deny
-                try:
-                    approval_id = int(parts[2])
-                except (ValueError, IndexError):
+                approval_id = parts[2].strip()
+                if not approval_id:
                     await query.answer(text="Invalid approval data.")
                     return
 
@@ -5370,9 +5368,34 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
-                if not session_key:
+                approval_state = self._approval_state.get(approval_id)
+                if not approval_state:
                     await query.answer(text="This approval has already been resolved.")
+                    return
+                session_key = approval_state["session_key"]
+
+                # Resolve the exact approval before changing the UI.  A late
+                # callback must never fall back to the oldest session entry.
+                try:
+                    from tools.approval import resolve_gateway_approval
+                    count = resolve_gateway_approval(
+                        session_key,
+                        choice,
+                        approval_id=approval_id,
+                    )
+                    self._approval_state.pop(approval_id, None)
+                    logger.info(
+                        "Telegram button resolved %d approval(s) for session %s "
+                        "(approval_id=%s, choice=%s, user=%s)",
+                        count, session_key, approval_id, choice,
+                        getattr(query.from_user, "first_name", "User"),
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Failed to resolve gateway approval from Telegram button: %s",
+                        exc,
+                    )
+                    await query.answer(text="Approval resolution failed. Please retry.")
                     return
 
                 # Map choice to human-readable label
@@ -5383,7 +5406,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     "deny": "❌ Denied",
                 }
                 user_display = getattr(query.from_user, "first_name", "User")
-                label = label_map.get(choice, "Resolved")
+                label = (
+                    label_map.get(choice, "Resolved")
+                    if count
+                    else "⚠️ Approval is no longer pending"
+                )
 
                 await query.answer(text=label)
 
@@ -5396,18 +5423,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception:
                     pass  # non-fatal if edit fails
-
-                # Resolve the approval — unblocks the agent thread
-                try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
-                    )
-                except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
-                    count = 0
 
                 # Resume the typing indicator — paused when the approval was
                 # sent (gateway/run.py).  The text /approve and /deny paths

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -175,6 +175,30 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_mobile_mutation_receipt_tags_bind_exactly_one_user_turn():
+    agent = _FakeAgent()
+    agent._pending_mobile_mutation_receipt_tags = ["proof-a", "proof-b"]
+
+    def persist(messages, *_args, **_kwargs):
+        messages[-1]["_db_persisted"] = True
+
+    agent._persist_session = persist
+
+    tagged = _build(agent)
+    following = _build(agent, user_message="later")
+
+    assert tagged.messages[-1]["_mobile_mutation_receipt_tags"] == [
+        "proof-a",
+        "proof-b",
+    ]
+    assert "_mobile_mutation_receipt_tags" not in following.messages[-1]
+    assert agent._pending_mobile_mutation_receipt_tags == []
+    assert agent._durable_mobile_mutation_receipt_tags == {
+        "proof-a",
+        "proof-b",
+    }
+
+
 def test_applies_agent_side_effects():
     agent = _FakeAgent()
     _build(agent)
@@ -363,4 +387,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -122,6 +122,46 @@ class TestApprovalCommandWiring:
 
         self._assert_redacts_then_uses(run, "_approval_notify_sync", "send_exec_approval")
 
+    def test_chat_platform_path_forwards_core_approval_identity(self):
+        """The notify bridge must not make adapters mint an unrelated ID."""
+        import ast
+        import inspect
+        import gateway.run as run
+
+        tree = ast.parse(inspect.getsource(run))
+        target_fn = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_approval_notify_sync"
+        )
+        reads_core_id = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "approval_data"
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "approval_id"
+            for node in ast.walk(target_fn)
+        )
+        writes_metadata_id = any(
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "approval_meta"
+                and isinstance(target.slice, ast.Constant)
+                and target.slice.value == "approval_id"
+                for target in node.targets
+            )
+            for node in ast.walk(target_fn)
+        )
+
+        assert reads_core_id
+        assert writes_metadata_id
+
     def test_sse_api_path_redacts_before_enqueue(self):
         from gateway.platforms import api_server
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -70,6 +70,7 @@ def _clear_approval_state():
     """Reset all module-level approval state between tests."""
     from tools import approval as mod
     mod._gateway_queues.clear()
+    mod._gateway_tombstones.clear()
     mod._gateway_notify_cbs.clear()
     mod._session_approved.clear()
     mod._permanent_approved.clear()
@@ -154,6 +155,32 @@ class TestBlockingGatewayApproval:
         assert e1.result == "once"
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
+
+    def test_resolve_specific_approval_id(self):
+        """Interactive buttons should resolve the intended queued approval."""
+        from tools.approval import (
+            resolve_gateway_approval, pending_approval_count,
+            _ApprovalEntry, _gateway_queues,
+        )
+        session_key = "test-targeted"
+        e1 = _ApprovalEntry(
+            {"command": "first"}, approval_id="approval-first"
+        )
+        e2 = _ApprovalEntry(
+            {"command": "second"}, approval_id="approval-second"
+        )
+        _gateway_queues[session_key] = [e1, e2]
+
+        count = resolve_gateway_approval(
+            session_key,
+            "deny",
+            approval_id="approval-second",
+        )
+        assert count == 1
+        assert not e1.event.is_set()
+        assert e2.event.is_set()
+        assert e2.result == "deny"
+        assert pending_approval_count(session_key) == 1
 
     def test_unregister_signals_all_entries(self):
         """unregister_gateway_notify signals all waiting entries to prevent hangs."""

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -13,6 +13,7 @@ handling, and fail-closed behavior so the parity cannot regress.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -224,6 +225,34 @@ def test_exec_approval_view_role_default_is_empty_set():
     assert view.allowed_role_ids == set()
     assert view._check_auth(_interaction(11111)) is True
     assert view._check_auth(_interaction(99999)) is False
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_view_resolves_exact_core_identity():
+    view = ExecApprovalView(
+        session_key="sess-1",
+        approval_id="approval-from-core",
+        allowed_user_ids={"11111"},
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=11111, roles=[], display_name="Owner"),
+        message=SimpleNamespace(embeds=[]),
+        response=SimpleNamespace(
+            send_message=AsyncMock(),
+            edit_message=AsyncMock(),
+        ),
+    )
+
+    with patch(
+        "tools.approval.resolve_gateway_approval", return_value=1
+    ) as mock_resolve:
+        await view._resolve(interaction, "once", object(), "Approved once")
+
+    mock_resolve.assert_called_once_with(
+        "sess-1",
+        "once",
+        approval_id="approval-from-core",
+    )
 
 
 def test_slash_confirm_view_accepts_role_allowlist():
@@ -462,4 +491,3 @@ def test_other_views_not_admin_gated():
         session_key="s", confirm_id="c", allowed_user_ids={"11111"}
     )
     assert sc._check_auth(_interaction(11111)) is True
-

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -66,3 +66,23 @@ async def test_exec_approval_prompt_truncates_long_command_in_content():
     assert "... [truncated]" in sent["content"]
     assert "long generated shell command" in sent["content"]
     assert len(sent["embed"].description) > len(sent["content"])
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_uses_core_id_and_force_redacts_prompt():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+    secret = "sk-proj-" + "D" * 40
+
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command=f"echo {secret}",
+        session_key="discord:555",
+        description=f"reason {secret}",
+        metadata={"approval_id": "approval-from-core"},
+    )
+
+    assert result.success is True
+    assert secret not in sent["content"]
+    assert secret not in sent["embed"].description
+    assert sent["view"].approval_id == "approval-from-core"

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -127,6 +127,10 @@ class TestFeishuExecApproval:
         assert action_names == [
             "approve_once", "approve_session", "approve_always", "deny"
         ]
+        approval_ids = {a["value"]["approval_id"] for a in actions}
+        assert len(approval_ids) == 1
+        approval_id = approval_ids.pop()
+        assert adapter._approval_state[approval_id]["session_key"] == "agent:main:feishu:group:oc_12345"
 
     @pytest.mark.asyncio
     async def test_stores_approval_state(self):
@@ -161,6 +165,36 @@ class TestFeishuExecApproval:
             chat_id="oc_12345", command="ls", session_key="s"
         )
         assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_uses_core_approval_id_and_force_redacts_prompt(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_secret"),
+        )
+        secret = "sk-proj-" + "F" * 40
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command=f"echo {secret}",
+                session_key="session-secret",
+                description=f"reason {secret}",
+                metadata={"approval_id": "approval-from-core"},
+            )
+
+        card = json.loads(mock_send.call_args.kwargs["payload"])
+        assert secret not in repr(card)
+        assert {
+            action["value"]["approval_id"]
+            for action in card["elements"][1]["actions"]
+        } == {"approval-from-core"}
 
     @pytest.mark.asyncio
     async def test_truncates_long_command(self):
@@ -313,66 +347,80 @@ class TestResolveApproval:
     @pytest.mark.asyncio
     async def test_resolves_once(self):
         adapter = _make_adapter()
-        adapter._approval_state[1] = {
+        adapter._approval_state["req-1"] = {
             "session_key": "agent:main:feishu:group:oc_12345",
             "message_id": "msg_001",
             "chat_id": "oc_12345",
+            "approval_id": "req-1",
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(1, "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
+            await adapter._resolve_approval("req-1", "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
 
-        mock_resolve.assert_called_once_with("agent:main:feishu:group:oc_12345", "once")
-        assert 1 not in adapter._approval_state
+        mock_resolve.assert_called_once_with(
+            "agent:main:feishu:group:oc_12345",
+            "once",
+            approval_id="req-1",
+        )
+        assert "req-1" not in adapter._approval_state
 
     @pytest.mark.asyncio
     async def test_resolves_deny(self):
         adapter = _make_adapter()
-        adapter._approval_state[2] = {
+        adapter._approval_state["req-2"] = {
             "session_key": "some-session",
             "message_id": "msg_002",
             "chat_id": "oc_12345",
+            "approval_id": "req-2",
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(2, "deny", "Alice", open_id="ou_user1", chat_id="oc_12345")
+            await adapter._resolve_approval("req-2", "deny", "Alice", open_id="ou_user1", chat_id="oc_12345")
 
-        mock_resolve.assert_called_once_with("some-session", "deny")
+        mock_resolve.assert_called_once_with(
+            "some-session", "deny", approval_id="req-2"
+        )
 
     @pytest.mark.asyncio
     async def test_resolves_session(self):
         adapter = _make_adapter()
-        adapter._approval_state[3] = {
+        adapter._approval_state["req-3"] = {
             "session_key": "sess-3",
             "message_id": "msg_003",
             "chat_id": "oc_99",
+            "approval_id": "req-3",
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(3, "session", "Bob", open_id="ou_user1", chat_id="oc_99")
+            await adapter._resolve_approval("req-3", "session", "Bob", open_id="ou_user1", chat_id="oc_99")
 
-        mock_resolve.assert_called_once_with("sess-3", "session")
+        mock_resolve.assert_called_once_with(
+            "sess-3", "session", approval_id="req-3"
+        )
 
     @pytest.mark.asyncio
     async def test_resolves_always(self):
         adapter = _make_adapter()
-        adapter._approval_state[4] = {
+        adapter._approval_state["req-4"] = {
             "session_key": "sess-4",
             "message_id": "msg_004",
             "chat_id": "oc_55",
+            "approval_id": "req-4",
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(4, "always", "Carol", open_id="ou_user1", chat_id="oc_55")
+            await adapter._resolve_approval("req-4", "always", "Carol", open_id="ou_user1", chat_id="oc_55")
 
-        mock_resolve.assert_called_once_with("sess-4", "always")
+        mock_resolve.assert_called_once_with(
+            "sess-4", "always", approval_id="req-4"
+        )
 
     @pytest.mark.asyncio
     async def test_already_resolved_drops_silently(self):
         adapter = _make_adapter()
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
-            await adapter._resolve_approval(99, "once", "Nobody", open_id="ou_user1", chat_id="oc_12345")
+            await adapter._resolve_approval("approval-missing", "once", "Nobody", open_id="ou_user1", chat_id="oc_12345")
 
         mock_resolve.assert_not_called()
 
@@ -380,32 +428,32 @@ class TestResolveApproval:
     async def test_unauthorized_click_does_not_resolve(self):
         adapter = _make_adapter()
         adapter._admins = {"ou_admin"}
-        adapter._approval_state[5] = {
+        adapter._approval_state["approval-5"] = {
             "session_key": "sess-5",
             "message_id": "msg_005",
             "chat_id": "oc_12345",
         }
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
-            await adapter._resolve_approval(5, "once", "Mallory", open_id="ou_intruder", chat_id="oc_12345")
+            await adapter._resolve_approval("approval-5", "once", "Mallory", open_id="ou_intruder", chat_id="oc_12345")
 
         mock_resolve.assert_not_called()
-        assert 5 in adapter._approval_state
+        assert "approval-5" in adapter._approval_state
 
     @pytest.mark.asyncio
     async def test_chat_mismatch_does_not_resolve(self):
         adapter = _make_adapter()
-        adapter._approval_state[6] = {
+        adapter._approval_state["approval-6"] = {
             "session_key": "sess-6",
             "message_id": "msg_006",
             "chat_id": "oc_expected",
         }
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
-            await adapter._resolve_approval(6, "session", "Norbert", open_id="ou_user1", chat_id="oc_wrong")
+            await adapter._resolve_approval("approval-6", "session", "Norbert", open_id="ou_user1", chat_id="oc_wrong")
 
         mock_resolve.assert_not_called()
-        assert 6 in adapter._approval_state
+        assert "approval-6" in adapter._approval_state
 
 # ===========================================================================
 # _handle_card_action_event — non-approval card actions
@@ -466,7 +514,7 @@ class TestCardActionCallbackResponse:
     def test_drops_action_when_loop_not_ready(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = None
-        data = _make_card_action_data({"hermes_action": "approve_once", "approval_id": 1})
+        data = _make_card_action_data({"hermes_action": "approve_once", "approval_id": "approval-1"})
 
         with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
             response = adapter._on_card_action_trigger(data)
@@ -480,18 +528,21 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_bob"}
-        adapter._approval_state[1] = {
+        adapter._approval_state["approval-1"] = {
             "session_key": "sess-1",
             "message_id": "msg-1",
             "chat_id": "oc_12345",
         }
         data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 1},
+            {"hermes_action": "approve_once", "approval_id": "approval-1"},
             open_id="ou_bob",
         )
         adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+        with (
+            patch("tools.approval.resolve_gateway_approval", return_value=1),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro),
+        ):
             response = adapter._on_card_action_trigger(data)
 
         assert response is not None
@@ -507,16 +558,19 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_user1"}
-        adapter._approval_state[2] = {
+        adapter._approval_state["approval-2"] = {
             "session_key": "sess-2",
             "message_id": "msg-2",
             "chat_id": "oc_12345",
         }
         data = _make_card_action_data(
-            {"hermes_action": "deny", "approval_id": 2},
+            {"hermes_action": "deny", "approval_id": "approval-2"},
         )
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+        with (
+            patch("tools.approval.resolve_gateway_approval", return_value=1),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro),
+        ):
             response = adapter._on_card_action_trigger(data)
 
         assert response.card is not None
@@ -554,17 +608,20 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_unknown"}
-        adapter._approval_state[3] = {
+        adapter._approval_state["approval-3"] = {
             "session_key": "sess-3",
             "message_id": "msg-3",
             "chat_id": "oc_12345",
         }
         data = _make_card_action_data(
-            {"hermes_action": "approve_session", "approval_id": 3},
+            {"hermes_action": "approve_session", "approval_id": "approval-3"},
             open_id="ou_unknown",
         )
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+        with (
+            patch("tools.approval.resolve_gateway_approval", return_value=1),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro),
+        ):
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
@@ -575,18 +632,21 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_expired"}
-        adapter._approval_state[4] = {
+        adapter._approval_state["approval-4"] = {
             "session_key": "sess-4",
             "message_id": "msg-4",
             "chat_id": "oc_12345",
         }
         data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 4},
+            {"hermes_action": "approve_once", "approval_id": "approval-4"},
             open_id="ou_expired",
         )
         adapter._sender_name_cache["ou_expired"] = ("Old Name", 1)
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+        with (
+            patch("tools.approval.resolve_gateway_approval", return_value=1),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro),
+        ):
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
@@ -598,13 +658,13 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_allowed"}
-        adapter._approval_state[5] = {
+        adapter._approval_state["approval-5"] = {
             "session_key": "sess-5",
             "message_id": "msg-5",
             "chat_id": "oc_12345",
         }
         data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 5},
+            {"hermes_action": "approve_once", "approval_id": "approval-5"},
             open_id="ou_attacker",
         )
 
@@ -620,13 +680,13 @@ class TestCardActionCallbackResponse:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_bob"}
-        adapter._approval_state[6] = {
+        adapter._approval_state["approval-6"] = {
             "session_key": "sess-6",
             "message_id": "msg-6",
             "chat_id": "oc_expected",
         }
         data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 6},
+            {"hermes_action": "approve_once", "approval_id": "approval-6"},
             chat_id="oc_mismatch",
             open_id="ou_bob",
         )
@@ -637,6 +697,42 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is None
         mock_submit.assert_not_called()
+
+    def test_late_approval_click_returns_authoritative_expired_card(
+        self, _patch_callback_card_types
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._approval_state["approval-late"] = {
+            "session_key": "sess-late",
+            "message_id": "msg-late",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_action": "approve_once",
+                "approval_id": "approval-late",
+            },
+            open_id="ou_bob",
+        )
+
+        with patch(
+            "tools.approval.resolve_gateway_approval", return_value=0
+        ) as mock_resolve:
+            response = adapter._on_card_action_trigger(data)
+
+        mock_resolve.assert_called_once_with(
+            "sess-late",
+            "once",
+            approval_id="approval-late",
+        )
+        assert response.card.data["header"]["template"] == "grey"
+        assert "no longer pending" in response.card.data["header"]["title"][
+            "content"
+        ].lower()
+        assert "approval-late" not in adapter._approval_state
 
     def test_returns_card_for_update_prompt_yes(self, _patch_callback_card_types):
         adapter = _make_adapter()

--- a/tests/gateway/test_matrix_approval_reaction_fail_closed.py
+++ b/tests/gateway/test_matrix_approval_reaction_fail_closed.py
@@ -110,7 +110,9 @@ def _run(adapter, event):
     adapter._redact_bot_approval_reactions = AsyncMock()
 
     fake_approval = types.ModuleType("tools.approval")
-    fake_approval.resolve_gateway_approval = lambda session_key, choice: 1
+    fake_approval.resolve_gateway_approval = (
+        lambda session_key, choice, approval_id=None: 1
+    )
     with patch.dict(sys.modules, {"tools.approval": fake_approval}):
         asyncio.run(adapter._on_reaction(event))
 

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -22,11 +22,13 @@ class TestMatrixExecApprovalReactions:
             command="rm -rf /tmp/test",
             session_key="sess-1",
             description="dangerous",
+            metadata={"approval_id": "approval-from-core"},
         )
 
         assert result.success is True
         assert adapter._approval_prompt_by_session["sess-1"] == "$evt1"
         assert adapter._approval_prompts_by_event["$evt1"].session_key == "sess-1"
+        assert adapter._approval_prompts_by_event["$evt1"].approval_id == "approval-from-core"
         assert adapter._send_reaction.await_count == 3
         emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
         assert emojis == ["✅", "♾️", "❌"]
@@ -40,7 +42,10 @@ class TestMatrixExecApprovalReactions:
         # Resolve user_id so _is_self_sender doesn't defensively drop all traffic (#15763).
         adapter._user_id = "@bot:example.org"
         adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
-            session_key="sess-1", chat_id="!room:example.org", message_id="$target"
+            session_key="sess-1",
+            chat_id="!room:example.org",
+            message_id="$target",
+            approval_id="approval-target",
         )
         adapter._approval_prompt_by_session["sess-1"] = "$target"
 
@@ -55,6 +60,39 @@ class TestMatrixExecApprovalReactions:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._on_reaction(event)
 
-        mock_resolve.assert_called_once_with("sess-1", "once")
+        mock_resolve.assert_called_once_with(
+            "sess-1", "once", approval_id="approval-target"
+        )
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session
+
+    @pytest.mark.asyncio
+    async def test_prompt_force_redacts_and_keeps_parallel_approval_ids(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._client = types.SimpleNamespace()
+        adapter.send = AsyncMock(
+            side_effect=[
+                types.SimpleNamespace(success=True, message_id="$first"),
+                types.SimpleNamespace(success=True, message_id="$second"),
+            ]
+        )
+        adapter._send_reaction = AsyncMock(return_value="$reaction")
+        secret = "sk-proj-" + "M" * 40
+
+        for approval_id in ("approval-first", "approval-second"):
+            await adapter.send_exec_approval(
+                chat_id="!room:example.org",
+                command=f"echo {secret}",
+                session_key="sess-shared",
+                description=f"reason {secret}",
+                metadata={"approval_id": approval_id},
+            )
+
+        assert secret not in repr(adapter.send.await_args_list)
+        assert {
+            prompt.approval_id
+            for prompt in adapter._approval_prompts_by_event.values()
+        } == {"approval-first", "approval-second"}

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1019,8 +1019,8 @@ class TestChunkedUploaderFlow:
 class TestApprovalButtonData:
     def test_parse_allow_once(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
-        result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once")
-        assert result == ("agent:main:qqbot:c2c:UID", "allow-once")
+        result = parse_approval_button_data("approve:approval-123:allow-once")
+        assert result == ("approval-123", "allow-once")
 
     def test_parse_allow_always(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
@@ -1069,13 +1069,13 @@ class TestBuildApprovalKeyboard:
         assert len(kb.content.rows) == 1
         assert len(kb.content.rows[0].buttons) == 3
 
-    def test_button_data_embeds_session_key(self):
+    def test_button_data_embeds_approval_id(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
-        kb = build_approval_keyboard("agent:main:qqbot:c2c:UID")
+        kb = build_approval_keyboard("approval-123")
         datas = [b.action.data for b in kb.content.rows[0].buttons]
-        assert datas[0] == "approve:agent:main:qqbot:c2c:UID:allow-once"
-        assert datas[1] == "approve:agent:main:qqbot:c2c:UID:allow-always"
-        assert datas[2] == "approve:agent:main:qqbot:c2c:UID:deny"
+        assert datas[0] == "approve:approval-123:allow-once"
+        assert datas[1] == "approve:approval-123:allow-always"
+        assert datas[2] == "approve:approval-123:deny"
 
     def test_buttons_share_group_id_for_mutual_exclusion(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
@@ -1102,12 +1102,12 @@ class TestBuildApprovalKeyboard:
         from gateway.platforms.qqbot.keyboards import (
             build_approval_keyboard, parse_approval_button_data,
         )
-        session_key = "agent:main:qqbot:c2c:UID123"
-        kb = build_approval_keyboard(session_key)
+        approval_id = "approval-123"
+        kb = build_approval_keyboard(approval_id)
         for btn in kb.content.rows[0].buttons:
             parsed = parse_approval_button_data(btn.action.data)
             assert parsed is not None
-            assert parsed[0] == session_key
+            assert parsed[0] == approval_id
             assert parsed[1] in {"allow-once", "allow-always", "deny"}
 
 
@@ -1584,11 +1584,12 @@ class TestDefaultInteractionDispatch:
     async def test_approval_click_once_maps_to_once(self):
         """'allow-once' button → resolve_gateway_approval(session, 'once')."""
         adapter = self._make_adapter()
+        adapter._approval_state["approval-once"] = "agent:main:qqbot:c2c:u-42"
 
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, approval_id=None):
+            resolve_calls.append((session_key, choice, approval_id))
             return 1
 
         # Patch the *module-level* function that _default_interaction_dispatch
@@ -1602,21 +1603,24 @@ class TestDefaultInteractionDispatch:
                 "id": "i",
                 "chat_type": 2,
                 "user_openid": "u-42",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"}},
+                "data": {"resolved": {"button_data": "approve:approval-once:allow-once"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
+        assert resolve_calls == [
+            ("agent:main:qqbot:c2c:u-42", "once", "approval-once")
+        ]
 
     @pytest.mark.asyncio
     async def test_approval_click_always_maps_to_always(self):
         adapter = self._make_adapter()
+        adapter._approval_state["approval-always"] = "agent:main:qqbot:c2c:u"
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, approval_id=None):
+            resolve_calls.append((session_key, choice, approval_id))
             return 1
 
         import tools.approval
@@ -1626,21 +1630,24 @@ class TestDefaultInteractionDispatch:
             from gateway.platforms.qqbot.keyboards import parse_interaction_event
             event = parse_interaction_event({
                 "id": "i", "chat_type": 2, "user_openid": "u",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u:allow-always"}},
+                "data": {"resolved": {"button_data": "approve:approval-always:allow-always"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u", "always", False)]
+        assert resolve_calls == [
+            ("agent:main:qqbot:c2c:u", "always", "approval-always")
+        ]
 
     @pytest.mark.asyncio
     async def test_approval_click_deny_maps_to_deny(self):
         adapter = self._make_adapter()
+        adapter._approval_state["approval-deny"] = "agent:main:qqbot:c2c:u"
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, approval_id=None):
+            resolve_calls.append((session_key, choice, approval_id))
             return 1
 
         import tools.approval
@@ -1650,22 +1657,27 @@ class TestDefaultInteractionDispatch:
             from gateway.platforms.qqbot.keyboards import parse_interaction_event
             event = parse_interaction_event({
                 "id": "i", "chat_type": 2, "user_openid": "u",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u:deny"}},
+                "data": {"resolved": {"button_data": "approve:approval-deny:deny"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u", "deny", False)]
+        assert resolve_calls == [
+            ("agent:main:qqbot:c2c:u", "deny", "approval-deny")
+        ]
 
 
     @pytest.mark.asyncio
     async def test_approval_click_rejects_unauthorized_operator(self):
         adapter = self._make_adapter()
+        adapter._approval_state["approval-owner"] = (
+            "agent:main:qqbot:group:g-1:owner"
+        )
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, approval_id=None):
+            resolve_calls.append((session_key, choice, approval_id))
             return 1
 
         import tools.approval
@@ -1677,7 +1689,7 @@ class TestDefaultInteractionDispatch:
                 "id": "i", "chat_type": 1,
                 "group_openid": "g-1",
                 "group_member_openid": "attacker",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:group:g-1:owner:allow-once"}},
+                "data": {"resolved": {"button_data": "approve:approval-owner:allow-once"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
@@ -1748,8 +1760,9 @@ class TestDefaultInteractionDispatch:
     async def test_resolve_exception_is_swallowed(self):
         """If resolve_gateway_approval raises, we log but don't propagate."""
         adapter = self._make_adapter()
+        adapter._approval_state["approval-error"] = "agent:main:qqbot:c2c:u"
 
-        def bad_resolve(session_key, choice, resolve_all=False):
+        def bad_resolve(session_key, choice, approval_id=None):
             raise RuntimeError("boom")
 
         import tools.approval
@@ -1759,7 +1772,7 @@ class TestDefaultInteractionDispatch:
             from gateway.platforms.qqbot.keyboards import parse_interaction_event
             event = parse_interaction_event({
                 "id": "i", "chat_type": 2, "user_openid": "u",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u:deny"}},
+                "data": {"resolved": {"button_data": "approve:approval-error:deny"}},
             })
             # Must not raise.
             await adapter._default_interaction_dispatch(event)
@@ -1794,31 +1807,44 @@ class TestSendExecApproval:
             command="rm -rf /tmp/demo",
             session_key="sess:abc",
             description="delete temp dir",
+            metadata={"approval_id": "approval-from-core"},
         )
         assert result.success
         assert len(calls) == 1
         req = calls[0]["req"]
         assert req.session_key == "sess:abc"
+        assert req.approval_id == "approval-from-core"
         assert req.command_preview == "rm -rf /tmp/demo"
         assert req.description == "delete temp dir"
         assert calls[0]["reply_to"] == "inbound-42"
 
     @pytest.mark.asyncio
-    async def test_accepts_metadata_arg(self):
-        """Gateway always passes metadata=…; the adapter must accept + ignore it."""
+    async def test_metadata_carries_core_id_and_prompt_is_force_redacted(self):
+        """The gateway identity reaches QQ buttons without leaking command secrets."""
         adapter = self._make_adapter()
+        captured = {}
 
         async def fake_send_approval(chat_id, req, reply_to=None):
             from gateway.platforms.base import SendResult
+            captured["req"] = req
             return SendResult(success=True)
 
         adapter.send_approval_request = fake_send_approval  # type: ignore[assignment]
 
-        # Should not raise even when metadata is a dict with unknown keys.
+        secret = "sk-proj-" + "Q" * 40
         await adapter.send_exec_approval(
-            chat_id="u", command="ls", session_key="s",
-            metadata={"thread_id": "ignored", "anything": "else"},
+            chat_id="u",
+            command=f"echo {secret}",
+            session_key="s",
+            description=f"reason {secret}",
+            metadata={"approval_id": "approval-secret", "thread_id": "ignored"},
         )
+
+        req = captured["req"]
+        assert req.approval_id == "approval-secret"
+        assert secret not in req.command_preview
+        assert secret not in req.description
+        assert adapter._approval_state["approval-secret"] == "s"
 
 
 class TestSendUpdatePrompt:

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -117,9 +117,11 @@ class TestSlackExecApproval:
         assert "hermes_approve_session" in action_ids
         assert "hermes_approve_always" in action_ids
         assert "hermes_deny" in action_ids
-        # Each button carries the session key as value
-        for e in elements:
-            assert e["value"] == "agent:main:slack:group:C1:1111"
+        approval_ids = {e["value"] for e in elements}
+        assert len(approval_ids) == 1
+        approval_id = approval_ids.pop()
+        assert approval_id
+        assert adapter._approval_state[approval_id]["session_key"] == "agent:main:slack:group:C1:1111"
 
     @pytest.mark.asyncio
     async def test_sends_in_thread(self):
@@ -136,6 +138,29 @@ class TestSlackExecApproval:
 
         kwargs = mock_client.chat_postMessage.call_args[1]
         assert kwargs.get("thread_ts") == "9999.0000"
+
+    @pytest.mark.asyncio
+    async def test_uses_core_approval_id_and_force_redacts_prompt(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "5.6"})
+        secret = "sk-proj-" + "S" * 40
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command=f"echo {secret}",
+            session_key="session-secret",
+            description=f"reason {secret}",
+            metadata={"approval_id": "approval-from-core"},
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert secret not in repr(kwargs)
+        values = {
+            element["value"]
+            for element in kwargs["blocks"][1]["elements"]
+        }
+        assert values == {"approval-from-core"}
 
     @pytest.mark.asyncio
     async def test_not_connected(self):
@@ -175,6 +200,9 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1234.5678"] = False
+        adapter._approval_state["req-123"] = {
+            "session_key": "agent:main:slack:group:C1:1111",
+        }
 
         ack = AsyncMock()
         body = {
@@ -190,7 +218,7 @@ class TestSlackApprovalAction:
         }
         action = {
             "action_id": "hermes_approve_once",
-            "value": "agent:main:slack:group:C1:1111",
+            "value": "req-123",
         }
 
         mock_client = adapter._team_clients["T1"]
@@ -200,7 +228,11 @@ class TestSlackApprovalAction:
             await adapter._handle_approval_action(ack, body, action)
 
         ack.assert_called_once()
-        mock_resolve.assert_called_once_with("agent:main:slack:group:C1:1111", "once")
+        mock_resolve.assert_called_once_with(
+            "agent:main:slack:group:C1:1111",
+            "once",
+            approval_id="req-123",
+        )
 
         # Message should be updated with decision
         mock_client.chat_update.assert_called_once()
@@ -212,6 +244,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1234.5678"] = True  # Already resolved
+        adapter._approval_state["req-123"] = {"session_key": "some-session"}
 
         ack = AsyncMock()
         body = {
@@ -221,7 +254,7 @@ class TestSlackApprovalAction:
         }
         action = {
             "action_id": "hermes_approve_once",
-            "value": "some-session",
+            "value": "req-123",
         }
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
@@ -236,6 +269,7 @@ class TestSlackApprovalAction:
         adapter = _make_adapter()
         _attach_auth_runner(adapter)
         adapter._approval_resolved["1.2"] = False
+        adapter._approval_state["req-deny"] = {"session_key": "session-key"}
 
         ack = AsyncMock()
         body = {
@@ -245,7 +279,7 @@ class TestSlackApprovalAction:
             "channel": {"id": "C1"},
             "user": {"name": "alice", "id": "U_ALICE"},
         }
-        action = {"action_id": "hermes_deny", "value": "session-key"}
+        action = {"action_id": "hermes_deny", "value": "req-deny"}
 
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_update = AsyncMock()
@@ -253,7 +287,11 @@ class TestSlackApprovalAction:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._handle_approval_action(ack, body, action)
 
-        mock_resolve.assert_called_once_with("session-key", "deny")
+        mock_resolve.assert_called_once_with(
+            "session-key",
+            "deny",
+            approval_id="req-deny",
+        )
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Denied by alice" in update_kwargs["text"]
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -750,6 +750,100 @@ class TestTeamsMessageHandling:
         assert adapter.handle_message.await_count == 1
 
 
+class TestTeamsApprovalIdentity:
+    class _Card:
+        def __init__(self):
+            self.body = []
+            self.actions = []
+
+        def with_version(self, _version):
+            return self
+
+        def with_body(self, body):
+            self.body = body
+            return self
+
+        def with_actions(self, actions):
+            self.actions = actions
+            return self
+
+    class _Block:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _Action:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    def _adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_send_uses_core_id_and_force_redacts_card_data(self, monkeypatch):
+        monkeypatch.setattr(_teams_mod, "AdaptiveCard", self._Card)
+        monkeypatch.setattr(_teams_mod, "TextBlock", self._Block)
+        monkeypatch.setattr(_teams_mod, "ExecuteAction", self._Action)
+        adapter = self._adapter()
+        adapter._send_card = AsyncMock(return_value=SimpleNamespace(id="msg-1"))
+        secret = "sk-proj-" + "E" * 40
+
+        result = await adapter.send_exec_approval(
+            chat_id="chat-1",
+            command=f"echo {secret}",
+            session_key="session-1",
+            description=f"reason {secret}",
+            metadata={"approval_id": "approval-from-core"},
+        )
+
+        assert result.success
+        card = adapter._send_card.await_args.args[1]
+        assert secret not in repr([block.__dict__ for block in card.body])
+        assert {
+            action.data["approval_id"] for action in card.actions
+        } == {"approval-from-core"}
+        assert all("session_key" not in action.data for action in card.actions)
+        assert all("cmd" not in action.data for action in card.actions)
+        assert adapter._approval_state["approval-from-core"]["session_key"] == "session-1"
+
+    @pytest.mark.asyncio
+    async def test_card_action_resolves_exact_core_identity(self, monkeypatch):
+        adapter = self._adapter()
+        adapter._approval_state["approval-target"] = {
+            "session_key": "session-target",
+            "cmd": "echo safe",
+            "desc": "test",
+        }
+        monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+        calls = []
+
+        def resolve(session_key, choice, approval_id=None):
+            calls.append((session_key, choice, approval_id))
+            return 1
+
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", resolve)
+        ctx = SimpleNamespace(
+            activity=SimpleNamespace(
+                value=SimpleNamespace(
+                    action=SimpleNamespace(data={
+                        "hermes_action": "approve_once",
+                        "approval_id": "approval-target",
+                    })
+                ),
+                from_=SimpleNamespace(id="user-1", aad_object_id="aad-1"),
+            )
+        )
+
+        response = await adapter._on_card_action(ctx)
+
+        assert response.status == 200
+        assert calls == [("session-target", "once", "approval-target")]
+        assert "approval-target" not in adapter._approval_state
+
+
 class TestTeamsAttachmentClassification:
     """Document attachments must set MessageType.DOCUMENT so run.py's
     document-context injection surfaces the cached file to the agent

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -118,10 +118,43 @@ class TestTelegramExecApproval:
             session_key="my-session-key",
         )
 
-        # The approval_id should map to the session_key
+        # The approval_id should map to the pending approval metadata
         assert len(adapter._approval_state) == 1
         approval_id = list(adapter._approval_state.keys())[0]
-        assert adapter._approval_state[approval_id] == "my-session-key"
+        assert adapter._approval_state[approval_id]["session_key"] == "my-session-key"
+
+    @pytest.mark.asyncio
+    async def test_uses_core_approval_id_and_force_redacts_prompt(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock(message_id=42)
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+        button_factory = sys.modules["telegram"].InlineKeyboardButton
+        button_factory.reset_mock()
+        secret = "sk-proj-" + "T" * 40
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command=f"echo {secret}",
+            session_key="session-secret",
+            description=f"reason {secret}",
+            metadata={"approval_id": "approval-from-core"},
+        )
+
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert secret not in repr(kwargs)
+        callback_values = {
+            call.kwargs["callback_data"]
+            for call in button_factory.call_args_list
+        }
+        assert callback_values == {
+            "ea:once:approval-from-core",
+            "ea:session:approval-from-core",
+            "ea:always:approval-from-core",
+            "ea:deny:approval-from-core",
+        }
+        assert adapter._approval_state["approval-from-core"] == {
+            "session_key": "session-secret"
+        }
 
     @pytest.mark.asyncio
     async def test_sends_in_thread(self):
@@ -242,14 +275,19 @@ class TestTelegramApprovalCallback:
     async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
         # Set up approval state
-        adapter._approval_state[1] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["req-1"] = {
+            "session_key": "agent:main:telegram:group:12345:99",
+        }
 
         # Mock callback query
         query = AsyncMock()
-        query.data = "ea:once:1"
+        query.data = "ea:once:req-1"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
         query.from_user = MagicMock()
+        query.from_user.id = 10
         query.from_user.first_name = "Norbert"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
@@ -263,12 +301,16 @@ class TestTelegramApprovalCallback:
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
                 await adapter._handle_callback_query(update, context)
 
-        mock_resolve.assert_called_once_with("agent:main:telegram:group:12345:99", "once")
+        mock_resolve.assert_called_once_with(
+            "agent:main:telegram:group:12345:99",
+            "once",
+            approval_id="req-1",
+        )
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
 
         # State should be cleaned up
-        assert 1 not in adapter._approval_state
+        assert "req-1" not in adapter._approval_state
 
     @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):
@@ -279,12 +321,14 @@ class TestTelegramApprovalCallback:
         rest of a long-running turn after a button click.
         """
         adapter = _make_adapter()
-        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["approval-5"] = {
+            "session_key": "agent:main:telegram:group:12345:99"
+        }
         adapter.pause_typing_for_chat("12345")
         assert "12345" in adapter._typing_paused
 
         query = AsyncMock()
-        query.data = "ea:once:5"
+        query.data = "ea:once:approval-5"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -308,11 +352,13 @@ class TestTelegramApprovalCallback:
         """If resolve_gateway_approval reports 0 resolves, the agent thread
         was never unblocked, so typing should NOT be force-resumed."""
         adapter = _make_adapter()
-        adapter._approval_state[6] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["approval-6"] = {
+            "session_key": "agent:main:telegram:group:12345:99"
+        }
         adapter.pause_typing_for_chat("12345")
 
         query = AsyncMock()
-        query.data = "ea:once:6"
+        query.data = "ea:once:approval-6"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -334,10 +380,12 @@ class TestTelegramApprovalCallback:
     @pytest.mark.asyncio
     async def test_approval_callback_escapes_dynamic_user_name(self):
         adapter = _make_adapter()
-        adapter._approval_state[3] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["approval-3"] = {
+            "session_key": "agent:main:telegram:group:12345:99"
+        }
 
         query = AsyncMock()
-        query.data = "ea:once:3"
+        query.data = "ea:once:approval-3"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -362,13 +410,16 @@ class TestTelegramApprovalCallback:
     @pytest.mark.asyncio
     async def test_deny_button(self):
         adapter = _make_adapter()
-        adapter._approval_state[2] = "some-session"
+        adapter._approval_state["req-2"] = {"session_key": "some-session"}
 
         query = AsyncMock()
-        query.data = "ea:deny:2"
+        query.data = "ea:deny:req-2"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
         query.from_user = MagicMock()
+        query.from_user.id = 11
         query.from_user.first_name = "Alice"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
@@ -382,19 +433,25 @@ class TestTelegramApprovalCallback:
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
                 await adapter._handle_callback_query(update, context)
 
-        mock_resolve.assert_called_once_with("some-session", "deny")
+        mock_resolve.assert_called_once_with(
+            "some-session",
+            "deny",
+            approval_id="req-2",
+        )
         edit_kwargs = query.edit_message_text.call_args[1]
         assert "Denied" in edit_kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_approval_callback_rejects_user_blocked_by_global_allowlist(self):
         adapter = _make_adapter()
-        adapter._approval_state[7] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["approval-7"] = {
+            "session_key": "agent:main:telegram:group:12345:99"
+        }
         runner = _AuthRunner(authorized=False)
         adapter._message_handler = runner._handle_message
 
         query = AsyncMock()
-        query.data = "ea:once:7"
+        query.data = "ea:once:approval-7"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.message.chat.type = "private"
@@ -415,7 +472,9 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         assert "not authorized" in query.answer.call_args[1]["text"].lower()
         query.edit_message_text.assert_not_called()
-        assert adapter._approval_state[7] == "agent:main:telegram:group:12345:99"
+        assert adapter._approval_state["approval-7"] == {
+            "session_key": "agent:main:telegram:group:12345:99"
+        }
         assert runner.last_source is not None
         assert runner.last_source.platform == Platform.TELEGRAM
         assert runner.last_source.user_id == "222"
@@ -427,7 +486,7 @@ class TestTelegramApprovalCallback:
         # No state for approval_id 99 — already resolved
 
         query = AsyncMock()
-        query.data = "ea:once:99"
+        query.data = "ea:once:req-missing"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -448,6 +507,35 @@ class TestTelegramApprovalCallback:
         # Should still ack with "already resolved" message
         query.answer.assert_called_once()
         assert "already been resolved" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_does_not_resolve(self):
+        adapter = _make_adapter()
+        adapter._approval_state["req-auth"] = {"session_key": "some-session"}
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+
+        query = AsyncMock()
+        query.data = "ea:once:req-auth"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = 12
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        assert "req-auth" in adapter._approval_state
+        assert "not authorized" in query.answer.call_args[1]["text"]
 
     @pytest.mark.asyncio
     async def test_model_picker_callback_not_affected(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1722,6 +1722,7 @@ class TestSendExecApprovalButtons:
             command="rm -rf /tmp/foo",
             session_key="sess-app-1",
             description="cleanup script",
+            metadata={"approval_id": "approval-from-core"},
         )
 
         assert result.success
@@ -1736,11 +1737,39 @@ class TestSendExecApprovalButtons:
         assert approve_id.startswith("appr:") and approve_id.endswith(":approve")
         assert deny_id.startswith("appr:") and deny_id.endswith(":deny")
         approval_id = approve_id.split(":")[1]
+        assert approval_id == "approval-from-core"
         assert deny_id.split(":")[1] == approval_id
         body = payload["interactive"]["body"]["text"]
         assert "rm -rf /tmp/foo" in body
         assert "cleanup script" in body
-        assert adapter._exec_approval_state[approval_id] == "sess-app-1"
+        assert adapter._exec_approval_state[approval_id] == {
+            "session_key": "sess-app-1",
+            "chat_id": "15551234567",
+        }
+
+    @pytest.mark.asyncio
+    async def test_approval_prompt_force_redacts_secret_shaped_data(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
+        )
+        secret = "sk-proj-" + "W" * 40
+
+        await adapter.send_exec_approval(
+            chat_id="15551234567",
+            command=f"echo {secret}",
+            session_key="sess-secret",
+            description=f"reason {secret}",
+            metadata={"approval_id": "approval-secret"},
+        )
+
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert secret not in repr(payload)
+        assert {
+            button["reply"]["id"]
+            for button in payload["interactive"]["action"]["buttons"]
+        } == {"appr:approval-secret:approve", "appr:approval-secret:deny"}
 
     @pytest.mark.asyncio
     async def test_long_command_is_truncated(self):
@@ -1936,7 +1965,10 @@ class TestDispatchInteractiveReplyApproval:
     @pytest.mark.asyncio
     async def test_approve_tap_calls_resolver_and_confirms(self, monkeypatch):
         adapter = _make_adapter()
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = {
+            "session_key": "sess-app-1",
+            "chat_id": "15551234567",
+        }
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1945,7 +1977,9 @@ class TestDispatchInteractiveReplyApproval:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, approval_id=None: calls.append(
+                (session_key, choice, approval_id)
+            ) or 1,
         )
 
         raw = {
@@ -1959,7 +1993,7 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        assert calls == [("sess-app-1", "once", "app1")]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
@@ -1968,7 +2002,10 @@ class TestDispatchInteractiveReplyApproval:
     @pytest.mark.asyncio
     async def test_deny_tap_passes_deny_choice(self, monkeypatch):
         adapter = _make_adapter()
-        adapter._exec_approval_state["app2"] = "sess-app-2"
+        adapter._exec_approval_state["app2"] = {
+            "session_key": "sess-app-2",
+            "chat_id": "15551234567",
+        }
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1977,7 +2014,9 @@ class TestDispatchInteractiveReplyApproval:
         choices_seen = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: choices_seen.append(choice) or 1,
+            lambda session_key, choice, approval_id=None: choices_seen.append(
+                (choice, approval_id)
+            ) or 1,
         )
 
         raw = {
@@ -1990,9 +2029,41 @@ class TestDispatchInteractiveReplyApproval:
         }
         await adapter._dispatch_interactive_reply(raw, {})
 
-        assert choices_seen == ["deny"]
+        assert choices_seen == [("deny", "app2")]
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert "Denied" in confirm_payload["text"]["body"]
+
+    @pytest.mark.asyncio
+    async def test_approval_tap_from_different_sender_is_consumed_and_rejected(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter()
+        adapter._exec_approval_state["app-owner"] = {
+            "session_key": "sess-owner",
+            "chat_id": "15550000001",
+        }
+        calls = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda *args, **kwargs: calls.append((args, kwargs)) or 1,
+        )
+        raw = {
+            "from": "15550000002",
+            "type": "interactive",
+            "interactive": {
+                "type": "button_reply",
+                "button_reply": {
+                    "id": "appr:app-owner:approve",
+                    "title": "Approve",
+                },
+            },
+        }
+
+        handled = await adapter._dispatch_interactive_reply(raw, {})
+
+        assert handled is True
+        assert calls == []
+        assert "app-owner" in adapter._exec_approval_state
 
 
 class TestDispatchInteractiveReplySlashConfirm:

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -13,6 +13,8 @@ pre-existing regression unrelated to dashboard-auth.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -20,14 +22,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
+from hermes_cli import mcp_startup
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
+    consume_ticket,
     consume_internal_credential,
     internal_ws_credential,
     mint_ticket,
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tui_gateway import server as tui_server
+from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +122,13 @@ class TestWsTicketEndpoint:
         r = gated_app.post("/api/auth/ws-ticket")
         assert r.status_code == 200
         body = r.json()
-        assert "ticket" in body
+        assert set(body) == {"ticket", "ttl_seconds"}
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "dashboard"
+        assert grant["scopes"] == ("*",)
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -132,6 +141,58 @@ class TestWsTicketEndpoint:
         tickets = {gated_app.post("/api/auth/ws-ticket").json()["ticket"]
                    for _ in range(5)}
         assert len(tickets) == 5
+
+    def test_mobile_ticket_returns_and_preserves_the_granted_scopes(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.read", "conversation.write"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["audience"] == "hermes.mobile"
+        assert body["granted_scopes"] == [
+            "conversation.read",
+            "conversation.write",
+        ]
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "hermes.mobile"
+        assert grant["scopes"] == ("conversation.read", "conversation.write")
+
+    @pytest.mark.parametrize("scope", ["approval.respond", "shell.exec"])
+    def test_mobile_ticket_rejects_scopes_not_enforced_by_this_contract(
+        self,
+        gated_app,
+        scope,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"audience": "hermes.mobile", "scopes": [scope]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"unsupported mobile scope: {scope}"
+
+    def test_scopes_without_a_mobile_audience_do_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"scopes": ["conversation.read"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "audience is required when scopes are requested"
 
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
@@ -150,6 +211,54 @@ class TestWsTicketEndpoint:
             f"GET /api/auth/ws-ticket leaked a ticket (status={r.status_code}, "
             f"body[:200]={body[:200]!r})"
         )
+
+
+def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
+    sent = []
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
+    ticket = mint_ticket(
+        user_id="mobile-user",
+        provider="stub",
+        audience="hermes.mobile",
+        scopes=("conversation.read",),
+    )
+
+    class QueryParams:
+        def get(self, key, default=""):
+            return {"ticket": ticket}.get(key, default)
+
+    class FakeWS:
+        query_params = QueryParams()
+        client = SimpleNamespace(host="203.0.113.10")
+        url = SimpleNamespace(path="/api/ws")
+        headers = {
+            "host": "fly-app.fly.dev",
+            "origin": "https://fly-app.fly.dev",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise tui_ws._WebSocketDisconnect()
+
+        async def close(self, code=None):
+            pass
+
+    asyncio.run(web_server.gateway_ws(FakeWS()))
+
+    authorization = sent[0]["params"]["payload"]["authorization"]
+    assert authorization == {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ["conversation.read"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +337,26 @@ class TestWsAuthOkGated:
         ticket = mint_ticket(user_id="u1", provider="stub")
         ws = _fake_ws(query={"ticket": ticket})
         assert web_server._ws_auth_ok(ws) is True
+
+    @pytest.mark.parametrize("path", ["/api/pty", "/api/console", "/api/pub", "/api/events"])
+    def test_mobile_ticket_cannot_authenticate_non_gateway_websockets(
+        self,
+        gated_app,
+        path,
+    ):
+        ticket = mint_ticket(
+            user_id="mobile-user",
+            provider="stub",
+            audience="hermes.mobile",
+            scopes=("conversation.read",),
+        )
+        ws = _fake_ws(query={"ticket": ticket}, path=path)
+
+        reason, credential, authorization = web_server._ws_auth_result(ws)
+
+        assert reason == "ticket_audience_mismatch"
+        assert credential == "ticket"
+        assert authorization is None
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -5,16 +5,14 @@ The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
-These tests exercise the helper at the unit level (no actual WS upgrade)
-plus the ticket-mint endpoint under realistic gated-mode setup. We don't
-test the full WS upgrade because the starlette TestClient WS path has a
-pre-existing regression unrelated to dashboard-auth.
+These tests exercise the helper at the unit level, the ticket-mint endpoint
+under realistic gated-mode setup, and one public mint-to-upgrade-to-dispatch
+round trip. The full upgrade supplies explicit Host/Origin headers because
+Starlette's WebSocket TestClient does not inherit the HTTP ``base_url`` host.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -33,7 +31,6 @@ from hermes_cli.dashboard_auth.ws_tickets import (
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 from tui_gateway import server as tui_server
-from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +191,35 @@ class TestWsTicketEndpoint:
         assert response.status_code == 400
         assert response.json()["detail"] == "audience is required when scopes are requested"
 
+    def test_nonempty_request_without_an_audience_does_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post("/api/auth/ws-ticket", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "audience is required for a non-empty ticket request"
+        )
+
+    def test_mobile_write_grant_requires_read_scope(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.write"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "conversation.read is required for every mobile WebSocket grant"
+        )
+
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
         r = gated_app.get("/api/auth/ws-ticket", follow_redirects=False)
@@ -213,52 +239,47 @@ class TestWsTicketEndpoint:
         )
 
 
-def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
-    sent = []
+def test_scoped_ticket_grant_reaches_gateway_ready_and_dispatch(gated_app, monkeypatch):
     monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
     monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
-    ticket = mint_ticket(
-        user_id="mobile-user",
-        provider="stub",
-        audience="hermes.mobile",
-        scopes=("conversation.read",),
+
+    _logged_in(gated_app)
+    minted = gated_app.post(
+        "/api/auth/ws-ticket",
+        json={
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
+        },
     )
+    assert minted.status_code == 200
 
-    class QueryParams:
-        def get(self, key, default=""):
-            return {"ticket": ticket}.get(key, default)
-
-    class FakeWS:
-        query_params = QueryParams()
-        client = SimpleNamespace(host="203.0.113.10")
-        url = SimpleNamespace(path="/api/ws")
-        headers = {
-            "host": "fly-app.fly.dev",
-            "origin": "https://fly-app.fly.dev",
+    with gated_app.websocket_connect(
+        f"/api/ws?ticket={minted.json()['ticket']}",
+        headers={
+            "Host": "fly-app.fly.dev",
+            "Origin": "https://fly-app.fly.dev",
+        },
+    ) as socket:
+        ready = socket.receive_json()
+        authorization = ready["params"]["payload"]["authorization"]
+        assert authorization == {
+            "subject": "stub-user-1",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
         }
 
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            sent.append(json.loads(line))
-
-        async def receive_text(self):
-            raise tui_ws._WebSocketDisconnect()
-
-        async def close(self, code=None):
-            pass
-
-    asyncio.run(web_server.gateway_ws(FakeWS()))
-
-    authorization = sent[0]["params"]["payload"]["authorization"]
-    assert authorization == {
-        "subject": "mobile-user",
-        "provider": "stub",
-        "audience": "hermes.mobile",
-        "scopes": ["conversation.read"],
-    }
+        socket.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": "denied-write",
+                "method": "prompt.submit",
+                "params": {},
+            }
+        )
+        denied = socket.receive_json()
+        assert denied["error"]["data"]["required_scope"] == "conversation.write"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,18 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_scoped_ticket_can_explicitly_grant_conversation_deletion(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.delete"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["scopes"] == ("conversation.read", "conversation.delete")
+
     def test_ticket_store_rejects_unknown_audiences(self):
         with pytest.raises(ValueError, match="unsupported WebSocket audience"):
             mint_ticket(

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -64,6 +64,27 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_ticket_store_rejects_unknown_audiences(self):
+        with pytest.raises(ValueError, match="unsupported WebSocket audience"):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.future",
+                scopes=("*",),
+            )
+
+    def test_ticket_store_rejects_mobile_grants_without_read_scope(self):
+        with pytest.raises(
+            ValueError,
+            match="conversation.read is required for every mobile WebSocket grant",
+        ):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.mobile",
+                scopes=("conversation.write",),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -51,6 +51,19 @@ class TestMintAndConsume:
         seen = {mint_ticket(user_id="u1", provider="x") for _ in range(50)}
         assert len(seen) == 50
 
+    def test_scoped_ticket_preserves_its_authorization_grant(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.write"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["audience"] == "hermes.mobile"
+        assert info["scopes"] == ("conversation.read", "conversation.write")
+
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -105,6 +105,43 @@ def test_repair_preserves_user_content_when_one_side_empty():
     assert messages == [{"role": "user", "content": "real message"}]
 
 
+def test_repair_preserves_persisted_mobile_receipt_proof_on_user_merge():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "mobile retry",
+            "_db_persisted": True,
+            "_mobile_mutation_receipt_tags": ["proof-1"],
+        },
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 1
+    assert messages[0]["_mobile_mutation_persisted_receipt_tags"] == [
+        "proof-1"
+    ]
+
+
+def test_repair_does_not_promote_unpersisted_mobile_receipt_proof():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "failed write",
+            "_mobile_mutation_receipt_tags": ["proof-1"],
+        },
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 1
+    assert "_mobile_mutation_persisted_receipt_tags" not in messages[0]
+
+
 def test_repair_does_not_rewind_ongoing_dialog_tool_pair():
     """assistant(tool_calls) + tool + user is a VALID pattern (user redirect
     before the model gets its continuation turn). Repair must not touch it —

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8383,8 +8383,9 @@ def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason: seen.append((session, end_reason)),
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
     # outlives the test; grace=0 short-circuits it so no thread lingers.
@@ -8394,8 +8395,10 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     server._sessions["a"] = {"transport": transport, "close_on_disconnect": True}
     server._sessions["b"] = {"transport": transport, "close_on_disconnect": False}
     try:
+        flagged = server._sessions["a"]
         server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
-        assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
+        assert seen == [(flagged, "ws_disconnect")]  # only the flagged one closed
+        assert "a" not in server._sessions  # claimed before teardown can race resume
         assert server._sessions["b"]["transport"] is server._detached_ws_transport  # re-pointed
     finally:
         server._sessions.clear()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -59,8 +59,20 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                     "gateway.ready": 1,
                     "authorization.grant": 1,
                     "authorization.error": 1,
+                    "session.synchronization": 1,
+                    "session.event": 1,
                 },
-                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "capabilities": {
+                    "auth.ws_scopes": {"version": 1},
+                    "conversation.sync": {
+                        "version": 1,
+                        "delta_offsets": {"unit": "utf8_bytes"},
+                        "replay": {
+                            "max_events": 512,
+                            "max_bytes": 1048576,
+                        },
+                    },
+                },
                 "authorization": {
                     "subject": "user-1",
                     "provider": "stub",
@@ -128,6 +140,147 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
             "grantable": False,
         },
     }
+
+
+def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
+    monkeypatch,
+):
+    """Exercise synchronization through the real handle_ws transport boundary."""
+    sent = []
+    receive_index = 0
+    state = {}
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id, "cwd": server.os.getcwd()}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+
+    async def wait_for_response(request_id):
+        deadline = asyncio.get_running_loop().time() + 2
+        while asyncio.get_running_loop().time() < deadline:
+            match = next(
+                (frame for frame in sent if frame.get("id") == request_id), None
+            )
+            if match is not None:
+                return match
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"missing WebSocket response {request_id}")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "create-sync",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await wait_for_response("create-sync"))["result"]
+                state["created"] = created
+                sid = created["session_id"]
+                session = server._sessions[sid]
+
+                def emit_deltas():
+                    with session["history_lock"]:
+                        server._start_inflight_turn(session, "question")
+                    server._emit_inflight_delta(sid, session, "A💡")
+                    server._emit_inflight_delta(sid, session, "B")
+
+                await asyncio.to_thread(emit_deltas)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "resume-sync",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": created["synchronization"]["recovery"]["cursor"],
+                        },
+                    }
+                )
+            await wait_for_response("resume-sync")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": (
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ),
+    }
+
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+    finally:
+        server._sessions.clear()
+
+    created = state["created"]
+    resumed = next(frame for frame in sent if frame.get("id") == "resume-sync")[
+        "result"
+    ]
+    deltas = [
+        frame["params"]
+        for frame in sent
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [params["payload"]["offset"] for params in deltas] == [0, 5]
+    assert len({params["payload"]["turn_id"] for params in deltas}) == 1
+    assert [params["sequence"] for params in deltas] == [1, 2]
+    assert resumed["session_id"] == created["session_id"]
+    assert (
+        resumed["synchronization"]["snapshot"]["stream_id"]
+        == created["synchronization"]["snapshot"]["stream_id"]
+    )
+    assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
+    assert len(resumed["synchronization"]["recovery"]["events"]) == 2
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -62,6 +62,7 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                     "authorization.error": 1,
                     "session.synchronization": 1,
                     "session.event": 1,
+                    "mutation.receipt": 1,
                 },
                 "capabilities": {
                     "auth.ws_scopes": {"version": 1},
@@ -72,6 +73,15 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                             "max_events": 512,
                             "max_bytes": 1048576,
                         },
+                    },
+                    "mutation.idempotency": {
+                        "version": 1,
+                        "methods": [
+                            "prompt.submit",
+                            "session.interrupt",
+                            "session.delete",
+                        ],
+                        "status_method": "mutation.status",
                     },
                 },
                 "authorization": {

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -7,6 +7,7 @@ from hermes_cli import mcp_startup
 from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+from tui_gateway.mobile_sync import SessionEventStream
 
 
 def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
@@ -281,6 +282,305 @@ def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
     )
     assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
     assert len(resumed["synchronization"]["recovery"]["events"]) == 2
+
+
+def _isolate_mobile_ws_gateway(monkeypatch, db):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+
+class _MobileSessionDB:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+_MOBILE_AUTHORIZATION = {
+    "subject": "mobile-user",
+    "provider": "stub",
+    "audience": "hermes.mobile",
+    "scopes": (
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    ),
+}
+
+
+async def _wait_for_ws_response(sent, request_id):
+    deadline = asyncio.get_running_loop().time() + 2
+    while asyncio.get_running_loop().time() < deadline:
+        match = next((frame for frame in sent if frame.get("id") == request_id), None)
+        if match is not None:
+            return match
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"missing WebSocket response {request_id}")
+
+
+def test_mobile_socket_cold_resume_reports_stream_reset(monkeypatch):
+    sent = []
+    received = False
+    stored_id = "stored-cold"
+    _isolate_mobile_ws_gateway(
+        monkeypatch,
+        _MobileSessionDB(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "cold-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": stored_id,
+                            "cols": 100,
+                            "cursor": {
+                                "server_instance_id": (
+                                    mobile_contract.SERVER_INSTANCE_ID
+                                ),
+                                "stream_id": "retired-stream",
+                                "sequence": 12,
+                            },
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "cold-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "cold-resume")[
+        "result"
+    ]
+    synchronization = result["synchronization"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+    assert synchronization["recovery"]["snapshot_required"] is True
+    assert synchronization["recovery"]["events"] == []
+
+
+def test_mobile_socket_resume_reports_gap_after_replay_eviction(monkeypatch):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await _wait_for_ws_response(sent, "gap-create"))["result"]
+                sid = created["session_id"]
+                db.session_id = created["stored_session_id"]
+                stream = SessionEventStream(
+                    mobile_contract.SERVER_INSTANCE_ID,
+                    max_events=2,
+                    max_bytes=1024 * 1024,
+                )
+                server._sessions[sid]["mobile_sync"] = stream
+                cursor = stream.cursor()
+
+                def fill_replay():
+                    for index in range(3):
+                        server._emit(
+                            "status.update",
+                            sid,
+                            {"kind": "step", "text": str(index)},
+                        )
+
+                await asyncio.to_thread(fill_replay)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": cursor,
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "gap-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "gap-resume")[
+        "result"
+    ]
+    recovery = result["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["available_after"] == 1
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_mobile_socket_concurrent_events_have_monotonic_wire_sequences(
+    monkeypatch,
+):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "concurrent-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+
+            created = (await _wait_for_ws_response(sent, "concurrent-create"))[
+                "result"
+            ]
+            sid = created["session_id"]
+            start = threading.Barrier(9)
+
+            def publish(index):
+                start.wait()
+                server._emit(
+                    "status.update",
+                    sid,
+                    {"kind": "worker", "text": str(index)},
+                )
+
+            def publish_concurrently():
+                threads = [
+                    threading.Thread(target=publish, args=(index,))
+                    for index in range(8)
+                ]
+                for thread in threads:
+                    thread.start()
+                start.wait()
+                for thread in threads:
+                    thread.join(timeout=1)
+                    assert not thread.is_alive()
+
+            await asyncio.to_thread(publish_concurrently)
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    events = [
+        frame
+        for frame in sent
+        if frame.get("params", {}).get("type") == "status.update"
+    ]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -63,6 +63,7 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                     "session.synchronization": 1,
                     "session.event": 1,
                     "mutation.receipt": 1,
+                    "approval.lifecycle": 1,
                 },
                 "capabilities": {
                     "auth.ws_scopes": {"version": 1},
@@ -79,9 +80,15 @@ def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
                         "methods": [
                             "prompt.submit",
                             "session.interrupt",
+                            "approval.respond",
                             "session.delete",
                         ],
                         "status_method": "mutation.status",
+                    },
+                    "interaction.lifecycle": {
+                        "version": 1,
+                        "kinds": ["approval"],
+                        "response_methods": ["approval.respond"],
                     },
                 },
                 "authorization": {

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -703,6 +703,53 @@ def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch)
         server._sessions.clear()
 
 
+def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    cleanup_reached_session = threading.Event()
+    allow_cleanup = threading.Event()
+    scheduled = []
+
+    class GateLock:
+        def __enter__(self):
+            cleanup_reached_session.set()
+            assert allow_cleanup.wait(timeout=2)
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    server._sessions.clear()
+    server._sessions["raced"] = {
+        "transport": old_transport,
+        "close_on_disconnect": False,
+        "history_lock": GateLock(),
+        "session_key": "stored",
+    }
+    monkeypatch.setattr(
+        server,
+        "_schedule_ws_orphan_reap",
+        lambda sid: scheduled.append(sid),
+    )
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert cleanup_reached_session.wait(timeout=1)
+    server._sessions["raced"]["transport"] = new_transport
+    allow_cleanup.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+
+    assert result["counts"] == (0, 0)
+    assert server._sessions["raced"]["transport"] is new_transport
+    assert scheduled == []
+    server._sessions.clear()
+
+
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     """A write that times out because the event loop is stalled (GIL-heavy
     agent turn) must NOT latch the transport closed — the frame is already

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -750,6 +750,55 @@ def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch)
     server._sessions.clear()
 
 
+def test_close_on_disconnect_claim_blocks_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    teardown_entered = threading.Event()
+    release_teardown = threading.Event()
+    session = {
+        "agent": None,
+        "close_on_disconnect": True,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "session_key": "stored",
+        "transport": old_transport,
+    }
+    server._sessions.clear()
+    server._sessions["flagged"] = session
+
+    def blocked_teardown(claimed, *, end_reason):
+        assert claimed is session
+        assert end_reason == "ws_disconnect"
+        teardown_entered.set()
+        assert release_teardown.wait(timeout=2)
+
+    monkeypatch.setattr(server, "_teardown_session", blocked_teardown)
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert teardown_entered.wait(timeout=1)
+    assert "flagged" not in server._sessions
+
+    payload = server._live_session_payload(
+        "flagged",
+        session,
+        transport=new_transport,
+    )
+    assert payload is None
+    assert session["transport"] is old_transport
+
+    release_teardown.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+    assert result["counts"] == (1, 0)
+    server._sessions.clear()
+
+
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     """A write that times out because the event loop is stalled (GIL-heavy
     agent turn) must NOT latch the transport closed — the frame is already

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -121,8 +121,11 @@ def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "not.a.mobile.method",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read"],
+            "grantable": False,
         },
     }
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,10 +1,130 @@
 import asyncio
+import json
 import threading
 import time
 
 from hermes_cli import mcp_startup
+from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+
+
+def test_gateway_ready_advertises_versioned_mobile_contract_and_authorization(
+    monkeypatch,
+):
+    sent = []
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(server, "resolve_skin", lambda: "test-skin")
+    monkeypatch.setattr(mobile_contract, "SERVER_VERSION", "test-version")
+    monkeypatch.setattr(mobile_contract, "SERVER_RELEASE_DATE", "test-release")
+    monkeypatch.setattr(mobile_contract, "SERVER_INSTANCE_ID", "test-instance")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "user-1",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ("conversation.read", "conversation.write"),
+    }
+
+    asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+
+    assert sent[0] == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": "test-skin",
+                "server": {
+                    "version": "test-version",
+                    "release_date": "test-release",
+                    "instance_id": "test-instance",
+                },
+                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
+                "contract": {"name": "hermes.mobile", "major": 1},
+                "schemas": {
+                    "gateway.ready": 1,
+                    "authorization.grant": 1,
+                    "authorization.error": 1,
+                },
+                "capabilities": {"auth.ws_scopes": {"version": 1}},
+                "authorization": {
+                    "subject": "user-1",
+                    "provider": "stub",
+                    "audience": "hermes.mobile",
+                    "scopes": ["conversation.read", "conversation.write"],
+                },
+            },
+        },
+    }
+
+
+def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
+    monkeypatch,
+):
+    sent = []
+    received = False
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "mobile-request",
+                        "method": "not.a.mobile.method",
+                        "params": {},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(
+        ws_mod.handle_ws(
+            FakeWS(),
+            authorization={
+                "subject": "user-1",
+                "provider": "stub",
+                "audience": "hermes.mobile",
+                "scopes": ("conversation.read",),
+            },
+        )
+    )
+
+    assert sent[1]["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "not.a.mobile.method",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read"],
+        },
+    }
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):

--- a/tests/tools/test_gateway_approval_identity.py
+++ b/tests/tools/test_gateway_approval_identity.py
@@ -2,15 +2,186 @@
 
 from __future__ import annotations
 
+import gc
 import threading
 import json
 import math
+import weakref
 
 
 def _queue_entry(approval, session_key: str, **kwargs):
     entry = approval._ApprovalEntry({"command": "dangerous"}, **kwargs)
     approval._gateway_queues.setdefault(session_key, []).append(entry)
     return entry
+
+
+class _ManualTimer:
+    """Deterministic stand-in for the single tombstone cleanup timer."""
+
+    created: list["_ManualTimer"] = []
+
+    def __init__(self, interval, function, args=None, kwargs=None):
+        self.interval = interval
+        self.function = function
+        self.args = tuple(args or ())
+        self.kwargs = dict(kwargs or {})
+        self.daemon = False
+        self.started = False
+        self.cancelled = False
+        self.created.append(self)
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        assert self.started
+        assert not self.cancelled
+        self.function(*self.args, **self.kwargs)
+
+
+def _detach_tombstone_scheduler(approval):
+    """Isolate the process-global scheduler and return state for restoration."""
+    with approval._lock:
+        timer = approval._gateway_tombstone_cleanup_timer
+        if timer is not None:
+            timer.cancel()
+        state = (
+            approval._gateway_tombstones,
+            approval._gateway_tombstone_cleanup_generation,
+        )
+        approval._gateway_tombstones = {}
+        approval._gateway_tombstone_cleanup_timer = None
+        approval._gateway_tombstone_cleanup_deadline = None
+        approval._gateway_tombstone_cleanup_generation += 1
+    return state
+
+
+def _restore_tombstone_scheduler(approval, state):
+    with approval._lock:
+        timer = approval._gateway_tombstone_cleanup_timer
+        if timer is not None:
+            timer.cancel()
+        approval._gateway_tombstones = state[0]
+        approval._gateway_tombstone_cleanup_timer = None
+        approval._gateway_tombstone_cleanup_deadline = None
+        approval._gateway_tombstone_cleanup_generation = state[1] + 1
+        approval._schedule_gateway_tombstone_cleanup_locked()
+
+
+def test_terminal_entry_is_released_by_scheduled_ttl_cleanup(monkeypatch):
+    from tools import approval
+
+    state = _detach_tombstone_scheduler(approval)
+    now = [100.0]
+    _ManualTimer.created = []
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(approval.threading, "Timer", _ManualTimer)
+            patch.setattr(approval.time, "monotonic", lambda: now[0])
+            patch.setattr(
+                approval,
+                "_GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS",
+                5,
+            )
+            entry = _queue_entry(
+                approval,
+                "scheduled-tombstone-cleanup",
+                approval_id="a" * 32,
+                timeout_seconds=30,
+                now_monotonic=now[0],
+            )
+            entry_ref = weakref.ref(entry)
+
+            outcome = approval.resolve_gateway_approval_by_id(
+                "scheduled-tombstone-cleanup",
+                entry.approval_id,
+                "deny",
+            )
+            assert outcome["outcome"] == "resolved"
+            assert len(_ManualTimer.created) == 1
+            timer = _ManualTimer.created[0]
+            assert timer.interval == 5
+            assert timer.daemon is True
+
+            del entry
+            gc.collect()
+            assert entry_ref() is not None
+
+            now[0] = 105.0
+            timer.fire()
+            gc.collect()
+
+            assert "scheduled-tombstone-cleanup" not in (
+                approval._gateway_tombstones
+            )
+            assert entry_ref() is None
+    finally:
+        _restore_tombstone_scheduler(approval, state)
+
+
+def test_unregister_and_clear_tombstones_share_scheduled_cleanup(monkeypatch):
+    from tools import approval
+
+    state = _detach_tombstone_scheduler(approval)
+    now = [200.0]
+    _ManualTimer.created = []
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(approval.threading, "Timer", _ManualTimer)
+            patch.setattr(approval.time, "monotonic", lambda: now[0])
+            patch.setattr(
+                approval,
+                "_GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS",
+                5,
+            )
+
+            stale_session = "scheduled-unregister-cleanup"
+            approval.register_gateway_notify(stale_session, lambda _: None)
+            stale = _queue_entry(
+                approval,
+                stale_session,
+                approval_id="b" * 32,
+                timeout_seconds=30,
+                now_monotonic=now[0],
+            )
+            stale_ref = weakref.ref(stale)
+            approval.unregister_gateway_notify(stale_session)
+
+            cleared_session = "scheduled-clear-cleanup"
+            cleared = _queue_entry(
+                approval,
+                cleared_session,
+                approval_id="c" * 32,
+                timeout_seconds=30,
+                now_monotonic=now[0],
+            )
+            cleared_ref = weakref.ref(cleared)
+            approval.clear_session(cleared_session)
+
+            assert set(approval._gateway_tombstones) == {
+                stale_session,
+                cleared_session,
+            }
+            assert len(_ManualTimer.created) == 1
+            timer = _ManualTimer.created[0]
+
+            del stale, cleared
+            gc.collect()
+            assert stale_ref() is not None
+            assert cleared_ref() is not None
+
+            now[0] = 205.0
+            timer.fire()
+            gc.collect()
+
+            assert approval._gateway_tombstones == {}
+            assert stale_ref() is None
+            assert cleared_ref() is None
+    finally:
+        _restore_tombstone_scheduler(approval, state)
 
 
 def test_pending_approval_exposes_stable_sanitized_public_descriptor(monkeypatch):

--- a/tests/tools/test_gateway_approval_identity.py
+++ b/tests/tools/test_gateway_approval_identity.py
@@ -1,0 +1,348 @@
+"""Behavior contract for stable, recoverable gateway Approval identities."""
+
+from __future__ import annotations
+
+import threading
+import json
+import math
+
+
+def _queue_entry(approval, session_key: str, **kwargs):
+    entry = approval._ApprovalEntry({"command": "dangerous"}, **kwargs)
+    approval._gateway_queues.setdefault(session_key, []).append(entry)
+    return entry
+
+
+def test_pending_approval_exposes_stable_sanitized_public_descriptor(monkeypatch):
+    from tools import approval
+
+    session_key = "mobile-approval-public-descriptor"
+    fake_secret = "sk-proj-" + "X" * 40
+    command = (
+        "rm -rf /tmp/hermes-approval-preview && "
+        f"export OPENAI_API_KEY={fake_secret}"
+    )
+    notified: list[dict] = []
+    notification = threading.Event()
+    result: dict = {}
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 30},
+    )
+
+    def notify(descriptor: dict) -> None:
+        notified.append(descriptor)
+        notification.set()
+
+    approval.register_gateway_notify(session_key, notify)
+
+    def run_guard() -> None:
+        token = approval.set_current_session_key(session_key)
+        try:
+            result.update(approval.check_all_command_guards(command, "local"))
+        finally:
+            approval.reset_current_session_key(token)
+
+    worker = threading.Thread(target=run_guard, daemon=True)
+    worker.start()
+
+    try:
+        assert notification.wait(timeout=5), "Approval request was not emitted"
+        assert len(notified) == 1
+
+        descriptor = notified[0]
+        assert descriptor["approval_id"]
+        assert descriptor["state"] == "pending"
+        assert descriptor["resolution"] is None
+        assert descriptor["created_at"] < descriptor["expires_at"]
+        assert fake_secret not in descriptor["command"]
+
+        pending = approval.list_pending_gateway_approvals(session_key)
+        assert pending == [descriptor]
+    finally:
+        approval.resolve_gateway_approval(
+            session_key,
+            "deny",
+            resolve_all=True,
+        )
+        worker.join(timeout=5)
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+    assert not worker.is_alive()
+    assert result["approved"] is False
+
+
+def test_targeted_resolution_is_out_of_order_and_duplicate_safe():
+    from tools import approval
+
+    session_key = "mobile-approval-targeted"
+    first = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-first",
+        timeout_seconds=30,
+    )
+    second = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-second",
+        timeout_seconds=30,
+    )
+
+    try:
+        outcome = approval.resolve_gateway_approval_by_id(
+            session_key,
+            second.approval_id,
+            "deny",
+            reason="not this one",
+            resolution_metadata={"source": "mobile"},
+        )
+
+        assert outcome["outcome"] == "resolved"
+        assert outcome["approval"]["approval_id"] == second.approval_id
+        assert outcome["approval"]["state"] == "resolved"
+        assert outcome["approval"]["resolution"]["choice"] == "deny"
+        assert outcome["approval"]["resolution"]["reason"] == "not this one"
+        assert outcome["approval"]["resolution"]["metadata"] == {
+            "source": "mobile"
+        }
+        assert outcome["approval"]["resolution"]["resolved_at"] >= outcome[
+            "approval"
+        ]["created_at"]
+        assert not first.event.is_set()
+        assert second.event.is_set()
+        assert [item["approval_id"] for item in approval.list_pending_gateway_approvals(session_key)] == [
+            first.approval_id
+        ]
+
+        duplicate = approval.resolve_gateway_approval_by_id(
+            session_key,
+            second.approval_id,
+            "once",
+        )
+        assert duplicate["outcome"] == "already_resolved"
+        assert duplicate["approval"] == outcome["approval"]
+        assert first.event.is_set() is False
+    finally:
+        approval.clear_session(session_key)
+
+
+def test_late_expired_and_stale_resolutions_are_deterministic():
+    from tools import approval
+
+    expired_session = "mobile-approval-expired"
+    expired = _queue_entry(
+        approval,
+        expired_session,
+        approval_id="approval-expired",
+        timeout_seconds=0,
+    )
+
+    expired_outcome = approval.resolve_gateway_approval_by_id(
+        expired_session,
+        expired.approval_id,
+        "once",
+    )
+    assert expired_outcome["outcome"] == "expired"
+    assert expired_outcome["approval"]["state"] == "expired"
+    assert expired_outcome["approval"]["resolution"]["choice"] is None
+    assert expired.event.is_set()
+
+    stale_session = "mobile-approval-stale"
+    approval.register_gateway_notify(stale_session, lambda _: None)
+    stale = _queue_entry(
+        approval,
+        stale_session,
+        approval_id="approval-stale",
+        timeout_seconds=30,
+    )
+    approval.unregister_gateway_notify(stale_session)
+
+    stale_outcome = approval.resolve_gateway_approval_by_id(
+        stale_session,
+        stale.approval_id,
+        "once",
+    )
+    assert stale_outcome["outcome"] == "stale"
+    assert stale_outcome["approval"]["state"] == "stale"
+    assert stale_outcome["approval"]["resolution"]["choice"] is None
+    assert stale.event.is_set()
+
+    missing = approval.resolve_gateway_approval_by_id(
+        stale_session,
+        "a" * 32,
+        "once",
+    )
+    assert missing == {
+        "outcome": "not_found",
+        "approval_id": "a" * 32,
+    }
+
+
+def test_public_descriptor_redacts_all_payload_and_resolution_metadata_paths():
+    from tools import approval
+
+    session_key = "mobile-approval-redaction"
+    secret = "ghp_" + "A" * 36
+    entry = approval._ApprovalEntry(
+        {
+            "command": f"curl -H 'Authorization: Bearer {secret}' example.test",
+            "description": f"nested {secret}",
+            "metadata": {
+                "list": [secret, {"deep": secret}],
+                "tuple": (secret,),
+            },
+        },
+        approval_id="approval-redacted",
+        timeout_seconds=30,
+    )
+    approval._gateway_queues.setdefault(session_key, []).append(entry)
+
+    pending = approval.list_pending_gateway_approvals(session_key)[0]
+    assert secret not in repr(pending)
+
+    resolved = approval.resolve_gateway_approval_by_id(
+        session_key,
+        entry.approval_id,
+        "deny",
+        reason=f"reason {secret}",
+        resolution_metadata={"nested": [secret, {"deep": secret}]},
+    )
+    assert secret not in repr(resolved)
+
+    # Returned descriptors are snapshots, not mutable views into core state.
+    resolved["approval"]["command"] = secret
+    duplicate = approval.resolve_gateway_approval_by_id(
+        session_key,
+        entry.approval_id,
+        "deny",
+    )
+    assert secret not in repr(duplicate)
+
+    missing = approval.resolve_gateway_approval_by_id(
+        session_key,
+        f"missing-{secret}",
+        "deny",
+    )
+    assert secret not in repr(missing)
+
+
+def test_concurrent_targeted_responses_resolve_exactly_once():
+    from tools import approval
+
+    session_key = "mobile-approval-concurrent"
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-concurrent",
+        timeout_seconds=30,
+    )
+    barrier = threading.Barrier(3)
+    outcomes: list[dict] = []
+
+    def resolve(choice: str) -> None:
+        barrier.wait()
+        outcomes.append(
+            approval.resolve_gateway_approval_by_id(
+                session_key,
+                entry.approval_id,
+                choice,
+            )
+        )
+
+    workers = [
+        threading.Thread(target=resolve, args=(choice,))
+        for choice in ("once", "deny")
+    ]
+    for worker in workers:
+        worker.start()
+    barrier.wait()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert sorted(item["outcome"] for item in outcomes) == [
+        "already_resolved",
+        "resolved",
+    ]
+    assert outcomes[0]["approval"] == outcomes[1]["approval"]
+
+
+def test_tombstones_are_short_lived(monkeypatch):
+    from tools import approval
+
+    session_key = "mobile-approval-tombstone-ttl"
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-short-lived",
+        timeout_seconds=30,
+    )
+    monkeypatch.setattr(
+        approval,
+        "_GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS",
+        0,
+    )
+
+    first = approval.resolve_gateway_approval_by_id(
+        session_key,
+        entry.approval_id,
+        "once",
+    )
+    after_ttl = approval.resolve_gateway_approval_by_id(
+        session_key,
+        entry.approval_id,
+        "once",
+    )
+
+    assert first["outcome"] == "resolved"
+    assert after_ttl == {
+        "outcome": "not_found",
+        "approval_id": "invalid-approval-id",
+    }
+
+
+def test_invalid_choice_fails_without_consuming_pending_approval():
+    from tools import approval
+
+    session_key = "mobile-approval-invalid-choice"
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="b" * 32,
+        timeout_seconds=30,
+    )
+
+    outcome = approval.resolve_gateway_approval_by_id(
+        session_key,
+        entry.approval_id,
+        "approve-ish",
+    )
+
+    assert outcome == {
+        "outcome": "invalid_choice",
+        "approval_id": "b" * 32,
+    }
+    assert entry.event.is_set() is False
+    assert approval.resolve_gateway_approval(session_key, "approve-ish") == 0
+    assert approval.list_pending_gateway_approvals(session_key)[0][
+        "approval_id"
+    ] == entry.approval_id
+    approval.clear_session(session_key)
+
+
+def test_non_finite_timeouts_fall_back_to_finite_public_expiry():
+    from tools import approval
+
+    for timeout in (math.nan, math.inf, -math.inf):
+        entry = approval._ApprovalEntry(
+            {"command": "dangerous"},
+            timeout_seconds=timeout,
+        )
+        descriptor = entry.public_descriptor()
+        assert descriptor["expires_at"] - descriptor["created_at"] == 300
+        json.dumps(descriptor, allow_nan=False)

--- a/tests/tools/test_gateway_approval_identity.py
+++ b/tests/tools/test_gateway_approval_identity.py
@@ -131,6 +131,444 @@ def test_targeted_resolution_is_out_of_order_and_duplicate_safe():
         approval.clear_session(session_key)
 
 
+def test_targeted_resolution_notifies_once_with_terminal_descriptor():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-notify"
+    terminal_descriptors: list[dict] = []
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-notify",
+        timeout_seconds=30,
+    )
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+
+    try:
+        outcome = approval.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "deny",
+            reason="not now",
+        )
+        duplicate = approval.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "once",
+        )
+
+        assert outcome["outcome"] == "resolved"
+        assert terminal_descriptors == [outcome["approval"]]
+        assert duplicate["outcome"] == "already_resolved"
+        assert terminal_descriptors == [outcome["approval"]]
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_gateway_timeout_notifies_once_with_expired_descriptor(monkeypatch):
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-timeout"
+    requests: list[dict] = []
+    terminal_descriptors: list[dict] = []
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 0},
+    )
+    approval.register_gateway_notify(session_key, requests.append)
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+
+    token = approval.set_current_session_key(session_key)
+    try:
+        result = approval.check_all_command_guards(
+            "rm -rf /tmp/hermes-approval-timeout",
+            "local",
+        )
+        assert result["approved"] is False
+        assert len(requests) == 1
+        assert terminal_descriptors[0]["approval_id"] == requests[0]["approval_id"]
+        assert terminal_descriptors[0]["state"] == "expired"
+        assert terminal_descriptors[0]["resolution"]["metadata"] == {
+            "source": "timeout"
+        }
+
+        late = approval.resolve_gateway_approval_by_id(
+            session_key,
+            requests[0]["approval_id"],
+            "once",
+        )
+        assert late == {
+            "outcome": "expired",
+            "approval": terminal_descriptors[0],
+        }
+        assert len(terminal_descriptors) == 1
+    finally:
+        approval.reset_current_session_key(token)
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_unregister_notifies_stale_once_and_clears_both_callbacks():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-unregister"
+    terminal_descriptors: list[dict] = []
+    approval.register_gateway_notify(session_key, lambda _: None)
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    stale = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-stale",
+        timeout_seconds=30,
+    )
+
+    try:
+        approval.unregister_gateway_notify(session_key)
+
+        assert len(terminal_descriptors) == 1
+        assert terminal_descriptors[0]["approval_id"] == stale.approval_id
+        assert terminal_descriptors[0]["state"] == "stale"
+        assert terminal_descriptors[0]["resolution"]["metadata"] == {
+            "source": "callback_unregistered"
+        }
+
+        late = approval.resolve_gateway_approval_by_id(
+            session_key,
+            stale.approval_id,
+            "once",
+        )
+        assert late == {
+            "outcome": "stale",
+            "approval": terminal_descriptors[0],
+        }
+
+        after_unregister = _queue_entry(
+            approval,
+            session_key,
+            approval_id="approval-after-unregister",
+            timeout_seconds=30,
+        )
+        approval.resolve_gateway_approval_by_id(
+            session_key,
+            after_unregister.approval_id,
+            "deny",
+        )
+        assert len(terminal_descriptors) == 1
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_resolution_notification_failure_does_not_change_approval_outcome():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-callback-failure"
+    callback_calls = 0
+
+    def broken_callback(_: dict) -> None:
+        nonlocal callback_calls
+        callback_calls += 1
+        raise RuntimeError("terminal transport unavailable")
+
+    approval.register_gateway_resolution_notify(session_key, broken_callback)
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-callback-failure",
+        timeout_seconds=30,
+    )
+
+    try:
+        outcome = approval.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "once",
+        )
+        duplicate = approval.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "once",
+        )
+
+        assert outcome["outcome"] == "resolved"
+        assert duplicate["outcome"] == "already_resolved"
+        assert callback_calls == 1
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_terminal_notification_happens_before_waiter_is_released():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-ordering"
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    outcome: dict = {}
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-ordering",
+        timeout_seconds=30,
+    )
+
+    def blocking_callback(_: dict) -> None:
+        callback_started.set()
+        assert release_callback.wait(timeout=5)
+
+    approval.register_gateway_resolution_notify(session_key, blocking_callback)
+
+    def resolve() -> None:
+        outcome.update(
+            approval.resolve_gateway_approval_by_id(
+                session_key,
+                entry.approval_id,
+                "deny",
+            )
+        )
+
+    resolver = threading.Thread(target=resolve, daemon=True)
+    resolver.start()
+    try:
+        assert callback_started.wait(timeout=5)
+        assert entry.event.is_set() is False
+        assert resolver.is_alive()
+    finally:
+        release_callback.set()
+        resolver.join(timeout=5)
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+    assert resolver.is_alive() is False
+    assert entry.event.is_set()
+    assert outcome["outcome"] == "resolved"
+
+
+def test_legacy_fifo_resolution_notifies_in_queue_order():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-fifo"
+    terminal_descriptors: list[dict] = []
+    approval.register_gateway_notify(session_key, lambda _: None)
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    first = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-fifo-first",
+        timeout_seconds=30,
+    )
+    second = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-fifo-second",
+        timeout_seconds=30,
+    )
+
+    try:
+        resolved = approval.resolve_gateway_approval(
+            session_key,
+            "deny",
+            resolve_all=True,
+        )
+
+        assert resolved == 2
+        assert [
+            descriptor["approval_id"] for descriptor in terminal_descriptors
+        ] == [first.approval_id, second.approval_id]
+        assert all(
+            descriptor["state"] == "resolved"
+            for descriptor in terminal_descriptors
+        )
+        assert all(
+            descriptor["resolution"]["metadata"] == {
+                "source": "legacy_fifo"
+            }
+            for descriptor in terminal_descriptors
+        )
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_pending_snapshot_notifies_when_it_expires_an_approval():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-snapshot-expiry"
+    terminal_descriptors: list[dict] = []
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-snapshot-expiry",
+        timeout_seconds=0,
+    )
+
+    try:
+        assert approval.list_pending_gateway_approvals(session_key) == []
+        assert len(terminal_descriptors) == 1
+        assert terminal_descriptors[0]["approval_id"] == entry.approval_id
+        assert terminal_descriptors[0]["state"] == "expired"
+
+        assert approval.list_pending_gateway_approvals(session_key) == []
+        assert len(terminal_descriptors) == 1
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_failed_request_notification_emits_stale_terminal_descriptor(monkeypatch):
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-request-failure"
+    terminal_descriptors: list[dict] = []
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 30},
+    )
+
+    def broken_request_callback(_: dict) -> None:
+        raise RuntimeError("request transport unavailable")
+
+    approval.register_gateway_notify(session_key, broken_request_callback)
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    token = approval.set_current_session_key(session_key)
+
+    try:
+        result = approval.check_all_command_guards(
+            "rm -rf /tmp/hermes-approval-request-failure",
+            "local",
+        )
+
+        assert result["approved"] is False
+        assert len(terminal_descriptors) == 1
+        descriptor = terminal_descriptors[0]
+        assert descriptor["state"] == "stale"
+        assert descriptor["resolution"]["metadata"] == {
+            "source": "notify_failed"
+        }
+
+        late = approval.resolve_gateway_approval_by_id(
+            session_key,
+            descriptor["approval_id"],
+            "once",
+        )
+        assert late == {"outcome": "stale", "approval": descriptor}
+        assert len(terminal_descriptors) == 1
+    finally:
+        approval.reset_current_session_key(token)
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_session_cleanup_notifies_resolved_denial_once():
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-session-cleanup"
+    terminal_descriptors: list[dict] = []
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    entry = _queue_entry(
+        approval,
+        session_key,
+        approval_id="approval-terminal-session-cleanup",
+        timeout_seconds=30,
+    )
+
+    try:
+        approval.clear_session(session_key)
+
+        assert len(terminal_descriptors) == 1
+        descriptor = terminal_descriptors[0]
+        assert descriptor["approval_id"] == entry.approval_id
+        assert descriptor["state"] == "resolved"
+        assert descriptor["resolution"]["choice"] == "deny"
+        assert descriptor["resolution"]["metadata"] == {
+            "source": "session_cleanup"
+        }
+
+        late = approval.resolve_gateway_approval_by_id(
+            session_key,
+            entry.approval_id,
+            "once",
+        )
+        assert late == {"outcome": "already_resolved", "approval": descriptor}
+        assert len(terminal_descriptors) == 1
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
+def test_legacy_direct_request_callback_still_emits_terminal_descriptor(
+    monkeypatch,
+):
+    from tools import approval
+
+    session_key = "mobile-approval-terminal-legacy-direct"
+    terminal_descriptors: list[dict] = []
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 30},
+    )
+
+    def resolve_directly(_: dict) -> None:
+        entry = approval._gateway_queues[session_key][0]
+        entry.result = "once"
+        entry.event.set()
+
+    approval.register_gateway_notify(session_key, resolve_directly)
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
+    token = approval.set_current_session_key(session_key)
+
+    try:
+        result = approval.check_all_command_guards(
+            "rm -rf /tmp/hermes-approval-legacy-direct",
+            "local",
+        )
+
+        assert result["approved"] is True
+        assert len(terminal_descriptors) == 1
+        descriptor = terminal_descriptors[0]
+        assert descriptor["state"] == "resolved"
+        assert descriptor["resolution"]["choice"] == "once"
+        assert descriptor["resolution"]["metadata"] == {
+            "source": "legacy_direct_callback"
+        }
+    finally:
+        approval.reset_current_session_key(token)
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
+
+
 def test_late_expired_and_stale_resolutions_are_deterministic():
     from tools import approval
 
@@ -235,6 +673,11 @@ def test_concurrent_targeted_responses_resolve_exactly_once():
     from tools import approval
 
     session_key = "mobile-approval-concurrent"
+    terminal_descriptors: list[dict] = []
+    approval.register_gateway_resolution_notify(
+        session_key,
+        terminal_descriptors.append,
+    )
     entry = _queue_entry(
         approval,
         session_key,
@@ -258,18 +701,23 @@ def test_concurrent_targeted_responses_resolve_exactly_once():
         threading.Thread(target=resolve, args=(choice,))
         for choice in ("once", "deny")
     ]
-    for worker in workers:
-        worker.start()
-    barrier.wait()
-    for worker in workers:
-        worker.join(timeout=5)
+    try:
+        for worker in workers:
+            worker.start()
+        barrier.wait()
+        for worker in workers:
+            worker.join(timeout=5)
 
-    assert all(not worker.is_alive() for worker in workers)
-    assert sorted(item["outcome"] for item in outcomes) == [
-        "already_resolved",
-        "resolved",
-    ]
-    assert outcomes[0]["approval"] == outcomes[1]["approval"]
+        assert all(not worker.is_alive() for worker in workers)
+        assert sorted(item["outcome"] for item in outcomes) == [
+            "already_resolved",
+            "resolved",
+        ]
+        assert outcomes[0]["approval"] == outcomes[1]["approval"]
+        assert terminal_descriptors == [outcomes[0]["approval"]]
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.clear_session(session_key)
 
 
 def test_tombstones_are_short_lived(monkeypatch):

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,0 +1,217 @@
+"""Public JSON-RPC conformance tests for the mobile authorization contract."""
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self, authorization=None):
+        self.authorization = authorization
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "prompt.submit",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-1",
+        "error": {
+            "code": 4030,
+            "message": "insufficient authorization scope",
+            "data": {
+                "reason": "missing_scope",
+                "method": "prompt.submit",
+                "required_scope": "conversation.write",
+                "granted_scopes": ["conversation.read"],
+            },
+        },
+    }
+
+
+def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-2",
+            "method": "shell.exec",
+            "params": {"command": "true"},
+        },
+        transport,
+    )
+
+    assert response["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "shell.exec",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read", "conversation.write"],
+        },
+    }
+
+
+def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-request",
+            "method": "approval.respond",
+            "params": {"choice": "once"},
+        },
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "method_not_available_to_mobile",
+        "method": "approval.respond",
+        "required_scope": None,
+        "granted_scopes": ["conversation.read", "conversation.write"],
+    }
+
+
+def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+    server._sessions.clear()
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-3",
+            "method": "session.active_list",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-3",
+        "result": {"sessions": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "required_scope"),
+    [
+        ("session.list", "conversation.read"),
+        ("session.active_list", "conversation.read"),
+        ("session.activate", "conversation.read"),
+        ("session.history", "conversation.read"),
+        ("session.status", "conversation.read"),
+        ("session.usage", "conversation.read"),
+        ("session.create", "conversation.write"),
+        ("session.resume", "conversation.write"),
+        ("prompt.submit", "conversation.write"),
+        ("session.interrupt", "conversation.control"),
+        ("session.steer", "conversation.control"),
+    ],
+)
+def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
+    method,
+    required_scope,
+):
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (),
+        }
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": method,
+        "required_scope": required_scope,
+        "granted_scopes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        {
+            "subject": "server-internal",
+            "provider": "server-internal",
+            "audience": "dashboard",
+            "scopes": ("*",),
+        },
+    ],
+)
+def test_legacy_and_internal_dispatch_keep_the_existing_behavior(authorization):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-request",
+            "method": "not.a.real.method",
+            "params": {},
+        },
+        RecordingTransport(authorization),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "legacy-request",
+        "error": {
+            "code": -32601,
+            "message": "unknown method: not.a.real.method",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -220,25 +220,28 @@ def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(metho
     assert response["error"]["data"]["grantable"] is False
 
 
-def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
-    authorization = _mobile_authorization(
-        "conversation.read",
-        "conversation.write",
-        "conversation.control",
+def test_mobile_dispatch_rejects_hidden_history_deletion():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "hidden-delete",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "known",
+                "text": "replace",
+                "truncate_before_user_ordinal": 1,
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
     )
 
-    delete_denial = mobile_contract.mobile_method_denial(
-        "prompt.submit",
-        authorization,
-        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
-    )
-    profile_denial = mobile_contract.mobile_method_denial(
-        "session.create",
-        authorization,
-        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
-    )
-
-    assert delete_denial == {
+    assert response["error"]["data"] == {
         "reason": "parameter_not_available_to_mobile",
         "method": "prompt.submit",
         "parameter": "truncate_before_user_ordinal",
@@ -252,10 +255,55 @@ def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters(
         ],
         "grantable": False,
     }
-    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
-    assert profile_denial["parameter"] == "messages"
-    assert profile_denial["required_scope"] == "mobile.unavailable"
-    assert profile_denial["grantable"] is False
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("close_on_disconnect", True),
+        ("cwd", "/tmp/outside"),
+        ("fast", True),
+        ("messages", [{"role": "system", "content": "override"}]),
+        ("model", "provider/model"),
+        ("parent_session_id", "parent"),
+        ("profile", "../../outside"),
+        ("provider", "custom"),
+        ("reasoning_effort", "high"),
+        ("source", "spoofed-platform"),
+    ],
+)
+def test_mobile_dispatch_rejects_each_privileged_create_parameter(
+    monkeypatch,
+    parameter,
+    value,
+):
+    def fail_if_handler_runs(_profile):
+        raise AssertionError("session.create handler ran before mobile authorization")
+
+    monkeypatch.setattr(server, "_profile_home", fail_if_handler_runs)
+    server._sessions.clear()
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "privileged-create",
+            "method": "session.create",
+            "params": {parameter: value},
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == parameter
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
+    assert server._sessions == {}
 
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
@@ -268,12 +316,13 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             self.interrupted = True
 
     agent = Agent()
+    original_transport = RecordingTransport()
     session = {
         "agent": agent,
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
-        "transport": None,
+        "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
@@ -294,7 +343,9 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     assert response["result"] == {"status": "queued"}
     assert agent.interrupted is False
+    assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
+    assert session["queued_prompt"]["transport"] is transport
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,7 +1,10 @@
 """Public JSON-RPC conformance tests for the mobile authorization contract."""
 
+import threading
+
 import pytest
 
+from tui_gateway import mobile_contract
 from tui_gateway import server
 
 
@@ -18,15 +21,17 @@ class RecordingTransport:
         pass
 
 
+def _mobile_authorization(*scopes):
+    return {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": scopes,
+    }
+
+
 def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
 
     response = server.dispatch(
         {
@@ -48,7 +53,10 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
                 "reason": "missing_scope",
                 "method": "prompt.submit",
                 "required_scope": "conversation.write",
+                "required_scopes": ["conversation.write"],
+                "missing_scopes": ["conversation.write"],
                 "granted_scopes": ["conversation.read"],
+                "grantable": True,
             },
         },
     }
@@ -56,12 +64,7 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
 
 def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -80,20 +83,18 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "shell.exec",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read", "conversation.write"],
+            "grantable": False,
         },
     }
 
 
 def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -109,20 +110,16 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     assert response["error"]["data"] == {
         "reason": "method_not_available_to_mobile",
         "method": "approval.respond",
-        "required_scope": None,
+        "required_scope": "mobile.unavailable",
+        "required_scopes": ["mobile.unavailable"],
+        "missing_scopes": ["mobile.unavailable"],
         "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": False,
     }
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
     server._sessions.clear()
 
     response = server.dispatch(
@@ -147,29 +144,19 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
     [
         ("session.list", "conversation.read"),
         ("session.active_list", "conversation.read"),
-        ("session.activate", "conversation.read"),
+        ("session.activate", "conversation.control"),
         ("session.history", "conversation.read"),
-        ("session.status", "conversation.read"),
-        ("session.usage", "conversation.read"),
         ("session.create", "conversation.write"),
-        ("session.resume", "conversation.write"),
+        ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
-        ("session.steer", "conversation.control"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
     method,
     required_scope,
 ):
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": (),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization())
 
     response = server.dispatch(
         {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
@@ -180,8 +167,142 @@ def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
         "reason": "missing_scope",
         "method": method,
         "required_scope": required_scope,
+        "required_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
+        "missing_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
         "granted_scopes": [],
+        "grantable": True,
     }
+
+
+def test_mobile_create_requires_write_and_control():
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": "session.create",
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.write", "conversation.control"],
+        "missing_scopes": ["conversation.control"],
+        "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": True,
+    }
+
+
+@pytest.mark.parametrize("method", ["session.status", "session.usage", "session.steer"])
+def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(method):
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "unavailable", "method": method, "params": {}},
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    assert response["error"]["data"]["required_scope"] == "mobile.unavailable"
+    assert response["error"]["data"]["grantable"] is False
+
+
+def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
+    authorization = _mobile_authorization(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+
+    delete_denial = mobile_contract.mobile_method_denial(
+        "prompt.submit",
+        authorization,
+        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
+    )
+    profile_denial = mobile_contract.mobile_method_denial(
+        "session.create",
+        authorization,
+        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
+    )
+
+    assert delete_denial == {
+        "reason": "parameter_not_available_to_mobile",
+        "method": "prompt.submit",
+        "parameter": "truncate_before_user_ordinal",
+        "required_scope": "conversation.delete",
+        "required_scopes": ["conversation.delete"],
+        "missing_scopes": ["conversation.delete"],
+        "granted_scopes": [
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ],
+        "grantable": False,
+    }
+    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
+    assert profile_denial["parameter"] == "messages"
+    assert profile_denial["required_scope"] == "mobile.unavailable"
+    assert profile_denial["grantable"] is False
+
+
+def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
+    monkeypatch,
+):
+    class Agent:
+        interrupted = False
+
+        def interrupt(self):
+            self.interrupted = True
+
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["busy"] = session
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "busy-write",
+            "method": "prompt.submit",
+            "params": {"session_id": "busy", "text": "next"},
+        },
+        transport,
+    )
+
+    assert response["result"] == {"status": "queued"}
+    assert agent.interrupted is False
+    assert session["queued_prompt"]["text"] == "next"
+
+
+def test_mobile_scope_grants_require_read_access():
+    with pytest.raises(
+        ValueError,
+        match="conversation.read is required for every mobile WebSocket grant",
+    ):
+        mobile_contract.normalize_mobile_scopes(["conversation.write"])
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -150,6 +150,8 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
         ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
+        ("session.delete", "conversation.delete"),
+        ("mutation.status", "conversation.read"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
@@ -308,7 +310,10 @@ def test_mobile_dispatch_rejects_each_privileged_create_parameter(
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
     monkeypatch,
+    tmp_path,
 ):
+    from tui_gateway.mobile_mutations import MobileMutationStore
+
     class Agent:
         interrupted = False
 
@@ -322,11 +327,14 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
+        "session_key": "stored-busy",
         "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
     transport = RecordingTransport(
         _mobile_authorization("conversation.read", "conversation.write")
     )
@@ -336,12 +344,24 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             "jsonrpc": "2.0",
             "id": "busy-write",
             "method": "prompt.submit",
-            "params": {"session_id": "busy", "text": "next"},
+            "params": {
+                "client_request_id": "busy-write-1",
+                "expected_stored_session_id": "stored-busy",
+                "session_id": "busy",
+                "text": "next",
+            },
         },
         transport,
     )
 
-    assert response["result"] == {"status": "queued"}
+    assert response["result"] == {
+        "mutation": {
+            "client_request_id": "busy-write-1",
+            "deduplicated": False,
+            "state": "completed",
+        },
+        "status": "queued",
+    }
     assert agent.interrupted is False
     assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -92,7 +92,7 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     }
 
 
-def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+def test_mobile_approval_response_requires_conversation_control():
     transport = RecordingTransport(
         _mobile_authorization("conversation.read", "conversation.write")
     )
@@ -102,20 +102,50 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
             "jsonrpc": "2.0",
             "id": "approval-request",
             "method": "approval.respond",
-            "params": {"choice": "once"},
+            "params": {},
         },
         transport,
     )
 
     assert response["error"]["data"] == {
-        "reason": "method_not_available_to_mobile",
+        "reason": "missing_scope",
         "method": "approval.respond",
-        "required_scope": "mobile.unavailable",
-        "required_scopes": ["mobile.unavailable"],
-        "missing_scopes": ["mobile.unavailable"],
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.control"],
+        "missing_scopes": ["conversation.control"],
         "granted_scopes": ["conversation.read", "conversation.write"],
-        "grantable": False,
+        "grantable": True,
     }
+
+
+def test_mobile_approval_response_cannot_reach_legacy_fifo_all():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-fifo-all",
+            "method": "approval.respond",
+            "params": {
+                "all": True,
+                "approval_id": "a" * 32,
+                "choice": "once",
+                "client_request_id": "approval-1",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == "all"
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
@@ -150,6 +180,7 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
         ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
+        ("approval.respond", "conversation.control"),
         ("session.delete", "conversation.delete"),
         ("mutation.status", "conversation.read"),
     ],

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -322,19 +322,52 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     agent = Agent()
     original_transport = RecordingTransport()
+    release_turn = threading.Event()
+    receipt_completed = threading.Event()
     session = {
         "agent": agent,
+        "history": [],
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
         "session_key": "stored-busy",
         "transport": original_transport,
     }
+
+    def finish_turn():
+        assert release_turn.wait(timeout=2)
+        with session["history_lock"]:
+            queued = session["queued_prompt"]
+            assert queued is not None
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": queued["text"],
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": list(
+                        queued["mobile_mutation_receipt_tags"]
+                    ),
+                }
+            )
+            session["queued_prompt"] = None
+            session["running"] = False
+
+    run_thread = threading.Thread(target=finish_turn)
+    session["_run_thread"] = run_thread
+    run_thread.start()
     server._sessions.clear()
     server._sessions["busy"] = session
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
     store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
     monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    original_complete = store.complete
+
+    def complete_receipt(claim, outcome):
+        completed = original_complete(claim, outcome)
+        receipt_completed.set()
+        return completed
+
+    monkeypatch.setattr(store, "complete", complete_receipt)
     transport = RecordingTransport(
         _mobile_authorization("conversation.read", "conversation.write")
     )
@@ -358,7 +391,7 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
         "mutation": {
             "client_request_id": "busy-write-1",
             "deduplicated": False,
-            "state": "completed",
+            "state": "in_progress",
         },
         "status": "queued",
     }
@@ -366,6 +399,11 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
     assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
     assert session["queued_prompt"]["transport"] is transport
+    release_turn.set()
+    run_thread.join(timeout=1)
+    assert not run_thread.is_alive()
+    assert receipt_completed.wait(timeout=1)
+    store.close()
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import logging
+import sqlite3
 import threading
 
 import pytest
@@ -27,6 +29,21 @@ class _MobileTransport:
         return True
 
 
+@pytest.fixture(autouse=True)
+def _isolated_gateway_mutation_store(tmp_path, monkeypatch):
+    """Keep every dispatch in this module off the user's Hermes home."""
+    from tui_gateway import server
+
+    store = MobileMutationStore(tmp_path / "gateway-mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    try:
+        yield store
+    finally:
+        server._sessions.clear()
+        store.close()
+        assert store._closed is True
+
+
 def _reserve(
     store: MobileMutationStore,
     *,
@@ -41,6 +58,123 @@ def _reserve(
         resource_id="conversation-root",
         semantic_parameters={"text": text},
     )
+
+
+def test_owned_pre_execution_reservation_can_be_released_and_retried(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    first = _reserve(store)
+    duplicate = _reserve(store)
+
+    assert duplicate.disposition is MutationDisposition.IN_PROGRESS
+    assert store.release_before_execution(duplicate) is False
+    assert store.release_before_execution(first) is True
+    assert store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    ) is None
+    assert _reserve(store).disposition is MutationDisposition.EXECUTE
+    store.close()
+
+
+def test_advertised_mutations_share_one_policy_and_resource_authority():
+    from tui_gateway import mobile_contract
+
+    payload = mobile_contract.gateway_ready_payload(skin="default")
+    advertised = set(
+        payload["capabilities"]["mutation.idempotency"]["methods"]
+    )
+    described = {
+        method
+        for method, policy in mobile_contract.MOBILE_METHOD_POLICIES.items()
+        if policy.mutation is not None
+    }
+
+    assert advertised == set(mobile_contract.MOBILE_MUTATION_METHODS)
+    assert advertised == described
+    for method in advertised:
+        policy = mobile_contract.MOBILE_METHOD_POLICIES[method]
+        descriptor = policy.mutation
+        assert descriptor is not None
+        assert descriptor.resource_parameter in policy.allowed_parameters
+        assert set(descriptor.semantic_parameters) <= policy.allowed_parameters
+
+
+def test_transient_lineage_failure_releases_receipt_for_identical_retry(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    outage = {"active": True}
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root", "conversation-tip"]
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        if outage["active"]:
+            raise sqlite3.OperationalError("lineage store unavailable")
+        yield Db()
+
+    class Agent:
+        session_id = "conversation-tip"
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-tip",
+    }
+    request = {
+        "jsonrpc": "2.0",
+        "id": "first-correlation",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "retry-after-lineage-outage",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    unavailable = server.dispatch(request, transport)
+
+    assert unavailable["error"] == {
+        "code": 5037,
+        "message": "mobile mutation preflight is temporarily unavailable",
+        "data": {
+            "client_request_id": "retry-after-lineage-outage",
+            "reason": "mutation_preflight_unavailable",
+        },
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="retry-after-lineage-outage",
+    ) is None
+
+    outage["active"] = False
+    request["id"] = "retry-correlation"
+    retry = server.dispatch(request, transport)
+
+    assert agent.interrupt_calls == 1
+    assert retry["result"]["status"] == "interrupted"
+    assert retry["result"]["mutation"] == {
+        "client_request_id": "retry-after-lineage-outage",
+        "deduplicated": False,
+        "state": "completed",
+    }
 
 
 def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path):
@@ -207,6 +341,272 @@ def test_mobile_mutation_rejects_an_oversized_request_identity():
     assert response["error"]["data"] == {
         "reason": "invalid_client_request_id"
     }
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_reservation_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    def fail_reservation(**_kwargs):
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "reserve",
+        fail_reservation,
+    )
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "store-outage",
+                "method": "session.interrupt",
+                "params": {
+                    "client_request_id": "store-outage-1",
+                    "expected_stored_session_id": "conversation-root",
+                    "session_id": "live-1",
+                },
+            },
+            _MobileTransport("conversation.read", "conversation.control"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_wait_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    original = _isolated_gateway_mutation_store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="wait-outage-1",
+        method="session.interrupt",
+        resource_id="conversation-root",
+        semantic_parameters={},
+    )
+    assert original.disposition is MutationDisposition.EXECUTE
+
+    def fail_wait(_claim, *, timeout):
+        assert timeout == 30.0
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "wait_for_outcome",
+        fail_wait,
+    )
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "wait-outage",
+                "method": "session.interrupt",
+                "params": {
+                    "client_request_id": "wait-outage-1",
+                    "expected_stored_session_id": "conversation-root",
+                    "session_id": "live-1",
+                },
+            },
+            _MobileTransport("conversation.read", "conversation.control"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_status_failures_return_structured_unavailable_errors(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    def fail_status(**_kwargs):
+        raise failure
+
+    monkeypatch.setattr(_isolated_gateway_mutation_store, "status", fail_status)
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "status-outage",
+                "method": "mutation.status",
+                "params": {"client_request_id": "status-outage-1"},
+            },
+            _MobileTransport("conversation.read"),
+        )
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "durable mutation receipt is temporarily unavailable",
+        "data": {"reason": "mutation_store_unavailable"},
+    }
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [sqlite3.OperationalError("database unavailable"), RuntimeError("unexpected")],
+)
+def test_receipt_completion_failures_become_structured_unknown_outcomes(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+    failure,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    original_complete = _isolated_gateway_mutation_store.complete
+
+    def fail_completion(_claim, _outcome):
+        raise failure
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "complete",
+        fail_completion,
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "completion-outage",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "completion-outage-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        response = server.dispatch(request, transport)
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "mutation outcome could not be recorded durably",
+        "data": {"reason": "mutation_outcome_unknown"},
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="completion-outage-1",
+    )["state"] == "outcome_unknown"
+    assert agent.interrupt_calls == 1
+    assert any(record.exc_info is not None for record in caplog.records)
+
+    monkeypatch.setattr(
+        _isolated_gateway_mutation_store,
+        "complete",
+        original_complete,
+    )
+    request["id"] = "completion-outage-retry"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert agent.interrupt_calls == 1
+
+
+def test_unexpected_handler_failure_returns_structured_unknown_outcome(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    caplog,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+            raise RuntimeError("interrupt transport failed")
+
+    agent = Agent()
+    server._sessions["live-1"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    request = {
+        "jsonrpc": "2.0",
+        "id": "handler-failure",
+        "method": "session.interrupt",
+        "params": {
+            "client_request_id": "handler-failure-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+        },
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+
+    with caplog.at_level(logging.ERROR, logger="tui_gateway.server"):
+        response = server.dispatch(request, transport)
+
+    assert response["error"] == {
+        "code": 5037,
+        "message": "mutation handler failed before a durable outcome was available",
+        "data": {"reason": "mutation_outcome_unknown"},
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="handler-failure-1",
+    )["state"] == "outcome_unknown"
+    assert agent.interrupt_calls == 1
+    assert any(record.exc_info is not None for record in caplog.records)
+
+    request["id"] = "handler-failure-retry"
+    retry = server.dispatch(request, transport)
+
+    assert retry["error"]["code"] == 4091
+    assert agent.interrupt_calls == 1
 
 
 

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import sqlite3
 import threading
+import time
 
 import pytest
 
@@ -753,16 +754,43 @@ def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkey
     monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
     monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
     counts = {"inflight": 0, "turn": 0}
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    inner_workers = []
     monkeypatch.setattr(
         server,
         "_start_inflight_turn",
         lambda *_args: counts.__setitem__("inflight", counts["inflight"] + 1),
     )
 
-    def run_turn(_rid, _sid, session, _text):
+    def run_turn(_rid, _sid, session, text):
         counts["turn"] += 1
-        with session["history_lock"]:
-            session["running"] = False
+
+        def persist_turn():
+            worker_started.set()
+            assert release_worker.wait(timeout=2)
+            with session["history_lock"]:
+                receipt_tags = list(
+                    session.get("_pending_mobile_mutation_receipt_tags") or ()
+                )
+                assert len(receipt_tags) == 1
+                session["history"].append(
+                    {
+                        "role": "user",
+                        "content": text,
+                        "_db_persisted": True,
+                        "_mobile_mutation_receipt_tags": receipt_tags,
+                    }
+                )
+                session["running"] = False
+
+        # Match the production topology: prompt.submit first runs an agent-ready
+        # wrapper, then _run_prompt_submit replaces its handle with the real turn
+        # worker. Receipt monitoring must follow that live handle replacement.
+        worker = threading.Thread(target=persist_turn)
+        inner_workers.append(worker)
+        session["_run_thread"] = worker
+        worker.start()
 
     monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
     session = {
@@ -818,17 +846,846 @@ def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkey
         args=("duplicate", "correlation-2"),
     )
     first.start()
+    assert worker_started.wait(timeout=2)
+    first.join(timeout=2)
+    assert not first.is_alive()
+    assert store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="prompt-1",
+    )["state"] == "in_progress"
+
+    release_worker.set()
     assert first_at_completion.wait(timeout=2)
     duplicate.start()
     release_completion.set()
-    first.join(timeout=2)
     duplicate.join(timeout=2)
+    inner_workers[0].join(timeout=2)
 
     assert counts == {"inflight": 1, "turn": 1}
     assert responses["first"]["result"]["mutation"]["deduplicated"] is False
+    assert responses["first"]["result"]["mutation"]["state"] == "in_progress"
     assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is True
+    assert responses["duplicate"]["result"]["mutation"]["state"] == "completed"
     assert responses["first"]["result"]["status"] == "streaming"
     assert responses["duplicate"]["result"]["status"] == "streaming"
+
+
+def test_mobile_prompt_proof_tag_is_scoped_to_authenticated_principal(tmp_path):
+    from tui_gateway import server
+
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    shared = {
+        "client_request_id": "same-request-id",
+        "method": "prompt.submit",
+        "resource_id": "conversation-root",
+        "semantic_parameters": {"text": "same text"},
+    }
+    alice = store.reserve(provider="password", subject="alice", **shared)
+    bob = store.reserve(provider="password", subject="bob", **shared)
+    session = {
+        "agent": object(),
+        "history": [
+            {
+                "role": "user",
+                "content": "same text",
+                "_db_persisted": True,
+                "_mobile_mutation_receipt_tags": [alice.proof_tag],
+            }
+        ],
+        "history_lock": threading.Lock(),
+    }
+
+    assert alice.proof_tag != bob.proof_tag
+    assert server._mobile_prompt_turn_is_durable(
+        ("live-1", session, alice.proof_tag)
+    )
+    assert not server._mobile_prompt_turn_is_durable(
+        ("live-1", session, bob.proof_tag)
+    )
+    store.close()
+
+
+def test_mobile_prompt_durable_proof_survives_user_sequence_repair():
+    from run_agent import AIAgent
+    from tui_gateway import server
+
+    proof_tag = "principal-scoped-proof"
+    messages = [
+        {"role": "user", "content": "interrupted", "_db_persisted": True},
+        {
+            "role": "user",
+            "content": "mobile send",
+            "_db_persisted": True,
+            "_mobile_mutation_receipt_tags": [proof_tag],
+        },
+    ]
+    session = {
+        "agent": object(),
+        "history": messages,
+        "history_lock": threading.Lock(),
+    }
+    context = ("live-1", session, proof_tag)
+
+    assert server._mobile_prompt_turn_is_durable(context)
+    AIAgent._repair_message_sequence(AIAgent.__new__(AIAgent), messages)
+    assert len(messages) == 1
+    assert server._mobile_prompt_turn_is_durable(context)
+
+
+def test_mobile_prompt_receipt_rechecks_proof_after_worker_exit_race(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    claim = _isolated_gateway_mutation_store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="persist-at-exit-1",
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": "persist at exit"},
+    )
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+    }
+    context = ("live-1", session, claim.proof_tag)
+
+    def persist_while_observing_worker_exit(_context):
+        with session["history_lock"]:
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": "persist at exit",
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": [claim.proof_tag],
+                }
+            )
+            session["running"] = False
+        return False
+
+    monkeypatch.setattr(
+        server,
+        "_mobile_prompt_turn_is_pending",
+        persist_while_observing_worker_exit,
+    )
+    assert server._defer_mobile_prompt_receipt(
+        store=_isolated_gateway_mutation_store,
+        claim=claim,
+        outcome={"result": {"status": "streaming"}},
+        context=context,
+    )
+
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="persist-at-exit-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "completed"
+
+
+def test_mobile_prompt_receipts_share_one_constant_time_session_monitor(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    claims = [
+        _isolated_gateway_mutation_store.reserve(
+            provider="password",
+            subject="mobile-user",
+            client_request_id=f"shared-monitor-{index}",
+            method="prompt.submit",
+            resource_id="conversation-root",
+            semantic_parameters={"text": f"prompt {index}"},
+        )
+        for index in (1, 2)
+    ]
+
+    class WorkThread:
+        alive = True
+
+        def is_alive(self):
+            return self.alive
+
+    work_thread = WorkThread()
+    proof_tags = [claim.proof_tag for claim in claims]
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "_pending_mobile_mutation_receipt_tags": proof_tags,
+        "_live_mobile_mutation_receipt_tags": set(proof_tags),
+        "_run_thread": work_thread,
+    }
+    contexts = [("live-1", session, tag) for tag in proof_tags]
+    original_durable_check = server._mobile_prompt_turn_is_durable
+    hot_path_scans = 0
+
+    def count_hot_path_scan(context):
+        nonlocal hot_path_scans
+        hot_path_scans += 1
+        return original_durable_check(context)
+
+    monkeypatch.setattr(
+        server,
+        "_mobile_prompt_turn_is_durable",
+        count_hot_path_scan,
+    )
+    for claim, context in zip(claims, contexts):
+        assert server._defer_mobile_prompt_receipt(
+            store=_isolated_gateway_mutation_store,
+            claim=claim,
+            outcome={"result": {"status": "queued"}},
+            context=context,
+        )
+
+    monitor = session["_mobile_prompt_receipt_monitor_thread"]
+    time.sleep(0.3)
+    assert session["_mobile_prompt_receipt_monitor_thread"] is monitor
+    assert len(session["_mobile_prompt_receipt_entries"]) == 2
+    assert hot_path_scans == 0
+
+    with session["history_lock"]:
+        work_thread.alive = False
+        session["running"] = False
+        session.pop("_pending_mobile_mutation_receipt_tags", None)
+    server._notify_mobile_prompt_receipt_change(session)
+
+    deadline = time.monotonic() + 1
+    statuses = []
+    while time.monotonic() < deadline:
+        statuses = [
+            _isolated_gateway_mutation_store.status(
+                provider="password",
+                subject="mobile-user",
+                client_request_id=f"shared-monitor-{index}",
+            )
+            for index in (1, 2)
+        ]
+        if all(status and status["state"] == "outcome_unknown" for status in statuses):
+            break
+        time.sleep(0.01)
+    assert all(
+        status is not None and status["state"] == "outcome_unknown"
+        for status in statuses
+    )
+    assert hot_path_scans == 2
+
+
+def test_mobile_prompt_receipt_follows_real_turn_context_and_session_db(
+    _isolated_gateway_mutation_store,
+    tmp_path,
+    monkeypatch,
+):
+    from agent.turn_context import build_turn_context
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+    from tui_gateway import server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        session_db=db,
+        session_id="conversation-root",
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cached_system_prompt = "SYSTEM"
+    agent.compression_enabled = False
+    agent._skip_mcp_refresh = True
+    turn_done = threading.Event()
+    turns = 0
+
+    class RuntimeAdapter:
+        @staticmethod
+        def _set_interrupt(_value, _thread_id):
+            return None
+
+    def run_turn(_rid, _sid, session, text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            receipt_tags = list(
+                session.pop("_pending_mobile_mutation_receipt_tags", ()) or ()
+            )
+            session["_active_mobile_mutation_receipt_tags"] = receipt_tags
+            history = list(session["history"])
+        agent._pending_mobile_mutation_receipt_tags = receipt_tags
+        context = build_turn_context(
+            agent=agent,
+            user_message=text,
+            system_message=None,
+            conversation_history=history,
+            task_id=None,
+            stream_callback=None,
+            persist_user_message=None,
+            restore_or_build_system_prompt=lambda *_args, **_kwargs: None,
+            install_safe_stdio=lambda: None,
+            sanitize_surrogates=lambda value: value,
+            summarize_user_message_for_log=lambda value: value,
+            set_session_context=lambda _session_id: None,
+            set_current_write_origin=lambda _origin: None,
+            ra=lambda: RuntimeAdapter,
+        )
+        agent._session_messages = context.messages
+        with session["history_lock"]:
+            session["history"] = context.messages
+            session.pop("_active_mobile_mutation_receipt_tags", None)
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    session = {
+        "agent": agent,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.write")
+    request = {
+        "jsonrpc": "2.0",
+        "id": "real-path-first",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "real-path-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "persist through the real path",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    assert turn_done.wait(timeout=2)
+    deadline = time.monotonic() + 2
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="real-path-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+
+    assert status is not None and status["state"] == "completed"
+    rows = db.get_messages("conversation-root")
+    assert [(row["role"], row["content"]) for row in rows] == [
+        ("user", "persist through the real path")
+    ]
+    assert session["history"][-1]["_db_persisted"] is True
+    assert session["history"][-1]["_mobile_mutation_receipt_tags"]
+
+    request["id"] = "real-path-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["result"]["mutation"]["deduplicated"] is True
+    assert turns == 1
+    db.close()
+
+
+def test_mobile_prompt_receipt_completes_only_after_durable_turn(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    class Agent:
+        @staticmethod
+        def steer(_text):
+            raise AssertionError("durable mobile prompts must queue, not steer")
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "steer")
+    entered = threading.Event()
+    release = threading.Event()
+    delivered = 0
+    session = {
+        "agent": Agent(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+
+    def finish_active_turn():
+        nonlocal delivered
+        entered.set()
+        assert release.wait(timeout=2)
+        with session["history_lock"]:
+            queued = session["queued_prompt"]
+            assert queued is not None
+            delivered += 1
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": queued["text"],
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": list(
+                        queued["mobile_mutation_receipt_tags"]
+                    ),
+                }
+            )
+            session["queued_prompt"] = None
+            session["running"] = False
+
+    active_turn = threading.Thread(target=finish_active_turn)
+    session["_run_thread"] = active_turn
+    server._sessions["live-1"] = session
+    active_turn.start()
+    assert entered.wait(timeout=1)
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "prompt-first",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "prompt-durable-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "persist this once",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["status"] == "queued"
+    assert first["result"]["mutation"] == {
+        "client_request_id": "prompt-durable-1",
+        "deduplicated": False,
+        "state": "in_progress",
+    }
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="prompt-durable-1",
+    )["state"] == "in_progress"
+
+    release.set()
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="prompt-durable-1",
+        )
+        if status and status["state"] == "completed":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "completed"
+
+    request["id"] = "prompt-retry"
+    retry = server.dispatch(request, transport)
+    assert delivered == 1
+    assert retry["result"]["status"] == "queued"
+    assert retry["result"]["mutation"]["deduplicated"] is True
+
+
+def test_interrupting_queued_mobile_prompt_terminalizes_its_receipt(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    class Agent:
+        interrupted = 0
+
+        def interrupt(self):
+            self.interrupted += 1
+
+    class LiveThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "transport": None,
+        "_run_thread": LiveThread(),
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    prompt = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "queued-prompt",
+            "method": "prompt.submit",
+            "params": {
+                "client_request_id": "queued-prompt-1",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+                "text": "cancel before delivery",
+            },
+        },
+        transport,
+    )
+    assert prompt["result"]["status"] == "queued"
+    assert prompt["result"]["mutation"]["state"] == "in_progress"
+    assert session["queued_prompt"] is not None
+
+    interrupted = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "interrupt-queued-prompt",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "interrupt-queued-prompt-1",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        transport,
+    )
+    assert interrupted["result"]["status"] == "interrupted"
+    assert interrupted["result"]["mutation"]["state"] == "completed"
+    assert agent.interrupted == 1
+    assert session["queued_prompt"] is None
+
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="queued-prompt-1",
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "outcome_unknown"
+    assert "_live_mobile_mutation_receipt_tags" not in session
+
+
+def test_mobile_prompt_without_durable_history_becomes_outcome_unknown(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    turn_done = threading.Event()
+    turns = 0
+
+    def run_turn(_rid, _sid, session, _text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": "banana",
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": ["different-proof"],
+                }
+            )
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    server._sessions["live-1"] = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": "prompt-undurable",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": "prompt-undurable-1",
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "a",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert turn_done.wait(timeout=1)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id="prompt-undurable-1",
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+    assert status is not None and status["state"] == "outcome_unknown"
+
+    request["id"] = "prompt-undurable-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["error"]["code"] == 4091
+    assert turns == 1
+
+
+@pytest.mark.parametrize(
+    "exit_mode",
+    ["agent_init_failure", "pre_worker_cancel", "worker_setup_failure"],
+)
+def test_mobile_prompt_pre_worker_exit_terminalizes_receipt(
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+    exit_mode,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    def wait_agent(session, *_args):
+        if exit_mode == "pre_worker_cancel":
+            session["_turn_cancel_requested"] = True
+            return None
+        if exit_mode == "agent_init_failure":
+            return {"error": {"message": "agent initialization failed"}}
+        return None
+
+    monkeypatch.setattr(server, "_wait_agent", wait_agent)
+    if exit_mode == "worker_setup_failure":
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("transport closed before worker start")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            server,
+            "_run_prompt_submit",
+            lambda *_args: pytest.fail("turn worker must not start"),
+        )
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.write")
+    client_request_id = f"prompt-{exit_mode}-1"
+    request = {
+        "jsonrpc": "2.0",
+        "id": f"prompt-{exit_mode}",
+        "method": "prompt.submit",
+        "params": {
+            "client_request_id": client_request_id,
+            "expected_stored_session_id": "conversation-root",
+            "session_id": "live-1",
+            "text": "never started",
+        },
+    }
+
+    first = server.dispatch(request, transport)
+    assert first["result"]["mutation"]["state"] == "in_progress"
+    deadline = time.monotonic() + 1
+    status = None
+    while time.monotonic() < deadline:
+        status = _isolated_gateway_mutation_store.status(
+            provider="password",
+            subject="mobile-user",
+            client_request_id=client_request_id,
+        )
+        if status and status["state"] == "outcome_unknown":
+            break
+        time.sleep(0.01)
+
+    assert status is not None and status["state"] == "outcome_unknown"
+    assert "_pending_mobile_mutation_receipt_tags" not in session
+    request["id"] = f"prompt-{exit_mode}-retry"
+    retry = server.dispatch(request, transport)
+    assert retry["error"]["code"] == 4091
+
+
+def test_blocked_context_clears_unconsumed_mobile_receipt_tag(
+    tmp_path,
+    monkeypatch,
+):
+    from agent import context_references, model_metadata
+    from tui_gateway import server
+
+    class Agent:
+        api_key = "test-key"
+        api_mode = "openai_chat"
+        base_url = ""
+        model = "test/model"
+        provider = "test"
+        _config_context_length = None
+        _pending_mobile_mutation_receipt_tags = []
+
+        @staticmethod
+        def run_conversation(*_args, **_kwargs):
+            raise AssertionError("blocked context must not reach the agent")
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        @staticmethod
+        def is_alive():
+            return False
+
+    monkeypatch.setattr(server.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(
+        server,
+        "_sync_agent_model_with_config",
+        lambda _sid, _session: None,
+    )
+    monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(
+        model_metadata,
+        "get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    monkeypatch.setattr(
+        context_references,
+        "preprocess_context_references",
+        lambda *_args, **_kwargs: type(
+            "BlockedContext",
+            (),
+            {
+                "blocked": True,
+                "message": "",
+                "warnings": ["Context injection refused."],
+            },
+        )(),
+    )
+    agent = Agent()
+    proof_tag = "principal-scoped-proof"
+    session = {
+        "agent": agent,
+        "attached_images": [],
+        "cols": 80,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+        "_pending_mobile_mutation_receipt_tags": [proof_tag],
+    }
+
+    server._run_prompt_submit("rid", "live-1", session, "@blocked")
+
+    assert session["running"] is False
+    assert "_pending_mobile_mutation_receipt_tags" not in session
+    assert "_active_mobile_mutation_receipt_tags" not in session
+    assert agent._pending_mobile_mutation_receipt_tags == []
+    assert not server._mobile_prompt_turn_is_pending(
+        ("live-1", session, proof_tag)
+    )
 
 
 def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
@@ -917,10 +1774,22 @@ def test_mobile_prompt_retry_uses_durable_identity_after_live_id_rotation(
     turns = 0
     turn_done = threading.Event()
 
-    def run_turn(_rid, _sid, session, _text):
+    def run_turn(_rid, _sid, session, text):
         nonlocal turns
         turns += 1
         with session["history_lock"]:
+            receipt_tags = list(
+                session.get("_pending_mobile_mutation_receipt_tags") or ()
+            )
+            assert len(receipt_tags) == 1
+            session["history"].append(
+                {
+                    "role": "user",
+                    "content": text,
+                    "_db_persisted": True,
+                    "_mobile_mutation_receipt_tags": receipt_tags,
+                }
+            )
             session["running"] = False
         turn_done.set()
 

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -99,6 +99,14 @@ def test_advertised_mutations_share_one_policy_and_resource_authority():
         assert descriptor is not None
         assert descriptor.resource_parameter in policy.allowed_parameters
         assert set(descriptor.semantic_parameters) <= policy.allowed_parameters
+        if descriptor.lineage_parameter is not None:
+            assert descriptor.lineage_parameter in policy.allowed_parameters
+    assert payload["schemas"]["approval.lifecycle"] == 1
+    assert payload["capabilities"]["interaction.lifecycle"] == {
+        "version": 1,
+        "kinds": ["approval"],
+        "response_methods": ["approval.respond"],
+    }
 
 
 def test_transient_lineage_failure_releases_receipt_for_identical_retry(
@@ -319,6 +327,367 @@ def test_mobile_interrupt_requires_a_client_request_identity(monkeypatch):
             "reason": "client_request_id_required",
         },
     }
+
+
+def test_mobile_approval_response_replays_exact_outcome_after_live_rotation(
+    monkeypatch,
+):
+    from tools import approval
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    calls = []
+
+    def resolve_exact(session_key, approval_id, choice, **kwargs):
+        calls.append((session_key, approval_id, choice, kwargs))
+        return {
+            "outcome": "resolved",
+            "approval": {
+                "approval_id": approval_id,
+                "state": "resolved",
+                "resolution": {"choice": "once"},
+            },
+        }
+
+    monkeypatch.setattr(approval, "resolve_gateway_approval_by_id", resolve_exact)
+    server._sessions["live-1"] = {
+        "agent": object(),
+        "agent_ready": None,
+        "history_lock": threading.Lock(),
+        "session_key": "conversation-root",
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    params = {
+        "approval_id": "a" * 32,
+        "choice": " Once ",
+        "client_request_id": "approval-response-1",
+        "expected_stored_session_id": "conversation-root",
+        "reason": "approved from phone",
+        "session_id": "live-1",
+    }
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-first",
+            "method": "approval.respond",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert first["result"]["outcome"] == "resolved"
+    assert first["result"]["mutation"] == {
+        "client_request_id": "approval-response-1",
+        "deduplicated": False,
+        "state": "completed",
+    }
+    params["session_id"] = "rotated-live-id"
+    params["choice"] = "once"
+    replay = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-replay",
+            "method": "approval.respond",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert replay["result"]["outcome"] == "resolved"
+    assert replay["result"]["mutation"]["deduplicated"] is True
+    assert calls == [
+        (
+            "conversation-root",
+            "a" * 32,
+            " Once ",
+            {
+                "reason": "approved from phone",
+                "resolution_metadata": {
+                    "source": "tui_gateway",
+                    "live_session_id": "live-1",
+                },
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("parameter", "different"),
+    [
+        ("approval_id", "b" * 32),
+        ("choice", "deny"),
+        ("reason", "different reason"),
+        ("expected_stored_session_id", "different-conversation"),
+    ],
+)
+def test_mobile_approval_response_conflicts_on_changed_semantics(
+    monkeypatch,
+    parameter,
+    different,
+):
+    from tools import approval
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    calls = 0
+
+    def resolve_exact(_session_key, approval_id, choice, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "outcome": "resolved",
+            "approval": {
+                "approval_id": approval_id,
+                "state": "resolved",
+                "resolution": {"choice": choice},
+            },
+        }
+
+    monkeypatch.setattr(approval, "resolve_gateway_approval_by_id", resolve_exact)
+    server._sessions["live-1"] = {
+        "agent": object(),
+        "agent_ready": None,
+        "history_lock": threading.Lock(),
+        "session_key": "conversation-root",
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    params = {
+        "approval_id": "a" * 32,
+        "choice": "once",
+        "client_request_id": "approval-conflict-1",
+        "expected_stored_session_id": "conversation-root",
+        "reason": "original reason",
+        "session_id": "live-1",
+    }
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-conflict-first",
+            "method": "approval.respond",
+            "params": params,
+        },
+        transport,
+    )
+    assert first["result"]["outcome"] == "resolved"
+
+    params[parameter] = different
+    conflict = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-conflict-second",
+            "method": "approval.respond",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert conflict["error"]["code"] == 4090
+    assert conflict["error"]["data"]["reason"] == "mutation_conflict"
+    assert calls == 1
+
+
+def test_simultaneous_mobile_approval_responses_resolve_exactly_once(
+    monkeypatch,
+):
+    from tools import approval
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def resolve_exact(_session_key, approval_id, choice, **_kwargs):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        return {
+            "outcome": "resolved",
+            "approval": {
+                "approval_id": approval_id,
+                "state": "resolved",
+                "resolution": {"choice": choice},
+            },
+        }
+
+    monkeypatch.setattr(approval, "resolve_gateway_approval_by_id", resolve_exact)
+    server._sessions["live-1"] = {
+        "agent": object(),
+        "agent_ready": None,
+        "history_lock": threading.Lock(),
+        "session_key": "conversation-root",
+    }
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    params = {
+        "approval_id": "a" * 32,
+        "choice": "once",
+        "client_request_id": "approval-simultaneous-1",
+        "expected_stored_session_id": "conversation-root",
+        "session_id": "live-1",
+    }
+    responses = {}
+
+    def dispatch(name, correlation):
+        responses[name] = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": correlation,
+                "method": "approval.respond",
+                "params": params,
+            },
+            transport,
+        )
+
+    first = threading.Thread(target=dispatch, args=("first", "approval-first"))
+    duplicate = threading.Thread(
+        target=dispatch,
+        args=("duplicate", "approval-duplicate"),
+    )
+    first.start()
+    assert entered.wait(timeout=1)
+    duplicate.start()
+    release.set()
+    first.join(timeout=2)
+    duplicate.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not duplicate.is_alive()
+    assert calls == 1
+    assert responses["first"]["result"]["mutation"]["deduplicated"] is False
+    assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is True
+    assert responses["first"]["result"]["outcome"] == "resolved"
+    assert responses["duplicate"]["result"]["outcome"] == "resolved"
+
+
+@pytest.mark.parametrize(
+    ("missing", "expected_message"),
+    [
+        ("client_request_id", "client_request_id is required"),
+        ("approval_id", "approval_id is required"),
+        ("choice", "choice is required"),
+        (
+            "expected_stored_session_id",
+            "expected_stored_session_id is required",
+        ),
+    ],
+)
+def test_mobile_approval_response_requires_durable_identities(
+    missing,
+    expected_message,
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tools import approval
+    from tui_gateway import server
+
+    resolver_calls = []
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval_by_id",
+        lambda *args, **kwargs: resolver_calls.append((args, kwargs)),
+    )
+    params = {
+        "approval_id": "a" * 32,
+        "choice": "once",
+        "client_request_id": "approval-required-ids",
+        "expected_stored_session_id": "conversation-root",
+        "session_id": "live-1",
+    }
+    params.pop(missing)
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": f"missing-{missing}",
+            "method": "approval.respond",
+            "params": params,
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"]["code"] == -32602
+    assert expected_message in response["error"]["message"]
+    assert resolver_calls == []
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="approval-required-ids",
+    ) is None
+
+
+@pytest.mark.parametrize("choice", ["", "   "])
+def test_mobile_approval_response_rejects_blank_choice_before_reserving_receipt(
+    choice,
+    _isolated_gateway_mutation_store,
+    monkeypatch,
+):
+    from tools import approval
+    from tui_gateway import server
+
+    resolver_calls = []
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval_by_id",
+        lambda *args, **kwargs: resolver_calls.append((args, kwargs)),
+    )
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "blank-approval-choice",
+            "method": "approval.respond",
+            "params": {
+                "approval_id": "a" * 32,
+                "choice": choice,
+                "client_request_id": "approval-blank-choice",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"] == {
+        "code": -32602,
+        "message": "choice is required for mobile approval response",
+        "data": {
+            "method": "approval.respond",
+            "reason": "approval_choice_required",
+        },
+    }
+    assert resolver_calls == []
+    assert _isolated_gateway_mutation_store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="approval-blank-choice",
+    ) is None
 
 
 def test_mobile_mutation_rejects_an_oversized_request_identity():
@@ -1712,9 +2081,9 @@ def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
 
     monkeypatch.setattr(db, "delete_session", counted_delete)
     transport = _MobileTransport("conversation.read", "conversation.delete")
-    params = {
+    first_params = {
         "client_request_id": "delete-1",
-        "session_id": "conversation-delete",
+        "session_id": "  conversation-delete  ",
     }
 
     first = server.dispatch(
@@ -1722,7 +2091,7 @@ def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
             "jsonrpc": "2.0",
             "id": "delete-correlation-1",
             "method": "session.delete",
-            "params": params,
+            "params": first_params,
         },
         transport,
     )
@@ -1731,7 +2100,10 @@ def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
             "jsonrpc": "2.0",
             "id": "delete-correlation-2",
             "method": "session.delete",
-            "params": params,
+            "params": {
+                "client_request_id": "delete-1",
+                "session_id": "conversation-delete",
+            },
         },
         transport,
     )

--- a/tests/tui_gateway/test_mobile_mutations.py
+++ b/tests/tui_gateway/test_mobile_mutations.py
@@ -1,0 +1,650 @@
+"""Durable receipt behavior for consequential mobile JSON-RPC mutations."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+
+import pytest
+
+from tui_gateway.mobile_mutations import (
+    MobileMutationStore,
+    MutationConflict,
+    MutationDisposition,
+)
+
+
+class _MobileTransport:
+    def __init__(self, *scopes: str, subject: str = "mobile-user"):
+        self.authorization = {
+            "audience": "hermes.mobile",
+            "provider": "password",
+            "scopes": scopes,
+            "subject": subject,
+        }
+
+    def write(self, _obj):
+        return True
+
+
+def _reserve(
+    store: MobileMutationStore,
+    *,
+    request_id: str = "request-1",
+    text: str = "hello",
+):
+    return store.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id=request_id,
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": text},
+    )
+
+
+def test_completed_mutation_replays_exact_outcome_after_database_reopen(tmp_path):
+    path = tmp_path / "mobile-mutations.sqlite3"
+    first = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = _reserve(first)
+    assert claim.disposition is MutationDisposition.EXECUTE
+    outcome = {
+        "jsonrpc": "2.0",
+        "id": "original-correlation",
+        "result": {"status": "streaming"},
+    }
+    assert first.complete(claim, outcome) is True
+    first.close()
+
+    reopened = MobileMutationStore(path, owner_instance_id="process-b")
+    replay = _reserve(reopened)
+
+    assert replay.disposition is MutationDisposition.REPLAY
+    assert replay.outcome == outcome
+    assert reopened.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )["state"] == "completed"
+
+
+def test_same_request_identity_with_different_semantics_conflicts(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    claim = _reserve(store, text="first")
+    store.complete(claim, {"result": {"status": "streaming"}})
+
+    with pytest.raises(MutationConflict):
+        _reserve(store, text="different")
+
+
+def test_abandoned_in_progress_mutation_becomes_outcome_unknown_after_reopen(
+    tmp_path,
+):
+    path = tmp_path / "mobile-mutations.sqlite3"
+    first = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = _reserve(first)
+    assert claim.disposition is MutationDisposition.EXECUTE
+    first.close()
+
+    reopened = MobileMutationStore(path, owner_instance_id="process-b")
+    uncertain = _reserve(reopened)
+
+    assert uncertain.disposition is MutationDisposition.OUTCOME_UNKNOWN
+    status = reopened.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )
+    assert status["state"] == "outcome_unknown"
+    assert status["outcome"] is None
+
+
+def test_principals_do_not_share_request_identity_namespaces(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    first = _reserve(store)
+    store.complete(first, {"result": {"status": "streaming"}})
+
+    other = store.reserve(
+        provider="password",
+        subject="different-user",
+        client_request_id="request-1",
+        method="prompt.submit",
+        resource_id="conversation-root",
+        semantic_parameters={"text": "hello"},
+    )
+
+    assert other.disposition is MutationDisposition.EXECUTE
+
+
+def test_same_process_duplicate_waits_for_one_authoritative_outcome(tmp_path):
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    original = _reserve(store)
+    duplicate = _reserve(store)
+    assert duplicate.disposition is MutationDisposition.IN_PROGRESS
+
+    completed = threading.Event()
+
+    def finish_original():
+        store.complete(original, {"result": {"status": "interrupted"}})
+        completed.set()
+
+    thread = threading.Thread(target=finish_original)
+    thread.start()
+    replay = store.wait_for_outcome(duplicate, timeout=2)
+    thread.join(timeout=2)
+
+    assert completed.is_set()
+    assert replay.disposition is MutationDisposition.REPLAY
+    assert replay.outcome == {"result": {"status": "interrupted"}}
+
+
+def test_status_lookup_does_not_require_a_live_conversation(tmp_path):
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    claim = _reserve(store)
+    store.complete(claim, {"result": {"deleted": "conversation-root"}})
+
+    status = store.status(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="request-1",
+    )
+
+    assert status == {
+        "client_request_id": "request-1",
+        "method": "prompt.submit",
+        "outcome": {"result": {"deleted": "conversation-root"}},
+        "state": "completed",
+    }
+
+
+def test_mobile_interrupt_requires_a_client_request_identity(monkeypatch):
+    from tui_gateway import server
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "missing-id",
+            "method": "session.interrupt",
+            "params": {
+                "session_id": "live-1",
+                "expected_stored_session_id": "conversation-root",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"] == {
+        "code": -32602,
+        "message": "client_request_id is required for mobile mutation",
+        "data": {
+            "method": "session.interrupt",
+            "reason": "client_request_id_required",
+        },
+    }
+
+
+def test_mobile_mutation_rejects_an_oversized_request_identity():
+    from tui_gateway import server
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "invalid-id",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "x" * 257,
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-1",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert response["error"]["code"] == -32602
+    assert response["error"]["data"] == {
+        "reason": "invalid_client_request_id"
+    }
+
+
+
+def test_mobile_interrupt_retry_executes_once_and_status_survives_session_removal(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    class RunThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(server, "_clear_pending", lambda _sid: None)
+    agent = Agent()
+    session = {
+        "_run_thread": RunThread(),
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    server._sessions.clear()
+    server._sessions["live-1"] = session
+    transport = _MobileTransport("conversation.read", "conversation.control")
+    params = {
+        "session_id": "live-1",
+        "expected_stored_session_id": "conversation-root",
+        "client_request_id": "interrupt-1",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "first-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "retry-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert agent.interrupt_calls == 1
+    assert first == {
+        "jsonrpc": "2.0",
+        "id": "first-correlation",
+        "result": {
+            "mutation": {
+                "client_request_id": "interrupt-1",
+                "deduplicated": False,
+                "state": "completed",
+            },
+            "status": "interrupted",
+        },
+    }
+    assert retry == {
+        "jsonrpc": "2.0",
+        "id": "retry-correlation",
+        "result": {
+            "mutation": {
+                "client_request_id": "interrupt-1",
+                "deduplicated": True,
+                "state": "completed",
+            },
+            "status": "interrupted",
+        },
+    }
+
+    server._sessions.clear()
+    replay_without_live_session = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "post-removal-correlation",
+            "method": "session.interrupt",
+            "params": params,
+        },
+        transport,
+    )
+    assert replay_without_live_session["result"]["status"] == "interrupted"
+    assert (
+        replay_without_live_session["result"]["mutation"]["deduplicated"] is True
+    )
+
+    status = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "status-correlation",
+            "method": "mutation.status",
+            "params": {"client_request_id": "interrupt-1"},
+        },
+        transport,
+    )
+
+    assert status["result"]["client_request_id"] == "interrupt-1"
+    assert status["result"]["method"] == "session.interrupt"
+    assert status["result"]["outcome"] == {
+        "result": {"status": "interrupted"}
+    }
+    assert status["result"]["state"] == "completed"
+
+
+def test_simultaneous_mobile_prompt_submissions_create_one_turn(tmp_path, monkeypatch):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    store = MobileMutationStore(
+        tmp_path / "mobile-mutations.sqlite3",
+        owner_instance_id="process-a",
+    )
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    counts = {"inflight": 0, "turn": 0}
+    monkeypatch.setattr(
+        server,
+        "_start_inflight_turn",
+        lambda *_args: counts.__setitem__("inflight", counts["inflight"] + 1),
+    )
+
+    def run_turn(_rid, _sid, session, _text):
+        counts["turn"] += 1
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(tmp_path),
+        "queued_prompt": None,
+        "running": False,
+        "session_key": "conversation-root",
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["live-1"] = session
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    params = {
+        "client_request_id": "prompt-1",
+        "expected_stored_session_id": "conversation-root",
+        "session_id": "live-1",
+        "text": "run exactly once",
+    }
+
+    original_complete = store.complete
+    first_at_completion = threading.Event()
+    release_completion = threading.Event()
+
+    def blocking_complete(claim, outcome):
+        first_at_completion.set()
+        assert release_completion.wait(timeout=2)
+        return original_complete(claim, outcome)
+
+    monkeypatch.setattr(store, "complete", blocking_complete)
+    responses = {}
+
+    def dispatch(name, correlation):
+        responses[name] = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": correlation,
+                "method": "prompt.submit",
+                "params": params,
+            },
+            transport,
+        )
+
+    first = threading.Thread(target=dispatch, args=("first", "correlation-1"))
+    duplicate = threading.Thread(
+        target=dispatch,
+        args=("duplicate", "correlation-2"),
+    )
+    first.start()
+    assert first_at_completion.wait(timeout=2)
+    duplicate.start()
+    release_completion.set()
+    first.join(timeout=2)
+    duplicate.join(timeout=2)
+
+    assert counts == {"inflight": 1, "turn": 1}
+    assert responses["first"]["result"]["mutation"]["deduplicated"] is False
+    assert responses["duplicate"]["result"]["mutation"]["deduplicated"] is True
+    assert responses["first"]["result"]["status"] == "streaming"
+    assert responses["duplicate"]["result"]["status"] == "streaming"
+
+
+def test_mobile_delete_retry_replays_after_conversation_row_is_gone(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_state import SessionDB
+    from tui_gateway import server
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("conversation-delete", source="tui")
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    server._sessions.clear()
+    calls = 0
+    original_delete = db.delete_session
+
+    def counted_delete(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_delete(*args, **kwargs)
+
+    monkeypatch.setattr(db, "delete_session", counted_delete)
+    transport = _MobileTransport("conversation.read", "conversation.delete")
+    params = {
+        "client_request_id": "delete-1",
+        "session_id": "conversation-delete",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "delete-correlation-1",
+            "method": "session.delete",
+            "params": params,
+        },
+        transport,
+    )
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "delete-correlation-2",
+            "method": "session.delete",
+            "params": params,
+        },
+        transport,
+    )
+
+    assert calls == 1
+    assert db.get_session("conversation-delete") is None
+    assert first["result"]["deleted"] == "conversation-delete"
+    assert first["result"]["mutation"]["deduplicated"] is False
+    assert retry["result"]["deleted"] == "conversation-delete"
+    assert retry["result"]["mutation"]["deduplicated"] is True
+    db.close()
+
+
+def test_mobile_prompt_retry_uses_durable_identity_after_live_id_rotation(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    class Db:
+        @staticmethod
+        def resolve_resume_session_id(session_id):
+            return "conversation-tip" if session_id == "conversation-root" else session_id
+
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root", "conversation-tip"]
+
+    store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: store)
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+    turns = 0
+    turn_done = threading.Event()
+
+    def run_turn(_rid, _sid, session, _text):
+        nonlocal turns
+        turns += 1
+        with session["history_lock"]:
+            session["running"] = False
+        turn_done.set()
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_turn)
+
+    def live_session(stored_id):
+        return {
+            "agent": type("Agent", (), {"session_id": stored_id})(),
+            "history": [],
+            "history_lock": threading.Lock(),
+            "profile_home": str(tmp_path),
+            "queued_prompt": None,
+            "running": False,
+            "session_key": stored_id,
+            "transport": None,
+        }
+
+    server._sessions.clear()
+    server._sessions["live-before"] = live_session("conversation-root")
+    transport = _MobileTransport(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+    base_params = {
+        "client_request_id": "prompt-rotation-1",
+        "expected_stored_session_id": "conversation-root",
+        "text": "continue exactly once",
+    }
+
+    first = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "before-rotation",
+            "method": "prompt.submit",
+            "params": {**base_params, "session_id": "live-before"},
+        },
+        transport,
+    )
+    assert turn_done.wait(timeout=2)
+    server._sessions.clear()
+    server._sessions["live-after"] = live_session("conversation-tip")
+    retry = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "after-rotation",
+            "method": "prompt.submit",
+            "params": {**base_params, "session_id": "live-after"},
+        },
+        transport,
+    )
+
+    assert turns == 1
+    assert first["result"]["mutation"]["deduplicated"] is False
+    assert retry["result"]["mutation"]["deduplicated"] is True
+
+
+def test_mobile_abandoned_interrupt_is_outcome_unknown_and_never_reexecuted(
+    tmp_path,
+    monkeypatch,
+):
+    from tui_gateway import server
+
+    path = tmp_path / "mobile-mutations.sqlite3"
+    before_restart = MobileMutationStore(path, owner_instance_id="process-a")
+    claim = before_restart.reserve(
+        provider="password",
+        subject="mobile-user",
+        client_request_id="interrupt-unknown",
+        method="session.interrupt",
+        resource_id="conversation-root",
+        semantic_parameters={},
+    )
+    assert claim.disposition is MutationDisposition.EXECUTE
+    before_restart.close()
+    after_restart = MobileMutationStore(path, owner_instance_id="process-b")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: after_restart)
+
+    class Db:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            return ["conversation-root"]
+
+    monkeypatch.setattr(
+        server,
+        "_session_db",
+        lambda _session: contextlib.nullcontext(Db()),
+    )
+
+    class Agent:
+        interrupt_calls = 0
+
+        def interrupt(self):
+            self.interrupt_calls += 1
+
+    agent = Agent()
+    server._sessions.clear()
+    server._sessions["live-unknown"] = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "conversation-root",
+    }
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "unknown-correlation",
+            "method": "session.interrupt",
+            "params": {
+                "client_request_id": "interrupt-unknown",
+                "expected_stored_session_id": "conversation-root",
+                "session_id": "live-unknown",
+            },
+        },
+        _MobileTransport("conversation.read", "conversation.control"),
+    )
+
+    assert agent.interrupt_calls == 0
+    assert response["error"] == {
+        "code": 4091,
+        "message": "the prior mutation outcome is unknown and will not be re-executed",
+        "data": {
+            "client_request_id": "interrupt-unknown",
+            "reason": "mutation_outcome_unknown",
+            "state": "outcome_unknown",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -479,6 +479,94 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     assert "mobile_sync" not in server._sessions[sid]
 
 
+def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    legacy_payload = server._live_session_payload(
+        sid,
+        session,
+        transport=legacy,
+        cursor=cursor,
+    )
+    assert "synchronization" not in legacy_payload
+
+    server._emit("status.update", sid, {"kind": "legacy", "text": "Still here"})
+    legacy_event = legacy.frames[-1]
+    assert "sequence" not in legacy_event["params"]
+    assert "stream_id" not in legacy_event["params"]
+
+    reconnected = resume_session(mobile, stored_id, cursor)
+    recovery = reconnected["synchronization"]["recovery"]
+    assert recovery["outcome"] == "complete"
+    assert [event["params"]["type"] for event in recovery["events"]] == [
+        "status.update"
+    ]
+    assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():
+    transport = RecordingTransport()
+    sid = "first-attach"
+    session = {
+        "agent": None,
+        "conversation_id": "first-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "running": False,
+        "session_key": "first-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    start = threading.Barrier(3)
+    attached = {}
+
+    def attach():
+        start.wait()
+        attached["payload"] = server._attach_synchronization({}, sid, session)
+
+    def publish():
+        start.wait()
+        server._emit("status.update", sid, {"kind": "race", "text": "Ready"})
+
+    attach_thread = threading.Thread(target=attach)
+    publish_thread = threading.Thread(target=publish)
+    attach_thread.start()
+    publish_thread.start()
+    start.wait()
+    attach_thread.join(timeout=1)
+    publish_thread.join(timeout=1)
+    assert not attach_thread.is_alive()
+    assert not publish_thread.is_alive()
+
+    snapshot = attached["payload"]["synchronization"]["snapshot"]
+    event = next(
+        frame
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "status.update"
+    )
+    assert snapshot["stream_id"] == event["params"]["stream_id"]
+    assert session["mobile_sync"].stream_id == snapshot["stream_id"]
+
+
 def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
     transport = RecordingTransport()
     sid = "barrier-live"
@@ -491,7 +579,7 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         "history_version": 0,
         "inflight_turn": None,
         "mobile_sync": stream,
-        "mobile_sync_enabled": True,
+        "mobile_sync_retention": True,
         "running": True,
         "session_key": "barrier-stored",
         "transport": transport,
@@ -558,6 +646,53 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         event["params"]["type"]
         for event in synchronization["recovery"]["events"]
     ] == ["message.complete"]
+
+
+def test_deferred_prompt_start_advances_revision_before_agent_ready(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    entered_wait = threading.Event()
+    release_wait = threading.Event()
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+
+    def blocked_wait(_session, rid):
+        entered_wait.set()
+        assert release_wait.wait(timeout=2)
+        return server._err(rid, 5000, "test build stopped")
+
+    monkeypatch.setattr(server, "_wait_agent", blocked_wait)
+    try:
+        submitted = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "deferred-submit",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "question"},
+            },
+            transport,
+        )
+        assert submitted["result"] == {"status": "streaming"}
+        assert entered_wait.wait(timeout=1)
+
+        resumed = resume_session(transport, stored_id, cursor)
+        synchronization = resumed["synchronization"]
+        assert synchronization["snapshot"]["revision"] == initial_revision + 1
+        assert synchronization["snapshot"]["watermark"] == cursor["sequence"]
+        assert synchronization["snapshot"]["inflight_turn"]["user"] == "question"
+        assert synchronization["recovery"]["outcome"] == "complete"
+        assert synchronization["recovery"]["events"] == []
+    finally:
+        release_wait.set()
+        run_thread = server._sessions.get(sid, {}).get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(timeout=1)
 
 
 def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
@@ -649,5 +784,21 @@ def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
     assert settled["active_tools"] == []
     assert settled["messages"][-1] == {
         "role": "assistant",
-        "text": "goal\nanswer",
+        "text": "answer",
     }
+    complete = next(
+        frame
+        for frame in reversed(transport.frames)
+        if frame.get("params", {}).get("type") == "message.complete"
+    )
+    assert complete["params"]["payload"]["text"] == "answer"
+
+
+def test_conversation_root_does_not_hide_callable_attribute_errors():
+    class BrokenLineageDB:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            raise AttributeError("lineage implementation bug")
+
+    with pytest.raises(AttributeError, match="lineage implementation bug"):
+        server._conversation_root(BrokenLineageDB(), "stored")

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -1,5 +1,6 @@
 """Public JSON-RPC conformance tests for revisioned conversation sync."""
 
+import json
 import threading
 import time
 
@@ -444,6 +445,223 @@ def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
 
     settled = resume_session(transport, stored_id)
     assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+
+
+def test_snapshot_recovers_exact_redacted_approval_until_terminal_event(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    approval_id = "a" * 32
+    raw_secret = "sk-proj-super-secret-mobile-contract"
+
+    server._emit_approval_request(
+        sid,
+        {
+            "approval_id": approval_id,
+            "command": f"curl -H 'Authorization: Bearer {raw_secret}' example.test",
+            "description": "network request",
+            "created_at": 10.0,
+            "expires_at": 310.0,
+            "state": "pending",
+            "resolution": None,
+        },
+    )
+
+    waiting = resume_session(transport, stored_id)
+    snapshot = waiting["synchronization"]["snapshot"]
+    assert snapshot["status"] == "waiting"
+    assert len(snapshot["pending_interactions"]) == 1
+    descriptor = snapshot["pending_interactions"][0]
+    assert set(descriptor) == {
+        "approval_id",
+        "command",
+        "description",
+        "created_at",
+        "expires_at",
+        "state",
+        "resolution",
+        "kind",
+    }
+    assert descriptor["approval_id"] == approval_id
+    assert descriptor["description"] == "network request"
+    assert descriptor["created_at"] == 10.0
+    assert descriptor["expires_at"] == 310.0
+    assert descriptor["state"] == "pending"
+    assert descriptor["resolution"] is None
+    assert descriptor["kind"] == "approval"
+    serialized = json.dumps(snapshot["pending_interactions"])
+    assert raw_secret not in serialized
+    assert "sk-proj-" not in serialized
+
+    server._emit_approval_terminal(
+        sid,
+        {
+            "approval_id": approval_id,
+            "state": "resolved",
+            "resolution": {"choice": "once", "resolved_at": 11.0},
+        },
+    )
+
+    terminal = next(
+        frame
+        for frame in reversed(transport.frames)
+        if frame.get("params", {}).get("type") == "approval.resolved"
+    )
+    assert terminal["params"]["payload"]["approval_id"] == approval_id
+    assert terminal["params"]["payload"]["state"] == "resolved"
+    settled = resume_session(transport, stored_id)
+    assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+
+
+def test_approval_response_targets_exact_identity_without_changing_legacy_fifo(
+    monkeypatch,
+):
+    from tools import approval
+
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["agent_ready"] = None
+    calls = []
+
+    def resolve_exact(session_key, approval_id, choice, **kwargs):
+        calls.append((session_key, approval_id, choice, kwargs))
+        return {
+            "outcome": "resolved",
+            "approval": {
+                "approval_id": approval_id,
+                "state": "resolved",
+                "resolution": {"choice": choice},
+            },
+        }
+
+    monkeypatch.setattr(approval, "resolve_gateway_approval_by_id", resolve_exact)
+    monkeypatch.setattr(approval, "resolve_gateway_approval", lambda *_a, **_k: 2)
+
+    exact = server._methods["approval.respond"](
+        "exact",
+        {
+            "session_id": sid,
+            "approval_id": "b" * 32,
+            "choice": "once",
+            "reason": "approved from phone",
+        },
+    )
+    assert exact["result"]["outcome"] == "resolved"
+    assert calls == [
+        (
+            session["session_key"],
+            "b" * 32,
+            "once",
+            {
+                "reason": "approved from phone",
+                "resolution_metadata": {
+                    "source": "tui_gateway",
+                    "live_session_id": sid,
+                },
+            },
+        )
+    ]
+
+    legacy = server._methods["approval.respond"](
+        "legacy",
+        {"session_id": sid, "choice": "deny", "all": True},
+    )
+    assert legacy["result"] == {"resolved": 2}
+
+
+def test_disconnect_resume_recovers_and_resolves_same_approval_once(monkeypatch):
+    from tools import approval
+
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    session["agent_ready"] = None
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 2},
+    )
+    server._register_gateway_approval_callbacks(session["session_key"], sid)
+    decision = {}
+
+    def wait_for_decision():
+        decision["value"] = approval._await_gateway_decision(
+            session["session_key"],
+            approval._gateway_notify_cbs[session["session_key"]],
+            {
+                "command": "rm -rf /tmp/example",
+                "description": "recursive delete",
+                "pattern_key": "rm_recursive",
+                "pattern_keys": ["rm_recursive"],
+            },
+        )
+
+    thread = threading.Thread(target=wait_for_decision)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 1
+        approval_id = ""
+        while time.monotonic() < deadline:
+            requests = [
+                frame
+                for frame in transport.frames
+                if frame.get("params", {}).get("type") == "approval.request"
+            ]
+            if requests:
+                approval_id = requests[-1]["params"]["payload"]["approval_id"]
+                break
+            time.sleep(0.01)
+        assert approval_id
+
+        reconnected = RecordingTransport()
+        recovered = resume_session(reconnected, stored_id)
+        pending = recovered["synchronization"]["snapshot"]["pending_interactions"]
+        assert [item["approval_id"] for item in pending] == [approval_id]
+
+        first = server._methods["approval.respond"](
+            "resolve-first",
+            {
+                "session_id": sid,
+                "approval_id": approval_id,
+                "choice": "once",
+            },
+        )
+        duplicate = server._methods["approval.respond"](
+            "resolve-duplicate",
+            {
+                "session_id": sid,
+                "approval_id": approval_id,
+                "choice": "once",
+            },
+        )
+        assert first["result"]["outcome"] == "resolved"
+        assert duplicate["result"]["outcome"] == "already_resolved"
+
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        assert decision == {
+            "value": {"resolved": True, "choice": "once", "reason": None}
+        }
+        terminal_events = [
+            frame
+            for frame in reconnected.frames
+            if frame.get("params", {}).get("type") == "approval.resolved"
+        ]
+        assert len(terminal_events) == 1
+        assert terminal_events[0]["params"]["payload"]["approval_id"] == approval_id
+        settled = resume_session(reconnected, stored_id)
+        assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+    finally:
+        approval.unregister_gateway_notify(session["session_key"])
+        approval._gateway_tombstones.pop(session["session_key"], None)
+        thread.join(timeout=1)
 
 
 def test_legacy_session_keeps_original_response_and_event_shape():

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -444,3 +444,210 @@ def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
 
     settled = resume_session(transport, stored_id)
     assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+
+
+def test_legacy_session_keeps_original_response_and_event_shape():
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    transport = LegacyTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+
+    assert "synchronization" not in created
+    assert "mobile_sync" not in server._sessions[sid]
+
+    server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
+
+    event = transport.frames[-1]
+    assert event == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "status.update",
+            "session_id": sid,
+            "payload": {"kind": "idle", "text": "Ready"},
+        },
+    }
+    assert "mobile_sync" not in server._sessions[sid]
+
+
+def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
+    transport = RecordingTransport()
+    sid = "barrier-live"
+    stream = SessionEventStream(mobile_contract.SERVER_INSTANCE_ID)
+    session = {
+        "agent": None,
+        "conversation_id": "barrier-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "mobile_sync": stream,
+        "mobile_sync_enabled": True,
+        "running": True,
+        "session_key": "barrier-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+    cursor = stream.cursor()
+
+    entered_completion = threading.Event()
+    release_completion = threading.Event()
+    original_clear = server._clear_inflight_turn
+
+    def blocking_clear(target):
+        entered_completion.set()
+        assert release_completion.wait(timeout=2)
+        original_clear(target)
+
+    monkeypatch.setattr(server, "_clear_inflight_turn", blocking_clear)
+    completion = threading.Thread(
+        target=server._commit_prompt_completion,
+        kwargs={
+            "sid": sid,
+            "session": session,
+            "expected_history_version": 0,
+            "result_messages": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+            "payload": {"text": "answer", "status": "complete", "usage": {}},
+        },
+    )
+    completion.start()
+    assert entered_completion.wait(timeout=1)
+
+    captured = {}
+    snapshot_started = threading.Event()
+    snapshot_done = threading.Event()
+
+    def capture_snapshot():
+        snapshot_started.set()
+        captured["value"] = server._session_synchronization(sid, session, cursor)
+        snapshot_done.set()
+
+    snapshot_thread = threading.Thread(target=capture_snapshot)
+    snapshot_thread.start()
+    assert snapshot_started.wait(timeout=1)
+    assert not snapshot_done.wait(timeout=0.05)
+
+    release_completion.set()
+    completion.join(timeout=1)
+    snapshot_thread.join(timeout=1)
+    assert not completion.is_alive()
+    assert not snapshot_thread.is_alive()
+
+    synchronization = captured["value"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "question"},
+        {"role": "assistant", "text": "answer"},
+    ]
+    assert synchronization["snapshot"]["inflight_turn"] is None
+    assert synchronization["snapshot"]["watermark"] == 1
+    assert [
+        event["params"]["type"]
+        for event in synchronization["recovery"]["events"]
+    ] == ["message.complete"]
+
+
+def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    session["agent"] = object()
+    session["history"] = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    initial_watermark = created["synchronization"]["snapshot"]["watermark"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+
+    result = server._methods["session.undo"]("undo", {"session_id": sid})
+    resumed = resume_session(transport, stored_id)
+
+    assert result["result"] == {"removed": 2}
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["messages"] == []
+    assert snapshot["revision"] == initial_revision + 1
+    assert snapshot["watermark"] == initial_watermark
+
+
+def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+
+    server._mirror_subagent_to_child(
+        "subagent.start",
+        {"child_session_id": stored_id, "text": "goal"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.text",
+        {"child_session_id": stored_id, "text": "answer"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.tool",
+        {
+            "child_session_id": stored_id,
+            "tool_name": "terminal",
+            "tool_preview": "workspace command",
+        },
+    )
+
+    running = resume_session(transport, stored_id)
+    snapshot = running["synchronization"]["snapshot"]
+    assert snapshot["status"] == "working"
+    assert snapshot["inflight_turn"]["assistant"] == "goal\nanswer"
+    assert snapshot["inflight_turn"]["streaming"] is True
+    assert snapshot["active_tools"] == [
+        {
+            "tool_id": snapshot["active_tools"][0]["tool_id"],
+            "name": "terminal",
+            "started_at": snapshot["active_tools"][0]["started_at"],
+        }
+    ]
+    assert isinstance(snapshot["active_tools"][0]["started_at"], float)
+    assert "preview" not in snapshot["active_tools"][0]
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [delta["offset"] for delta in deltas] == [0, 5]
+    assert len({delta["turn_id"] for delta in deltas}) == 1
+
+    server._mirror_subagent_to_child(
+        "subagent.complete",
+        {
+            "child_session_id": stored_id,
+            "summary": "done",
+        },
+    )
+    completed = resume_session(transport, stored_id)
+    settled = completed["synchronization"]["snapshot"]
+    assert settled["status"] == "idle"
+    assert settled["inflight_turn"] is None
+    assert settled["active_tools"] == []
+    assert settled["messages"][-1] == {
+        "role": "assistant",
+        "text": "goal\nanswer",
+    }

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -8,6 +8,7 @@ import pytest
 
 from tui_gateway import mobile_contract
 from tui_gateway import server
+from tui_gateway.mobile_mutations import MobileMutationStore
 from tui_gateway.mobile_sync import SessionEventStream
 
 
@@ -57,8 +58,10 @@ class SessionDBStub:
 
 
 @pytest.fixture(autouse=True)
-def isolated_gateway(monkeypatch):
+def isolated_gateway(monkeypatch, tmp_path):
     server._sessions.clear()
+    mutation_store = MobileMutationStore(tmp_path / "mobile-mutations.sqlite3")
+    monkeypatch.setattr(server, "_mobile_mutation_store", lambda: mutation_store)
     monkeypatch.setattr(
         server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
     )
@@ -74,6 +77,7 @@ def isolated_gateway(monkeypatch):
     monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
     yield
     server._sessions.clear()
+    mutation_store.close()
 
 
 def create_session(transport):
@@ -624,25 +628,37 @@ def test_disconnect_resume_recovers_and_resolves_same_approval_once(monkeypatch)
         recovered = resume_session(reconnected, stored_id)
         pending = recovered["synchronization"]["snapshot"]["pending_interactions"]
         assert [item["approval_id"] for item in pending] == [approval_id]
+        active_sid = recovered["session_id"]
+        response_params = {
+            "approval_id": approval_id,
+            "choice": "once",
+            "client_request_id": "resume-approval-response-1",
+            "expected_stored_session_id": stored_id,
+            "session_id": active_sid,
+        }
 
-        first = server._methods["approval.respond"](
-            "resolve-first",
+        first = server.dispatch(
             {
-                "session_id": sid,
-                "approval_id": approval_id,
-                "choice": "once",
+                "jsonrpc": "2.0",
+                "id": "resolve-first",
+                "method": "approval.respond",
+                "params": response_params,
             },
+            reconnected,
         )
-        duplicate = server._methods["approval.respond"](
-            "resolve-duplicate",
+        duplicate = server.dispatch(
             {
-                "session_id": sid,
-                "approval_id": approval_id,
-                "choice": "once",
+                "jsonrpc": "2.0",
+                "id": "resolve-duplicate",
+                "method": "approval.respond",
+                "params": response_params,
             },
+            reconnected,
         )
         assert first["result"]["outcome"] == "resolved"
-        assert duplicate["result"]["outcome"] == "already_resolved"
+        assert first["result"]["mutation"]["deduplicated"] is False
+        assert duplicate["result"]["outcome"] == "resolved"
+        assert duplicate["result"]["mutation"]["deduplicated"] is True
 
         thread.join(timeout=1)
         assert not thread.is_alive()
@@ -662,6 +678,101 @@ def test_disconnect_resume_recovers_and_resolves_same_approval_once(monkeypatch)
         approval.unregister_gateway_notify(session["session_key"])
         approval._gateway_tombstones.pop(session["session_key"], None)
         thread.join(timeout=1)
+
+
+def test_mobile_resolves_second_approval_before_legacy_fifo_first(monkeypatch):
+    from tools import approval
+
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    session["agent_ready"] = None
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"gateway_timeout": 2},
+    )
+    server._register_gateway_approval_callbacks(session["session_key"], sid)
+    decisions = {}
+
+    def wait_for_decision(name):
+        decisions[name] = approval._await_gateway_decision(
+            session["session_key"],
+            approval._gateway_notify_cbs[session["session_key"]],
+            {
+                "command": f"dangerous {name}",
+                "description": name,
+                "pattern_key": name,
+                "pattern_keys": [name],
+            },
+        )
+
+    def wait_for_request(description):
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            for frame in transport.frames:
+                params = frame.get("params", {})
+                payload = params.get("payload", {})
+                if (
+                    params.get("type") == "approval.request"
+                    and payload.get("description") == description
+                ):
+                    return payload["approval_id"]
+            time.sleep(0.01)
+        raise AssertionError(f"approval request {description!r} not emitted")
+
+    first_thread = threading.Thread(target=wait_for_decision, args=("first",))
+    second_thread = threading.Thread(target=wait_for_decision, args=("second",))
+    first_thread.start()
+    first_id = wait_for_request("first")
+    second_thread.start()
+    second_id = wait_for_request("second")
+    try:
+        second = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "resolve-second",
+                "method": "approval.respond",
+                "params": {
+                    "approval_id": second_id,
+                    "choice": "once",
+                    "client_request_id": "resolve-second-1",
+                    "expected_stored_session_id": stored_id,
+                    "session_id": sid,
+                },
+            },
+            transport,
+        )
+        assert second["result"]["outcome"] == "resolved"
+        assert second["result"]["approval"]["approval_id"] == second_id
+        second_thread.join(timeout=1)
+        assert not second_thread.is_alive()
+        assert first_thread.is_alive()
+
+        pending = resume_session(transport, stored_id)["synchronization"][
+            "snapshot"
+        ]["pending_interactions"]
+        assert [item["approval_id"] for item in pending] == [first_id]
+
+        legacy = server._methods["approval.respond"](
+            "legacy-first",
+            {"session_id": sid, "choice": "deny"},
+        )
+        assert legacy["result"] == {"resolved": 1}
+        first_thread.join(timeout=1)
+        assert not first_thread.is_alive()
+        assert decisions == {
+            "first": {"resolved": True, "choice": "deny", "reason": None},
+            "second": {"resolved": True, "choice": "once", "reason": None},
+        }
+    finally:
+        approval.unregister_gateway_notify(session["session_key"])
+        approval._gateway_tombstones.pop(session["session_key"], None)
+        first_thread.join(timeout=1)
+        second_thread.join(timeout=1)
 
 
 def test_legacy_session_keeps_original_response_and_event_shape():
@@ -1003,11 +1114,23 @@ def test_deferred_prompt_start_advances_revision_before_agent_ready(monkeypatch)
                 "jsonrpc": "2.0",
                 "id": "deferred-submit",
                 "method": "prompt.submit",
-                "params": {"session_id": sid, "text": "question"},
+                "params": {
+                    "client_request_id": "deferred-submit-1",
+                    "expected_stored_session_id": stored_id,
+                    "session_id": sid,
+                    "text": "question",
+                },
             },
             transport,
         )
-        assert submitted["result"] == {"status": "streaming"}
+        assert submitted["result"] == {
+            "mutation": {
+                "client_request_id": "deferred-submit-1",
+                "deduplicated": False,
+                "state": "in_progress",
+            },
+            "status": "streaming",
+        }
         assert entered_wait.wait(timeout=1)
 
         resumed = resume_session(transport, stored_id, cursor)

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -1,0 +1,446 @@
+"""Public JSON-RPC conformance tests for revisioned conversation sync."""
+
+import threading
+import time
+
+import pytest
+
+from tui_gateway import mobile_contract
+from tui_gateway import server
+from tui_gateway.mobile_sync import SessionEventStream
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.authorization = {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            ),
+        }
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+class SessionDBStub:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": self.session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+@pytest.fixture(autouse=True)
+def isolated_gateway(monkeypatch):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    yield
+    server._sessions.clear()
+
+
+def create_session(transport):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "create",
+            "method": "session.create",
+            "params": {"cols": 100},
+        },
+        transport,
+    )
+    assert response is not None
+    return response["result"]
+
+
+def resume_session(transport, stored_session_id, cursor=None):
+    params = {"session_id": stored_session_id, "cols": 100}
+    if cursor is not None:
+        params["cursor"] = cursor
+    request_id = f"resume-{len(transport.frames)}"
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "session.resume",
+            "params": params,
+        },
+        transport,
+    )
+    if response is not None:
+        return response["result"]
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        responses = [
+            frame for frame in transport.frames if frame.get("id") == request_id
+        ]
+        if responses:
+            assert "error" not in responses[-1]
+            return responses[-1]["result"]
+        time.sleep(0.01)
+    raise AssertionError("session.resume response was not delivered")
+
+
+def test_create_returns_revisioned_authoritative_sync_snapshot():
+    transport = RecordingTransport()
+
+    result = create_session(transport)
+
+    synchronization = result["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert synchronization["schema_major"] == 1
+    assert snapshot == {
+        "schema_major": 1,
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": snapshot["stream_id"],
+        "revision": 1,
+        "watermark": 0,
+        "conversation_id": result["stored_session_id"],
+        "stored_session_id": result["stored_session_id"],
+        "live_session_id": result["session_id"],
+        "messages": [],
+        "inflight_turn": None,
+        "active_tools": [],
+        "pending_interactions": [],
+        "status": "idle",
+    }
+    assert synchronization["recovery"] == {
+        "outcome": "reset",
+        "reason": "cursor_missing",
+        "snapshot_required": True,
+        "events": [],
+        "cursor": {
+            "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+            "stream_id": snapshot["stream_id"],
+            "sequence": 0,
+        },
+    }
+
+
+def test_live_resume_replays_every_event_after_a_matching_cursor(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    sid = created["session_id"]
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "working", "text": "Working"})
+    server._emit("session.info", sid, {"running": True})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    synchronization = resumed["synchronization"]
+    assert resumed["session_id"] == sid
+    assert synchronization["snapshot"]["stream_id"] == cursor["stream_id"]
+    assert synchronization["snapshot"]["watermark"] == 2
+    assert synchronization["snapshot"]["revision"] == 3
+    assert synchronization["recovery"]["outcome"] == "complete"
+    assert synchronization["recovery"]["snapshot_required"] is False
+    assert [
+        event["params"]["type"] for event in synchronization["recovery"]["events"]
+    ] == ["status.update", "session.info"]
+    assert [
+        event["params"]["sequence"] for event in synchronization["recovery"]["events"]
+    ] == [1, 2]
+
+
+def test_cold_resume_has_the_same_shape_and_requires_stream_reset(monkeypatch):
+    stored_id = "stored-cold"
+    transport = RecordingTransport()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+    prior_cursor = {
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": "retired-stream",
+        "sequence": 12,
+    }
+
+    resumed = resume_session(transport, stored_id, prior_cursor)
+
+    synchronization = resumed["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert set(snapshot) == {
+        "schema_major",
+        "server_instance_id",
+        "stream_id",
+        "revision",
+        "watermark",
+        "conversation_id",
+        "stored_session_id",
+        "live_session_id",
+        "messages",
+        "inflight_turn",
+        "active_tools",
+        "pending_interactions",
+        "status",
+    }
+    assert snapshot["conversation_id"] == stored_id
+    assert snapshot["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+
+
+def test_resume_preserves_conversation_lineage_while_exposing_current_ids(
+    monkeypatch,
+):
+    class LineageDB(SessionDBStub):
+        def get_compression_lineage(self, _session_id):
+            return ["conversation-root", self.session_id]
+
+    stored_id = "compression-tip"
+    transport = RecordingTransport()
+    monkeypatch.setattr(server, "_get_db", lambda: LineageDB(stored_id))
+
+    resumed = resume_session(transport, stored_id)
+
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["conversation_id"] == "conversation-root"
+    assert snapshot["stored_session_id"] == stored_id
+    assert snapshot["live_session_id"] == resumed["session_id"]
+
+
+def test_replay_overflow_is_an_explicit_gap(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=2,
+        max_bytes=1024 * 1024,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    for index in range(3):
+        server._emit("status.update", sid, {"kind": "step", "text": str(index)})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_oversized_event_is_delivered_live_but_not_claimed_as_replayable(
+    monkeypatch,
+):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=20,
+        max_bytes=128,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "large", "text": "x" * 256})
+    assert transport.frames[-1]["params"]["sequence"] == 1
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_concurrent_session_events_are_monotonic_in_wire_order():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    start = threading.Barrier(9)
+
+    def publish(index):
+        start.wait()
+        server._emit("status.update", sid, {"kind": "worker", "text": str(index)})
+
+    threads = [threading.Thread(target=publish, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    events = [frame for frame in transport.frames if frame.get("method") == "event"]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
+
+
+def test_coalesced_deltas_carry_one_turn_identity_and_absolute_utf8_offsets():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+        turn_id = session["inflight_turn"]["turn_id"]
+    server._emit_inflight_delta(sid, session, "A💡")
+    server._emit_inflight_delta(sid, session, "B")
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert deltas == [
+        {"text": "A💡", "turn_id": turn_id, "offset": 0},
+        {"text": "B", "turn_id": turn_id, "offset": 5},
+    ]
+
+
+def test_snapshot_tracks_only_sanitized_active_tool_descriptors(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+    monkeypatch.setattr(server, "_tool_ctx", lambda _name, _args: "workspace file")
+
+    server._on_tool_start(
+        sid,
+        "tool-1",
+        "terminal",
+        {"command": "printf super-secret"},
+    )
+    running = resume_session(transport, stored_id)
+
+    descriptor = running["synchronization"]["snapshot"]["active_tools"][0]
+    assert descriptor["tool_id"] == "tool-1"
+    assert descriptor["name"] == "terminal"
+    assert isinstance(descriptor["started_at"], float)
+    assert "context" not in descriptor
+    assert "args" not in descriptor
+    assert "command" not in descriptor
+
+    server._on_tool_complete(sid, "tool-1", "terminal", {}, "{}")
+    finished = resume_session(transport, stored_id)
+    assert finished["synchronization"]["snapshot"]["active_tools"] == []
+
+
+def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    answer = {}
+
+    def ask():
+        answer["value"] = server._block(
+            "clarify.request",
+            sid,
+            {"question": "Pick one", "choices": ["A", "B"]},
+            timeout=2,
+        )
+
+    thread = threading.Thread(target=ask)
+    thread.start()
+    deadline = time.monotonic() + 1
+    request = None
+    while time.monotonic() < deadline:
+        request = next(
+            (
+                frame
+                for frame in transport.frames
+                if frame.get("params", {}).get("type") == "clarify.request"
+            ),
+            None,
+        )
+        if request is not None:
+            break
+        time.sleep(0.01)
+    assert request is not None
+    request_id = request["params"]["payload"]["request_id"]
+
+    waiting = resume_session(transport, stored_id)
+    snapshot = waiting["synchronization"]["snapshot"]
+    assert snapshot["status"] == "waiting"
+    assert snapshot["pending_interactions"] == [
+        {
+            "request_id": request_id,
+            "kind": "clarify",
+            "payload": {
+                "request_id": request_id,
+                "question": "Pick one",
+                "choices": ["A", "B"],
+            },
+        }
+    ]
+
+    response = server._methods["clarify.respond"](
+        "answer",
+        {"request_id": request_id, "answer": "A"},
+    )
+    assert response["result"] == {"status": "ok"}
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert answer == {"value": "A"}
+
+    settled = resume_session(transport, stored_id)
+    assert settled["synchronization"]["snapshot"]["pending_interactions"] == []

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -462,7 +462,7 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     sid = created["session_id"]
 
     assert "synchronization" not in created
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
 
     server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
 
@@ -476,7 +476,8 @@ def test_legacy_session_keeps_original_response_and_event_shape():
             "payload": {"kind": "idle", "text": "Ready"},
         },
     }
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
+    assert server._sessions[sid]["mobile_sync"].cursor()["sequence"] == 0
 
 
 def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
@@ -519,6 +520,116 @@ def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
         "status.update"
     ]
     assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_transport_handoffs_serialize_audience_snapshot_and_delivery(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    class BlockingWriteMobile(RecordingTransport):
+        def __init__(self, entered, release):
+            super().__init__()
+            self._entered = entered
+            self._release = release
+
+        def write(self, obj):
+            self._entered.set()
+            assert self._release.wait(timeout=2)
+            return super().write(obj)
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    blocking_mobile = BlockingWriteMobile(write_entered, release_write)
+    with session["history_lock"]:
+        server._set_session_transport_locked(session, blocking_mobile)
+
+    emitted = threading.Thread(
+        target=server._emit,
+        args=("status.update", sid, {"kind": "race", "text": "mobile"}),
+    )
+    legacy_result = {}
+
+    def attach_legacy():
+        legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    emitted.start()
+    assert write_entered.wait(timeout=1)
+    legacy_handoff = threading.Thread(target=attach_legacy)
+    legacy_handoff.start()
+    assert legacy_handoff.is_alive()
+    release_write.set()
+    emitted.join(timeout=1)
+    legacy_handoff.join(timeout=1)
+    assert not emitted.is_alive()
+    assert not legacy_handoff.is_alive()
+    mobile_event = blocking_mobile.frames[-1]
+    assert mobile_event["params"]["sequence"] == 1
+    assert "synchronization" not in legacy_result["payload"]
+
+    auth_entered = threading.Event()
+    release_auth = threading.Event()
+
+    class BlockingAuthMobile(RecordingTransport):
+        def __init__(self):
+            self._authorization = dict(RecordingTransport().authorization)
+            self.frames = []
+
+        @property
+        def authorization(self):
+            auth_entered.set()
+            assert release_auth.wait(timeout=2)
+            return self._authorization
+
+    blocking_auth_mobile = BlockingAuthMobile()
+    mobile_result = {}
+    final_legacy_result = {}
+
+    def attach_mobile():
+        mobile_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=blocking_auth_mobile,
+        )
+
+    def attach_final_legacy():
+        final_legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    mobile_handoff = threading.Thread(target=attach_mobile)
+    mobile_handoff.start()
+    assert auth_entered.wait(timeout=1)
+    final_legacy_handoff = threading.Thread(target=attach_final_legacy)
+    final_legacy_handoff.start()
+    assert final_legacy_handoff.is_alive()
+    release_auth.set()
+    mobile_handoff.join(timeout=1)
+    final_legacy_handoff.join(timeout=1)
+    assert not mobile_handoff.is_alive()
+    assert not final_legacy_handoff.is_alive()
+    assert "synchronization" in mobile_result["payload"]
+    assert "synchronization" not in final_legacy_result["payload"]
 
 
 def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -107,7 +107,8 @@ def test_live_child_session_gets_native_stream(server, emits):
     assert child[2][1] == {"text": "hmm"}
     # The rotated-out tool closes with the same id it opened with.
     assert child[3][1]["tool_id"] == first_tool["tool_id"]
-    assert child[6][1] == {"text": "done deal"}
+    assert child[6][1]["text"] == "done deal"
+    assert child[6][1]["turn_id"] == child[0][1]["turn_id"]
 
     # Parent relay is untouched alongside the mirror.
     assert [e for e, s, _ in emits if s == "parent-sid"] == [
@@ -212,9 +213,17 @@ def test_start_mirrors_as_immediate_header_line(server, emits):
     _relay(server, "subagent.progress", preview="step 1/3", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "starting child branch\n"}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {
+                "text": "starting child branch\n",
+                "turn_id": turn_id,
+                "offset": 0,
+            },
+        ),
     ]
 
 
@@ -228,10 +237,17 @@ def test_text_mirrors_as_message_delta(server, emits):
     _relay(server, "subagent.text", preview="the answer.", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "Here is "}),
-        ("message.delta", {"text": "the answer."}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {"text": "Here is ", "turn_id": turn_id, "offset": 0},
+        ),
+        (
+            "message.delta",
+            {"text": "the answer.", "turn_id": turn_id, "offset": 8},
+        ),
     ]
 
 
@@ -267,5 +283,9 @@ def test_text_routes_to_watch_transport_without_contextvar(server, monkeypatch):
         for f in frames
         if f.get("method") == "event" and f["params"]["session_id"] == "live-1"
     ]
-    assert ("message.start", "live-1", None) in routed
-    assert ("message.delta", "live-1", {"text": "streamed reply"}) in routed
+    start = next(payload for event, sid, payload in routed if event == "message.start")
+    assert (
+        "message.delta",
+        "live-1",
+        {"text": "streamed reply", "turn_id": start["turn_id"], "offset": 0},
+    ) in routed

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1446,6 +1446,7 @@ class _ApprovalEntry:
         "resolution",
         "_deadline",
         "_tombstone_deadline",
+        "__weakref__",
     )
 
     def __init__(
@@ -1548,9 +1549,80 @@ _gateway_resolution_notify_cbs: dict[str, object] = {}  # terminal descriptor cb
 _gateway_tombstones: dict[str, dict[str, _ApprovalEntry]] = {}
 _GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS = 300.0
 _GatewayTerminalTransition = tuple[_ApprovalEntry, Optional[object], dict]
+_gateway_tombstone_cleanup_timer: Optional[threading.Timer] = None
+_gateway_tombstone_cleanup_deadline: Optional[float] = None
+_gateway_tombstone_cleanup_generation = 0
 
 
-def _prune_gateway_tombstones_locked(now_monotonic: Optional[float] = None) -> None:
+def _schedule_gateway_tombstone_cleanup_locked() -> None:
+    """Keep one daemon timer aimed at the earliest tombstone deadline."""
+    global _gateway_tombstone_cleanup_deadline
+    global _gateway_tombstone_cleanup_generation
+    global _gateway_tombstone_cleanup_timer
+
+    deadline = min(
+        (
+            entry._tombstone_deadline
+            for tombstones in _gateway_tombstones.values()
+            for entry in tombstones.values()
+            if entry._tombstone_deadline is not None
+        ),
+        default=None,
+    )
+    if deadline is None:
+        if _gateway_tombstone_cleanup_timer is not None:
+            _gateway_tombstone_cleanup_timer.cancel()
+            _gateway_tombstone_cleanup_generation += 1
+        _gateway_tombstone_cleanup_timer = None
+        _gateway_tombstone_cleanup_deadline = None
+        return
+
+    if (
+        _gateway_tombstone_cleanup_timer is not None
+        and _gateway_tombstone_cleanup_deadline is not None
+        and _gateway_tombstone_cleanup_deadline <= deadline
+    ):
+        return
+
+    if _gateway_tombstone_cleanup_timer is not None:
+        _gateway_tombstone_cleanup_timer.cancel()
+    _gateway_tombstone_cleanup_generation += 1
+    generation = _gateway_tombstone_cleanup_generation
+    timer = threading.Timer(
+        max(0.0, deadline - time.monotonic()),
+        _run_gateway_tombstone_cleanup,
+        args=(generation,),
+    )
+    timer.daemon = True
+    _gateway_tombstone_cleanup_timer = timer
+    _gateway_tombstone_cleanup_deadline = deadline
+    timer.start()
+
+
+def _run_gateway_tombstone_cleanup(generation: int) -> None:
+    """Prune expired tombstones and schedule the next bounded cleanup."""
+    global _gateway_tombstone_cleanup_deadline
+    global _gateway_tombstone_cleanup_generation
+    global _gateway_tombstone_cleanup_timer
+
+    with _lock:
+        if generation != _gateway_tombstone_cleanup_generation:
+            return
+        _gateway_tombstone_cleanup_timer = None
+        _gateway_tombstone_cleanup_deadline = None
+        _gateway_tombstone_cleanup_generation += 1
+        _prune_gateway_tombstones_locked(
+            time.monotonic(),
+            reschedule=False,
+        )
+        _schedule_gateway_tombstone_cleanup_locked()
+
+
+def _prune_gateway_tombstones_locked(
+    now_monotonic: Optional[float] = None,
+    *,
+    reschedule: bool = True,
+) -> None:
     """Discard completed approval records after their short explanation TTL."""
     if now_monotonic is None:
         now_monotonic = time.monotonic()
@@ -1568,6 +1640,8 @@ def _prune_gateway_tombstones_locked(now_monotonic: Optional[float] = None) -> N
             empty_sessions.append(session_key)
     for session_key in empty_sessions:
         _gateway_tombstones.pop(session_key, None)
+    if reschedule:
+        _schedule_gateway_tombstone_cleanup_locked()
 
 
 def _remove_gateway_entry_locked(session_key: str, entry: _ApprovalEntry) -> None:
@@ -1616,6 +1690,7 @@ def _finish_gateway_entry_locked(
         float(now_monotonic) + _GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS
     )
     _gateway_tombstones.setdefault(session_key, {})[entry.approval_id] = entry
+    _schedule_gateway_tombstone_cleanup_locked()
     callback = _gateway_resolution_notify_cbs.get(session_key)
     return entry, callback, entry.public_descriptor()
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -13,6 +13,7 @@ import fnmatch
 import functools
 import hashlib
 import logging
+import math
 import os
 import re
 import shlex
@@ -20,6 +21,7 @@ import sys
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -1416,23 +1418,233 @@ _permanent_approved: set = set()
 # its own threading.Event.  /approve resolves the oldest, /approve all
 # resolves every pending approval in the session.
 
+_GATEWAY_APPROVAL_CHOICES = frozenset({"once", "session", "always", "deny"})
+_DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS = 300.0
+
+
+def _coerce_gateway_approval_timeout(value) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS
+    if not math.isfinite(timeout):
+        return _DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS
+    return max(timeout, 0.0)
+
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = (
+        "event",
+        "data",
+        "result",
+        "reason",
+        "approval_id",
+        "created_at",
+        "expires_at",
+        "state",
+        "resolution",
+        "_deadline",
+        "_tombstone_deadline",
+    )
 
-    def __init__(self, data: dict):
+    def __init__(
+        self,
+        data: dict,
+        *,
+        approval_id: Optional[str] = None,
+        timeout_seconds: float = 300,
+        now_wall: Optional[float] = None,
+        now_monotonic: Optional[float] = None,
+    ):
+        timeout_seconds = _coerce_gateway_approval_timeout(timeout_seconds)
+        if now_wall is None:
+            now_wall = time.time()
+        if now_monotonic is None:
+            now_monotonic = time.monotonic()
+
+        # Reserved lifecycle fields are always Hermes-owned.  Callers supply
+        # only the approval payload; they cannot choose an identity or forge a
+        # terminal state by placing those fields in ``data``.
+        reserved = {
+            "approval_id",
+            "request_id",
+            "created_at",
+            "expires_at",
+            "state",
+            "resolution",
+        }
+        public_data = {
+            key: value for key, value in dict(data or {}).items()
+            if key not in reserved
+        }
+        self.data = _sanitize_public_approval_value(public_data)
+        self.approval_id = str(approval_id or uuid.uuid4().hex)
+        self.created_at = float(now_wall)
+        self.expires_at = self.created_at + timeout_seconds
+        self._deadline = float(now_monotonic) + timeout_seconds
+        self._tombstone_deadline: Optional[float] = None
+        self.state = "pending"
+        self.resolution: Optional[dict] = None
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
         self.reason: Optional[str] = None
 
+    def public_descriptor(self) -> dict:
+        """Return a detached, JSON-safe and forcibly redacted descriptor."""
+        descriptor = _sanitize_public_approval_value(self.data)
+        descriptor.update({
+            "approval_id": self.approval_id,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "state": self.state,
+            "resolution": _sanitize_public_approval_value(self.resolution),
+        })
+        return descriptor
+
+
+def _sanitize_public_approval_value(value):
+    """Recursively make approval data safe for public/mobile transport.
+
+    This is deliberately force-redacted at the approval-core boundary even
+    when global log redaction is disabled.  Platform adapters and future
+    snapshot/event serializers therefore never need to remember to redact an
+    individual metadata path.
+    """
+    from agent.redact import redact_sensitive_text
+
+    def _walk(item):
+        if isinstance(item, str):
+            return redact_sensitive_text(item, force=True)
+        if isinstance(item, dict):
+            return {
+                redact_sensitive_text(str(key), force=True): _walk(val)
+                for key, val in item.items()
+            }
+        if isinstance(item, (list, tuple)):
+            return [_walk(val) for val in item]
+        if isinstance(item, set):
+            return [_walk(val) for val in sorted(item, key=repr)]
+        if item is None or isinstance(item, (bool, int, float)):
+            return item
+        return redact_sensitive_text(str(item), force=True)
+
+    return _walk(value)
+
+
+def _public_not_found_approval_id(approval_id: str) -> str:
+    """Echo only the UUID-shaped identity format Hermes itself issues."""
+    if re.fullmatch(r"[0-9a-fA-F]{32}", approval_id):
+        return approval_id
+    return "invalid-approval-id"
+
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_gateway_tombstones: dict[str, dict[str, _ApprovalEntry]] = {}
+_GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS = 300.0
+
+
+def _prune_gateway_tombstones_locked(now_monotonic: Optional[float] = None) -> None:
+    """Discard completed approval records after their short explanation TTL."""
+    if now_monotonic is None:
+        now_monotonic = time.monotonic()
+    empty_sessions = []
+    for session_key, tombstones in _gateway_tombstones.items():
+        expired_ids = [
+            approval_id
+            for approval_id, entry in tombstones.items()
+            if entry._tombstone_deadline is not None
+            and entry._tombstone_deadline <= now_monotonic
+        ]
+        for approval_id in expired_ids:
+            tombstones.pop(approval_id, None)
+        if not tombstones:
+            empty_sessions.append(session_key)
+    for session_key in empty_sessions:
+        _gateway_tombstones.pop(session_key, None)
+
+
+def _remove_gateway_entry_locked(session_key: str, entry: _ApprovalEntry) -> None:
+    queue = _gateway_queues.get(session_key)
+    if queue and entry in queue:
+        queue.remove(entry)
+    if not queue:
+        _gateway_queues.pop(session_key, None)
+
+
+def _finish_gateway_entry_locked(
+    session_key: str,
+    entry: _ApprovalEntry,
+    *,
+    state: str,
+    choice: Optional[str],
+    reason: Optional[str] = None,
+    resolution_metadata: Optional[dict] = None,
+    now_wall: Optional[float] = None,
+    now_monotonic: Optional[float] = None,
+) -> bool:
+    """Atomically move one pending approval into a terminal tombstone."""
+    if entry.state != "pending":
+        return False
+    if now_wall is None:
+        now_wall = time.time()
+    if now_monotonic is None:
+        now_monotonic = time.monotonic()
+
+    _remove_gateway_entry_locked(session_key, entry)
+    entry.state = state
+    entry.result = choice if state == "resolved" else None
+    entry.reason = reason
+    entry.resolution = _sanitize_public_approval_value({
+        "choice": entry.result,
+        "resolved_at": float(now_wall),
+        "reason": reason,
+        "metadata": dict(resolution_metadata or {}),
+    })
+    entry._tombstone_deadline = (
+        float(now_monotonic) + _GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS
+    )
+    _gateway_tombstones.setdefault(session_key, {})[entry.approval_id] = entry
+    entry.event.set()
+    return True
+
+
+def _expire_gateway_entry_locked(
+    session_key: str,
+    entry: _ApprovalEntry,
+    *,
+    now_wall: Optional[float] = None,
+    now_monotonic: Optional[float] = None,
+) -> bool:
+    return _finish_gateway_entry_locked(
+        session_key,
+        entry,
+        state="expired",
+        choice=None,
+        reason="approval expired",
+        resolution_metadata={"source": "timeout"},
+        now_wall=now_wall,
+        now_monotonic=now_monotonic,
+    )
+
+
+def _expire_due_gateway_entries_locked(
+    session_key: str,
+    now_monotonic: Optional[float] = None,
+) -> None:
+    if now_monotonic is None:
+        now_monotonic = time.monotonic()
+    for entry in list(_gateway_queues.get(session_key, [])):
+        if entry._deadline <= now_monotonic:
+            _expire_gateway_entry_locked(
+                session_key,
+                entry,
+                now_monotonic=now_monotonic,
+            )
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1455,20 +1667,106 @@ def unregister_gateway_notify(session_key: str) -> None:
     """
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
-    for entry in entries:
-        entry.event.set()
+        entries = list(_gateway_queues.get(session_key, []))
+        for entry in entries:
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="stale",
+                choice=None,
+                reason="approval callback is no longer available",
+                resolution_metadata={"source": "callback_unregistered"},
+            )
+
+
+def resolve_gateway_approval_by_id(
+    session_key: str,
+    approval_id: str,
+    choice: str,
+    *,
+    reason: Optional[str] = None,
+    resolution_metadata: Optional[dict] = None,
+) -> dict:
+    """Resolve exactly one approval and report deterministic late outcomes.
+
+    The returned ``outcome`` is one of ``resolved``, ``already_resolved``,
+    ``expired``, ``stale``, ``not_found``, or ``invalid_choice``. Terminal
+    descriptors are kept briefly as in-memory tombstones so a suspended client
+    receives an explainable answer instead of consuming the next FIFO item.
+    """
+    approval_id = str(approval_id or "")
+    choice = str(choice or "").strip().lower()
+    if choice not in _GATEWAY_APPROVAL_CHOICES:
+        return {
+            "outcome": "invalid_choice",
+            "approval_id": _public_not_found_approval_id(approval_id),
+        }
+    with _lock:
+        now_monotonic = time.monotonic()
+        _prune_gateway_tombstones_locked(now_monotonic)
+
+        entry = next(
+            (
+                candidate
+                for candidate in _gateway_queues.get(session_key, [])
+                if candidate.approval_id == approval_id
+            ),
+            None,
+        )
+        if entry is not None:
+            if entry._deadline <= now_monotonic:
+                _expire_gateway_entry_locked(
+                    session_key,
+                    entry,
+                    now_monotonic=now_monotonic,
+                )
+                return {
+                    "outcome": "expired",
+                    "approval": entry.public_descriptor(),
+                }
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="resolved",
+                choice=choice,
+                reason=reason,
+                resolution_metadata=resolution_metadata,
+                now_monotonic=now_monotonic,
+            )
+            return {
+                "outcome": "resolved",
+                "approval": entry.public_descriptor(),
+            }
+
+        tombstone = _gateway_tombstones.get(session_key, {}).get(approval_id)
+        if tombstone is not None:
+            outcome = {
+                "resolved": "already_resolved",
+                "expired": "expired",
+                "stale": "stale",
+            }.get(tombstone.state, "stale")
+            return {
+                "outcome": outcome,
+                "approval": tombstone.public_descriptor(),
+            }
+
+    return {
+        "outcome": "not_found",
+        "approval_id": _public_not_found_approval_id(approval_id),
+    }
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             approval_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
     When *resolve_all* is True every pending approval in the session is
     resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    is resolved (FIFO), unless *approval_id* is provided to target the
+    specific pending approval created for an interactive button payload.
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -1476,30 +1774,65 @@ def resolve_gateway_approval(session_key: str, choice: str,
 
     Returns the number of approvals resolved (0 means nothing was pending).
     """
+    choice = str(choice or "").strip().lower()
+    if choice not in _GATEWAY_APPROVAL_CHOICES:
+        return 0
+    if approval_id is not None:
+        result = resolve_gateway_approval_by_id(
+            session_key,
+            approval_id,
+            choice,
+            reason=reason,
+        )
+        return 1 if result["outcome"] == "resolved" else 0
+
     with _lock:
+        now_monotonic = time.monotonic()
+        _prune_gateway_tombstones_locked(now_monotonic)
+        _expire_due_gateway_entries_locked(session_key, now_monotonic)
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
         if resolve_all:
             targets = list(queue)
-            queue.clear()
         else:
-            targets = [queue.pop(0)]
-        if not queue:
-            _gateway_queues.pop(session_key, None)
-
-    for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
+            targets = [queue[0]]
+        for entry in targets:
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="resolved",
+                choice=choice,
+                reason=reason,
+                resolution_metadata={"source": "legacy_fifo"},
+                now_monotonic=now_monotonic,
+            )
     return len(targets)
 
 
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
+        _expire_due_gateway_entries_locked(session_key)
         return bool(_gateway_queues.get(session_key))
+
+
+def pending_approval_count(session_key: str) -> int:
+    """Return the number of unexpired approvals waiting for *session_key*."""
+    with _lock:
+        _expire_due_gateway_entries_locked(session_key)
+        return len(_gateway_queues.get(session_key, []))
+
+
+def list_pending_gateway_approvals(session_key: str) -> list[dict]:
+    """Return authoritative public descriptors for pending approvals."""
+    with _lock:
+        _prune_gateway_tombstones_locked()
+        _expire_due_gateway_entries_locked(session_key)
+        return [
+            entry.public_descriptor()
+            for entry in _gateway_queues.get(session_key, [])
+        ]
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -1538,12 +1871,18 @@ def clear_session(session_key: str) -> None:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
-    for entry in entries:
-        # Session-boundary cleanup should cancel any blocked approval waits
-        # immediately so the old run can unwind instead of idling until timeout.
-        entry.result = "deny"
-        entry.event.set()
+        entries = list(_gateway_queues.get(session_key, []))
+        for entry in entries:
+            # Session-boundary cleanup should cancel blocked waits immediately
+            # while retaining a short explanation for a late phone response.
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="resolved",
+                choice="deny",
+                reason="approval session ended",
+                resolution_metadata={"source": "session_cleanup"},
+            )
 
 
 def is_session_yolo_enabled(session_key: str) -> bool:
@@ -2436,17 +2775,13 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
-    entry = _ApprovalEntry(approval_data)
+    timeout = _coerce_gateway_approval_timeout(
+        _get_approval_config().get("gateway_timeout", 300)
+    )
+
+    entry = _ApprovalEntry(approval_data, timeout_seconds=timeout)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
-
-    def _drop_entry() -> None:
-        with _lock:
-            queue = _gateway_queues.get(session_key, [])
-            if entry in queue:
-                queue.remove(entry)
-            if not queue:
-                _gateway_queues.pop(session_key, None)
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -2462,31 +2797,32 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(entry.public_descriptor())
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
-        _drop_entry()
+        with _lock:
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="stale",
+                choice=None,
+                reason="approval notification failed",
+                resolution_metadata={"source": "notify_failed"},
+            )
         return {"resolved": False, "choice": None, "notify_failed": True}
 
     # Block until the user responds or timeout (default 5 min). Poll in short
     # slices so we can fire activity heartbeats every ~10s to the agent's
     # inactivity tracker — otherwise the gateway watchdog kills the agent
     # while the user is still responding. Mirrors _wait_for_process() cadence.
-    timeout = _get_approval_config().get("gateway_timeout", 300)
-    try:
-        timeout = int(timeout)
-    except (ValueError, TypeError):
-        timeout = 300
-
     try:
         from tools.environments.base import touch_activity_if_due
     except Exception:  # pragma: no cover
         touch_activity_if_due = None
 
     _now = time.monotonic()
-    _deadline = _now + max(timeout, 0)
+    _deadline = entry._deadline
     _activity_state = {"last_touch": _now, "start": _now}
-    resolved = False
     while True:
         # Respect interrupt signals (e.g. /stop, /new, or an inactivity
         # timeout from the gateway) so a pending approval doesn't keep the
@@ -2501,22 +2837,51 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 "returning deny for session %s",
                 session_key,
             )
-            entry.result = "deny"
-            entry.event.set()
-            resolved = True
+            resolve_gateway_approval_by_id(
+                session_key,
+                entry.approval_id,
+                "deny",
+                resolution_metadata={"source": "interrupt"},
+            )
             break
         _remaining = _deadline - time.monotonic()
         if _remaining <= 0:
+            with _lock:
+                _expire_gateway_entry_locked(session_key, entry)
             break
         if entry.event.wait(timeout=min(1.0, _remaining)):
-            resolved = True
             break
         if touch_activity_if_due is not None:
             touch_activity_if_due(_activity_state, "waiting for user approval")
 
-    _drop_entry()
-
-    choice = entry.result
+    # Backward compatibility for older in-process callbacks that set the
+    # entry result/event directly instead of calling the public resolver.
+    with _lock:
+        if (
+            entry.state == "pending"
+            and entry.event.is_set()
+            and entry.result in _GATEWAY_APPROVAL_CHOICES
+        ):
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="resolved",
+                choice=entry.result,
+                reason=entry.reason,
+                resolution_metadata={"source": "legacy_direct_callback"},
+            )
+        elif entry.state == "pending" and entry.event.is_set():
+            _finish_gateway_entry_locked(
+                session_key,
+                entry,
+                state="stale",
+                choice=None,
+                reason="approval wait ended without a decision",
+                resolution_metadata={"source": "legacy_event_without_result"},
+            )
+        resolved = entry.state == "resolved"
+        choice = entry.result
+        reason = entry.reason if resolved else None
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.
@@ -2531,7 +2896,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         surface=surface,
         choice=_outcome,
     )
-    return {"resolved": resolved, "choice": choice, "reason": entry.reason}
+    return {"resolved": resolved, "choice": choice, "reason": reason}
 
 
 def check_all_command_guards(command: str, env_type: str,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1544,8 +1544,10 @@ def _public_not_found_approval_id(approval_id: str) -> str:
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_gateway_resolution_notify_cbs: dict[str, object] = {}  # terminal descriptor cb
 _gateway_tombstones: dict[str, dict[str, _ApprovalEntry]] = {}
 _GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS = 300.0
+_GatewayTerminalTransition = tuple[_ApprovalEntry, Optional[object], dict]
 
 
 def _prune_gateway_tombstones_locked(now_monotonic: Optional[float] = None) -> None:
@@ -1586,10 +1588,15 @@ def _finish_gateway_entry_locked(
     resolution_metadata: Optional[dict] = None,
     now_wall: Optional[float] = None,
     now_monotonic: Optional[float] = None,
-) -> bool:
-    """Atomically move one pending approval into a terminal tombstone."""
+) -> Optional[_GatewayTerminalTransition]:
+    """Move a pending approval to terminal state without releasing its waiter.
+
+    The caller must publish the returned transition after releasing ``_lock``.
+    Publication invokes the terminal callback before setting ``entry.event`` so
+    downstream turn/tool events cannot overtake the terminal descriptor.
+    """
     if entry.state != "pending":
-        return False
+        return None
     if now_wall is None:
         now_wall = time.time()
     if now_monotonic is None:
@@ -1609,8 +1616,21 @@ def _finish_gateway_entry_locked(
         float(now_monotonic) + _GATEWAY_APPROVAL_TOMBSTONE_TTL_SECONDS
     )
     _gateway_tombstones.setdefault(session_key, {})[entry.approval_id] = entry
-    entry.event.set()
-    return True
+    callback = _gateway_resolution_notify_cbs.get(session_key)
+    return entry, callback, entry.public_descriptor()
+
+
+def _dispatch_gateway_resolution_notification(notification) -> None:
+    if notification is None:
+        return
+    entry, callback, descriptor = notification
+    try:
+        if callback is not None:
+            callback(descriptor)
+    except Exception as exc:
+        logger.warning("Gateway approval resolution notify failed: %s", exc)
+    finally:
+        entry.event.set()
 
 
 def _expire_gateway_entry_locked(
@@ -1619,7 +1639,7 @@ def _expire_gateway_entry_locked(
     *,
     now_wall: Optional[float] = None,
     now_monotonic: Optional[float] = None,
-) -> bool:
+) -> Optional[_GatewayTerminalTransition]:
     return _finish_gateway_entry_locked(
         session_key,
         entry,
@@ -1635,16 +1655,20 @@ def _expire_gateway_entry_locked(
 def _expire_due_gateway_entries_locked(
     session_key: str,
     now_monotonic: Optional[float] = None,
-) -> None:
+) -> list[_GatewayTerminalTransition]:
     if now_monotonic is None:
         now_monotonic = time.monotonic()
+    notifications = []
     for entry in list(_gateway_queues.get(session_key, [])):
         if entry._deadline <= now_monotonic:
-            _expire_gateway_entry_locked(
+            notification = _expire_gateway_entry_locked(
                 session_key,
                 entry,
                 now_monotonic=now_monotonic,
             )
+            if notification is not None:
+                notifications.append(notification)
+    return notifications
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1659,17 +1683,31 @@ def register_gateway_notify(session_key: str, cb) -> None:
         _gateway_notify_cbs[session_key] = cb
 
 
+def register_gateway_resolution_notify(session_key: str, cb) -> None:
+    """Register a per-session callback for terminal approval descriptors.
+
+    The callback signature is ``cb(approval_data: dict) -> None``. It runs at
+    most once for each approval that transitions to ``resolved``, ``expired``,
+    or ``stale``. Callback failures are logged and never change the approval
+    outcome or prevent a blocked waiter from being released.
+    """
+    with _lock:
+        _gateway_resolution_notify_cbs[session_key] = cb
+
+
 def unregister_gateway_notify(session_key: str) -> None:
-    """Unregister the per-session gateway approval callback.
+    """Unregister both per-session gateway approval callbacks.
 
     Signals ALL blocked threads for this session so they don't hang forever
-    (e.g. when the agent run finishes or is interrupted).
+    (e.g. when the agent run finishes or is interrupted). Pending approvals
+    first emit a final ``stale`` descriptor through the terminal callback.
     """
+    notifications = []
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
         entries = list(_gateway_queues.get(session_key, []))
         for entry in entries:
-            _finish_gateway_entry_locked(
+            notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="stale",
@@ -1677,6 +1715,11 @@ def unregister_gateway_notify(session_key: str) -> None:
                 reason="approval callback is no longer available",
                 resolution_metadata={"source": "callback_unregistered"},
             )
+            if notification is not None:
+                notifications.append(notification)
+        _gateway_resolution_notify_cbs.pop(session_key, None)
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
 
 
 def resolve_gateway_approval_by_id(
@@ -1701,6 +1744,8 @@ def resolve_gateway_approval_by_id(
             "outcome": "invalid_choice",
             "approval_id": _public_not_found_approval_id(approval_id),
         }
+    result = None
+    resolution_notification = None
     with _lock:
         now_monotonic = time.monotonic()
         _prune_gateway_tombstones_locked(now_monotonic)
@@ -1715,41 +1760,46 @@ def resolve_gateway_approval_by_id(
         )
         if entry is not None:
             if entry._deadline <= now_monotonic:
-                _expire_gateway_entry_locked(
+                resolution_notification = _expire_gateway_entry_locked(
                     session_key,
                     entry,
                     now_monotonic=now_monotonic,
                 )
-                return {
+                result = {
                     "outcome": "expired",
                     "approval": entry.public_descriptor(),
                 }
-            _finish_gateway_entry_locked(
-                session_key,
-                entry,
-                state="resolved",
-                choice=choice,
-                reason=reason,
-                resolution_metadata=resolution_metadata,
-                now_monotonic=now_monotonic,
-            )
-            return {
-                "outcome": "resolved",
-                "approval": entry.public_descriptor(),
-            }
+            else:
+                resolution_notification = _finish_gateway_entry_locked(
+                    session_key,
+                    entry,
+                    state="resolved",
+                    choice=choice,
+                    reason=reason,
+                    resolution_metadata=resolution_metadata,
+                    now_monotonic=now_monotonic,
+                )
+                result = {
+                    "outcome": "resolved",
+                    "approval": entry.public_descriptor(),
+                }
 
         tombstone = _gateway_tombstones.get(session_key, {}).get(approval_id)
-        if tombstone is not None:
+        if result is None and tombstone is not None:
             outcome = {
                 "resolved": "already_resolved",
                 "expired": "expired",
                 "stale": "stale",
             }.get(tombstone.state, "stale")
-            return {
+            result = {
                 "outcome": outcome,
                 "approval": tombstone.public_descriptor(),
             }
 
+    if resolution_notification is not None:
+        _dispatch_gateway_resolution_notification(resolution_notification)
+    if result is not None:
+        return result
     return {
         "outcome": "not_found",
         "approval_id": _public_not_found_approval_id(approval_id),
@@ -1786,19 +1836,22 @@ def resolve_gateway_approval(session_key: str, choice: str,
         )
         return 1 if result["outcome"] == "resolved" else 0
 
+    notifications = []
     with _lock:
         now_monotonic = time.monotonic()
         _prune_gateway_tombstones_locked(now_monotonic)
-        _expire_due_gateway_entries_locked(session_key, now_monotonic)
+        notifications.extend(
+            _expire_due_gateway_entries_locked(session_key, now_monotonic)
+        )
         queue = _gateway_queues.get(session_key)
         if not queue:
-            return 0
-        if resolve_all:
+            targets = []
+        elif resolve_all:
             targets = list(queue)
         else:
             targets = [queue[0]]
         for entry in targets:
-            _finish_gateway_entry_locked(
+            notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="resolved",
@@ -1807,32 +1860,45 @@ def resolve_gateway_approval(session_key: str, choice: str,
                 resolution_metadata={"source": "legacy_fifo"},
                 now_monotonic=now_monotonic,
             )
+            if notification is not None:
+                notifications.append(notification)
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
     return len(targets)
 
 
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
-        _expire_due_gateway_entries_locked(session_key)
-        return bool(_gateway_queues.get(session_key))
+        notifications = _expire_due_gateway_entries_locked(session_key)
+        has_pending = bool(_gateway_queues.get(session_key))
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
+    return has_pending
 
 
 def pending_approval_count(session_key: str) -> int:
     """Return the number of unexpired approvals waiting for *session_key*."""
     with _lock:
-        _expire_due_gateway_entries_locked(session_key)
-        return len(_gateway_queues.get(session_key, []))
+        notifications = _expire_due_gateway_entries_locked(session_key)
+        count = len(_gateway_queues.get(session_key, []))
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
+    return count
 
 
 def list_pending_gateway_approvals(session_key: str) -> list[dict]:
     """Return authoritative public descriptors for pending approvals."""
     with _lock:
         _prune_gateway_tombstones_locked()
-        _expire_due_gateway_entries_locked(session_key)
-        return [
+        notifications = _expire_due_gateway_entries_locked(session_key)
+        descriptors = [
             entry.public_descriptor()
             for entry in _gateway_queues.get(session_key, [])
         ]
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
+    return descriptors
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -1867,6 +1933,7 @@ def clear_session(session_key: str) -> None:
     """Remove all approval and yolo state for a given session."""
     if not session_key:
         return
+    notifications = []
     with _lock:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
@@ -1875,7 +1942,7 @@ def clear_session(session_key: str) -> None:
         for entry in entries:
             # Session-boundary cleanup should cancel blocked waits immediately
             # while retaining a short explanation for a late phone response.
-            _finish_gateway_entry_locked(
+            notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="resolved",
@@ -1883,6 +1950,10 @@ def clear_session(session_key: str) -> None:
                 reason="approval session ended",
                 resolution_metadata={"source": "session_cleanup"},
             )
+            if notification is not None:
+                notifications.append(notification)
+    for notification in notifications:
+        _dispatch_gateway_resolution_notification(notification)
 
 
 def is_session_yolo_enabled(session_key: str) -> bool:
@@ -2801,7 +2872,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         with _lock:
-            _finish_gateway_entry_locked(
+            resolution_notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="stale",
@@ -2809,6 +2880,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 reason="approval notification failed",
                 resolution_metadata={"source": "notify_failed"},
             )
+        _dispatch_gateway_resolution_notification(resolution_notification)
         return {"resolved": False, "choice": None, "notify_failed": True}
 
     # Block until the user responds or timeout (default 5 min). Poll in short
@@ -2847,7 +2919,11 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         _remaining = _deadline - time.monotonic()
         if _remaining <= 0:
             with _lock:
-                _expire_gateway_entry_locked(session_key, entry)
+                resolution_notification = _expire_gateway_entry_locked(
+                    session_key,
+                    entry,
+                )
+            _dispatch_gateway_resolution_notification(resolution_notification)
             break
         if entry.event.wait(timeout=min(1.0, _remaining)):
             break
@@ -2856,13 +2932,14 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Backward compatibility for older in-process callbacks that set the
     # entry result/event directly instead of calling the public resolver.
+    resolution_notification = None
     with _lock:
         if (
             entry.state == "pending"
             and entry.event.is_set()
             and entry.result in _GATEWAY_APPROVAL_CHOICES
         ):
-            _finish_gateway_entry_locked(
+            resolution_notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="resolved",
@@ -2871,7 +2948,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 resolution_metadata={"source": "legacy_direct_callback"},
             )
         elif entry.state == "pending" and entry.event.is_set():
-            _finish_gateway_entry_locked(
+            resolution_notification = _finish_gateway_entry_locked(
                 session_key,
                 entry,
                 state="stale",
@@ -2882,6 +2959,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         resolved = entry.state == "resolved"
         choice = entry.result
         reason = entry.reason if resolved else None
+    _dispatch_gateway_resolution_notification(resolution_notification)
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -32,8 +32,6 @@ SERVER_RELEASE_DATE = __release_date__
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
 # Advertise only schemas implemented by the stacked contract slices.
-# Recoverable approvals still land later and must not be inferred from Mobile
-# Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
@@ -41,6 +39,7 @@ CLIENT_SCHEMA_MAJORS = {
     "session.synchronization": 1,
     "session.event": 1,
     "mutation.receipt": 1,
+    "approval.lifecycle": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
@@ -71,7 +70,7 @@ class MobileMutationDescriptor:
 
     resource_parameter: str
     semantic_parameters: tuple[str, ...] = ()
-    requires_live_lineage_validation: bool = False
+    lineage_parameter: str | None = None
 
 
 @dataclass(frozen=True)
@@ -126,7 +125,7 @@ MOBILE_METHOD_POLICIES = {
         mutation=MobileMutationDescriptor(
             resource_parameter="expected_stored_session_id",
             semantic_parameters=("text",),
-            requires_live_lineage_validation=True,
+            lineage_parameter="expected_stored_session_id",
         ),
     ),
     "session.interrupt": MobileMethodPolicy(
@@ -140,7 +139,29 @@ MOBILE_METHOD_POLICIES = {
         ),
         mutation=MobileMutationDescriptor(
             resource_parameter="expected_stored_session_id",
-            requires_live_lineage_validation=True,
+            lineage_parameter="expected_stored_session_id",
+        ),
+    ),
+    "approval.respond": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset(
+            {
+                "approval_id",
+                "choice",
+                "client_request_id",
+                "expected_stored_session_id",
+                "reason",
+                "session_id",
+            }
+        ),
+        mutation=MobileMutationDescriptor(
+            resource_parameter="approval_id",
+            semantic_parameters=(
+                "choice",
+                "reason",
+                "expected_stored_session_id",
+            ),
+            lineage_parameter="expected_stored_session_id",
         ),
     ),
     "session.delete": MobileMethodPolicy(
@@ -223,6 +244,11 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
                 "version": 1,
                 "methods": list(MOBILE_MUTATION_POLICIES),
                 "status_method": "mutation.status",
+            },
+            "interaction.lifecycle": {
+                "version": 1,
+                "kinds": ["approval"],
+                "response_methods": ["approval.respond"],
             },
         },
         "authorization": effective_authorization(authorization),

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -31,22 +31,23 @@ SERVER_RELEASE_DATE = __release_date__
 # durable deployment identity remains outside this first contract slice.
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
-# Advertise only schemas implemented by the stacked contract slices. Mutation
-# idempotency and recoverable approvals still land later and must not be
-# inferred from Mobile Client Contract v1 alone.
+# Advertise only schemas implemented by the stacked contract slices.
+# Recoverable approvals still land later and must not be inferred from Mobile
+# Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
     "authorization.error": 1,
     "session.synchronization": 1,
     "session.event": 1,
+    "mutation.receipt": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
 CONVERSATION_WRITE_SCOPE = "conversation.write"
-# This scope is an authorization boundary only.  It does not claim durable
-# mutation idempotency; clients must wait for that separately advertised
-# capability before treating retries as safe.
+# This scope is an authorization boundary only. Clients must still intersect it
+# with the separately advertised mutation capability before treating retries as
+# safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
 CONVERSATION_DELETE_SCOPE = "conversation.delete"
 # Error-only marker for a method or parameter that has no grantable mobile
@@ -59,6 +60,7 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
         CONVERSATION_READ_SCOPE,
         CONVERSATION_WRITE_SCOPE,
         CONVERSATION_CONTROL_SCOPE,
+        CONVERSATION_DELETE_SCOPE,
     }
 )
 
@@ -102,11 +104,32 @@ MOBILE_METHOD_POLICIES = {
     ),
     "prompt.submit": MobileMethodPolicy(
         (CONVERSATION_WRITE_SCOPE,),
-        frozenset({"session_id", "text"}),
+        frozenset(
+            {
+                "client_request_id",
+                "expected_stored_session_id",
+                "session_id",
+                "text",
+            }
+        ),
     ),
     "session.interrupt": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
-        frozenset({"session_id"}),
+        frozenset(
+            {
+                "client_request_id",
+                "expected_stored_session_id",
+                "session_id",
+            }
+        ),
+    ),
+    "session.delete": MobileMethodPolicy(
+        (CONVERSATION_DELETE_SCOPE,),
+        frozenset({"client_request_id", "session_id"}),
+    ),
+    "mutation.status": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"client_request_id"}),
     ),
 }
 
@@ -167,6 +190,15 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
                     "max_events": DEFAULT_REPLAY_MAX_EVENTS,
                     "max_bytes": DEFAULT_REPLAY_MAX_BYTES,
                 },
+            },
+            "mutation.idempotency": {
+                "version": 1,
+                "methods": [
+                    "prompt.submit",
+                    "session.interrupt",
+                    "session.delete",
+                ],
+                "status_method": "mutation.status",
             },
         },
         "authorization": effective_authorization(authorization),

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -12,6 +12,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
+from tui_gateway.mobile_sync import (
+    DEFAULT_REPLAY_MAX_BYTES,
+    DEFAULT_REPLAY_MAX_EVENTS,
+)
 
 MOBILE_AUDIENCE = "hermes.mobile"
 LEGACY_AUDIENCE = "dashboard"
@@ -27,13 +31,15 @@ SERVER_RELEASE_DATE = __release_date__
 # durable deployment identity remains outside this first contract slice.
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
-# Advertise only schemas this slice actually defines.  Conversation snapshots,
-# replay, mutation idempotency, and recoverable approvals land in later slices
-# and must not be inferred from Mobile Client Contract v1 alone.
+# Advertise only schemas implemented by the stacked contract slices. Mutation
+# idempotency and recoverable approvals still land later and must not be
+# inferred from Mobile Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
     "authorization.error": 1,
+    "session.synchronization": 1,
+    "session.event": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
@@ -92,7 +98,7 @@ MOBILE_METHOD_POLICIES = {
     ),
     "session.resume": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
-        frozenset({"cols", "session_id"}),
+        frozenset({"cols", "cursor", "session_id"}),
     ),
     "prompt.submit": MobileMethodPolicy(
         (CONVERSATION_WRITE_SCOPE,),
@@ -152,7 +158,17 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
             "major": MOBILE_CONTRACT_MAJOR,
         },
         "schemas": dict(CLIENT_SCHEMA_MAJORS),
-        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "capabilities": {
+            "auth.ws_scopes": {"version": 1},
+            "conversation.sync": {
+                "version": 1,
+                "delta_offsets": {"unit": "utf8_bytes"},
+                "replay": {
+                    "max_events": DEFAULT_REPLAY_MAX_EVENTS,
+                    "max_bytes": DEFAULT_REPLAY_MAX_BYTES,
+                },
+            },
+        },
         "authorization": effective_authorization(authorization),
     }
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
 
@@ -41,6 +42,11 @@ CONVERSATION_WRITE_SCOPE = "conversation.write"
 # mutation idempotency; clients must wait for that separately advertised
 # capability before treating retries as safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
+CONVERSATION_DELETE_SCOPE = "conversation.delete"
+# Error-only marker for a method or parameter that has no grantable mobile
+# scope in this contract version.  It is deliberately absent from
+# SUPPORTED_MOBILE_SCOPES; clients must also inspect ``grantable``.
+MOBILE_UNAVAILABLE_SCOPE = "mobile.unavailable"
 
 SUPPORTED_MOBILE_SCOPES = frozenset(
     {
@@ -50,18 +56,52 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
-MOBILE_METHOD_SCOPES = {
-    "session.list": CONVERSATION_READ_SCOPE,
-    "prompt.submit": CONVERSATION_WRITE_SCOPE,
-    "session.active_list": CONVERSATION_READ_SCOPE,
-    "session.activate": CONVERSATION_READ_SCOPE,
-    "session.history": CONVERSATION_READ_SCOPE,
-    "session.status": CONVERSATION_READ_SCOPE,
-    "session.usage": CONVERSATION_READ_SCOPE,
-    "session.create": CONVERSATION_WRITE_SCOPE,
-    "session.resume": CONVERSATION_WRITE_SCOPE,
-    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
-    "session.steer": CONVERSATION_CONTROL_SCOPE,
+@dataclass(frozen=True)
+class MobileMethodPolicy:
+    """Scopes and parameters that make one existing gateway method mobile-safe."""
+
+    required_scopes: tuple[str, ...]
+    allowed_parameters: frozenset[str]
+
+
+MOBILE_METHOD_POLICIES = {
+    "session.list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset(),
+    ),
+    "session.active_list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"current_session_id"}),
+    ),
+    # Activating or resuming rebinds the live transport, so read access alone
+    # is intentionally insufficient even though both responses contain history.
+    "session.activate": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    "session.history": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    # Creating a live session starts Hermes-owned workers and hooks.  It is both
+    # a conversation write and a runtime-control action, with server-derived
+    # profile/source/model/cwd rather than client-selected privileged knobs.
+    "session.create": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE, CONVERSATION_CONTROL_SCOPE),
+        frozenset({"cols", "title"}),
+    ),
+    "session.resume": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"cols", "session_id"}),
+    ),
+    "prompt.submit": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE,),
+        frozenset({"session_id", "text"}),
+    ),
+    "session.interrupt": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
 }
 
 
@@ -76,6 +116,10 @@ def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
             granted.append(scope)
     if not granted:
         raise ValueError("at least one mobile scope is required")
+    if CONVERSATION_READ_SCOPE not in granted:
+        raise ValueError(
+            "conversation.read is required for every mobile WebSocket grant"
+        )
     return tuple(granted)
 
 
@@ -113,25 +157,85 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
     }
 
 
-def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+def authorization_allows_scope(authorization: dict | None, scope: str) -> bool:
+    """Return whether a connection may perform a scope-gated side effect."""
+    grant = effective_authorization(authorization)
+    return grant["audience"] != MOBILE_AUDIENCE or scope in grant["scopes"]
+
+
+def _denial(
+    *,
+    reason: str,
+    method: str,
+    grant: dict,
+    required_scopes: tuple[str, ...],
+    grantable: bool,
+    parameter: str | None = None,
+) -> dict:
+    missing = (
+        list(required_scopes)
+        if not grantable
+        else [scope for scope in required_scopes if scope not in grant["scopes"]]
+    )
+    data = {
+        "reason": reason,
+        "method": method,
+        "required_scope": missing[0] if missing else required_scopes[0],
+        "required_scopes": list(required_scopes),
+        "missing_scopes": missing,
+        "granted_scopes": grant["scopes"],
+        "grantable": grantable,
+    }
+    if parameter is not None:
+        data["parameter"] = parameter
+    return data
+
+
+def mobile_method_denial(
+    method: str,
+    authorization: dict | None,
+    params: dict | None = None,
+) -> dict | None:
     """Describe why a mobile grant cannot call *method*, or return ``None``."""
     grant = effective_authorization(authorization)
     if grant["audience"] != MOBILE_AUDIENCE:
         return None
 
-    required_scope = MOBILE_METHOD_SCOPES.get(method)
-    if required_scope is None:
-        return {
-            "reason": "method_not_available_to_mobile",
-            "method": method,
-            "required_scope": None,
-            "granted_scopes": grant["scopes"],
-        }
-    if required_scope not in grant["scopes"]:
-        return {
-            "reason": "missing_scope",
-            "method": method,
-            "required_scope": required_scope,
-            "granted_scopes": grant["scopes"],
-        }
+    policy = MOBILE_METHOD_POLICIES.get(method)
+    if policy is None:
+        return _denial(
+            reason="method_not_available_to_mobile",
+            method=method,
+            grant=grant,
+            required_scopes=(MOBILE_UNAVAILABLE_SCOPE,),
+            grantable=False,
+        )
+
+    params = params or {}
+    unsupported_parameters = sorted(set(params) - policy.allowed_parameters)
+    if unsupported_parameters:
+        parameter = unsupported_parameters[0]
+        required_scope = (
+            CONVERSATION_DELETE_SCOPE
+            if method == "prompt.submit"
+            and parameter == "truncate_before_user_ordinal"
+            else MOBILE_UNAVAILABLE_SCOPE
+        )
+        return _denial(
+            reason="parameter_not_available_to_mobile",
+            method=method,
+            parameter=parameter,
+            grant=grant,
+            required_scopes=(required_scope,),
+            grantable=False,
+        )
+
+    if any(scope not in grant["scopes"] for scope in policy.required_scopes):
+        return _denial(
+            reason="missing_scope",
+            method=method,
+            grant=grant,
+            required_scopes=policy.required_scopes,
+            grantable=True,
+        )
     return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -1,0 +1,137 @@
+"""Versioned authorization contract for native/mobile gateway clients.
+
+This module is deliberately transport-only: it defines what a scoped client
+may ask the existing TUI JSON-RPC gateway to do. It does not introduce a new
+runtime or duplicate any Hermes-owned session state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from hermes_cli import __release_date__, __version__
+
+MOBILE_AUDIENCE = "hermes.mobile"
+LEGACY_AUDIENCE = "dashboard"
+PROTOCOL_NAME = "hermes.tui.jsonrpc"
+PROTOCOL_MAJOR = 1
+MOBILE_CONTRACT_NAME = "hermes.mobile"
+MOBILE_CONTRACT_MAJOR = 1
+
+SERVER_VERSION = __version__
+SERVER_RELEASE_DATE = __release_date__
+# A new server process is a new event-stream authority.  This identity is
+# intentionally stable across connections but changes after process restart;
+# durable deployment identity remains outside this first contract slice.
+SERVER_INSTANCE_ID = str(uuid.uuid4())
+
+# Advertise only schemas this slice actually defines.  Conversation snapshots,
+# replay, mutation idempotency, and recoverable approvals land in later slices
+# and must not be inferred from Mobile Client Contract v1 alone.
+CLIENT_SCHEMA_MAJORS = {
+    "gateway.ready": 1,
+    "authorization.grant": 1,
+    "authorization.error": 1,
+}
+
+CONVERSATION_READ_SCOPE = "conversation.read"
+CONVERSATION_WRITE_SCOPE = "conversation.write"
+# This scope is an authorization boundary only.  It does not claim durable
+# mutation idempotency; clients must wait for that separately advertised
+# capability before treating retries as safe.
+CONVERSATION_CONTROL_SCOPE = "conversation.control"
+
+SUPPORTED_MOBILE_SCOPES = frozenset(
+    {
+        CONVERSATION_READ_SCOPE,
+        CONVERSATION_WRITE_SCOPE,
+        CONVERSATION_CONTROL_SCOPE,
+    }
+)
+
+MOBILE_METHOD_SCOPES = {
+    "session.list": CONVERSATION_READ_SCOPE,
+    "prompt.submit": CONVERSATION_WRITE_SCOPE,
+    "session.active_list": CONVERSATION_READ_SCOPE,
+    "session.activate": CONVERSATION_READ_SCOPE,
+    "session.history": CONVERSATION_READ_SCOPE,
+    "session.status": CONVERSATION_READ_SCOPE,
+    "session.usage": CONVERSATION_READ_SCOPE,
+    "session.create": CONVERSATION_WRITE_SCOPE,
+    "session.resume": CONVERSATION_WRITE_SCOPE,
+    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
+    "session.steer": CONVERSATION_CONTROL_SCOPE,
+}
+
+
+def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested mobile authorization grant."""
+    granted: list[str] = []
+    for raw in scopes:
+        scope = str(raw or "").strip()
+        if not scope or scope not in SUPPORTED_MOBILE_SCOPES:
+            raise ValueError(f"unsupported mobile scope: {scope or '<empty>'}")
+        if scope not in granted:
+            granted.append(scope)
+    if not granted:
+        raise ValueError("at least one mobile scope is required")
+    return tuple(granted)
+
+
+def effective_authorization(raw: dict | None = None) -> dict:
+    """Return the stable, JSON-safe authorization grant exposed to a client."""
+    raw = raw or {}
+    scopes = raw.get("scopes", ("*",))
+    if not isinstance(scopes, (list, tuple)):
+        scopes = (str(scopes),)
+    return {
+        "subject": str(raw.get("subject") or raw.get("user_id") or "legacy"),
+        "provider": str(raw.get("provider") or "legacy"),
+        "audience": str(raw.get("audience") or LEGACY_AUDIENCE),
+        "scopes": [str(scope) for scope in scopes],
+    }
+
+
+def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> dict:
+    """Build the additive first-frame contract for every WebSocket client."""
+    return {
+        "skin": skin,
+        "server": {
+            "version": SERVER_VERSION,
+            "release_date": SERVER_RELEASE_DATE,
+            "instance_id": SERVER_INSTANCE_ID,
+        },
+        "protocol": {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR},
+        "contract": {
+            "name": MOBILE_CONTRACT_NAME,
+            "major": MOBILE_CONTRACT_MAJOR,
+        },
+        "schemas": dict(CLIENT_SCHEMA_MAJORS),
+        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "authorization": effective_authorization(authorization),
+    }
+
+
+def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+    """Describe why a mobile grant cannot call *method*, or return ``None``."""
+    grant = effective_authorization(authorization)
+    if grant["audience"] != MOBILE_AUDIENCE:
+        return None
+
+    required_scope = MOBILE_METHOD_SCOPES.get(method)
+    if required_scope is None:
+        return {
+            "reason": "method_not_available_to_mobile",
+            "method": method,
+            "required_scope": None,
+            "granted_scopes": grant["scopes"],
+        }
+    if required_scope not in grant["scopes"]:
+        return {
+            "reason": "missing_scope",
+            "method": method,
+            "required_scope": required_scope,
+            "granted_scopes": grant["scopes"],
+        }
+    return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -64,12 +64,23 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
+
+@dataclass(frozen=True)
+class MobileMutationDescriptor:
+    """Durable identity and pre-execution checks for an idempotent mutation."""
+
+    resource_parameter: str
+    semantic_parameters: tuple[str, ...] = ()
+    requires_live_lineage_validation: bool = False
+
+
 @dataclass(frozen=True)
 class MobileMethodPolicy:
-    """Scopes and parameters that make one existing gateway method mobile-safe."""
+    """Authorization and mutation policy for one mobile-safe gateway method."""
 
     required_scopes: tuple[str, ...]
     allowed_parameters: frozenset[str]
+    mutation: MobileMutationDescriptor | None = None
 
 
 MOBILE_METHOD_POLICIES = {
@@ -112,6 +123,11 @@ MOBILE_METHOD_POLICIES = {
                 "text",
             }
         ),
+        mutation=MobileMutationDescriptor(
+            resource_parameter="expected_stored_session_id",
+            semantic_parameters=("text",),
+            requires_live_lineage_validation=True,
+        ),
     ),
     "session.interrupt": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
@@ -122,16 +138,28 @@ MOBILE_METHOD_POLICIES = {
                 "session_id",
             }
         ),
+        mutation=MobileMutationDescriptor(
+            resource_parameter="expected_stored_session_id",
+            requires_live_lineage_validation=True,
+        ),
     ),
     "session.delete": MobileMethodPolicy(
         (CONVERSATION_DELETE_SCOPE,),
         frozenset({"client_request_id", "session_id"}),
+        mutation=MobileMutationDescriptor(resource_parameter="session_id"),
     ),
     "mutation.status": MobileMethodPolicy(
         (CONVERSATION_READ_SCOPE,),
         frozenset({"client_request_id"}),
     ),
 }
+
+MOBILE_MUTATION_POLICIES = {
+    method: policy.mutation
+    for method, policy in MOBILE_METHOD_POLICIES.items()
+    if policy.mutation is not None
+}
+MOBILE_MUTATION_METHODS = frozenset(MOBILE_MUTATION_POLICIES)
 
 
 def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
@@ -193,11 +221,7 @@ def gateway_ready_payload(*, skin: str, authorization: dict | None = None) -> di
             },
             "mutation.idempotency": {
                 "version": 1,
-                "methods": [
-                    "prompt.submit",
-                    "session.interrupt",
-                    "session.delete",
-                ],
+                "methods": list(MOBILE_MUTATION_POLICIES),
                 "status_method": "mutation.status",
             },
         },

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -1,0 +1,389 @@
+"""Durable at-most-once receipts for consequential mobile mutations.
+
+The store is deliberately independent of any live TUI session.  A receipt is
+scoped to the authenticated principal plus a client-generated request identity,
+while its fingerprint binds the durable Hermes resource and semantic request
+parameters.  An unfinished receipt owned by another process is never released
+for automatic execution: it becomes ``outcome_unknown`` and stays queryable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_MAX_REQUEST_ID_CHARS = 256
+
+
+class MutationConflict(ValueError):
+    """One client request identity was reused for different semantics."""
+
+
+class MutationDisposition(str, Enum):
+    EXECUTE = "execute"
+    IN_PROGRESS = "in_progress"
+    REPLAY = "replay"
+    OUTCOME_UNKNOWN = "outcome_unknown"
+
+
+@dataclass(frozen=True)
+class MutationClaim:
+    disposition: MutationDisposition
+    outcome: dict[str, Any] | None = None
+    _principal_digest: str = ""
+    _request_digest: str = ""
+    _fingerprint: str = ""
+    _owner_instance_id: str = ""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+class MobileMutationStore:
+    """SQLite-backed mutation receipts shared across reconnects and restarts."""
+
+    def __init__(
+        self,
+        db_path: str | os.PathLike[str],
+        *,
+        owner_instance_id: str | None = None,
+    ) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.close(fd)
+        elif os.name != "nt":
+            os.chmod(self._path, 0o600)
+
+        self._owner_instance_id = owner_instance_id or str(uuid.uuid4())
+        self._lock = threading.RLock()
+        self._changed = threading.Condition(self._lock)
+        self._closed = False
+        self._conn = sqlite3.connect(
+            self._path,
+            check_same_thread=False,
+            isolation_level=None,
+            timeout=5.0,
+        )
+        self._conn.execute("PRAGMA busy_timeout = 5000")
+        # Import lazily so loading the gateway does not freeze SessionDB's
+        # profile path before reload-style tests and embedded callers install
+        # their Hermes-home override. The receipt store itself is lazy too.
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(
+            self._conn,
+            db_label=f"mobile mutations ({self._path.name})",
+        )
+        self._conn.execute("PRAGMA synchronous = FULL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mobile_mutations (
+                principal_digest TEXT NOT NULL,
+                request_digest TEXT NOT NULL,
+                method TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                state TEXT NOT NULL,
+                owner_instance_id TEXT,
+                outcome_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY (principal_digest, request_digest)
+            )
+            """
+        )
+        # A process that disappeared after reservation may already have caused
+        # side effects.  Preserve that uncertainty durably instead of making a
+        # new process guess that the request is safe to execute again.
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE mobile_mutations
+            SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
+            WHERE state = 'in_progress' AND owner_instance_id <> ?
+            """,
+            (now, self._owner_instance_id),
+        )
+
+    @staticmethod
+    def _key(
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+    ) -> tuple[str, str, str]:
+        request_id = str(client_request_id or "").strip()
+        if not request_id or len(request_id) > _MAX_REQUEST_ID_CHARS:
+            raise ValueError(
+                "client_request_id must contain 1 to 256 non-whitespace characters"
+            )
+        principal = [str(provider or ""), str(subject or "")]
+        return _digest(principal), _digest(request_id), request_id
+
+    @staticmethod
+    def _fingerprint(
+        *,
+        method: str,
+        resource_id: str,
+        semantic_parameters: dict[str, Any],
+    ) -> str:
+        return _digest(
+            {
+                "method": str(method),
+                "resource_id": str(resource_id),
+                "semantic_parameters": semantic_parameters,
+            }
+        )
+
+    def reserve(
+        self,
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+        method: str,
+        resource_id: str,
+        semantic_parameters: dict[str, Any],
+    ) -> MutationClaim:
+        principal_digest, request_digest, _ = self._key(
+            provider=provider,
+            subject=subject,
+            client_request_id=client_request_id,
+        )
+        fingerprint = self._fingerprint(
+            method=method,
+            resource_id=resource_id,
+            semantic_parameters=semantic_parameters,
+        )
+        now = time.time()
+
+        with self._changed:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    """
+                    SELECT method, fingerprint, state, owner_instance_id, outcome_json
+                    FROM mobile_mutations
+                    WHERE principal_digest = ? AND request_digest = ?
+                    """,
+                    (principal_digest, request_digest),
+                ).fetchone()
+                if row is None:
+                    self._conn.execute(
+                        """
+                        INSERT INTO mobile_mutations (
+                            principal_digest, request_digest, method, fingerprint,
+                            state, owner_instance_id, outcome_json, created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, 'in_progress', ?, NULL, ?, ?)
+                        """,
+                        (
+                            principal_digest,
+                            request_digest,
+                            str(method),
+                            fingerprint,
+                            self._owner_instance_id,
+                            now,
+                            now,
+                        ),
+                    )
+                    disposition = MutationDisposition.EXECUTE
+                    outcome = None
+                else:
+                    _, existing_fingerprint, state, owner, outcome_json = row
+                    if existing_fingerprint != fingerprint:
+                        raise MutationConflict(
+                            "client_request_id was already used for different semantics"
+                        )
+                    if state == "completed":
+                        disposition = MutationDisposition.REPLAY
+                        outcome = json.loads(outcome_json) if outcome_json else None
+                    elif state == "outcome_unknown":
+                        disposition = MutationDisposition.OUTCOME_UNKNOWN
+                        outcome = None
+                    elif owner == self._owner_instance_id:
+                        disposition = MutationDisposition.IN_PROGRESS
+                        outcome = None
+                    else:
+                        self._conn.execute(
+                            """
+                            UPDATE mobile_mutations
+                            SET state = 'outcome_unknown', owner_instance_id = NULL,
+                                updated_at = ?
+                            WHERE principal_digest = ? AND request_digest = ?
+                              AND state = 'in_progress' AND owner_instance_id = ?
+                            """,
+                            (now, principal_digest, request_digest, owner),
+                        )
+                        disposition = MutationDisposition.OUTCOME_UNKNOWN
+                        outcome = None
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+            return MutationClaim(
+                disposition=disposition,
+                outcome=outcome,
+                _principal_digest=principal_digest,
+                _request_digest=request_digest,
+                _fingerprint=fingerprint,
+                _owner_instance_id=self._owner_instance_id,
+            )
+
+    def complete(self, claim: MutationClaim, outcome: dict[str, Any]) -> bool:
+        if claim.disposition is not MutationDisposition.EXECUTE:
+            return False
+        encoded = _canonical_json(outcome)
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'completed', outcome_json = ?, updated_at = ?
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    encoded,
+                    time.time(),
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            completed = cursor.rowcount == 1
+            self._changed.notify_all()
+            return completed
+
+    def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
+        """Terminalize a reserved request after an unexpected execution failure."""
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'outcome_unknown', owner_instance_id = NULL,
+                    outcome_json = NULL, updated_at = ?
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    time.time(),
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            changed = cursor.rowcount == 1
+            self._changed.notify_all()
+            return changed
+
+    def wait_for_outcome(
+        self,
+        claim: MutationClaim,
+        *,
+        timeout: float,
+    ) -> MutationClaim:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._changed:
+            while True:
+                row = self._conn.execute(
+                    """
+                    SELECT state, outcome_json
+                    FROM mobile_mutations
+                    WHERE principal_digest = ? AND request_digest = ?
+                      AND fingerprint = ?
+                    """,
+                    (
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                    ),
+                ).fetchone()
+                if row is None:
+                    return claim
+                state, outcome_json = row
+                if state == "completed":
+                    return MutationClaim(
+                        MutationDisposition.REPLAY,
+                        json.loads(outcome_json) if outcome_json else None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
+                if state == "outcome_unknown":
+                    return MutationClaim(
+                        MutationDisposition.OUTCOME_UNKNOWN,
+                        None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return claim
+                self._changed.wait(remaining)
+
+    def status(
+        self,
+        *,
+        provider: str,
+        subject: str,
+        client_request_id: str,
+    ) -> dict[str, Any] | None:
+        principal_digest, request_digest, request_id = self._key(
+            provider=provider,
+            subject=subject,
+            client_request_id=client_request_id,
+        )
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT method, state, outcome_json
+                FROM mobile_mutations
+                WHERE principal_digest = ? AND request_digest = ?
+                """,
+                (principal_digest, request_digest),
+            ).fetchone()
+        if row is None:
+            return None
+        method, state, outcome_json = row
+        return {
+            "client_request_id": request_id,
+            "method": method,
+            "outcome": json.loads(outcome_json) if outcome_json else None,
+            "state": state,
+        }
+
+    def close(self) -> None:
+        with self._changed:
+            if self._closed:
+                return
+            self._closed = True
+            self._conn.close()
+            self._changed.notify_all()

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -277,6 +277,29 @@ class MobileMutationStore:
             self._changed.notify_all()
             return completed
 
+    def release_before_execution(self, claim: MutationClaim) -> bool:
+        """Remove this process's reservation before any side effect can run."""
+        if claim.disposition is not MutationDisposition.EXECUTE:
+            return False
+        with self._changed:
+            cursor = self._conn.execute(
+                """
+                DELETE FROM mobile_mutations
+                WHERE principal_digest = ? AND request_digest = ?
+                  AND fingerprint = ? AND state = 'in_progress'
+                  AND owner_instance_id = ?
+                """,
+                (
+                    claim._principal_digest,
+                    claim._request_digest,
+                    claim._fingerprint,
+                    claim._owner_instance_id,
+                ),
+            )
+            released = cursor.rowcount == 1
+            self._changed.notify_all()
+            return released
+
     def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
         """Terminalize a reserved request after an unexpected execution failure."""
         with self._changed:

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -28,9 +28,14 @@ class MutationConflict(ValueError):
     """One client request identity was reused for different semantics."""
 
 
+class InvalidMutationRequestIdentity(ValueError):
+    """A client request identity is empty or exceeds the wire contract."""
+
+
 class MutationDisposition(str, Enum):
     EXECUTE = "execute"
     IN_PROGRESS = "in_progress"
+    RETRY = "retry"
     REPLAY = "replay"
     OUTCOME_UNKNOWN = "outcome_unknown"
 
@@ -93,51 +98,84 @@ class MobileMutationStore:
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._closed = False
-        self._conn = sqlite3.connect(
+        self._recycle_required = False
+        self._conn = self._open_connection(self._owner_instance_id)
+
+    def _open_connection(self, owner_instance_id: str) -> sqlite3.Connection:
+        connection = sqlite3.connect(
             self._path,
             check_same_thread=False,
             isolation_level=None,
             timeout=5.0,
         )
-        self._conn.execute("PRAGMA busy_timeout = 5000")
-        # Import lazily so loading the gateway does not freeze SessionDB's
-        # profile path before reload-style tests and embedded callers install
-        # their Hermes-home override. The receipt store itself is lazy too.
-        from hermes_state import apply_wal_with_fallback
+        try:
+            connection.execute("PRAGMA busy_timeout = 5000")
+            # Import lazily so loading the gateway does not freeze SessionDB's
+            # profile path before reload-style tests and embedded callers install
+            # their Hermes-home override. The receipt store itself is lazy too.
+            from hermes_state import apply_wal_with_fallback
 
-        apply_wal_with_fallback(
-            self._conn,
-            db_label=f"mobile mutations ({self._path.name})",
-        )
-        self._conn.execute("PRAGMA synchronous = FULL")
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS mobile_mutations (
-                principal_digest TEXT NOT NULL,
-                request_digest TEXT NOT NULL,
-                method TEXT NOT NULL,
-                fingerprint TEXT NOT NULL,
-                state TEXT NOT NULL,
-                owner_instance_id TEXT,
-                outcome_json TEXT,
-                created_at REAL NOT NULL,
-                updated_at REAL NOT NULL,
-                PRIMARY KEY (principal_digest, request_digest)
+            apply_wal_with_fallback(
+                connection,
+                db_label=f"mobile mutations ({self._path.name})",
             )
-            """
-        )
-        # A process that disappeared after reservation may already have caused
-        # side effects.  Preserve that uncertainty durably instead of making a
-        # new process guess that the request is safe to execute again.
-        now = time.time()
-        self._conn.execute(
-            """
-            UPDATE mobile_mutations
-            SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
-            WHERE state = 'in_progress' AND owner_instance_id <> ?
-            """,
-            (now, self._owner_instance_id),
-        )
+            connection.execute("PRAGMA synchronous = FULL")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mobile_mutations (
+                    principal_digest TEXT NOT NULL,
+                    request_digest TEXT NOT NULL,
+                    method TEXT NOT NULL,
+                    fingerprint TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    owner_instance_id TEXT,
+                    outcome_json TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (principal_digest, request_digest)
+                )
+                """
+            )
+            # A process that disappeared after reservation may already have caused
+            # side effects. Preserve that uncertainty durably instead of making a
+            # new process guess that the request is safe to execute again.
+            connection.execute(
+                """
+                UPDATE mobile_mutations
+                SET state = 'outcome_unknown', owner_instance_id = NULL, updated_at = ?
+                WHERE state = 'in_progress' AND owner_instance_id <> ?
+                """,
+                (time.time(), owner_instance_id),
+            )
+        except Exception:
+            connection.close()
+            raise
+        return connection
+
+    def _recycle_connection_locked(self) -> None:
+        if self._closed:
+            raise sqlite3.ProgrammingError("mobile mutation store is closed")
+        replacement_owner = str(uuid.uuid4())
+        replacement = self._open_connection(replacement_owner)
+        previous = self._conn
+        self._conn = replacement
+        self._owner_instance_id = replacement_owner
+        self._recycle_required = False
+        try:
+            previous.close()
+        except sqlite3.Error:
+            pass
+        self._changed.notify_all()
+
+    def _ensure_connection_locked(self) -> None:
+        if self._recycle_required:
+            self._recycle_connection_locked()
+
+    def recycle_after_storage_failure(self) -> None:
+        """Poison and replace the connection, terminalizing all open claims."""
+        with self._changed:
+            self._recycle_required = True
+            self._recycle_connection_locked()
 
     @staticmethod
     def _key(
@@ -148,7 +186,7 @@ class MobileMutationStore:
     ) -> tuple[str, str, str]:
         request_id = str(client_request_id or "").strip()
         if not request_id or len(request_id) > _MAX_REQUEST_ID_CHARS:
-            raise ValueError(
+            raise InvalidMutationRequestIdentity(
                 "client_request_id must contain 1 to 256 non-whitespace characters"
             )
         principal = [str(provider or ""), str(subject or "")]
@@ -192,6 +230,7 @@ class MobileMutationStore:
         now = time.time()
 
         with self._changed:
+            self._ensure_connection_locked()
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 row = self._conn.execute(
@@ -269,6 +308,7 @@ class MobileMutationStore:
             return False
         encoded = _canonical_json(outcome)
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 UPDATE mobile_mutations
@@ -295,6 +335,7 @@ class MobileMutationStore:
         if claim.disposition is not MutationDisposition.EXECUTE:
             return False
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 DELETE FROM mobile_mutations
@@ -316,6 +357,7 @@ class MobileMutationStore:
     def mark_outcome_unknown(self, claim: MutationClaim) -> bool:
         """Terminalize a reserved request after an unexpected execution failure."""
         with self._changed:
+            self._ensure_connection_locked()
             cursor = self._conn.execute(
                 """
                 UPDATE mobile_mutations
@@ -346,6 +388,7 @@ class MobileMutationStore:
         deadline = time.monotonic() + max(0.0, timeout)
         with self._changed:
             while True:
+                self._ensure_connection_locked()
                 row = self._conn.execute(
                     """
                     SELECT state, outcome_json
@@ -360,7 +403,14 @@ class MobileMutationStore:
                     ),
                 ).fetchone()
                 if row is None:
-                    return claim
+                    return MutationClaim(
+                        MutationDisposition.RETRY,
+                        None,
+                        claim._principal_digest,
+                        claim._request_digest,
+                        claim._fingerprint,
+                        claim._owner_instance_id,
+                    )
                 state, outcome_json = row
                 if state == "completed":
                     return MutationClaim(
@@ -398,6 +448,7 @@ class MobileMutationStore:
             client_request_id=client_request_id,
         )
         with self._lock:
+            self._ensure_connection_locked()
             row = self._conn.execute(
                 """
                 SELECT method, state, outcome_json

--- a/tui_gateway/mobile_mutations.py
+++ b/tui_gateway/mobile_mutations.py
@@ -44,6 +44,19 @@ class MutationClaim:
     _fingerprint: str = ""
     _owner_instance_id: str = ""
 
+    @property
+    def proof_tag(self) -> str:
+        """Opaque identity for binding an in-memory effect to this receipt."""
+        if not (
+            self._principal_digest
+            and self._request_digest
+            and self._fingerprint
+        ):
+            return ""
+        return _digest(
+            [self._principal_digest, self._request_digest, self._fingerprint]
+        )
+
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(

--- a/tui_gateway/mobile_sync.py
+++ b/tui_gateway/mobile_sync.py
@@ -1,0 +1,241 @@
+"""Revisioned conversation snapshots and bounded session-event replay.
+
+The synchronization boundary is one lock per live session stream.  Callers
+mutate snapshot-visible state, allocate the matching event sequence, and queue
+that event for transport while this lock is held.  Snapshot capture takes the
+conversation history lock first and this stream lock second.  A snapshot's
+``watermark`` therefore covers every state transition published before it;
+clients install the snapshot at that watermark and apply only events with a
+larger sequence.
+
+Replay is intentionally process-local and bounded.  A process restart changes
+``server_instance_id`` and rebuilding a live session changes ``stream_id``;
+either condition produces an explicit reset instead of pretending replay is
+complete.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import uuid
+from collections import deque
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+SYNC_SCHEMA_MAJOR = 1
+EVENT_SCHEMA_MAJOR = 1
+DEFAULT_REPLAY_MAX_EVENTS = 512
+DEFAULT_REPLAY_MAX_BYTES = 1024 * 1024
+
+
+class SessionEventStream:
+    """Thread-safe synchronization authority for one live Hermes session."""
+
+    def __init__(
+        self,
+        server_instance_id: str,
+        *,
+        max_events: int = DEFAULT_REPLAY_MAX_EVENTS,
+        max_bytes: int = DEFAULT_REPLAY_MAX_BYTES,
+    ) -> None:
+        self.server_instance_id = str(server_instance_id)
+        self.stream_id = str(uuid.uuid4())
+        self.max_events = max(1, int(max_events))
+        self.max_bytes = max(1, int(max_bytes))
+        self._lock = threading.RLock()
+        self._sequence = 0
+        self._revision = 1
+        self._discarded_through = 0
+        self._replay_bytes = 0
+        self._replay: deque[tuple[int, int, dict[str, Any]]] = deque()
+        self._active_tools: dict[str, dict[str, Any]] = {}
+        self._pending_interactions: dict[str, dict[str, Any]] = {}
+
+    def track_tool(self, descriptor: dict[str, Any]) -> None:
+        tool_id = str(descriptor.get("tool_id") or "")
+        if tool_id:
+            self._active_tools[tool_id] = copy.deepcopy(descriptor)
+
+    def finish_tool(self, tool_id: str) -> None:
+        self._active_tools.pop(str(tool_id), None)
+
+    def track_pending_interaction(self, descriptor: dict[str, Any]) -> None:
+        request_id = str(descriptor.get("request_id") or "")
+        if request_id:
+            self._pending_interactions[request_id] = copy.deepcopy(descriptor)
+
+    def finish_pending_interaction(self, request_id: str) -> None:
+        """Remove state that has no legacy completion event.
+
+        The revision changes so the next authoritative snapshot cannot compare
+        equal to one that still contained the interaction.  The future
+        addressable-approval slice can replace this with an explicit lifecycle
+        event without changing the synchronization envelope.
+        """
+        with self._lock:
+            if self._pending_interactions.pop(str(request_id), None) is not None:
+                self._revision += 1
+
+    def mutate(self, update: Callable[[SessionEventStream], None]) -> None:
+        """Apply snapshot-only state when the legacy protocol emits no event."""
+        with self._lock:
+            update(self)
+            self._revision += 1
+
+    @contextmanager
+    def transition(self, update: Callable[[SessionEventStream], None]):
+        """Keep a state update and the caller's event publication atomic."""
+        with self._lock:
+            update(self)
+            yield
+
+    def publish(
+        self,
+        event: str,
+        session_id: str,
+        payload: dict[str, Any] | None,
+        deliver: Callable[[dict[str, Any]], Any],
+        *,
+        update: Callable[[SessionEventStream], None] | None = None,
+    ) -> dict[str, Any]:
+        """Allocate, retain, and deliver one event in monotonic wire order."""
+        with self._lock:
+            retained_payload = copy.deepcopy(payload) if payload is not None else None
+            if update is not None:
+                update(self)
+            self._sequence += 1
+            self._revision += 1
+            params: dict[str, Any] = {
+                "type": event,
+                "session_id": session_id,
+                "schema_major": EVENT_SCHEMA_MAJOR,
+                "stream_id": self.stream_id,
+                "sequence": self._sequence,
+            }
+            if retained_payload is not None:
+                params["payload"] = retained_payload
+            frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+            retained = copy.deepcopy(frame)
+            try:
+                size = len(
+                    json.dumps(
+                        retained,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+            except (TypeError, ValueError):
+                # A malformed event cannot be replayed. Preserve the explicit
+                # gap invariant even if its producer catches serialization.
+                self._discard_all_through(self._sequence)
+                raise
+            self._retain(self._sequence, size, retained)
+            # Keep delivery under the stream lock so concurrent publishers
+            # cannot put sequence N+1 on the transport before sequence N.
+            deliver(frame)
+            return copy.deepcopy(frame)
+
+    def synchronization(
+        self,
+        snapshot_factory: Callable[[dict[str, Any]], dict[str, Any]],
+        cursor: object = None,
+    ) -> dict[str, Any]:
+        """Capture one authoritative snapshot and classify cursor recovery."""
+        with self._lock:
+            watermark = self._sequence
+            snapshot = snapshot_factory({
+                "active_tools": copy.deepcopy(list(self._active_tools.values())),
+                "pending_interactions": copy.deepcopy(
+                    list(self._pending_interactions.values())
+                ),
+            })
+            snapshot.update({
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "server_instance_id": self.server_instance_id,
+                "stream_id": self.stream_id,
+                "revision": self._revision,
+                "watermark": watermark,
+            })
+            recovery = self._recovery(cursor, watermark)
+            return {
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "snapshot": snapshot,
+                "recovery": recovery,
+            }
+
+    def cursor(self) -> dict[str, Any]:
+        with self._lock:
+            return self._cursor(self._sequence)
+
+    def _retain(self, sequence: int, size: int, frame: dict[str, Any]) -> None:
+        if size > self.max_bytes:
+            self._discard_all_through(sequence)
+            return
+        self._replay.append((sequence, size, frame))
+        self._replay_bytes += size
+        while (
+            len(self._replay) > self.max_events or self._replay_bytes > self.max_bytes
+        ):
+            evicted_sequence, evicted_size, _ = self._replay.popleft()
+            self._replay_bytes -= evicted_size
+            self._discarded_through = max(
+                self._discarded_through,
+                evicted_sequence,
+            )
+
+    def _discard_all_through(self, sequence: int) -> None:
+        self._replay.clear()
+        self._replay_bytes = 0
+        self._discarded_through = max(self._discarded_through, sequence)
+
+    def _cursor(self, sequence: int) -> dict[str, Any]:
+        return {
+            "server_instance_id": self.server_instance_id,
+            "stream_id": self.stream_id,
+            "sequence": sequence,
+        }
+
+    def _recovery(self, cursor: object, watermark: int) -> dict[str, Any]:
+        current = self._cursor(watermark)
+        base: dict[str, Any] = {
+            "cursor": current,
+            "events": [],
+            "snapshot_required": True,
+        }
+        if not isinstance(cursor, dict):
+            return {**base, "outcome": "reset", "reason": "cursor_missing"}
+        if cursor.get("server_instance_id") != self.server_instance_id:
+            return {
+                **base,
+                "outcome": "reset",
+                "reason": "server_instance_changed",
+            }
+        if cursor.get("stream_id") != self.stream_id:
+            return {**base, "outcome": "reset", "reason": "stream_changed"}
+        raw_sequence = cursor.get("sequence")
+        if isinstance(raw_sequence, bool) or not isinstance(raw_sequence, int):
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        sequence = raw_sequence
+        if sequence < 0 or sequence > watermark:
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        if sequence < self._discarded_through:
+            return {
+                **base,
+                "outcome": "gap",
+                "reason": "replay_evicted",
+                "available_after": self._discarded_through,
+            }
+        events = [
+            copy.deepcopy(frame)
+            for event_sequence, _size, frame in self._replay
+            if sequence < event_sequence <= watermark
+        ]
+        return {
+            **base,
+            "outcome": "complete",
+            "events": events,
+            "snapshot_required": False,
+        }

--- a/tui_gateway/mobile_sync.py
+++ b/tui_gateway/mobile_sync.py
@@ -63,9 +63,11 @@ class SessionEventStream:
         self._active_tools.pop(str(tool_id), None)
 
     def track_pending_interaction(self, descriptor: dict[str, Any]) -> None:
-        request_id = str(descriptor.get("request_id") or "")
-        if request_id:
-            self._pending_interactions[request_id] = copy.deepcopy(descriptor)
+        interaction_id = str(
+            descriptor.get("request_id") or descriptor.get("approval_id") or ""
+        )
+        if interaction_id:
+            self._pending_interactions[interaction_id] = copy.deepcopy(descriptor)
 
     def finish_pending_interaction(self, request_id: str) -> None:
         """Remove state that has no legacy completion event.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -29,6 +29,11 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.mobile_sync import SessionEventStream
+from tui_gateway.mobile_mutations import (
+    MobileMutationStore,
+    MutationConflict,
+    MutationDisposition,
+)
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -870,6 +875,32 @@ except (TypeError, ValueError):
 _SESSION_TTL_S = max(0.0, _SESSION_TTL_S)
 _REAPER_SCAN_S = 300.0
 
+_mobile_mutation_store_instance: MobileMutationStore | None = None
+_mobile_mutation_store_lock = threading.Lock()
+
+
+def _mobile_mutation_store() -> MobileMutationStore:
+    """Return the gateway-profile receipt store, opening it only when needed."""
+    global _mobile_mutation_store_instance
+    with _mobile_mutation_store_lock:
+        if _mobile_mutation_store_instance is None:
+            _mobile_mutation_store_instance = MobileMutationStore(
+                Path(_hermes_home) / "state" / "mobile_mutations.sqlite3"
+            )
+        return _mobile_mutation_store_instance
+
+
+def _close_mobile_mutation_store() -> None:
+    global _mobile_mutation_store_instance
+    with _mobile_mutation_store_lock:
+        store = _mobile_mutation_store_instance
+        _mobile_mutation_store_instance = None
+    if store is not None:
+        store.close()
+
+
+atexit.register(_close_mobile_mutation_store)
+
 
 def _transport_is_dead(transport) -> bool:
     # _detached_ws_transport is the post-WS-disconnect drop sentinel; a session
@@ -1418,6 +1449,258 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
+_MOBILE_MUTATION_METHODS = frozenset(
+    {"prompt.submit", "session.interrupt", "session.delete"}
+)
+_NOT_A_MOBILE_MUTATION = object()
+
+
+def _mobile_mutation_resource(
+    method: str,
+    params: dict,
+    rid: Any,
+) -> tuple[str, dict[str, Any]] | dict:
+    """Resolve client-supplied durable semantics without consulting live state."""
+    if method in {"prompt.submit", "session.interrupt"}:
+        expected = str(params.get("expected_stored_session_id") or "").strip()
+        if not expected:
+            return _err(
+                rid,
+                -32602,
+                "expected_stored_session_id is required for mobile mutation",
+                data={
+                    "method": method,
+                    "reason": "durable_resource_id_required",
+                },
+            )
+        semantics = {"text": params.get("text")} if method == "prompt.submit" else {}
+        # Cuttle keeps this server-issued Conversation identity stable while the
+        # process-local live session id and compression tip can rotate. Binding
+        # the receipt to the live id would turn a valid reconnect retry into a
+        # different mutation. The execute path validates this identity against
+        # current Hermes state before the handler can mutate anything.
+        return expected, semantics
+
+    target = str(params.get("session_id") or "").strip()
+    if not target:
+        return _err(rid, -32602, "session_id is required")
+    # A stored session id is itself the durable resource being deleted. Do not
+    # normalize it through a compression lineage: after successful deletion
+    # that lineage is intentionally gone, while a retry must still fingerprint
+    # to the same tombstoned target and replay the original outcome.
+    return target, {}
+
+
+def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | None:
+    """Validate live routing only for a newly reserved mutation, not a replay."""
+    if method not in {"prompt.submit", "session.interrupt"}:
+        return None
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    assert session is not None
+
+    expected = str(params.get("expected_stored_session_id") or "").strip()
+    runtime_id = str(params.get("session_id") or "").strip()
+    current_ids = {
+        str(session.get("session_key") or "").strip(),
+        str(session.get("resume_session_id") or "").strip(),
+        _session_lookup_key(session, fallback=runtime_id).strip(),
+    }
+    current_ids.discard("")
+    if expected in current_ids:
+        return None
+
+    lazy_watch = bool(session.get("lazy") and session.get("agent") is None)
+    if not lazy_watch:
+        try:
+            with _session_db(session) as db:
+                lineage = getattr(db, "get_compression_lineage", None)
+                if callable(lineage):
+                    expected_lineage = lineage(expected)
+                    expected_root = str(expected_lineage[0]) if expected_lineage else ""
+                    for current in current_ids:
+                        current_lineage = lineage(current)
+                        if (
+                            expected_root
+                            and current_lineage
+                            and str(current_lineage[0]) == expected_root
+                        ):
+                            return None
+        except Exception:
+            logger.debug(
+                "failed to validate mobile mutation conversation identity",
+                exc_info=True,
+            )
+
+    live = ", ".join(sorted(current_ids)) or "unknown"
+    return _err(
+        rid,
+        4019,
+        f"stored session mismatch: expected {expected!r}; live session is {live}",
+    )
+
+
+def _mutation_outcome(response: dict) -> dict[str, Any]:
+    if "result" in response:
+        return {"result": copy.deepcopy(response["result"])}
+    return {"error": copy.deepcopy(response.get("error") or {})}
+
+
+def _mutation_response(
+    rid: Any,
+    outcome: dict[str, Any],
+    *,
+    client_request_id: str,
+    deduplicated: bool,
+) -> dict:
+    receipt = {
+        "client_request_id": client_request_id,
+        "deduplicated": deduplicated,
+        "state": "completed",
+    }
+    if "result" in outcome:
+        result = copy.deepcopy(outcome["result"])
+        if not isinstance(result, dict):
+            result = {"value": result}
+        result["mutation"] = receipt
+        return _ok(rid, result)
+
+    error = copy.deepcopy(outcome.get("error") or {})
+    data = error.get("data")
+    if not isinstance(data, dict):
+        data = {}
+    data["mutation"] = receipt
+    error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
+
+
+def _dispatch_mobile_mutation(
+    req: dict,
+    *,
+    rid: Any,
+    method: str,
+    params: dict,
+    transport: Transport,
+) -> object:
+    from tui_gateway.mobile_contract import (
+        MOBILE_AUDIENCE,
+        effective_authorization,
+    )
+
+    grant = effective_authorization(getattr(transport, "authorization", None))
+    if grant["audience"] != MOBILE_AUDIENCE or method not in _MOBILE_MUTATION_METHODS:
+        return _NOT_A_MOBILE_MUTATION
+
+    client_request_id = str(params.get("client_request_id") or "").strip()
+    if not client_request_id:
+        return _err(
+            rid,
+            -32602,
+            "client_request_id is required for mobile mutation",
+            data={"method": method, "reason": "client_request_id_required"},
+        )
+
+    resource = _mobile_mutation_resource(method, params, rid)
+    if isinstance(resource, dict):
+        return resource
+    resource_id, semantic_parameters = resource
+    try:
+        store = _mobile_mutation_store()
+        claim = store.reserve(
+            provider=grant["provider"],
+            subject=grant["subject"],
+            client_request_id=client_request_id,
+            method=method,
+            resource_id=resource_id,
+            semantic_parameters=semantic_parameters,
+        )
+    except MutationConflict:
+        return _err(
+            rid,
+            4090,
+            "client_request_id was already used for different semantics",
+            data={"reason": "mutation_conflict"},
+        )
+    except ValueError as exc:
+        return _err(
+            rid,
+            -32602,
+            str(exc),
+            data={"reason": "invalid_client_request_id"},
+        )
+    except (OSError, sqlite3.Error):
+        logger.warning("mobile mutation receipt reservation failed", exc_info=True)
+        return _err(
+            rid,
+            5037,
+            "durable mutation receipt is temporarily unavailable",
+            data={"reason": "mutation_store_unavailable"},
+        )
+
+    if claim.disposition is MutationDisposition.IN_PROGRESS:
+        claim = store.wait_for_outcome(claim, timeout=30.0)
+    if claim.disposition is MutationDisposition.REPLAY:
+        return _mutation_response(
+            rid,
+            claim.outcome or {},
+            client_request_id=client_request_id,
+            deduplicated=True,
+        )
+    if claim.disposition is MutationDisposition.OUTCOME_UNKNOWN:
+        return _err(
+            rid,
+            4091,
+            "the prior mutation outcome is unknown and will not be re-executed",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_outcome_unknown",
+                "state": "outcome_unknown",
+            },
+        )
+    if claim.disposition is MutationDisposition.IN_PROGRESS:
+        return _err(
+            rid,
+            4092,
+            "the mutation is still in progress",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_in_progress",
+                "state": "in_progress",
+            },
+        )
+
+    try:
+        response = _mobile_mutation_preflight(method, params, rid)
+        if response is None:
+            response = handle_request(req)
+    except Exception:
+        store.mark_outcome_unknown(claim)
+        raise
+    if response is None:
+        store.mark_outcome_unknown(claim)
+        return _err(
+            rid,
+            5037,
+            "mutation handler did not produce a durable outcome",
+            data={"reason": "mutation_outcome_unknown"},
+        )
+    outcome = _mutation_outcome(response)
+    if not store.complete(claim, outcome):
+        return _err(
+            rid,
+            5037,
+            "mutation outcome could not be recorded durably",
+            data={"reason": "mutation_outcome_unknown"},
+        )
+    return _mutation_response(
+        rid,
+        outcome,
+        client_request_id=client_request_id,
+        deduplicated=False,
+    )
+
+
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     """Route inbound RPCs — long handlers to the pool, everything else inline.
 
@@ -1452,6 +1735,15 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
                 "insufficient authorization scope",
                 data=denial,
             )
+        mutation_response = _dispatch_mobile_mutation(
+            req,
+            rid=_rid,
+            method=method,
+            params=_params,
+            transport=t,
+        )
+        if mutation_response is not _NOT_A_MOBILE_MUTATION:
+            return mutation_response
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 
@@ -6670,6 +6962,40 @@ def _(rid, params: dict) -> dict:
     if not deleted:
         return _err(rid, 4007, "session not found")
     return _ok(rid, {"deleted": target})
+
+
+@method("mutation.status")
+def _(rid, params: dict) -> dict:
+    """Return the authenticated principal's durable mutation outcome."""
+    from tui_gateway.mobile_contract import effective_authorization
+
+    client_request_id = str(params.get("client_request_id") or "").strip()
+    if not client_request_id:
+        return _err(rid, -32602, "client_request_id is required")
+    transport = current_transport()
+    grant = effective_authorization(getattr(transport, "authorization", None))
+    try:
+        status = _mobile_mutation_store().status(
+            provider=grant["provider"],
+            subject=grant["subject"],
+            client_request_id=client_request_id,
+        )
+    except (OSError, sqlite3.Error, ValueError):
+        logger.warning("mobile mutation status lookup failed", exc_info=True)
+        return _err(
+            rid,
+            5037,
+            "durable mutation receipt is temporarily unavailable",
+            data={"reason": "mutation_store_unavailable"},
+        )
+    if status is None:
+        return _err(
+            rid,
+            4040,
+            "mutation receipt not found",
+            data={"reason": "mutation_not_found"},
+        )
+    return _ok(rid, status)
 
 
 @method("session.title")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -31,6 +31,7 @@ from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.mobile_sync import SessionEventStream
 from tui_gateway.mobile_mutations import (
+    InvalidMutationRequestIdentity,
     MobileMutationStore,
     MutationClaim,
     MutationConflict,
@@ -1502,6 +1503,34 @@ def _mobile_mutation_resource(
         parameter: params.get(parameter)
         for parameter in descriptor.semantic_parameters
     }
+    lineage_parameter = descriptor.lineage_parameter
+    if lineage_parameter is not None:
+        lineage_id = str(params.get(lineage_parameter) or "").strip()
+        if not lineage_id:
+            return _err(
+                rid,
+                -32602,
+                f"{lineage_parameter} is required for mobile mutation",
+                data={
+                    "method": method,
+                    "reason": "durable_lineage_id_required",
+                },
+            )
+        if lineage_parameter in semantics:
+            semantics[lineage_parameter] = lineage_id
+    if method == "approval.respond":
+        normalized_choice = str(params.get("choice") or "").strip().lower()
+        if not normalized_choice:
+            return _err(
+                rid,
+                -32602,
+                "choice is required for mobile approval response",
+                data={
+                    "method": method,
+                    "reason": "approval_choice_required",
+                },
+            )
+        semantics["choice"] = normalized_choice
     if descriptor.resource_parameter == "expected_stored_session_id":
         # Cuttle keeps this server-issued Conversation identity stable while the
         # process-local live session id and compression tip can rotate. Binding
@@ -1514,7 +1543,16 @@ def _mobile_mutation_resource(
         # A stored session id is itself the durable resource being deleted. Do not
         # normalize it through a compression lineage: after successful deletion
         # that lineage is intentionally gone, while a retry must still fingerprint
-        # to the same tombstoned target and replay the original outcome.
+        # to the same tombstoned target and replay the original outcome. Execute
+        # with this normalized value too, so the handler semantics cannot differ
+        # from the durable fingerprint on a whitespace-only variation.
+        params[descriptor.resource_parameter] = resource_id
+        return resource_id, semantics
+
+    if descriptor.resource_parameter == "approval_id":
+        # Approval identity is Hermes-owned and stable across reconnects. The
+        # separate expected-stored-session semantic prevents one receipt from
+        # being replayed against the same ID under a different Conversation.
         return resource_id, semantics
 
     return _err(
@@ -1530,14 +1568,14 @@ def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | No
     from tui_gateway.mobile_contract import MOBILE_MUTATION_POLICIES
 
     descriptor = MOBILE_MUTATION_POLICIES.get(method)
-    if descriptor is None or not descriptor.requires_live_lineage_validation:
+    if descriptor is None or descriptor.lineage_parameter is None:
         return None
     session, err = _sess_nowait(params, rid)
     if err:
         return err
     assert session is not None
 
-    expected = str(params.get(descriptor.resource_parameter) or "").strip()
+    expected = str(params.get(descriptor.lineage_parameter) or "").strip()
     runtime_id = str(params.get("session_id") or "").strip()
     current_ids = {
         str(session.get("session_key") or "").strip(),
@@ -2083,46 +2121,51 @@ def _dispatch_mobile_mutation(
     if isinstance(resource, dict):
         return resource
     resource_id, semantic_parameters = resource
-    try:
-        store = _mobile_mutation_store()
-        claim = store.reserve(
-            provider=grant["provider"],
-            subject=grant["subject"],
-            client_request_id=client_request_id,
-            method=method,
-            resource_id=resource_id,
-            semantic_parameters=semantic_parameters,
-        )
-    except MutationConflict:
-        return _err(
-            rid,
-            4090,
-            "client_request_id was already used for different semantics",
-            data={"reason": "mutation_conflict"},
-        )
-    except ValueError as exc:
-        return _err(
-            rid,
-            -32602,
-            str(exc),
-            data={"reason": "invalid_client_request_id"},
-        )
-    except (OSError, sqlite3.Error):
-        logger.warning("mobile mutation receipt reservation failed", exc_info=True)
-        return _mobile_mutation_store_unavailable(rid)
-    except Exception:
-        logger.exception("unexpected mobile mutation receipt reservation failure")
-        return _mobile_mutation_store_unavailable(rid)
-
-    if claim.disposition is MutationDisposition.IN_PROGRESS:
+    while True:
         try:
-            claim = store.wait_for_outcome(claim, timeout=30.0)
-        except (OSError, sqlite3.Error):
-            logger.warning("mobile mutation receipt wait failed", exc_info=True)
+            store = _mobile_mutation_store()
+            claim = store.reserve(
+                provider=grant["provider"],
+                subject=grant["subject"],
+                client_request_id=client_request_id,
+                method=method,
+                resource_id=resource_id,
+                semantic_parameters=semantic_parameters,
+            )
+        except MutationConflict:
+            return _err(
+                rid,
+                4090,
+                "client_request_id was already used for different semantics",
+                data={"reason": "mutation_conflict"},
+            )
+        except InvalidMutationRequestIdentity as exc:
+            return _err(
+                rid,
+                -32602,
+                str(exc),
+                data={"reason": "invalid_client_request_id"},
+            )
+        except (OSError, sqlite3.Error, ValueError):
+            logger.warning(
+                "mobile mutation receipt reservation failed",
+                exc_info=True,
+            )
             return _mobile_mutation_store_unavailable(rid)
         except Exception:
-            logger.exception("unexpected mobile mutation receipt wait failure")
+            logger.exception("unexpected mobile mutation receipt reservation failure")
             return _mobile_mutation_store_unavailable(rid)
+        if claim.disposition is MutationDisposition.IN_PROGRESS:
+            try:
+                claim = store.wait_for_outcome(claim, timeout=30.0)
+            except (OSError, sqlite3.Error):
+                logger.warning("mobile mutation receipt wait failed", exc_info=True)
+                return _mobile_mutation_store_unavailable(rid)
+            except Exception:
+                logger.exception("unexpected mobile mutation receipt wait failure")
+                return _mobile_mutation_store_unavailable(rid)
+        if claim.disposition is not MutationDisposition.RETRY:
+            break
     if claim.disposition is MutationDisposition.REPLAY:
         return _mutation_response(
             rid,
@@ -2199,11 +2242,13 @@ def _dispatch_mobile_mutation(
             response = handle_request(req)
     except Exception:
         logger.exception("mobile mutation handler failed")
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="handler failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         return _err(
             rid,
             5037,
@@ -2213,11 +2258,13 @@ def _dispatch_mobile_mutation(
     finally:
         params.pop("_mobile_mutation_receipt_tag", None)
     if response is None:
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="empty handler response",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         return _err(
             rid,
             5037,
@@ -2265,19 +2312,23 @@ def _dispatch_mobile_mutation(
         completed = store.complete(claim, outcome)
     except (OSError, sqlite3.Error):
         logger.warning("mobile mutation receipt completion failed", exc_info=True)
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="receipt completion failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         completed = False
     except Exception:
         logger.exception("unexpected mobile mutation receipt completion failure")
-        _mark_mobile_mutation_outcome_unknown(
+        recovered = _recover_mobile_mutation_outcome_unknown(
             store,
             claim,
             context="unexpected receipt completion failure",
         )
+        if not recovered:
+            return _mobile_mutation_store_unavailable(rid)
         completed = False
     if not completed:
         return _err(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1277,7 +1277,53 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
         from gateway.run import _redact_approval_command
 
         payload["command"] = _redact_approval_command(payload.get("command"))
-    _emit("approval.request", sid, payload)
+    descriptor = dict(payload)
+    descriptor["kind"] = "approval"
+    _emit_with_sync_update(
+        "approval.request",
+        sid,
+        payload,
+        lambda stream: stream.track_pending_interaction(descriptor),
+    )
+
+
+def _emit_approval_terminal(sid: str, data: dict | None) -> None:
+    """Publish one approval terminal transition and clear snapshot state."""
+    session = _sessions.get(sid)
+    payload = dict(data or {})
+    approval_id = str(payload.get("approval_id") or "")
+    if session is None or not approval_id:
+        return
+    state = str(payload.get("state") or "stale")
+    event = {
+        "resolved": "approval.resolved",
+        "expired": "approval.expired",
+        "stale": "approval.stale",
+    }.get(state, "approval.stale")
+    _emit_with_sync_update(
+        event,
+        sid,
+        payload,
+        lambda stream: stream.finish_pending_interaction(approval_id),
+    )
+
+
+def _register_gateway_approval_callbacks(session_key: str, sid: str) -> None:
+    """Wire request and optional terminal approval callbacks for one session."""
+    from tools.approval import register_gateway_notify
+
+    register_gateway_notify(
+        session_key,
+        lambda data: _emit_approval_request(sid, data),
+    )
+    try:
+        from tools.approval import register_gateway_resolution_notify
+    except ImportError:
+        return
+    register_gateway_resolution_notify(
+        session_key,
+        lambda data: _emit_approval_terminal(sid, data),
+    )
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -1539,14 +1585,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 pass
 
             try:
-                from tools.approval import (
-                    register_gateway_notify,
-                    load_permanent_allowlist,
-                )
+                from tools.approval import load_permanent_allowlist
 
-                register_gateway_notify(
-                    key, lambda data: _emit_approval_request(sid, data)
-                )
+                _register_gateway_approval_callbacks(key, sid)
                 notify_registered = True
                 load_permanent_allowlist()
             except Exception:
@@ -3311,7 +3352,6 @@ def _sync_session_key_after_compress(
             disable_session_yolo,
             enable_session_yolo,
             is_session_yolo_enabled,
-            register_gateway_notify,
             unregister_gateway_notify,
         )
 
@@ -3331,10 +3371,7 @@ def _sync_session_key_after_compress(
             except Exception:
                 pass
         try:
-            register_gateway_notify(
-                new_session_id,
-                lambda data: _emit_approval_request(sid, data),
-            )
+            _register_gateway_approval_callbacks(new_session_id, sid)
         except Exception:
             pass
     except Exception:
@@ -4955,9 +4992,9 @@ def _init_session(
         # Defer hard-failure to slash.exec; chat still works without slash worker.
         _sessions[sid]["slash_worker"] = None
     try:
-        from tools.approval import register_gateway_notify, load_permanent_allowlist
+        from tools.approval import load_permanent_allowlist
 
-        register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
+        _register_gateway_approval_callbacks(key, sid)
         load_permanent_allowlist()
     except Exception:
         pass
@@ -10720,7 +10757,26 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     try:
-        from tools.approval import resolve_gateway_approval
+        from tools.approval import (
+            resolve_gateway_approval,
+            resolve_gateway_approval_by_id,
+        )
+
+        approval_id = str(params.get("approval_id") or "").strip()
+        if approval_id:
+            return _ok(
+                rid,
+                resolve_gateway_approval_by_id(
+                    session["session_key"],
+                    approval_id,
+                    params.get("choice", "deny"),
+                    reason=params.get("reason"),
+                    resolution_metadata={
+                        "source": "tui_gateway",
+                        "live_session_id": str(params.get("session_id") or ""),
+                    },
+                ),
+            )
 
         return _ok(
             rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1205,8 +1205,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, *, data: dict | None = None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):
@@ -1268,6 +1271,16 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        from tui_gateway.mobile_contract import mobile_method_denial
+
+        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        if denial is not None:
+            return _err(
+                _rid,
+                4030,
+                "insufficient authorization scope",
+                data=denial,
+            )
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1273,7 +1273,11 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
         _rid, method, _params = normalized
         from tui_gateway.mobile_contract import mobile_method_denial
 
-        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        denial = mobile_method_denial(
+            method,
+            getattr(t, "authorization", None),
+            _params,
+        )
         if denial is not None:
             return _err(
                 _rid,
@@ -5101,7 +5105,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     session["queued_prompt"] = {"text": text, "transport": transport}
 
 
-def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any) -> dict:
+def _handle_busy_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    allow_control: bool = True,
+) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
 
@@ -5116,6 +5128,14 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
     without interrupting; ``steer`` → inject into the live turn if accepted,
     else queue.
     """
+    # A scoped writer may enqueue the next user turn, but must not inherit the
+    # dashboard's interrupt/steer preference unless its connection also holds
+    # conversation.control.
+    if not allow_control:
+        _enqueue_prompt(session, text, transport)
+        session["last_active"] = time.time()
+        return _ok(rid, {"status": "queued"})
+
     mode = _load_busy_input_mode()
     agent = session.get("agent")
     if mode == "steer" and agent is not None and hasattr(agent, "steer"):
@@ -8137,7 +8157,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.interrupt")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Interrupting a deferred/lazy session must not build the very agent the
+    # caller is trying to stop. Operate on live state only.
+    session, err = _sess_nowait(params, rid)
     if err:
         return err
     # Safety net: if the turn's run thread is already gone but `running` stayed
@@ -8459,7 +8481,23 @@ def _(rid, params: dict) -> dict:
             # interrupt the live turn) so it runs as the next turn. See
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
-            return _handle_busy_submit(rid, sid, session, text, t or session.get("transport"))
+            active_transport = t or session.get("transport")
+            from tui_gateway.mobile_contract import (
+                CONVERSATION_CONTROL_SCOPE,
+                authorization_allows_scope,
+            )
+
+            return _handle_busy_submit(
+                rid,
+                sid,
+                session,
+                text,
+                active_transport,
+                allow_control=authorization_allows_scope(
+                    getattr(active_transport, "authorization", None),
+                    CONVERSATION_CONTROL_SCOPE,
+                ),
+            )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1149,13 +1149,35 @@ def _session_event_stream(session: dict) -> SessionEventStream:
     return stream
 
 
+def _session_sync_enabled(session: dict) -> bool:
+    """Return whether this live session negotiated revisioned mobile sync.
+
+    Legacy stdio and Desktop clients retain the original response/event shape
+    and avoid replay copies.  Once a mobile transport attaches, keep retention
+    enabled for the rest of the live stream so a later reconnect can replay
+    events emitted while the socket was detached.
+    """
+    if session.get("mobile_sync_enabled"):
+        return True
+    transport = session.get("transport") or current_transport()
+    authorization = getattr(transport, "authorization", None)
+    if not isinstance(authorization, dict):
+        return False
+    from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
+
+    if effective_authorization(authorization)["audience"] != MOBILE_AUDIENCE:
+        return False
+    session["mobile_sync_enabled"] = True
+    return True
+
+
 def _emit(
     event: str,
     sid: str,
     payload: dict | None = None,
 ):
     session = _sessions.get(sid)
-    if session is not None:
+    if session is not None and _session_sync_enabled(session):
         return _session_event_stream(session).publish(
             event,
             sid,
@@ -1176,6 +1198,15 @@ def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
         return _emit(event, sid, payload)
     with _session_event_stream(session).transition(update):
         return _emit(event, sid, payload)
+
+
+def _mark_snapshot_mutation(session: dict) -> None:
+    """Advance the snapshot revision for a state change with no wire event.
+
+    Callers hold ``history_lock`` first, preserving the same history -> stream
+    lock order used by snapshot capture and event publication.
+    """
+    _session_event_stream(session).mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -2513,6 +2544,7 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         with lock:
             session.setdefault("history", []).append(entry)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     else:
         session.setdefault("history", []).append(entry)
         session["history_version"] = int(session.get("history_version", 0)) + 1
@@ -3170,6 +3202,7 @@ def _compress_session_history(
             return 0, usage
         session["history"] = compressed
         session["history_version"] = history_version + 1
+        _mark_snapshot_mutation(session)
     usage = _get_usage(agent)
     return len(history) - len(compressed), usage
 
@@ -3913,12 +3946,36 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         with _child_mirrors_lock:
             _child_mirrors.pop(child_key, None)
         return
-    csid = live[0]
+    csid, child_session = live
+    history_lock = child_session.setdefault("history_lock", threading.RLock())
+    child_session.setdefault("history", [])
+    child_session.setdefault("history_version", 0)
+    child_session.setdefault("inflight_turn", None)
+    child_session.setdefault("running", False)
+
+    def finish_open_tool(tool: dict | None) -> None:
+        if not tool:
+            return
+        tool_id = str(tool.get("tool_id") or "")
+        _emit_with_sync_update(
+            "tool.complete",
+            csid,
+            tool,
+            lambda stream: stream.finish_tool(tool_id),
+        )
+
     with _child_mirrors_lock:
         st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
         if not st["started"]:
             st["started"] = True
-            _emit("message.start", csid)
+            with history_lock:
+                child_session["running"] = True
+                if not isinstance(child_session.get("inflight_turn"), dict):
+                    _start_inflight_turn(child_session, "")
+                turn_id = str(
+                    (child_session.get("inflight_turn") or {}).get("turn_id") or ""
+                )
+                _emit("message.start", csid, {"turn_id": turn_id})
         if event_type == "subagent.thinking":
             if text := str(payload.get("text") or ""):
                 _emit("reasoning.delta", csid, {"text": text})
@@ -3927,15 +3984,14 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             # Relayed token-by-token from the child's run_conversation
             # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": text})
+                _emit_inflight_delta(csid, child_session, text)
         elif event_type == "subagent.start":
             # One-time header line (the child's goal) so a freshly opened window
             # shows immediate context before the first reply token streams.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": f"{text}\n"})
+                _emit_inflight_delta(csid, child_session, f"{text}\n")
         elif event_type == "subagent.tool":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
             st["seq"] += 1
             tool = {
                 "name": str(payload.get("tool_name") or "tool"),
@@ -3945,12 +4001,43 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             if preview := str(payload.get("tool_preview") or payload.get("text") or ""):
                 tool["preview"] = preview
             st["open_tool"] = tool
-            _emit("tool.start", csid, tool)
+            descriptor = {
+                "tool_id": tool["tool_id"],
+                "name": tool["name"],
+                "started_at": time.time(),
+            }
+            _emit_with_sync_update(
+                "tool.start",
+                csid,
+                tool,
+                lambda stream: stream.track_tool(descriptor),
+            )
         elif event_type == "subagent.complete":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
+            st["open_tool"] = None
             summary = str(payload.get("summary") or payload.get("text") or "")
-            _emit("message.complete", csid, {"text": summary})
+            with history_lock:
+                turn = child_session.get("inflight_turn") or {}
+                turn_id = str(turn.get("turn_id") or "")
+                assistant = str(turn.get("assistant") or "")
+                final_text = assistant or summary
+                history = child_session.setdefault("history", [])
+                if final_text and not (
+                    history
+                    and history[-1].get("role") == "assistant"
+                    and history[-1].get("content") == final_text
+                ):
+                    history.append({"role": "assistant", "content": final_text})
+                    child_session["history_version"] = int(
+                        child_session.get("history_version", 0)
+                    ) + 1
+                child_session["running"] = False
+                _clear_inflight_turn(child_session)
+                _emit(
+                    "message.complete",
+                    csid,
+                    {"text": summary or final_text, "turn_id": turn_id},
+                )
             _child_mirrors.pop(child_key, None)
 
 
@@ -4194,6 +4281,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         info = _session_info(agent)
         _emit("session.info", sid, info)
         return False, info
@@ -4445,6 +4533,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
+        _mark_snapshot_mutation(session)
     info = _session_info(new_agent, session)
     _emit("session.info", sid, info)
     _restart_slash_worker(sid, session)
@@ -4754,7 +4843,6 @@ def _init_session(
             "history_version": 0,
             "inflight_turn": None,
             "conversation_id": key,
-            "mobile_sync": _new_session_event_stream(),
             "created_at": now,
             "last_active": now,
             "running": False,
@@ -5313,17 +5401,21 @@ def _inflight_snapshot(
     return snapshot
 
 
-def _new_session_event_stream() -> SessionEventStream:
-    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
-
-    return SessionEventStream(SERVER_INSTANCE_ID)
-
-
 def _conversation_root(db, session_id: str) -> str:
     try:
         lineage = db.get_compression_lineage(session_id)
-    except Exception:
+    except AttributeError:
+        # Compatibility with old/embedded SessionDB stubs that predate
+        # compression lineage. Unexpected database failures must not silently
+        # change a conversation's supposedly stable identity to its current tip.
         lineage = []
+    except Exception:
+        logger.warning(
+            "failed to resolve stable conversation lineage for %s",
+            session_id,
+            exc_info=True,
+        )
+        raise
     return str(
         lineage[0]
         if isinstance(lineage, (list, tuple)) and lineage
@@ -5373,6 +5465,8 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
+    if not _session_sync_enabled(session):
+        return payload
     payload["synchronization"] = _session_synchronization(sid, session, cursor)
     return payload
 
@@ -5463,7 +5557,6 @@ def _(rid, params: dict) -> dict:
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
-            "mobile_sync": _new_session_event_stream(),
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id,
@@ -5720,7 +5813,6 @@ def _deferred_session_record(
         "last_active": now,
         "lazy": lazy,
         "model_override": model_override,
-        "mobile_sync": _new_session_event_stream(),
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
         "resume_runtime_overrides": resume_runtime_overrides,
@@ -6148,7 +6240,6 @@ def _(rid, params: dict) -> dict:
                 "history": history,
                 "history_lock": threading.Lock(),
                 "inflight_turn": None,
-                "mobile_sync": _new_session_event_stream(),
                 "running": False,
                 "session_key": target,
             }
@@ -6157,7 +6248,6 @@ def _(rid, params: dict) -> dict:
             session.setdefault("history", history)
             session.setdefault("history_lock", threading.Lock())
             session.setdefault("inflight_turn", None)
-            session.setdefault("mobile_sync", _new_session_event_stream())
             session.setdefault("running", False)
         session["conversation_id"] = conversation_id
     payload = {
@@ -8135,6 +8225,7 @@ def _(rid, params: dict) -> dict:
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     return _ok(rid, {"removed": removed})
 
 
@@ -8412,6 +8503,7 @@ def _(rid, params: dict) -> dict:
             if session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
 
     # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
     # foreground subprocess). Background processes the agent started (dev servers,
@@ -8705,6 +8797,13 @@ def _(rid, params: dict) -> dict:
     # must not seize the in-flight turn from the currently attached client.
     t = current_transport()
     with session["history_lock"]:
+        # A watch session's run lives in the PARENT turn. Reject before the
+        # ordinary busy/queue path: queuing onto a lazy mirror would otherwise
+        # build a second agent against the child's still-running transcript.
+        if session.get("lazy") and _child_run_active(
+            str(session.get("session_key") or "")
+        ):
+            return _err(rid, 4009, "subagent still running — wait for it to finish")
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
             # interrupt the live turn) so it runs as the next turn. See
@@ -8730,13 +8829,6 @@ def _(rid, params: dict) -> dict:
                 active_transport,
                 allow_control=allow_control,
             )
-        # A watch session's run lives in the PARENT turn, so its own running
-        # flag is False — without this, typing mid-run builds a second agent
-        # racing the in-flight child on the same stored session (interleaved
-        # transcript, stale fork). After the run completes, submitting is fine:
-        # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
-            return _err(rid, 4009, "subagent still running — wait for it to finish")
         if t is not None:
             session["transport"] = t
         if truncate_user_ordinal is not None:
@@ -8756,6 +8848,7 @@ def _(rid, params: dict) -> dict:
             truncated = history[: user_indices[ordinal]]
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
             if (db := _get_db()) is not None:
                 try:
                     db.replace_messages(session["session_key"], truncated)
@@ -8788,11 +8881,13 @@ def _(rid, params: dict) -> dict:
             with session["history_lock"]:
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             return
         with session["history_lock"]:
             if session.get("_turn_cancel_requested") or not session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
                 return
         _run_prompt_submit(rid, sid, session, text)
 
@@ -9182,6 +9277,49 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _commit_prompt_completion(
+    sid: str,
+    session: dict,
+    *,
+    expected_history_version: int,
+    result_messages: list | None,
+    payload: dict[str, Any],
+) -> str | None:
+    """Publish final history and completion at one snapshot/event barrier."""
+    status_note = None
+    with session["history_lock"]:
+        if result_messages is not None:
+            current_version = int(session.get("history_version", 0))
+            if current_version == expected_history_version:
+                session["history"] = result_messages
+                session["history_version"] = expected_history_version + 1
+            else:
+                # History mutated externally during the turn
+                # (undo/compress/retry/rollback guard on session.running, but
+                # this is the defensive backstop for any path that slips past).
+                # Surface the desync rather than silently dropping output.
+                print(
+                    f"[tui_gateway] prompt.submit: history_version mismatch "
+                    f"(expected={expected_history_version} current={current_version}) — "
+                    f"agent output NOT written to session history",
+                    file=sys.stderr,
+                )
+                status_note = (
+                    "History changed during this turn — the response above is visible "
+                    "but was not saved to session history."
+                )
+                payload["warning"] = status_note
+
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        payload["turn_id"] = turn_id
+        _clear_inflight_turn(session)
+        # _emit allocates the stream sequence while history_lock is still held.
+        # Snapshot capture takes the same locks in this order, so it can observe
+        # either the streaming turn or the completed history, never a mixture.
+        _emit("message.complete", sid, payload)
+    return status_note
+
+
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
         history = list(session["history"])
@@ -9381,33 +9519,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     session["model_override"] = _restore
 
             last_reasoning = None
-            status_note = None
+            result_messages = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
-                    with session["history_lock"]:
-                        current_version = int(session.get("history_version", 0))
-                        if current_version == history_version:
-                            session["history"] = result["messages"]
-                            session["history_version"] = history_version + 1
-                        else:
-                            # History mutated externally during the turn
-                            # (undo/compress/retry/rollback now guard on
-                            # session.running, but this is the defensive
-                            # backstop for any path that slips past).
-                            # Surface the desync rather than silently
-                            # dropping the agent's output — the UI can
-                            # show the response and warn that it was
-                            # not persisted.
-                            print(
-                                f"[tui_gateway] prompt.submit: history_version mismatch "
-                                f"(expected={history_version} current={current_version}) — "
-                                f"agent output NOT written to session history",
-                                file=sys.stderr,
-                            )
-                            status_note = (
-                                "History changed during this turn — the response above is visible "
-                                "but was not saved to session history."
-                            )
+                    result_messages = result["messages"]
 
                 # If auto-compression fired inside run_conversation(), agent.session_id
                 # may have rotated. Sync session_key before downstream title/goal/finalize
@@ -9447,18 +9562,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
-            if status_note:
-                payload["warning"] = status_note
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
-            with session["history_lock"]:
-                turn_id = str(
-                    (session.get("inflight_turn") or {}).get("turn_id") or ""
-                )
-                payload["turn_id"] = turn_id
-                _clear_inflight_turn(session)
-                _emit("message.complete", sid, payload)
+            _commit_prompt_completion(
+                sid,
+                session,
+                expected_history_version=history_version,
+                result_messages=result_messages,
+                payload=payload,
+            )
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge
@@ -9612,6 +9725,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             _emit("session.info", sid, _session_info(agent, session))
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
@@ -12371,6 +12485,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = history[:last_user_idx]
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         return _ok(rid, {"type": "send", "message": content})
 
     if name == "steer":
@@ -12517,6 +12632,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = list(active)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         # Notify memory providers — same hook /branch fires, plus the
         # rewound flag so providers caching per-turn document state
         # know to invalidate. See #6672 + #21910.
@@ -13900,6 +14016,7 @@ def _(rid, params: dict) -> dict:
                         session["history_version"] = (
                             int(session.get("history_version", 0)) + 1
                         )
+                        _mark_snapshot_mutation(session)
                 result["history_removed"] = removed
             return result
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -815,6 +815,7 @@ def _close_sessions_for_transport(
     detached = 0
     for sid, session in owned:
         claimed = False
+        close_claim = False
         with session.setdefault("history_lock", threading.RLock()):
             stream = _session_event_stream(session)
             with stream.transition(lambda _stream: None):
@@ -822,13 +823,23 @@ def _close_sessions_for_transport(
                 # socket may detach only if it still owns the session at this
                 # exact handoff boundary.
                 if session.get("transport") is transport:
-                    claimed = True
-                    if not session.get("close_on_disconnect"):
+                    if session.get("close_on_disconnect"):
+                        # Pop while the transport handoff boundary is still
+                        # held. A resume/activate that already captured this
+                        # record will recheck membership before rebinding.
+                        with _sessions_lock:
+                            if _sessions.get(sid) is session:
+                                _sessions.pop(sid, None)
+                                session["_sid"] = sid
+                                claimed = True
+                                close_claim = True
+                    else:
                         session["transport"] = _detached_ws_transport
+                        claimed = True
         if not claimed:
             continue
-        if session.get("close_on_disconnect"):
-            _close_session_by_id(sid, end_reason=end_reason)
+        if close_claim:
+            _teardown_session(session, end_reason=end_reason)
             reaped += 1
         else:
             # Point detached sessions at the drop sentinel (NOT real stdio) so
@@ -6001,7 +6012,7 @@ def _(rid, params: dict) -> dict:
     )
     conversation_id = _conversation_root(db, target)
 
-    def _reuse_live_payload(sid: str, session: dict) -> dict:
+    def _reuse_live_payload(sid: str, session: dict) -> dict | None:
         payload = _live_session_payload(
             sid,
             session,
@@ -6010,6 +6021,8 @@ def _(rid, params: dict) -> dict:
             transport=current_transport() or _stdio_transport,
             cursor=params.get("cursor"),
         )
+        if payload is None:
+            return None
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
         # flag is always False — overlay the child-run registry so a reconnecting
@@ -6023,7 +6036,9 @@ def _(rid, params: dict) -> dict:
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
-            return _ok(rid, _reuse_live_payload(*live))
+            payload = _reuse_live_payload(*live)
+            if payload is not None:
+                return _ok(rid, payload)
 
     # Lazy/watch resume: register the live session WITHOUT building an agent.
     # Used by the desktop's subagent windows — the child runs inside the
@@ -6245,13 +6260,6 @@ def _(rid, params: dict) -> dict:
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
-            try:
-                if hasattr(agent, "close"):
-                    agent.close()
-            except Exception:
-                pass
-            if lease is not None:
-                lease.release()
             other_sid, other_session = live
             payload = _live_session_payload(
                 other_sid,
@@ -6261,8 +6269,16 @@ def _(rid, params: dict) -> dict:
                 transport=current_transport() or _stdio_transport,
                 cursor=params.get("cursor"),
             )
-            payload["resumed"] = target
-            return _ok(rid, payload)
+            if payload is not None:
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                if lease is not None:
+                    lease.release()
+                payload["resumed"] = target
+                return _ok(rid, payload)
         try:
             init_home_token = (
                 set_hermes_home_override(str(profile_home))
@@ -6473,11 +6489,14 @@ def _live_session_payload(
     touch: bool = False,
     transport: Transport | None = None,
     cursor: object = None,
-) -> dict:
+) -> dict | None:
     info = _fallback_session_info(session)
     with session["history_lock"]:
         stream = _session_event_stream(session)
         with stream.transition(lambda _stream: None):
+            with _sessions_lock:
+                if _sessions.get(sid) is not session:
+                    return None
             if cols is not None:
                 session["cols"] = cols
             if transport is not None:
@@ -6563,15 +6582,15 @@ def _(rid, params: dict) -> dict:
         return err
     assert session is not None
 
-    return _ok(
-        rid,
-        _live_session_payload(
-            sid,
-            session,
-            touch=True,
-            transport=current_transport() or _stdio_transport,
-        ),
+    payload = _live_session_payload(
+        sid,
+        session,
+        touch=True,
+        transport=current_transport() or _stdio_transport,
     )
+    if payload is None:
+        return _err(rid, 4001, "session closed during transport handoff")
+    return _ok(rid, payload)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -28,6 +28,7 @@ from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
+from tui_gateway.mobile_sync import SessionEventStream
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -1137,11 +1138,44 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
+def _session_event_stream(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    stream = SessionEventStream(SERVER_INSTANCE_ID)
+    session["mobile_sync"] = stream
+    return stream
+
+
+def _emit(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+):
+    session = _sessions.get(sid)
+    if session is not None:
+        return _session_event_stream(session).publish(
+            event,
+            sid,
+            payload,
+            write_json,
+        )
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+    write_json(frame)
+    return frame
+
+
+def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
+    session = _sessions.get(sid)
+    if session is None:
+        return _emit(event, sid, payload)
+    with _session_event_stream(session).transition(update):
+        return _emit(event, sid, payload)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -2056,7 +2090,17 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
     answer = ""
     answer_present = False
     try:
-        _emit(event, sid, payload)
+        descriptor = {
+            "request_id": rid,
+            "kind": event.removesuffix(".request"),
+            "payload": dict(payload),
+        }
+        _emit_with_sync_update(
+            event,
+            sid,
+            payload,
+            lambda stream: stream.track_pending_interaction(descriptor),
+        )
         answered = ev.wait(timeout=timeout)
     finally:
         with _prompt_lock:
@@ -2064,6 +2108,9 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
             _pending_prompt_payloads.pop(rid, None)
             answer_present = rid in _answers
             answer = _answers.pop(rid, "")
+        session = _sessions.get(sid)
+        if session is not None:
+            _session_event_stream(session).finish_pending_interaction(rid)
 
     if not answered and not answer_present and event in {"secret.request", "sudo.request"}:
         _emit(
@@ -3617,6 +3664,11 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         except Exception:
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+    descriptor = {
+        "tool_id": tool_call_id,
+        "name": name,
+        "started_at": time.time(),
+    }
     if _tool_progress_enabled(sid):
         payload = {
             "tool_id": tool_call_id,
@@ -3629,7 +3681,16 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 payload["args_text"] = args_text
         # tool.complete is the source of truth for todos (full list from the
         # tool result). args.todos here may be a partial merge update.
-        _emit("tool.start", sid, payload)
+        _emit_with_sync_update(
+            "tool.start",
+            sid,
+            payload,
+            lambda stream: stream.track_tool(descriptor),
+        )
+    elif session is not None:
+        _session_event_stream(session).mutate(
+            lambda stream: stream.track_tool(descriptor)
+        )
 
 
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
@@ -3676,7 +3737,16 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     except Exception:
         pass
     if _tool_progress_enabled(sid) or payload.get("inline_diff"):
-        _emit("tool.complete", sid, payload)
+        _emit_with_sync_update(
+            "tool.complete",
+            sid,
+            payload,
+            lambda stream: stream.finish_tool(tool_call_id),
+        )
+    elif session is not None:
+        _session_event_stream(session).mutate(
+            lambda stream: stream.finish_tool(tool_call_id)
+        )
 
 
 def _on_tool_progress(
@@ -4683,6 +4753,8 @@ def _init_session(
             "history_lock": threading.Lock(),
             "history_version": 0,
             "inflight_turn": None,
+            "conversation_id": key,
+            "mobile_sync": _new_session_event_stream(),
             "created_at": now,
             "last_active": now,
             "running": False,
@@ -5063,22 +5135,57 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
         "assistant": "",
         "started_at": now,
         "streaming": True,
+        "turn_id": str(uuid.uuid4()),
         "updated_at": now,
         "user": _inflight_text(text),
     }
 
 
-def _append_inflight_delta(session: dict, delta: Any) -> None:
+def _append_inflight_delta(session: dict, delta: Any) -> int:
     text = "" if delta is None else str(delta)
-    if not text:
-        return
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
-        turn = {"assistant": "", "streaming": True, "user": ""}
+        turn = {
+            "assistant": "",
+            "streaming": True,
+            "turn_id": str(uuid.uuid4()),
+            "user": "",
+        }
+    offset = len(str(turn.get("assistant") or "").encode("utf-8"))
+    if not text:
+        return offset
     turn["assistant"] = f"{turn.get('assistant') or ''}{text}"
     turn["streaming"] = True
     turn["updated_at"] = time.time()
     session["inflight_turn"] = turn
+    return offset
+
+
+def _emit_inflight_delta(
+    sid: str,
+    session: dict,
+    delta: Any,
+    *,
+    rendered: Any = None,
+) -> None:
+    """Append and publish a delta with its absolute UTF-8 byte offset.
+
+    UTF-8 bytes give clients a language-neutral overlap key even when one
+    streamed chunk contains extended grapheme clusters.
+    """
+    with session["history_lock"]:
+        offset = _append_inflight_delta(session, delta)
+        turn_id = str(
+            (session.get("inflight_turn") or {}).get("turn_id") or ""
+        )
+        payload = {
+            "text": delta,
+            "turn_id": turn_id,
+            "offset": offset,
+        }
+        if rendered is not None:
+            payload["rendered"] = rendered
+        _emit("message.delta", sid, payload)
 
 
 def _clear_inflight_turn(session: dict) -> None:
@@ -5183,7 +5290,11 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
-def _inflight_snapshot(session: dict) -> dict | None:
+def _inflight_snapshot(
+    session: dict,
+    *,
+    include_turn_id: bool = False,
+) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
         return None
@@ -5192,11 +5303,78 @@ def _inflight_snapshot(session: dict) -> dict | None:
     streaming = bool(turn.get("streaming"))
     if not user and not assistant and not streaming:
         return None
-    return {
+    snapshot = {
         "assistant": assistant,
         "streaming": streaming,
         "user": user,
     }
+    if include_turn_id:
+        snapshot["turn_id"] = str(turn.get("turn_id") or "")
+    return snapshot
+
+
+def _new_session_event_stream() -> SessionEventStream:
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    return SessionEventStream(SERVER_INSTANCE_ID)
+
+
+def _conversation_root(db, session_id: str) -> str:
+    try:
+        lineage = db.get_compression_lineage(session_id)
+    except Exception:
+        lineage = []
+    return str(
+        lineage[0]
+        if isinstance(lineage, (list, tuple)) and lineage
+        else session_id
+    )
+
+
+def _session_synchronization(
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    """Capture history then the stream watermark using the documented lock order."""
+    with session["history_lock"]:
+        history = list(session.get("display_history_prefix") or []) + list(
+            session.get("history") or []
+        )
+        messages = _history_to_messages(history)
+        inflight = _inflight_snapshot(session, include_turn_id=True)
+        stored_session_id = _session_lookup_key(session, fallback=sid)
+        conversation_id = str(
+            session.get("conversation_id") or stored_session_id or sid
+        )
+        running = bool(session.get("running"))
+
+        def snapshot(state: dict) -> dict:
+            status = "waiting" if state["pending_interactions"] else (
+                "working" if running else "idle"
+            )
+            return {
+                "conversation_id": conversation_id,
+                "stored_session_id": stored_session_id,
+                "live_session_id": sid,
+                "messages": messages,
+                "inflight_turn": inflight,
+                "active_tools": state["active_tools"],
+                "pending_interactions": state["pending_interactions"],
+                "status": status,
+            }
+
+        return _session_event_stream(session).synchronization(snapshot, cursor)
+
+
+def _attach_synchronization(
+    payload: dict,
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    payload["synchronization"] = _session_synchronization(sid, session, cursor)
+    return payload
 
 
 # ── Methods: session ─────────────────────────────────────────────────
@@ -5273,6 +5451,7 @@ def _(rid, params: dict) -> dict:
             "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
             "active_session_lease": lease,
             "cols": cols,
+            "conversation_id": key,
             "created_at": now,
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
@@ -5284,6 +5463,7 @@ def _(rid, params: dict) -> dict:
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
+            "mobile_sync": _new_session_event_stream(),
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id,
@@ -5314,37 +5494,38 @@ def _(rid, params: dict) -> dict:
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
+    payload = {
+        "session_id": sid,
+        "stored_session_id": key,
+        "message_count": len(history),
+        "messages": _history_to_messages(history),
+        "info": {
+            # Reflect the per-session model override (desktop composer pick)
+            # in the immediate response so the client doesn't briefly clobber
+            # its sticky pick with the global default before the deferred
+            # build's session.info lands.
+            "model": (
+                session_model_override.get("model")
+                if session_model_override
+                else _resolve_model()
+            ),
+            **(
+                {"provider": session_model_override["provider"]}
+                if session_model_override and session_model_override.get("provider")
+                else {}
+            ),
+            "tools": {},
+            "skills": {},
+            "cwd": _sessions[sid]["cwd"],
+            "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
+            "lazy": True,
+            "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+            "profile_name": _current_profile_name(),
+        },
+    }
     return _ok(
         rid,
-        {
-            "session_id": sid,
-            "stored_session_id": key,
-            "message_count": len(history),
-            "messages": _history_to_messages(history),
-            "info": {
-                # Reflect the per-session model override (desktop composer pick)
-                # in the immediate response so the client doesn't briefly clobber
-                # its sticky pick with the global default before the deferred
-                # build's session.info lands.
-                "model": (
-                    session_model_override.get("model")
-                    if session_model_override
-                    else _resolve_model()
-                ),
-                **(
-                    {"provider": session_model_override["provider"]}
-                    if session_model_override and session_model_override.get("provider")
-                    else {}
-                ),
-                "tools": {},
-                "skills": {},
-                "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
-                "lazy": True,
-                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _current_profile_name(),
-            },
-        },
+        _attach_synchronization(payload, sid, _sessions[sid]),
     )
 
 
@@ -5512,6 +5693,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    conversation_id: str | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -5524,6 +5706,7 @@ def _deferred_session_record(
         "close_on_disconnect": close_on_disconnect,
         "active_session_lease": lease,
         "cols": cols,
+        "conversation_id": conversation_id or session_key,
         "created_at": now,
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
@@ -5537,6 +5720,7 @@ def _deferred_session_record(
         "last_active": now,
         "lazy": lazy,
         "model_override": model_override,
+        "mobile_sync": _new_session_event_stream(),
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
         "resume_runtime_overrides": resume_runtime_overrides,
@@ -5653,6 +5837,7 @@ def _(rid, params: dict) -> dict:
     profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
         profile_home
     )
+    conversation_id = _conversation_root(db, target)
 
     def _reuse_live_payload(sid: str, session: dict) -> dict:
         payload = _live_session_payload(
@@ -5661,6 +5846,7 @@ def _(rid, params: dict) -> dict:
             cols=cols,
             touch=True,
             transport=current_transport() or _stdio_transport,
+            cursor=params.get("cursor"),
         )
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
@@ -5712,6 +5898,7 @@ def _(rid, params: dict) -> dict:
             close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
             profile_home=profile_home,
             lazy=True,
+            conversation_id=conversation_id,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -5719,20 +5906,26 @@ def _(rid, params: dict) -> dict:
         # its liveness from the relay registry so the window shows a busy turn.
         child_running = _child_run_active(target)
         messages = _history_to_messages(history)
+        payload = {
+            "session_id": sid,
+            "resumed": target,
+            "message_count": len(messages),
+            "messages": messages,
+            "info": _lazy_resume_info(cwd),
+            "inflight": None,
+            "running": child_running,
+            "session_key": target,
+            "started_at": record["created_at"],
+            "status": "streaming" if child_running else "idle",
+        }
         return _ok(
             rid,
-            {
-                "session_id": sid,
-                "resumed": target,
-                "message_count": len(messages),
-                "messages": messages,
-                "info": _lazy_resume_info(cwd),
-                "inflight": None,
-                "running": child_running,
-                "session_key": target,
-                "started_at": record["created_at"],
-                "status": "streaming" if child_running else "idle",
-            },
+            _attach_synchronization(
+                payload,
+                sid,
+                record,
+                params.get("cursor"),
+            ),
         )
 
     # Cold resume default: register the live session and read its stored
@@ -5790,6 +5983,7 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
+            conversation_id=conversation_id,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -5798,24 +5992,30 @@ def _(rid, params: dict) -> dict:
         _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
         messages = _history_to_messages(display_history)
+        payload = {
+            "session_id": sid,
+            "resumed": target,
+            "message_count": len(messages),
+            "messages": messages,
+            "info": _lazy_resume_info(
+                cwd,
+                model=model_override.get("model") or "",
+                provider=overrides.get("provider_override") or "",
+            ),
+            "inflight": None,
+            "running": False,
+            "session_key": target,
+            "started_at": record["created_at"],
+            "status": "idle",
+        }
         return _ok(
             rid,
-            {
-                "session_id": sid,
-                "resumed": target,
-                "message_count": len(messages),
-                "messages": messages,
-                "info": _lazy_resume_info(
-                    cwd,
-                    model=model_override.get("model") or "",
-                    provider=overrides.get("provider_override") or "",
-                ),
-                "inflight": None,
-                "running": False,
-                "session_key": target,
-                "started_at": record["created_at"],
-                "status": "idle",
-            },
+            _attach_synchronization(
+                payload,
+                sid,
+                record,
+                params.get("cursor"),
+            ),
         )
 
     # Build the agent OUTSIDE the lock — _make_agent can block for seconds
@@ -5897,6 +6097,7 @@ def _(rid, params: dict) -> dict:
                 cols=cols,
                 touch=True,
                 transport=current_transport() or _stdio_transport,
+                cursor=params.get("cursor"),
             )
             payload["resumed"] = target
             return _ok(rid, payload)
@@ -5936,21 +6137,49 @@ def _(rid, params: dict) -> dict:
             if lease is not None:
                 lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
-        session = _sessions.get(sid) or {}
+        session = _sessions.get(sid)
+        if session is None:
+            # Keep the response contract robust for embedders/tests that
+            # replace _init_session with an external session owner.
+            session = {
+                "agent": agent,
+                "conversation_id": conversation_id,
+                "display_history_prefix": display_history_prefix,
+                "history": history,
+                "history_lock": threading.Lock(),
+                "inflight_turn": None,
+                "mobile_sync": _new_session_event_stream(),
+                "running": False,
+                "session_key": target,
+            }
+        else:
+            session.setdefault("display_history_prefix", display_history_prefix)
+            session.setdefault("history", history)
+            session.setdefault("history_lock", threading.Lock())
+            session.setdefault("inflight_turn", None)
+            session.setdefault("mobile_sync", _new_session_event_stream())
+            session.setdefault("running", False)
+        session["conversation_id"] = conversation_id
+    payload = {
+        "session_id": sid,
+        "resumed": target,
+        "message_count": len(messages),
+        "messages": messages,
+        "info": _session_info(agent, session),
+        "inflight": None,
+        "running": False,
+        "session_key": target,
+        "started_at": float(session.get("created_at") or time.time()),
+        "status": "idle",
+    }
     return _ok(
         rid,
-        {
-            "session_id": sid,
-            "resumed": target,
-            "message_count": len(messages),
-            "messages": messages,
-            "info": _session_info(agent, session),
-            "inflight": None,
-            "running": False,
-            "session_key": target,
-            "started_at": float(session.get("created_at") or time.time()),
-            "status": "idle",
-        },
+        _attach_synchronization(
+            payload,
+            sid,
+            session,
+            params.get("cursor"),
+        ),
     )
 
 
@@ -6083,6 +6312,7 @@ def _live_session_payload(
     cols: int | None = None,
     touch: bool = False,
     transport: Transport | None = None,
+    cursor: object = None,
 ) -> dict:
     with session["history_lock"]:
         if cols is not None:
@@ -6108,7 +6338,7 @@ def _live_session_payload(
     }
     if inflight:
         payload["inflight"] = inflight
-    return payload
+    return _attach_synchronization(payload, sid, session, cursor)
 
 
 @method("session.active_list")
@@ -8960,14 +9190,14 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session["attached_images"] = []
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        _emit("message.start", sid, {"turn_id": turn_id})
     agent = session["agent"]
     if hasattr(agent, "clear_interrupt"):
         try:
             agent.clear_interrupt()
         except Exception:
             pass
-    _emit("message.start", sid)
-
     def run():
         approval_token = None
         session_tokens = []
@@ -9090,12 +9320,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_message = _enrich_with_attached_images(prompt, images)
 
             def _stream(delta):
-                with session["history_lock"]:
-                    _append_inflight_delta(session, delta)
-                payload = {"text": delta}
-                if streamer and (r := streamer.feed(delta)) is not None:
-                    payload["rendered"] = r
-                _emit("message.delta", sid, payload)
+                rendered_delta = streamer.feed(delta) if streamer else None
+                _emit_inflight_delta(
+                    sid,
+                    session,
+                    delta,
+                    rendered=rendered_delta,
+                )
 
             run_kwargs = {
                 "conversation_history": list(history),
@@ -9222,8 +9453,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             if rendered:
                 payload["rendered"] = rendered
             with session["history_lock"]:
+                turn_id = str(
+                    (session.get("inflight_turn") or {}).get("turn_id") or ""
+                )
+                payload["turn_id"] = turn_id
                 _clear_inflight_turn(session)
-            _emit("message.complete", sid, payload)
+                _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -814,6 +814,19 @@ def _close_sessions_for_transport(
     reaped = 0
     detached = 0
     for sid, session in owned:
+        claimed = False
+        with session.setdefault("history_lock", threading.RLock()):
+            stream = _session_event_stream(session)
+            with stream.transition(lambda _stream: None):
+                # The ownership snapshot above can race a reconnect. The old
+                # socket may detach only if it still owns the session at this
+                # exact handoff boundary.
+                if session.get("transport") is transport:
+                    claimed = True
+                    if not session.get("close_on_disconnect"):
+                        session["transport"] = _detached_ws_transport
+        if not claimed:
+            continue
         if session.get("close_on_disconnect"):
             _close_session_by_id(sid, end_reason=end_reason)
             reaped += 1
@@ -821,8 +834,6 @@ def _close_sessions_for_transport(
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            with session.setdefault("history_lock", threading.RLock()):
-                _set_session_transport_locked(session, _detached_ws_transport)
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8470,11 +8470,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    # Re-bind accepted idle work to the current client. A busy scoped writer
+    # without conversation.control queues its next turn on this transport but
+    # must not seize the in-flight turn from the currently attached client.
+    t = current_transport()
     with session["history_lock"]:
         if session.get("running"):
             # Don't reject a mid-turn prompt — queue it (and, by default,
@@ -8487,16 +8486,19 @@ def _(rid, params: dict) -> dict:
                 authorization_allows_scope,
             )
 
+            allow_control = authorization_allows_scope(
+                getattr(active_transport, "authorization", None),
+                CONVERSATION_CONTROL_SCOPE,
+            )
+            if t is not None and allow_control:
+                session["transport"] = t
             return _handle_busy_submit(
                 rid,
                 sid,
                 session,
                 text,
                 active_transport,
-                allow_control=authorization_allows_scope(
-                    getattr(active_transport, "authorization", None),
-                    CONVERSATION_CONTROL_SCOPE,
-                ),
+                allow_control=allow_control,
             )
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -8505,6 +8507,8 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if t is not None:
+            session["transport"] = t
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -821,7 +821,8 @@ def _close_sessions_for_transport(
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            session["transport"] = _detached_ws_transport
+            with session.setdefault("history_lock", threading.RLock()):
+                _set_session_transport_locked(session, _detached_ws_transport)
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)
@@ -1160,38 +1161,24 @@ def _session_event_stream(session: dict) -> SessionEventStream:
         return _session_event_stream_locked(session)
 
 
-def _session_transport_requests_sync(session: dict) -> bool:
-    transport = session.get("transport") or current_transport()
+def _transport_requests_sync(transport: Any) -> bool:
     authorization = getattr(transport, "authorization", None)
     if not isinstance(authorization, dict):
         return False
     from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
 
-
     return effective_authorization(authorization)["audience"] == MOBILE_AUDIENCE
 
 
-def _enable_session_sync_retention(session: dict) -> SessionEventStream:
-    """Atomically enable replay retention and return its single stream."""
-    with _session_event_stream_init_lock:
-        stream = _session_event_stream_locked(session)
-        session["mobile_sync_retention"] = True
-        return stream
+def _captured_session_transport(session: dict) -> Transport:
+    return session.get("transport") or current_transport() or _stdio_transport
 
 
-def _session_retains_sync(session: dict) -> bool:
-    """Keep replay after mobile disconnect without changing legacy wire shape.
-
-    Legacy stdio and Desktop clients retain the original response/event shape
-    even after a mobile client previously attached. The sticky bit controls
-    replay retention only; the current transport audience controls envelopes.
-    """
-    if session.get("mobile_sync_retention"):
-        return True
-    if _session_transport_requests_sync(session):
-        _enable_session_sync_retention(session)
-        return True
-    return False
+def _set_session_transport_locked(session: dict, transport: Transport) -> None:
+    """Replace the event recipient while holding history then stream locks."""
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        session["transport"] = transport
 
 
 def _emit(
@@ -1204,24 +1191,34 @@ def _emit(
     if payload is not None:
         params["payload"] = payload
     legacy_frame = {"jsonrpc": "2.0", "method": "event", "params": params}
-    if session is None or not _session_retains_sync(session):
+    if session is None:
         write_json(legacy_frame)
         return legacy_frame
 
-    mobile_recipient = _session_transport_requests_sync(session)
     stream = _session_event_stream(session)
-    if mobile_recipient:
-        return stream.publish(event, sid, payload, write_json)
+    with stream.transition(lambda _stream: None):
+        # Capture the recipient once under the same boundary used by transport
+        # handoff. Never classify one transport and then let write_json re-read
+        # a different transport before delivery.
+        recipient = _captured_session_transport(session)
+        mobile_recipient = _transport_requests_sync(recipient)
+        if mobile_recipient:
+            session["mobile_sync_retention"] = True
+        if not session.get("mobile_sync_retention"):
+            recipient.write(legacy_frame)
+            return legacy_frame
+        if mobile_recipient:
+            return stream.publish(event, sid, payload, recipient.write)
 
-    # Retain a sequenced copy for a future mobile reconnect, but preserve the
-    # original unsequenced event shape on the currently attached legacy wire.
-    stream.publish(
-        event,
-        sid,
-        payload,
-        lambda _sequenced: write_json(legacy_frame),
-    )
-    return legacy_frame
+        # Retain a sequenced copy for a future mobile reconnect, but preserve
+        # the original event shape on the currently attached legacy wire.
+        stream.publish(
+            event,
+            sid,
+            payload,
+            lambda _sequenced: recipient.write(legacy_frame),
+        )
+        return legacy_frame
 
 
 def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
@@ -1238,8 +1235,12 @@ def _mark_snapshot_mutation(session: dict) -> None:
     Callers hold ``history_lock`` first, preserving the same history -> stream
     lock order used by snapshot capture and event publication.
     """
-    if _session_retains_sync(session):
-        _session_event_stream(session).mutate(lambda _stream: None)
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        if _transport_requests_sync(_captured_session_transport(session)):
+            session["mobile_sync_retention"] = True
+        if session.get("mobile_sync_retention"):
+            stream.mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -5402,7 +5403,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         session["queued_prompt"] = None
         session["running"] = True
         if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+            _set_session_transport_locked(session, queued["transport"])
     try:
         _run_prompt_submit(rid, sid, session, queued["text"])
     except Exception as exc:
@@ -5459,6 +5460,42 @@ def _conversation_root(db, session_id: str) -> str:
     )
 
 
+def _session_synchronization_locked(
+    sid: str,
+    session: dict,
+    stream: SessionEventStream,
+    cursor: object = None,
+) -> dict:
+    """Capture synchronization while history and stream boundaries are held."""
+    history = list(session.get("display_history_prefix") or []) + list(
+        session.get("history") or []
+    )
+    messages = _history_to_messages(history)
+    inflight = _inflight_snapshot(session, include_turn_id=True)
+    stored_session_id = _session_lookup_key(session, fallback=sid)
+    conversation_id = str(
+        session.get("conversation_id") or stored_session_id or sid
+    )
+    running = bool(session.get("running"))
+
+    def snapshot(state: dict) -> dict:
+        status = "waiting" if state["pending_interactions"] else (
+            "working" if running else "idle"
+        )
+        return {
+            "conversation_id": conversation_id,
+            "stored_session_id": stored_session_id,
+            "live_session_id": sid,
+            "messages": messages,
+            "inflight_turn": inflight,
+            "active_tools": state["active_tools"],
+            "pending_interactions": state["pending_interactions"],
+            "status": status,
+        }
+
+    return stream.synchronization(snapshot, cursor)
+
+
 def _session_synchronization(
     sid: str,
     session: dict,
@@ -5466,33 +5503,10 @@ def _session_synchronization(
 ) -> dict:
     """Capture history then the stream watermark using the documented lock order."""
     with session["history_lock"]:
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        messages = _history_to_messages(history)
-        inflight = _inflight_snapshot(session, include_turn_id=True)
-        stored_session_id = _session_lookup_key(session, fallback=sid)
-        conversation_id = str(
-            session.get("conversation_id") or stored_session_id or sid
-        )
-        running = bool(session.get("running"))
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            return _session_synchronization_locked(sid, session, stream, cursor)
 
-        def snapshot(state: dict) -> dict:
-            status = "waiting" if state["pending_interactions"] else (
-                "working" if running else "idle"
-            )
-            return {
-                "conversation_id": conversation_id,
-                "stored_session_id": stored_session_id,
-                "live_session_id": sid,
-                "messages": messages,
-                "inflight_turn": inflight,
-                "active_tools": state["active_tools"],
-                "pending_interactions": state["pending_interactions"],
-                "status": status,
-            }
-
-        return _session_event_stream(session).synchronization(snapshot, cursor)
 
 
 def _attach_synchronization(
@@ -5501,11 +5515,19 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
-    if not _session_transport_requests_sync(session):
-        return payload
-    _enable_session_sync_retention(session)
-    payload["synchronization"] = _session_synchronization(sid, session, cursor)
-    return payload
+    with session["history_lock"]:
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            if not _transport_requests_sync(_captured_session_transport(session)):
+                return payload
+            session["mobile_sync_retention"] = True
+            payload["synchronization"] = _session_synchronization_locked(
+                sid,
+                session,
+                stream,
+                cursor,
+            )
+            return payload
 
 
 # ── Methods: session ─────────────────────────────────────────────────
@@ -6441,31 +6463,42 @@ def _live_session_payload(
     transport: Transport | None = None,
     cursor: object = None,
 ) -> dict:
+    info = _fallback_session_info(session)
     with session["history_lock"]:
-        if cols is not None:
-            session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
-        if touch:
-            session["last_active"] = time.time()
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        inflight = _inflight_snapshot(session)
-        running = bool(session.get("running"))
-    payload = {
-        "info": _fallback_session_info(session),
-        "message_count": len(history),
-        "messages": _history_to_messages(history),
-        "running": running,
-        "session_id": sid,
-        "session_key": _session_lookup_key(session, fallback=sid),
-        "started_at": float(session.get("created_at") or time.time()),
-        "status": _session_live_status(sid, session),
-    }
-    if inflight:
-        payload["inflight"] = inflight
-    return _attach_synchronization(payload, sid, session, cursor)
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            if cols is not None:
+                session["cols"] = cols
+            if transport is not None:
+                session["transport"] = transport
+            if touch:
+                session["last_active"] = time.time()
+            history = list(session.get("display_history_prefix") or []) + list(
+                session.get("history") or []
+            )
+            inflight = _inflight_snapshot(session)
+            running = bool(session.get("running"))
+            payload = {
+                "info": info,
+                "message_count": len(history),
+                "messages": _history_to_messages(history),
+                "running": running,
+                "session_id": sid,
+                "session_key": _session_lookup_key(session, fallback=sid),
+                "started_at": float(session.get("created_at") or time.time()),
+                "status": _session_live_status(sid, session),
+            }
+            if inflight:
+                payload["inflight"] = inflight
+            if _transport_requests_sync(_captured_session_transport(session)):
+                session["mobile_sync_retention"] = True
+                payload["synchronization"] = _session_synchronization_locked(
+                    sid,
+                    session,
+                    stream,
+                    cursor,
+                )
+            return payload
 
 
 @method("session.active_list")
@@ -8857,7 +8890,7 @@ def _(rid, params: dict) -> dict:
                 CONVERSATION_CONTROL_SCOPE,
             )
             if t is not None and allow_control:
-                session["transport"] = t
+                _set_session_transport_locked(session, t)
             return _handle_busy_submit(
                 rid,
                 sid,
@@ -8867,7 +8900,7 @@ def _(rid, params: dict) -> dict:
                 allow_control=allow_control,
             )
         if t is not None:
-            session["transport"] = t
+            _set_session_transport_locked(session, t)
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -31,6 +32,7 @@ from tui_gateway import git_probe
 from tui_gateway.mobile_sync import SessionEventStream
 from tui_gateway.mobile_mutations import (
     MobileMutationStore,
+    MutationClaim,
     MutationConflict,
     MutationDisposition,
 )
@@ -1449,10 +1451,20 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
-_MOBILE_MUTATION_METHODS = frozenset(
-    {"prompt.submit", "session.interrupt", "session.delete"}
-)
 _NOT_A_MOBILE_MUTATION = object()
+
+
+class _MobileMutationPreflightUnavailable(RuntimeError):
+    """Live lineage validation could not safely authorize execution."""
+
+
+def _mobile_mutation_store_unavailable(rid: Any) -> dict:
+    return _err(
+        rid,
+        5037,
+        "durable mutation receipt is temporarily unavailable",
+        data={"reason": "mutation_store_unavailable"},
+    )
 
 
 def _mobile_mutation_resource(
@@ -1461,9 +1473,20 @@ def _mobile_mutation_resource(
     rid: Any,
 ) -> tuple[str, dict[str, Any]] | dict:
     """Resolve client-supplied durable semantics without consulting live state."""
-    if method in {"prompt.submit", "session.interrupt"}:
-        expected = str(params.get("expected_stored_session_id") or "").strip()
-        if not expected:
+    from tui_gateway.mobile_contract import MOBILE_MUTATION_POLICIES
+
+    descriptor = MOBILE_MUTATION_POLICIES.get(method)
+    if descriptor is None:
+        return _err(
+            rid,
+            -32601,
+            f"unknown mobile mutation: {method}",
+            data={"method": method, "reason": "unknown_mobile_mutation"},
+        )
+
+    resource_id = str(params.get(descriptor.resource_parameter) or "").strip()
+    if not resource_id:
+        if descriptor.resource_parameter == "expected_stored_session_id":
             return _err(
                 rid,
                 -32602,
@@ -1473,34 +1496,48 @@ def _mobile_mutation_resource(
                     "reason": "durable_resource_id_required",
                 },
             )
-        semantics = {"text": params.get("text")} if method == "prompt.submit" else {}
+        return _err(rid, -32602, f"{descriptor.resource_parameter} is required")
+
+    semantics = {
+        parameter: params.get(parameter)
+        for parameter in descriptor.semantic_parameters
+    }
+    if descriptor.resource_parameter == "expected_stored_session_id":
         # Cuttle keeps this server-issued Conversation identity stable while the
         # process-local live session id and compression tip can rotate. Binding
         # the receipt to the live id would turn a valid reconnect retry into a
         # different mutation. The execute path validates this identity against
         # current Hermes state before the handler can mutate anything.
-        return expected, semantics
+        return resource_id, semantics
 
-    target = str(params.get("session_id") or "").strip()
-    if not target:
-        return _err(rid, -32602, "session_id is required")
-    # A stored session id is itself the durable resource being deleted. Do not
-    # normalize it through a compression lineage: after successful deletion
-    # that lineage is intentionally gone, while a retry must still fingerprint
-    # to the same tombstoned target and replay the original outcome.
-    return target, {}
+    if descriptor.resource_parameter == "session_id":
+        # A stored session id is itself the durable resource being deleted. Do not
+        # normalize it through a compression lineage: after successful deletion
+        # that lineage is intentionally gone, while a retry must still fingerprint
+        # to the same tombstoned target and replay the original outcome.
+        return resource_id, semantics
+
+    return _err(
+        rid,
+        5037,
+        "mobile mutation resource policy is unavailable",
+        data={"method": method, "reason": "mutation_policy_unavailable"},
+    )
 
 
 def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | None:
     """Validate live routing only for a newly reserved mutation, not a replay."""
-    if method not in {"prompt.submit", "session.interrupt"}:
+    from tui_gateway.mobile_contract import MOBILE_MUTATION_POLICIES
+
+    descriptor = MOBILE_MUTATION_POLICIES.get(method)
+    if descriptor is None or not descriptor.requires_live_lineage_validation:
         return None
     session, err = _sess_nowait(params, rid)
     if err:
         return err
     assert session is not None
 
-    expected = str(params.get("expected_stored_session_id") or "").strip()
+    expected = str(params.get(descriptor.resource_parameter) or "").strip()
     runtime_id = str(params.get("session_id") or "").strip()
     current_ids = {
         str(session.get("session_key") or "").strip(),
@@ -1527,11 +1564,17 @@ def _mobile_mutation_preflight(method: str, params: dict, rid: Any) -> dict | No
                             and str(current_lineage[0]) == expected_root
                         ):
                             return None
-        except Exception:
-            logger.debug(
+        except (OSError, sqlite3.Error) as exc:
+            logger.warning(
                 "failed to validate mobile mutation conversation identity",
                 exc_info=True,
             )
+            raise _MobileMutationPreflightUnavailable from exc
+        except Exception as exc:
+            logger.exception(
+                "unexpected failure validating mobile mutation conversation identity"
+            )
+            raise _MobileMutationPreflightUnavailable from exc
 
     live = ", ".join(sorted(current_ids)) or "unknown"
     return _err(
@@ -1575,6 +1618,36 @@ def _mutation_response(
     return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
+def _mark_mobile_mutation_outcome_unknown(
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    *,
+    context: str,
+) -> bool:
+    """Best-effort terminalization after execution may have begun."""
+    try:
+        changed = store.mark_outcome_unknown(claim)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile mutation outcome-unknown update failed after %s",
+            context,
+            exc_info=True,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "unexpected mobile mutation outcome-unknown update failure after %s",
+            context,
+        )
+        return False
+    if not changed:
+        logger.error(
+            "mobile mutation receipt was not owned while marking outcome unknown after %s",
+            context,
+        )
+    return changed
+
+
 def _dispatch_mobile_mutation(
     req: dict,
     *,
@@ -1585,11 +1658,12 @@ def _dispatch_mobile_mutation(
 ) -> object:
     from tui_gateway.mobile_contract import (
         MOBILE_AUDIENCE,
+        MOBILE_MUTATION_METHODS,
         effective_authorization,
     )
 
     grant = effective_authorization(getattr(transport, "authorization", None))
-    if grant["audience"] != MOBILE_AUDIENCE or method not in _MOBILE_MUTATION_METHODS:
+    if grant["audience"] != MOBILE_AUDIENCE or method not in MOBILE_MUTATION_METHODS:
         return _NOT_A_MOBILE_MUTATION
 
     client_request_id = str(params.get("client_request_id") or "").strip()
@@ -1631,15 +1705,20 @@ def _dispatch_mobile_mutation(
         )
     except (OSError, sqlite3.Error):
         logger.warning("mobile mutation receipt reservation failed", exc_info=True)
-        return _err(
-            rid,
-            5037,
-            "durable mutation receipt is temporarily unavailable",
-            data={"reason": "mutation_store_unavailable"},
-        )
+        return _mobile_mutation_store_unavailable(rid)
+    except Exception:
+        logger.exception("unexpected mobile mutation receipt reservation failure")
+        return _mobile_mutation_store_unavailable(rid)
 
     if claim.disposition is MutationDisposition.IN_PROGRESS:
-        claim = store.wait_for_outcome(claim, timeout=30.0)
+        try:
+            claim = store.wait_for_outcome(claim, timeout=30.0)
+        except (OSError, sqlite3.Error):
+            logger.warning("mobile mutation receipt wait failed", exc_info=True)
+            return _mobile_mutation_store_unavailable(rid)
+        except Exception:
+            logger.exception("unexpected mobile mutation receipt wait failure")
+            return _mobile_mutation_store_unavailable(rid)
     if claim.disposition is MutationDisposition.REPLAY:
         return _mutation_response(
             rid,
@@ -1672,13 +1751,57 @@ def _dispatch_mobile_mutation(
 
     try:
         response = _mobile_mutation_preflight(method, params, rid)
+    except _MobileMutationPreflightUnavailable:
+        try:
+            released = store.release_before_execution(claim)
+        except (OSError, sqlite3.Error):
+            logger.warning(
+                "mobile mutation receipt release failed after preflight outage",
+                exc_info=True,
+            )
+            released = False
+        except Exception:
+            logger.exception(
+                "unexpected mobile mutation receipt release failure after preflight outage"
+            )
+            released = False
+        if not released:
+            logger.error(
+                "mobile mutation receipt could not be released after preflight outage"
+            )
+            return _mobile_mutation_store_unavailable(rid)
+        return _err(
+            rid,
+            5037,
+            "mobile mutation preflight is temporarily unavailable",
+            data={
+                "client_request_id": client_request_id,
+                "reason": "mutation_preflight_unavailable",
+            },
+        )
+
+    try:
         if response is None:
             response = handle_request(req)
     except Exception:
-        store.mark_outcome_unknown(claim)
-        raise
+        logger.exception("mobile mutation handler failed")
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="handler failure",
+        )
+        return _err(
+            rid,
+            5037,
+            "mutation handler failed before a durable outcome was available",
+            data={"reason": "mutation_outcome_unknown"},
+        )
     if response is None:
-        store.mark_outcome_unknown(claim)
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="empty handler response",
+        )
         return _err(
             rid,
             5037,
@@ -1686,7 +1809,25 @@ def _dispatch_mobile_mutation(
             data={"reason": "mutation_outcome_unknown"},
         )
     outcome = _mutation_outcome(response)
-    if not store.complete(claim, outcome):
+    try:
+        completed = store.complete(claim, outcome)
+    except (OSError, sqlite3.Error):
+        logger.warning("mobile mutation receipt completion failed", exc_info=True)
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="receipt completion failure",
+        )
+        completed = False
+    except Exception:
+        logger.exception("unexpected mobile mutation receipt completion failure")
+        _mark_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="unexpected receipt completion failure",
+        )
+        completed = False
+    if not completed:
         return _err(
             rid,
             5037,
@@ -6982,12 +7123,10 @@ def _(rid, params: dict) -> dict:
         )
     except (OSError, sqlite3.Error, ValueError):
         logger.warning("mobile mutation status lookup failed", exc_info=True)
-        return _err(
-            rid,
-            5037,
-            "durable mutation receipt is temporarily unavailable",
-            data={"reason": "mutation_store_unavailable"},
-        )
+        return _mobile_mutation_store_unavailable(rid)
+    except Exception:
+        logger.exception("unexpected mobile mutation status lookup failure")
+        return _mobile_mutation_store_unavailable(rid)
     if status is None:
         return _err(
             rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1138,7 +1138,10 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _session_event_stream(session: dict) -> SessionEventStream:
+_session_event_stream_init_lock = threading.RLock()
+
+
+def _session_event_stream_locked(session: dict) -> SessionEventStream:
     stream = session.get("mobile_sync")
     if isinstance(stream, SessionEventStream):
         return stream
@@ -1149,26 +1152,46 @@ def _session_event_stream(session: dict) -> SessionEventStream:
     return stream
 
 
-def _session_sync_enabled(session: dict) -> bool:
-    """Return whether this live session negotiated revisioned mobile sync.
+def _session_event_stream(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    with _session_event_stream_init_lock:
+        return _session_event_stream_locked(session)
 
-    Legacy stdio and Desktop clients retain the original response/event shape
-    and avoid replay copies.  Once a mobile transport attaches, keep retention
-    enabled for the rest of the live stream so a later reconnect can replay
-    events emitted while the socket was detached.
-    """
-    if session.get("mobile_sync_enabled"):
-        return True
+
+def _session_transport_requests_sync(session: dict) -> bool:
     transport = session.get("transport") or current_transport()
     authorization = getattr(transport, "authorization", None)
     if not isinstance(authorization, dict):
         return False
     from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
 
-    if effective_authorization(authorization)["audience"] != MOBILE_AUDIENCE:
-        return False
-    session["mobile_sync_enabled"] = True
-    return True
+
+    return effective_authorization(authorization)["audience"] == MOBILE_AUDIENCE
+
+
+def _enable_session_sync_retention(session: dict) -> SessionEventStream:
+    """Atomically enable replay retention and return its single stream."""
+    with _session_event_stream_init_lock:
+        stream = _session_event_stream_locked(session)
+        session["mobile_sync_retention"] = True
+        return stream
+
+
+def _session_retains_sync(session: dict) -> bool:
+    """Keep replay after mobile disconnect without changing legacy wire shape.
+
+    Legacy stdio and Desktop clients retain the original response/event shape
+    even after a mobile client previously attached. The sticky bit controls
+    replay retention only; the current transport audience controls envelopes.
+    """
+    if session.get("mobile_sync_retention"):
+        return True
+    if _session_transport_requests_sync(session):
+        _enable_session_sync_retention(session)
+        return True
+    return False
 
 
 def _emit(
@@ -1177,19 +1200,28 @@ def _emit(
     payload: dict | None = None,
 ):
     session = _sessions.get(sid)
-    if session is not None and _session_sync_enabled(session):
-        return _session_event_stream(session).publish(
-            event,
-            sid,
-            payload,
-            write_json,
-        )
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    frame = {"jsonrpc": "2.0", "method": "event", "params": params}
-    write_json(frame)
-    return frame
+    legacy_frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+    if session is None or not _session_retains_sync(session):
+        write_json(legacy_frame)
+        return legacy_frame
+
+    mobile_recipient = _session_transport_requests_sync(session)
+    stream = _session_event_stream(session)
+    if mobile_recipient:
+        return stream.publish(event, sid, payload, write_json)
+
+    # Retain a sequenced copy for a future mobile reconnect, but preserve the
+    # original unsequenced event shape on the currently attached legacy wire.
+    stream.publish(
+        event,
+        sid,
+        payload,
+        lambda _sequenced: write_json(legacy_frame),
+    )
+    return legacy_frame
 
 
 def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
@@ -1206,7 +1238,8 @@ def _mark_snapshot_mutation(session: dict) -> None:
     Callers hold ``history_lock`` first, preserving the same history -> stream
     lock order used by snapshot capture and event publication.
     """
-    _session_event_stream(session).mutate(lambda _stream: None)
+    if _session_retains_sync(session):
+        _session_event_stream(session).mutate(lambda _stream: None)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -3965,7 +3998,11 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         )
 
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_key,
+            {"seq": 0, "open_tool": None, "reply_text": "", "started": False},
+        )
+        st.setdefault("reply_text", "")
         if not st["started"]:
             st["started"] = True
             with history_lock:
@@ -3984,6 +4021,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             # Relayed token-by-token from the child's run_conversation
             # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
+                st["reply_text"] = f"{st['reply_text']}{text}"
                 _emit_inflight_delta(csid, child_session, text)
         elif event_type == "subagent.start":
             # One-time header line (the child's goal) so a freshly opened window
@@ -4020,7 +4058,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
                 turn = child_session.get("inflight_turn") or {}
                 turn_id = str(turn.get("turn_id") or "")
                 assistant = str(turn.get("assistant") or "")
-                final_text = assistant or summary
+                final_text = str(st.get("reply_text") or "") or summary or assistant
                 history = child_session.setdefault("history", [])
                 if final_text and not (
                     history
@@ -4036,7 +4074,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
                 _emit(
                     "message.complete",
                     csid,
-                    {"text": summary or final_text, "turn_id": turn_id},
+                    {"text": final_text, "turn_id": turn_id},
                 )
             _child_mirrors.pop(child_key, None)
 
@@ -5402,13 +5440,11 @@ def _inflight_snapshot(
 
 
 def _conversation_root(db, session_id: str) -> str:
+    lineage_reader = getattr(db, "get_compression_lineage", None)
+    if not callable(lineage_reader):
+        return str(session_id)
     try:
-        lineage = db.get_compression_lineage(session_id)
-    except AttributeError:
-        # Compatibility with old/embedded SessionDB stubs that predate
-        # compression lineage. Unexpected database failures must not silently
-        # change a conversation's supposedly stable identity to its current tip.
-        lineage = []
+        lineage = lineage_reader(session_id)
     except Exception:
         logger.warning(
             "failed to resolve stable conversation lineage for %s",
@@ -5465,8 +5501,9 @@ def _attach_synchronization(
     session: dict,
     cursor: object = None,
 ) -> dict:
-    if not _session_sync_enabled(session):
+    if not _session_transport_requests_sync(session):
         return payload
+    _enable_session_sync_retention(session)
     payload["synchronization"] = _session_synchronization(sid, session, cursor)
     return payload
 
@@ -8858,6 +8895,7 @@ def _(rid, params: dict) -> dict:
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
+        _mark_snapshot_mutation(session)
 
     # Persist the DB row lazily, now that the user has actually sent a message.
     _ensure_session_db_row(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1596,11 +1596,12 @@ def _mutation_response(
     *,
     client_request_id: str,
     deduplicated: bool,
+    state: str = "completed",
 ) -> dict:
     receipt = {
         "client_request_id": client_request_id,
         "deduplicated": deduplicated,
-        "state": "completed",
+        "state": state,
     }
     if "result" in outcome:
         result = copy.deepcopy(outcome["result"])
@@ -1646,6 +1647,409 @@ def _mark_mobile_mutation_outcome_unknown(
             context,
         )
     return changed
+
+
+def _recover_mobile_mutation_outcome_unknown(
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    *,
+    context: str,
+) -> bool:
+    """Terminalize an uncertain claim, recycling a failed SQLite connection."""
+    if _mark_mobile_mutation_outcome_unknown(store, claim, context=context):
+        return True
+    try:
+        store.recycle_after_storage_failure()
+        recovered = store.wait_for_outcome(claim, timeout=0.0)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile mutation receipt recovery failed after %s",
+            context,
+            exc_info=True,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "unexpected mobile mutation receipt recovery failure after %s",
+            context,
+        )
+        return False
+    if recovered.disposition is MutationDisposition.OUTCOME_UNKNOWN:
+        return True
+    logger.error(
+        "mobile mutation receipt remained %s after recovery from %s",
+        recovered.disposition.value,
+        context,
+    )
+    return False
+
+
+def _capture_mobile_prompt_receipt_context(
+    params: dict,
+    *,
+    proof_tag: str,
+) -> tuple | None:
+    """Capture the exact receipt identity expected on the user row."""
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None or not proof_tag:
+        return None
+    return sid, session, proof_tag
+
+
+def _mobile_prompt_turn_is_durable(context: tuple) -> bool:
+    _, session, proof_tag = context
+    agent = session.get("agent")
+    if proof_tag in (
+        getattr(agent, "_durable_mobile_mutation_receipt_tags", set()) or set()
+    ):
+        return True
+    with session.setdefault("history_lock", threading.RLock()):
+        history = list(session.get("history") or ())
+    agent_messages = list(getattr(agent, "_session_messages", ()) or ())
+    # ``_db_persisted`` is stamped only after SessionDB.append_message succeeds.
+    # The turn-context tag binds that proof to this exact receipt, so an older,
+    # substring-matching, or later queued user turn cannot satisfy it. Sequence
+    # repair may merge away that exact dict; in that case it carries only the
+    # receipt's already-persisted proof, never a blanket DB marker for the
+    # merged content.
+    return any(
+        isinstance(message, dict)
+        and message.get("role") == "user"
+        and (
+            (
+                message.get("_db_persisted")
+                and proof_tag
+                in (message.get("_mobile_mutation_receipt_tags") or ())
+            )
+            or proof_tag
+            in (
+                message.get("_mobile_mutation_persisted_receipt_tags")
+                or ()
+            )
+        )
+        for message in [*history, *agent_messages]
+    )
+
+
+def _mobile_prompt_turn_is_pending(context: tuple) -> bool:
+    _, session, proof_tag = context
+    with session.setdefault("history_lock", threading.RLock()):
+        live_tags = session.get("_live_mobile_mutation_receipt_tags")
+        starting_tags = set(
+            session.get("_starting_mobile_mutation_receipt_tags") or ()
+        )
+        run_thread = session.get("_run_thread")
+        if isinstance(live_tags, set):
+            tag_owned = proof_tag in live_tags
+        else:
+            # Compatibility for legacy/synthetic session dictionaries. New
+            # gateway paths maintain the O(1) live-tag set below.
+            queued_tags = (
+                (session.get("queued_prompt") or {}).get(
+                    "mobile_mutation_receipt_tags"
+                )
+                or ()
+            )
+            pending_tags = (
+                session.get("_pending_mobile_mutation_receipt_tags") or ()
+            )
+            active_tags = (
+                session.get("_active_mobile_mutation_receipt_tags") or ()
+            )
+            agent_pending_tags = (
+                getattr(
+                    session.get("agent"),
+                    "_pending_mobile_mutation_receipt_tags",
+                    (),
+                )
+                or ()
+            )
+            tag_owned = any(
+                proof_tag in tags
+                for tags in (
+                    queued_tags,
+                    pending_tags,
+                    active_tags,
+                    starting_tags,
+                    agent_pending_tags,
+                )
+            )
+    is_alive = getattr(run_thread, "is_alive", None)
+    thread_alive = bool(callable(is_alive) and is_alive())
+    # ``Thread.is_alive()`` is briefly false between assigning a replacement
+    # worker handle and starting it. An explicit starting tag covers only that
+    # handoff; generic ``running`` cannot let orphan tags survive a dead worker.
+    execution_live = thread_alive or proof_tag in starting_tags
+    return tag_owned and execution_live
+
+
+def _mobile_prompt_receipt_condition(session: dict) -> threading.Condition:
+    with session.setdefault("history_lock", threading.RLock()):
+        condition = session.get("_mobile_prompt_receipt_condition")
+        if condition is None:
+            condition = threading.Condition()
+            session["_mobile_prompt_receipt_condition"] = condition
+        agent = session.get("agent")
+        if agent is not None:
+            try:
+                agent._mobile_mutation_receipt_condition = condition
+            except (AttributeError, TypeError):
+                pass
+    return condition
+
+
+def _notify_mobile_prompt_receipt_change(session: dict) -> None:
+    condition = session.get("_mobile_prompt_receipt_condition")
+    if condition is None:
+        return
+    with condition:
+        condition.notify_all()
+
+
+def _track_mobile_prompt_receipt_tags_locked(
+    session: dict,
+    proof_tags: list[str] | tuple[str, ...],
+) -> None:
+    live_tags = set(session.get("_live_mobile_mutation_receipt_tags") or ())
+    live_tags.update(tag for tag in proof_tags if tag)
+    if live_tags:
+        session["_live_mobile_mutation_receipt_tags"] = live_tags
+
+
+def _discard_mobile_prompt_receipt_tags_locked(
+    session: dict,
+    proof_tags: list[str] | tuple[str, ...],
+    *,
+    agent: Any = None,
+) -> None:
+    """Remove only the named receipt identities from live handoff state."""
+    remove = {tag for tag in proof_tags if tag}
+    if not remove:
+        return
+    for key in (
+        "_pending_mobile_mutation_receipt_tags",
+        "_active_mobile_mutation_receipt_tags",
+        "_starting_mobile_mutation_receipt_tags",
+        "_live_mobile_mutation_receipt_tags",
+    ):
+        current = session.get(key) or ()
+        remaining = type(current)(
+            tag for tag in current if tag not in remove
+        )
+        if remaining:
+            session[key] = remaining
+        else:
+            session.pop(key, None)
+    if agent is not None:
+        remaining = [
+            tag
+            for tag in (
+                getattr(agent, "_pending_mobile_mutation_receipt_tags", ())
+                or ()
+            )
+            if tag not in remove
+        ]
+        if remaining or hasattr(
+            agent,
+            "_pending_mobile_mutation_receipt_tags",
+        ):
+            agent._pending_mobile_mutation_receipt_tags = remaining
+    _notify_mobile_prompt_receipt_change(session)
+
+
+def _complete_mobile_prompt_receipt(
+    *,
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    outcome: dict[str, Any],
+) -> None:
+    try:
+        completed = store.complete(claim, outcome)
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "mobile prompt receipt completion failed",
+            exc_info=True,
+        )
+        completed = False
+    except Exception:
+        logger.exception("unexpected mobile prompt receipt completion failure")
+        completed = False
+    if not completed:
+        _recover_mobile_mutation_outcome_unknown(
+            store,
+            claim,
+            context="prompt receipt completion failure",
+        )
+
+
+def _forget_mobile_prompt_durable_tag(context: tuple) -> None:
+    _, session, proof_tag = context
+    agent = session.get("agent")
+    condition = session.get("_mobile_prompt_receipt_condition")
+
+    def discard() -> None:
+        durable = getattr(
+            agent,
+            "_durable_mobile_mutation_receipt_tags",
+            None,
+        )
+        if isinstance(durable, set):
+            durable.discard(proof_tag)
+
+    if condition is None:
+        discard()
+    else:
+        with condition:
+            discard()
+
+
+def _run_mobile_prompt_receipt_monitor(
+    session: dict,
+    condition: threading.Condition,
+) -> None:
+    """Resolve all deferred prompt receipts for one live session."""
+    try:
+        while True:
+            with condition:
+                entries = dict(
+                    session.get("_mobile_prompt_receipt_entries") or {}
+                )
+                if not entries:
+                    current = session.get(
+                        "_mobile_prompt_receipt_monitor_thread"
+                    )
+                    if current is threading.current_thread():
+                        session.pop(
+                            "_mobile_prompt_receipt_monitor_thread",
+                            None,
+                        )
+                    condition.notify_all()
+                    return
+
+            terminal: list[tuple[str, dict[str, Any]]] = []
+            for proof_tag, entry in entries.items():
+                context = entry["context"]
+                _, entry_session, _ = context
+                agent = entry_session.get("agent")
+                durable_tags = (
+                    getattr(
+                        agent,
+                        "_durable_mobile_mutation_receipt_tags",
+                        set(),
+                    )
+                    or set()
+                )
+                durable = proof_tag in durable_tags
+                try:
+                    if not durable and _mobile_prompt_turn_is_pending(context):
+                        continue
+                    # One transcript scan at the terminal edge supports legacy
+                    # and test paths that predate the O(1) durable-tag signal,
+                    # while the queued hot path remains constant-time.
+                    if not durable:
+                        durable = _mobile_prompt_turn_is_durable(context)
+                    if durable:
+                        _complete_mobile_prompt_receipt(
+                            store=entry["store"],
+                            claim=entry["claim"],
+                            outcome=entry["outcome"],
+                        )
+                    else:
+                        _recover_mobile_mutation_outcome_unknown(
+                            entry["store"],
+                            entry["claim"],
+                            context="prompt turn lacked durable history",
+                        )
+                except Exception:
+                    logger.exception("mobile prompt receipt monitor failed")
+                    _recover_mobile_mutation_outcome_unknown(
+                        entry["store"],
+                        entry["claim"],
+                        context="unexpected prompt receipt monitor failure",
+                    )
+                terminal.append((proof_tag, entry))
+
+            if terminal:
+                with condition:
+                    live_entries = session.get(
+                        "_mobile_prompt_receipt_entries"
+                    ) or {}
+                    for proof_tag, entry in terminal:
+                        if live_entries.get(proof_tag) is entry:
+                            live_entries.pop(proof_tag, None)
+                    condition.notify_all()
+                for _, entry in terminal:
+                    _forget_mobile_prompt_durable_tag(entry["context"])
+                continue
+
+            with condition:
+                condition.wait(timeout=0.25)
+    finally:
+        stranded: list[dict[str, Any]] = []
+        with condition:
+            current = session.get("_mobile_prompt_receipt_monitor_thread")
+            if current is threading.current_thread():
+                session.pop("_mobile_prompt_receipt_monitor_thread", None)
+                live_entries = session.get(
+                    "_mobile_prompt_receipt_entries"
+                ) or {}
+                stranded = list(live_entries.values())
+                live_entries.clear()
+            condition.notify_all()
+        for entry in stranded:
+            _recover_mobile_mutation_outcome_unknown(
+                entry["store"],
+                entry["claim"],
+                context="prompt receipt coordinator stopped unexpectedly",
+            )
+            _forget_mobile_prompt_durable_tag(entry["context"])
+
+
+def _defer_mobile_prompt_receipt(
+    *,
+    store: MobileMutationStore,
+    claim: MutationClaim,
+    outcome: dict[str, Any],
+    context: tuple | None,
+) -> bool:
+    """Register a prompt receipt with the session's bounded monitor."""
+    if context is None:
+        return False
+    _, session, proof_tag = context
+    condition = _mobile_prompt_receipt_condition(session)
+    entry = {
+        "claim": claim,
+        "context": context,
+        "outcome": outcome,
+        "store": store,
+    }
+    monitor = None
+    try:
+        with condition:
+            entries = session.setdefault("_mobile_prompt_receipt_entries", {})
+            entries[proof_tag] = entry
+            monitor = session.get("_mobile_prompt_receipt_monitor_thread")
+            is_alive = getattr(monitor, "is_alive", None)
+            if not (callable(is_alive) and is_alive()):
+                monitor = threading.Thread(
+                    target=_run_mobile_prompt_receipt_monitor,
+                    args=(session, condition),
+                    daemon=True,
+                )
+                session["_mobile_prompt_receipt_monitor_thread"] = monitor
+                monitor.start()
+            condition.notify_all()
+    except Exception:
+        logger.exception("mobile prompt receipt monitor failed to start")
+        with condition:
+            entries = session.get("_mobile_prompt_receipt_entries") or {}
+            if entries.get(proof_tag) is entry:
+                entries.pop(proof_tag, None)
+            if session.get("_mobile_prompt_receipt_monitor_thread") is monitor:
+                session.pop("_mobile_prompt_receipt_monitor_thread", None)
+        return False
+    return True
 
 
 def _dispatch_mobile_mutation(
@@ -1780,6 +2184,16 @@ def _dispatch_mobile_mutation(
             },
         )
 
+    prompt_receipt_context = None
+    if method == "prompt.submit" and response is None:
+        proof_tag = claim.proof_tag
+        if proof_tag:
+            params["_mobile_mutation_receipt_tag"] = proof_tag
+            prompt_receipt_context = _capture_mobile_prompt_receipt_context(
+                params,
+                proof_tag=proof_tag,
+            )
+
     try:
         if response is None:
             response = handle_request(req)
@@ -1796,6 +2210,8 @@ def _dispatch_mobile_mutation(
             "mutation handler failed before a durable outcome was available",
             data={"reason": "mutation_outcome_unknown"},
         )
+    finally:
+        params.pop("_mobile_mutation_receipt_tag", None)
     if response is None:
         _mark_mobile_mutation_outcome_unknown(
             store,
@@ -1809,6 +2225,42 @@ def _dispatch_mobile_mutation(
             data={"reason": "mutation_outcome_unknown"},
         )
     outcome = _mutation_outcome(response)
+    prompt_status = (
+        str((outcome.get("result") or {}).get("status") or "")
+        if isinstance(outcome.get("result"), dict)
+        else ""
+    )
+    if method == "prompt.submit" and prompt_status in {
+        "queued",
+        "steered",
+        "streaming",
+    }:
+        if not _defer_mobile_prompt_receipt(
+            store=store,
+            claim=claim,
+            outcome=outcome,
+            context=prompt_receipt_context,
+        ):
+            recovered = _recover_mobile_mutation_outcome_unknown(
+                store,
+                claim,
+                context="prompt receipt monitor startup failure",
+            )
+            if not recovered:
+                return _mobile_mutation_store_unavailable(rid)
+            return _err(
+                rid,
+                5037,
+                "prompt mutation outcome could not be monitored durably",
+                data={"reason": "mutation_outcome_unknown"},
+            )
+        return _mutation_response(
+            rid,
+            outcome,
+            client_request_id=client_request_id,
+            deduplicated=False,
+            state="in_progress",
+        )
     try:
         completed = store.complete(claim, outcome)
     except (OSError, sqlite3.Error):
@@ -5811,7 +6263,13 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
-def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
+def _enqueue_prompt(
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    mobile_mutation_receipt_tag: str = "",
+) -> None:
     """Stash a message to run as the very next turn once the live one ends.
 
     Used when a prompt arrives mid-turn (see ``_handle_busy_submit``). A single
@@ -5821,6 +6279,15 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     the client that sent it even if the session transport is rebound meanwhile.
     """
     existing = session.get("queued_prompt")
+    receipt_tags = list(
+        (existing or {}).get("mobile_mutation_receipt_tags") or ()
+    )
+    if (
+        mobile_mutation_receipt_tag
+        and mobile_mutation_receipt_tag not in receipt_tags
+    ):
+        receipt_tags.append(mobile_mutation_receipt_tag)
+    _track_mobile_prompt_receipt_tags_locked(session, receipt_tags)
     if (
         existing
         and isinstance(existing.get("text"), str)
@@ -5828,7 +6295,11 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     ):
         prev = existing["text"]
         text = f"{prev}\n\n{text}" if prev and text else (prev or text)
-    session["queued_prompt"] = {"text": text, "transport": transport}
+    session["queued_prompt"] = {
+        "text": text,
+        "transport": transport,
+        "mobile_mutation_receipt_tags": receipt_tags,
+    }
 
 
 def _handle_busy_submit(
@@ -5839,6 +6310,7 @@ def _handle_busy_submit(
     transport: Any,
     *,
     allow_control: bool = True,
+    mobile_mutation_receipt_tag: str = "",
 ) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -5858,7 +6330,12 @@ def _handle_busy_submit(
     # dashboard's interrupt/steer preference unless its connection also holds
     # conversation.control.
     if not allow_control:
-        _enqueue_prompt(session, text, transport)
+        _enqueue_prompt(
+            session,
+            text,
+            transport,
+            mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
+        )
         session["last_active"] = time.time()
         return _ok(rid, {"status": "queued"})
 
@@ -5876,7 +6353,12 @@ def _handle_busy_submit(
             agent.interrupt()
         except Exception:
             pass
-    _enqueue_prompt(session, text, transport)
+    _enqueue_prompt(
+        session,
+        text,
+        transport,
+        mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
+    )
     session["last_active"] = time.time()
     return _ok(rid, {"status": "queued"})
 
@@ -5894,6 +6376,14 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             return False
         session["queued_prompt"] = None
         session["running"] = True
+        receipt_tags = list(
+            queued.get("mobile_mutation_receipt_tags") or ()
+        )
+        if receipt_tags:
+            session["_pending_mobile_mutation_receipt_tags"] = receipt_tags
+            _track_mobile_prompt_receipt_tags_locked(session, receipt_tags)
+        else:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
         if queued.get("transport") is not None:
             _set_session_transport_locked(session, queued["transport"])
     try:
@@ -5905,7 +6395,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             file=sys.stderr,
         )
         with session["history_lock"]:
+            _discard_mobile_prompt_receipt_tags_locked(
+                session,
+                receipt_tags,
+                agent=session.get("agent"),
+            )
             session["running"] = False
+            _clear_inflight_turn(session)
     return True
 
 
@@ -9099,7 +9595,18 @@ def _(rid, params: dict) -> dict:
         session["agent"].interrupt()
     with session["history_lock"]:
         session["_turn_cancel_requested"] = True
+        queued_receipt_tags = list(
+            (session.get("queued_prompt") or {}).get(
+                "mobile_mutation_receipt_tags"
+            )
+            or ()
+        )
         session["queued_prompt"] = None
+        _discard_mobile_prompt_receipt_tags_locked(
+            session,
+            queued_receipt_tags,
+            agent=session.get("agent"),
+        )
     if not run_thread_alive:
         with session["history_lock"]:
             if session.get("running"):
@@ -9398,6 +9905,23 @@ def _(rid, params: dict) -> dict:
     # without conversation.control queues its next turn on this transport but
     # must not seize the in-flight turn from the currently attached client.
     t = current_transport()
+    active_authorization = getattr(t, "authorization", None)
+    from tui_gateway.mobile_contract import (
+        CONVERSATION_CONTROL_SCOPE,
+        MOBILE_AUDIENCE,
+        authorization_allows_scope,
+        effective_authorization,
+    )
+
+    mobile_mutation_receipt_tag = str(
+        params.get("_mobile_mutation_receipt_tag") or ""
+    ).strip()
+    durable_mobile_prompt = bool(mobile_mutation_receipt_tag) and (
+        effective_authorization(active_authorization)["audience"]
+        == MOBILE_AUDIENCE
+    )
+    if not durable_mobile_prompt:
+        mobile_mutation_receipt_tag = ""
     with session["history_lock"]:
         # A watch session's run lives in the PARENT turn. Reject before the
         # ordinary busy/queue path: queuing onto a lazy mirror would otherwise
@@ -9412,13 +9936,13 @@ def _(rid, params: dict) -> dict:
             # _handle_busy_submit for why the old "session busy" rejection
             # dropped messages when teardown outlived the client's retry window.
             active_transport = t or session.get("transport")
-            from tui_gateway.mobile_contract import (
-                CONVERSATION_CONTROL_SCOPE,
-                authorization_allows_scope,
-            )
-
-            allow_control = authorization_allows_scope(
-                getattr(active_transport, "authorization", None),
+            authorization = getattr(active_transport, "authorization", None)
+            # A durable mobile send always becomes its own next user turn.
+            # Interrupt/steer are separate idempotent control operations; using
+            # either implicit busy-input policy here would make persistence of
+            # this prompt identity impossible to prove after an uncertain ACK.
+            allow_control = not durable_mobile_prompt and authorization_allows_scope(
+                authorization,
                 CONVERSATION_CONTROL_SCOPE,
             )
             if t is not None and allow_control:
@@ -9430,6 +9954,7 @@ def _(rid, params: dict) -> dict:
                 text,
                 active_transport,
                 allow_control=allow_control,
+                mobile_mutation_receipt_tag=mobile_mutation_receipt_tag,
             )
         if t is not None:
             _set_session_transport_locked(session, t)
@@ -9456,6 +9981,16 @@ def _(rid, params: dict) -> dict:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+        if mobile_mutation_receipt_tag:
+            session["_pending_mobile_mutation_receipt_tags"] = [
+                mobile_mutation_receipt_tag
+            ]
+            _track_mobile_prompt_receipt_tags_locked(
+                session,
+                [mobile_mutation_receipt_tag],
+            )
+        else:
+            session.pop("_pending_mobile_mutation_receipt_tags", None)
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
@@ -9482,17 +10017,39 @@ def _(rid, params: dict) -> dict:
                 },
             )
             with session["history_lock"]:
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
                 session["running"] = False
                 _clear_inflight_turn(session)
                 _mark_snapshot_mutation(session)
             return
         with session["history_lock"]:
             if session.get("_turn_cancel_requested") or not session.get("running"):
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
                 session["running"] = False
                 _clear_inflight_turn(session)
                 _mark_snapshot_mutation(session)
                 return
-        _run_prompt_submit(rid, sid, session, text)
+        try:
+            _run_prompt_submit(rid, sid, session, text)
+        except Exception as exc:
+            logger.exception("mobile prompt worker setup failed")
+            with session["history_lock"]:
+                _discard_mobile_prompt_receipt_tags_locked(
+                    session,
+                    [mobile_mutation_receipt_tag],
+                    agent=session.get("agent"),
+                )
+                session["running"] = False
+                _clear_inflight_turn(session)
+            _emit("error", sid, {"message": str(exc)})
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck
@@ -9931,9 +10488,58 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session["attached_images"] = []
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
+        mobile_mutation_receipt_tags = list(
+            session.get("_pending_mobile_mutation_receipt_tags") or ()
+        )
+        _track_mobile_prompt_receipt_tags_locked(
+            session,
+            mobile_mutation_receipt_tags,
+        )
+        agent = session.get("agent")
+        if agent is None:
+            _discard_mobile_prompt_receipt_tags_locked(
+                session,
+                mobile_mutation_receipt_tags,
+            )
+            session["running"] = False
+            _clear_inflight_turn(session)
+            raise RuntimeError("prompt agent is unavailable")
+        receipt_condition = session.get("_mobile_prompt_receipt_condition")
+        if receipt_condition is not None:
+            try:
+                agent._mobile_mutation_receipt_condition = receipt_condition
+            except (AttributeError, TypeError):
+                pass
+        active_receipt_tags = list(
+            session.get("_active_mobile_mutation_receipt_tags") or ()
+        )
+        for tag in mobile_mutation_receipt_tags:
+            if tag not in active_receipt_tags:
+                active_receipt_tags.append(tag)
+        if active_receipt_tags:
+            session["_active_mobile_mutation_receipt_tags"] = (
+                active_receipt_tags
+            )
         turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
-        _emit("message.start", sid, {"turn_id": turn_id})
-    agent = session["agent"]
+        try:
+            _emit("message.start", sid, {"turn_id": turn_id})
+        except Exception:
+            _discard_mobile_prompt_receipt_tags_locked(
+                session,
+                mobile_mutation_receipt_tags,
+                agent=agent,
+            )
+            session["running"] = False
+            _clear_inflight_turn(session)
+            raise
+
+    def discard_mobile_receipt_tags_locked() -> None:
+        _discard_mobile_prompt_receipt_tags_locked(
+            session,
+            mobile_mutation_receipt_tags,
+            agent=agent,
+        )
+
     if hasattr(agent, "clear_interrupt"):
         try:
             agent.clear_interrupt()
@@ -10078,6 +10684,39 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
+            if mobile_mutation_receipt_tags:
+                with session["history_lock"]:
+                    pending = [
+                        tag
+                        for tag in (
+                            session.get(
+                                "_pending_mobile_mutation_receipt_tags"
+                            )
+                            or ()
+                        )
+                        if tag not in set(mobile_mutation_receipt_tags)
+                    ]
+                    if pending:
+                        session["_pending_mobile_mutation_receipt_tags"] = (
+                            pending
+                        )
+                    else:
+                        session.pop(
+                            "_pending_mobile_mutation_receipt_tags",
+                            None,
+                        )
+                    agent_pending = list(
+                        getattr(
+                            agent,
+                            "_pending_mobile_mutation_receipt_tags",
+                            (),
+                        )
+                        or ()
+                    )
+                    for tag in mobile_mutation_receipt_tags:
+                        if tag not in agent_pending:
+                            agent_pending.append(tag)
+                    agent._pending_mobile_mutation_receipt_tags = agent_pending
             result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
@@ -10325,6 +10964,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 reset_hermes_home_override(home_token)
             _clear_session_context(session_tokens)
             with session["history_lock"]:
+                discard_mobile_receipt_tags_locked()
                 session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
@@ -10400,9 +11040,41 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 file=sys.stderr,
             )
 
-    run_thread = threading.Thread(target=run, daemon=True)
-    session["_run_thread"] = run_thread
-    run_thread.start()
+    try:
+        run_thread = threading.Thread(target=run, daemon=True)
+        with session["history_lock"]:
+            starting_tags = list(
+                session.get("_starting_mobile_mutation_receipt_tags") or ()
+            )
+            for tag in mobile_mutation_receipt_tags:
+                if tag not in starting_tags:
+                    starting_tags.append(tag)
+            if starting_tags:
+                session["_starting_mobile_mutation_receipt_tags"] = (
+                    starting_tags
+                )
+            session["_run_thread"] = run_thread
+        run_thread.start()
+        with session["history_lock"]:
+            remove = set(mobile_mutation_receipt_tags)
+            remaining = [
+                tag
+                for tag in (
+                    session.get("_starting_mobile_mutation_receipt_tags")
+                    or ()
+                )
+                if tag not in remove
+            ]
+            if remaining:
+                session["_starting_mobile_mutation_receipt_tags"] = remaining
+            else:
+                session.pop("_starting_mobile_mutation_receipt_tags", None)
+    except Exception:
+        with session["history_lock"]:
+            discard_mobile_receipt_tags_locked()
+            session["running"] = False
+            _clear_inflight_turn(session)
+        raise
 
 
 @method("clipboard.paste")

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,6 +81,10 @@ class WSTransport:
     the loop we're currently blocking. We detect that case and fire-and-
     forget instead. Callers that need to know when the bytes are on the wire
     should use :meth:`write_async` from the loop thread.
+
+    ``authorization`` is the server-derived grant for this connection. The
+    dispatcher reads it before resolving any method; clients cannot mutate it
+    through JSON-RPC input.
     """
 
     def __init__(
@@ -89,10 +93,12 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        authorization: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        self.authorization = authorization
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -280,7 +286,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, authorization: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -298,7 +304,12 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            authorization=authorization,
+        )
 
         # The desktop app and dashboard chat reach the agent through this WS
         # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
@@ -316,13 +327,18 @@ async def handle_ws(ws: Any) -> None:
             thread_name="tui-ws-mcp-discovery",
         )
 
+        from tui_gateway.mobile_contract import gateway_ready_payload
+
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    "payload": {"skin": server.resolve_skin()},
+                    "payload": gateway_ready_payload(
+                        skin=server.resolve_skin(),
+                        authorization=authorization,
+                    ),
                 },
             }
         )


### PR DESCRIPTION
## Summary

- give gateway approvals stable Hermes-owned identities, redacted lifecycle descriptors, expiry/state/resolution metadata, and short-lived terminal tombstones
- synchronize pending approvals into authoritative resume snapshots and publish matching terminal events
- add mobile-scoped, ID-targeted `approval.respond` with durable `client_request_id` receipts, stable lineage validation, replay/conflict semantics, and exact out-of-FIFO resolution
- preserve existing ID-less desktop/stdin FIFO behavior and fail closed on missing mobile choice, scope, lineage, or resource identity
- guarantee tombstone TTL cleanup with one coalesced generation-protected timer

## Stack / review order

This integration branch intentionally combines the foundations under:

1. #62858 — versioned hello and scoped WebSocket grants
2. #63149 — revisioned snapshots and replay
3. #63190 — durable mobile mutation receipts

Approval recovery depends on all three seams, so this PR is the end-to-end integration review for the approval slice. It should remain draft until those foundations are reconciled.

Cuttle contract tracking: https://github.com/ericlewis/cuttle/issues/5
Parent contract: https://github.com/ericlewis/cuttle/issues/1

## Safety and compatibility

- approval presentation and resolution metadata are recursively redacted server-side
- mobile responses require `conversation.control`, exact `approval_id`, durable `client_request_id`, and stable `expected_stored_session_id`
- omitted or blank mobile choices are rejected before receipt reservation or resolution
- duplicate IDs replay; changed semantics conflict; abandoned outcomes never auto-reexecute
- existing legacy ID-less FIFO and `all` behavior is unchanged

## Validation

- `139 passed` — focused approval identity + mobile contract/sync/mutation suites
- `732 passed` — every test file changed by this branch relative to the revisioned-sync base
- Ruff passed on all changed Python files
- `git diff --check` passed
- two independent standards/spec reviews completed with no remaining findings

Eight existing async-mock warnings remain in QQ/Slack adapter tests; there were no failures.
