### PR TITLE
fix(agent): parse vLLM/Qwen output-cap error that omits 'max_tokens' (#63161)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2978,6 +2978,35 @@ def run_conversation(
                 
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
+                # Enrich error_msg with body error message and OpenRouter
+                # metadata.raw so downstream parsers (output-cap parsing,
+                # context-limit extraction) can see the actual provider error
+                # even when the upstream is wrapped.  The classifier already
+                # does this internally (error_classifier.py lines ~585-595),
+                # but the conversation loop's local parsers also need the
+                # full text.  (#63161)
+                _err_body = getattr(api_error, "body", None) or {}
+                if isinstance(_err_body, dict):
+                    _err_obj = _err_body.get("error", {})
+                    if isinstance(_err_obj, dict):
+                        _body_msg = str(_err_obj.get("message") or "").lower()
+                        if _body_msg and _body_msg not in error_msg:
+                            error_msg += " " + _body_msg
+                        _metadata = _err_obj.get("metadata", {})
+                        if isinstance(_metadata, dict):
+                            _raw_json = _metadata.get("raw") or ""
+                            if isinstance(_raw_json, str) and _raw_json.strip():
+                                try:
+                                    import json
+                                    _inner = json.loads(_raw_json)
+                                    if isinstance(_inner, dict):
+                                        _inner_err = _inner.get("error", {})
+                                        if isinstance(_inner_err, dict):
+                                            _meta_msg = str(_inner_err.get("message") or "").lower()
+                                            if _meta_msg and _meta_msg not in error_msg:
+                                                error_msg += " " + _meta_msg
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
                 _error_summary = agent._summarize_api_error(api_error)
                 logger.warning(
                     "API call failed (attempt %s/%s) error_type=%s %s summary=%s",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1368,6 +1368,41 @@ def is_output_cap_error(error_msg: str) -> bool:
     """
     error_lower = error_msg.lower()
 
+    # vLLM / Qwen / OpenAI-compatible server style:
+    #   "This model's maximum context length is 262144 tokens. However, you
+    #    requested 65536 output tokens and your prompt contains at least 196609
+    #    input tokens, for a total of at least 262145 tokens."
+    # The input alone fits; input + max_tokens exceeds the window.  This is an
+    # output-cap error even though "max_tokens" is never mentioned.  Return
+    # True immediately so we skip the ``mentions_output_param`` gate below
+    # (which requires "max_tokens" / "max_output_tokens" /
+    # ``max_completion_tokens``) AND the ``input_overflow_signal`` guard that
+    # would otherwise reject the error because "prompt contains" / "reduce the
+    # length" appear in the vLLM message without indicating an actual input
+    # overflow.  (#63161)
+    if (
+        "maximum context length" in error_lower
+        and "requested" in error_lower
+        and "output tokens" in error_lower
+        and "prompt contains" in error_lower
+        and "input tokens" in error_lower
+    ):
+        # Guard: only classify as output-cap when the INPUT fits inside the
+        # window.  If the reported input alone >= context length, lowering
+        # max_tokens cannot help (the caller must compress or fail).
+        import re
+        _m_ctx = re.search(r'maximum context length is (\d+)', error_lower)
+        _m_inp = re.search(r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower)
+        if _m_ctx and _m_inp:
+            _ctx = int(_m_ctx.group(1))
+            _input_tok = int(_m_inp.group(1))
+            if _input_tok < _ctx:
+                return True
+        else:
+            # Can't parse numbers; err on the side of treating as output cap
+            # (stale but safer than routing to compression death-loop).
+            return True
+
     mentions_output_param = (
         "max_tokens" in error_lower
         or "max_output_tokens" in error_lower

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -121,6 +121,32 @@ class TestIsOutputCapError:
     def test_unrelated_error_is_not_output_cap(self):
         assert is_output_cap_error("some unrelated 400 error") is False
 
+    def test_vllm_qwen_format_is_output_cap_without_max_tokens(self):
+        # vLLM / Qwen format does not mention "max_tokens" but clearly
+        # describes an output-cap error: input fits, output exceeds window.
+        msg = ("This model's maximum context length is 262144 tokens. However, you "
+               "requested 65536 output tokens and your prompt contains at least 196609 "
+               "input tokens, for a total of at least 262145 tokens.")
+        assert is_output_cap_error(msg) is True
+
+    def test_vllm_qwen_format_with_http_prefix(self):
+        # Same format but with the HTTP 400: prefix and parameter suffix
+        # that appears when logged via _summarize_api_error.
+        msg = ("HTTP 400: This model's maximum context length is 262144 tokens. "
+               "However, you requested 65536 output tokens and your prompt contains "
+               "at least 196609 input tokens, for a total of at least 262145 tokens. "
+               "Please reduce the length of the input prompt or the number of "
+               "requested output tokens. (parameter=input_token")
+        assert is_output_cap_error(msg) is True
+
+    def test_vllm_input_overflow_is_not_output_cap(self):
+        # When the INPUT alone exceeds the window, it's NOT an output-cap
+        # error even if the format otherwise looks similar to vLLM/Qwen.
+        msg = ("This model's maximum context length is 131072 tokens. However, you "
+               "requested 1024 output tokens and your prompt contains at least "
+               "140000 input tokens, for a total of at least 141024 tokens.")
+        assert is_output_cap_error(msg) is False
+
 
 class TestParseVllmTokenBasedOutputCap:
     """vLLM reports both the window and the prompt in TOKENS.


### PR DESCRIPTION
Fixes #63161

**Problem:** The Qwen/Qwen3.6-35B-A3B model (via a compatible OpenAI endpoint) returns HTTP 400 with a context-length error that omits the literal string `max_tokens` entirely.  The existing `is_output_cap_error()` guard requires `max_tokens` (or `max_output_tokens`/`max_completion_tokens`) to be present, so this error falls through to the compression path — which retries with the same oversized `max_tokens`, gets the identical 400, and death-loops until it fails with "cannot compress further".

Additionally, the conversation loop's `error_msg` (used by the output-cap parser) is built from `str(api_error)`.  When an upstream proxy like OpenRouter wraps the provider error, `str(api_error)` may contain only the wrapper message ("Provider returned error") while the actual context-length text lives in the body's `metadata.raw` field — invisible to the parser.

**Fix (two-part):**

1. **`model_metadata.py` — `is_output_cap_error()`:** Add an early-return guard for the vLLM / Qwen / OpenAI-compatible error format that reports input + requested output > window without mentioning `max_tokens`.  Includes an input-vs-window check so genuine input overflows (input alone >= window) still route to compression instead of the output-cap path.

2. **`conversation_loop.py` — error_msg enrichment:** Extract the API response body's `error.message` and `metadata.raw` (OpenRouter's inner wrapper) and append them to `error_msg` before passing to downstream parsers.

**Testing:** Added three test cases to `test_output_cap_parsing.py`:
- vLLM/Qwen format (no max_tokens string) → `is_output_cap_error` returns `True`
- Same format with HTTP 400: prefix and parameter suffix → `is_output_cap_error` returns `True`
- Input-overflow variant (input alone >= window) → `is_output_cap_error` returns `False` (routes to compression)