### PR TITLE
fix(cron): compute interval next-run in absolute time so DST transitions don't shift the gap

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -31,7 +31,7 @@ try:
     import msvcrt
 except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union
@@ -793,12 +793,23 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         if last_run_at:
             try:
                 last = _ensure_aware(datetime.fromisoformat(last_run_at))
-                next_run = last + timedelta(minutes=minutes)
+                # Interval schedules mean N minutes of *real* (absolute) time, so
+                # compute in UTC and convert back. Adding a timedelta directly to
+                # a ZoneInfo-aware datetime is wall-clock arithmetic, which shifts
+                # the true instant by the DST offset when the interval spans a
+                # spring-forward/fall-back boundary (job fires ~1h early/late).
+                next_run = (
+                    last.astimezone(timezone.utc) + timedelta(minutes=minutes)
+                ).astimezone(last.tzinfo)
             except Exception:
-                next_run = now + timedelta(minutes=minutes)
+                next_run = (
+                    now.astimezone(timezone.utc) + timedelta(minutes=minutes)
+                ).astimezone(now.tzinfo)
         else:
-            # First run is now + interval
-            next_run = now + timedelta(minutes=minutes)
+            # First run is now + interval (computed in absolute time; see above).
+            next_run = (
+                now.astimezone(timezone.utc) + timedelta(minutes=minutes)
+            ).astimezone(now.tzinfo)
         return next_run.isoformat()
 
     elif kind == "cron":

--- a/tests/cron/test_compute_next_run_last_run_at.py
+++ b/tests/cron/test_compute_next_run_last_run_at.py
@@ -4,7 +4,7 @@ Regression test for: cron jobs computing next_run_at from _hermes_now()
 instead of from last_run_at, making them inconsistent with interval jobs.
 """
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 pytest.importorskip("croniter")
@@ -46,3 +46,144 @@ class TestCronComputeNextRunUsesLastRunAt:
         assert next_dt.hour == 18
 
 
+class TestIntervalNextRunIsAbsoluteAcrossDST:
+    """Interval schedules mean N minutes of *real* time. When last_run_at is
+    anchored on the far side of a DST transition, the next run must land at the
+    correct absolute instant (last_run + interval in UTC), not at a wall-clock
+    offset that the DST jump shifts by ~1h."""
+
+    def test_spring_forward_does_not_fire_early(self, monkeypatch):
+        """last_run 2026-03-08 01:30 EST, every 120 min. Spring-forward is at
+        02:00. Wall-clock addition yields 03:30 EDT = 07:30 UTC (only 60 real
+        minutes -> fires ~1h early). Absolute math yields 08:30 UTC."""
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 3, 8, 12, 0, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(
+            schedule, last_run_at="2026-03-08T01:30:00-05:00"
+        )
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 3, 8, 8, 30, tzinfo=timezone.utc), (
+            f"Expected 08:30 UTC (last_run + 120 real minutes), got {got_utc}"
+        )
+
+    def test_fall_back_does_not_fire_late(self, monkeypatch):
+        """last_run 2026-11-01 01:30 EDT, every 120 min. Fall-back is at 02:00.
+        Wall-clock addition yields 03:30 EST = 08:30 UTC (150 real minutes ->
+        fires ~1h late). Absolute math yields 07:30 UTC."""
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 11, 1, 12, 0, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(
+            schedule, last_run_at="2026-11-01T01:30:00-04:00"
+        )
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 11, 1, 7, 30, tzinfo=timezone.utc), (
+            f"Expected 07:30 UTC (last_run + 120 real minutes), got {got_utc}"
+        )
+
+    def test_first_run_spring_forward_does_not_fire_early(self, monkeypatch):
+        """First-run branch (no last_run_at): the interval is measured from
+        `now` and must still be absolute.
+
+        now = 2026-03-08 01:30 EST (06:30 UTC), every 120 min. Wall-clock
+        addition yields 03:30, which on that date resolves to EDT = 07:30 UTC
+        — only 60 real minutes, so the first run fires ~1h early. Absolute
+        math yields 08:30 UTC.
+        """
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 3, 8, 1, 30, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(schedule)
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 3, 8, 8, 30, tzinfo=timezone.utc), (
+            f"Expected 08:30 UTC (now + 120 real minutes), got {got_utc}"
+        )
+
+    def test_first_run_fall_back_does_not_fire_late(self, monkeypatch):
+        """First-run branch across the fall-back boundary.
+
+        now = 2026-11-01 01:30 EDT (05:30 UTC), every 120 min. Wall-clock
+        addition yields 03:30 EST = 08:30 UTC — 150 real minutes, so the first
+        run fires ~1h late. Absolute math yields 07:30 UTC.
+        """
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 11, 1, 1, 30, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(schedule)
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 11, 1, 7, 30, tzinfo=timezone.utc), (
+            f"Expected 07:30 UTC (now + 120 real minutes), got {got_utc}"
+        )
+
+    @pytest.mark.parametrize(
+        "bad_last_run_at",
+        ["not-a-timestamp", "2026-13-45T99:99:99", "1772000000"],
+        ids=["garbage", "out-of-range", "epoch-seconds"],
+    )
+    def test_exception_fallback_spring_forward_does_not_fire_early(
+        self, monkeypatch, bad_last_run_at
+    ):
+        """Exception-fallback branch: an unparseable `last_run_at` falls back to
+        `now`, and that fallback must be absolute too.
+
+        `datetime.fromisoformat` raises on these, so the handler recomputes from
+        now = 2026-03-08 01:30 EST (06:30 UTC). Wall-clock addition would give
+        03:30 EDT = 07:30 UTC (~1h early); absolute math gives 08:30 UTC.
+        """
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 3, 8, 1, 30, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(schedule, last_run_at=bad_last_run_at)
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 3, 8, 8, 30, tzinfo=timezone.utc), (
+            f"Expected 08:30 UTC (now + 120 real minutes), got {got_utc}"
+        )
+
+    def test_exception_fallback_fall_back_does_not_fire_late(self, monkeypatch):
+        """Exception-fallback branch across the fall-back boundary.
+
+        now = 2026-11-01 01:30 EDT (05:30 UTC). Wall-clock addition would give
+        03:30 EST = 08:30 UTC (~1h late); absolute math gives 07:30 UTC.
+        """
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 11, 1, 1, 30, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(schedule, last_run_at="not-a-timestamp")
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 11, 1, 7, 30, tzinfo=timezone.utc), (
+            f"Expected 07:30 UTC (now + 120 real minutes), got {got_utc}"
+        )
+
+    def test_non_dst_interval_is_exact(self, monkeypatch):
+        """An interval that does not cross a DST boundary is unchanged: the
+        absolute-time round-trip is a no-op when the offset is stable."""
+        ny = ZoneInfo("America/New_York")
+        now = datetime(2026, 6, 1, 18, 0, 0, tzinfo=ny)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "interval", "minutes": 120}
+        result = compute_next_run(
+            schedule, last_run_at="2026-06-01T12:00:00-04:00"
+        )
+        assert result is not None
+        got_utc = datetime.fromisoformat(result).astimezone(timezone.utc)
+        assert got_utc == datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## What does this PR do?

`compute_next_run` for `interval` schedules added the interval as a raw wall-clock `timedelta` to a `ZoneInfo`-aware `last_run_at`:

```python
last = _ensure_aware(datetime.fromisoformat(last_run_at))
next_run = last + timedelta(minutes=minutes)
```

Adding a `timedelta` to a `ZoneInfo`-aware datetime is **wall-clock arithmetic** (it shifts the naive fields and keeps the zone), so when the interval spans a DST transition the resulting *absolute instant* is off by the DST delta. An interval schedule means N minutes of **real** time, so the job fires ~1h early on spring-forward and ~1h late on fall-back. The two first-run/fallback branches (`now + timedelta`) shared the same class of bug.

Fix: compute the interval in UTC and convert back to the original zone. When the offset doesn't change (the common non-DST case) the `astimezone` round-trip is a no-op, so those results are byte-identical. Cron-expression jobs (croniter, wall-clock by design) and `once` jobs are untouched.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: import `timezone`; compute the `interval` next-run in absolute time at all three interval sites (last-run, exception fallback, first-run). No change to the `once`/`cron` branches.
- `tests/cron/test_compute_next_run_last_run_at.py`: add `TestIntervalNextRunIsAbsoluteAcrossDST` covering spring-forward, fall-back, and a non-DST no-op invariant.

## How to Test

Reproduction (America/New_York), `{"kind":"interval","minutes":120}`:

| case | last_run_at | before (buggy) | after (fixed) |
|------|-------------|----------------|---------------|
| spring-forward | `2026-03-08T01:30:00-05:00` | 07:30 UTC (60 real min → ~1h early) | **08:30 UTC** |
| fall-back | `2026-11-01T01:30:00-04:00` | 08:30 UTC (150 real min → ~1h late) | **07:30 UTC** |
| non-DST | `2026-06-01T12:00:00-04:00` | 18:00 UTC | 18:00 UTC (unchanged) |

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cron/test_compute_next_run_last_run_at.py -v`
2. New DST tests FAIL on `main` (07:30 / 08:30 UTC) and PASS with the fix.
3. Full `tests/cron/` suite: 682 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A