### PR TITLE
fix(gateway): restore multiplex secondary adapters

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -236,8 +236,16 @@ def _looks_like_e164_number(value: str) -> bool:
 
 
 def check_signal_requirements() -> bool:
-    """Check if Signal is configured (has URL and account)."""
-    return bool(os.getenv("SIGNAL_HTTP_URL") and os.getenv("SIGNAL_ACCOUNT"))
+    """Check if Signal runtime dependencies are available."""
+    return True
+
+
+def validate_signal_config(config: PlatformConfig) -> bool:
+    """Check if Signal has enough config to connect."""
+    extra = getattr(config, "extra", {}) or {}
+    http_url = (extra.get("http_url", "") or os.getenv("SIGNAL_HTTP_URL", "")).strip()
+    account = (extra.get("account", "") or os.getenv("SIGNAL_ACCOUNT", "")).strip()
+    return bool(http_url and account)
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8754,8 +8754,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return WhatsAppCloudAdapter(config)
         
         elif platform == Platform.SIGNAL:
-            from gateway.platforms.signal import SignalAdapter, check_signal_requirements
+            from gateway.platforms.signal import (
+                SignalAdapter,
+                check_signal_requirements,
+                validate_signal_config,
+            )
             if not check_signal_requirements():
+                logger.warning("Signal: runtime requirements not met")
+                return None
+            if not validate_signal_config(config):
                 logger.warning("Signal: SIGNAL_HTTP_URL or SIGNAL_ACCOUNT not configured")
                 return None
             return SignalAdapter(config)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8578,9 +8578,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"'{profile_name}'s config.yaml (configure it only on the "
                     f"default profile)."
                 )
-            with _profile_runtime_scope(profile_home):
-                adapter = self._create_adapter(platform, platform_config)
+            try:
+                with _profile_runtime_scope(profile_home):
+                    adapter = self._create_adapter(platform, platform_config)
+            except Exception as e:
+                logger.error(
+                    "[MULTIPLEX] Profile '%s': _create_adapter('%s') raised %s",
+                    profile_name,
+                    platform.value,
+                    e,
+                    exc_info=True,
+                )
+                continue
             if not adapter:
+                logger.warning(
+                    "[MULTIPLEX] Profile '%s': skipping platform '%s' - adapter creation returned None",
+                    profile_name,
+                    platform.value,
+                )
                 continue
 
             # Same-token conflict detection — refuse a duplicate poll.
@@ -8610,6 +8625,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
             adapter._busy_text_mode = self._busy_text_mode
+            setattr(adapter, "_gateway_profile_label", profile_name)
+            if hasattr(adapter, "config") and hasattr(adapter.config, "extra") and isinstance(adapter.config.extra, dict):
+                adapter.config.extra.setdefault("_gateway_profile", profile_name)
 
             try:
                 with _profile_runtime_scope(profile_home):
@@ -8617,12 +8635,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if success:
                     profile_map[platform] = adapter
                     connected += 1
-                    logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
+                    logger.info(
+                        "✓ %s connected (profile: %s, token_fp=%s)",
+                        platform.value,
+                        profile_name,
+                        fp or "-",
+                    )
                 else:
-                    logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
+                    logger.warning(
+                        "✗ %s failed to connect (profile: %s, token_fp=%s)",
+                        platform.value,
+                        profile_name,
+                        fp or "-",
+                    )
                     await self._safe_adapter_disconnect(adapter, platform)
             except Exception as e:
-                logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
+                logger.error(
+                    "✗ %s error (profile: %s, token_fp=%s): %s",
+                    platform.value,
+                    profile_name,
+                    fp or "-",
+                    e,
+                )
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
 

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -41,13 +41,13 @@ logger = logging.getLogger(__name__)
 
 def check_ha_requirements() -> bool:
     """Check if Home Assistant runtime dependencies are available."""
-    return bool(AIOHTTP_AVAILABLE)
+    return AIOHTTP_AVAILABLE
 
 
 def validate_ha_config(config: PlatformConfig) -> bool:
-    """Accept either a scoped config token or an env-provided HASS_TOKEN."""
-    token = getattr(config, "token", None) or os.getenv("HASS_TOKEN", "")
-    return bool(str(token or "").strip())
+    """Return True when Home Assistant has enough credential config to connect."""
+    token = (getattr(config, "token", None) or os.getenv("HASS_TOKEN", "")).strip()
+    return bool(token)
 
 
 class HomeAssistantAdapter(BasePlatformAdapter):

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -40,12 +40,14 @@ logger = logging.getLogger(__name__)
 
 
 def check_ha_requirements() -> bool:
-    """Check if Home Assistant dependencies are available and configured."""
-    if not AIOHTTP_AVAILABLE:
-        return False
-    if not os.getenv("HASS_TOKEN"):
-        return False
-    return True
+    """Check if Home Assistant runtime dependencies are available."""
+    return bool(AIOHTTP_AVAILABLE)
+
+
+def validate_ha_config(config: PlatformConfig) -> bool:
+    """Accept either a scoped config token or an env-provided HASS_TOKEN."""
+    token = getattr(config, "token", None) or os.getenv("HASS_TOKEN", "")
+    return bool(str(token or "").strip())
 
 
 class HomeAssistantAdapter(BasePlatformAdapter):
@@ -560,6 +562,7 @@ def register(ctx) -> None:
         label="Home Assistant",
         adapter_factory=_build_adapter,
         check_fn=check_ha_requirements,
+        validate_config=validate_ha_config,
         is_connected=_is_connected,
         required_env=["HASS_TOKEN"],
         install_hint="pip install aiohttp",

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -51,21 +51,27 @@ _RECONNECT_JITTER = 0.2
 
 
 def check_mattermost_requirements() -> bool:
-    """Return True if the Mattermost adapter can be used."""
-    token = os.getenv("MATTERMOST_TOKEN", "")
-    url = os.getenv("MATTERMOST_URL", "")
-    if not token:
-        logger.debug("Mattermost: MATTERMOST_TOKEN not set")
-        return False
-    if not url:
-        logger.warning("Mattermost: MATTERMOST_URL not set")
-        return False
+    """Return True if the Mattermost adapter runtime dependency is available."""
     try:
         import aiohttp  # noqa: F401
         return True
     except ImportError:
         logger.warning("Mattermost: aiohttp not installed")
         return False
+
+
+def validate_mattermost_config(config: PlatformConfig) -> bool:
+    """Return True when Mattermost has enough config to connect."""
+    extra = getattr(config, "extra", {}) or {}
+    token = (getattr(config, "token", None) or os.getenv("MATTERMOST_TOKEN", "")).strip()
+    url = (extra.get("url", "") or os.getenv("MATTERMOST_URL", "")).strip()
+    if not token:
+        logger.debug("Mattermost: MATTERMOST_TOKEN not set")
+        return False
+    if not url:
+        logger.warning("Mattermost: MATTERMOST_URL not set")
+        return False
+    return True
 
 
 class MattermostAdapter(BasePlatformAdapter):
@@ -1248,6 +1254,7 @@ def register(ctx) -> None:
         label="Mattermost",
         adapter_factory=_build_adapter,
         check_fn=check_mattermost_requirements,
+        validate_config=validate_mattermost_config,
         is_connected=_is_connected,
         required_env=["MATTERMOST_URL", "MATTERMOST_TOKEN"],
         install_hint="pip install aiohttp",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -678,6 +678,42 @@ class TelegramAdapter(BasePlatformAdapter):
         # blow the gateway's connect timeout (#46298).
         self._post_connect_task: Optional[asyncio.Task] = None
 
+    @staticmethod
+    def _token_fingerprint(token: Optional[str]) -> Optional[str]:
+        """Return a stable, log-safe fingerprint for a Telegram bot token."""
+        if not isinstance(token, str):
+            return None
+        token = token.strip()
+        if not token:
+            return None
+        import hashlib
+
+        return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]
+
+    def _gateway_profile_name(self) -> str:
+        """Best-effort profile label for connect-path diagnostics."""
+        raw = getattr(self, "_gateway_profile_label", None)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+        extra = getattr(self.config, "extra", None)
+        if isinstance(extra, dict):
+            for key in ("_gateway_profile", "profile"):
+                value = extra.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return "default"
+
+    def _connect_diagnostic_summary(self, token: Optional[str] = None) -> str:
+        """Profile-attributed, masked token diagnostics for connect logs."""
+        if token is None:
+            token = getattr(self.config, "token", None)
+        token = token.strip() if isinstance(token, str) else ""
+        fingerprint = self._token_fingerprint(token) or "-"
+        return (
+            f"profile={self._gateway_profile_name()} "
+            f"token_len={len(token)} token_fp={fingerprint}"
+        )
+
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
         super()._mark_connected()
@@ -3016,23 +3052,28 @@ class TelegramAdapter(BasePlatformAdapter):
             TELEGRAM_WEBHOOK_PORT   Local listen port (default 8443)
             TELEGRAM_WEBHOOK_SECRET Secret token for update verification
         """
+        token = getattr(self.config, "token", None)
+        connect_diag = self._connect_diagnostic_summary(token)
         if not TELEGRAM_AVAILABLE:
             logger.error(
-                "[%s] python-telegram-bot not installed. Run: pip install python-telegram-bot",
+                "[%s] python-telegram-bot not installed (%s). Run: pip install python-telegram-bot",
                 self.name,
+                connect_diag,
             )
             return False
         
-        if not self.config.token:
-            logger.error("[%s] No bot token configured", self.name)
+        if not token:
+            logger.error("[%s] No bot token configured (%s)", self.name, connect_diag)
             return False
+
+        logger.info("[%s] Telegram connect starting (%s)", self.name, connect_diag)
         
         try:
-            if not self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
+            if not self._acquire_platform_lock('telegram-bot-token', token, 'Telegram bot token'):
                 return False
 
             # Build the application
-            builder = Application.builder().token(self.config.token)
+            builder = Application.builder().token(token)
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
                 builder = builder.base_url(custom_base_url)
@@ -3210,8 +3251,9 @@ class TelegramAdapter(BasePlatformAdapter):
             for _attempt in range(_max_connect):
                 try:
                     logger.warning(
-                        "[%s] Connecting to Telegram (attempt %d/%d)…",
+                        "[%s] Connecting to Telegram (attempt %d/%d, %s)…",
                         self.name, _attempt + 1, _max_connect,
+                        connect_diag,
                     )
                     await _await_with_thread_deadline(
                         self._app.initialize(),
@@ -3367,7 +3409,12 @@ class TelegramAdapter(BasePlatformAdapter):
             
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
-            logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            logger.info(
+                "[%s] Connected to Telegram (%s mode, %s)",
+                self.name,
+                mode,
+                connect_diag,
+            )
 
             # Start the persistent heartbeat loop in polling mode. Webhook mode
             # receives updates via incoming pushes — there is no long-poll
@@ -3396,7 +3443,12 @@ class TelegramAdapter(BasePlatformAdapter):
             safe_error = _redact_telegram_error_text(e)
             message = f"Telegram startup failed: {safe_error}"
             self._set_fatal_error("telegram_connect_error", message, retryable=True)
-            logger.error("[%s] Failed to connect to Telegram: %s", self.name, safe_error)
+            logger.error(
+                "[%s] Failed to connect to Telegram (%s): %s",
+                self.name,
+                connect_diag,
+                safe_error,
+            )
             return False
 
     async def _set_status_indicator(self, online: bool) -> None:

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -17,6 +17,7 @@ from gateway.config import (
 from plugins.platforms.homeassistant.adapter import (
     HomeAssistantAdapter,
     check_ha_requirements,
+    validate_ha_config,
 )
 
 
@@ -26,18 +27,28 @@ from plugins.platforms.homeassistant.adapter import (
 
 
 class TestCheckRequirements:
-    def test_returns_false_without_token(self, monkeypatch):
+    def test_returns_true_when_aiohttp_present(self, monkeypatch):
         monkeypatch.delenv("HASS_TOKEN", raising=False)
-        assert check_ha_requirements() is False
-
-    def test_returns_true_with_token(self, monkeypatch):
-        monkeypatch.setenv("HASS_TOKEN", "test-token")
         assert check_ha_requirements() is True
 
     @patch("plugins.platforms.homeassistant.adapter.AIOHTTP_AVAILABLE", False)
     def test_returns_false_without_aiohttp(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "test-token")
         assert check_ha_requirements() is False
+
+
+class TestValidateConfig:
+    def test_returns_false_without_token_in_config_or_env(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        assert validate_ha_config(PlatformConfig(enabled=True)) is False
+
+    def test_returns_true_with_token_in_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
+        assert validate_ha_config(PlatformConfig(enabled=True)) is True
+
+    def test_returns_true_with_token_in_config(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        assert validate_ha_config(PlatformConfig(enabled=True, token="cfg-token")) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -27,14 +27,28 @@ from plugins.platforms.homeassistant.adapter import (
 
 
 class TestCheckRequirements:
-    def test_returns_true_when_aiohttp_present(self, monkeypatch):
+    def test_returns_true_without_token_when_aiohttp_available(self, monkeypatch):
         monkeypatch.delenv("HASS_TOKEN", raising=False)
+        assert check_ha_requirements() is True
+
+    def test_returns_true_with_token(self, monkeypatch):
+        monkeypatch.setenv("HASS_TOKEN", "test-token")
         assert check_ha_requirements() is True
 
     @patch("plugins.platforms.homeassistant.adapter.AIOHTTP_AVAILABLE", False)
     def test_returns_false_without_aiohttp(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "test-token")
         assert check_ha_requirements() is False
+
+    def test_validate_config_accepts_platform_token(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        config = PlatformConfig(enabled=True, token="config-token")
+        assert validate_ha_config(config) is True
+
+    def test_validate_config_rejects_missing_token(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        config = PlatformConfig(enabled=True, token="")
+        assert validate_ha_config(config) is False
 
 
 class TestValidateConfig:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -916,13 +916,32 @@ class TestMattermostRequirements:
         monkeypatch.delenv("MATTERMOST_TOKEN", raising=False)
         monkeypatch.delenv("MATTERMOST_URL", raising=False)
         from plugins.platforms.mattermost.adapter import check_mattermost_requirements
-        assert check_mattermost_requirements() is False
+        assert check_mattermost_requirements() is True
 
     def test_check_requirements_without_url(self, monkeypatch):
         monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
         monkeypatch.delenv("MATTERMOST_URL", raising=False)
         from plugins.platforms.mattermost.adapter import check_mattermost_requirements
-        assert check_mattermost_requirements() is False
+        assert check_mattermost_requirements() is True
+
+    def test_validate_config_accepts_platform_values(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_TOKEN", raising=False)
+        monkeypatch.delenv("MATTERMOST_URL", raising=False)
+        from plugins.platforms.mattermost.adapter import validate_mattermost_config
+
+        config = PlatformConfig(
+            enabled=True,
+            token="cfg-token",
+            extra={"url": "https://mm.example.com"},
+        )
+        assert validate_mattermost_config(config) is True
+
+    def test_validate_config_rejects_missing_url(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_URL", raising=False)
+        from plugins.platforms.mattermost.adapter import validate_mattermost_config
+
+        config = PlatformConfig(enabled=True, token="cfg-token", extra={})
+        assert validate_mattermost_config(config) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,4 +1,9 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
+import asyncio
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, cast
+
 import pytest
 
 from gateway.run import GatewayRunner
@@ -8,6 +13,42 @@ class _FakeAdapter:
     def __init__(self, token=None, config=None):
         self.token = token
         self.config = config
+
+
+class _FakeTelegramAdapter(_FakeAdapter):
+    def __init__(self, token=None, config=None):
+        super().__init__(token=token, config=config)
+        self.platform: Any = None
+        self._busy_text_mode = None
+        self._gateway_profile_label = None
+        self.message_handler = None
+        self.fatal_error_handler = None
+        self.session_store = None
+        self.busy_session_handler = None
+        self.topic_recovery_fn = None
+        self.authorization_check = None
+        self.disconnect_called = False
+
+    def set_message_handler(self, handler):
+        self.message_handler = handler
+
+    def set_fatal_error_handler(self, handler):
+        self.fatal_error_handler = handler
+
+    def set_session_store(self, session_store):
+        self.session_store = session_store
+
+    def set_busy_session_handler(self, handler):
+        self.busy_session_handler = handler
+
+    def set_topic_recovery_fn(self, fn):
+        self.topic_recovery_fn = fn
+
+    def set_authorization_check(self, fn):
+        self.authorization_check = fn
+
+    async def disconnect(self):
+        self.disconnect_called = True
 
 
 class TestCredentialFingerprint:
@@ -186,6 +227,60 @@ class TestPortBindingHardError:
         assert connected == 0
         assert duplicate.disconnected is True
         assert runner._profile_adapters["reviewer"] == {}
+
+    @pytest.mark.asyncio
+    async def test_secondary_telegram_connect_logs_profile_and_token_fingerprint(self, monkeypatch, caplog):
+        """Secondary-profile Telegram startup logs must attribute profile + token.
+
+        Regression guard for the multiplex diagnostic blind spot: when a
+        secondary Telegram adapter hangs or fails, the logs must still tell the
+        operator WHICH profile/token was in play, and the adapter must inherit
+        the profile label before connect() runs.
+        """
+        import logging
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner._busy_text_mode = "interrupt"
+        runner.session_store = cast(Any, object())
+        runner._handle_adapter_fatal_error = cast(Any, object())
+        runner._handle_active_session_busy_message = cast(Any, object())
+        runner._recover_telegram_topic_thread_id = cast(Any, object())
+        runner._make_profile_message_handler = cast(Any, lambda profile_name: f"handler:{profile_name}")
+        runner._make_adapter_auth_check = cast(Any, lambda platform: "auth-check")
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="reviewer-token-123"),
+        }
+        adapter = _FakeTelegramAdapter(config=reviewer_cfg.platforms[Platform.TELEGRAM])
+        adapter.platform = Platform.TELEGRAM
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr("gateway.run._profile_runtime_scope", lambda _home: nullcontext())
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: adapter)
+        monkeypatch.setattr(
+            runner,
+            "_connect_adapter_with_timeout",
+            lambda a, p: asyncio.sleep(0, result=True),
+        )
+
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            connected = await runner._start_one_profile_adapters("reviewer", Path("/tmp/reviewer"), {})
+
+        assert connected == 1
+        assert adapter._gateway_profile_label == "reviewer"
+        assert adapter.config.extra.get("_gateway_profile") == "reviewer"
+        expected_fp = GatewayRunner._adapter_credential_fingerprint(adapter)
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "✓ telegram connected" in msg
+            and "profile: reviewer" in msg
+            and f"token_fp={expected_fp}" in msg
+            for msg in messages
+        )
 
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -302,7 +302,29 @@ class TestSignalHelpers:
         from gateway.platforms.signal import check_signal_requirements
         monkeypatch.delenv("SIGNAL_HTTP_URL", raising=False)
         monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
-        assert check_signal_requirements() is False
+        assert check_signal_requirements() is True
+
+    def test_validate_signal_config_accepts_platform_values(self, monkeypatch):
+        monkeypatch.delenv("SIGNAL_HTTP_URL", raising=False)
+        monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
+        from gateway.platforms.signal import validate_signal_config
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "http_url": "http://localhost:8080",
+                "account": "+155****4567",
+            },
+        )
+        assert validate_signal_config(config) is True
+
+    def test_validate_signal_config_rejects_missing_account(self, monkeypatch):
+        monkeypatch.delenv("SIGNAL_HTTP_URL", raising=False)
+        monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
+        from gateway.platforms.signal import validate_signal_config
+
+        config = PlatformConfig(enabled=True, extra={"http_url": "http://localhost:8080"})
+        assert validate_signal_config(config) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the **source bug class** behind multiplex secondary-profile adapter failures by separating:

- **runtime dependency checks** (`check_*requirements()`)
- **profile-scoped credential/config validation** (`validate_*config(config)`)

It also preserves the earlier secondary Telegram regression fix and expands the validation pattern across the affected adapter family.

Specifically, this PR:

- restores secondary Telegram adapter startup after profile-attributed diagnostics were added
- fixes Home Assistant so profile-scoped config tokens work in multiplex mode
- propagates the same dependency-vs-config split to **Mattermost** and **Signal**
- adds regression coverage for the widened adapter family

## Related Issue

Addresses #13827

Related: #49415, #51029, #54675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - preserves safe secondary-profile attribution for multiplexed adapters
  - updates built-in Signal startup to separate dependency checks from config validation
- `plugins/platforms/telegram/adapter.py`
  - keeps profile-attributed diagnostics on the Telegram connect path without method-name collision
- `plugins/platforms/homeassistant/adapter.py`
  - makes `check_ha_requirements()` dependency-only
  - adds `validate_ha_config(config)` so profile-scoped tokens work correctly
- `plugins/platforms/mattermost/adapter.py`
  - makes `check_mattermost_requirements()` dependency-only
  - adds `validate_mattermost_config(config)` so profile-scoped config works correctly
- `gateway/platforms/signal.py`
  - makes `check_signal_requirements()` dependency-only
  - adds `validate_signal_config(config)` so profile-scoped config works correctly
- `tests/gateway/test_homeassistant.py`
  - covers config-aware Home Assistant validation
- `tests/gateway/test_mattermost.py`
  - covers config-aware Mattermost validation
- `tests/gateway/test_signal.py`
  - covers config-aware Signal validation
- `tests/gateway/test_multiplex_adapter_registry.py`
  - keeps regression coverage for secondary Telegram attribution/startup

## Why this is a source fix

The underlying issue was not just one adapter failing; it was a broader pattern where some adapters mixed:

1. “are the runtime dependencies installed?”
2. “does the current process environment happen to contain credentials?”

That breaks multiplexed secondary profiles, where valid credentials may live in **profile-scoped config** rather than process-global env vars.

This PR fixes that bug class by normalizing the contract:

- `check_*requirements()` = runtime/import/dependency availability only
- `validate_*config(config)` = config-aware credential validation with env fallback

## How to Test

1. Run targeted gateway tests:
   - `./venv/bin/python -m pytest tests/gateway/test_homeassistant.py tests/gateway/test_mattermost.py tests/gateway/test_signal.py tests/gateway/test_multiplex_adapter_registry.py -q`
2. Start or restart a multiplexed gateway with secondary profiles using Telegram and one or more config-backed adapters.
3. Verify that:
   - the secondary Telegram adapter connects successfully
   - Home Assistant connects when its token is provided via profile-scoped config
   - Mattermost connects when its token/URL are provided via profile-scoped config
   - Signal connects when its HTTP URL/account are provided via profile-scoped config
   - logs attribute successful secondary connections to the correct profile without exposing raw credentials
4. Verify that genuinely missing credentials still fail explicitly rather than silently collapsing.

## Verification

Targeted test result on this branch:

- `261 passed, 1 skipped`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Representative runtime evidence (anonymized):

- `✓ telegram connected (profile: <secondary>, token_fp=...)`
- `✓ homeassistant connected (profile: <secondary>, token_fp=...)`
- `✓ mattermost connected (profile: <secondary>, token_fp=...)`
- `✓ signal connected (profile: <secondary>, token_fp=...)`
