### PR TITLE
fix(run): apply Copilot-Integration-Id header on codex_responses credential refresh to fix integrator routing (#63188)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4255,6 +4255,7 @@ class AIAgent:
         self.base_url = base_url.strip().rstrip("/")
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
+        self._apply_client_headers_for_base_url(str(self.base_url or ""))
 
         if not self._replace_primary_openai_client(reason=f"{self.provider}_credential_refresh"):
             return False


### PR DESCRIPTION
## Summary
When `model.api_mode = codex_responses`, requests to Copilot arrive at GitHub without `Copilot-Integration-Id: vscode-chat`. GitHub attributes the request to `copilot-language-server` (smaller model whitelist) and returns 400 for models like claude-opus-4.8 that are available on the user's seat but not on that integrator's whitelist.

The `chat_completions` path correctly applies `copilot_default_headers()` via `_apply_client_headers_for_base_url`, but `_try_refresh_codex_client_credentials` never called that method after updating the base URL.

## Change
Added `self._apply_client_headers_for_base_url(str(self.base_url or ""))` in `_try_refresh_codex_client_credentials` after the base_url and api_key are set, mirroring the pattern already present in `_try_refresh_copilot_client_credentials` and `_swap_credential`.

## Verification
Provider attribution header tests pass.