### PR TITLE
fix(auth): send explicit JWKS request headers

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -131,6 +131,14 @@ _EXPECTED_CONTRACT_VERSION = 1
 # Contract C7: JWKS Cache-Control max-age=300.
 _JWKS_CACHE_SECONDS = 300
 
+# Some WAF/CDN setups reject urllib's default fingerprint for the public JWKS
+# fetch even though the endpoint is otherwise healthy. Send explicit JSON-client
+# headers without changing TLS or JWT verification semantics.
+_JWKS_REQUEST_HEADERS = {
+    "User-Agent": "Hermes-Agent Dashboard OIDC JWKS",
+    "Accept": "application/json, application/jwk-set+json",
+}
+
 # httpx timeout for the token endpoint POST.
 _TOKEN_ENDPOINT_TIMEOUT_SEC = 10.0
 
@@ -420,6 +428,7 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
                 self._jwks_url,
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers=dict(_JWKS_REQUEST_HEADERS),
             )
         return self._jwks_client
 

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -162,6 +162,18 @@ class TestConstruction:
                 client_id="hermes-dashboard", portal_url="https://x"
             )
 
+    def test_jwks_client_uses_explicit_request_headers(self):
+        provider = nous_plugin.NousDashboardAuthProvider(
+            client_id="agent:inst1", portal_url="https://portal.example.com"
+        )
+        fake_client = object()
+        with patch("jwt.PyJWKClient", return_value=fake_client) as mock_cls:
+            assert provider._get_jwks_client() is fake_client
+        _, kwargs = mock_cls.call_args
+        assert kwargs["headers"] == nous_plugin._JWKS_REQUEST_HEADERS
+        assert kwargs["cache_keys"] is True
+        assert kwargs["lifespan"] == nous_plugin._JWKS_CACHE_SECONDS
+
 
 # ---------------------------------------------------------------------------
 # Plugin entry point: env-gated registration


### PR DESCRIPTION
## What does this PR do?

Adds explicit JSON/JWK request headers when the dashboard auth provider constructs its JWKS client. This avoids WAF/CDN setups rejecting PyJWT's default urllib fingerprint for the public JWKS fetch while keeping the existing TLS, issuer, audience, PKCE, and JWT-signature verification behavior unchanged.

## Related Issue

Fixes #63273

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/dashboard_auth/nous/__init__.py`: add `_JWKS_REQUEST_HEADERS` and pass a copied header dict into `jwt.PyJWKClient(...)`
- `tests/plugins/dashboard_auth/test_nous_provider.py`: add a focused regression asserting the provider constructs `PyJWKClient` with the explicit headers and the existing cache lifetime

## Thinking Path

The issue's reported failure mode was narrow and reproducible from static code inspection: the dashboard auth provider already centralizes JWKS client creation in `_get_jwks_client()`, and that code path currently relies on PyJWT's default urllib request headers. Since the intended behavior is only to make the public JWKS fetch compatible with stricter WAF/CDN rules, the smallest truthful fix is to set explicit request headers at that construction point and prove the call shape with a focused unit test instead of widening the auth flow.

## How to Test

1. Run `uv run pytest tests/plugins/dashboard_auth/test_nous_provider.py -q`
2. Run `python3 -m py_compile plugins/dashboard_auth/nous/__init__.py tests/plugins/dashboard_auth/test_nous_provider.py`
3. Run `git diff --check`

## Verification

- `uv run pytest tests/plugins/dashboard_auth/test_nous_provider.py -q` -> `56 passed in 2.79s`
- `python3 -m py_compile plugins/dashboard_auth/nous/__init__.py tests/plugins/dashboard_auth/test_nous_provider.py`
- `git diff --check`

## Risks

The change only alters HTTP headers on the JWKS GET request. A provider or WAF that depends on the exact previous urllib default fingerprint could behave differently, but the code does not relax certificate validation, JWT verification, or claim checks.

## Model Used

- OpenAI GPT-5.4-level Codex

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and the focused affected suite passes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 / CPython 3.11.14 via `uv run`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused proof: `codex-proof/63273-proof.txt`
