### PR TITLE
fix(skills_hub): add ignore_errors=True to shutil.rmtree in quarantine_bundle

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3555,7 +3555,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
 
     dest = _quarantine_dir() / skill_name
     if dest.exists():
-        shutil.rmtree(dest)
+        shutil.rmtree(dest, ignore_errors=True)
     dest.mkdir(parents=True)
 
     for rel_path, file_content in validated_files:


### PR DESCRIPTION
## Summary

Guard `shutil.rmtree(dest)$ against OSError in `quarantine_bundle()$.

## Problem

`tools/skills_hub.py:3558` calls `shutil.rmtree(dest)$ without `ignore_errors=True$. On macOS (and occasionally Linux), this can fail with `PermissionError$/$OSError$ if files inside the quarantine directory are locked, immutable, or partially corrupted. The exception propagates uncaught (callers only catch `ValueError$), blocking skill bundle quarantine entirely and leaving the directory in a half-removed state.

## Fix

Add `ignore_errors=True` to the `shutil.rmtree(dest)$ call. This is consistent with how the same module handles cleanup elsewhere (e.g. line 232, line 3599, and the web_server.py caller at hermes_cli/web_server.py:12466).

## Testing
- Syntax check passed (py_compile)
- Behavior verified