### PR TITLE
fix(codex): preserve azure reasoning replay ids

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -893,8 +893,14 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        _is_azure_foundry_for_input = (
+            ".services.ai.azure.com" in _host_for_input.lower()
+            or ".openai.azure.com" in _host_for_input.lower()
+        )
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=_is_github_for_input,
+            replay_messages,
+            is_github_responses=_is_github_for_input,
+            is_azure_foundry=_is_azure_foundry_for_input,
         )
 
         resp_kwargs: Dict[str, Any] = {

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -867,6 +867,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
+            base_url=agent.base_url,
             reasoning_config=agent.reasoning_config,
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -315,6 +315,7 @@ def _chat_messages_to_responses_input(
     *,
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
+    is_azure_foundry: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
@@ -397,11 +398,12 @@ def _chat_messages_to_responses_input(
                 )
                 has_codex_reasoning = False
                 if isinstance(codex_reasoning, list):
-                    for ri in codex_reasoning:
-                        if isinstance(ri, dict) and ri.get("encrypted_content"):
-                            item_id = ri.get("id")
-                            if item_id and item_id in seen_item_ids:
-                                continue
+                        for ri in codex_reasoning:
+                            if isinstance(ri, dict) and ri.get("encrypted_content"):
+                                encrypted = ri.get("encrypted_content")
+                                item_id = ri.get("id")
+                                if item_id and item_id in seen_item_ids:
+                                    continue
                             # Cross-issuer guard: drop reasoning blocks that
                             # were minted by a different Responses endpoint.
                             # The current endpoint cannot decrypt foreign
@@ -425,17 +427,37 @@ def _chat_messages_to_responses_input(
                                     )
                                     _CROSS_ISSUER_WARN_EMITTED = True
                                 continue
-                            # Strip the "id" field — with store=False the
-                            # Responses API cannot look up items by ID and
-                            # returns 404.  The encrypted_content blob is
-                            # self-contained for reasoning chain continuity.
-                            # Also strip the internal "_issuer_kind" stamp;
-                            # it is a Hermes-side metadata key and not part
-                            # of the Responses API schema.
-                            replay_item = {
-                                k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
-                            }
+                            # Azure AI Foundry re-validates replayed reasoning
+                            # items against its stricter wire schema and
+                            # requires the original ``id`` to be present.
+                            # Preserve only the fields it accepts; other
+                            # Responses surfaces reject or ignore the same
+                            # extras, so keep the narrower payload Azure-only.
+                            if is_azure_foundry:
+                                replay_item = {
+                                    "type": "reasoning",
+                                    "encrypted_content": encrypted,
+                                    "summary": (
+                                        ri.get("summary")
+                                        if isinstance(ri.get("summary"), list)
+                                        else []
+                                    ),
+                                }
+                                if isinstance(item_id, str) and item_id:
+                                    replay_item["id"] = item_id
+                            else:
+                                # Strip the "id" field — with store=False the
+                                # OpenAI/Codex Responses API cannot look up
+                                # items by ID and returns 404. The
+                                # encrypted_content blob is self-contained for
+                                # reasoning chain continuity. Also strip the
+                                # internal "_issuer_kind" stamp; it is a
+                                # Hermes-side metadata key and not part of the
+                                # Responses API schema.
+                                replay_item = {
+                                    k: v for k, v in ri.items()
+                                    if k not in ("id", "_issuer_kind")
+                                }
                             items.append(replay_item)
                             if item_id:
                                 seen_item_ids.add(item_id)
@@ -604,6 +626,7 @@ def _preflight_codex_input_items(
     raw_items: Any,
     *,
     is_github_responses: bool = False,
+    is_azure_foundry: bool = False,
 ) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -700,10 +723,12 @@ def _preflight_codex_input_items(
                         continue
                     seen_ids.add(item_id)
                 reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
-                # Do NOT include the "id" in the outgoing item — with
-                # store=False (our default) the API tries to resolve the
-                # id server-side and returns 404.  The id is still used
-                # above for local deduplication via seen_ids.
+                # Do NOT include the "id" in the general Responses path —
+                # with store=False (our default) OpenAI/Codex tries to resolve
+                # the id server-side and returns 404. Azure AI Foundry expects
+                # the replayed reasoning id, so preserve it only there.
+                if is_azure_foundry and isinstance(item_id, str) and item_id:
+                    reasoning_item["id"] = item_id
                 summary = item.get("summary")
                 if isinstance(summary, list):
                     reasoning_item["summary"] = summary
@@ -825,6 +850,7 @@ def _preflight_codex_api_kwargs(
     *,
     allow_stream: bool = False,
     is_github_responses: bool = False,
+    is_azure_foundry: bool = False,
 ) -> Dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
@@ -849,6 +875,7 @@ def _preflight_codex_api_kwargs(
     normalized_input = _preflight_codex_input_items(
         api_kwargs.get("input"),
         is_github_responses=is_github_responses,
+        is_azure_foundry=is_azure_foundry,
     )
 
     tools = api_kwargs.get("tools")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1171,6 +1171,7 @@ def run_conversation(
                         api_kwargs,
                         allow_stream=False,
                         is_github_responses=agent._is_copilot_url(),
+                        is_azure_foundry=agent._is_azure_foundry_url(),
                     )
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
@@ -1323,6 +1324,7 @@ def run_conversation(
                             next_api_kwargs,
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
+                            is_azure_foundry=agent._is_azure_foundry_url(),
                         )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,6 +13,11 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _is_azure_foundry_base_url(base_url: Optional[str]) -> bool:
+    url = str(base_url or "").lower()
+    return ".services.ai.azure.com" in url or ".openai.azure.com" in url
+
+
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
     """Content-address the prompt cache key from the static request prefix.
 
@@ -82,6 +87,7 @@ class ResponsesApiTransport(ProviderTransport):
             messages,
             is_xai_responses=kwargs.get("is_xai_responses") is True,
             is_github_responses=kwargs.get("is_github_responses") is True,
+            is_azure_foundry=_is_azure_foundry_base_url(kwargs.get("base_url")),
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -141,6 +147,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_azure_foundry = _is_azure_foundry_base_url(params.get("base_url"))
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -247,6 +254,7 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
                 is_github_responses=is_github_responses,
+                is_azure_foundry=is_azure_foundry,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
             ),
@@ -452,6 +460,7 @@ class ResponsesApiTransport(ProviderTransport):
         *,
         allow_stream: bool = False,
         is_github_responses: bool = False,
+        is_azure_foundry: bool = False,
     ) -> dict:
         """Validate and sanitize Codex API kwargs before the call.
 
@@ -462,6 +471,7 @@ class ResponsesApiTransport(ProviderTransport):
             api_kwargs,
             allow_stream=allow_stream,
             is_github_responses=is_github_responses,
+            is_azure_foundry=is_azure_foundry,
         )
 
     def map_finish_reason(self, raw_reason: str) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1200,6 +1200,14 @@ class AIAgent:
             url = getattr(self, "_base_url_lower", "") or ""
         return "openai.azure.com" in url
 
+    def _is_azure_foundry_url(self, base_url: str = None) -> bool:
+        """Return True when a base URL targets Azure AI Foundry/OpenAI."""
+        if base_url is not None:
+            url = str(base_url).lower()
+        else:
+            url = getattr(self, "_base_url_lower", "") or ""
+        return ".services.ai.azure.com" in url or ".openai.azure.com" in url
+
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""
         if base_url is not None:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4141,6 +4141,86 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         assert message_item["id"] == "msg_short_but_connection_scoped"
 
 
+class TestCodexAdapterAzureFoundryReasoningReplay:
+    """Auxiliary Codex adapter must preserve Azure Foundry reasoning ids.
+
+    Auxiliary calls bypass ``ResponsesApiTransport.build_kwargs()``, so the
+    Azure-specific reasoning replay shape has to be applied here too. Azure AI
+    Foundry rejects replayed encrypted reasoning when Hermes strips the
+    reasoning item ``id`` from prior turns.
+    """
+
+    @staticmethod
+    def _build_adapter(base_url):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text="ok")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed", id="resp_test", usage=None,
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.base_url = base_url
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.5")
+        return adapter, captured_kwargs
+
+    def test_keeps_reasoning_id_for_azure_foundry_host(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://paperclip.services.ai.azure.com/models"
+        )
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {
+                    "role": "assistant",
+                    "content": "thinking",
+                    "codex_reasoning_items": [
+                        {
+                            "type": "reasoning",
+                            "id": "rs_123",
+                            "encrypted_content": "enc_blob",
+                            "summary": [{"type": "summary_text", "text": "brief"}],
+                            "status": "completed",
+                            "response_id": "resp_123",
+                        }
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ]
+        )
+
+        reasoning_item = next(
+            item for item in captured["input"] if item.get("type") == "reasoning"
+        )
+        assert reasoning_item == {
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "enc_blob",
+            "summary": [{"type": "summary_text", "text": "brief"}],
+        }
+
+
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -204,6 +204,36 @@ def test_chat_messages_to_responses_input_keeps_short_message_id():
     assert message_item["id"] == _VALID_ITEM_ID
 
 
+def test_chat_messages_to_responses_input_keeps_reasoning_id_for_azure_foundry():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "encrypted_content": "enc_blob",
+                    "summary": [{"type": "summary_text", "text": "brief"}],
+                    "status": "completed",
+                    "response_id": "resp_123",
+                    "_issuer_kind": "other",
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages, is_azure_foundry=True)
+
+    reasoning_item = next(item for item in items if item.get("type") == "reasoning")
+    assert reasoning_item == {
+        "type": "reasoning",
+        "id": "rs_123",
+        "encrypted_content": "enc_blob",
+        "summary": [{"type": "summary_text", "text": "brief"}],
+    }
+
+
 def test_preflight_codex_input_items_drops_oversized_message_id():
     items = _preflight_codex_input_items(
         [
@@ -236,6 +266,29 @@ def test_preflight_codex_input_items_keeps_short_message_id():
     )
 
     assert items[0]["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_codex_input_items_keeps_reasoning_id_for_azure_foundry():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "reasoning",
+                "id": "rs_123",
+                "encrypted_content": "enc_blob",
+                "summary": [{"type": "summary_text", "text": "brief"}],
+                "status": "completed",
+                "response_id": "resp_123",
+            }
+        ],
+        is_azure_foundry=True,
+    )
+
+    assert items[0] == {
+        "type": "reasoning",
+        "id": "rs_123",
+        "encrypted_content": "enc_blob",
+        "summary": [{"type": "summary_text", "text": "brief"}],
+    }
 
 
 def test_preflight_codex_input_items_drops_short_id_for_github_responses():

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -243,6 +243,65 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
+    def test_azure_foundry_build_kwargs_keeps_reasoning_id(self, transport):
+        messages = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "thinking",
+                "codex_reasoning_items": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_123",
+                        "encrypted_content": "enc_blob",
+                        "summary": [{"type": "summary_text", "text": "brief"}],
+                        "status": "completed",
+                        "response_id": "resp_123",
+                    }
+                ],
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            base_url="https://paperclip.services.ai.azure.com/models",
+        )
+
+        reasoning_item = next(item for item in kw["input"] if item.get("type") == "reasoning")
+        assert reasoning_item == {
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "enc_blob",
+            "summary": [{"type": "summary_text", "text": "brief"}],
+        }
+
+    def test_azure_foundry_preflight_keeps_reasoning_id(self, transport):
+        kw = {
+            "model": "gpt-5.5",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "encrypted_content": "enc_blob",
+                    "summary": [{"type": "summary_text", "text": "brief"}],
+                    "status": "completed",
+                    "response_id": "resp_123",
+                }
+            ],
+            "store": False,
+        }
+
+        preflight = transport.preflight_kwargs(kw, is_azure_foundry=True)
+        assert preflight["input"][0] == {
+            "type": "reasoning",
+            "id": "rs_123",
+            "encrypted_content": "enc_blob",
+            "summary": [{"type": "summary_text", "text": "brief"}],
+        }
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is


### PR DESCRIPTION
## What does this PR do?

Fixes Azure AI Foundry/OpenAI Responses replay failures by preserving reasoning item `id` fields only on Azure Foundry-style endpoints, while keeping the existing OpenAI/Codex behavior that strips those ids from general Responses replay. The change threads Azure endpoint detection through the main transport preflight path and the auxiliary Codex adapter so both request builders replay the same compatible reasoning shape.

## Related Issue

Fixes #63257

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve replayed reasoning `id` fields for Azure AI Foundry/OpenAI Responses endpoints in `agent/codex_responses_adapter.py`.
- Thread Azure endpoint detection through `agent/transports/codex.py`, `agent/conversation_loop.py`, `agent/chat_completion_helpers.py`, `agent/auxiliary_client.py`, and `run_agent.py`.
- Add regression tests covering adapter replay normalization, transport build/preflight behavior, and auxiliary Codex replay behavior.

## How to Test

1. Reproduce with an Azure AI Foundry/OpenAI Responses endpoint and a prior assistant turn containing replayable `codex_reasoning_items`.
2. Run `uv run pytest tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/agent/test_auxiliary_client.py -q`.
3. Confirm replayed reasoning items sent to Azure retain `{type, id, encrypted_content, summary}` while non-Azure Responses paths continue stripping the reasoning `id`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run pytest tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/agent/test_auxiliary_client.py -q` → `396 passed in 26.45s`
- `uv run python -m py_compile agent/codex_responses_adapter.py agent/transports/codex.py agent/auxiliary_client.py agent/chat_completion_helpers.py agent/conversation_loop.py run_agent.py tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/agent/test_auxiliary_client.py`
- `git diff --check`
