### PR TITLE
feat(security): opt-in allow agent file-tool writes to config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2631,6 +2631,12 @@ DEFAULT_CONFIG = {
         # for restricted networks, audited environments, or air-gapped
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
+        # When false (default), write_file/patch hard-deny writes to the
+        # active Hermes config.yaml so a prompt-injected agent cannot flip
+        # approvals.mode or related security settings. Set true if you want
+        # the agent to edit config.yaml via file tools (terminal can still
+        # reach it under approvals.mode=smart/off either way).
+        "allow_agent_config_writes": False,
     },
 
     "cron": {

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,8 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -594,40 +596,69 @@ class TestSensitivePathCheck:
     """Verify that _check_sensitive_path blocks writes to protected locations."""
 
     def test_hermes_config_blocked_for_write_file(self, tmp_path, monkeypatch):
-        fake_config = tmp_path / "config.yaml"
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        # Avoid macOS /private/var temp roots — those match _SENSITIVE_PATH_PREFIXES
+        # before the Hermes-config check runs.
+        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_block_{os.getpid()}.yaml"
+        fake_config.write_text("")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
 
         from tools.file_tools import write_file_tool
-        result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
+        try:
+            result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
+            assert "error" in result
+            assert "Hermes config" in result["error"]
+        finally:
+            fake_config.unlink(missing_ok=True)
 
     def test_hermes_config_blocked_via_tilde_path(self, tmp_path, monkeypatch):
-        fake_config = tmp_path / "config.yaml"
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_tilde_{os.getpid()}.yaml"
+        fake_config.write_text("")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
 
         from tools.file_tools import write_file_tool
-        result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
+        try:
+            result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
+            assert "error" in result
+            assert "Hermes config" in result["error"]
+        finally:
+            fake_config.unlink(missing_ok=True)
 
     def test_hermes_config_blocked_for_patch(self, tmp_path, monkeypatch):
-        fake_config = tmp_path / "config.yaml"
+        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_patch_{os.getpid()}.yaml"
         fake_config.write_text("approvals:\n  mode: manual\n")
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
 
         from tools.file_tools import patch_tool
-        result = json.loads(patch_tool(
-            mode="replace",
-            path=str(fake_config),
-            old_string="mode: manual",
-            new_string="mode: off",
-        ))
-        assert "error" in result
-        assert "Hermes config" in result["error"]
+        try:
+            result = json.loads(patch_tool(
+                mode="replace",
+                path=str(fake_config),
+                old_string="mode: manual",
+                new_string="mode: off",
+            ))
+            assert "error" in result
+            assert "Hermes config" in result["error"]
+        finally:
+            fake_config.unlink(missing_ok=True)
+
+    def test_hermes_config_allowed_when_opted_in(self, tmp_path, monkeypatch):
+        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_allow_{os.getpid()}.yaml"
+        fake_config.write_text("approvals:\n  mode: manual\n")
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: True)
+
+        from tools.file_tools import _check_sensitive_path
+        try:
+            assert _check_sensitive_path(str(fake_config)) is None
+        finally:
+            fake_config.unlink(missing_ok=True)
 
     def test_system_path_still_blocked(self, monkeypatch):
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/some/other/path")

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -7,8 +7,13 @@ handling without requiring a running terminal environment.
 import json
 import logging
 import os
+import shutil
+import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tools.file_tools import (
     PATCH_SCHEMA,
@@ -592,73 +597,98 @@ class TestSearchHints:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def hermes_config_env(monkeypatch):
+    """Isolated Hermes home whose config.yaml survives _check_sensitive_path.
+
+    pytest's tmp_path lives under /private/var on macOS, which matches
+    _SENSITIVE_PATH_PREFIXES before the Hermes-config check runs, so the fake
+    home is allocated under /tmp (/private/tmp once resolved — not a sensitive
+    prefix) instead. Never touches the real ~/.hermes (AGENTS.md forbids tests
+    writing there). Yields the active config.yaml path; the config resolver
+    cache is reset so it re-derives from this fixture's HERMES_HOME.
+    """
+    root = Path(tempfile.mkdtemp(
+        prefix="hermes_cfg_test_",
+        dir="/tmp" if sys.platform != "win32" else None,
+    ))
+    hermes_home = root / ".hermes"
+    hermes_home.mkdir()
+    config = hermes_home / "config.yaml"
+    config.write_text("approvals:\n  mode: manual\n")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("tools.file_tools._hermes_config_resolved", None)
+    monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", False)
+    yield config
+    shutil.rmtree(root, ignore_errors=True)
+
+
 class TestSensitivePathCheck:
-    """Verify that _check_sensitive_path blocks writes to protected locations."""
+    """Verify that _check_sensitive_path blocks writes to protected locations.
 
-    def test_hermes_config_blocked_for_write_file(self, tmp_path, monkeypatch):
-        # Avoid macOS /private/var temp roots — those match _SENSITIVE_PATH_PREFIXES
-        # before the Hermes-config check runs.
-        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_block_{os.getpid()}.yaml"
-        fake_config.write_text("")
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
-        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
+    The Hermes-config cases run end to end through write_file_tool/patch_tool
+    and the real load_config() gate — no patching of
+    _agent_config_writes_allowed — so both the default hard deny and the
+    security.allow_agent_config_writes opt-in exercise the production path.
+    """
+
+    def test_hermes_config_blocked_for_write_file(self, hermes_config_env):
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(str(hermes_config_env), "approvals:\n  mode: off\n"))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        assert hermes_config_env.read_text() == "approvals:\n  mode: manual\n"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="tilde expansion uses POSIX HOME")
+    def test_hermes_config_blocked_via_tilde_path(self, hermes_config_env, monkeypatch):
+        monkeypatch.setenv("HOME", str(hermes_config_env.parent.parent))
 
         from tools.file_tools import write_file_tool
-        try:
-            result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-            assert "error" in result
-            assert "Hermes config" in result["error"]
-        finally:
-            fake_config.unlink(missing_ok=True)
+        result = json.loads(write_file_tool("~/.hermes/config.yaml", "approvals:\n  mode: off\n"))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        assert hermes_config_env.read_text() == "approvals:\n  mode: manual\n"
 
-    def test_hermes_config_blocked_via_tilde_path(self, tmp_path, monkeypatch):
-        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_tilde_{os.getpid()}.yaml"
-        fake_config.write_text("")
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
-        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
+    def test_hermes_config_blocked_for_patch(self, hermes_config_env):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace",
+            path=str(hermes_config_env),
+            old_string="mode: manual",
+            new_string="mode: off",
+        ))
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        assert hermes_config_env.read_text() == "approvals:\n  mode: manual\n"
+
+    def test_hermes_config_write_allowed_when_opted_in(self, hermes_config_env):
+        hermes_config_env.write_text(
+            "security:\n  allow_agent_config_writes: true\napprovals:\n  mode: manual\n"
+        )
 
         from tools.file_tools import write_file_tool
-        try:
-            result = json.loads(write_file_tool(str(fake_config), "approvals:\n  mode: off\n"))
-            assert "error" in result
-            assert "Hermes config" in result["error"]
-        finally:
-            fake_config.unlink(missing_ok=True)
+        new_content = (
+            "security:\n  allow_agent_config_writes: true\n"
+            "approvals:\n  mode: manual\nmoa:\n  preset: fast\n"
+        )
+        result = json.loads(write_file_tool(str(hermes_config_env), new_content))
+        assert "error" not in result
+        assert "moa" in hermes_config_env.read_text()
 
-    def test_hermes_config_blocked_for_patch(self, tmp_path, monkeypatch):
-        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_patch_{os.getpid()}.yaml"
-        fake_config.write_text("approvals:\n  mode: manual\n")
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
-        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: False)
+    def test_hermes_config_patch_allowed_when_opted_in(self, hermes_config_env):
+        hermes_config_env.write_text(
+            "security:\n  allow_agent_config_writes: true\napprovals:\n  mode: manual\n"
+        )
 
         from tools.file_tools import patch_tool
-        try:
-            result = json.loads(patch_tool(
-                mode="replace",
-                path=str(fake_config),
-                old_string="mode: manual",
-                new_string="mode: off",
-            ))
-            assert "error" in result
-            assert "Hermes config" in result["error"]
-        finally:
-            fake_config.unlink(missing_ok=True)
-
-    def test_hermes_config_allowed_when_opted_in(self, tmp_path, monkeypatch):
-        fake_config = Path.home() / ".hermes" / f"_pytest_cfg_allow_{os.getpid()}.yaml"
-        fake_config.write_text("approvals:\n  mode: manual\n")
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config.resolve()))
-        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
-        monkeypatch.setattr("tools.file_tools._agent_config_writes_allowed", lambda: True)
-
-        from tools.file_tools import _check_sensitive_path
-        try:
-            assert _check_sensitive_path(str(fake_config)) is None
-        finally:
-            fake_config.unlink(missing_ok=True)
+        result = json.loads(patch_tool(
+            mode="replace",
+            path=str(hermes_config_env),
+            old_string="mode: manual",
+            new_string="mode: readonly",
+        ))
+        assert "error" not in result
+        assert "mode: readonly" in hermes_config_env.read_text()
 
     def test_system_path_still_blocked(self, monkeypatch):
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/some/other/path")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -659,6 +659,24 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _agent_config_writes_allowed() -> bool:
+    """Return True when the operator has opted into agent config.yaml writes.
+
+    Default is False: a prompt-injected agent could otherwise flip
+    ``approvals.mode`` (or similar) by writing config.yaml through the file
+    tools. Operators who run Hermes as a trusted co-pilot can set
+    ``security.allow_agent_config_writes: true`` to lift that hard deny.
+    System paths and ``~/.hermes/.env`` remain protected regardless.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        return bool((cfg.get("security") or {}).get("allow_agent_config_writes", False))
+    except Exception:
+        return False
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -675,16 +693,20 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
-    # Prevent agents from modifying the Hermes config file directly.
-    # approvals.mode and other security settings live here; a malicious or
-    # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # Prevent agents from modifying the Hermes config file directly unless the
+    # operator has opted in. approvals.mode and other security settings live
+    # here; a malicious or prompt-injected agent could silently disable exec
+    # approval by writing to this file when the hard deny is active.
     hermes_config = _get_hermes_config_resolved()
     if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+        if _agent_config_writes_allowed():
+            return None
         return (
             f"Refusing to write to Hermes config file: {filepath}\n"
             "Agent cannot modify security-sensitive configuration. "
-            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+            "Edit ~/.hermes/config.yaml directly, use 'hermes config', "
+            "or set security.allow_agent_config_writes: true to allow "
+            "agent file-tool writes."
         )
     return None
 


### PR DESCRIPTION
## Summary

- Add `security.allow_agent_config_writes` (default `false`) so operators can opt into `write_file`/`patch` on the active Hermes `config.yaml`.
- Keep the hard deny as the default: a prompt-injected agent could otherwise flip `approvals.mode` or related security settings mid-session.
- Leave system-path protections and `~/.hermes/.env` coverage unchanged. Terminal still routes config edits through the approvals gate.

This is useful for trusted co-pilot setups where agents regularly edit nested config (e.g. MoA presets) without shelling out.

## Usage

```yaml
security:
  allow_agent_config_writes: true
```

Or:

```bash
hermes config set security.allow_agent_config_writes true
```

## Test plan

- [x] `pytest tests/tools/test_file_tools.py::TestSensitivePathCheck` (6 passed)
- [x] Default deny still blocks config writes when the flag is false
- [x] Flag true allows `_check_sensitive_path` for the active config path
- [x] `/etc` (and other system paths) remain blocked
- [x] macOS pytest tmp under `/private/var` no longer false-fires the hermes-config tests (paths moved under `~/.hermes/_pytest_cfg_*`)