### PR TITLE
fix(models): align Kimi and Fireworks model pickers

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1899,7 +1899,7 @@ def _model_flow_kimi(config, current_model=""):
         load_config,
         save_config,
     )
-    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.models import provider_model_ids
 
     provider_id = "kimi-coding"
     pconfig = PROVIDER_REGISTRY[provider_id]
@@ -1932,8 +1932,8 @@ def _model_flow_kimi(config, current_model=""):
         save_env_value(base_url_env, "")
     print()
 
-    # Step 3: Model selection — show appropriate models for the endpoint
-    model_list = _PROVIDER_MODELS.get("kimi-coding" if is_coding_plan else "moonshot", [])
+    # Step 3: Model selection — use live discovery for all Kimi endpoints
+    model_list = provider_model_ids("kimi-coding", force_refresh=True)
 
     if model_list:
         selected = _prompt_model_selection(
@@ -2550,6 +2550,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         fetch_api_models,
         opencode_model_api_mode,
         normalize_opencode_model_id,
+        provider_model_ids,
     )
 
     pconfig = PROVIDER_REGISTRY[provider_id]
@@ -2673,9 +2674,14 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     #   2. Curated static fallback list (offline insurance)
     #   3. Live /models endpoint probe (small providers without models.dev data)
     #
-    # LM Studio: live /api/v1/models probe (no models.dev catalog).
-    # Ollama Cloud: merged discovery (live API + models.dev + disk cache).
-    if provider_id == "lmstudio":
+    # Model selection — Fireworks must use the same provider resolver as /model.
+    # Its models.dev entries include router IDs and image models that are not
+    # appropriate for the direct Fireworks agent picker.
+    if provider_id == "fireworks":
+        model_list = provider_model_ids("fireworks", force_refresh=True)
+        if model_list:
+            print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
+    elif provider_id == "lmstudio":
         from hermes_cli.auth import AuthError
         from hermes_cli.models import fetch_lmstudio_models
 

--- a/plugins/model-providers/fireworks/__init__.py
+++ b/plugins/model-providers/fireworks/__init__.py
@@ -2,18 +2,64 @@
 
 Fireworks AI serves fast, production-grade inference for open and proprietary
 models through an OpenAI-compatible chat-completions endpoint.
-
-Address models directly by their catalog ID, e.g.
-``accounts/fireworks/models/kimi-k2p6`` or ``accounts/fireworks/models/glm-5p2``.
-Model IDs here track the canonical Fireworks catalog (fw-ai/fireconnect
-``setup-cli``).
 """
 
 from providers import register_provider
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, _profile_user_agent
 
 
-fireworks = ProviderProfile(
+class FireworksProfile(ProviderProfile):
+    """Fireworks provider with agent-compatible live model discovery."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        import json
+        import urllib.request
+
+        url = (self.models_url or "").strip()
+        if not url:
+            return None
+
+        req = urllib.request.Request(url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception:
+            return None
+
+        items = data if isinstance(data, list) else data.get("models", [])
+        models = []
+        for item in items:
+            if not isinstance(item, dict) or item.get("public") is False:
+                continue
+            if not item.get("supportsTools"):
+                continue
+            name = item.get("name")
+            if not name:
+                continue
+            model_name = name.rsplit("/", 1)[-1].lower()
+            if (
+                model_name.startswith(("flux-", "bge-"))
+                or "embed" in model_name
+                or model_name.endswith("-base")
+                or "-base-v" in model_name
+            ):
+                continue
+            models.append(name)
+        return models
+
+
+fireworks = FireworksProfile(
     name="fireworks",
     aliases=("fireworks-ai", "fw"),
     display_name="Fireworks AI",
@@ -21,11 +67,9 @@ fireworks = ProviderProfile(
     signup_url="https://app.fireworks.ai/settings/users/api-keys",
     env_vars=("FIREWORKS_API_KEY",),
     base_url="https://api.fireworks.ai/inference/v1",
+    models_url="https://api.fireworks.ai/v1/accounts/fireworks/models",
     auth_type="api_key",
-    # Auxiliary model for cheap tasks (compaction, title generation, vision).
-    # A standard pay-as-you-go catalog ``/models/`` ID.
     default_aux_model="accounts/fireworks/models/glm-5p2",
-    # Curated safety net shown in the picker when the live catalog fetch fails.
     fallback_models=(
         "accounts/fireworks/models/kimi-k2p6",
         "accounts/fireworks/models/glm-5p2",

--- a/tests/hermes_cli/test_fireworks_provider.py
+++ b/tests/hermes_cli/test_fireworks_provider.py
@@ -142,6 +142,39 @@ class TestFireworksCredentials:
         assert creds["api_key"] == "fw_test_key"
         assert creds["base_url"] == "https://api.fireworks.ai/inference/v1"
 
+class TestFireworksSetupPicker:
+    def test_setup_uses_same_resolver_as_model_picker(self, monkeypatch):
+        from unittest.mock import patch
+
+        from hermes_cli.model_setup_flows import _model_flow_api_key_provider
+
+        resolved = [
+            "accounts/fireworks/models/kimi-k2p6",
+            "accounts/fireworks/models/kimi-k2p7-code",
+        ]
+        captured = {}
+
+        def capture_models(model_ids, **_kwargs):
+            captured["models"] = model_ids
+            return None
+
+        monkeypatch.setattr("builtins.input", lambda *_args: "")
+        with (
+            patch("hermes_cli.main._prompt_api_key", return_value=("fw_test_key", False)),
+            patch("hermes_cli.config.get_env_value", return_value=""),
+            patch("hermes_cli.config.load_config", return_value={"model": {}}),
+            patch("hermes_cli.config.save_config"),
+            patch("hermes_cli.config.save_env_value"),
+            patch("hermes_cli.auth._prompt_model_selection", side_effect=capture_models),
+            patch("hermes_cli.auth.deactivate_provider"),
+            patch("hermes_cli.models.provider_model_ids", return_value=resolved) as resolver,
+        ):
+            _model_flow_api_key_provider({}, "fireworks")
+
+        resolver.assert_called_once_with("fireworks", force_refresh=True)
+        assert captured["models"] == resolved
+
+
 class TestFireworksAuxiliary:
     """resolve_provider_client wires the BYOK key and PAYG-safe aux model."""
 

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -132,11 +132,15 @@ class TestProviderModelIdsPreferred:
             patch("hermes_cli.auth._prompt_model_selection", side_effect=fake_select),
             patch("hermes_cli.config.get_env_value", return_value=""),
             patch("hermes_cli.config.save_env_value"),
+            patch(
+                "hermes_cli.models.provider_model_ids",
+                return_value=["kimi-k2.7-code", "kimi-k2.7-code-highspeed"],
+            ) as resolver,
         ):
             _model_flow_kimi({}, current_model="")
 
-        assert captured["models"] == _PROVIDER_MODELS["kimi-coding"]
-        assert captured["models"][0] == "kimi-k2.7-code"
+        resolver.assert_called_once_with("kimi-coding", force_refresh=True)
+        assert captured["models"] == ["kimi-k2.7-code", "kimi-k2.7-code-highspeed"]
 
 
 class TestOpenRouterAndNousUnchanged:

--- a/tests/plugins/model_providers/test_fireworks_profile.py
+++ b/tests/plugins/model_providers/test_fireworks_profile.py
@@ -79,3 +79,37 @@ class TestFireworksModelDefaults:
             assert model.startswith("accounts/fireworks/models/"), model
             assert "/routers/" not in model
             assert "turbo" not in model.lower(), model
+
+
+class TestFireworksModelDiscovery:
+    def test_keeps_agent_models_and_excludes_non_agent_models(
+        self, fireworks_profile, monkeypatch
+    ):
+        import json
+
+        payload = {
+            "models": [
+                {"name": "accounts/fireworks/models/kimi-k2p7-code", "public": True, "supportsTools": True},
+                {"name": "accounts/fireworks/models/flux-1-schnell-fp8", "public": True, "supportsTools": True},
+                {"name": "accounts/fireworks/models/bge-m3", "public": True, "supportsTools": True},
+                {"name": "accounts/fireworks/models/code-llama-7b-base", "public": True, "supportsTools": True},
+                {"name": "accounts/fireworks/models/deepseek-r1", "public": True, "supportsTools": False},
+                {"name": "accounts/fireworks/models/private-chat", "public": False, "supportsTools": True},
+            ]
+        }
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(payload).encode()
+
+        monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response())
+
+        assert fireworks_profile.fetch_models(api_key="fw-test") == [
+            "accounts/fireworks/models/kimi-k2p7-code"
+        ]


### PR DESCRIPTION
## Summary

This PR fixes inconsistent model catalogs between the `hermes model` setup wizard and the in-session `/model` picker for Kimi and Fireworks AI.

The two pickers were using different discovery paths. As a result, models available through the provider APIs were missing from setup, while Fireworks setup exposed router and image-generation models that are not appropriate for the direct agent provider.

## Kimi / Kimi Coding Plan

### Problem

The Kimi setup flow used the static `_PROVIDER_MODELS` catalog:

```python
_PROVIDER_MODELS["kimi-coding"]
```

That catalog did not contain newer live models such as:

```text
kimi-k2.7-code
kimi-k2.7-code-highspeed
```

The `/model` path already had access to `provider_model_ids()`, which can resolve the provider catalog dynamically. Therefore, the setup wizard and `/model` could show different Kimi model lists.

### Fix

The Kimi setup flow now uses:

```python
provider_model_ids("kimi-coding", force_refresh=True)
```

This makes the setup wizard use live provider discovery and preserves the current-model selection behavior.

### Result

Newer Kimi Coding Plan models are available in `hermes model` without waiting for the static catalog to be updated.

## Fireworks AI

### Problem

The Fireworks setup flow checked `models.dev` before the Fireworks provider resolver. That catalog included router IDs such as:

```text
accounts/fireworks/routers/kimi-k2p6-turbo
accounts/fireworks/routers/glm-5p2-fast
```

It could also include models that are not suitable for Hermes agents, including image-generation models such as:

```text
accounts/fireworks/models/flux-1-schnell-fp8
```

Fireworks does not expose its complete account catalog through the normal OpenAI-compatible `/inference/v1/models` endpoint. Its documented account catalog is:

```text
https://api.fireworks.ai/v1/accounts/fireworks/models
```

The response uses a top-level `models` array and the model identifier is stored in `name`, not `id`.

### Fix

This PR adds a `FireworksProfile` live catalog implementation that:

1. Calls the correct Fireworks account catalog endpoint.
2. Reads the Fireworks `models` response shape.
3. Uses the model `name` field as the Hermes model ID.
4. Keeps public models with tool-calling support.
5. Excludes image-generation models such as `flux-*`.
6. Excludes embedding models such as `bge-*` and models containing `embed`.
7. Excludes base model variants.
8. Keeps curated fallback models available if live discovery fails.

The generic setup flow now calls the same `provider_model_ids("fireworks")` resolver used by `/model`, with an explicit refresh. This removes the setup/`/model` catalog divergence.

### Result

Both picker paths now resolve the same direct Fireworks agent catalog:

```text
accounts/fireworks/models/kimi-k2p6
accounts/fireworks/models/kimi-k2p7-code
accounts/fireworks/models/glm-5p2
accounts/fireworks/models/deepseek-v4-pro
accounts/fireworks/models/deepseek-v4-flash
```

Router IDs and Flux image models are no longer displayed.

## Files changed

- `hermes_cli/model_setup_flows.py`
  - Use live Kimi discovery.
  - Use the Fireworks resolver in the setup wizard.
- `plugins/model-providers/fireworks/__init__.py`
  - Add Fireworks-specific live catalog discovery and filtering.
- `tests/hermes_cli/test_models_dev_preferred_merge.py`
  - Verify Kimi setup calls live discovery.
- `tests/hermes_cli/test_fireworks_provider.py`
  - Verify Fireworks setup uses the same resolver as `/model`.
- `tests/plugins/model_providers/test_fireworks_profile.py`
  - Verify Fireworks model filtering.

## Verification

The following tests pass locally:

```text
43 passed, 1 warning
80 passed, 1 skipped
```

The warning is a pre-existing Python `audioop` deprecation warning from the Discord dependency.

Additional verification confirmed:

```text
setup_count:        18
model_picker_count: 18
same_list:          True
router IDs:         none
Flux models:        none
```

This PR does not include the separate Matrix/CMake change.
