### PR TITLE
fix(acp): reset stale route on provider switch

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2004,7 +2004,11 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            # Treat a missing/legacy provider attribution as a provider change.
+            # Otherwise a stale base URL from the previous provider survives the
+            # switch (for example Gemini's endpoint with an OpenAI Codex model),
+            # and every request fails at the wrong backend with HTTP 404.
+            provider_changed = requested_provider != current_provider
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -997,6 +997,78 @@ class TestSessionConfiguration:
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
 
+    @pytest.mark.asyncio
+    async def test_set_session_model_resets_stale_route_when_current_provider_is_blank(
+        self, tmp_path, monkeypatch
+    ):
+        """A legacy/unknown provider must not preserve another provider's base URL."""
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            if requested == "openai-codex":
+                return {
+                    "provider": "openai-codex",
+                    "api_mode": "codex_responses",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_key": "codex-token",
+                    "command": None,
+                    "args": [],
+                }
+            return {
+                "provider": requested or "",
+                "api_mode": "codex_responses",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "api_key": "gemini-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "gemini", "default": "gemini-3.5-flash"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openai-codex", "gpt-5.6-sol"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            # Reproduce the affected persisted ACP session: its provider field
+            # predates provider attribution, while its Gemini base URL remains.
+            state.agent.provider = ""
+            state.agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+            state.agent.api_mode = "codex_responses"
+
+            result = await acp_agent.set_session_model(
+                model_id="openai-codex:gpt-5.6-sol",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert state.agent.provider == "openai-codex"
+        assert state.agent.base_url == "https://chatgpt.com/backend-api/codex"
+        assert runtime_calls[-1] == "openai-codex"
+
 
 # ---------------------------------------------------------------------------
 # prompt


### PR DESCRIPTION
## Summary
- treat blank or legacy ACP provider attribution as a provider change when a concrete provider is selected
- rebuild `base_url` and `api_mode` from the requested provider instead of retaining a previous provider's route
- cover the observed Gemini-endpoint/OpenAI-Codex mismatch with a focused regression

Fixes #63222

## Root cause

`session/set_model` used `bool(current_provider and requested_provider != current_provider)`. A blank legacy `current_provider` therefore preserved the old agent route even when the requested provider was `openai-codex`, producing contradictory persisted state and HTTP 404 responses at the wrong endpoint.

## Verification
- focused RED regression failed with Gemini's endpoint retained instead of the Codex endpoint
- `pytest -q tests/acp/test_server.py` — 81 passed
- `ruff check acp_adapter/server.py tests/acp/test_server.py`
- `git diff --check`
- added-line security scan — clean
- independent review — PASS, no security concerns or logic errors
