### PR TITLE
fix(whatsapp): prevent reconnect console flashes on Windows

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,7 +27,10 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli._subprocess_compat import (
+    windows_detach_popen_kwargs,
+    windows_hide_flags,
+)
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -83,8 +86,6 @@ def _kill_port_process(port: int) -> None:
     """Kill any process *listening* on the given TCP port (a stale bridge)."""
     try:
         if _IS_WINDOWS:
-            from hermes_cli._subprocess_compat import windows_hide_flags
-
             # Use netstat to find the PID bound to this port, then taskkill
             result = subprocess.run(
                 ["netstat", "-ano", "-p", "TCP"],
@@ -225,6 +226,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             if force:
@@ -350,7 +352,8 @@ def check_whatsapp_requirements() -> bool:
             [_node, "--version"],
             capture_output=True,
             text=True,
-            timeout=5
+            timeout=5,
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -550,6 +553,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         text=True,
                         timeout=npm_install_timeout,
                         env=with_hermes_node_path(),
+                        creationflags=windows_hide_flags(),
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -105,6 +105,40 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
 
 
 # ---------------------------------------------------------------------------
+# Windows subprocess visibility
+# ---------------------------------------------------------------------------
+
+class TestWindowsSubprocessVisibility:
+    """Short-lived WhatsApp subprocesses must not open console windows."""
+
+    def test_requirement_probe_uses_hidden_window_flags(self):
+        from plugins.platforms.whatsapp.adapter import check_whatsapp_requirements
+
+        hidden_flags = 0x08000000
+        run_result = MagicMock(returncode=0)
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.find_node_executable",
+            return_value="node.exe",
+        ), patch(
+            "plugins.platforms.whatsapp.adapter.windows_hide_flags",
+            return_value=hidden_flags,
+        ), patch(
+            "plugins.platforms.whatsapp.adapter.subprocess.run",
+            return_value=run_result,
+        ) as mock_run:
+            assert check_whatsapp_requirements() is True
+
+        mock_run.assert_called_once_with(
+            ["node.exe", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            creationflags=hidden_flags,
+        )
+
+
+# ---------------------------------------------------------------------------
 # _close_bridge_log() unit tests
 # ---------------------------------------------------------------------------
 
@@ -218,6 +252,7 @@ class TestConnectCleanup:
     @pytest.mark.asyncio
     async def test_releases_lock_when_npm_install_fails(self):
         adapter = _make_adapter()
+        hidden_flags = 0x08000000
 
         def _path_exists(path_obj):
             return not str(path_obj).endswith("node_modules")
@@ -226,12 +261,14 @@ class TestConnectCleanup:
 
         with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
              patch.object(Path, "exists", autospec=True, side_effect=_path_exists), \
-             patch("subprocess.run", return_value=install_result), \
+             patch("plugins.platforms.whatsapp.adapter.windows_hide_flags", return_value=hidden_flags), \
+             patch("subprocess.run", return_value=install_result) as mock_run, \
              patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
              patch("gateway.status.release_scoped_lock") as mock_release:
             result = await adapter.connect()
 
         assert result is False
+        assert mock_run.call_args.kwargs["creationflags"] == hidden_flags
         mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
         assert adapter._platform_lock_identity is None
 
@@ -573,6 +610,7 @@ class TestHttpSessionLifecycle:
     async def test_disconnect_uses_taskkill_tree_on_windows(self):
         """Windows disconnect should target the bridge process tree, not just the parent PID."""
         adapter = _make_adapter()
+        hidden_flags = 0x08000000
         mock_proc = MagicMock()
         mock_proc.pid = 12345
         mock_proc.poll.side_effect = [0]
@@ -583,6 +621,7 @@ class TestHttpSessionLifecycle:
         adapter._session_lock_identity = None
 
         with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), \
+             patch("plugins.platforms.whatsapp.adapter.windows_hide_flags", return_value=hidden_flags), \
              patch("plugins.platforms.whatsapp.adapter.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run, \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock):
             await adapter.disconnect()
@@ -592,6 +631,7 @@ class TestHttpSessionLifecycle:
             capture_output=True,
             text=True,
             timeout=10,
+            creationflags=hidden_flags,
         )
         mock_proc.terminate.assert_not_called()
         mock_proc.kill.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes #63212.

Prevents visible console windows from flashing during WhatsApp reconnects on Windows. The long-running bridge process was already started with the correct detached-process helper, but three short-lived subprocesses still ran without `CREATE_NO_WINDOW`:

- the `node --version` requirements check
- the bridge dependency `npm install`
- the `taskkill` bridge cleanup

This change uses the existing `windows_hide_flags()` helper for those calls. It does not change command arguments, timeouts, output capture, process cleanup, or non-Windows behavior.

## Related Issue

Fixes #63212

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Apply `windows_hide_flags()` to the three short-lived WhatsApp subprocess calls.
- Reuse the same helper already used by the Windows port-cleanup path.
- Add focused regression coverage for the Node probe, npm install, and bridge `taskkill` calls.

## How to Test

```bash
/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/gateway/test_whatsapp_connect.py -q
# 30 passed

/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/tools/test_windows_native_support.py -q -k SubprocessCompatHelpers
# 8 passed, 58 deselected

git diff --check
```

The tests mock the Windows flag value and verify that all three subprocess calls receive it. I ran the focused tests on macOS; I did not claim a separate Windows machine test. The source issue includes real Windows process/window monitoring for the same change.

## Checklist

- [x] Searched for existing PRs by issue number and implementation keywords.
- [x] Kept the PR limited to the WhatsApp adapter and focused tests.
- [x] Added regression coverage for every changed subprocess path.
- [x] Confirmed the shared helper returns `0` on non-Windows platforms.
- [x] No config, dependency, documentation, or tool schema changes are required.
