### PR TITLE
fix(acp): treat blank current_provider as a real provider change so base_url is correctly rebuilt (#63222)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2004,7 +2004,7 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            provider_changed = requested_provider != current_provider
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(


### PR DESCRIPTION
Closing as duplicate — see comment above.