### PR TITLE
fix(acp): clear stale runtime on provider switch

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2319,7 +2319,7 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            provider_changed = requested_provider != current_provider
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1318,6 +1318,82 @@ class TestSessionConfiguration:
             api_mode="chat_completions",
         )
 
+    @pytest.mark.asyncio
+    async def test_provider_switch_replaces_legacy_unattributed_runtime_and_persists(
+        self, tmp_path, monkeypatch
+    ):
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "gemini"
+            return {
+                "provider": provider,
+                "api_mode": (
+                    "codex_responses"
+                    if provider == "openai-codex"
+                    else "chat_completions"
+                ),
+                "base_url": (
+                    "https://chatgpt.com/backend-api/codex"
+                    if provider == "openai-codex"
+                    else "https://generativelanguage.googleapis.com/v1beta"
+                ),
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                session_id=kwargs.get("session_id"),
+                _session_db=kwargs.get("session_db"),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "gemini", "default": "gemini-2.5-pro"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openai-codex", "gpt-5.6-sol"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(db=db)
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            state.agent.provider = ""
+            state.agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+            state.agent.api_mode = "chat_completions"
+
+            result = await acp_agent.set_session_model(
+                model_id="openai-codex:gpt-5.6-sol",
+                session_id=state.session_id,
+            )
+
+            assert isinstance(result, SetSessionModelResponse)
+            assert state.agent.provider == "openai-codex"
+            assert state.agent.base_url == "https://chatgpt.com/backend-api/codex"
+            assert state.agent.api_mode == "codex_responses"
+
+            restored = SessionManager(db=db).get_session(state.session_id)
+
+        assert restored is not None
+        assert restored.agent.provider == "openai-codex"
+        assert restored.agent.base_url == "https://chatgpt.com/backend-api/codex"
+        assert restored.agent.api_mode == "codex_responses"
+
 
 # ---------------------------------------------------------------------------
 # prompt


### PR DESCRIPTION
## Summary
- treat a concrete ACP provider selection as a provider change when the live legacy agent has blank attribution
- force `_make_agent()` to re-resolve `base_url` and `api_mode` instead of carrying the previous provider route
- cover live reconstruction plus SessionDB persistence/reload of the repaired provider tuple

Fixes #63222.

## Current-main proof
On untouched `7b5ba20547`, switching an ACP session with blank `agent.provider` from a Gemini endpoint to `openai-codex:gpt-5.6-sol` produced `provider=openai-codex` while retaining `https://generativelanguage.googleapis.com/v1beta`. The regression failed on that stale endpoint. It now rebuilds and reloads with `https://chatgpt.com/backend-api/codex` and `api_mode=codex_responses`.

Same-provider switches are unchanged: only a requested provider that differs from current attribution clears the carried endpoint and API mode.

## Validation
- `tests/acp/test_server.py` — 81 passed
- all other `tests/acp` + `tests/acp_adapter` suites — 314 passed
- ruff, py_compile, `git diff --check`, contribution publish gate, and pushed-range gitleaks — clean

`tests/acp/test_edit_approval.py` has three unrelated macOS failures caused by pytest paths resolving under `/private/var` and being classified as sensitive. All three reproduce in a fresh process and on an untouched worktree at exact base `7b5ba20547` (7 other tests in that file pass).