### PR TITLE
fix(plugins): loop-safe await of async invoke_hook callbacks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1913,6 +1913,12 @@ class PluginManager:
         for cb in callbacks:
             try:
                 ret = cb(**kwargs)
+                # Plugin hooks may be async def (or otherwise return awaitables).
+                # Resolve them loop-safely so CLI (no loop) and gateway pathway
+                # (running loop at gateway/run.py) both work — never bare
+                # asyncio.run() here, which raises when a loop is already active.
+                if inspect.isawaitable(ret):
+                    ret = resolve_plugin_command_result(ret)
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -745,6 +745,77 @@ class TestPluginHooks:
                                   user_message="hi", assistant_response="bye", model="test")
         assert results == []
 
+    def test_async_hook_awaits_without_running_loop(self):
+        """Async hook callbacks are resolved when no event loop is running."""
+        mgr = PluginManager()
+
+        async def async_hook(**kwargs):
+            return {"context": "from-async", "schema": kwargs.get("telemetry_schema_version")}
+
+        mgr._hooks.setdefault("pre_llm_call", []).append(async_hook)
+
+        results = mgr.invoke_hook(
+            "pre_llm_call",
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="test",
+        )
+        assert results == [{"context": "from-async", "schema": "hermes.observer.v1"}]
+
+    def test_async_hook_awaits_with_running_loop(self, monkeypatch):
+        """Async hooks must resolve even when called under an active event loop.
+
+        Gateway paths (e.g. gateway/run.py) call PluginManager.invoke_hook from
+        async handlers, so bare asyncio.run(ret) would raise RuntimeError.
+        """
+
+        class _Loop:
+            pass
+
+        mgr = PluginManager()
+
+        async def async_hook(**kwargs):
+            return {"context": "from-async-loop"}
+
+        mgr._hooks.setdefault("pre_llm_call", []).append(async_hook)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.asyncio.get_running_loop", lambda: _Loop()
+        )
+
+        results = mgr.invoke_hook(
+            "pre_llm_call",
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="test",
+        )
+        assert results == [{"context": "from-async-loop"}]
+
+    def test_sync_hook_return_untouched_alongside_async(self):
+        """Synchronous hook results stay concrete values when mixed with async."""
+        mgr = PluginManager()
+
+        def sync_hook(**kwargs):
+            return {"context": "sync"}
+
+        async def async_hook(**kwargs):
+            return {"context": "async"}
+
+        mgr._hooks.setdefault("pre_llm_call", []).extend([sync_hook, async_hook])
+
+        results = mgr.invoke_hook(
+            "pre_llm_call",
+            session_id="s1",
+            user_message="hi",
+            conversation_history=[],
+            is_first_turn=True,
+            model="test",
+        )
+        assert results == [{"context": "sync"}, {"context": "async"}]
+
     def test_request_hooks_are_invokeable(self, tmp_path, monkeypatch):
         plugins_dir = tmp_path / "hermes_test" / "plugins"
         _make_plugin_dir(


### PR DESCRIPTION
## Summary

- Salvage of #12507 by @flobo3: resolve awaitable returns from `PluginManager.invoke_hook` so async plugin hooks actually run instead of printing `<coroutine object>` / `RuntimeWarning: coroutine was never awaited`.
- Uses the existing loop-safe `resolve_plugin_command_result` helper (same path as slash-command/TUI) so this works both with **no running loop** (CLI) and under an **active loop** (gateway `gateway/run.py` sync call from async handlers).
- Does **not** touch the slash-command/TUI half — already fixed on main via `resolve_plugin_command_result` (`ca9a61ae`).

## Motivation

#12507 correctly identified unawaited async plugin callbacks. teknium1's review noted:

1. The slash-command half is already on main (`cli.py` + TUI).
2. A naive `asyncio.run(ret)` in `invoke_hook` is unsafe when the gateway's event loop is already running.
3. Hook path regression tests for async callbacks were missing.

This PR is the tightly-scoped salvage of the remaining live defect at `hermes_cli/plugins.py` `PluginManager.invoke_hook`.

## Changes from original (#12507)

- Only the hook path; leave `cli.py` alone.
- Reuse `resolve_plugin_command_result` (isawaitable + no-loop `asyncio.run` / active-loop threaded helper) instead of bare `asyncio.run`.
- Synchronous hook results remain untouched (only awaitables are resolved).
- Regression tests: async hook with no running loop, async hook with simulated active loop, mixed sync+async hooks.

## Verification

```
python3 -m pytest \
  tests/hermes_cli/test_plugins.py::TestPluginHooks::test_async_hook_awaits_without_running_loop \
  tests/hermes_cli/test_plugins.py::TestPluginHooks::test_async_hook_awaits_with_running_loop \
  tests/hermes_cli/test_plugins.py::TestPluginHooks::test_sync_hook_return_untouched_alongside_async \
  tests/hermes_cli/test_plugins.py::TestPluginHooks::test_hook_return_values_collected \
  tests/hermes_cli/test_plugins.py::TestPluginCommandResultResolution -q
```

→ 8 passed

## Credit

Salvage of #12507 by @flobo3. Guided by @teknium1's review (keep_open / salvageability=medium).
