### PR TITLE
fix(godmode): close file-descriptor leaks in godmode script loaders

### DIFF
--- a/optional-skills/security/godmode/scripts/auto_jailbreak.py
+++ b/optional-skills/security/godmode/scripts/auto_jailbreak.py
@@ -49,9 +49,9 @@ import inspect as _inspect
 _caller_globals = _inspect.stack()[0][0].f_globals if len(_inspect.stack()) > 0 else globals()
 
 if _parseltongue_path.exists():
-    exec(compile(open(_parseltongue_path).read(), str(_parseltongue_path), 'exec'), _caller_globals)
+    exec(compile(_parseltongue_path.read_text(), str(_parseltongue_path), 'exec'), _caller_globals)
 if _race_path.exists():
-    exec(compile(open(_race_path).read(), str(_race_path), 'exec'), _caller_globals)
+    exec(compile(_race_path.read_text(), str(_race_path), 'exec'), _caller_globals)
 
 # ═══════════════════════════════════════════════════════════════════
 # Hermes config paths

--- a/optional-skills/security/godmode/scripts/load_godmode.py
+++ b/optional-skills/security/godmode/scripts/load_godmode.py
@@ -26,7 +26,7 @@ def _gm_load(path):
     ns = dict(globals())
     ns["__name__"] = "_godmode_module"
     ns["__file__"] = str(path)
-    exec(compile(open(path).read(), str(path), 'exec'), ns)
+    exec(compile(Path(path).read_text(), str(path), 'exec'), ns)
     return ns
 
 for _gm_script in ["parseltongue.py", "godmode_race.py", "auto_jailbreak.py"]:


### PR DESCRIPTION
### Summary
Closes leaked file descriptors in the godmode script loaders by replacing `exec(compile(open(path).read(), ...))` with `Path.read_text()` in:
- `optional-skills/security/godmode/scripts/auto_jailbreak.py` (parseltongue + race loaders)
- `optional-skills/security/godmode/scripts/load_godmode.py` (`_gm_load`)

### Context / credit
Salvages the still-valid portion of #12779 by @bowenliang123. Per the maintainer (`hermes-sweeper`) review on that PR, commit `fdc90346e` moved the godmode sources from `skills/red-teaming/godmode/` to `optional-skills/security/godmode/`, so the original PR's paths no longer touched the shipped source. This reapplies the two script fixes at their **current** paths.

The `tools/environments/local.py` hunk from the original PR is intentionally **omitted** — that read is already context-managed on current main.

### Type of Change
- [x] 🐛 Bug fix (non-breaking)

### How to Test
1. `python3 -m py_compile optional-skills/security/godmode/scripts/auto_jailbreak.py optional-skills/security/godmode/scripts/load_godmode.py` — compiles clean.
2. Behavior is unchanged; `Path.read_text()` opens, reads, and closes the file handle deterministically instead of relying on GC to close the leaked `open()` object.

Credit to @bowenliang123 for the original diagnosis.