### PR TITLE
fix(runtime-provider): append /v1 to bare custom chat_completions URLs

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -133,6 +133,40 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _append_v1_if_needed(base_url: str, api_mode: str) -> str:
+    """Append /v1 to a custom OpenAI-compatible base URL when needed.
+
+    The OpenAI SDK constructs request URLs by appending the operation path
+    (e.g. /chat/completions) directly to base_url. When a user configures
+    a provider like https://api.x.ai (without /v1), the SDK produces
+    https://api.x.ai/chat/completions instead of the correct
+    https://api.x.ai/v1/chat/completions, resulting in a 404.
+
+    Only append /v1 when:
+    - api_mode is chat_completions (the only mode that uses /v1)
+    - the URL does not already end with a path version segment
+      (/v1, /v2, /v3, /v4) or a provider-specific path (/anthropic,
+      /api/v1, /backend-api/codex) that must be left intact.
+
+    This is intentionally conservative: Codex (chatgpt.com/backend-api/codex),
+    Anthropic native (anthropic_messages mode), and already-versioned URLs
+    are all excluded so we never corrupt a working endpoint.
+    """
+    if api_mode != "chat_completions":
+        return base_url
+
+    from urllib.parse import urlparse
+    path = urlparse(base_url).path.rstrip("/").lower()
+
+    # Already versioned or provider-specific -- leave intact.
+    _NO_V1_SUFFIXES = ("/v1", "/v2", "/v3", "/v4", "/anthropic", "/api/v1",
+                       "/backend-api/codex", "/v1beta")
+    if any(path.endswith(s) for s in _NO_V1_SUFFIXES):
+        return base_url
+
+    return base_url.rstrip("/") + "/v1"
+
+
 def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> str:
     """Resolve api_mode for legacy/plain ``provider: custom`` endpoints.
 
@@ -1169,13 +1203,24 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
-    return {
-        "provider": effective_provider,
-        "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
+    resolved_api_mode = (
+        _resolve_plain_custom_api_mode(model_cfg, base_url)
         if effective_provider == "custom"
         else _parse_api_mode(model_cfg.get("api_mode"))
         or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        or "chat_completions"
+    )
+    # Append /v1 to bare custom chat_completions URLs.  The OpenAI SDK
+    # constructs /chat/completions from base_url directly; without /v1 the
+    # request lands at /chat/completions instead of /v1/chat/completions,
+    # returning a 404 (issue #4600).  Only applies to custom providers in
+    # chat_completions mode with unversioned paths; Codex, Anthropic, and
+    # already-versioned URLs are excluded.
+    if effective_provider == "custom":
+        base_url = _append_v1_if_needed(base_url, resolved_api_mode)
+    return {
+        "provider": effective_provider,
+        "api_mode": resolved_api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3375,3 +3375,55 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+# ---------------------------------------------------------------------------
+# _append_v1_if_needed unit tests (issue #4600)
+# ---------------------------------------------------------------------------
+
+class TestAppendV1IfNeeded:
+    """Unit tests for the /v1 suffix normalizer -- covers every combination
+    the resolver boundary can produce (issue #4600).
+    """
+
+    def _call(self, url, mode):
+        from hermes_cli.runtime_provider import _append_v1_if_needed
+        return _append_v1_if_needed(url, mode)
+
+    def test_bare_custom_url_gets_v1(self):
+        """http://localhost:11434 → http://localhost:11434/v1 in chat_completions."""
+        assert self._call("http://localhost:11434", "chat_completions") == "http://localhost:11434/v1"
+
+    def test_bare_xai_url_gets_v1(self):
+        assert self._call("https://api.x.ai", "chat_completions") == "https://api.x.ai/v1"
+
+    def test_already_versioned_url_unchanged(self):
+        """https://api.example.com/v1 must not become /v1/v1."""
+        url = "https://api.example.com/v1"
+        assert self._call(url, "chat_completions") == url
+
+    def test_codex_endpoint_unchanged(self):
+        """https://chatgpt.com/backend-api/codex must not get /v1 appended."""
+        url = "https://chatgpt.com/backend-api/codex"
+        assert self._call(url, "chat_completions") == url
+
+    def test_anthropic_mode_unchanged(self):
+        """anthropic_messages mode must never trigger /v1 append."""
+        url = "https://api.anthropic.com"
+        assert self._call(url, "anthropic_messages") == url
+
+    def test_codex_responses_mode_unchanged(self):
+        """codex_responses mode is a non-/v1 path -- must not be touched."""
+        url = "https://api.openai.com"
+        assert self._call(url, "codex_responses") == url
+
+    def test_anthropic_suffix_proxy_unchanged(self):
+        """/anthropic path suffixes mark native Anthropic protocol -- leave intact."""
+        url = "https://proxy.example.com/anthropic"
+        assert self._call(url, "chat_completions") == url
+
+    def test_trailing_slash_stripped_before_append(self):
+        """Trailing slash on input must not produce double-slash."""
+        result = self._call("http://localhost:11434/", "chat_completions")
+        assert result == "http://localhost:11434/v1"
+        assert "//" not in result.split("://", 1)[1]


### PR DESCRIPTION
## Problem

The OpenAI SDK constructs request URLs by appending the operation path directly to base_url. A bare URL like https://api.x.ai or http://localhost:11434 (without /v1) produces /chat/completions instead of /v1/chat/completions, returning a 404 (issue #4600).

## Fix

Add _append_v1_if_needed() at the resolver boundary in resolve_runtime() after effective provider, api_mode, and base_url are all finalized.

Scope (conservative): only custom provider + chat_completions mode. Already-versioned paths, /anthropic, /backend-api/codex (Codex), and non-chat_completions modes (anthropic_messages, codex_responses) are all explicitly excluded.

## Verification

8 unit tests in TestAppendV1IfNeeded: bare local/xAI URL gets /v1, already-versioned unchanged, Codex unchanged, anthropic_messages unchanged, codex_responses unchanged, /anthropic suffix unchanged, trailing slash handled. 157/157 tests pass (149 existing + 8 new).

Fixes #4600