### PR TITLE
fix(file-safety): return POSIX inner_path from classify_sandbox_mirro…

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -542,7 +542,15 @@ def classify_sandbox_mirror_target(path: str) -> Optional[dict]:
         return None
 
     mirror_root = str(Path(*parts[: inner_idx + 1]))
-    inner_path = str(Path(*parts[inner_idx + 1 :])) if inner_idx + 1 < len(parts) else ""
+    # ``inner_path`` is a logical HERMES_HOME-relative identifier surfaced to the
+    # model ("the authoritative file is likely <inner_path>"), not an on-disk
+    # path, so emit it POSIX-style. ``str(Path(...))`` leaks OS-native separators
+    # (``profiles\group1\SOUL.md`` on Windows), which diverges from the
+    # ``classify_container_mirror_target`` sibling below (already ``.as_posix()``)
+    # and mangles the hint. ``mirror_root`` stays native — it names a real host dir.
+    inner_path = (
+        Path(*parts[inner_idx + 1 :]).as_posix() if inner_idx + 1 < len(parts) else ""
+    )
 
     return {
         "target_path": str(target),

--- a/tests/agent/test_file_safety_sandbox_mirror.py
+++ b/tests/agent/test_file_safety_sandbox_mirror.py
@@ -41,7 +41,7 @@ class TestClassifySandboxMirrorTarget:
         result = classify_sandbox_mirror_target(str(target))
         assert result is not None
         assert result["target_path"] == str(target.resolve())
-        assert result["mirror_root"].endswith(
+        assert result["mirror_root"].replace("\\", "/").endswith(
             "sandboxes/docker/default/home/.hermes"
         )
         assert result["inner_path"] == "profiles/group1/SOUL.md"
@@ -70,6 +70,29 @@ class TestClassifySandboxMirrorTarget:
         assert result is not None
         assert result["inner_path"] == inner
         assert backend in result["mirror_root"]
+
+    def test_inner_path_uses_posix_separators(self, tmp_path):
+        """``inner_path`` is a logical HERMES_HOME-relative identifier (surfaced
+        to the model as "the authoritative file is likely <inner_path>"), not an
+        on-disk path, so it must be POSIX-style on every platform — matching the
+        ``classify_container_mirror_target`` sibling. Regression guard: on Windows
+        ``str(Path(...))`` leaked native separators (``profiles\\group1\\...``),
+        diverging from the sibling and mangling the hint.
+        """
+        from agent.file_safety import classify_sandbox_mirror_target
+
+        target = (
+            tmp_path
+            / "sandboxes" / "docker" / "task-1" / "home" / ".hermes"
+            / "profiles" / "group1" / "memories" / "MEMORY.md"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text("x")
+
+        result = classify_sandbox_mirror_target(str(target))
+        assert result is not None
+        assert result["inner_path"] == "profiles/group1/memories/MEMORY.md"
+        assert "\\" not in result["inner_path"]
 
     def test_path_outside_sandbox_returns_none(self, tmp_path):
         """A plain Hermes path is not a mirror."""
@@ -168,7 +191,10 @@ class TestGetSandboxMirrorWarning:
         warn = get_sandbox_mirror_warning(str(target))
         assert warn is not None
         # Must name the mirror root so the user can locate the sandbox.
-        assert "sandboxes/docker/default/home/.hermes" in warn
+        # ``mirror_root`` is a native host path (backslashes on Windows), so
+        # normalize separators before the substring check — same pattern the
+        # container-mirror tests use. ``inner_path`` below stays POSIX-exact.
+        assert "sandboxes/docker/default/home/.hermes" in warn.replace("\\", "/")
         # Must hint at what the agent likely meant.
         assert "profiles/group1/SOUL.md" in warn
         # Must name the bypass kwarg shared with the cross-profile guard.


### PR DESCRIPTION
…r_target on Windows

classify_sandbox_mirror_target built inner_path with str(Path(*parts)), which emits OS-native separators — "profiles\group1\SOUL.md" on Windows. inner_path is a logical HERMES_HOME-relative identifier surfaced to the model ("the authoritative file is likely <inner_path>"), not an on-disk path, and its classify_container_mirror_target sibling already builds it with .as_posix(). Emit it POSIX-style so the two mirror classifiers agree and the hint stays canonical on every platform. mirror_root stays native (str) — it names a real host dir for display, matching the sibling.

tests: the sandbox-mirror suite already encodes the POSIX inner_path contract but only ran green on POSIX CI (the project's CI is Linux-only); on native Windows five cases failed. Normalize the two mirror_root assertions the same way the container-mirror tests already do, and add a regression guard that inner_path never contains a native separator.

Assisted-by: Claude Code (Opus 4.8)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

