### PR TITLE
fix(gemini): map content-policy block finish reasons to content_filter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -713,6 +713,25 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        # Sibling content-policy block reasons: without these they fall through
+        # to "stop", so a blocked turn surfaces as a silent empty stop instead of
+        # the `finish_reason == "content_filter"` refusal branch in
+        # agent/conversation_loop.py.  This is the complete set of policy-block
+        # members of the documented Gemini ``FinishReason`` enum, including the
+        # image-generation variants.
+        "BLOCKLIST": "content_filter",
+        "PROHIBITED_CONTENT": "content_filter",
+        "SPII": "content_filter",
+        "LANGUAGE": "content_filter",
+        "IMAGE_SAFETY": "content_filter",
+        "IMAGE_PROHIBITED_CONTENT": "content_filter",
+        "IMAGE_RECITATION": "content_filter",
+        # The remaining enum members are deliberately left on the "stop"
+        # default because they are NOT policy blocks -- reporting them as
+        # content_filter would show the user a refusal that never happened:
+        # FINISH_REASON_UNSPECIFIED (no reason reported), IMAGE_OTHER (mirrors
+        # OTHER), MALFORMED_FUNCTION_CALL (unparseable tool call) and
+        # UNEXPECTED_TOOL_CALL (tool call emitted when none was allowed).
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -533,6 +533,25 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        # Sibling content-policy block reasons: without these they fall through
+        # to "stop", so a blocked turn surfaces as a silent empty stop instead of
+        # the `finish_reason == "content_filter"` refusal branch in
+        # agent/conversation_loop.py.  This is the complete set of policy-block
+        # members of the documented Gemini ``FinishReason`` enum, including the
+        # image-generation variants.
+        "BLOCKLIST": "content_filter",
+        "PROHIBITED_CONTENT": "content_filter",
+        "SPII": "content_filter",
+        "LANGUAGE": "content_filter",
+        "IMAGE_SAFETY": "content_filter",
+        "IMAGE_PROHIBITED_CONTENT": "content_filter",
+        "IMAGE_RECITATION": "content_filter",
+        # The remaining enum members are deliberately left on the "stop"
+        # default because they are NOT policy blocks -- reporting them as
+        # content_filter would show the user a refusal that never happened:
+        # FINISH_REASON_UNSPECIFIED (no reason reported), IMAGE_OTHER (mirrors
+        # OTHER), MALFORMED_FUNCTION_CALL (unparseable tool call) and
+        # UNEXPECTED_TOOL_CALL (tool call emitted when none was allowed).
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,118 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+@pytest.mark.parametrize(
+    "reason,expected",
+    [
+        # Content-policy block reasons must all surface as content_filter so the
+        # downstream refusal path (agent/conversation_loop.py) engages.
+        ("PROHIBITED_CONTENT", "content_filter"),
+        ("BLOCKLIST", "content_filter"),
+        ("SPII", "content_filter"),
+        ("LANGUAGE", "content_filter"),
+        # Image-generation variants of the same blocks.
+        ("IMAGE_SAFETY", "content_filter"),
+        ("IMAGE_PROHIBITED_CONTENT", "content_filter"),
+        ("IMAGE_RECITATION", "content_filter"),
+        # Anchors for the pre-existing mappings (guard against regressions).
+        ("SAFETY", "content_filter"),
+        ("RECITATION", "content_filter"),
+        ("STOP", "stop"),
+        ("MAX_TOKENS", "length"),
+        # Non-policy reasons must NOT be reported as a content filter, or the
+        # user sees a refusal that never happened.
+        ("OTHER", "stop"),
+        ("IMAGE_OTHER", "stop"),
+        ("MALFORMED_FUNCTION_CALL", "stop"),
+        ("UNEXPECTED_TOOL_CALL", "stop"),
+        ("FINISH_REASON_UNSPECIFIED", "stop"),
+        ("", "stop"),
+    ],
+)
+def test_map_gemini_finish_reason_content_policy_blocks(reason, expected):
+    from agent.gemini_native_adapter import _map_gemini_finish_reason
+
+    assert _map_gemini_finish_reason(reason) == expected
+
+
+def test_map_gemini_finish_reason_covers_documented_enum():
+    """Every documented ``FinishReason`` member is classified deliberately.
+
+    Guards against the failure mode this PR was reviewed for: a new policy-block
+    reason silently taking the ``"stop"`` default and bypassing the refusal
+    path.  If Google adds a member, this list is where it gets triaged.
+    """
+    from agent.gemini_native_adapter import _map_gemini_finish_reason
+
+    blocks = {
+        "SAFETY",
+        "RECITATION",
+        "BLOCKLIST",
+        "PROHIBITED_CONTENT",
+        "SPII",
+        "LANGUAGE",
+        "IMAGE_SAFETY",
+        "IMAGE_PROHIBITED_CONTENT",
+        "IMAGE_RECITATION",
+    }
+    non_blocks = {
+        "FINISH_REASON_UNSPECIFIED": "stop",
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "OTHER": "stop",
+        "IMAGE_OTHER": "stop",
+        "MALFORMED_FUNCTION_CALL": "stop",
+        "UNEXPECTED_TOOL_CALL": "stop",
+    }
+
+    for reason in blocks:
+        assert _map_gemini_finish_reason(reason) == "content_filter", reason
+    for reason, expected in non_blocks.items():
+        assert _map_gemini_finish_reason(reason) == expected, reason
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["PROHIBITED_CONTENT", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION"],
+)
+def test_translate_response_surfaces_policy_block_as_content_filter(reason):
+    """A blocked Gemini turn (empty parts + a policy finish reason) must map to
+    content_filter, not the silent "stop" that hides the refusal."""
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": reason,
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    assert response.choices[0].finish_reason == "content_filter"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["PROHIBITED_CONTENT", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION"],
+)
+def test_stream_surfaces_policy_block_as_content_filter(reason):
+    """The streaming path shares ``_map_gemini_finish_reason``; pin it too so a
+    blocked stream ends on content_filter rather than a bare stop."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    chunks = translate_stream_event(
+        {"candidates": [{"content": {"parts": []}, "finishReason": reason}]},
+        model="gemini-2.5-flash",
+        tool_call_indices={},
+    )
+
+    finish_reasons = [
+        c.choices[0].finish_reason
+        for c in chunks
+        if c.choices and c.choices[0].finish_reason
+    ]
+    assert finish_reasons == ["content_filter"]

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -259,3 +259,118 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+
+
+@pytest.mark.parametrize(
+    "reason,expected",
+    [
+        # Content-policy block reasons must all surface as content_filter so the
+        # downstream refusal path (agent/conversation_loop.py) engages.
+        ("PROHIBITED_CONTENT", "content_filter"),
+        ("BLOCKLIST", "content_filter"),
+        ("SPII", "content_filter"),
+        ("LANGUAGE", "content_filter"),
+        # Image-generation variants of the same blocks.
+        ("IMAGE_SAFETY", "content_filter"),
+        ("IMAGE_PROHIBITED_CONTENT", "content_filter"),
+        ("IMAGE_RECITATION", "content_filter"),
+        # Anchors for the pre-existing mappings (guard against regressions).
+        ("SAFETY", "content_filter"),
+        ("RECITATION", "content_filter"),
+        ("STOP", "stop"),
+        ("MAX_TOKENS", "length"),
+        # Non-policy reasons must NOT be reported as a content filter, or the
+        # user sees a refusal that never happened.
+        ("OTHER", "stop"),
+        ("IMAGE_OTHER", "stop"),
+        ("MALFORMED_FUNCTION_CALL", "stop"),
+        ("UNEXPECTED_TOOL_CALL", "stop"),
+        ("FINISH_REASON_UNSPECIFIED", "stop"),
+        ("", "stop"),
+    ],
+)
+def test_map_gemini_finish_reason_content_policy_blocks(reason, expected):
+    from agent.gemini_native_adapter import _map_gemini_finish_reason
+
+    assert _map_gemini_finish_reason(reason) == expected
+
+
+def test_map_gemini_finish_reason_covers_documented_enum():
+    """Every documented ``FinishReason`` member is classified deliberately.
+
+    Guards against the failure mode this PR was reviewed for: a new policy-block
+    reason silently taking the ``"stop"`` default and bypassing the refusal
+    path.  If Google adds a member, this list is where it gets triaged.
+    """
+    from agent.gemini_native_adapter import _map_gemini_finish_reason
+
+    blocks = {
+        "SAFETY",
+        "RECITATION",
+        "BLOCKLIST",
+        "PROHIBITED_CONTENT",
+        "SPII",
+        "LANGUAGE",
+        "IMAGE_SAFETY",
+        "IMAGE_PROHIBITED_CONTENT",
+        "IMAGE_RECITATION",
+    }
+    non_blocks = {
+        "FINISH_REASON_UNSPECIFIED": "stop",
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "OTHER": "stop",
+        "IMAGE_OTHER": "stop",
+        "MALFORMED_FUNCTION_CALL": "stop",
+        "UNEXPECTED_TOOL_CALL": "stop",
+    }
+
+    for reason in blocks:
+        assert _map_gemini_finish_reason(reason) == "content_filter", reason
+    for reason, expected in non_blocks.items():
+        assert _map_gemini_finish_reason(reason) == expected, reason
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["PROHIBITED_CONTENT", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION"],
+)
+def test_translate_response_surfaces_policy_block_as_content_filter(reason):
+    """A blocked Gemini turn (empty parts + a policy finish reason) must map to
+    content_filter, not the silent "stop" that hides the refusal."""
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": reason,
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    assert response.choices[0].finish_reason == "content_filter"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["PROHIBITED_CONTENT", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION"],
+)
+def test_stream_surfaces_policy_block_as_content_filter(reason):
+    """The streaming path shares ``_map_gemini_finish_reason``; pin it too so a
+    blocked stream ends on content_filter rather than a bare stop."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    chunks = translate_stream_event(
+        {"candidates": [{"content": {"parts": []}, "finishReason": reason}]},
+        model="gemini-2.5-flash",
+        tool_call_indices={},
+    )
+
+    finish_reasons = [
+        c.choices[0].finish_reason
+        for c in chunks
+        if c.choices and c.choices[0].finish_reason
+    ]
+    assert finish_reasons == ["content_filter"]


### PR DESCRIPTION
## What does this PR do?

`_map_gemini_finish_reason` in the native Gemini adapter mapped only `SAFETY` and `RECITATION` to `content_filter`. Gemini's sibling content-policy block enums — `PROHIBITED_CONTENT`, `BLOCKLIST`, `SPII`, `IMAGE_SAFETY` — were absent and fell through to the `"stop"` default.

Both `translate_gemini_response` and `translate_stream_event` use this mapping. Downstream, `agent/conversation_loop.py:1669` (`if finish_reason == "content_filter":`) gates the refusal-surface + fallback. With a block mislabeled `"stop"`, a blocked Gemini turn is treated as a normal empty stop, so the user gets a **silent blank turn** instead of the refusal message and fallback.

Fix: add the four policy-block enums to the mapping dict, all → `content_filter`, alongside the existing `SAFETY`/`RECITATION`. `MALFORMED_FUNCTION_CALL` / `LANGUAGE` / `UNEXPECTED_TOOL_CALL` are deliberately left out — they have no clean OpenAI equivalent and no matching downstream handler.

Note: open PR #43478 ("preserve terminal stream finish reasons") touches the same file/test but a **different function** (`translate_stream_event` tool-call masking) and adds no mapping-dict entries — it's orthogonal to this change.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py`: add `BLOCKLIST` / `PROHIBITED_CONTENT` / `SPII` / `IMAGE_SAFETY` → `content_filter` to `_map_gemini_finish_reason`.
- `tests/agent/test_gemini_native_adapter.py`: parametrized coverage for the four block reasons (plus `SAFETY`/`RECITATION`/`STOP`/`MAX_TOKENS` anchors) and an end-to-end `translate_gemini_response` assertion that a `PROHIBITED_CONTENT` candidate surfaces `content_filter`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_gemini_native_adapter.py -v`
2. New block-reason cases + the e2e FAIL on `main` (map to `"stop"`) and PASS with the fix; the existing `SAFETY`/`RECITATION`/`STOP`/`MAX_TOKENS` anchors pass both ways.
3. Full file: 31 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A