### PR TITLE
fix(desktop): degrade model settings on probe timeout

### DIFF
--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -10,11 +10,13 @@ import type {
 
 import { capabilityScoped, hermesApi, type ProfileScope, profileScoped, STARTUP_REQUEST_TIMEOUT_MS } from './client'
 
+const MODEL_INFO_REQUEST_TIMEOUT_MS = 5_000
+
 export function getGlobalModelInfo(profile?: null | string): Promise<ModelInfoResponse> {
   return hermesApi<ModelInfoResponse>({
     ...profileScoped(profile),
     path: '/api/model/info',
-    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    timeoutMs: MODEL_INFO_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -30,6 +30,7 @@ export function getGlobalModelOptions(
     refresh?: boolean
     includeUnconfigured?: boolean
     explicitOnly?: boolean
+    timeoutMs?: number
   },
   profile?: null | string
 ): Promise<ModelOptionsResponse> {
@@ -50,7 +51,7 @@ export function getGlobalModelOptions(
   return hermesApi<ModelOptionsResponse>({
     ...profileScoped(profile),
     path: params.size > 0 ? `/api/model/options?${params.toString()}` : '/api/model/options',
-    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    timeoutMs: opts?.timeoutMs ?? STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -10,13 +10,11 @@ import type {
 
 import { capabilityScoped, hermesApi, type ProfileScope, profileScoped, STARTUP_REQUEST_TIMEOUT_MS } from './client'
 
-const MODEL_INFO_REQUEST_TIMEOUT_MS = 5_000
-
-export function getGlobalModelInfo(profile?: null | string): Promise<ModelInfoResponse> {
+export function getGlobalModelInfo(profile?: null | string, opts?: { timeoutMs?: number }): Promise<ModelInfoResponse> {
   return hermesApi<ModelInfoResponse>({
     ...profileScoped(profile),
     path: '/api/model/info',
-    timeoutMs: MODEL_INFO_REQUEST_TIMEOUT_MS
+    timeoutMs: opts?.timeoutMs ?? STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -27,7 +27,7 @@ const startManualProviderOAuth = vi.fn()
 let profileSwitchHandler: (() => void) | null = null
 
 vi.mock('@/hermes', () => ({
-  getGlobalModelInfo: () => getGlobalModelInfo(),
+  getGlobalModelInfo: (opts?: unknown) => getGlobalModelInfo(opts),
   getGlobalModelOptions: () => getGlobalModelOptions(),
   getAuxiliaryModels: () => getAuxiliaryModels(),
   getMoaModels: () => getMoaModels(),
@@ -35,7 +35,6 @@ vi.mock('@/hermes', () => ({
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
-  setApiRequestProfile: vi.fn(),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   setApiRequestProfile: () => {}
@@ -270,6 +269,27 @@ describe('ModelSettings', () => {
     const provider = (await screen.findAllByRole('combobox'))[0]
     fireEvent.click(provider)
     expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
+  })
+
+  it('renders recovered settings before a delayed model-options request settles', async () => {
+    let resolveOptions!: (value: { providers: never[] }) => void
+    getGlobalModelInfo.mockRejectedValueOnce(new Error('Model metadata request timed out'))
+    getGlobalModelOptions.mockReturnValueOnce(
+      new Promise<{ providers: never[] }>(resolve => {
+        resolveOptions = resolve
+      })
+    )
+
+    await renderModelSettings()
+
+    expect(await screen.findByText('Vision')).toBeTruthy()
+    expect(screen.getByText('Applies to new sessions. Use the model picker in the composer to hot-swap the active chat.')).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'Set to main' }).length).toBeGreaterThan(0)
+    expect(getGlobalModelInfo).toHaveBeenCalledWith({ timeoutMs: 5_000 })
+
+    await act(async () => {
+      resolveOptions({ providers: [] })
+    })
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/hermes', () => ({
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
+  setApiRequestProfile: vi.fn(),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   setApiRequestProfile: () => {}
@@ -49,6 +50,16 @@ vi.mock('@/store/onboarding', () => ({
 vi.mock('../hooks/use-on-profile-switch', () => ({
   useOnProfileSwitch: (handler: () => void) => {
     profileSwitchHandler = handler
+  }
+}))
+
+vi.mock('@/app/hooks/use-config-record', () => ({
+  invalidateHermesConfig: vi.fn(),
+  setHermesConfigCache: vi.fn(),
+  useHermesConfigRecord: () => {
+    getHermesConfigRecord()
+
+    return { data: { agent: { reasoning_effort: 'medium', service_tier: 'normal' } } }
   }
 }))
 
@@ -245,6 +256,20 @@ describe('ModelSettings', () => {
 
     expect(await screen.findByText('Vision')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
+  })
+
+  it('keeps config-backed settings usable when live model metadata times out', async () => {
+    getGlobalModelInfo.mockRejectedValueOnce(new Error('Model metadata request timed out'))
+
+    await renderModelSettings()
+
+    expect(await screen.findByText('Vision')).toBeTruthy()
+    expect(screen.getByText('Model metadata request timed out')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Apply' }).hasAttribute('disabled')).toBe(false)
+
+    const provider = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(provider)
+    expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -28,7 +28,7 @@ const startManualProviderOAuth = vi.fn()
 let profileSwitchHandler: (() => void) | null = null
 
 vi.mock('@/hermes', () => ({
-  getGlobalModelInfo: (profile?: null | string) => getGlobalModelInfo(profile),
+  getGlobalModelInfo: (profile?: null | string, opts?: unknown) => getGlobalModelInfo(profile, opts),
   getGlobalModelOptions: (opts?: unknown, profile?: null | string) => getGlobalModelOptions(opts, profile),
   getAuxiliaryModels: (profile?: null | string) => getAuxiliaryModels(profile),
   getApiRequestProfile: () => 'default',
@@ -38,7 +38,6 @@ vi.mock('@/hermes', () => ({
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
-  setApiRequestProfile: vi.fn(),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   setApiRequestProfile: () => {}
@@ -349,6 +348,27 @@ describe('ModelSettings', () => {
     const provider = (await screen.findAllByRole('combobox'))[0]
     fireEvent.click(provider)
     expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
+  })
+
+  it('renders recovered settings before a delayed model-options request settles', async () => {
+    let resolveOptions!: (value: { providers: never[] }) => void
+    getGlobalModelInfo.mockRejectedValueOnce(new Error('Model metadata request timed out'))
+    getGlobalModelOptions.mockReturnValueOnce(
+      new Promise<{ providers: never[] }>(resolve => {
+        resolveOptions = resolve
+      })
+    )
+
+    await renderModelSettings()
+
+    expect(await screen.findByText('Vision')).toBeTruthy()
+    expect(screen.getByText('Applies to new sessions. Use the model picker in the composer to hot-swap the active chat.')).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'Set to main' }).length).toBeGreaterThan(0)
+    expect(getGlobalModelInfo).toHaveBeenCalledWith(null, { timeoutMs: 5_000 })
+
+    await act(async () => {
+      resolveOptions({ providers: [] })
+    })
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -56,8 +56,8 @@ vi.mock('../hooks/use-on-profile-switch', () => ({
 }))
 
 vi.mock('@/app/hooks/use-config-record', () => ({
+  hermesConfigCacheWriter: () => vi.fn(),
   invalidateHermesConfig: vi.fn(),
-  setHermesConfigCache: vi.fn(),
   useHermesConfigRecord: () => {
     getHermesConfigRecord()
 
@@ -119,8 +119,10 @@ describe('ModelSettings profile scope', () => {
   it('follows the active profile (undefined, never null) when unscoped', async () => {
     await renderModelSettings()
 
-    await waitFor(() => expect(getGlobalModelInfo).toHaveBeenCalledWith(undefined))
-    expect(getGlobalModelOptions).toHaveBeenCalledWith(undefined, undefined)
+    await waitFor(() =>
+      expect(getGlobalModelInfo).toHaveBeenCalledWith(undefined, { timeoutMs: 5_000 })
+    )
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ timeoutMs: 5_000 }, undefined)
     expect(getAuxiliaryModels).toHaveBeenCalledWith(undefined)
     expect(getMoaModels).toHaveBeenCalledWith(undefined)
   })
@@ -128,8 +130,10 @@ describe('ModelSettings profile scope', () => {
   it('reads through the explicit scope override when one is set', async () => {
     await renderModelSettings('research')
 
-    await waitFor(() => expect(getGlobalModelInfo).toHaveBeenCalledWith('research'))
-    expect(getGlobalModelOptions).toHaveBeenCalledWith(undefined, 'research')
+    await waitFor(() =>
+      expect(getGlobalModelInfo).toHaveBeenCalledWith('research', { timeoutMs: 5_000 })
+    )
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ timeoutMs: 5_000 }, 'research')
     expect(getAuxiliaryModels).toHaveBeenCalledWith('research')
     expect(getMoaModels).toHaveBeenCalledWith('research')
   })
@@ -362,12 +366,32 @@ describe('ModelSettings', () => {
     await renderModelSettings()
 
     expect(await screen.findByText('Vision')).toBeTruthy()
-    expect(screen.getByText('Applies to new sessions. Use the model picker in the composer to hot-swap the active chat.')).toBeTruthy()
+    expect(
+      screen.getByText('Applies to new sessions. Use the model picker in the composer to hot-swap the active chat.')
+    ).toBeTruthy()
     expect(screen.getAllByRole('button', { name: 'Set to main' }).length).toBeGreaterThan(0)
-    expect(getGlobalModelInfo).toHaveBeenCalledWith(null, { timeoutMs: 5_000 })
+    expect(getGlobalModelInfo).toHaveBeenCalledWith(undefined, { timeoutMs: 5_000 })
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ timeoutMs: 5_000 }, undefined)
 
     await act(async () => {
       resolveOptions({ providers: [] })
+    })
+  })
+
+  it('lists independent refresh failures on separate lines', async () => {
+    getGlobalModelInfo.mockRejectedValueOnce(new Error('Model metadata request timed out'))
+    getGlobalModelOptions.mockRejectedValueOnce(new Error('Model options request timed out'))
+
+    await renderModelSettings()
+
+    await waitFor(() => {
+      const error = screen.getByText(/Model metadata request timed out/)
+      const lines = error.textContent?.split('\n') ?? []
+      expect(lines).toHaveLength(2)
+      expect(lines).toEqual(
+        expect.arrayContaining(['Model metadata request timed out', 'Model options request timed out'])
+      )
+      expect(error.className).toContain('whitespace-pre-line')
     })
   })
 

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/hermes', () => ({
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
+  setApiRequestProfile: vi.fn(),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   setApiRequestProfile: () => {}
@@ -52,6 +53,16 @@ vi.mock('@/store/onboarding', () => ({
 vi.mock('../hooks/use-on-profile-switch', () => ({
   useOnProfileSwitch: (handler: () => void) => {
     profileSwitchHandler = handler
+  }
+}))
+
+vi.mock('@/app/hooks/use-config-record', () => ({
+  invalidateHermesConfig: vi.fn(),
+  setHermesConfigCache: vi.fn(),
+  useHermesConfigRecord: () => {
+    getHermesConfigRecord()
+
+    return { data: { agent: { reasoning_effort: 'medium', service_tier: 'normal' } } }
   }
 }))
 
@@ -324,6 +335,20 @@ describe('ModelSettings', () => {
 
     expect(await screen.findByText('Vision')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
+  })
+
+  it('keeps config-backed settings usable when live model metadata times out', async () => {
+    getGlobalModelInfo.mockRejectedValueOnce(new Error('Model metadata request timed out'))
+
+    await renderModelSettings()
+
+    expect(await screen.findByText('Vision')).toBeTruthy()
+    expect(screen.getByText('Model metadata request timed out')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Apply' }).hasAttribute('disabled')).toBe(false)
+
+    const provider = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(provider)
+    expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -238,9 +238,30 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       setError(prev => (prev ? `${prev}; ${message}` : message))
     }
 
+    let modelInfoSettled = false
+    let modelInfoAvailable = false
+    let auxiliaryMainFallback: { model: string; provider: string } | null = null
+
+    const publishAuxiliaryMainFallback = () => {
+      if (!isCurrent() || !modelInfoSettled || modelInfoAvailable || !auxiliaryMainFallback?.model) {
+        return
+      }
+
+      const fallback = auxiliaryMainFallback
+      setMainModel(prev => prev ?? fallback)
+      setSelectedProvider(prev => prev || fallback.provider)
+      setSelectedModel(prev => prev || fallback.model)
+    }
+
     const modelInfoRequest = getGlobalModelInfo({ timeoutMs: MODEL_SETTINGS_METADATA_TIMEOUT_MS })
       .then(modelInfo => {
-        if (!isCurrent() || !modelInfo.model) {
+        if (!isCurrent()) {
+          return
+        }
+
+        modelInfoAvailable = Boolean(modelInfo.provider || modelInfo.model)
+
+        if (!modelInfoAvailable) {
           return
         }
 
@@ -256,6 +277,9 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       })
       .catch(reportFailure)
       .finally(() => {
+        modelInfoSettled = true
+        publishAuxiliaryMainFallback()
+
         if (isCurrent()) {
           setLoading(false)
         }
@@ -278,14 +302,11 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         setAuxiliary(auxiliaryModels)
 
         if (auxiliaryModels.main?.model) {
-          setMainModel(prev =>
-            prev ?? {
-              model: auxiliaryModels.main.model,
-              provider: auxiliaryModels.main.provider
-            }
-          )
-          setSelectedProvider(prev => prev || auxiliaryModels.main.provider)
-          setSelectedModel(prev => prev || auxiliaryModels.main.model)
+          auxiliaryMainFallback = {
+            model: auxiliaryModels.main.model,
+            provider: auxiliaryModels.main.provider
+          }
+          publishAuxiliaryMainFallback()
         }
       })
       .catch(reportFailure)

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -187,6 +187,8 @@ interface ModelSettingsProps {
   onMainModelChanged?: (provider: string, model: string) => void
 }
 
+const MODEL_SETTINGS_METADATA_TIMEOUT_MS = 5_000
+
 export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const { t } = useI18n()
   const m = t.settings.model
@@ -225,76 +227,100 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setLoading(true)
     setError('')
 
-    try {
-      const [modelInfoResult, modelOptionsResult, auxiliaryModelsResult, moaModelsResult] = await Promise.allSettled([
-        getGlobalModelInfo(),
-        getGlobalModelOptions(),
-        getAuxiliaryModels(),
-        getMoaModels()
-      ])
+    const isCurrent = () => profileEpoch.current === epoch
 
-      if (profileEpoch.current !== epoch) {
+    const reportFailure = (reason: unknown) => {
+      if (!isCurrent()) {
         return
       }
 
-      const failures: string[] = []
+      const message = reason instanceof Error ? reason.message : String(reason)
+      setError(prev => (prev ? `${prev}; ${message}` : message))
+    }
 
-      const settledValue = <T,>(result: PromiseSettledResult<T>, reportFailure = true): T | null => {
-        if (result.status === 'fulfilled') {
-          return result.value
+    const modelInfoRequest = getGlobalModelInfo({ timeoutMs: MODEL_SETTINGS_METADATA_TIMEOUT_MS })
+      .then(modelInfo => {
+        if (!isCurrent() || !modelInfo.model) {
+          return
         }
 
-        if (reportFailure) {
-          failures.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
-        }
-
-        return null
-      }
-
-      const modelInfo = settledValue(modelInfoResult)
-      const modelOptions = settledValue(modelOptionsResult)
-      const auxiliaryModels = settledValue(auxiliaryModelsResult)
-      const moaModels = settledValue(moaModelsResult, false)
-      const resolvedMain = modelInfo?.model ? modelInfo : auxiliaryModels?.main
-
-      if (resolvedMain?.model) {
-        setMainModel({ model: resolvedMain.model, provider: resolvedMain.provider })
+        setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
 
         if (replaceSelection) {
-          setSelectedProvider(resolvedMain.provider)
-          setSelectedModel(resolvedMain.model)
+          setSelectedProvider(modelInfo.provider)
+          setSelectedModel(modelInfo.model)
         } else {
-          setSelectedProvider(prev => prev || resolvedMain.provider)
-          setSelectedModel(prev => prev || resolvedMain.model)
+          setSelectedProvider(prev => prev || modelInfo.provider)
+          setSelectedModel(prev => prev || modelInfo.model)
         }
-      }
+      })
+      .catch(reportFailure)
+      .finally(() => {
+        if (isCurrent()) {
+          setLoading(false)
+        }
+      })
 
-      if (modelOptions) {
-        setProviders(modelOptions.providers || [])
-      }
+    const modelOptionsRequest = getGlobalModelOptions()
+      .then(modelOptions => {
+        if (isCurrent()) {
+          setProviders(modelOptions.providers || [])
+        }
+      })
+      .catch(reportFailure)
 
-      if (auxiliaryModels) {
+    const auxiliaryModelsRequest = getAuxiliaryModels()
+      .then(auxiliaryModels => {
+        if (!isCurrent()) {
+          return
+        }
+
         setAuxiliary(auxiliaryModels)
-      }
 
-      setMoa(moaModels)
-      setError(failures.join('; '))
+        if (auxiliaryModels.main?.model) {
+          setMainModel(prev =>
+            prev ?? {
+              model: auxiliaryModels.main.model,
+              provider: auxiliaryModels.main.provider
+            }
+          )
+          setSelectedProvider(prev => prev || auxiliaryModels.main.provider)
+          setSelectedModel(prev => prev || auxiliaryModels.main.model)
+        }
+      })
+      .catch(reportFailure)
+      .finally(() => {
+        if (isCurrent()) {
+          setLoading(false)
+        }
+      })
 
-      if (moaModels) {
-        setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))
-      }
+    const moaModelsRequest = getMoaModels()
+      .then(moaModels => {
+        if (!isCurrent()) {
+          return
+        }
 
+        setMoa(moaModels)
+
+        if (moaModels) {
+          setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))
+        }
+      })
+      .catch(() => undefined)
+
+    await Promise.allSettled([
+      modelInfoRequest,
+      modelOptionsRequest,
+      auxiliaryModelsRequest,
+      moaModelsRequest
+    ])
+
+    if (isCurrent()) {
       // The config record loads via its own shared query; a model switch can
       // change it server-side (aux slots), so nudge that cache to refetch.
       void invalidateHermesConfig()
-    } catch (err) {
-      if (profileEpoch.current === epoch) {
-        setError(err instanceof Error ? err.message : String(err))
-      }
-    } finally {
-      if (profileEpoch.current === epoch) {
-        setLoading(false)
-      }
+      setLoading(false)
     }
   }, [])
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -226,30 +226,59 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setError('')
 
     try {
-      const [modelInfo, modelOptions, auxiliaryModels, moaModels] = await Promise.all([
+      const [modelInfoResult, modelOptionsResult, auxiliaryModelsResult, moaModelsResult] = await Promise.allSettled([
         getGlobalModelInfo(),
         getGlobalModelOptions(),
         getAuxiliaryModels(),
-        getMoaModels().catch(() => null)
+        getMoaModels()
       ])
 
       if (profileEpoch.current !== epoch) {
         return
       }
 
-      setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
-      setProviders(modelOptions.providers || [])
+      const failures: string[] = []
 
-      if (replaceSelection) {
-        setSelectedProvider(modelInfo.provider)
-        setSelectedModel(modelInfo.model)
-      } else {
-        setSelectedProvider(prev => prev || modelInfo.provider)
-        setSelectedModel(prev => prev || modelInfo.model)
+      const settledValue = <T,>(result: PromiseSettledResult<T>, reportFailure = true): T | null => {
+        if (result.status === 'fulfilled') {
+          return result.value
+        }
+
+        if (reportFailure) {
+          failures.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
+        }
+
+        return null
       }
 
-      setAuxiliary(auxiliaryModels)
+      const modelInfo = settledValue(modelInfoResult)
+      const modelOptions = settledValue(modelOptionsResult)
+      const auxiliaryModels = settledValue(auxiliaryModelsResult)
+      const moaModels = settledValue(moaModelsResult, false)
+      const resolvedMain = modelInfo?.model ? modelInfo : auxiliaryModels?.main
+
+      if (resolvedMain?.model) {
+        setMainModel({ model: resolvedMain.model, provider: resolvedMain.provider })
+
+        if (replaceSelection) {
+          setSelectedProvider(resolvedMain.provider)
+          setSelectedModel(resolvedMain.model)
+        } else {
+          setSelectedProvider(prev => prev || resolvedMain.provider)
+          setSelectedModel(prev => prev || resolvedMain.model)
+        }
+      }
+
+      if (modelOptions) {
+        setProviders(modelOptions.providers || [])
+      }
+
+      if (auxiliaryModels) {
+        setAuxiliary(auxiliaryModels)
+      }
+
       setMoa(moaModels)
+      setError(failures.join('; '))
 
       if (moaModels) {
         setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -236,30 +236,59 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setError('')
 
       try {
-        const [modelInfo, modelOptions, auxiliaryModels, moaModels] = await Promise.all([
+        const [modelInfoResult, modelOptionsResult, auxiliaryModelsResult, moaModelsResult] = await Promise.allSettled([
           getGlobalModelInfo(scopeProfile),
           getGlobalModelOptions(undefined, scopeProfile),
           getAuxiliaryModels(scopeProfile),
-          getMoaModels(scopeProfile).catch(() => null)
+          getMoaModels(scopeProfile)
         ])
 
         if (profileEpoch.current !== epoch) {
           return
         }
 
-        setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
-        setProviders(modelOptions.providers || [])
+        const failures: string[] = []
 
-        if (replaceSelection) {
-          setSelectedProvider(modelInfo.provider)
-          setSelectedModel(modelInfo.model)
-        } else {
-          setSelectedProvider(prev => prev || modelInfo.provider)
-          setSelectedModel(prev => prev || modelInfo.model)
+        const settledValue = <T,>(result: PromiseSettledResult<T>, reportFailure = true): T | null => {
+          if (result.status === 'fulfilled') {
+            return result.value
+          }
+
+          if (reportFailure) {
+            failures.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
+          }
+
+          return null
         }
 
-        setAuxiliary(auxiliaryModels)
+        const modelInfo = settledValue(modelInfoResult)
+        const modelOptions = settledValue(modelOptionsResult)
+        const auxiliaryModels = settledValue(auxiliaryModelsResult)
+        const moaModels = settledValue(moaModelsResult, false)
+        const resolvedMain = modelInfo?.model ? modelInfo : auxiliaryModels?.main
+
+        if (resolvedMain?.model) {
+          setMainModel({ model: resolvedMain.model, provider: resolvedMain.provider })
+
+          if (replaceSelection) {
+            setSelectedProvider(resolvedMain.provider)
+            setSelectedModel(resolvedMain.model)
+          } else {
+            setSelectedProvider(prev => prev || resolvedMain.provider)
+            setSelectedModel(prev => prev || resolvedMain.model)
+          }
+        }
+
+        if (modelOptions) {
+          setProviders(modelOptions.providers || [])
+        }
+
+        if (auxiliaryModels) {
+          setAuxiliary(auxiliaryModels)
+        }
+
         setMoa(moaModels)
+        setError(failures.join('; '))
 
         if (moaModels) {
           setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -245,7 +245,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         }
 
         const message = reason instanceof Error ? reason.message : String(reason)
-        setError(prev => (prev ? `${prev}; ${message}` : message))
+        setError(prev => (prev ? `${prev}\n${message}` : message))
       }
 
       let modelInfoSettled = false
@@ -259,8 +259,8 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
 
         const fallback = auxiliaryMainFallback
         setMainModel(prev => prev ?? fallback)
-        setSelectedProvider(prev => prev || fallback.provider)
-        setSelectedModel(prev => prev || fallback.model)
+        setSelectedProvider(prev => (prev.length > 0 ? prev : fallback.provider))
+        setSelectedModel(prev => (prev.length > 0 ? prev : fallback.model))
       }
 
       const modelInfoRequest = getGlobalModelInfo(scopeProfile, {
@@ -283,8 +283,8 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
             setSelectedProvider(modelInfo.provider)
             setSelectedModel(modelInfo.model)
           } else {
-            setSelectedProvider(prev => prev || modelInfo.provider)
-            setSelectedModel(prev => prev || modelInfo.model)
+            setSelectedProvider(prev => (prev.length > 0 ? prev : modelInfo.provider))
+            setSelectedModel(prev => (prev.length > 0 ? prev : modelInfo.model))
           }
         })
         .catch(reportFailure)
@@ -297,7 +297,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
           }
         })
 
-      const modelOptionsRequest = getGlobalModelOptions(undefined, scopeProfile)
+      const modelOptionsRequest = getGlobalModelOptions({ timeoutMs: MODEL_SETTINGS_METADATA_TIMEOUT_MS }, scopeProfile)
         .then(modelOptions => {
           if (isCurrent()) {
             setProviders(modelOptions.providers || [])
@@ -342,12 +342,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         })
         .catch(() => undefined)
 
-      await Promise.allSettled([
-        modelInfoRequest,
-        modelOptionsRequest,
-        auxiliaryModelsRequest,
-        moaModelsRequest
-      ])
+      await Promise.allSettled([modelInfoRequest, modelOptionsRequest, auxiliaryModelsRequest, moaModelsRequest])
 
       if (isCurrent()) {
         // The config record loads via its own shared query; a model switch can
@@ -978,7 +973,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
             )}
           </div>
         )}
-        {error && <div className="mt-2 text-xs text-destructive">{error}</div>}
+        {error && <div className="mt-2 whitespace-pre-line text-xs text-destructive">{error}</div>}
         {switchStaleAux.length > 0 && (
           <div className="mt-2">
             <StaleAuxWarning

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -188,6 +188,8 @@ interface ModelSettingsProps {
   scopeProfile?: string
 }
 
+const MODEL_SETTINGS_METADATA_TIMEOUT_MS = 5_000
+
 export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSettingsProps) {
   const { t } = useI18n()
   const m = t.settings.model
@@ -235,76 +237,102 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setLoading(true)
       setError('')
 
-      try {
-        const [modelInfoResult, modelOptionsResult, auxiliaryModelsResult, moaModelsResult] = await Promise.allSettled([
-          getGlobalModelInfo(scopeProfile),
-          getGlobalModelOptions(undefined, scopeProfile),
-          getAuxiliaryModels(scopeProfile),
-          getMoaModels(scopeProfile)
-        ])
+      const isCurrent = () => profileEpoch.current === epoch
 
-        if (profileEpoch.current !== epoch) {
+      const reportFailure = (reason: unknown) => {
+        if (!isCurrent()) {
           return
         }
 
-        const failures: string[] = []
+        const message = reason instanceof Error ? reason.message : String(reason)
+        setError(prev => (prev ? `${prev}; ${message}` : message))
+      }
 
-        const settledValue = <T,>(result: PromiseSettledResult<T>, reportFailure = true): T | null => {
-          if (result.status === 'fulfilled') {
-            return result.value
+      const modelInfoRequest = getGlobalModelInfo(scopeProfile, {
+        timeoutMs: MODEL_SETTINGS_METADATA_TIMEOUT_MS
+      })
+        .then(modelInfo => {
+          if (!isCurrent() || !modelInfo.model) {
+            return
           }
 
-          if (reportFailure) {
-            failures.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
-          }
-
-          return null
-        }
-
-        const modelInfo = settledValue(modelInfoResult)
-        const modelOptions = settledValue(modelOptionsResult)
-        const auxiliaryModels = settledValue(auxiliaryModelsResult)
-        const moaModels = settledValue(moaModelsResult, false)
-        const resolvedMain = modelInfo?.model ? modelInfo : auxiliaryModels?.main
-
-        if (resolvedMain?.model) {
-          setMainModel({ model: resolvedMain.model, provider: resolvedMain.provider })
+          setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
 
           if (replaceSelection) {
-            setSelectedProvider(resolvedMain.provider)
-            setSelectedModel(resolvedMain.model)
+            setSelectedProvider(modelInfo.provider)
+            setSelectedModel(modelInfo.model)
           } else {
-            setSelectedProvider(prev => prev || resolvedMain.provider)
-            setSelectedModel(prev => prev || resolvedMain.model)
+            setSelectedProvider(prev => prev || modelInfo.provider)
+            setSelectedModel(prev => prev || modelInfo.model)
           }
-        }
+        })
+        .catch(reportFailure)
+        .finally(() => {
+          if (isCurrent()) {
+            setLoading(false)
+          }
+        })
 
-        if (modelOptions) {
-          setProviders(modelOptions.providers || [])
-        }
+      const modelOptionsRequest = getGlobalModelOptions(undefined, scopeProfile)
+        .then(modelOptions => {
+          if (isCurrent()) {
+            setProviders(modelOptions.providers || [])
+          }
+        })
+        .catch(reportFailure)
 
-        if (auxiliaryModels) {
+      const auxiliaryModelsRequest = getAuxiliaryModels(scopeProfile)
+        .then(auxiliaryModels => {
+          if (!isCurrent()) {
+            return
+          }
+
           setAuxiliary(auxiliaryModels)
-        }
 
-        setMoa(moaModels)
-        setError(failures.join('; '))
+          if (auxiliaryModels.main?.model) {
+            setMainModel(prev =>
+              prev ?? {
+                model: auxiliaryModels.main.model,
+                provider: auxiliaryModels.main.provider
+              }
+            )
+            setSelectedProvider(prev => prev || auxiliaryModels.main.provider)
+            setSelectedModel(prev => prev || auxiliaryModels.main.model)
+          }
+        })
+        .catch(reportFailure)
+        .finally(() => {
+          if (isCurrent()) {
+            setLoading(false)
+          }
+        })
 
-        if (moaModels) {
-          setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))
-        }
+      const moaModelsRequest = getMoaModels(scopeProfile)
+        .then(moaModels => {
+          if (!isCurrent()) {
+            return
+          }
 
+          setMoa(moaModels)
+
+          if (moaModels) {
+            setSelectedMoaPreset(prev => (prev && moaModels.presets[prev] ? prev : moaModels.default_preset))
+          }
+        })
+        .catch(() => undefined)
+
+      await Promise.allSettled([
+        modelInfoRequest,
+        modelOptionsRequest,
+        auxiliaryModelsRequest,
+        moaModelsRequest
+      ])
+
+      if (isCurrent()) {
         // The config record loads via its own shared query; a model switch can
         // change it server-side (aux slots), so nudge that cache to refetch.
         void invalidateHermesConfig(scopeProfile)
-      } catch (err) {
-        if (profileEpoch.current === epoch) {
-          setError(err instanceof Error ? err.message : String(err))
-        }
-      } finally {
-        if (profileEpoch.current === epoch) {
-          setLoading(false)
-        }
+        setLoading(false)
       }
     },
     [scopeProfile]

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -248,11 +248,32 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         setError(prev => (prev ? `${prev}; ${message}` : message))
       }
 
+      let modelInfoSettled = false
+      let modelInfoAvailable = false
+      let auxiliaryMainFallback: { model: string; provider: string } | null = null
+
+      const publishAuxiliaryMainFallback = () => {
+        if (!isCurrent() || !modelInfoSettled || modelInfoAvailable || !auxiliaryMainFallback?.model) {
+          return
+        }
+
+        const fallback = auxiliaryMainFallback
+        setMainModel(prev => prev ?? fallback)
+        setSelectedProvider(prev => prev || fallback.provider)
+        setSelectedModel(prev => prev || fallback.model)
+      }
+
       const modelInfoRequest = getGlobalModelInfo(scopeProfile, {
         timeoutMs: MODEL_SETTINGS_METADATA_TIMEOUT_MS
       })
         .then(modelInfo => {
-          if (!isCurrent() || !modelInfo.model) {
+          if (!isCurrent()) {
+            return
+          }
+
+          modelInfoAvailable = Boolean(modelInfo.provider || modelInfo.model)
+
+          if (!modelInfoAvailable) {
             return
           }
 
@@ -268,6 +289,9 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
         })
         .catch(reportFailure)
         .finally(() => {
+          modelInfoSettled = true
+          publishAuxiliaryMainFallback()
+
           if (isCurrent()) {
             setLoading(false)
           }
@@ -290,14 +314,11 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
           setAuxiliary(auxiliaryModels)
 
           if (auxiliaryModels.main?.model) {
-            setMainModel(prev =>
-              prev ?? {
-                model: auxiliaryModels.main.model,
-                provider: auxiliaryModels.main.provider
-              }
-            )
-            setSelectedProvider(prev => prev || auxiliaryModels.main.provider)
-            setSelectedModel(prev => prev || auxiliaryModels.main.model)
+            auxiliaryMainFallback = {
+              model: auxiliaryModels.main.model,
+              provider: auxiliaryModels.main.provider
+            }
+            publishAuxiliaryMainFallback()
           }
         })
         .catch(reportFailure)

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -93,12 +93,13 @@ describe('Hermes REST session helpers', () => {
     )
   })
 
-  it('gives slow startup data calls the long timeout', async () => {
+  it('gives the whole startup data burst the long timeout, not just profiles', async () => {
     api.mockResolvedValue({})
 
     const bootCalls: [() => Promise<unknown>, string][] = [
       [getHermesConfig, '/api/config'],
       [getHermesConfigDefaults, '/api/config/defaults'],
+      [getGlobalModelInfo, '/api/model/info'],
       [() => getGlobalModelOptions(), '/api/model/options?explicit_only=1'],
       [getCronJobs, '/api/cron/jobs']
     ]
@@ -110,10 +111,10 @@ describe('Hermes REST session helpers', () => {
     }
   })
 
-  it('bounds the optional live model metadata probe', async () => {
+  it('allows Settings to bound its optional live model metadata probe', async () => {
     api.mockResolvedValue({})
 
-    await getGlobalModelInfo()
+    await getGlobalModelInfo({ timeoutMs: 5_000 })
 
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 })

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -93,13 +93,12 @@ describe('Hermes REST session helpers', () => {
     )
   })
 
-  it('gives the whole startup data burst the long timeout, not just profiles', async () => {
+  it('gives slow startup data calls the long timeout', async () => {
     api.mockResolvedValue({})
 
     const bootCalls: [() => Promise<unknown>, string][] = [
       [getHermesConfig, '/api/config'],
       [getHermesConfigDefaults, '/api/config/defaults'],
-      [getGlobalModelInfo, '/api/model/info'],
       [() => getGlobalModelOptions(), '/api/model/options?explicit_only=1'],
       [getCronJobs, '/api/cron/jobs']
     ]
@@ -109,6 +108,16 @@ describe('Hermes REST session helpers', () => {
       await call()
       expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
     }
+  })
+
+  it('bounds the optional live model metadata probe', async () => {
+    api.mockResolvedValue({})
+
+    await getGlobalModelInfo()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 })
+    )
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -337,13 +337,12 @@ describe('Hermes REST helpers', () => {
     )
   })
 
-  it('gives the whole startup data burst the long timeout, not just profiles', async () => {
+  it('gives slow startup data calls the long timeout', async () => {
     api.mockResolvedValue({})
 
     const bootCalls: [() => Promise<unknown>, string][] = [
       [getHermesConfig, '/api/config'],
       [getHermesConfigDefaults, '/api/config/defaults'],
-      [getGlobalModelInfo, '/api/model/info'],
       [() => getGlobalModelOptions(), '/api/model/options?explicit_only=1'],
       [getCronJobs, '/api/cron/jobs']
     ]
@@ -368,6 +367,16 @@ describe('Hermes REST helpers', () => {
       })
     )
     expect(request.timeoutMs).toBeGreaterThanOrEqual(60 * 60 * 1000)
+  })
+
+  it('bounds the optional live model metadata probe', async () => {
+    api.mockResolvedValue({})
+
+    await getGlobalModelInfo()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 })
+    )
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -375,8 +375,16 @@ describe('Hermes REST helpers', () => {
 
     await getGlobalModelInfo(null, { timeoutMs: 5_000 })
 
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 }))
+  })
+
+  it('allows Settings to bound its optional model-options probe', async () => {
+    api.mockResolvedValue({})
+
+    await getGlobalModelOptions({ timeoutMs: 5_000 })
+
     expect(api).toHaveBeenCalledWith(
-      expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 })
+      expect.objectContaining({ path: '/api/model/options?explicit_only=1', timeoutMs: 5_000 })
     )
   })
 

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -337,12 +337,13 @@ describe('Hermes REST helpers', () => {
     )
   })
 
-  it('gives slow startup data calls the long timeout', async () => {
+  it('gives the whole startup data burst the long timeout, not just profiles', async () => {
     api.mockResolvedValue({})
 
     const bootCalls: [() => Promise<unknown>, string][] = [
       [getHermesConfig, '/api/config'],
       [getHermesConfigDefaults, '/api/config/defaults'],
+      [getGlobalModelInfo, '/api/model/info'],
       [() => getGlobalModelOptions(), '/api/model/options?explicit_only=1'],
       [getCronJobs, '/api/cron/jobs']
     ]
@@ -369,10 +370,10 @@ describe('Hermes REST helpers', () => {
     expect(request.timeoutMs).toBeGreaterThanOrEqual(60 * 60 * 1000)
   })
 
-  it('bounds the optional live model metadata probe', async () => {
+  it('allows Settings to bound its optional live model metadata probe', async () => {
     api.mockResolvedValue({})
 
-    await getGlobalModelInfo()
+    await getGlobalModelInfo(null, { timeoutMs: 5_000 })
 
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({ path: '/api/model/info', timeoutMs: 5_000 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -71,7 +71,6 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
-const MODEL_INFO_REQUEST_TIMEOUT_MS = 5_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -426,11 +425,11 @@ export function renameSession(
   })
 }
 
-export function getGlobalModelInfo(): Promise<ModelInfoResponse> {
+export function getGlobalModelInfo(opts?: { timeoutMs?: number }): Promise<ModelInfoResponse> {
   return window.hermesDesktop.api<ModelInfoResponse>({
     ...profileScoped(),
     path: '/api/model/info',
-    timeoutMs: MODEL_INFO_REQUEST_TIMEOUT_MS
+    timeoutMs: opts?.timeoutMs ?? STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -71,6 +71,7 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+const MODEL_INFO_REQUEST_TIMEOUT_MS = 5_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -429,7 +430,7 @@ export function getGlobalModelInfo(): Promise<ModelInfoResponse> {
   return window.hermesDesktop.api<ModelInfoResponse>({
     ...profileScoped(),
     path: '/api/model/info',
-    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    timeoutMs: MODEL_INFO_REQUEST_TIMEOUT_MS
   })
 }
 


### PR DESCRIPTION
## Summary

- preserve the shared 60-second startup budget for `/api/model/info` and `/api/model/options`, including startup and composer callers
- let Model Settings bound both optional live probes to five seconds without changing shared defaults
- publish model info, provider options, auxiliary assignments, and MoA configuration independently as each request settles
- fall back to the config-backed auxiliary `main` tuple without waiting for provider options
- retain current-main profile-scoped routing and profile-epoch guards so stale responses cannot update another profile
- show independent probe failures on separate lines and preserve explicit empty-selection semantics

Fixes #63214.

## Current-main proof

Model Settings waited for the complete request aggregate before publishing recovered state. A provider-options request could therefore hold the full startup budget even after auxiliary configuration supplied a usable main model. The shared helpers retain their 60-second startup contract for non-Settings callers.

The regressions hold model options unresolved, reject live metadata, and prove the config-backed panel and auxiliary rows render before options settle. API-helper tests prove the shared defaults and explicit five-second Settings overrides for both probes. Profile-switch coverage verifies recovered data remains scoped to the selected backend.

The current-main refresh preserves `undefined` as "follow the active profile" and does not substitute `null`, which deliberately targets the default backend.

## Verification

- rebased onto exact current `main` `8b09a9df8476010a78e86d6c32254b4ac14a8c4f`
- 57 focused Model Settings and REST-helper tests passed
- Desktop renderer, Electron, and E2E TypeScript checks passed
- ESLint, `git diff --check`, public identity/privacy checks, gitleaks, and the existing-PR review-follow-up gate passed

Current head: `4eb25e3c5b01a7b7e49b5febea927bcf8292ee06`
