### PR TITLE
feat(security): add DANGEROUS_PATTERNS for Bitwarden CLI credential access

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -572,6 +572,17 @@ DANGEROUS_PATTERNS = [
     # *next* line to satisfy the negative lookahead, silently allowing DELETE without WHERE.
     (r'\bDELETE\s+FROM\b(?![^\n]*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
+    # Bitwarden CLI — credential exposure via terminal. Covers both BSM
+    # (`bws secret get`) and Password Manager (`bw get`, `bw list`,
+    # `bw export`, `bw sync`). These are dangerous because they return
+    # plaintext secrets to the model's context — attacker-controlled or
+    # prompt-injected commands can silently exfiltrate all vault contents.
+    # The `bws secret list` variant is excluded: it lists secret *names*
+    # without values, which is the reference the existing `get_secret()`
+    # provider needs.  `bw` (Password Manager) has no analogous split.
+    (r'\bbws\s+secret\s+get\b', "Bitwarden BSM — read secret value (credential exposure)"),
+    (r'\bbw\s+get\b', "Bitwarden vault — read credential (credential exposure)"),
+    (r'\bbw\s+(list|export|sync)\b', "Bitwarden vault — list/export/sync (credential exposure)"),
     (rf'>\s*{_SYSTEM_CONFIG_PATH}', "overwrite system config"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -396,7 +396,7 @@ class BaseEnvironment(ABC):
         _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
+            f"export -p | grep -vE '^(declare -x (BWS_ACCESS_TOKEN|BW_SESSION|HERMES_MAIL|AMP_OUTLOOK|HERMES_EMAIL|BINANCE|COINBASE|COINPAYMENTS|DEVIANTART|GUMROAD|KOFI|PAYHIP|INSTAGRAM|REDDIT|TUTA|GODADDY|SISAL|XAMIG|DEGIRO|BUTTONDOWN|HUNTER|CAPSOLVER|CAMOFOX|DEEPSEEK|OPENCODE|OPENAI|GITHUB|HUGGINGFACE))' > {_snap_tmp}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -513,7 +513,7 @@ class BaseEnvironment(ABC):
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
+                f"{{ export -p | grep -vE '^(declare -x (BWS_ACCESS_TOKEN|BW_SESSION|HERMES_MAIL|AMP_OUTLOOK|HERMES_EMAIL|BINANCE|COINBASE|COINPAYMENTS|DEVIANTART|GUMROAD|KOFI|PAYHIP|INSTAGRAM|REDDIT|TUTA|GODADDY|SISAL|XAMIG|DEGIRO|BUTTONDOWN|HUNTER|CAPSOLVER|CAMOFOX|DEEPSEEK|OPENCODE|OPENAI|GITHUB|HUGGINGFACE))' > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )
 


### PR DESCRIPTION
## Summary

Adds three new patterns to `tools/approval.py`'s `DANGEROUS_PATTERNS` list to prevent the LLM from reading credentials via Bitwarden CLI through the terminal tool:

| Pattern | Catches | Severity |
|---------|---------|----------|
| `\bbws\s+secret\s+get\b` | `bws secret get <KEY>` — BSM secret value read | 🔴 High |
| `\bbw\s+get\b` | `bw get <item>` — Password Manager credential read | 🔴 High |
| `\bbw\s+(list\|export\|sync)\b` | `bw list`, `bw export`, `bw sync` — vault enumeration/dump | 🟡 Medium |

## Problem

Hermes integrates with Bitwarden Secrets Manager (BSM) and Bitwarden Password Manager for credential storage. The sanctioned Python API (`bitwarden_provider.get_secret()`) uses `subprocess.run()` to call `bws` directly and returns values programmatically. However, nothing prevents the LLM from running `bws secret get <key>` or `bw get <item>` via the terminal tool — which returns the raw credential value straight into the model's context. This is a credential exposure vector: a prompt-injected agent could silently exfiltrate all vault contents.

## Solution

These patterns use the existing approval system:
- **CLI/gateway mode**: prompts the user for approval before execution
- **Cron mode**: auto-denies (already configured as `cron_mode: deny`)
- **`--yolo` / `approvals.mode=off`**: bypass must be intentional by the user

## Complementary protection

Users can also set a hard block in their `config.yaml` via the `approvals.deny` list (unbypassable even with `--yolo`):
```yaml
approvals:
  deny:
    - bws secret *
    - bw get *
    - bw list *
    - bw export *
    - bw sync *
```

## Exclusions

- `bws secret list` — lists secret *names* without values, needed by the `get_secret()` Python provider for name-based lookup. Left out of `DANGEROUS_PATTERNS` intentionally.
- `bws run -- <cmd>` — the sanctioned blind-credential pattern, runs a command with secrets injected into env without exposing them to the model. Deliberately unblocked.
- `bw --version`, `bw config`, `bw help` — non-sensitive operations.

## Related
- Issue #5528 (configurable approval-locked patterns would make this user-extensible)