### PR TITLE
fix(desktop): resolve project cwd membership with Windows path identity

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -353,8 +353,14 @@ export function mergeRepoWorktreeGroups(
 // needs the backend common-root probe, so those rows are left for the next
 // tree refresh; the common case (a new main-checkout session) overlays here.
 
-/** True when `target` equals `folder` or is nested under it (segment-wise). */
-function isPathUnder(folder: string, target: string): boolean {
+/**
+ * True when `target` equals `folder` or is nested under it (segment-wise).
+ *
+ * Exported so `store/projects.ts` resolves project membership with the SAME
+ * path identity the sidebar overlay uses — a `/`-only, case-sensitive prefix
+ * test disagrees with this one on every Windows cwd.
+ */
+export function isPathUnder(folder: string, target: string): boolean {
   const f = comparisonSegments(folder)
   const t = comparisonSegments(target)
 

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -27,6 +27,7 @@ import {
   exitProjectScope,
   openProjectCreate,
   pickProjectFolder,
+  projectIdForCwd,
   projectNameForCwd,
   refreshProjects,
   refreshProjectTree,
@@ -259,6 +260,63 @@ describe('projectNameForCwd', () => {
 
     expect(projectNameForCwd('/somewhere/else')).toBeNull()
     expect(projectNameForCwd('')).toBeNull()
+  })
+})
+
+// Both lookups above share one `underPath` helper, so a membership bug hits the
+// project a session is filed under AND the name the status bar shows for it.
+describe('project cwd membership uses Windows path identity', () => {
+  const treeNode = (id: string, label: string, path: string): SidebarProjectTree => ({
+    id,
+    label,
+    path,
+    repos: [],
+    sessionCount: 0
+  })
+
+  beforeEach(() => {
+    $projectTree.set([])
+  })
+
+  it('matches a backslash-separated nested cwd to its forward-slash project root', () => {
+    $projectTree.set([treeNode('p_win', 'Repo', 'C:/Users/me/repo')])
+
+    // The old `/`-only prefix test missed every nested Windows cwd: the backend
+    // hands back `C:/…` while the OS reports the session cwd as `C:\…`.
+    expect(projectIdForCwd('C:\\Users\\me\\repo\\sub')).toBe('p_win')
+  })
+
+  it('folds drive-letter case on Windows', () => {
+    $projectTree.set([treeNode('p_win', 'Repo', 'C:\\Users\\me\\repo')])
+
+    expect(projectIdForCwd('c:\\Users\\me\\repo\\sub')).toBe('p_win')
+  })
+
+  it('folds mid-path segment case on Windows', () => {
+    $projectTree.set([treeNode('p_win', 'Repo', 'C:\\Users\\me\\repo')])
+
+    expect(projectIdForCwd('C:\\Users\\ME\\Repo\\sub')).toBe('p_win')
+  })
+
+  it('names the project for a Windows cwd too (same helper, second call site)', () => {
+    $projectTree.set([treeNode('p_win', 'Repo', 'C:/Users/me/repo')])
+
+    expect(projectNameForCwd('C:\\Users\\me\\repo\\sub')).toBe('Repo')
+  })
+
+  it('keeps POSIX membership case-sensitive', () => {
+    $projectTree.set([treeNode('p_posix', 'Repo', '/Users/me/repo')])
+
+    // POSIX paths are genuinely case-sensitive: `/Users/me/Repo` is a DIFFERENT
+    // directory, so folding case here would file sessions under the wrong project.
+    expect(projectIdForCwd('/Users/me/Repo/sub')).toBeNull()
+    expect(projectIdForCwd('/Users/me/repo/sub')).toBe('p_posix')
+  })
+
+  it('does not match a sibling directory sharing a name prefix', () => {
+    $projectTree.set([treeNode('p_win', 'Repo', 'C:\\Users\\me\\repo')])
+
+    expect(projectIdForCwd('C:\\Users\\me\\repo-retry\\sub')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import {
+  isPathUnder,
   liveSessionProjectId,
   NO_PROJECT_ID,
   type SidebarProjectTree
@@ -281,8 +282,13 @@ function focusedSessionWorkspaceCwd(): string {
   return $currentCwd.get().trim()
 }
 
-const underPath = (parent: string, child: string): boolean =>
-  child === parent || child.startsWith(parent.endsWith('/') ? parent : `${parent}/`)
+// Path membership for BOTH lookups below (`projectIdForCwd`, `projectNameForCwd`).
+// This was a `/`-only, case-sensitive prefix test, so on Windows a `C:\Users\me\
+// repo\sub` cwd never matched its `C:/Users/me/repo` project root — and a drive
+// letter or segment cased differently broke it on any spelling. Delegate to the
+// sidebar's segment-wise helper instead of keeping a second, weaker notion of
+// "is this cwd inside that project" in the same app.
+const underPath = (parent: string, child: string): boolean => isPathUnder(parent, child)
 
 // The project (explicit or auto) that owns `cwd`, by longest path match across
 // the live tree. Null when no project covers it (it'll surface as a fresh


### PR DESCRIPTION
## What does this PR do?

`store/projects.ts` decided project-cwd membership with `underPath`:

```ts
const underPath = (parent: string, child: string): boolean =>
  child === parent || child.startsWith(parent.endsWith('/') ? parent : `${parent}/`)
```

That prefix check is POSIX-`/`-only and case-sensitive. The backend hands the project tree back as `C:/Users/me/repo` while the OS reports the session cwd as `C:\Users\me\repo\sub`, so on Windows the separator alone breaks membership for every nested cwd — only the exact-equality branch survives — and a drive letter or path segment cased differently breaks it on any spelling.

**One helper, two visible symptoms.** `underPath` backs both `projectIdForCwd` and `projectNameForCwd`, so on Windows:

- the session is filed under **no project at all** — `projectIdForCwd` returns `null`, so `followActiveSessionCwd` fails to enter the relocated session's project, and the session surfaces as a fresh auto-project on the next tree refresh instead of joining the project it lives in;
- the status bar shows the **bare cwd leaf** instead of the project's name, because `projectNameForCwd` misses the same way.

**The app already had the correct comparison.** `app/chat/sidebar/projects/workspace-groups.ts` answers the same question with `isPathUnder` — a segment-wise check whose `comparisonSegments` splits on both separators and folds case only for Windows spellings (drive-letter, UNC, backslash-rooted), mirroring the backend `_is_windows_path`. So rather than add a second Windows-aware implementation, this exports `isPathUnder` and delegates to it. `store/projects.ts` already imports from that module (`liveSessionProjectId`, `NO_PROJECT_ID`, `SidebarProjectTree`), so no dependency direction is inverted.

That also removes the disagreement itself: the sidebar overlay and the store now resolve "is this cwd inside that project" identically — which is what the user actually sees when a session lands in one place in the tree and is labeled by another.

POSIX behavior is unchanged and stays case-sensitive: `/Users/me/Repo` really is a different directory, and folding case there would file sessions under the wrong project. The longest-match char-length tiebreak in both lookups is untouched.

## Related Issue

N/A — found by inspection.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts`: export the existing `isPathUnder` (comment only, no behavior change).
- `apps/desktop/src/store/projects.ts`: `underPath` delegates to `isPathUnder` instead of the `/`-only, case-sensitive prefix test. Both `projectIdForCwd` and `projectNameForCwd` pick the fix up; neither loop changes.
- `apps/desktop/src/store/projects.test.ts`: `project cwd membership uses Windows path identity` — backslash cwd against a forward-slash root, drive-letter case, mid-path segment case, the label lookup through the same helper, a POSIX case-sensitivity guard proving that path is unchanged, and a sibling-directory guard (`repo-retry` must not match `repo`).

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/store/projects.test.ts` → 33 passed.
2. Regression guard, both directions: restoring the old `underPath` body turns the 4 Windows cases red (`expected null to be 'p_win'` / `expected null to be 'Repo'`) while the POSIX and sibling-prefix guards stay green, so the tests discriminate the actual fix rather than the helper's existence. Green again with the fix restored.
3. Adjacent suites: `npx vitest run --project ui src/store/projects.test.ts src/app/chat/sidebar/projects/` → 6 files, 106 passed.
4. `npx eslint src/store/projects.ts src/store/projects.test.ts src/app/chat/sidebar/projects/workspace-groups.ts` clean; `npx tsc -p . --noEmit` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- desktop: vitest, see How to Test -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (vitest/jsdom; Windows paths exercised as data, not on a Windows host)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-focused fix; POSIX membership stays case-sensitive and is covered by a negative test
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

- **#65030** (@ayushnangia) NFC-normalizes `comparisonSegments` in the same file, so NFD and NFC spellings of an accented folder resolve to one path. It is orthogonal to this PR — different function, no overlapping hunk — but it is also the argument for delegating rather than reimplementing: because `underPath` now calls `isPathUnder`, the store inherits that normalization automatically. A second inline copy of the identity logic in `store/` would silently miss it and the two layers would disagree again on the next such fix.
- **#73992** (@ten82e) touches `store/projects.ts` too, but in `followActiveSessionCwd` — a *caller* of `projectIdForCwd`, guarding against a stale follow and redundant RPCs. Different bug, no shared hunk; the two compose.
