### PR TITLE
fix(cli): hide duplicate reload aliases from autocomplete

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -50,6 +50,7 @@ class CommandDef:
     description: str                   # human-readable description
     category: str                      # "Session", "Configuration", etc.
     aliases: tuple[str, ...] = ()      # alternative names: ("bg",)
+    hidden_completion_aliases: tuple[str, ...] = ()  # accepted but omitted from autocomplete
     args_hint: str = ""                # argument placeholder: "<prompt>", "[name]"
     subcommands: tuple[str, ...] = ()  # tab-completable subcommands
     cli_only: bool = False             # only available in CLI
@@ -213,9 +214,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
-               aliases=("reload_mcp",)),
+               aliases=("reload_mcp",), hidden_completion_aliases=("reload_mcp",)),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
-               "Tools & Skills", aliases=("reload_skills",)),
+               "Tools & Skills", aliases=("reload_skills",),
+               hidden_completion_aliases=("reload_skills",)),
     CommandDef("browser", "Connect browser tools to your live Chromium-family browser via CDP", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status]",
                subcommands=("connect", "disconnect", "status")),
@@ -294,6 +296,13 @@ for _cmd in COMMAND_REGISTRY:
         COMMANDS[f"/{_cmd.name}"] = _build_description(_cmd)
         for _alias in _cmd.aliases:
             COMMANDS[f"/{_alias}"] = f"{_cmd.description} (alias for /{_cmd.name})"
+
+# Compatibility aliases stay executable but can be omitted from autocomplete
+# when listing them beside the canonical spelling would create visual duplicates.
+COMPLETION_COMMANDS: dict[str, str] = dict(COMMANDS)
+for _cmd in COMMAND_REGISTRY:
+    for _alias in _cmd.hidden_completion_aliases:
+        COMPLETION_COMMANDS.pop(f"/{_alias}", None)
 
 # Backwards-compatible categorized dict
 COMMANDS_BY_CATEGORY: dict[str, dict[str, str]] = {}
@@ -2002,7 +2011,7 @@ class SlashCommandCompleter(Completer):
 
         word = text[1:]
 
-        for cmd, desc in COMMANDS.items():
+        for cmd, desc in COMPLETION_COMMANDS.items():
             if not self._command_allowed(cmd):
                 continue
             cmd_name = cmd[1:]
@@ -2091,7 +2100,7 @@ class SlashCommandAutoSuggest(AutoSuggest):
         if len(parts) == 1 and not text.endswith(" "):
             # Still typing the command name: /upd → suggest "ate"
             word = text[1:].lower()
-            for cmd in COMMANDS:
+            for cmd in COMPLETION_COMMANDS:
                 if self._completer is not None and not self._completer._command_allowed(cmd):
                     continue
                 cmd_name = cmd[1:]  # strip leading /

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3327,6 +3327,30 @@ def test_complete_slash_drops_removed_provider_alias():
     assert any(item["text"] == "model" for item in resp_model["result"]["items"])
 
 
+def test_complete_slash_hides_underscore_reload_aliases_but_keeps_them_executable():
+    from hermes_cli.commands import resolve_command
+
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/reload"}}
+    )
+    assert resp is not None
+    result = resp.get("result")
+    assert isinstance(result, dict)
+    completion_texts = {item["text"].strip() for item in result["items"]}
+
+    assert "reload-mcp" in completion_texts
+    assert "reload-skills" in completion_texts
+    assert "reload_mcp" not in completion_texts
+    assert "reload_skills" not in completion_texts
+
+    reload_mcp = resolve_command("reload_mcp")
+    reload_skills = resolve_command("reload_skills")
+    assert reload_mcp is not None
+    assert reload_skills is not None
+    assert reload_mcp.name == "reload-mcp"
+    assert reload_skills.name == "reload-skills"
+
+
 def test_complete_slash_returns_plain_string_fields():
     # prompt_toolkit hands us FormattedText (a list subclass) for
     # display/display_meta; the TUI's CompletionItem contract is plain


### PR DESCRIPTION
## Summary

- keep `/reload_mcp` and `/reload_skills` executable for backward compatibility
- omit those underscore-only compatibility aliases from slash autocomplete
- show only canonical `/reload-mcp` and `/reload-skills` entries in the completion menu

## Motivation

The underscore aliases are displayed immediately beside their canonical hyphenated commands, producing duplicate-looking rows in the TUI completion menu without adding discovery value.

## Tests

```text
490 passed in 15.65s
```

Relevant suites:

- `tests/hermes_cli/test_commands.py`
- `tests/test_tui_gateway_server.py`
