### PR TITLE
fix(agent): add SSL compatibility layer for macOS 10.13 and Windows corporate proxies

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -5,4 +5,15 @@ that were previously embedded in the 3,600-line run_agent.py. Extracting
 them makes run_agent.py focused on the AIAgent orchestrator class.
 """
 
-from . import jiter_preload as _jiter_preload  # noqa: F401
+try:
+    from . import jiter_preload as _jiter_preload  # noqa: F401
+except ImportError:
+    pass
+
+# SSL compatibility: ensure certifi-based CA bundle on old macOS / Windows
+# corporate proxies before any network calls are made.
+try:
+    from .ssl_compat import setup_ssl_compat  # noqa: F401
+    setup_ssl_compat()
+except ImportError:
+    pass

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -40,6 +40,15 @@ def _resolve_requests_verify() -> bool | str:
         val = os.getenv(env_var)
         if val and os.path.isfile(val):
             return val
+    # certifi fallback — covers startup paths where setup_ssl_compat()
+    # wasn't called first (short-lived subprocesses, test fixtures).
+    try:
+        import certifi  # noqa: F811
+        ca = certifi.where()
+        if os.path.isfile(ca):
+            return ca
+    except ImportError:
+        pass
     return True
 
 # Provider names that can appear as a "provider:" prefix before a model ID.

--- a/agent/ssl_compat.py
+++ b/agent/ssl_compat.py
@@ -1,0 +1,221 @@
+"""SSL/TLS compatibility layer for Hermes Agent.
+
+Auto-configures SSL on platforms where the system CA bundle is outdated
+(macOS 10.13/High Sierra, Windows corporate networks with proxy-inspected certs).
+
+On macOS with certifi installed, sets ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE``
+so that all stdlib ``ssl``, ``requests``, and ``httpx`` callers transparently use
+the modern CA bundle from certifi.  Respects user-explicit env vars and a
+``tls`` config section so the user can override or disable verification.
+
+Usage:
+    from agent.ssl_compat import setup_ssl_compat
+    setup_ssl_compat()  # call once at process startup
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import ssl
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Env vars that the ``ssl`` stdlib module / ``requests`` / ``httpx`` respect.
+# We set all three so every callsite is covered regardless of which library it uses.
+_CA_ENV_VARS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HERMES_CA_BUNDLE")
+
+
+def _detect_macos_high_sierra() -> bool:
+    """Return True if running on macOS High Sierra (10.13) or older."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        release = platform.mac_ver()[0]
+        if release:
+            major_minor = tuple(int(x) for x in release.split(".")[:2])
+            return major_minor <= (10, 13)
+    except (ValueError, TypeError):
+        pass
+    return False
+
+
+def _certifi_path() -> Optional[str]:
+    """Return certifi's CA bundle path, or None if not installed."""
+    try:
+        import certifi  # noqa: F811
+
+        return certifi.where()
+    except ImportError:
+        return None
+
+
+def _any_ca_env_var_set() -> bool:
+    """Return True if any known CA env var is already set to an existing file."""
+    for var in _CA_ENV_VARS:
+        val = os.environ.get(var, "").strip()
+        if val and os.path.isfile(val):
+            return True
+    return False
+
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+
+def setup_ssl_compat(config: Optional[dict] = None) -> None:
+    """One-time process-wide SSL setup.
+
+    Should be called at process startup, before any network calls are made.
+    Safe to call multiple times — subsequent calls are no-ops once env vars
+    have been set.
+
+    Parameters
+    ----------
+    config:
+        Optional ``tls`` subsection of the agent config.  Recognised keys:
+
+        ``ca_bundle``
+            Path to a custom CA bundle PEM file.
+        ``insecure``
+            ``True`` to disable certificate verification entirely.
+
+    Environment variables (checked in order of precedence):
+
+    1. ``HERMES_CA_BUNDLE`` (Hermes convention — highest precedence)
+    2. ``SSL_CERT_FILE`` (stdlib / httpx convention)
+    3. ``REQUESTS_CA_BUNDLE`` (requests convention)
+
+    If none of these are set:
+
+    - On **macOS High Sierra (10.13) or older**: automatically uses
+      ``certifi.where()`` if certifi is installed, and logs a warning
+      suggesting the user ``pip install certifi`` if it isn't.
+    - On **other platforms**: does nothing — the system CA bundle is
+      presumed adequate.
+    """
+    # --- Guard: already configured? ---
+    if _any_ca_env_var_set():
+        logger.debug("ssl_compat: CA env var already set; skipping setup")
+        return
+
+    # --- Respect config overrides ---
+    tls_cfg = (config or {}).get("tls") or {}
+    ca_bundle: Optional[str] = tls_cfg.get("ca_bundle")
+    insecure: bool = bool(tls_cfg.get("insecure", False))
+
+    if insecure:
+        # The caller is expected to pass verify=False on each client.
+        # We do NOT set env vars here because that would turn off
+        # verification for ALL requests, including ones the user
+        # might not expect.
+        logger.info("ssl_compat: TLS verification disabled via config")
+        return
+
+    # --- Custom CA bundle from config ---
+    if ca_bundle:
+        ca_path = os.path.expanduser(ca_bundle)
+        if os.path.isfile(ca_path):
+            for var in _CA_ENV_VARS:
+                os.environ[var] = ca_path
+            logger.info("ssl_compat: using custom CA bundle from %s", ca_path)
+            return
+        logger.warning(
+            "ssl_compat: configured ca_bundle %r not found; falling back", ca_bundle
+        )
+
+    # --- Auto-detect: macOS 10.13 + certifi ---
+    is_old_macos = _detect_macos_high_sierra()
+    certifi_path = _certifi_path()
+
+    if is_old_macos and certifi_path:
+        for var in _CA_ENV_VARS:
+            os.environ[var] = certifi_path
+        logger.info(
+            "ssl_compat: macOS 10.13 detected — pinned CA bundle to certifi (%s)",
+            certifi_path,
+        )
+        return
+
+    if is_old_macos and not certifi_path:
+        logger.warning(
+            "ssl_compat: macOS 10.13 detected but certifi is not installed. "
+            "Run `pip install certifi` to fix SSL certificate verification errors."
+        )
+
+    # --- certifi available on any platform ---
+    if certifi_path and not _any_ca_env_var_set():
+        # Set env vars so that all subsequent requests/httpx calls benefit.
+        # This is safe on any platform — certifi is a well-maintained bundle
+        # that's strictly newer than most system bundles.
+        for var in _CA_ENV_VARS:
+            os.environ[var] = certifi_path
+        logger.debug(
+            "ssl_compat: pinned CA bundle to certifi (%s)", certifi_path
+        )
+
+
+def resolve_requests_verify(config: Optional[dict] = None) -> bool | str:
+    """Resolve SSL verify param for the ``requests`` library.
+
+    Precedence:
+    1. ``tls.insecure`` config → ``False``
+    2. ``tls.ca_bundle`` config → path (if file exists)
+    3. Known CA env vars → path (if file exists)
+    4. certifi fallback → ``certifi.where()``
+    5. Default → ``True`` (defer to requests built-in)
+    """
+    tls_cfg = (config or {}).get("tls") or {}
+
+    if tls_cfg.get("insecure", False):
+        return False
+
+    ca_bundle: Optional[str] = tls_cfg.get("ca_bundle")
+    if ca_bundle:
+        ca_path = os.path.expanduser(ca_bundle)
+        if os.path.isfile(ca_path):
+            return ca_path
+
+    for var in _CA_ENV_VARS:
+        val = os.environ.get(var, "").strip()
+        if val and os.path.isfile(val):
+            return val
+
+    certifi_path = _certifi_path()
+    if certifi_path:
+        return certifi_path
+
+    return True
+
+
+def resolve_httpx_verify(config: Optional[dict] = None) -> bool | ssl.SSLContext:
+    """Resolve SSL verify param for the ``httpx`` library.
+
+    Returns an ``ssl.SSLContext`` when a custom CA bundle is available,
+    ``False`` when verification is disabled, or ``True`` for the default.
+    """
+    tls_cfg = (config or {}).get("tls") or {}
+
+    if tls_cfg.get("insecure", False):
+        return False
+
+    ca_bundle: Optional[str] = tls_cfg.get("ca_bundle")
+    if ca_bundle:
+        ca_path = os.path.expanduser(ca_bundle)
+        if os.path.isfile(ca_path):
+            return ssl.create_default_context(cafile=ca_path)
+
+    for var in _CA_ENV_VARS:
+        val = os.environ.get(var, "").strip()
+        if val and os.path.isfile(val):
+            return ssl.create_default_context(cafile=val)
+
+    certifi_path = _certifi_path()
+    if certifi_path:
+        return ssl.create_default_context(cafile=certifi_path)
+
+    return True

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4495,6 +4495,15 @@ def _default_verify() -> bool | ssl.SSLContext:
     defer to httpx's built-in default (certifi via its own dependency).
     Mirrors the weixin fix in 3a0ec1d93.
     """
+    # First pass: let ssl_compat handle config, env vars, and certifi.
+    try:
+        from agent.ssl_compat import resolve_httpx_verify
+        result = resolve_httpx_verify()
+        if result is not True:
+            return result
+    except ImportError:
+        pass
+    # Second pass: legacy fallback for macOS + certifi.
     if sys.platform == "darwin":
         try:
             import certifi

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -903,6 +903,13 @@ DEFAULT_CONFIG = {
     "max_concurrent_sessions": None,
     "agent": {
         "max_turns": 90,
+        # SSL/TLS configuration for all HTTP clients.
+        # ca_bundle: path to a custom CA bundle PEM file.
+        # insecure: set True to disable certificate verification.
+        "tls": {
+            "ca_bundle": "",
+            "insecure": False,
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "luxuguang-leo@users.noreply.github.com": "luxuguang-leo",  # PR #63270 (SSL compat layer)
     "benbenwyb@gmail.com": "benbenlijie",  # PR #47205 salvage (named custom-provider extra_body + Z.AI Coding overload adaptive backoff; #50663)
     "dana@added-value.co.il": "Danamove",  # PR #46726 salvage (kill venv-resident pythonw gateway before recreating venv on Windows; #47036/#47557/#47910)
     "145739220+wgu9@users.noreply.github.com": "wgu9",  # PR #51468 salvage (WSL/no-systemd orphan gateway tracking, #51325)

--- a/tests/agent/test_ssl_compat.py
+++ b/tests/agent/test_ssl_compat.py
@@ -1,0 +1,195 @@
+"""Tests for agent.ssl_compat — SSL/TLS compatibility layer."""
+
+from __future__ import annotations
+
+import os
+import ssl
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agent.ssl_compat import (
+    _any_ca_env_var_set,
+    _certifi_path,
+    _detect_macos_high_sierra,
+    resolve_httpx_verify,
+    resolve_requests_verify,
+    setup_ssl_compat,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HERMES_CA_BUNDLE"):
+        os.environ.pop(var, None)
+
+
+@pytest.fixture
+def fake_ca_bundle(tmp_path: Path) -> str:
+    bundle = tmp_path / "ca-bundle.crt"
+    try:
+        import certifi
+        content = Path(certifi.where()).read_text()
+    except ImportError:
+        content = "# Empty CA bundle\n"
+    bundle.write_text(content)
+    return str(bundle)
+
+
+# =============================================================================
+# macOS detection
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("platform", "mac_ver", "expected"),
+    [
+        ("linux", ("", "", ""), False),
+        ("darwin", ("14.5.0", ("", "", ""), "arm64"), False),
+        ("darwin", ("10.13.6", ("", "", ""), "x86_64"), True),
+        ("darwin", ("10.12.0", ("", "", ""), "x86_64"), True),
+        ("darwin", ("", ("", "", ""), "arm64"), False),
+    ],
+)
+def test_detect_macos_high_sierra(platform, mac_ver, expected):
+    with (
+        mock.patch.object(sys, "platform", platform),
+        mock.patch("platform.mac_ver", return_value=mac_ver),
+    ):
+        assert _detect_macos_high_sierra() is expected
+
+
+# =============================================================================
+# env var helpers
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, False),
+        ({"SSL_CERT_FILE": "/no/such/file.pem"}, False),
+        ({"HERMES_CA_BUNDLE": ""}, False),
+    ],
+)
+def test_any_ca_env_var_not_set(env, expected):
+    os.environ.update(env)
+    assert _any_ca_env_var_set() is expected
+
+
+def test_any_ca_env_var_set_true(fake_ca_bundle):
+    os.environ["SSL_CERT_FILE"] = fake_ca_bundle
+    assert _any_ca_env_var_set() is True
+
+
+# =============================================================================
+# certifi path
+# =============================================================================
+
+
+def test_certifi_path():
+    path = _certifi_path()
+    if path:
+        assert os.path.isfile(path)
+    else:
+        assert path is None
+
+
+def test_certifi_path_missing():
+    with mock.patch.dict("sys.modules", {"certifi": None}):
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            assert _certifi_path() is None
+
+
+# =============================================================================
+# setup_ssl_compat
+# =============================================================================
+
+
+def test_skips_when_env_var_already_set(fake_ca_bundle):
+    os.environ["SSL_CERT_FILE"] = fake_ca_bundle
+    setup_ssl_compat()
+    assert os.environ["SSL_CERT_FILE"] == fake_ca_bundle
+
+
+def test_respects_custom_ca_bundle_config(fake_ca_bundle):
+    setup_ssl_compat({"tls": {"ca_bundle": fake_ca_bundle}})
+    assert os.environ["SSL_CERT_FILE"] == fake_ca_bundle
+
+
+def test_custom_ca_bundle_not_found_does_not_crash():
+    setup_ssl_compat({"tls": {"ca_bundle": "/no/such/file.pem"}})
+
+
+def test_insecure_config_returns_without_setting_env():
+    setup_ssl_compat({"tls": {"insecure": True}})
+    for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HERMES_CA_BUNDLE"):
+        assert not os.environ.get(var)
+
+
+def test_macos_10_13_no_certifi_does_not_crash():
+    with (
+        mock.patch("agent.ssl_compat._detect_macos_high_sierra", return_value=True),
+        mock.patch("agent.ssl_compat._certifi_path", return_value=None),
+    ):
+        setup_ssl_compat()
+        assert not any(os.environ.get(v) for v in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HERMES_CA_BUNDLE"))
+
+
+def test_sets_env_vars_when_certifi_available():
+    certifi_path = _certifi_path()
+    if not certifi_path:
+        pytest.skip("certifi not installed")
+    setup_ssl_compat()
+    assert os.environ["SSL_CERT_FILE"] == certifi_path
+    assert os.environ["REQUESTS_CA_BUNDLE"] == certifi_path
+
+
+# =============================================================================
+# resolve_requests_verify
+# =============================================================================
+
+
+def test_resolve_requests_default():
+    result = resolve_requests_verify()
+    assert result is True or (isinstance(result, str) and os.path.isfile(result))
+
+
+def test_resolve_requests_insecure():
+    assert resolve_requests_verify({"tls": {"insecure": True}}) is False
+
+
+def test_resolve_requests_ca_bundle(fake_ca_bundle):
+    assert resolve_requests_verify({"tls": {"ca_bundle": fake_ca_bundle}}) == fake_ca_bundle
+
+
+def test_resolve_requests_env_var(fake_ca_bundle):
+    os.environ["REQUESTS_CA_BUNDLE"] = fake_ca_bundle
+    assert resolve_requests_verify() == fake_ca_bundle
+
+
+# =============================================================================
+# resolve_httpx_verify
+# =============================================================================
+
+
+def test_resolve_httpx_default():
+    result = resolve_httpx_verify()
+    assert result is True or isinstance(result, ssl.SSLContext)
+
+
+def test_resolve_httpx_insecure():
+    assert resolve_httpx_verify({"tls": {"insecure": True}}) is False
+
+
+def test_resolve_httpx_ca_bundle(fake_ca_bundle):
+    result = resolve_httpx_verify({"tls": {"ca_bundle": fake_ca_bundle}})
+    assert isinstance(result, ssl.SSLContext)
+
+
+def test_resolve_httpx_env_var(fake_ca_bundle):
+    os.environ["SSL_CERT_FILE"] = fake_ca_bundle
+    result = resolve_httpx_verify()
+    assert isinstance(result, ssl.SSLContext)


### PR DESCRIPTION
Add an SSL/TLS compatibility layer that auto-configures certifi CA bundles for platforms where the system trust store is outdated.

## Problem
- macOS 10.13 (High Sierra) system CA bundle is too old → `SSL: CERTIFICATE_VERIFY_FAILED` on many modern HTTPS endpoints
- Windows corporate proxies with MITM-inspected certs hit the same issue
- Multiple user reports in #29384

## Changes
- **agent/ssl_compat.py** — new module with `setup_ssl_compat()` and `resolve_httpx_verify()`
- **agent/__init__.py** — startup hook calls `setup_ssl_compat()` before any network calls
- **agent/model_metadata.py** — certifi fallback in `_resolve_requests_verify()`
- **hermes_cli/auth.py** — ssl_compat integration in `_default_verify()`
- **hermes_cli/config.py** — new `tls.ca_bundle` / `tls.insecure` config options
- 25 tests covering all paths

Closes #29384