### PR TITLE
fix(models): add nvidia/nemotron-3-nano-30b-a3b to static nous provider catalog (#63192)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -82,6 +82,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # StepFun
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
+    ("nvidia/nemotron-3-nano-30b-a3b",         ""),
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
@@ -91,6 +92,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),
     ("tencent/hy3:free",                       "free"),
+    ("nvidia/nemotron-3-nano-30b-a3b:free",    "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
     ("inclusionai/ring-2.6-1t:free",           "free"),
@@ -233,6 +235,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # StepFun
         "stepfun/step-3.7-flash",
         # NVIDIA
+        "nvidia/nemotron-3-nano-30b-a3b",
         "nvidia/nemotron-3-super-120b-a12b",
         # Sakana
         "sakana/fugu-ultra",
@@ -311,6 +314,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # NVIDIA flagship reasoning models
         "nvidia/nemotron-3-ultra-550b-a55b",
         "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia/nemotron-3-nano-30b-a3b",
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         # Third-party agentic models hosted on build.nvidia.com
         # (map to OpenRouter defaults — users get familiar picks on NIM)

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-09T18:38:59Z",
+  "updated_at": "2026-07-12T13:32:50Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -137,6 +137,10 @@
           "description": ""
         },
         {
+          "id": "nvidia/nemotron-3-nano-30b-a3b",
+          "description": ""
+        },
+        {
           "id": "nvidia/nemotron-3-super-120b-a12b",
           "description": ""
         },
@@ -158,6 +162,10 @@
         },
         {
           "id": "tencent/hy3:free",
+          "description": "free"
+        },
+        {
+          "id": "nvidia/nemotron-3-nano-30b-a3b:free",
           "description": "free"
         },
         {
@@ -269,6 +277,9 @@
         },
         {
           "id": "stepfun/step-3.7-flash"
+        },
+        {
+          "id": "nvidia/nemotron-3-nano-30b-a3b"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b"


### PR DESCRIPTION
## Summary
`nvidia/nemotron-3-nano-30b-a3b` was missing from the static nous provider catalog. When ACP tries to set this model, detection falls through to the NVIDIA NIM catalog and silently switches provider to a keyless backend, resulting in a generic "Internal error".

## Change
Added the model to the static nous/OpenRouter catalog in `hermes_cli/models.py` and regenerated `model-catalog.json`.

## Verification
All model catalog tests pass.