### PR TITLE
fix(gateway): make Slack platform note capability-aware when slack tools present

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -301,6 +301,31 @@ that requires raw IDs).  Discord is excluded because mentions use ``<@user_id>``
 and the LLM needs the real ID to tag users."""
 
 
+def _slack_tools_loaded() -> bool:
+    """True iff the agent will actually have Slack tools this session.
+
+    Two conditions must hold:
+      1. The `slack` toolset is enabled for the Slack platform via
+         `hermes tools` (opt-in, default OFF).
+      2. `SLACK_BOT_TOKEN` is set — the tool check_fn gates on it at
+         registry time, so the toolset being enabled in config is not
+         enough if the token is missing.
+
+    Returns False (safe default — keeps the stale-API disclaimer) on any
+    error so a bad config can never silently promise tools the agent lacks.
+    """
+    if not (os.environ.get("SLACK_BOT_TOKEN") or "").strip():
+        return False
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = load_config()
+        enabled = _get_platform_tools(cfg, "slack", include_default_mcp_servers=False)
+        return "slack" in enabled
+    except Exception:
+        return False
+
+
 def _discord_tools_loaded() -> bool:
     """True iff the agent will actually have Discord tools this session.
 
@@ -454,15 +479,29 @@ def build_session_context_prompt(
 
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
-        lines.append("")
-        lines.append(
-            "**Platform notes:** You are running inside Slack. "
-            "You do NOT have access to Slack-specific APIs — you cannot search "
-            "channel history, pin/unpin messages, manage channels, or list users. "
-            "Do not promise to perform these actions. The gateway may inline the "
-            "current message's Slack block/attachment payload when available, but "
-            "you still cannot call Slack APIs yourself."
-        )
+        # Inject Slack capability note only when the agent actually has
+        # Slack tools loaded this session — i.e. the user opted into
+        # `slack` via `hermes tools` AND SLACK_BOT_TOKEN is configured.
+        # Otherwise keep the stale-API disclaimer honest so we never
+        # promise tools the agent lacks.  Mirrors the Discord pattern.
+        if _slack_tools_loaded():
+            lines.append("")
+            lines.append(
+                "**Platform notes:** You are running inside Slack and have access "
+                "to Slack-specific tools. You CAN search channel history, post "
+                "messages, react to messages, and perform other Slack operations "
+                "via the `slack` toolset."
+            )
+        else:
+            lines.append("")
+            lines.append(
+                "**Platform notes:** You are running inside Slack. "
+                "You do NOT have access to Slack-specific APIs — you cannot search "
+                "channel history, pin/unpin messages, manage channels, or list users. "
+                "Do not promise to perform these actions. The gateway may inline the "
+                "current message's Slack block/attachment payload when available, but "
+                "you still cannot call Slack APIs yourself."
+            )
     elif context.source.platform == Platform.DISCORD:
         # Inject the Discord IDs block only when the agent actually has
         # Discord tools loaded this session — i.e. the user opted into

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -277,7 +277,9 @@ class TestBuildSessionContextPrompt:
         # Static pointer tells the agent where the volatile id actually lives.
         assert "provided per-turn in the incoming user message" in p1
 
-    def test_slack_prompt_includes_platform_notes(self):
+    def test_slack_prompt_no_tools_shows_disclaimer(self):
+        """Without slack toolset loaded, prompt must show the stale-API disclaimer."""
+        from unittest.mock import patch
         config = GatewayConfig(
             platforms={
                 Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
@@ -291,7 +293,59 @@ class TestBuildSessionContextPrompt:
             user_name="bob",
         )
         ctx = build_session_context(source, config)
-        prompt = build_session_context_prompt(ctx)
+        with patch("gateway.session._slack_tools_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+
+        assert "Slack" in prompt
+        assert "cannot search" in prompt.lower()
+        assert "pin" in prompt.lower()
+        assert "current message's slack block/attachment payload" in prompt.lower()
+        # Must NOT claim API access when tools are absent.
+        assert "you can" not in prompt.lower() or "you cannot" in prompt.lower()
+
+    def test_slack_prompt_with_tools_shows_capability(self):
+        """When slack toolset is loaded, prompt must advertise API access."""
+        from unittest.mock import patch
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="general",
+            chat_type="group",
+            user_name="bob",
+        )
+        ctx = build_session_context(source, config)
+        with patch("gateway.session._slack_tools_loaded", return_value=True):
+            prompt = build_session_context_prompt(ctx)
+
+        assert "Slack" in prompt
+        # Must advertise capability when tools ARE present.
+        assert "have access" in prompt.lower() or "you can" in prompt.lower()
+        # Must NOT show the stale-API disclaimer when tools are present.
+        assert "you do not have access" not in prompt.lower()
+
+    def test_slack_prompt_includes_platform_notes(self):
+        """Legacy: backward-compat alias -- no tools loaded shows disclaimer."""
+        from unittest.mock import patch
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="general",
+            chat_type="group",
+            user_name="bob",
+        )
+        ctx = build_session_context(source, config)
+        with patch("gateway.session._slack_tools_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
 
         assert "Slack" in prompt
         assert "cannot search" in prompt.lower()


### PR DESCRIPTION
## Problem

gateway/session.py hard-coded the stale-API disclaimer for every Slack session regardless of whether the slack toolset was actually loaded. This contradicted the system prompt when MCP or slack tools were present, causing the agent to refuse Slack API actions it could perform.

## Fix

Add _slack_tools_loaded() (mirrors existing _discord_tools_loaded()) that checks both SLACK_BOT_TOKEN and the platform toolset config. When the toolset is active, the prompt advertises Slack API access; when absent (or on config error), the safe stale-API disclaimer is kept.

Capability decisions are based on the session actual tool availability, not the global process-wide registry (which was the problem with the earlier PR approach using get_all_tool_names()).

## Verification

3 Slack-specific tests: test_slack_prompt_no_tools_shows_disclaimer, test_slack_prompt_with_tools_shows_capability, and updated test_slack_prompt_includes_platform_notes (mocked for determinism). 99 pass, 3 pre-existing errors in TestSenderPrefixWithBackfill unrelated to this change (also present on upstream/main).

Fixes #6536