### PR TITLE
docs: fix Discord permission integer in invite URL and table

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -170,7 +170,7 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 You can construct the invite URL directly using this format:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878286912
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878024768
 ```
 
 Replace `YOUR_APP_ID` with the Application ID from Step 1.
@@ -194,8 +194,8 @@ These are the minimum permissions your bot needs:
 
 | Level | Permissions Integer | What's Included |
 |-------|-------------------|-----------------|
-| Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files |
-| Recommended | `274878286912` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
+| Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files, Embed Links |
+| Recommended | `274878024768` | All of the above plus Send Messages in Threads, Add Reactions |
 
 ## Step 6: Invite to Your Server
 


### PR DESCRIPTION
## Summary

The Recommended permission integer in the Discord setup docs was wrong.

### What changed

- `permissions=274878286912` → `274878024768` in the manual invite URL
- Same correction in the Permission Integers table
- Added **Embed Links** to the Minimal row's description — the integer 117760 already included it but the text didn't list it

### Why

`274878286912` includes **Use External Emojis** (262144), which isn't in the described permission set. Selecting the described checkboxes in Discord's OAuth2 URL Generator produces `274878024768`.

Verified against Discord's permission bit flags:

| Permission | Value |
|---|---|
| View Channels | 1,024 |
| Send Messages | 2,048 |
| Embed Links | 16,384 |
| Attach Files | 32,768 |
| Read Message History | 65,536 |
| *Minimal subtotal* | *117,760* ✓ |
| Send Messages in Threads | 274,877,906,944 |
| Add Reactions | 64 |
| **Recommended total** | **274,878,024,768** ✓ |