### PR TITLE
fix(gateway): normalize boolean transport value in StreamingConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -23,6 +23,33 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+_STREAMING_TRANSPORT_VALUES = frozenset({"edit", "draft", "auto", "off"})
+
+
+def _coerce_streaming_transport(value: Any) -> str:
+    """Normalize a YAML-loaded transport value to a documented string.
+
+    yaml.safe_load() converts bare ``true``/``false`` in config.yaml to
+    Python booleans before from_dict sees them.  The active streaming gates
+    compare transport against the string "off" (gateway/run.py), so a
+    boolean False silently evaluates as truthy transport and streaming is
+    never suppressed when the user writes ``transport: false``.
+
+    Rules (only documented values are produced):
+    - False  → "off"   (user explicitly disabled streaming)
+    - True   → "auto"  (user enabled without specifying a mode; safe default)
+    - Known string ("edit", "draft", "auto", "off") → unchanged
+    - Anything else  → "auto"  (safe fallback to documented default)
+    """
+    if value is False:
+        return "off"
+    if value is True:
+        return "auto"
+    if isinstance(value, str) and value in _STREAMING_TRANSPORT_VALUES:
+        return value
+    return "auto"
+
+
 def _coerce_bool(value: Any, default: bool = True) -> bool:
     """Coerce bool-ish config values, preserving a caller-provided default."""
     if value is None:
@@ -548,7 +575,7 @@ class StreamingConfig:
             return cls()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "auto"),
+            transport=_coerce_streaming_transport(data.get("transport", "auto")),
             edit_interval=_coerce_float(
                 data.get("edit_interval"), DEFAULT_STREAMING_EDIT_INTERVAL,
             ),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -263,6 +263,42 @@ class TestStreamingConfig:
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 0.0
 
+    def test_yaml_boolean_false_transport_maps_to_off(self):
+        """yaml.safe_load() converts bare ``false`` to Python False before
+        from_dict; without normalization the boolean silently evaluates as
+        a truthy non-"off" transport and streaming is never suppressed.
+        This is the YAML scalar-type issue reported in the gateway PR.
+        """
+        import yaml
+        raw = yaml.safe_load("enabled: true\ntransport: false\n")
+        assert raw["transport"] is False  # confirm yaml produced a bool
+        restored = StreamingConfig.from_dict(raw)
+        assert restored.transport == "off", (
+            f"Expected 'off', got {restored.transport!r} -- "
+            "boolean False transport not normalized"
+        )
+
+    def test_yaml_boolean_true_transport_maps_to_auto(self):
+        """``transport: true`` in YAML should map to 'auto' (documented default),
+        not introduce an undocumented 'on' value.
+        """
+        import yaml
+        raw = yaml.safe_load("enabled: true\ntransport: true\n")
+        assert raw["transport"] is True
+        restored = StreamingConfig.from_dict(raw)
+        assert restored.transport == "auto"
+
+    def test_documented_string_transports_pass_through_unchanged(self):
+        """All four documented transport values must round-trip unchanged."""
+        for val in ("edit", "draft", "auto", "off"):
+            restored = StreamingConfig.from_dict({"transport": val})
+            assert restored.transport == val, f"transport={val!r} was rewritten"
+
+    def test_unknown_transport_value_falls_back_to_auto(self):
+        """An unknown transport string is normalized to 'auto' (safe default)."""
+        restored = StreamingConfig.from_dict({"transport": "mystery_mode"})
+        assert restored.transport == "auto"
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):


### PR DESCRIPTION
## Problem

yaml.safe_load() converts bare true/false scalars in config.yaml to Python booleans before StreamingConfig.from_dict() sees them. A boolean False silently evaluates as a truthy non-off transport, so the active streaming gates (gateway/run.py:16611 and gateway/run.py:17934, which compare transport == off) never suppress streaming when the user writes transport: false (issue #6558).

## Fix

Add _coerce_streaming_transport(): False -> off, True -> auto (documented default), known strings unchanged, unknown values -> auto. Intentionally does NOT introduce on -- it is undocumented and stream_consumer.py treats unknown non-empty values as draft-eligible.

## Verification

4 new tests in TestStreamingConfig: YAML false -> off, YAML true -> auto (no undocumented on), all 4 documented strings pass through unchanged, unknown string -> auto. 7/7 pass (3 existing + 4 new). Change is scoped to gateway/config.py only.

Fixes #6558