### PR TITLE
fix(whatsapp): degrade flapping bridge health

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -779,6 +779,52 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             await self._notify_fatal_error()
         return self.fatal_error_message or message
 
+    async def _check_bridge_health_degraded(self) -> Optional[str]:
+        """Surface sustained bridge flapping as a retryable fatal error."""
+        if not self._http_session:
+            return None
+
+        import aiohttp
+
+        try:
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/health",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return None
+
+        if data.get("status") != "degraded":
+            return None
+
+        disconnect_count = data.get("disconnectCount60s")
+        disconnect_window = data.get("disconnectWindowSeconds")
+        connection_state = data.get("connectionState", "unknown")
+        detail_bits = [f"connectionState={connection_state}"]
+        if disconnect_count is not None:
+            if disconnect_window is not None:
+                detail_bits.append(
+                    f"disconnects={disconnect_count}/{disconnect_window}s"
+                )
+            else:
+                detail_bits.append(f"disconnects={disconnect_count}")
+        message = (
+            "WhatsApp bridge health is degraded after repeated reconnects "
+            f"({', '.join(detail_bits)})."
+        )
+        if not self.has_fatal_error:
+            logger.error("[%s] %s", self.name, message)
+            self._set_fatal_error(
+                "whatsapp_bridge_degraded", message, retryable=True
+            )
+            await self._notify_fatal_error()
+        return self.fatal_error_message or message
+
     async def disconnect(self) -> None:
         """Stop the WhatsApp bridge and clean up any orphaned processes."""
         # Flip the shutdown flag BEFORE signalling the child so the exit-check
@@ -1240,6 +1286,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_exit = await self._check_managed_bridge_exit()
             if bridge_exit:
                 print(f"[{self.name}] {bridge_exit}")
+                break
+            bridge_health = await self._check_bridge_health_degraded()
+            if bridge_health:
+                print(f"[{self.name}] {bridge_health}")
                 break
             try:
                 async with self._http_session.get(

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -378,6 +378,42 @@ function rememberSentId(id) {
 
 let sock = null;
 let connectionState = 'disconnected';
+let disconnectTimestamps = [];
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const HEALTH_FLAP_WINDOW_MS = parsePositiveInt(
+  process.env.WHATSAPP_HEALTH_FLAP_WINDOW_MS,
+  60_000,
+);
+const HEALTH_FLAP_THRESHOLD = parsePositiveInt(
+  process.env.WHATSAPP_HEALTH_FLAP_THRESHOLD,
+  5,
+);
+
+function pruneRecentDisconnects(now = Date.now()) {
+  disconnectTimestamps = disconnectTimestamps.filter(
+    (timestamp) => now - timestamp <= HEALTH_FLAP_WINDOW_MS,
+  );
+  return disconnectTimestamps;
+}
+
+function buildHealthSnapshot(now = Date.now()) {
+  const recentDisconnects = pruneRecentDisconnects(now).length;
+  const isDegraded = recentDisconnects > HEALTH_FLAP_THRESHOLD;
+  return {
+    status: isDegraded ? 'degraded' : connectionState,
+    connectionState,
+    disconnectCount60s: recentDisconnects,
+    disconnectWindowSeconds: Math.floor(HEALTH_FLAP_WINDOW_MS / 1000),
+    queueLength: messageQueue.length,
+    uptime: process.uptime(),
+    scriptHash: SCRIPT_HASH,
+  };
+}
 
 function emitPairEvent(event) {
   if (!PAIR_JSON) return;
@@ -425,6 +461,8 @@ async function startSocket() {
     if (connection === 'close') {
       const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
       connectionState = 'disconnected';
+      disconnectTimestamps.push(Date.now());
+      pruneRecentDisconnects();
 
       if (reason === DisconnectReason.loggedOut) {
         emitPairEvent({ event: 'error', error: 'logged_out', reason });
@@ -1069,12 +1107,7 @@ app.get('/chat/:id', async (req, res) => {
 
 // Health check
 app.get('/health', (req, res) => {
-  res.json({
-    status: connectionState,
-    queueLength: messageQueue.length,
-    uptime: process.uptime(),
-    scriptHash: SCRIPT_HASH,
-  });
+  res.json(buildHealthSnapshot());
 });
 
 // Start

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -15,7 +15,7 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 import asyncio
 import signal
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -81,6 +81,25 @@ def _mock_aiohttp(status=200, json_data=None, json_side_effect=None):
     mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
 
     return MagicMock(return_value=_AsyncCM(mock_session))
+
+
+def _mock_http_response(*, status=200, json_data=None):
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=json_data or {})
+    return mock_resp
+
+
+def _mock_http_session(routes):
+    session = MagicMock()
+
+    def get(url, **kwargs):
+        if url not in routes:
+            raise AssertionError(f"Unexpected GET {url}")
+        return _AsyncCM(routes[url])
+
+    session.get = MagicMock(side_effect=get)
+    return session
 
 
 def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
@@ -329,6 +348,38 @@ class TestBridgeRuntimeFailure:
         fatal_handler.assert_awaited_once()
         mock_fh.close.assert_called_once()
         assert adapter._bridge_log_fh is None
+
+    @pytest.mark.asyncio
+    async def test_poll_messages_marks_retryable_fatal_when_bridge_health_is_degraded(self):
+        adapter = _make_adapter()
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._http_session = _mock_http_session({
+            "http://127.0.0.1:19876/health": _mock_http_response(
+                json_data={
+                    "status": "degraded",
+                    "connectionState": "connected",
+                    "disconnectCount60s": 6,
+                    "disconnectWindowSeconds": 60,
+                }
+            ),
+        })
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        adapter._bridge_process = mock_proc
+
+        await adapter._poll_messages()
+
+        assert adapter.fatal_error_code == "whatsapp_bridge_degraded"
+        assert adapter.fatal_error_retryable is True
+        assert "disconnects=6/60s" in adapter.fatal_error_message
+        fatal_handler.assert_awaited_once()
+        adapter._http_session.get.assert_called_once_with(
+            "http://127.0.0.1:19876/health",
+            timeout=ANY,
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("returncode", [0, -2, -15])


### PR DESCRIPTION
## What does this PR do?

This makes WhatsApp bridge flapping observable and recoverable. The bridge now reports sustained reconnect loops as `status: "degraded"` in `/health`, and the Python WhatsApp adapter treats that degraded health as a retryable fatal error so Hermes can restart or reconnect the platform instead of silently staying "connected" while inbound messages are dropped.

## Related Issue

Fixes #63277

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added rolling disconnect tracking in [`scripts/whatsapp-bridge/bridge.js`](scripts/whatsapp-bridge/bridge.js) so `/health` returns `degraded` plus reconnect counters during sustained Baileys flap loops.
- Added adapter-side degraded-health handling in [`plugins/platforms/whatsapp/adapter.py`](plugins/platforms/whatsapp/adapter.py) so `_poll_messages()` escalates flapping into the existing retryable fatal/reconnect path.
- Added a regression test in [`tests/gateway/test_whatsapp_connect.py`](tests/gateway/test_whatsapp_connect.py) covering degraded bridge health.

## How to Test

1. Run `node --check scripts/whatsapp-bridge/bridge.js`.
2. Run `uv run pytest tests/gateway/test_whatsapp_connect.py -q`.
3. Reproduce a WhatsApp reconnect loop and confirm `/health` reports `status: "degraded"`, then verify Hermes queues WhatsApp for reconnect instead of leaving it silently connected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `node --check scripts/whatsapp-bridge/bridge.js`
- `uv run pytest tests/gateway/test_whatsapp_connect.py -q` → `30 passed, 1 existing warning in 1.72s`
