### PR TITLE
fix: suppress leaked invoke tool calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -642,7 +642,7 @@ def strip_think_blocks(agent, content: str) -> str:
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
     for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                      "function_call", "function_calls"):
+                      "function_call", "function_calls", "invoke"):
         content = re.sub(
             rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
             '',
@@ -684,7 +684,7 @@ def strip_think_blocks(agent, content: str) -> str:
     #     during streaming may still be valuable to the user; matches
     #     OpenClaw's intentional asymmetry.)
     content = re.sub(
-        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
+        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function|invoke)>\s*',
         '',
         content,
         flags=re.IGNORECASE,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -104,11 +104,11 @@ class GatewayStreamConsumer:
     # run_agent.py _strip_think_blocks() tag variants.
     _OPEN_THINK_TAGS = (
         "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
-        "<THINKING>", "<thinking>", "<thought>",
+        "<THINKING>", "<thinking>", "<thought>", "<invoke",
     )
     _CLOSE_THINK_TAGS = (
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
-        "</THINKING>", "</thinking>", "</thought>",
+        "</THINKING>", "</thinking>", "</thought>", "</invoke>",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -353,6 +353,13 @@ class TestStripThinkBlocks:
     def test_no_blocks_unchanged(self, agent):
         assert agent._strip_think_blocks("hello world") == "hello world"
 
+    def test_invoke_payload_removed(self, agent):
+        result = agent._strip_think_blocks(
+            'before\n<invoke name="terminal">secret</invoke>\nafter'
+        )
+        assert "<invoke" not in result
+        assert "secret" not in result
+
     def test_single_block_removed(self, agent):
         result = agent._strip_think_blocks("<think>reasoning</think> answer")
         assert "reasoning" not in result


### PR DESCRIPTION
Summary: scrub standalone invoke XML payloads from final assistant content; hide invoke blocks during streaming; add a regression test. Testing: not run locally because the host Python environment does not include pytest.