### PR TITLE
fix(sessions): preserve Hermes web source categories

### DIFF
--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MESSAGING_SESSION_SOURCE_IDS,
+  isMessagingSource,
+  sessionSourceLabel,
+  sessionSourceSearchTerms,
+} from './session-source'
+
+describe('session-source registry', () => {
+  it('groups Hermes Browser Extension sessions as their own sidebar source', () => {
+    expect(sessionSourceLabel('hermes_browser')).toBe('Hermes Browser Extension')
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('hermes_browser')
+    expect(isMessagingSource('hermes_browser')).toBe(true)
+    expect(sessionSourceSearchTerms('hermes_browser')).toContain('Hermes Browser Extension')
+  })
+
+  it('groups Hermes Web sessions as their own sidebar source', () => {
+    expect(sessionSourceLabel('hermes_web')).toBe('Hermes Web')
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('hermes_web')
+    expect(isMessagingSource('hermes_web')).toBe(true)
+    expect(sessionSourceSearchTerms('hermes_web')).toContain('Hermes Web')
+  })
+})

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  MESSAGING_SESSION_SOURCE_IDS,
   isMessagingSource,
+  MESSAGING_SESSION_SOURCE_IDS,
   sessionSourceLabel,
   sessionSourceSearchTerms,
 } from './session-source'

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { isMessagingSource, MESSAGING_SESSION_SOURCE_IDS, sessionSourceSearchTerms } from './session-source'
+import {
+  isMessagingSource,
+  MESSAGING_SESSION_SOURCE_IDS,
+  sessionSourceLabel,
+  sessionSourceSearchTerms,
+} from './session-source'
 
 // Regression guard for #46761 / PR #47395: Photon (iMessage) must keep its own
 // sidebar section. refreshMessagingSessions() filters rows through
@@ -31,5 +36,21 @@ describe('photon messaging source registration', () => {
     expect(isMessagingSource('cli')).toBe(false)
     expect(isMessagingSource(null)).toBe(false)
     expect(isMessagingSource(undefined)).toBe(false)
+  })
+})
+
+describe('session-source registry', () => {
+  it('groups Hermes Browser Extension sessions as their own sidebar source', () => {
+    expect(sessionSourceLabel('hermes_browser')).toBe('Hermes Browser Extension')
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('hermes_browser')
+    expect(isMessagingSource('hermes_browser')).toBe(true)
+    expect(sessionSourceSearchTerms('hermes_browser')).toContain('Hermes Browser Extension')
+  })
+
+  it('groups Hermes Web sessions as their own sidebar source', () => {
+    expect(sessionSourceLabel('hermes_web')).toBe('Hermes Web')
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('hermes_web')
+    expect(isMessagingSource('hermes_web')).toBe(true)
+    expect(sessionSourceSearchTerms('hermes_web')).toContain('Hermes Web')
   })
 })

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -2,6 +2,8 @@ import { normalize } from '@/lib/text'
 
 const SOURCE_LABELS: Record<string, string> = {
   api_server: 'API',
+  hermes_browser: 'Hermes Browser Extension',
+  hermes_web: 'Hermes Web',
   bluebubbles: 'iMessage',
   cli: 'CLI',
   codex: 'Codex',
@@ -60,6 +62,8 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'sms',
   'webhook',
   'api_server',
+  'hermes_browser',
+  'hermes_web',
   'weixin',
   'wecom',
   'qqbot',

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -2,6 +2,8 @@ import { normalize } from '@/lib/text'
 
 const SOURCE_LABELS: Record<string, string> = {
   api_server: 'API',
+  hermes_browser: 'Hermes Browser Extension',
+  hermes_web: 'Hermes Web',
   bluebubbles: 'iMessage',
   cli: 'CLI',
   codex: 'Codex',
@@ -64,6 +66,8 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'sms',
   'webhook',
   'api_server',
+  'hermes_browser',
+  'hermes_web',
   'weixin',
   'wecom',
   'qqbot',

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1694,9 +1694,19 @@ class APIServerAdapter(BasePlatformAdapter):
         return payload
 
     @staticmethod
-    def _normalize_session_source(value: Any, *, default: str = "api_server") -> Optional[str]:
+    def _normalize_session_source(
+        value: Any,
+        *,
+        default: str = "api_server",
+        session_id: str = "",
+    ) -> Optional[str]:
         """Accept the small public source taxonomy used by first-party clients."""
         if value is None:
+            normalized_id = str(session_id or "").strip().lower()
+            if normalized_id.startswith("hermes-web-"):
+                return "hermes_web"
+            if normalized_id.startswith("hermes-browser-"):
+                return "hermes_browser"
             return default
         source = str(value).strip().lower()
         if source in {"api_server", "hermes_browser", "hermes_web"}:
@@ -1792,7 +1802,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if db.get_session(session_id):
             return web.json_response(_openai_error(f"Session already exists: {session_id}", code="session_exists"), status=409)
 
-        source = self._normalize_session_source(body.get("source"))
+        source = self._normalize_session_source(body.get("source"), session_id=session_id)
         if source is None:
             return web.json_response(
                 _openai_error("Invalid session source", code="invalid_session_source"),

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1694,6 +1694,16 @@ class APIServerAdapter(BasePlatformAdapter):
         return payload
 
     @staticmethod
+    def _normalize_session_source(value: Any, *, default: str = "api_server") -> Optional[str]:
+        """Accept the small public source taxonomy used by first-party clients."""
+        if value is None:
+            return default
+        source = str(value).strip().lower()
+        if source in {"api_server", "hermes_browser", "hermes_web"}:
+            return source
+        return None
+
+    @staticmethod
     def _message_response(message: Dict[str, Any]) -> Dict[str, Any]:
         safe_keys = (
             "id", "session_id", "role", "content", "tool_call_id", "tool_calls",
@@ -1782,11 +1792,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if db.get_session(session_id):
             return web.json_response(_openai_error(f"Session already exists: {session_id}", code="session_exists"), status=409)
 
+        source = self._normalize_session_source(body.get("source"))
+        if source is None:
+            return web.json_response(
+                _openai_error("Invalid session source", code="invalid_session_source"),
+                status=400,
+            )
         model = body.get("model") or self._model_name
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
-        db.create_session(session_id, "api_server", model=str(model) if model else None, system_prompt=system_prompt)
+        db.create_session(session_id, source, model=str(model) if model else None, system_prompt=system_prompt)
         title = body.get("title")
         if title is not None:
             try:
@@ -1794,7 +1810,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except ValueError as exc:
                 db.delete_session(session_id)
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
-        session = db.get_session(session_id) or {"id": session_id, "source": "api_server", "model": model, "title": title}
+        session = db.get_session(session_id) or {"id": session_id, "source": source, "model": model, "title": title}
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)}, status=201)
 
     async def _handle_get_session(self, request: "web.Request") -> "web.Response":
@@ -1819,12 +1835,20 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        allowed = {"title", "end_reason", "source"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
 
         db = self._ensure_session_db()
+        if "source" in body:
+            source = self._normalize_session_source(body["source"], default="")
+            if source is None or not source:
+                return web.json_response(
+                    _openai_error("Invalid session source", code="invalid_session_source"),
+                    status=400,
+                )
+            db.set_session_source(session_id, source)
         if "title" in body:
             try:
                 db.set_session_title(session_id, "" if body["title"] is None else str(body["title"]))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1919,6 +1919,8 @@ class APIServerAdapter(BasePlatformAdapter):
         if db.get_session(fork_id):
             return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
+        fork_source = self._normalize_session_source(source.get("source")) or "api_server"
+
         # Match the CLI /branch semantics: mark the original as branched, then
         # create a child session that carries the transcript forward. This uses
         # SessionDB's native parent_session_id/end_reason visibility model rather
@@ -1926,7 +1928,7 @@ class APIServerAdapter(BasePlatformAdapter):
         db.end_session(source_id, "branched")
         db.create_session(
             fork_id,
-            "api_server",
+            fork_source,
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
             parent_session_id=source_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2573,12 +2573,33 @@ class APIServerAdapter(BasePlatformAdapter):
         return result
 
     @staticmethod
-    def _normalize_session_source(value: Any) -> str:
-        text = str(value or "").strip().lower()
-        allowed = {"api_server", "hermes_browser", "browser", "cli", "telegram", "discord", "slack", "desktop", "dashboard"}
+    def _normalize_session_source(
+        value: Any,
+        *,
+        default: str = "api_server",
+        session_id: str = "",
+    ) -> str:
+        """Accept the small public source taxonomy used by first-party clients.
+
+        Known sources pass through; unknown values fall back to *default*
+        (callers may pass ``default=""`` to turn an unknown source into a
+        rejection). When ``value`` is None, first-party sources are inferred
+        from the session-id prefix (``hermes-web-*`` / ``hermes-browser-*``)
+        so stale clients that predate explicit ``source`` still group
+        correctly.
+        """
+        if value is None:
+            normalized_id = str(session_id or "").strip().lower()
+            if normalized_id.startswith("hermes-web-"):
+                return "hermes_web"
+            if normalized_id.startswith("hermes-browser-"):
+                return "hermes_browser"
+            return default
+        text = str(value).strip().lower()
+        allowed = {"api_server", "hermes_browser", "hermes_web", "browser", "cli", "telegram", "discord", "slack", "desktop", "dashboard"}
         if text in allowed:
             return "hermes_browser" if text == "browser" else text
-        return "api_server"
+        return default
 
     def _session_model_override_for(self, session_key: Optional[str]) -> Optional[Dict[str, Any]]:
         """Return the gateway's session ``/model`` override for *session_key*, if any.
@@ -3463,7 +3484,7 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
-        source = self._normalize_session_source(body.get("source") or "api_server")
+        source = self._normalize_session_source(body.get("source"), session_id=session_id)
         runtime_request = self._session_runtime_request_from_body(body)
         lock_error = self._runtime_lock_error(runtime_request)
         if lock_error is not None:
@@ -3580,7 +3601,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # sweep). Rejecting them here was silently 400ing every pin the desktop
         # made, so pins only ever lived in that one app's localStorage.
         # `unread` is the read-state watermark toggle (same desktop owner).
-        allowed = {"title", "end_reason", "pinned", "archived", "hidden", "unread"}
+        # `source` is the client-facing source label correction (first-party
+        # clients can fix mislabeled sessions; validated below).
+        allowed = {"title", "end_reason", "source", "pinned", "archived", "hidden", "unread"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
@@ -3592,6 +3615,14 @@ class APIServerAdapter(BasePlatformAdapter):
         db = await self._ensure_session_db_async()
         if db is None:
             return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+        if "source" in body:
+            source = self._normalize_session_source(body["source"], default="")
+            if not source:
+                return web.json_response(
+                    _openai_error("Invalid session source", code="invalid_session_source"),
+                    status=400,
+                )
+            await asyncio.to_thread(db.set_session_source, session_id, source)
         if "title" in body:
             try:
                 await asyncio.to_thread(db.set_session_title, session_id, "" if body["title"] is None else str(body["title"]))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2581,12 +2581,12 @@ class APIServerAdapter(BasePlatformAdapter):
     ) -> str:
         """Accept the small public source taxonomy used by first-party clients.
 
-        Known sources pass through; unknown values fall back to *default*
-        (callers may pass ``default=""`` to turn an unknown source into a
-        rejection). When ``value`` is None, first-party sources are inferred
+        Known sources pass through; an explicit unknown source normalizes to
+        an empty string so callers can reject it (or pass ``default`` to
+        coerce). When ``value`` is None, first-party sources are inferred
         from the session-id prefix (``hermes-web-*`` / ``hermes-browser-*``)
         so stale clients that predate explicit ``source`` still group
-        correctly.
+        correctly; otherwise *default* is returned.
         """
         if value is None:
             normalized_id = str(session_id or "").strip().lower()
@@ -2599,7 +2599,7 @@ class APIServerAdapter(BasePlatformAdapter):
         allowed = {"api_server", "hermes_browser", "hermes_web", "browser", "cli", "telegram", "discord", "slack", "desktop", "dashboard"}
         if text in allowed:
             return "hermes_browser" if text == "browser" else text
-        return default
+        return ""
 
     def _session_model_override_for(self, session_key: Optional[str]) -> Optional[Dict[str, Any]]:
         """Return the gateway's session ``/model`` override for *session_key*, if any.
@@ -3485,6 +3485,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
         source = self._normalize_session_source(body.get("source"), session_id=session_id)
+        if not source:
+            return web.json_response(
+                _openai_error("Invalid session source", code="invalid_session_source"),
+                status=400,
+            )
         runtime_request = self._session_runtime_request_from_body(body)
         lock_error = self._runtime_lock_error(runtime_request)
         if lock_error is not None:
@@ -3732,6 +3737,8 @@ class APIServerAdapter(BasePlatformAdapter):
         if await asyncio.to_thread(db.get_session, fork_id):
             return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
+        fork_source = self._normalize_session_source(source.get("source")) or "api_server"
+
         # Match the CLI /branch semantics: mark the original as branched, then
         # create a child session that carries the transcript forward. This uses
         # SessionDB's native parent_session_id/end_reason visibility model rather
@@ -3739,7 +3746,7 @@ class APIServerAdapter(BasePlatformAdapter):
         await asyncio.to_thread(db.end_session, source_id, "branched")
         await asyncio.to_thread(db.create_session,
             fork_id,
-            "api_server",
+            fork_source,
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
             parent_session_id=source_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1754,6 +1754,17 @@ class SessionDB:
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
 
+    def set_session_source(self, session_id: str, source: str) -> bool:
+        """Update the client-facing source label for an existing session."""
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET source = ? WHERE id = ?",
+                (source, session_id),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
     def record_gateway_session_peer(
         self,
         session_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4716,6 +4716,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
 
+    def set_session_source(self, session_id: str, source: str) -> bool:
+        """Update the client-facing source label for an existing session."""
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET source = ? WHERE id = ?",
+                (source, session_id),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
     def record_gateway_session_peer(
         self,
         session_id: str,

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -170,6 +170,30 @@ async def test_session_crud_and_message_history(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_session_api_preserves_hermes_web_source_and_allows_source_correction(adapter, session_db):
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        created = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-web-source-session", "source": "hermes_web", "title": "Hermes Web source"},
+        )
+        assert created.status == 201, await created.text()
+        created_payload = await created.json()
+        assert created_payload["session"]["source"] == "hermes_web"
+
+        legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
+        corrected = await cli.patch(
+            f"/api/sessions/{legacy_id}",
+            json={"source": "hermes_web"},
+        )
+        assert corrected.status == 200, await corrected.text()
+        corrected_payload = await corrected.json()
+
+    assert corrected_payload["session"]["source"] == "hermes_web"
+    assert session_db.get_session("hermes-web-legacy-source")["source"] == "hermes_web"
+
+
+@pytest.mark.asyncio
 async def test_session_messages_follow_compression_tip(adapter, session_db):
     source_id = session_db.create_session("source-session", "api_server")
     session_db.append_message(source_id, "user", "before compression")

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -181,6 +181,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         created_payload = await created.json()
         assert created_payload["session"]["source"] == "hermes_web"
 
+        stale_client = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-web-stale-client", "title": "Hermes Web stale client"},
+        )
+        assert stale_client.status == 201, await stale_client.text()
+        stale_payload = await stale_client.json()
+        assert stale_payload["session"]["source"] == "hermes_web"
+
         legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
         corrected = await cli.patch(
             f"/api/sessions/{legacy_id}",

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -170,16 +170,24 @@ async def test_session_crud_and_message_history(adapter, session_db):
 
 
 @pytest.mark.asyncio
-async def test_session_api_preserves_hermes_web_source_and_allows_source_correction(adapter, session_db):
+async def test_session_api_preserves_first_party_sources_and_rejects_invalid_sources(adapter, session_db):
     app = _create_session_app(adapter)
     async with TestClient(TestServer(app)) as cli:
-        created = await cli.post(
+        web_created = await cli.post(
             "/api/sessions",
             json={"id": "hermes-web-source-session", "source": "hermes_web", "title": "Hermes Web source"},
         )
-        assert created.status == 201, await created.text()
-        created_payload = await created.json()
-        assert created_payload["session"]["source"] == "hermes_web"
+        assert web_created.status == 201, await web_created.text()
+        web_payload = await web_created.json()
+        assert web_payload["session"]["source"] == "hermes_web"
+
+        browser_created = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-browser-source-session", "source": "hermes_browser"},
+        )
+        assert browser_created.status == 201, await browser_created.text()
+        browser_payload = await browser_created.json()
+        assert browser_payload["session"]["source"] == "hermes_browser"
 
         stale_client = await cli.post(
             "/api/sessions",
@@ -189,6 +197,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         stale_payload = await stale_client.json()
         assert stale_payload["session"]["source"] == "hermes_web"
 
+        invalid_create = await cli.post(
+            "/api/sessions",
+            json={"id": "invalid-source-session", "source": "desktop"},
+        )
+        assert invalid_create.status == 400
+        invalid_create_payload = await invalid_create.json()
+        assert invalid_create_payload["error"]["code"] == "invalid_session_source"
+
         legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
         corrected = await cli.patch(
             f"/api/sessions/{legacy_id}",
@@ -196,6 +212,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         )
         assert corrected.status == 200, await corrected.text()
         corrected_payload = await corrected.json()
+
+        invalid_patch = await cli.patch(
+            f"/api/sessions/{legacy_id}",
+            json={"source": "desktop"},
+        )
+        assert invalid_patch.status == 400
+        invalid_patch_payload = await invalid_patch.json()
+        assert invalid_patch_payload["error"]["code"] == "invalid_session_source"
 
     assert corrected_payload["session"]["source"] == "hermes_web"
     assert session_db.get_session("hermes-web-legacy-source")["source"] == "hermes_web"
@@ -223,7 +247,7 @@ async def test_session_messages_follow_compression_tip(adapter, session_db):
 
 @pytest.mark.asyncio
 async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, session_db):
-    source_id = session_db.create_session("source-session", "api_server", model="test-model")
+    source_id = session_db.create_session("source-session", "hermes_web", model="test-model")
     session_db.set_session_title(source_id, "Original")
     session_db.append_message(source_id, "user", "first path")
     session_db.append_message(source_id, "assistant", "answer")
@@ -238,9 +262,23 @@ async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, se
     assert payload["object"] == "hermes.session"
     assert fork["id"] != source_id
     assert fork["parent_session_id"] == source_id
+    assert fork["source"] == "hermes_web"
     assert fork["title"] == "Alternative"
     assert [m["content"] for m in session_db.get_messages(fork["id"])] == ["first path", "answer"]
     assert session_db.get_session(source_id)["end_reason"] == "branched"
+
+
+@pytest.mark.asyncio
+async def test_session_fork_falls_back_to_api_server_for_non_client_source(adapter, session_db):
+    source_id = session_db.create_session("legacy-source-session", "desktop")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={})
+        assert resp.status == 201
+        payload = await resp.json()
+
+    assert payload["session"]["source"] == "api_server"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -207,6 +207,30 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_session_api_preserves_hermes_web_source_and_allows_source_correction(adapter, session_db):
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        created = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-web-source-session", "source": "hermes_web", "title": "Hermes Web source"},
+        )
+        assert created.status == 201, await created.text()
+        created_payload = await created.json()
+        assert created_payload["session"]["source"] == "hermes_web"
+
+        legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
+        corrected = await cli.patch(
+            f"/api/sessions/{legacy_id}",
+            json={"source": "hermes_web"},
+        )
+        assert corrected.status == 200, await corrected.text()
+        corrected_payload = await corrected.json()
+
+    assert corrected_payload["session"]["source"] == "hermes_web"
+    assert session_db.get_session("hermes-web-legacy-source")["source"] == "hermes_web"
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_disconnect_keeps_control_refs_until_executor_finishes(
     adapter, session_db
 ):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -218,6 +218,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         created_payload = await created.json()
         assert created_payload["session"]["source"] == "hermes_web"
 
+        stale_client = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-web-stale-client", "title": "Hermes Web stale client"},
+        )
+        assert stale_client.status == 201, await stale_client.text()
+        stale_payload = await stale_client.json()
+        assert stale_payload["session"]["source"] == "hermes_web"
+
         legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
         corrected = await cli.patch(
             f"/api/sessions/{legacy_id}",

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -207,16 +207,24 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_session_api_preserves_hermes_web_source_and_allows_source_correction(adapter, session_db):
+async def test_session_api_preserves_first_party_sources_and_rejects_invalid_sources(adapter, session_db):
     app = _create_session_app(adapter)
     async with TestClient(TestServer(app)) as cli:
-        created = await cli.post(
+        web_created = await cli.post(
             "/api/sessions",
             json={"id": "hermes-web-source-session", "source": "hermes_web", "title": "Hermes Web source"},
         )
-        assert created.status == 201, await created.text()
-        created_payload = await created.json()
-        assert created_payload["session"]["source"] == "hermes_web"
+        assert web_created.status == 201, await web_created.text()
+        web_payload = await web_created.json()
+        assert web_payload["session"]["source"] == "hermes_web"
+
+        browser_created = await cli.post(
+            "/api/sessions",
+            json={"id": "hermes-browser-source-session", "source": "hermes_browser"},
+        )
+        assert browser_created.status == 201, await browser_created.text()
+        browser_payload = await browser_created.json()
+        assert browser_payload["session"]["source"] == "hermes_browser"
 
         stale_client = await cli.post(
             "/api/sessions",
@@ -226,6 +234,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         stale_payload = await stale_client.json()
         assert stale_payload["session"]["source"] == "hermes_web"
 
+        invalid_create = await cli.post(
+            "/api/sessions",
+            json={"id": "invalid-source-session", "source": "bogus_source"},
+        )
+        assert invalid_create.status == 400
+        invalid_create_payload = await invalid_create.json()
+        assert invalid_create_payload["error"]["code"] == "invalid_session_source"
+
         legacy_id = session_db.create_session("hermes-web-legacy-source", "api_server")
         corrected = await cli.patch(
             f"/api/sessions/{legacy_id}",
@@ -233,6 +249,14 @@ async def test_session_api_preserves_hermes_web_source_and_allows_source_correct
         )
         assert corrected.status == 200, await corrected.text()
         corrected_payload = await corrected.json()
+
+        invalid_patch = await cli.patch(
+            f"/api/sessions/{legacy_id}",
+            json={"source": "bogus_source"},
+        )
+        assert invalid_patch.status == 400
+        invalid_patch_payload = await invalid_patch.json()
+        assert invalid_patch_payload["error"]["code"] == "invalid_session_source"
 
     assert corrected_payload["session"]["source"] == "hermes_web"
     assert session_db.get_session("hermes-web-legacy-source")["source"] == "hermes_web"
@@ -328,6 +352,42 @@ async def test_session_chat_stream_disconnect_keeps_control_refs_until_executor_
         await handler_task
 
     assert run_id not in adapter._active_run_agents
+
+
+@pytest.mark.asyncio
+async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, session_db):
+    source_id = session_db.create_session("source-session", "hermes_web", model="test-model")
+    session_db.set_session_title(source_id, "Original")
+    session_db.append_message(source_id, "user", "first path")
+    session_db.append_message(source_id, "assistant", "answer")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={"title": "Alternative"})
+        assert resp.status == 201
+        payload = await resp.json()
+
+    fork = payload["session"]
+    assert payload["object"] == "hermes.session"
+    assert fork["id"] != source_id
+    assert fork["parent_session_id"] == source_id
+    assert fork["source"] == "hermes_web"
+    assert fork["title"] == "Alternative"
+    assert [m["content"] for m in session_db.get_messages(fork["id"])] == ["first path", "answer"]
+    assert session_db.get_session(source_id)["end_reason"] == "branched"
+
+
+@pytest.mark.asyncio
+async def test_session_fork_falls_back_to_api_server_for_non_client_source(adapter, session_db):
+    source_id = session_db.create_session("legacy-source-session", "bogus_source")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={})
+        assert resp.status == 201
+        payload = await resp.json()
+
+    assert payload["session"]["source"] == "api_server"
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -336,9 +336,9 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`) |
-| `POST` | `/api/sessions` | Create an empty session |
+| `POST` | `/api/sessions` | Create an empty session; accepts an optional client `source` |
 | `GET` | `/api/sessions/{id}` | Read session metadata |
-| `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
+| `PATCH` | `/api/sessions/{id}` | Update `title`, `end_reason`, or client `source` |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
@@ -346,6 +346,8 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+The public client `source` values are `api_server`, `hermes_web`, and `hermes_browser`. `POST /api/sessions` defaults to `api_server` when `source` is omitted, while first-party IDs beginning with `hermes-web-` or `hermes-browser-` are categorized automatically. `PATCH /api/sessions/{id}` rejects any other `source` value with `invalid_session_source`. Forks preserve a validated first-party source from their parent and otherwise fall back to `api_server`.
 
 ```bash
 # fork a session and run one turn

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -448,9 +448,9 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`) |
-| `POST` | `/api/sessions` | Create an empty session |
+| `POST` | `/api/sessions` | Create an empty session; accepts an optional client `source` |
 | `GET` | `/api/sessions/{id}` | Read session metadata |
-| `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
+| `PATCH` | `/api/sessions/{id}` | Update `title`, `end_reason`, or client `source` |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
@@ -458,6 +458,8 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+The public client `source` values are `api_server`, `hermes_web`, and `hermes_browser`. `POST /api/sessions` defaults to `api_server` when `source` is omitted, while first-party IDs beginning with `hermes-web-` or `hermes-browser-` are categorized automatically. `PATCH /api/sessions/{id}` rejects any other `source` value with `invalid_session_source`. Forks preserve a validated first-party source from their parent and otherwise fall back to `api_server`.
 
 ```bash
 # fork a session and run one turn


### PR DESCRIPTION
## Summary

- Preserve explicit `hermes_web` and `hermes_browser` sources when API clients create session records.
- Allow safe correction of existing client-owned session source metadata through the existing session PATCH endpoint.
- Preserve validated first-party source categories when API sessions are forked, with `api_server` as the fallback.
- Render **Hermes Web** and **Hermes Browser Extension** as first-class Desktop session groups.
- Document the public session `source` values and validation behavior.

## Tests

- `python -m pytest tests/gateway/test_session_api.py -q -n 0` — 14 passed
- `npm --prefix apps/desktop run test:ui -- src/lib/session-source.test.ts` — 2 passed
- `npm --prefix apps/desktop run typecheck`
- `npx eslint src/lib/session-source.ts src/lib/session-source.test.ts` (from `apps/desktop`)
- `git diff --check`

The complete PR patch also applied cleanly to current `main`; the API tests, Desktop test, Desktop typecheck, targeted lint, and diff check passed there.
