### PR TITLE
fix(setup): remove saved custom provider from migrated config

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3821,27 +3821,50 @@ def _save_custom_provider(
 
 
 def _remove_custom_provider(config):
-    """Let the user remove a saved custom provider from config.yaml."""
+    """Let the user remove a saved custom provider from config.yaml.
+
+    Supports both legacy ``custom_providers`` list and migrated ``providers`` dict.
+    """
     from hermes_cli.config import load_config, save_config
 
     cfg = load_config()
-    providers = cfg.get("custom_providers") or []
-    if not isinstance(providers, list) or not providers:
+
+    legacy = cfg.get("custom_providers") or []
+    if not isinstance(legacy, list):
+        legacy = []
+
+    migrated = cfg.get("providers") or {}
+    if not isinstance(migrated, dict):
+        migrated = {}
+
+    # Entries: (source, key/index, display)
+    entries = []
+
+    for i, entry in enumerate(legacy):
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name", "unnamed")
+        url = entry.get("base_url", "")
+        short_url = str(url).replace("https://", "").replace("http://", "").rstrip("/")
+        entries.append(("custom_providers", i, f"{name} ({short_url})"))
+
+    for key, entry in migrated.items():
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("api", "")
+        if not url:
+            continue
+        name = entry.get("name") or key or "unnamed"
+        short_url = str(url).replace("https://", "").replace("http://", "").rstrip("/")
+        entries.append(("providers", key, f"{name} ({short_url})"))
+
+    if not entries:
         print("No custom providers configured.")
         return
 
     print("Remove a custom provider:\n")
 
-    choices = []
-    for entry in providers:
-        if isinstance(entry, dict):
-            name = entry.get("name", "unnamed")
-            url = entry.get("base_url", "")
-            short_url = url.replace("https://", "").replace("http://", "").rstrip("/")
-            choices.append(f"{name} ({short_url})")
-        else:
-            choices.append(str(entry))
-    choices.append("Cancel")
+    choices = [d for _, _, d in entries] + ["Cancel"]
 
     try:
         from hermes_cli.curses_ui import curses_radiolist
@@ -3865,17 +3888,45 @@ def _remove_custom_provider(config):
         except (ValueError, KeyboardInterrupt, EOFError):
             idx = None
 
-    if idx is None or idx >= len(providers):
+    if idx is None or idx >= len(entries):
         print("No change.")
         return
 
-    removed = providers.pop(idx)
-    cfg["custom_providers"] = providers
-    save_config(cfg)
-    removed_name = (
-        removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)
-    )
-    print(f'✅ Removed "{removed_name}" from custom providers.')
+    source, key, display = entries[idx]
+
+    if source == "custom_providers":
+        try:
+            removed = legacy.pop(int(key))
+            cfg["custom_providers"] = legacy
+        except Exception:
+            print("No change.")
+            return
+        removed_name = (
+            removed.get("name", "unnamed")
+            if isinstance(removed, dict)
+            else str(removed)
+        )
+        save_config(cfg)
+        print(f'✅ Removed "{removed_name}" from custom providers.')
+        return
+
+    if source == "providers":
+        if key not in migrated:
+            print("No change.")
+            return
+        removed = migrated.pop(key)
+        cfg["providers"] = migrated
+        save_config(cfg)
+        removed_name = (
+            removed.get("name")
+            if isinstance(removed, dict) and removed.get("name")
+            else str(key)
+        )
+        print(f'✅ Removed "{removed_name}" from providers.')
+        return
+
+    print("No change.")
+    return
 
 
 

--- a/tests/hermes_cli/test_remove_custom_provider.py
+++ b/tests/hermes_cli/test_remove_custom_provider.py
@@ -1,0 +1,86 @@
+"""Regression tests for removing saved custom providers."""
+
+
+def test_remove_custom_provider_from_providers_dict(tmp_path, monkeypatch, capsys):
+    """Removing a saved custom provider must work for migrated `providers:` config."""
+    from hermes_cli.config import load_config, save_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    cfg = load_config()
+    cfg["providers"] = {
+        "local": {"name": "Local", "api": "http://localhost:8080/v1", "api_key": "x"},
+        "other": {"name": "Other", "api": "http://example.com/v1"},
+    }
+    save_config(cfg)
+
+    # Force the fallback numbered-input path by making curses_radiolist import fail
+    import builtins
+
+    _real_import = builtins.__import__
+
+    def _block_import(name, *args, **kwargs):
+        if name == "hermes_cli.curses_ui":
+            raise ImportError("blocked for test")
+        return _real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_import)
+    # Also need to ensure the cached module doesn't exist
+    import sys
+
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+
+    from hermes_cli.main import _remove_custom_provider
+
+    _remove_custom_provider(load_config())
+
+    out = capsys.readouterr().out
+    assert "Removed" in out
+
+    reloaded = load_config()
+    assert "local" not in (reloaded.get("providers") or {})
+    assert "other" in (reloaded.get("providers") or {})
+
+
+def test_remove_custom_provider_from_legacy_list(tmp_path, monkeypatch, capsys):
+    """Removing a saved custom provider from legacy custom_providers list."""
+    from hermes_cli.config import load_config, save_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {"name": "Test1", "base_url": "http://localhost:8080/v1", "api_key": "x"},
+        {"name": "Test2", "base_url": "http://example.com/v1"},
+    ]
+    save_config(cfg)
+
+    import builtins
+
+    _real_import = builtins.__import__
+
+    def _block_import(name, *args, **kwargs):
+        if name == "hermes_cli.curses_ui":
+            raise ImportError("blocked for test")
+        return _real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_import)
+    import sys
+
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+
+    from hermes_cli.main import _remove_custom_provider
+
+    _remove_custom_provider(load_config())
+
+    out = capsys.readouterr().out
+    assert "Removed" in out
+
+    reloaded = load_config()
+    providers = reloaded.get("custom_providers") or []
+    assert len(providers) == 1
+    assert providers[0]["name"] == "Test2"


### PR DESCRIPTION
Fixes removing a saved custom provider in `hermes setup model`.

Hermes stores named custom endpoints in two formats:
- Legacy `custom_providers:` list
- Migrated `providers:` dict (after config migration)

The remove flow previously only edited `custom_providers`, so migrated providers could not be removed — the menu would show 'No custom providers configured' even when entries existed in `providers:`.

This PR:
- Lists custom providers from both `custom_providers` and `providers`
- Removes the selected entry from the correct section
- Adds regression tests for both paths

Fixes #5525