### PR TITLE
fix(kanban): do not treat spawn/workspace errors as blocker_auth

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6827,14 +6827,16 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     #    the regex would otherwise match → defer forever (no failure counter
     #    increment on this path means the breaker can never free it).
     #
-    #    We look at the LATEST run only (ORDER BY ended_at DESC LIMIT 1): if a
+    #    We look at the LATEST run only (ORDER BY ended_at DESC, id DESC): if a
     #    newer crash/completion superseded the rate-limit run, this guard
-    #    no longer applies and the normal paths take over.
+    #    no longer applies and the normal paths take over. ``id DESC`` breaks
+    #    integer-second ties so a same-second newer provider failure is not
+    #    shadowed by an older spawn_failed (and vice versa) — see #63248.
     rl_cooldown = _resolve_rate_limit_cooldown_seconds()
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY ended_at DESC LIMIT 1",
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     if (

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6786,6 +6786,14 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         blocks via the normal path — but a transient 429 gets a few
         ticks of recovery first.
 
+        Skipped when the latest ended run was a deterministic local
+        outcome (``spawn_failed`` / ``gave_up``). Workspace/spawn errors
+        embed issue slugs and paths that often contain words like
+        ``quota`` or ``auth``; treating those as provider walls wedges
+        the task in ``ready`` forever (the guard returns before spawn,
+        so ``consecutive_failures`` never advances). Those failures
+        follow the normal breaker path instead.
+
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
         seconds.  Useful work already succeeded for this task; wait for
@@ -6849,9 +6857,19 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return None
 
     # 2. Quota / auth blocker: retrying immediately will not help.
-    err = row["last_failure_error"]
-    if err and _RESPAWN_BLOCKER_RE.search(err):
-        return "blocker_auth"
+    #    Do NOT apply the regex when the latest run was a deterministic local
+    #    failure (spawn/workspace). Those messages embed paths and issue slugs
+    #    that frequently contain auth/quota slug words (e.g. "issue-12-quota-…")
+    #    and would trap the task in ready forever without advancing the
+    #    failure counter (guard returns before spawn). See #63248.
+    deterministic_local = (
+        latest_run is not None
+        and latest_run["outcome"] in ("spawn_failed", "gave_up")
+    )
+    if not deterministic_local:
+        err = row["last_failure_error"]
+        if err and _RESPAWN_BLOCKER_RE.search(err):
+            return "blocker_auth"
 
     # 3. Completed run within guard window — proof of recent success.
     #    Exception: an explicit re-queue AFTER that success (an operator

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1949,6 +1949,46 @@ def test_respawn_guard_real_quota_still_blocker_auth_after_crashed_run(kanban_ho
     assert reason == "blocker_auth"
 
 
+def test_respawn_guard_same_second_latest_run_uses_id_tiebreak(kanban_home):
+    """When two runs share ended_at, the higher id wins so a newer provider
+    quota failure is not shadowed by an older same-second spawn_failed."""
+    now = int(time.time())
+    workspace_err = (
+        "workspace: worktree path "
+        "'/home/u/worktrees/repo/issue-12-quota-governance' is not a git root"
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="tiebreak-latest", assignee="alice")
+        # Older id: deterministic local spawn_failed (would bypass blocker_auth).
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'spawn_failed', ?, ?)",
+            (t, now - 5, now),
+        )
+        # Newer id, same ended_at second: non-local crash with real quota text.
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'crashed', ?, ?)",
+            (t, now - 4, now),
+        )
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("HTTP 429: quota exceeded for organization", t),
+        )
+        # Sanity: higher id is the crashed row.
+        rows = conn.execute(
+            "SELECT id, outcome FROM task_runs WHERE task_id = ? "
+            "ORDER BY ended_at DESC, id DESC",
+            (t,),
+        ).fetchall()
+        assert rows[0]["outcome"] == "crashed"
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth", (
+        f"newer same-second crashed/quota run must still defer; got {reason!r} "
+        f"(workspace_err would have been: {workspace_err[:40]}…)"
+    )
+
+
 def test_respawn_guard_recent_success(kanban_home):
     """A completed run within the guard window triggers recent_success."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1865,6 +1865,90 @@ def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
     assert reason == "blocker_auth"
 
 
+def test_respawn_guard_spawn_failed_workspace_path_with_quota_slug_not_blocker_auth(
+    kanban_home,
+):
+    """#63248: workspace spawn_failed whose path embeds 'quota' must not
+    false-positive blocker_auth (would wedge ready forever)."""
+    now = int(time.time())
+    workspace_err = (
+        "workspace: task abc worktree path "
+        "'/home/u/worktrees/repo/issue-12-quota-governance' "
+        "is not inside a git repo and does not point at a git repo root"
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="quota-governance", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'spawn_failed', ?, ?)",
+            (t, now - 30, now - 10),
+        )
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ?, consecutive_failures = 1 "
+            "WHERE id = ?",
+            (workspace_err, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None, (
+        f"spawn_failed workspace error with slug word 'quota' must not return "
+        f"blocker_auth; got {reason!r}"
+    )
+
+
+def test_respawn_guard_gave_up_with_auth_slug_in_path_not_blocker_auth(kanban_home):
+    """#63248: gave_up + path embedding 'auth' is local, not provider auth."""
+    now = int(time.time())
+    err = (
+        "spawn failed preparing workspace "
+        "/tmp/hermes-worktrees/issue-auth-refactor/src: not a git root"
+    )
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="auth-refactor", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'gave_up', ?, ?)",
+            (t, now - 40, now - 5),
+        )
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (err, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_real_quota_error_still_blocker_auth_without_local_outcome(
+    kanban_home,
+):
+    """Provider quota text with no deterministic-local run still defers."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="real-quota", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("API quota exceeded: rate limit hit", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+def test_respawn_guard_real_quota_still_blocker_auth_after_crashed_run(kanban_home):
+    """A real provider-style error after a crashed (non-local) run still defers."""
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="crash-then-quota", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'crashed', ?, ?)",
+            (t, now - 60, now - 30),
+        )
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("HTTP 429: quota exceeded for organization", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
 def test_respawn_guard_recent_success(kanban_home):
     """A completed run within the guard window triggers recent_success."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Summary
Fixes #63248.

`check_respawn_guard` classified auth/quota blockers by regex-matching `last_failure_error`. Workspace `spawn_failed` messages embed issue slugs/paths that often contain words like `quota` or `auth` (e.g. `issue-12-quota-governance`). That returned `blocker_auth` every tick **before** spawn, so `consecutive_failures` never advanced and the task wedged in `ready` forever.

## Fix
- Skip the `_RESPAWN_BLOCKER_RE` path when the latest ended run outcome is `spawn_failed` or `gave_up` (deterministic local). Those failures use the normal breaker path.
- Select latest run with `ORDER BY ended_at DESC, id DESC` so same-second ties pick the newer id (provider failure not shadowed by older spawn_failed).
- Real provider quota/auth strings still return `blocker_auth`.

## Test plan
- [x] `pytest tests/hermes_cli/test_kanban_db.py -k respawn_guard` — 23 passed
- [x] New cases: workspace path with `quota` slug + `spawn_failed` → not blocked; `gave_up` + `auth` in path → not blocked; real quota text still `blocker_auth`; same-second tiebreak prefers newer crashed/quota run

## Notes
- No open competing PRs found for #63248 (issue # + keyword search).
