### PR TITLE
fix(gateway): keep stale route when recovery lookup fails

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1156,12 +1156,14 @@ class SessionStore:
                 # end_reason not None -> session ended — prune
                 if row is not None and row.get("end_reason") is not None:
                     recovered_entry = None
+                    recovery_lookup_failed = False
                     if entry.origin is not None:
                         try:
                             recovered_entry = self._recover_session_from_db(
                                 session_key=key,
                                 source=entry.origin,
                                 now=_now(),
+                                raise_on_lookup_error=True,
                             )
                         except Exception as exc:
                             logger.debug(
@@ -1171,6 +1173,10 @@ class SessionStore:
                                 entry.session_id,
                                 exc,
                             )
+                            recovery_lookup_failed = True
+
+                    if recovery_lookup_failed:
+                        continue
 
                     # If the stale entry points at a compression-ended parent but
                     # a newer live child session exists for the exact same gateway
@@ -1394,6 +1400,7 @@ class SessionStore:
         session_key: str,
         source: SessionSource,
         now: datetime,
+        raise_on_lookup_error: bool = False,
     ) -> Optional[SessionEntry]:
         """Rebuild a missing session-key mapping from durable state.db data."""
         if not self._db:
@@ -1412,6 +1419,8 @@ class SessionStore:
             )
         except Exception as exc:
             logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)
+            if raise_on_lookup_error:
+                raise
             return None
         if not recovered:
             return None

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -151,6 +151,25 @@ class TestPruneStaleSessionsLocked:
 
         assert key not in store._entries
 
+    def test_keeps_stale_entry_when_recovery_lookup_raises(self, tmp_path):
+        """Indeterminate recovery must not delete the only routing handle.
+
+        Startup pruning sees an ended parent and tries to repoint it to the
+        latest live gateway child.  If that recovery query raises, deleting the
+        sessions.json entry loses the routing key entirely; keeping it lets the
+        runtime stale guard retry recovery on the next message.
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning({"sid_parent": {"end_reason": "compression", "id": "sid_parent"}})
+        db.find_latest_gateway_session_for_peer.side_effect = RuntimeError("db busy")
+        store = _make_store_with_db(tmp_path, db)
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        store._prune_stale_sessions_locked()
+
+        assert key in store._entries
+        assert store._entries[key].session_id == "sid_parent"
+
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
         with patch("gateway.session.SessionStore._ensure_loaded"):


### PR DESCRIPTION
## Summary

`SessionStore._prune_stale_sessions_locked()` could delete the only gateway routing entry when startup stale-session recovery hit a transient lookup error.

When `sessions.json` points at an ended parent session, startup pruning tries to recover the latest live gateway child through `_recover_session_from_db()`. If that recovery lookup fails unexpectedly, the current code treats it the same as “no recoverable row exists” and prunes the routing key. That loses the only fast routing handle for the peer, so the next gateway message can mint a fresh empty session instead of retrying recovery.

## Why

This is the same fail-safe shape as the recent session-state P1 fixes: an indeterminate safety/recovery check should not destroy session routing state.

Keeping the stale entry on lookup failure is safer than deleting it, because the runtime stale guard can retry recovery on the next message. The existing behavior for a clean “no recovery found” result is unchanged.

## Changes

- Add an opt-in `raise_on_lookup_error` path to `_recover_session_from_db()`.
- Use it from startup stale pruning so lookup exceptions are distinguishable from “no recovered row.”
- Keep the stale routing entry when recovery lookup is indeterminate.
- Add a regression test proving the routing key survives a recovery lookup exception.

## Tests

```text
python -m pytest -p no:cacheprovider --basetemp=.pytest_tmp_session_prune tests/gateway/test_session_store_stale_prune.py -k "recovery_lookup_raises or repoints_stale_compression_parent or prunes_stale_entry_when_recovery_only_finds_same_ended_session" -q --timeout-method=thread
3 passed, 11 deselected

python -m pytest -p no:cacheprovider --basetemp=.pytest_tmp_session_prune tests/gateway/test_session_store_stale_prune.py tests/gateway/test_session_store_runtime_stale_guard.py -q --timeout-method=thread
25 passed