### PR TITLE
fix(qqbot): allow dm chat_type in approval interaction auth check

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in ("c2c", "dm"):
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2254,3 +2254,87 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+# ---------------------------------------------------------------------------
+# _is_authorized_interaction_for_session — approval button auth check
+# ---------------------------------------------------------------------------
+
+class TestAuthorizedInteractionForSession:
+    """Verify approval button interaction authorization accepts both
+    'c2c' and 'dm' as private-chat chat types (fix #63232)."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def _make_event(self, user_openid: str = "", group_member_openid: str = "", group_openid: str = "", guild_id: str = ""):
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+        return InteractionEvent(
+            id="evt_1",
+            scene="c2c",
+            button_data="approve:agent:main:qqbot:c2c:user123:once",
+            user_openid=user_openid,
+            group_member_openid=group_member_openid,
+            group_openid=group_openid,
+            guild_id=guild_id,
+        )
+
+    # --- c2c chat_type ---
+
+    def test_c2c_operator_matches(self):
+        adapter = self._make_adapter()
+        event = self._make_event(user_openid="user123")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:c2c:user123"
+        ) is True
+
+    def test_c2c_operator_mismatch(self):
+        adapter = self._make_adapter()
+        event = self._make_event(user_openid="attacker")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:c2c:user123"
+        ) is False
+
+    # --- dm chat_type (C2C mapped to dm) ---
+
+    def test_dm_operator_matches(self):
+        """'dm' chat_type should be accepted — C2C messages are dispatched
+        with chat_type='dm' in the session key."""
+        adapter = self._make_adapter()
+        event = self._make_event(user_openid="user123")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:dm:user123"
+        ) is True
+
+    def test_dm_operator_mismatch(self):
+        adapter = self._make_adapter()
+        event = self._make_event(user_openid="attacker")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:dm:user123"
+        ) is False
+
+    # --- group chat_type ---
+
+    def test_group_matches_both_ids(self):
+        adapter = self._make_adapter()
+        event = self._make_event(group_member_openid="member1", group_openid="grp1")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:group:grp1:member1"
+        ) is True
+
+    def test_group_mismatch_user(self):
+        adapter = self._make_adapter()
+        event = self._make_event(group_member_openid="other_user", group_openid="grp1")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:group:grp1:member1"
+        ) is False
+
+    # --- malformed session key ---
+
+    def test_malformed_key_returns_false(self):
+        adapter = self._make_adapter()
+        event = self._make_event(user_openid="user123")
+        assert adapter._is_authorized_interaction_for_session(
+            event, "invalid_key"
+        ) is False


### PR DESCRIPTION
## What does this PR do?

C2C (private chat) messages from QQ are dispatched with `chat_type="dm"` in the session key (see `_handle_c2c_message` → `build_source(chat_type="dm")` at line 1296), but the approval interaction authorization check in `_is_authorized_interaction_for_session` only accepted `chat_type == "c2c"`.

This meant that when a user in a QQ C2C conversation clicked an approval button (allow-once / allow-always / deny), the interaction was always rejected because `"dm" != "c2c"`. The agent thread would remain blocked on the approval, effectively breaking the entire command approval flow for QQ private chats.

## Related Issue

No existing issue — discovered during local usage of the QQ Bot adapter.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py:1103` — Changed `if chat_type == "c2c":` to `if chat_type in ("c2c", "dm"):` in `_is_authorized_interaction_for_session`

## How to Test

1. Set up a QQ Bot with `dm_policy: pairing` (default)
2. Send a C2C private message to the bot that triggers a dangerous command approval
3. Click the "allow-once" approval button in the QQ inline keyboard response
4. **Before:** button rejected with "unauthorized approval click", agent stays blocked
5. **After:** button accepted, approval resolved, agent continues

## How This Was Tested

```
python -m pytest tests/gateway/test_qqbot.py -q --tb=short
173 passed in 4.07s
```

Added 7 new test cases in `TestAuthorizedInteractionForSession` covering c2c match/mismatch, dm match/mismatch, group match/mismatch, and malformed session key.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/ -q` and all tests pass — 173 passed in QQ adapter tests
- [x] I have added tests for my changes — 7 new test cases
- [x] I have tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] No documentation update needed
- [x] No config keys changed
- [x] No architecture or workflow changes
- [x] Cross-platform: QQ Bot adapter is Linux/macOS only; no Windows impact
- [x] No tool behavior changes

## Screenshots / Logs

**Before fix log:**
```
[QQBot:xxxx] Rejected unauthorized approval click for session agent:main:qqbot:dm:USER_OPENID (operator=USER_OPENID)
```

**After fix:** The `"dm"` in the session key is accepted by `if chat_type in ("c2c", "dm"):` so the button click resolves the approval normally.
