### PR TITLE
feat(pets): support v2 directional gaze atlases

### DIFF
--- a/agent/pet/store.py
+++ b/agent/pet/store.py
@@ -43,6 +43,7 @@ class InstalledPet:
     directory: Path
     spritesheet: Path
     created_by: str = ""  # "generator" for pets hatched locally; "" for petdex installs
+    sprite_version_number: int = 1
 
     @property
     def exists(self) -> bool:
@@ -69,6 +70,18 @@ def _read_pet_json(directory: Path) -> dict:
     except (OSError, ValueError) as exc:
         logger.debug("unreadable pet.json in %s: %s", directory, exc)
         return {}
+
+
+def _sprite_version_number(meta: dict) -> int:
+    """Return a positive manifest sprite version, defaulting malformed values to v1."""
+    raw = meta.get("spriteVersionNumber", 1)
+    if isinstance(raw, bool):
+        return 1
+    try:
+        version = int(raw)
+    except (TypeError, ValueError):
+        return 1
+    return version if version >= 1 else 1
 
 
 def _resolve_spritesheet(directory: Path, meta: dict) -> Path:
@@ -120,6 +133,7 @@ def load_pet(slug: str) -> InstalledPet | None:
         directory=directory,
         spritesheet=_resolve_spritesheet(directory, meta),
         created_by=str(meta.get("createdBy", "") or ""),
+        sprite_version_number=_sprite_version_number(meta),
     )
 
 

--- a/agent/pet/store.py
+++ b/agent/pet/store.py
@@ -75,13 +75,9 @@ def _read_pet_json(directory: Path) -> dict:
 def _sprite_version_number(meta: dict) -> int:
     """Return a positive manifest sprite version, defaulting malformed values to v1."""
     raw = meta.get("spriteVersionNumber", 1)
-    if isinstance(raw, bool):
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
         return 1
-    try:
-        version = int(raw)
-    except (TypeError, ValueError):
-        return 1
-    return version if version >= 1 else 1
+    return raw
 
 
 def _resolve_spritesheet(directory: Path, meta: dict) -> Path:

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -430,7 +430,7 @@ export function PetOverlayApp() {
           <PetBubble />
         </div>
         <div style={{ lineHeight: 0, position: 'relative' }}>
-          <PetSprite info={info} />
+          <PetSprite info={info} lookAtPointer />
 
           {/* Hearts on the popped-out pet — identical to in-window. */}
           <PetHeartField

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -22,6 +22,7 @@ import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
+import { supportsPetLookDirections } from './pet-look'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -44,6 +45,8 @@ interface PetInfoMeta {
   displayName?: string
   scale?: number
   spritesheetRevision?: string
+  spriteVersionNumber?: number
+  lookDirectionCount?: number
 }
 
 function samePetRevision(info: PetInfo, meta: PetInfoMeta): boolean {
@@ -53,7 +56,9 @@ function samePetRevision(info: PetInfo, meta: PetInfoMeta): boolean {
     info.slug === meta.slug &&
     info.displayName === meta.displayName &&
     info.scale === meta.scale &&
-    info.spritesheetRevision === meta.spritesheetRevision
+    info.spritesheetRevision === meta.spritesheetRevision &&
+    info.spriteVersionNumber === meta.spriteVersionNumber &&
+    info.lookDirectionCount === meta.lookDirectionCount
   )
 }
 
@@ -189,7 +194,9 @@ export function FloatingPet() {
             current.displayName === next.displayName &&
             current.scale === next.scale &&
             current.spritesheetRevision &&
-            current.spritesheetRevision === next.spritesheetRevision
+            current.spritesheetRevision === next.spritesheetRevision &&
+            current.spriteVersionNumber === next.spriteVersionNumber &&
+            current.lookDirectionCount === next.lookDirectionCount
           ) {
             return
           }
@@ -397,8 +404,9 @@ export function FloatingPet() {
   })
 
   // While roaming, drive the directional run row + mirror from the travel
-  // direction; at rest, fall back to the inward-facing static mascot.
+  // direction; validated v2 pets use their fixed look cells while resting.
   const walk = roamWalkRow(roamDir, info.stateRows)
+  const gazeEnabled = atRest && roamDir === 0 && supportsPetLookDirections(info)
 
   // While popped out, the desktop overlay window owns the mascot — hide the
   // in-window one so there aren't two.
@@ -442,11 +450,12 @@ export function FloatingPet() {
         style={{
           lineHeight: 0,
           position: 'relative',
-          transform: roamDir !== 0 ? (walk.mirror ? 'scaleX(-1)' : 'none') : facing(position.x, petW),
+          transform:
+            roamDir !== 0 ? (walk.mirror ? 'scaleX(-1)' : 'none') : gazeEnabled ? 'none' : facing(position.x, petW),
           zIndex: 1
         }}
       >
-        <PetSprite info={info} rowOverride={walk.row} />
+        <PetSprite info={info} lookAtPointer={gazeEnabled} rowOverride={walk.row} />
       </div>
       {/* Hearts puff off the pet; its celebrate ("yay"/jump) pose is driven by
           burstVibeHearts's router. */}

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -9,6 +9,7 @@ import { persistString, storedString } from '@/lib/storage'
 import {
   $petAtRest,
   $petInfo,
+  $petMotion,
   $petRoam,
   $petRoamDir,
   clearPetUnread,
@@ -22,7 +23,7 @@ import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
-import { supportsPetLookDirections } from './pet-look'
+import { shouldEnablePetGaze } from './pet-look'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -123,6 +124,7 @@ export function FloatingPet() {
   const overlayActive = useStore($petOverlayActive)
   const roamEnabled = useStore($petRoam)
   const atRest = useStore($petAtRest)
+  const motion = useStore($petMotion)
   const roamDir = useStore($petRoamDir)
   const routeOverlayOpen = useRouteOverlayActive()
 
@@ -133,6 +135,7 @@ export function FloatingPet() {
   const spriteWrapRef = useRef<HTMLDivElement | null>(null)
   const petW = (info.frameW ?? 192) * (info.scale ?? 0.33)
   const petH = (info.frameH ?? 208) * (info.scale ?? 0.33)
+  const gazeEnabled = shouldEnablePetGaze(info, atRest, motion, roamDir)
   // Soft contact shadow, sized off the pet so every scale/species grounds the
   // same way (cf. lairp's per-actor feet ellipse). Lighter on light backgrounds.
   const shadowW = Math.round(petW * 0.55)
@@ -329,10 +332,10 @@ export function FloatingPet() {
       el.style.top = `${next.y}px`
 
       if (spriteWrapRef.current) {
-        spriteWrapRef.current.style.transform = facing(next.x, petW)
+        spriteWrapRef.current.style.transform = gazeEnabled ? 'none' : facing(next.x, petW)
       }
     },
-    [clamp, petW]
+    [clamp, gazeEnabled, petW]
   )
 
   const onPointerUp = useCallback((e: React.PointerEvent) => {
@@ -406,7 +409,6 @@ export function FloatingPet() {
   // While roaming, drive the directional run row + mirror from the travel
   // direction; validated v2 pets use their fixed look cells while resting.
   const walk = roamWalkRow(roamDir, info.stateRows)
-  const gazeEnabled = atRest && roamDir === 0 && supportsPetLookDirections(info)
 
   // While popped out, the desktop overlay window owns the mascot — hide the
   // in-window one so there aren't two.

--- a/apps/desktop/src/components/pet/pet-look.test.ts
+++ b/apps/desktop/src/components/pet/pet-look.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { lookCellForVector, supportsPetLookDirections } from './pet-look'
+
+describe('supportsPetLookDirections', () => {
+  it('requires the validated v2 capability from the gateway', () => {
+    expect(supportsPetLookDirections({ lookDirectionCount: 16, spriteVersionNumber: 2 })).toBe(true)
+    expect(supportsPetLookDirections({ lookDirectionCount: 0, spriteVersionNumber: 2 })).toBe(false)
+    expect(supportsPetLookDirections({ lookDirectionCount: 16, spriteVersionNumber: 1 })).toBe(false)
+    expect(supportsPetLookDirections({})).toBe(false)
+  })
+})
+
+describe('lookCellForVector', () => {
+  it.each([
+    ['up', 0, -100, 9, 0],
+    ['up-right', 100, -100, 9, 2],
+    ['right', 100, 0, 9, 4],
+    ['down-right', 100, 100, 9, 6],
+    ['down', 0, 100, 10, 0],
+    ['down-left', -100, 100, 10, 2],
+    ['left', -100, 0, 10, 4],
+    ['up-left', -100, -100, 10, 6]
+  ])('maps %s clockwise into the v2 atlas', (_name, dx, dy, row, column) => {
+    expect(lookCellForVector(dx as number, dy as number, 10)).toEqual({ column, row })
+  })
+
+  it('uses the neutral animation inside the pointer deadzone', () => {
+    expect(lookCellForVector(3, 4, 5)).toBeNull()
+  })
+
+  it('rounds to the nearest 22.5-degree direction', () => {
+    const radians = (22.5 * Math.PI) / 180
+    expect(lookCellForVector(Math.sin(radians) * 100, -Math.cos(radians) * 100, 0)).toEqual({ column: 1, row: 9 })
+  })
+})

--- a/apps/desktop/src/components/pet/pet-look.test.ts
+++ b/apps/desktop/src/components/pet/pet-look.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { lookCellForVector, supportsPetLookDirections } from './pet-look'
+import { lookCellForVector, shouldEnablePetGaze, supportsPetLookDirections } from './pet-look'
 
 describe('supportsPetLookDirections', () => {
   it('requires the validated v2 capability from the gateway', () => {
@@ -8,6 +8,17 @@ describe('supportsPetLookDirections', () => {
     expect(supportsPetLookDirections({ lookDirectionCount: 0, spriteVersionNumber: 2 })).toBe(false)
     expect(supportsPetLookDirections({ lookDirectionCount: 16, spriteVersionNumber: 1 })).toBe(false)
     expect(supportsPetLookDirections({})).toBe(false)
+  })
+})
+
+describe('shouldEnablePetGaze', () => {
+  const v2 = { lookDirectionCount: 16, spriteVersionNumber: 2 }
+
+  it('only enables gaze while the agent and roam loop are both idle', () => {
+    expect(shouldEnablePetGaze(v2, true, null, 0)).toBe(true)
+    expect(shouldEnablePetGaze(v2, false, null, 0)).toBe(false)
+    expect(shouldEnablePetGaze(v2, true, 'jump', 0)).toBe(false)
+    expect(shouldEnablePetGaze(v2, true, 'run', 1)).toBe(false)
   })
 })
 
@@ -25,7 +36,7 @@ describe('lookCellForVector', () => {
     expect(lookCellForVector(dx as number, dy as number, 10)).toEqual({ column, row })
   })
 
-  it('uses the neutral animation inside the pointer deadzone', () => {
+  it('signals the fixed neutral frame inside the pointer deadzone', () => {
     expect(lookCellForVector(3, 4, 5)).toBeNull()
   })
 

--- a/apps/desktop/src/components/pet/pet-look.ts
+++ b/apps/desktop/src/components/pet/pet-look.ts
@@ -19,12 +19,22 @@ export function supportsPetLookDirections(info: PetLookCapability): boolean {
   return info.spriteVersionNumber === 2 && info.lookDirectionCount === PET_V2_LOOK_DIRECTION_COUNT
 }
 
+/** Gaze is an idle-only presentation; roam motion and travel retain priority. */
+export function shouldEnablePetGaze(
+  info: PetLookCapability,
+  atRest: boolean,
+  motion: null | string,
+  roamDirection: number
+): boolean {
+  return atRest && motion === null && roamDirection === 0 && supportsPetLookDirections(info)
+}
+
 /**
  * Map a pointer vector to one of the 16 v2 look cells.
  *
  * The atlas starts at north (000°), advances clockwise in 22.5° steps, and
- * packs eight cells per row across rows 9 and 10. Inside the deadzone the
- * caller should keep rendering the normal idle animation.
+ * packs eight cells per row across rows 9 and 10. Inside the deadzone this
+ * returns null so the caller can render the fixed neutral v2 frame.
  */
 export function lookCellForVector(dx: number, dy: number, deadzone: number): PetLookCell | null {
   if (!Number.isFinite(dx) || !Number.isFinite(dy) || Math.hypot(dx, dy) <= Math.max(0, deadzone)) {

--- a/apps/desktop/src/components/pet/pet-look.ts
+++ b/apps/desktop/src/components/pet/pet-look.ts
@@ -1,0 +1,42 @@
+export interface PetLookCapability {
+  lookDirectionCount?: number
+  spriteVersionNumber?: number
+}
+
+export interface PetLookCell {
+  column: number
+  row: number
+}
+
+export const PET_V2_LOOK_DIRECTION_COUNT = 16
+export const PET_V2_LOOK_ROW_START = 9
+export const PET_V2_NEUTRAL_LOOK_CELL: PetLookCell = { column: 6, row: 0 }
+
+const DEGREES_PER_DIRECTION = 360 / PET_V2_LOOK_DIRECTION_COUNT
+
+/** Only the gateway may declare a sheet safe for the v2 look-row contract. */
+export function supportsPetLookDirections(info: PetLookCapability): boolean {
+  return info.spriteVersionNumber === 2 && info.lookDirectionCount === PET_V2_LOOK_DIRECTION_COUNT
+}
+
+/**
+ * Map a pointer vector to one of the 16 v2 look cells.
+ *
+ * The atlas starts at north (000°), advances clockwise in 22.5° steps, and
+ * packs eight cells per row across rows 9 and 10. Inside the deadzone the
+ * caller should keep rendering the normal idle animation.
+ */
+export function lookCellForVector(dx: number, dy: number, deadzone: number): PetLookCell | null {
+  if (!Number.isFinite(dx) || !Number.isFinite(dy) || Math.hypot(dx, dy) <= Math.max(0, deadzone)) {
+    return null
+  }
+
+  const clockwiseFromNorth = (Math.atan2(dx, -dy) * 180) / Math.PI
+  const normalized = (clockwiseFromNorth + 360) % 360
+  const index = Math.round(normalized / DEGREES_PER_DIRECTION) % PET_V2_LOOK_DIRECTION_COUNT
+
+  return {
+    column: index % 8,
+    row: PET_V2_LOOK_ROW_START + Math.floor(index / 8)
+  }
+}

--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -1,0 +1,108 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $petActivity, $petMotion, type PetInfo } from '@/store/pet'
+
+import { PetSprite } from './pet-sprite'
+
+const info: PetInfo = {
+  enabled: true,
+  displayName: 'V2 Test',
+  frameH: 208,
+  frameW: 192,
+  framesPerState: 6,
+  lookDirectionCount: 16,
+  loopMs: 1100,
+  mime: 'image/webp',
+  scale: 1,
+  spriteVersionNumber: 2,
+  spritesheetBase64: 'AA==',
+  stateRows: ['idle', 'running-right', 'running-left', 'waving', 'jumping', 'failed', 'waiting', 'running', 'review']
+}
+
+describe('PetSprite v2 gaze', () => {
+  let nextFrame: FrameRequestCallback | undefined
+  let drawImage: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    $petActivity.set({})
+    $petMotion.set(null)
+    drawImage = vi.fn()
+
+    class ReadyImage {
+      complete = true
+      naturalWidth = 1536
+      src = ''
+    }
+
+    vi.stubGlobal('Image', ReadyImage)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        nextFrame = callback
+
+        return 1
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      clearRect: vi.fn(),
+      drawImage,
+      imageSmoothingEnabled: false
+    } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('draws the fixed v2 cell nearest the pointer while idle', () => {
+    render(<PetSprite info={info} lookAtPointer />)
+
+    act(() => nextFrame?.(0))
+    expect(drawImage).toHaveBeenLastCalledWith(expect.anything(), 6 * 192, 0, 192, 208, 0, 0, 192, 208)
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 50 }))
+      nextFrame?.(16)
+    })
+
+    expect(drawImage).toHaveBeenLastCalledWith(expect.anything(), 4 * 192, 9 * 208, 192, 208, 0, 0, 192, 208)
+  })
+
+  it('keeps agent activity above cosmetic gaze', () => {
+    $petActivity.set({ busy: true })
+    render(<PetSprite info={info} lookAtPointer />)
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 50 }))
+      nextFrame?.(0)
+    })
+
+    expect(drawImage).toHaveBeenLastCalledWith(expect.anything(), 0, 7 * 208, 192, 208, 0, 0, 192, 208)
+  })
+
+  it('never reads look rows from a v1 package', () => {
+    render(<PetSprite info={{ ...info, lookDirectionCount: 0, spriteVersionNumber: 1 }} lookAtPointer />)
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 50 }))
+      nextFrame?.(0)
+    })
+
+    expect(drawImage).toHaveBeenLastCalledWith(expect.anything(), 0, 0, 192, 208, 0, 0, 192, 208)
+  })
+})

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -2,6 +2,8 @@ import { memo, useEffect, useMemo, useRef } from 'react'
 
 import { $petState, type PetInfo, type PetState } from '@/store/pet'
 
+import { lookCellForVector, PET_V2_NEUTRAL_LOOK_CELL, supportsPetLookDirections } from './pet-look'
+
 const DEFAULT_FRAME_W = 192
 const DEFAULT_FRAME_H = 208
 const DEFAULT_FRAMES = 6
@@ -101,6 +103,8 @@ interface PetSpriteProps {
   stateOverride?: PetState
   /** Force a concrete row name from `info.stateRows` (e.g. `running-right`). */
   rowOverride?: string
+  /** Follow the pointer with validated v2 look rows while the live state is idle. */
+  lookAtPointer?: boolean
 }
 
 /**
@@ -114,11 +118,12 @@ interface PetSpriteProps {
  * with `memo`, this component effectively never re-renders after mount until
  * the pet itself changes.
  */
-function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride }: PetSpriteProps) {
+function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, lookAtPointer = false }: PetSpriteProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const stateRef = useRef<PetState>($petState.get())
   const overrideRef = useRef<PetState | undefined>(stateOverride)
   const rowOverrideRef = useRef<string | undefined>(rowOverride)
+  const lookCellRef = useRef<ReturnType<typeof lookCellForVector>>(null)
 
   // Keep the override current without re-running the RAF setup effect.
   useEffect(() => {
@@ -128,6 +133,48 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride }: PetSprite
   useEffect(() => {
     rowOverrideRef.current = rowOverride
   }, [rowOverride])
+
+  const gazeEnabled = lookAtPointer && supportsPetLookDirections(info)
+  useEffect(() => {
+    lookCellRef.current = null
+
+    if (!gazeEnabled) {
+      return
+    }
+
+    lookCellRef.current = PET_V2_NEUTRAL_LOOK_CELL
+
+    const onMove = (event: MouseEvent) => {
+      const rect = canvasRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        return
+      }
+
+      const deadzone = Math.max(10, Math.min(rect.width, rect.height) * 0.18)
+      lookCellRef.current =
+        lookCellForVector(
+          event.clientX - (rect.left + rect.width / 2),
+          event.clientY - (rect.top + rect.height / 2),
+          deadzone
+        ) ?? PET_V2_NEUTRAL_LOOK_CELL
+    }
+
+    const reset = () => {
+      lookCellRef.current = PET_V2_NEUTRAL_LOOK_CELL
+    }
+
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('blur', reset)
+    document.addEventListener('mouseleave', reset)
+
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('blur', reset)
+      document.removeEventListener('mouseleave', reset)
+      lookCellRef.current = null
+    }
+  }, [gazeEnabled])
 
   const frameW = info.frameW ?? DEFAULT_FRAME_W
   const frameH = info.frameH ?? DEFAULT_FRAME_H
@@ -221,7 +268,14 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride }: PetSprite
 
     const render = (now: number) => {
       const forcedRow = rowOverrideRef.current
-      const { row, count } = forcedRow ? resolveRow(forcedRow) : resolve(overrideRef.current ?? stateRef.current)
+      const state = overrideRef.current ?? stateRef.current
+      const lookCell = !forcedRow && state === 'idle' ? lookCellRef.current : null
+
+      const { row, count } = lookCell
+        ? { row: lookCell.row, count: 1 }
+        : forcedRow
+          ? resolveRow(forcedRow)
+          : resolve(state)
 
       if (row !== activeRow || count !== activeCount) {
         activeRow = row
@@ -241,17 +295,18 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride }: PetSprite
       }
 
       frame %= count
+      const visibleFrame = lookCell?.column ?? frame
 
       // Only touch the canvas when the visible cell actually changes. The RAF
       // ticks at ~60Hz but the sprite only steps ~5Hz, so this skips ~90% of
       // the clear+draw work and keeps the main thread free.
-      if ((frame !== drawnFrame || row !== drawnRow) && image.complete && image.naturalWidth > 0) {
-        const sx = frame * frameW
+      if ((visibleFrame !== drawnFrame || row !== drawnRow) && image.complete && image.naturalWidth > 0) {
+        const sx = visibleFrame * frameW
         const sy = row * frameH
         ctx.clearRect(0, 0, canvas.width, canvas.height)
         ctx.imageSmoothingEnabled = false
         ctx.drawImage(image, sx, sy, frameW, frameH, 0, 0, drawW, drawH)
-        drawnFrame = frame
+        drawnFrame = visibleFrame
         drawnRow = row
       }
 

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -24,6 +24,10 @@ export interface PetInfo {
   // Stable sheet revision (`mtime_ns:size`) from the gateway; lets the desktop
   // skip full sprite payload refreshes when the active pet hasn't changed.
   spritesheetRevision?: string
+  // Versioned atlas contract from pet.json. The gateway only exposes look rows
+  // when both v2 metadata and exact 8x11 geometry validate.
+  spriteVersionNumber?: number
+  lookDirectionCount?: number
   frameW?: number
   frameH?: number
   framesPerState?: number

--- a/tests/agent/test_pet_engine.py
+++ b/tests/agent/test_pet_engine.py
@@ -153,6 +153,23 @@ def test_store_install_resolution(boba_like):
     assert store.resolve_active_pet("does-not-exist").slug == "boba"
     # display metadata flows from pet.json
     assert store.load_pet("boba").display_name == "Boba"
+    # Existing manifests without a version remain v1.
+    assert store.load_pet("boba").sprite_version_number == 1
+
+
+def test_store_reads_v2_sprite_version(boba_like):
+    pet_json = boba_like / "pet.json"
+    pet_json.write_text(
+        '{"id":"boba","displayName":"Boba","spriteVersionNumber":2,"spritesheetPath":"spritesheet.webp"}'
+    )
+
+    assert store.load_pet("boba").sprite_version_number == 2
+
+    # Malformed metadata must fail closed to the legacy contract.
+    pet_json.write_text(
+        '{"id":"boba","displayName":"Boba","spriteVersionNumber":"future","spritesheetPath":"spritesheet.webp"}'
+    )
+    assert store.load_pet("boba").sprite_version_number == 1
 
 
 def test_store_remove(boba_like):

--- a/tests/agent/test_pet_engine.py
+++ b/tests/agent/test_pet_engine.py
@@ -166,10 +166,15 @@ def test_store_reads_v2_sprite_version(boba_like):
     assert store.load_pet("boba").sprite_version_number == 2
 
     # Malformed metadata must fail closed to the legacy contract.
-    pet_json.write_text(
-        '{"id":"boba","displayName":"Boba","spriteVersionNumber":"future","spritesheetPath":"spritesheet.webp"}'
-    )
-    assert store.load_pet("boba").sprite_version_number == 1
+    for malformed in ('"future"', "2.9", "1e1000", "true"):
+        pet_json.write_text(
+            '{"id":"boba","displayName":"Boba","spriteVersionNumber":'
+            + malformed
+            + ',"spritesheetPath":"spritesheet.webp"}'
+        )
+        pet = store.load_pet("boba")
+        assert pet is not None
+        assert pet.sprite_version_number == 1
 
 
 def test_store_remove(boba_like):

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -276,6 +276,34 @@ def test_v2_look_capability_requires_manifest_and_11_row_geometry():
     assert server._pet_sprite_payload(legacy, scale=0.7)["lookDirectionCount"] == 0
 
 
+def test_pet_payload_cache_invalidates_when_only_manifest_version_changes():
+    import json
+
+    from agent.pet import constants, store
+
+    sheet = Image.new(
+        "RGBA",
+        (constants.FRAME_W * 8, constants.FRAME_H * 11),
+        (80, 120, 220, 255),
+    )
+    pet = store.register_local_pet(sheet, slug="metadata-cache")
+    before = server._pet_sprite_payload(pet, scale=0.7)
+    assert before["spriteVersionNumber"] == 1
+    assert before["lookDirectionCount"] == 0
+
+    manifest = pet.directory / "pet.json"
+    meta = json.loads(manifest.read_text(encoding="utf-8"))
+    meta["spriteVersionNumber"] = 2
+    manifest.write_text(json.dumps(meta), encoding="utf-8")
+    pet = store.load_pet(pet.slug)
+
+    assert pet is not None
+    after = server._pet_sprite_payload(pet, scale=0.7)
+    assert after["spritesheetBase64"] == before["spritesheetBase64"]
+    assert after["spriteVersionNumber"] == 2
+    assert after["lookDirectionCount"] == 16
+
+
 @pytest.mark.parametrize("blank_cell", [(0, 6), (9, 0), (10, 7)])
 def test_v2_look_capability_rejects_blank_required_cells(blank_cell):
     import json

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -243,3 +243,34 @@ def test_pet_info_meta_avoids_full_payload(monkeypatch):
     assert result["displayName"] == "Meta Pet"
     assert result["scale"] == 0.7
     assert ":" in result["spritesheetRevision"]
+    assert result["spriteVersionNumber"] == 1
+    assert result["lookDirectionCount"] == 0
+
+
+def test_v2_look_capability_requires_manifest_and_11_row_geometry():
+    import json
+
+    from agent.pet import constants, store
+
+    def install(slug: str, rows: int, version: int):
+        sheet = Image.new("RGBA", (constants.FRAME_W * 8, constants.FRAME_H * rows), (80, 120, 220, 255))
+        pet = store.register_local_pet(sheet, slug=slug, display_name=slug)
+        manifest = pet.directory / "pet.json"
+        meta = json.loads(manifest.read_text(encoding="utf-8"))
+        meta["spriteVersionNumber"] = version
+        manifest.write_text(json.dumps(meta), encoding="utf-8")
+        return store.load_pet(slug)
+
+    v2 = install("v2-ready", rows=11, version=2)
+    assert v2 is not None
+    payload = server._pet_sprite_payload(v2, scale=0.7)
+    assert payload["spriteVersionNumber"] == 2
+    assert payload["lookDirectionCount"] == 16
+
+    short = install("v2-short", rows=9, version=2)
+    assert short is not None
+    assert server._pet_sprite_payload(short, scale=0.7)["lookDirectionCount"] == 0
+
+    legacy = install("legacy-tall", rows=11, version=1)
+    assert legacy is not None
+    assert server._pet_sprite_payload(legacy, scale=0.7)["lookDirectionCount"] == 0

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -274,3 +274,30 @@ def test_v2_look_capability_requires_manifest_and_11_row_geometry():
     legacy = install("legacy-tall", rows=11, version=1)
     assert legacy is not None
     assert server._pet_sprite_payload(legacy, scale=0.7)["lookDirectionCount"] == 0
+
+
+@pytest.mark.parametrize("blank_cell", [(0, 6), (9, 0), (10, 7)])
+def test_v2_look_capability_rejects_blank_required_cells(blank_cell):
+    import json
+
+    from agent.pet import constants, store
+
+    sheet = Image.new(
+        "RGBA",
+        (constants.FRAME_W * 8, constants.FRAME_H * 11),
+        (80, 120, 220, 255),
+    )
+    row, column = blank_cell
+    sheet.paste(
+        Image.new("RGBA", (constants.FRAME_W, constants.FRAME_H), (0, 0, 0, 0)),
+        (column * constants.FRAME_W, row * constants.FRAME_H),
+    )
+    pet = store.register_local_pet(sheet, slug=f"blank-{row}-{column}")
+    manifest = pet.directory / "pet.json"
+    meta = json.loads(manifest.read_text(encoding="utf-8"))
+    meta["spriteVersionNumber"] = 2
+    manifest.write_text(json.dumps(meta), encoding="utf-8")
+    pet = store.load_pet(pet.slug)
+
+    assert pet is not None
+    assert server._pet_sprite_payload(pet, scale=0.7)["lookDirectionCount"] == 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14,6 +14,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
@@ -6595,19 +6596,45 @@ def _clone_pet_payload(payload: dict) -> dict:
     return out
 
 
+@lru_cache(maxsize=32)
+def _pet_v2_cells_valid(spritesheet: str, mtime_ns: int, size: int) -> bool:
+    """Validate and cache the geometry/content required by the v2 gaze contract."""
+    del mtime_ns, size  # cache-key revision inputs; the path is the value input
+    from PIL import Image
+
+    from agent.pet import constants
+
+    with Image.open(spritesheet) as image:
+        if image.width != constants.FRAME_W * 8 or image.height != constants.FRAME_H * 11:
+            return False
+
+        rgba = image.convert("RGBA")
+        required_cells = [(0, 6), *[(9 + index // 8, index % 8) for index in range(16)]]
+        for row, column in required_cells:
+            left = column * constants.FRAME_W
+            top = row * constants.FRAME_H
+            alpha_extrema = rgba.crop(
+                (left, top, left + constants.FRAME_W, top + constants.FRAME_H)
+            ).getchannel("A").getextrema()
+            alpha_max = alpha_extrema[1]
+            if not isinstance(alpha_max, (int, float)) or alpha_max <= 8:
+                return False
+    return True
+
+
 def _pet_look_direction_count(pet) -> int:
-    """Return the supported v2 gaze-frame count, gated by manifest and geometry."""
+    """Return the supported v2 gaze-frame count, gated by manifest and sheet."""
     if getattr(pet, "sprite_version_number", 1) != 2:
         return 0
     try:
-        from PIL import Image
-
-        from agent.pet import constants
-
-        with Image.open(pet.spritesheet) as image:
-            if image.width != constants.FRAME_W * 8 or image.height != constants.FRAME_H * 11:
-                return 0
-        return 16
+        stat = pet.spritesheet.stat()
+        return (
+            16
+            if _pet_v2_cells_valid(
+                str(pet.spritesheet), stat.st_mtime_ns, stat.st_size
+            )
+            else 0
+        )
     except Exception:  # noqa: BLE001 - cosmetic, never break the surface
         return 0
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6578,6 +6578,7 @@ def _pet_payload_cache_key(pet, *, scale: float) -> tuple | None:
         stat.st_size,
         pet.slug,
         pet.display_name,
+        getattr(pet, "sprite_version_number", 1),
         round(scale, 4),
     )
 
@@ -6592,6 +6593,23 @@ def _clone_pet_payload(payload: dict) -> dict:
     if isinstance(payload.get("stateRows"), list):
         out["stateRows"] = list(payload["stateRows"])
     return out
+
+
+def _pet_look_direction_count(pet) -> int:
+    """Return the supported v2 gaze-frame count, gated by manifest and geometry."""
+    if getattr(pet, "sprite_version_number", 1) != 2:
+        return 0
+    try:
+        from PIL import Image
+
+        from agent.pet import constants
+
+        with Image.open(pet.spritesheet) as image:
+            if image.width != constants.FRAME_W * 8 or image.height != constants.FRAME_H * 11:
+                return 0
+        return 16
+    except Exception:  # noqa: BLE001 - cosmetic, never break the surface
+        return 0
 
 
 def _pet_row_frame_counts(spritesheet) -> dict:
@@ -6663,6 +6681,8 @@ def _pet_sprite_payload(pet, *, scale: float) -> dict:
         "mime": mime,
         "spritesheetBase64": base64.standard_b64encode(raw).decode("ascii"),
         "spritesheetRevision": _pet_sheet_revision(pet.spritesheet),
+        "spriteVersionNumber": getattr(pet, "sprite_version_number", 1),
+        "lookDirectionCount": _pet_look_direction_count(pet),
         "frameW": constants.FRAME_W,
         "frameH": constants.FRAME_H,
         "framesPerState": constants.FRAMES_PER_STATE,
@@ -6763,6 +6783,8 @@ def _(rid, params: dict) -> dict:
                 "displayName": pet.display_name,
                 "scale": scale,
                 "spritesheetRevision": _pet_sheet_revision(pet.spritesheet),
+                "spriteVersionNumber": getattr(pet, "sprite_version_number", 1),
+                "lookDirectionCount": _pet_look_direction_count(pet),
             },
         )
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface

--- a/website/docs/user-guide/features/pets.md
+++ b/website/docs/user-guide/features/pets.md
@@ -46,7 +46,9 @@ Unicode **half-block** rendering. Inside a pipe or redirect (no TTY), terminal
 rendering is disabled by design.
 
 The desktop app draws the pet as a floating sprite on a canvas and toggles it
-from **Settings → Appearance**.
+from **Settings → Appearance**. A validated v2 pet follows the pointer with its
+16 fixed look-direction cells while idle; agent activity and roaming still use
+the standard animated state rows.
 
 ## Quick start (CLI)
 
@@ -157,6 +159,25 @@ quiet there.
 
 The overlay is a pure puppet of the in-app pet — it carries no separate gateway
 connection and never appears in the dock or app switcher.
+
+### Sprite atlas versions
+
+Hermes remains compatible with legacy 8-row atlases and the standard 8×9
+Petdex/Codex atlas. Version 2 adds two fixed-gaze rows without changing the first
+nine rows:
+
+- The grid is exactly **8 columns × 11 rows**, with **192×208** cells.
+- Rows 0–8 retain the standard animation taxonomy.
+- Rows 9–10 contain 16 look directions, starting at north (`000°`) and advancing
+  clockwise in `22.5°` steps; eight cells are packed into each row.
+- Idle row 0, column 6 is the fixed neutral frame used inside the pointer
+  deadzone and while the pointer is outside the host window.
+- `pet.json` must declare `"spriteVersionNumber": 2`.
+
+Hermes enables directional gaze only when both the manifest version and exact
+8×11 geometry validate. A malformed or mislabeled package safely falls back to
+the standard animation rows. The terminal renderer intentionally continues to
+use those state rows because a terminal surface has no pointer to follow.
 
 ## Configuration
 

--- a/website/docs/user-guide/features/pets.md
+++ b/website/docs/user-guide/features/pets.md
@@ -174,10 +174,11 @@ nine rows:
   deadzone and while the pointer is outside the host window.
 - `pet.json` must declare `"spriteVersionNumber": 2`.
 
-Hermes enables directional gaze only when both the manifest version and exact
-8×11 geometry validate. A malformed or mislabeled package safely falls back to
-the standard animation rows. The terminal renderer intentionally continues to
-use those state rows because a terminal surface has no pointer to follow.
+Hermes enables directional gaze only when the manifest version, exact 8×11
+geometry, neutral cell, and all 16 directional cells validate. A malformed,
+incomplete, or mislabeled package safely falls back to the standard animation
+rows. The terminal renderer intentionally continues to use those state rows
+because a terminal surface has no pointer to follow.
 
 ## Configuration
 


### PR DESCRIPTION
## What does this PR do?

Adds backward-compatible support for version 2 pet atlases in Hermes Desktop.

A v2 package keeps the existing nine animation rows and adds two rows containing 16 fixed gaze directions. Hermes now advertises that capability only when `pet.json` declares `spriteVersionNumber: 2` **and** the spritesheet is exactly 8×11 cells. While the desktop pet is idle it follows the pointer using those cells; agent activity and roaming retain priority. Legacy 8-row and standard 8×9 pets keep their existing behavior.

## Related Issue

No matching issue or PR was found after searching open and closed items for pet v2, sprite atlas, and directional-gaze terms.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Parse `spriteVersionNumber` from installed pet manifests with a fail-closed v1 fallback.
- Add `spriteVersionNumber` and content-validated `lookDirectionCount` to `pet.info` and `pet.info.meta`, including revision-keyed validation caching and payload invalidation.
- Map pointer vectors clockwise from north into the 16 v2 gaze cells across atlas rows 9–10.
- Use idle row 0, column 6 as the v2 neutral/deadzone frame, matching the generated v2 package contract.
- Enable gaze in both the in-window mascot and pop-out overlay while preserving activity, roam, and v1 behavior.
- Document the 8×11 v2 atlas contract and add Python/TypeScript regression coverage.

## How to Test

1. Run backend pet coverage:
   ```bash
   scripts/run_tests.sh tests/agent/test_pet_engine.py tests/tui_gateway/test_pet_generate_rpc.py -q
   ```
   Result: 44 passed.
2. Run desktop pet coverage and type checking:
   ```bash
   npm run test:ui --workspace apps/desktop -- src/components/pet/pet-look.test.ts src/components/pet/pet-sprite.test.tsx src/store/pet.test.ts
   npm run typecheck --workspace apps/desktop
   ```
   Result: 23 passed; typecheck passed.
3. Build the production desktop and documentation:
   ```bash
   npm run build --workspace apps/desktop
   cd website && npm run build
   ```
   Result: both builds passed. The docs build retained existing unrelated broken-link warnings.
4. Real-package compatibility was exercised against a generated Aegis v2 atlas (`1536×2288`, RGBA): the gateway reported v2/16-direction capability after validating the neutral plus all 16 look cells. Validation measured 47.8 ms cold and 0.03 ms from the revision cache.

Repository-wide diagnostic runs also surfaced failures outside this diff: the Python suite reached 95% before the 10-minute timeout with 37 failures in unrelated MCP/file-tool tests, and the blanket desktop Vitest invocation mixes Node `node:test` files into jsdom plus reports unrelated stale tests. All changed-area tests, changed-file lint, typecheck, and production builds pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — repository-wide diagnostics are documented above; changed-area tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — renderer uses standard browser pointer/canvas APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changes

## Screenshots / Logs

The regression tests assert the exact canvas source cells for neutral and directional gaze. No pet assets are included in this PR.
