### PR TITLE
fix(kanban): ignore slug words on spawn failures

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6850,6 +6850,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     # 2. Quota / auth blocker: retrying immediately will not help.
     err = row["last_failure_error"]
+    if (
+        latest_run is not None
+        and latest_run["outcome"] in {"spawn_failed", "gave_up"}
+    ):
+        err = None
     if err and _RESPAWN_BLOCKER_RE.search(err):
         return "blocker_auth"
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1865,6 +1865,29 @@ def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
     assert reason == "blocker_auth"
 
 
+def test_respawn_guard_ignores_sluggy_workspace_error_for_spawn_failed_run(kanban_home):
+    """A workspace/spawn failure with quota-ish path text must not trip blocker_auth."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="quota-governance", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (
+                "workspace: task worktree path "
+                "'/tmp/worktrees/issue-12-quota-governance' "
+                "is not inside a git repo and does not point at a git repo root",
+                t,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'failed', 'spawn_failed', ?, ?)",
+            (t, now - 120, now - 60),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
 def test_respawn_guard_recent_success(kanban_home):
     """A completed run within the guard window triggers recent_success."""
     with kb.connect() as conn:
@@ -1987,6 +2010,39 @@ def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     # retry without manual unblock.
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_allows_spawn_failed_workspace_error_with_quota_slug(
+    kanban_home, all_assignees_spawnable
+):
+    """Workspace spawn failures should retry even if the path contains quota/auth words."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="quota-governance", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (
+                "workspace: task worktree path "
+                "'/tmp/worktrees/issue-12-quota-governance' "
+                "is not inside a git repo and does not point at a git repo root",
+                t,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'failed', 'spawn_failed', ?, ?)",
+            (t, now - 120, now - 60),
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert t in spawned_ids
+    assert (t, "blocker_auth") not in res.respawn_guarded
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_skips_recent_success(


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive `blocker_auth` respawn guard in Kanban. When the latest run failed locally during workspace/spawn setup, Hermes was still regex-matching the raw `last_failure_error` text for quota/auth words. If the workspace path itself contained a slug like `quota-governance`, the dispatcher could park the task in `ready` forever even though no provider auth/quota failure happened. This change skips the auth/quota blocker path for latest outcomes that are already known local failures (`spawn_failed` / `gave_up`).

## Related Issue

Fixes #63248

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip `blocker_auth` regex classification when the latest closed run outcome is `spawn_failed` or `gave_up` in `hermes_cli/kanban_db.py`.
- Add a direct regression test for workspace-path false positives containing `quota` in `tests/hermes_cli/test_kanban_db.py`.
- Add a dispatcher integration test proving those tasks now respawn instead of being recorded as `respawn_guarded` with `blocker_auth`.

## How to Test

1. Create a ready Kanban task whose `last_failure_error` is a workspace/spawn failure mentioning a path like `issue-12-quota-governance`.
2. Record the latest closed run as `spawn_failed` (or `gave_up`) and run the dispatcher.
3. Confirm `check_respawn_guard()` returns `None` and the task is spawned instead of being deferred as `blocker_auth`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run pytest tests/hermes_cli/test_kanban_db.py -q -k 'respawn_guard'` → `20 passed, 206 deselected in 1.04s`
- `uv run python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `git diff --check`
- Unrelated existing baseline in the same file: `test_write_txn_check_reads_correct_header_fields` currently fails because SQLite returns `database disk image is malformed` instead of the test's expected message regex.
