### PR TITLE
fix(desktop): treat interrupted completions as metadata

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.message_sanitization import (
-    _FULL_ARGS_LOG_BOUND, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
+    _FULL_ARGS_LOG_BOUND, INTERRUPTED_TOOL_TAIL_KEY, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
 )
 from agent.prompt_builder import STEER_DISPLAY_KIND, steer_user_row
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
@@ -2861,7 +2861,45 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     messages = _drop_results_without_ids(messages)
     messages = _pair_tool_calls_positionally(messages)
     messages = _dedupe_tool_call_ids(messages)
-    return _realign_tool_result_names(messages)
+    messages = _realign_tool_result_names(messages)
+    # A user redirect after an explicitly interrupted tool-result tail needs
+    # an API-only assistant closure. The same role shape is also a valid normal
+    # redirect, so interruption provenance is mandatory; role adjacency alone
+    # must never synthesize cancellation context (#48879, #63292).
+    closed_tool_tails: List[Dict[str, Any]] = []
+    inserted_closures = 0
+    stripped_markers = 0
+    previous_was_interrupted_tool = False
+    for msg in messages:
+        if msg.get("role") == "user" and previous_was_interrupted_tool:
+            closed_tool_tails.append({
+                "role": "assistant",
+                "content": "Operation interrupted.",
+            })
+            inserted_closures += 1
+
+        api_msg = msg
+        if INTERRUPTED_TOOL_TAIL_KEY in msg:
+            api_msg = {
+                key: value
+                for key, value in msg.items()
+                if key != INTERRUPTED_TOOL_TAIL_KEY
+            }
+            stripped_markers += 1
+        closed_tool_tails.append(api_msg)
+        previous_was_interrupted_tool = (
+            msg.get("role") == "tool"
+            and msg.get(INTERRUPTED_TOOL_TAIL_KEY) is True
+        )
+
+    if inserted_closures or stripped_markers:
+        messages = closed_tool_tails
+    if inserted_closures:
+        logger.debug(
+            "Pre-call sanitizer: closed %d interrupted tool-result tail(s)",
+            inserted_closures,
+        )
+    return messages
 
 
 _ACK_FUTURE_RE = re.compile(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b")

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -197,6 +197,25 @@ def close_interrupted_tool_sequence(messages: list, final_response: Any = None) 
     return True
 
 
+INTERRUPTED_TOOL_TAIL_KEY = "_interrupted_tool_tail"
+
+
+def mark_interrupted_tool_tail(messages: list) -> bool:
+    """Mark a tool-result tail as ended by an explicit turn interruption.
+
+    The marker is durable internal metadata. API-copy sanitization consumes it
+    when a later user redirect needs a synthetic assistant closure; provider
+    transports strip the underscore-prefixed key from the wire payload.
+    """
+    if not messages:
+        return False
+    tail = messages[-1]
+    if not isinstance(tail, dict) or tail.get("role") != "tool":
+        return False
+    tail[INTERRUPTED_TOOL_TAIL_KEY] = True
+    return True
+
+
 def serialized_messages_bytes(messages: list) -> int:
     """Exact serialized byte size of ``messages`` (HTTP 413 is a BYTE-size error the token
     estimator, pricing images flat, cannot score). Non-serializable values fall back to
@@ -285,6 +304,7 @@ def _looks_like_image_content_rejection(error_body: str) -> bool:
 
 
 __all__ = [
+    "INTERRUPTED_TOOL_TAIL_KEY", "mark_interrupted_tool_tail",
     "_SURROGATE_RE", "close_interrupted_tool_sequence",
     "_sanitize_surrogates", "_sanitize_structure_surrogates", "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings", "_repair_tool_call_arguments",

--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -210,11 +210,15 @@ def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optiona
                 and msg.get("_interrupted_tool_tail") is True
                 and not msg.get("_db_interrupted_tail_stamped")
             ):
-                agent._session_db.mark_tool_tail_interrupted(
+                # Only latch the one-shot guard when the durable UPDATE actually
+                # matched a row — a 0-row match (row not yet flushed, raced
+                # rewind) must stay eligible for a later flush's back-stamp
+                # (quad review P2: silent provenance loss otherwise).
+                if agent._session_db.mark_tool_tail_interrupted(
                     agent.session_id,
                     msg.get("tool_call_id"),
-                )
-                msg["_db_interrupted_tail_stamped"] = True
+                ):
+                    msg["_db_interrupted_tail_stamped"] = True
             continue
         # Already durable (history copy or caller-seeded): stamp so future flushes skip it.
         if id(msg) in history_ids or id(msg) in seed_ids:

--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -178,6 +178,7 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
         "timestamp": timestamp, "api_content": api_content,
         "display_kind": _summary_display_kind(msg), "display_metadata": msg.get("display_metadata"),
         "platform_message_id": msg.get("platform_message_id"),  # load-bearing for restart drain-window recovery dedup
+        "_interrupted_tool_tail": bool(msg.get("_interrupted_tool_tail")),
     }
     if isinstance(msg.get("_row_id"), int):
         row["_row_id"] = msg["_row_id"]
@@ -198,7 +199,22 @@ def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optiona
         msg = messages[msg_idx]
         # Append-only flush: a mid-turn persist of scaffolding would commit a synthetic turn the end-of-turn
         # drop cannot un-write. Skip regardless of position.
-        if not isinstance(msg, dict) or _is_ephemeral_scaffolding(msg) or msg.get(_DB_PERSISTED_MARKER):
+        if not isinstance(msg, dict) or _is_ephemeral_scaffolding(msg):
+            continue
+        if msg.get(_DB_PERSISTED_MARKER):
+            # Already-durable tool rows marked interrupted at finalize time still need
+            # the durable provenance column stamped — they were flushed before the
+            # marker existed (#63292).
+            if (
+                msg.get("role") == "tool"
+                and msg.get("_interrupted_tool_tail") is True
+                and not msg.get("_db_interrupted_tail_stamped")
+            ):
+                agent._session_db.mark_tool_tail_interrupted(
+                    agent.session_id,
+                    msg.get("tool_call_id"),
+                )
+                msg["_db_interrupted_tail_stamped"] = True
             continue
         # Already durable (history copy or caller-seeded): stamp so future flushes skip it.
         if id(msg) in history_ids or id(msg) in seed_ids:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -217,11 +217,16 @@ def _recover_final_from_stream(agent, final_response, interrupted, failed) -> Tu
 def _close_transcript_tail(agent, messages, final_response, interrupted, _recovered_from_stream) -> None:
     """Shape the transcript tail before the durable snapshot (scaffolding already dropped
     and ``final_response`` already stream-recovered by the caller)."""
-    # An interrupt can leave a tool result as the tail; close the sequence so strict
-    # providers don't see ``tool → user`` (placeholder: final_response is usually empty).
+    # When the turn was interrupted and the last message is a tool result, persist
+    # interruption PROVENANCE on the tool tail instead of a synthetic assistant
+    # closure (#48879, #63292). A persisted ``tool → user`` alternation makes strict
+    # providers (Gemini, Claude) hallucinate a continuation of the user's message; the
+    # durable ``interrupted_tool_tail`` marker lets the API-copy sanitizer close the
+    # sequence provider-side at the next call while the stored transcript keeps real
+    # rows only.
     if interrupted:
-        from agent.message_sanitization import close_interrupted_tool_sequence
-        close_interrupted_tool_sequence(messages, final_response)
+        from agent.message_sanitization import mark_interrupted_tool_tail
+        mark_interrupted_tool_tail(messages)
 
     # Recovery ``break`` sites can return a final_response with no closing assistant
     # row; enforce "delivered final_response ⇒ assistant row" here. Compare content,

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -24,7 +24,7 @@ from agent.message_sanitization import (
     _looks_like_image_content_rejection, _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates, _sanitize_structure_non_ascii, _sanitize_structure_surrogates,
     _sanitize_tools_non_ascii, _strip_images_from_messages, _strip_non_ascii,
-    close_interrupted_tool_sequence,
+    mark_interrupted_tool_tail,
 )
 from agent.thinking_timeout_guidance import build_thinking_timeout_guidance, is_thinking_timeout
 from agent.turn_retry_state import TurnRetryState
@@ -969,10 +969,10 @@ def abort_turn_on_interrupt(
     agent: Any, messages: List[Dict[str, Any]], conversation_history: Any, api_call_count: int, *,
     abort_message: str, interrupt_text: str,
 ) -> Dict[str, Any]:
-    """Announce ``abort_message``, close any open tool sequence with ``interrupt_text``,
+    """Announce ``abort_message``, mark an open tool sequence with interruption provenance,
     persist, clear the interrupt and return the ``interrupted`` result dict."""
     _vlines(agent, f"⚡ {abort_message}")
-    close_interrupted_tool_sequence(messages, interrupt_text)
+    mark_interrupted_tool_tail(messages)
     agent._persist_session(messages, conversation_history)
     agent.clear_interrupt()
     return {

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from agent.message_metadata import append_message
-from agent.message_sanitization import close_interrupted_tool_sequence, coalesce_tool_call_id
+from agent.message_sanitization import coalesce_tool_call_id, mark_interrupted_tool_tail
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -52,9 +52,10 @@ def _append_tool_error_results(messages, tool_calls, content_for) -> None:
 
 def _partial_exit(agent, messages, conversation_history, api_call_count, final_response: str) -> Dict[str, Any]:
     """Terminal partial result. Prior retries or an earlier tool batch leave a tool-result
-    tail; close it as interrupt aborts do so the next turn is not tool→user (#48879).
+    tail; stamp interruption provenance as interrupt aborts do so the API-copy sanitizer
+    closes the next turn's tool→user provider-side (#48879, #63292).
     This path never reaches finalize_turn, so persist here."""
-    close_interrupted_tool_sequence(messages, final_response)
+    mark_interrupted_tool_tail(messages)
     agent._persist_session(messages, conversation_history)
     return {
         "final_response": final_response,

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.error_classifier import FailoverReason
 from agent.message_metadata import append_message
-from agent.message_sanitization import close_interrupted_tool_sequence
+from agent.message_sanitization import close_interrupted_tool_sequence, mark_interrupted_tool_tail
 from agent.repetition_guard import is_repetition_dominated
 from agent.turn_api_call import stop_thinking_spinner
 from agent.turn_retry_state import TurnRetryState
@@ -343,7 +343,9 @@ def _retry_truncated_tool_call(st: _Trunc, api_kwargs: Any) -> TruncationVerdict
         _final_response = _TRUNCATED_FINAL
     agent._cleanup_task_resources(st.effective_task_id)
     # Prior tool batches can leave a tool-result tail; this path never reaches finalize_turn.
-    close_interrupted_tool_sequence(st.messages, _final_response)
+    # Stamp interruption provenance — the API-copy sanitizer closes ``tool → user``
+    # provider-side so the durable transcript keeps real rows only (#63292).
+    mark_interrupted_tool_tail(st.messages)
     return st.end_turn(_final_response, cleanup=False)
 
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -24,6 +24,18 @@ function firstBillingLine(text: string): string {
   return (text || '').split('\n')[0]?.trim() ?? ''
 }
 
+// Legacy backends close interrupted turns with a synthetic status string as
+// the final text. Anchored EXACT patterns (not prefixes): a genuine answer
+// that merely opens with "Operation interrupted…" must survive; only the
+// whole-message sentinel is demoted to metadata (#63292).
+const LEGACY_INTERRUPT_STATUS_PATTERNS = [
+  /^Operation interrupted\.$/,
+  /^Operation interrupted: waiting for model response \(\d+\.\d+s elapsed\)\.$/,
+  /^Operation interrupted during retry \(.+, attempt \d+\/\d+\)\.$/,
+  /^Operation interrupted: handling API error \([^:\r\n]+: .*\)\.$/,
+  /^Operation interrupted: retrying API call after error \(retry \d+\/\d+\)\.$/
+] as const
+
 /**
  * A turn failed on a billing wall (out of credits / payment required). The
  * gateway forwards the structured descriptor built by `agent/billing_links.py`;
@@ -77,6 +89,7 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     finalizeInterimAssistantMessage,
     flushQueuedDeltas,
     nativeSubagentSessionsRef,
+    sessionInterrupted,
     sessionStateByRuntimeIdRef,
     updateSessionState
   } = deps
@@ -331,10 +344,21 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
 
     flushQueuedDeltas(sessionId)
 
-    // Keyed by session so only one window beeps when several are open.
-    playCompletionSound(sessionId)
+    const completionInterrupted = payload?.status === 'interrupted' || sessionInterrupted(sessionId)
+    const completionText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
 
-    const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
+    // An interrupted completion whose text is just the legacy synthetic
+    // sentinel is metadata, not content — keep any real partial text.
+    const finalText =
+      completionInterrupted && LEGACY_INTERRUPT_STATUS_PATTERNS.some(pattern => pattern.test(completionText.trim()))
+        ? ''
+        : completionText
+
+    // Keyed by session so only one window beeps when several are open.
+    // Interruptions are cancellations, not completions — no fanfare.
+    if (!completionInterrupted) {
+      playCompletionSound(sessionId)
+    }
 
     // Terminal error frames (status "error") carry the failure in
     // structured fields: `error` is the message, `partial` marks
@@ -349,7 +373,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
           }
         : undefined
 
-    completeAssistantMessage(sessionId, finalText, payload?.response_previewed, failure, occurredAt)
+    completeAssistantMessage(
+      sessionId,
+      finalText,
+      payload?.response_previewed,
+      failure,
+      occurredAt,
+      completionInterrupted
+    )
 
     // Structured billing wall forwarded by the gateway (out of credits /
     // payment required) — cache it + raise a billing-specific toast.
@@ -360,18 +391,24 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     if (isActiveEvent) {
       setTurnStartedAt(null)
 
-      // Pet beat: a finished turn always celebrates — go straight to the
-      // jump, never linger on the run/reason pose. One atom update (clears
-      // toolRunning/reasoning AND sets celebrate together) so no stray "run"
-      // frame leaks to the sprite — including the popped-out overlay, which
-      // mirrors each activity change. The jump runs ~2 loops, then settles.
-      flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
+      if (completionInterrupted) {
+        // Clear stale working poses without turning a cancellation into a
+        // completion celebration — and never flag the turn as unread.
+        setPetActivity({ reasoning: false, toolRunning: false })
+      } else {
+        // Pet beat: a finished turn always celebrates — go straight to the
+        // jump, never linger on the run/reason pose. One atom update (clears
+        // toolRunning/reasoning AND sets celebrate together) so no stray "run"
+        // frame leaks to the sprite — including the popped-out overlay, which
+        // mirrors each activity change. The jump runs ~2 loops, then settles.
+        flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
 
-      // Light up the pet's mail icon if the user wasn't looking when the turn
-      // finished — a glanceable "new message" hint on the popped-out overlay.
-      // Cleared when they open the app via the mail icon or refocus the window.
-      if (typeof document !== 'undefined' && !document.hasFocus()) {
-        markPetUnread()
+        // Light up the pet's mail icon if the user wasn't looking when the turn
+        // finished — a glanceable "new message" hint on the popped-out overlay.
+        // Cleared when they open the app via the mail icon or refocus the window.
+        if (typeof document !== 'undefined' && !document.hasFocus()) {
+          markPetUnread()
+        }
       }
     }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -33,7 +33,10 @@ const LEGACY_INTERRUPT_STATUS_PATTERNS = [
   /^Operation interrupted: waiting for model response \(\d+\.\d+s elapsed\)\.$/,
   /^Operation interrupted during retry \(.+, attempt \d+\/\d+\)\.$/,
   /^Operation interrupted: handling API error \([^:\r\n]+: .*\)\.$/,
-  /^Operation interrupted: retrying API call after error \(retry \d+\/\d+\)\.$/
+  /^Operation interrupted: retrying API call after error \(retry \d+\/\d+\)\.$/,
+  // Empty-response retry backoff producer (agent/turn_empty_response.py) — same
+  // synthetic-interrupt family; the whole-message sentinel demotes to metadata.
+  /^Operation interrupted: retrying empty response from model \(retry \d+\/\d+\)\.$/
 ] as const
 
 /**

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -19,7 +19,8 @@ export interface GatewayEventDeps {
     text: string,
     responsePreviewed?: boolean,
     failure?: { error: string; partial: boolean },
-    occurredAt?: number
+    occurredAt?: number,
+    interrupted?: boolean
   ) => void
   failAssistantMessage: (sessionId: string, errorMessage: string, occurredAt?: number) => void
   flushQueuedDeltas: (sessionId?: string) => void

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -563,7 +563,8 @@ export function useMessageStream({
       text: string,
       responsePreviewed?: boolean,
       failure?: { error: string; partial: boolean; surface?: ErrorSurface | null },
-      occurredAt = Date.now() / 1000
+      occurredAt = Date.now() / 1000,
+      interrupted = false
     ) => {
       let shouldHydrate = false
 
@@ -790,12 +791,16 @@ export function useMessageStream({
         void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
       }
 
-      dispatchNativeNotification({
-        body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
-        kind: 'turnDone',
-        sessionId,
-        title: translateNow('notifications.native.turnDoneTitle')
-      })
+      if (!interrupted) {
+        // A cancelled turn is not a "turn done" — suppress the fanfare
+        // notification so the user is not told work finished when it stopped.
+        dispatchNativeNotification({
+          body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
+          kind: 'turnDone',
+          sessionId,
+          title: translateNow('notifications.native.turnDoneTitle')
+        })
+      }
     },
     [hydrateFromStoredSession, scheduleSessionsRefresh, updateSessionState]
   )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interrupted-completion.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interrupted-completion.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { chatMessageText } from '@/lib/chat-messages'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const cues = vi.hoisted(() => ({
+  dispatchNativeNotification: vi.fn(),
+  flashPetActivity: vi.fn(),
+  markPetUnread: vi.fn(),
+  playCompletionSound: vi.fn(),
+  setPetActivity: vi.fn()
+}))
+
+vi.mock('@/lib/completion-sound', async importOriginal => ({
+  ...(await importOriginal<object>()),
+  playCompletionSound: cues.playCompletionSound
+}))
+vi.mock('@/store/native-notifications', async importOriginal => ({
+  ...(await importOriginal<object>()),
+  dispatchNativeNotification: cues.dispatchNativeNotification
+}))
+vi.mock('@/store/pet', async importOriginal => ({
+  ...(await importOriginal<object>()),
+  flashPetActivity: cues.flashPetActivity,
+  markPetUnread: cues.markPetUnread,
+  setPetActivity: cues.setPetActivity
+}))
+
+const SID = 'session-1'
+
+// Whole-message cancellation sentinels older backends settle with. Newer
+// backends blank `text` for interrupted turns, so these arrive only from
+// legacy gateways — they are metadata, not assistant prose.
+const LEGACY_INTERRUPT_SENTINELS = [
+  'Operation interrupted.',
+  'Operation interrupted: waiting for model response (0.3s elapsed).',
+  'Operation interrupted during retry (upstream gateway timeout (504, 42s), attempt 1/3).',
+  'Operation interrupted: handling API error (RateLimitError: Too many requests).',
+  'Operation interrupted: retrying API call after error (retry 2/3).'
+] as const
+
+const PREFIX_COLLIDING_PARTIAL =
+  'Operation interrupted: waiting for model response (this phrase describes the log; the real answer continues here.'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+  // A live turn awaiting its completion frame.
+  stream.states.set(SID, { ...stream.state(SID), awaitingResponse: true, busy: true })
+}
+
+const completeInterrupted = (text: string) =>
+  act(() => stream.handleEvent({ payload: { status: 'interrupted', text }, session_id: SID, type: 'message.complete' }))
+
+const start = () => act(() => stream.handleEvent({ payload: {}, session_id: SID, type: 'message.start' }))
+
+describe('useMessageStream interrupted completion', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it.each(LEGACY_INTERRUPT_SENTINELS)(
+    'settles backend interruption without prose or completion cues, then accepts the queued turn start: %s',
+    interruptText => {
+      mountStream()
+      completeInterrupted(interruptText)
+
+      const settled = stream.state(SID)
+      expect(settled.interrupted).toBe(false)
+      expect(settled.busy).toBe(false)
+      expect(settled.awaitingResponse).toBe(false)
+      expect(settled.messages.map(chatMessageText)).not.toContain(interruptText)
+      expect(cues.playCompletionSound).not.toHaveBeenCalled()
+      expect(cues.flashPetActivity).not.toHaveBeenCalled()
+      expect(cues.dispatchNativeNotification).not.toHaveBeenCalled()
+
+      start()
+
+      const restarted = stream.state(SID)
+      expect(restarted.busy).toBe(true)
+      expect(restarted.awaitingResponse).toBe(true)
+      expect(restarted.interrupted).toBe(false)
+    }
+  )
+
+  it('keeps real partial assistant text that begins with a legacy prefix', () => {
+    mountStream()
+    completeInterrupted(PREFIX_COLLIDING_PARTIAL)
+
+    expect(stream.state(SID).messages.map(chatMessageText)).toContain(PREFIX_COLLIDING_PARTIAL)
+    expect(cues.playCompletionSound).not.toHaveBeenCalled()
+    expect(cues.flashPetActivity).not.toHaveBeenCalled()
+    expect(cues.dispatchNativeNotification).not.toHaveBeenCalled()
+  })
+})

--- a/contributors/emails/yingliangzhang@users.noreply.github.com
+++ b/contributors/emails/yingliangzhang@users.noreply.github.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1238,7 +1238,7 @@ class SessionDB(
     # can split compaction-archived rows without a second query.
     _CONVERSATION_ROW_COLUMNS = (
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
-        "finish_reason, reasoning, reasoning_content, reasoning_details, "
+        "interrupted_tool_tail, finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
         "_compressed_summary, timestamp, active, api_content, display_kind, display_metadata"
     )

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -371,7 +371,8 @@ CREATE TABLE IF NOT EXISTS messages (
     display_kind TEXT,
     display_metadata TEXT,
     display_identity BLOB,
-    display_order INTEGER
+    display_order INTEGER,
+    interrupted_tool_tail INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -23,8 +23,8 @@ _INSERT_MESSAGE_SQL = """INSERT INTO messages (session_id, role, content, tool_c
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind,
-                   display_metadata, display_identity)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                   display_metadata, display_identity, interrupted_tool_tail)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _BUMP_GENERATION_SQL = """
             INSERT INTO conversation_generations (source, session_key, generation)
             VALUES (?, ?, 1)
@@ -263,7 +263,8 @@ class SessionMessagesMixin:
             msg.get("platform_message_id") or msg.get("message_id"),
             1 if msg.get("observed") else 0, 1 if msg.get("_compressed_summary") else 0, 1,
             _str_or_none(msg.get("api_content")), _str_or_none(msg.get("display_kind")),
-            display_metadata, self._display_identity(self._display_dedupe_key(identity_row)))
+            display_metadata, self._display_identity(self._display_dedupe_key(identity_row)),
+            1 if (msg.get("_interrupted_tool_tail") or msg.get("interrupted_tool_tail")) else 0)
 
     @staticmethod
     def _bump_session_counters(conn, session_id: str, inserted: int, tool_calls: int, *, unit: bool) -> None:
@@ -306,6 +307,30 @@ class SessionMessagesMixin:
         # THE critical write (failure aborts the turn): long patience so a sibling legitimately
         # holding the lock for seconds (VACUUM, checkpoint) can't kill it.
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def mark_tool_tail_interrupted(
+        self,
+        session_id: str,
+        tool_call_id: str,
+    ) -> bool:
+        """Persist interruption provenance on an already-written tool result."""
+        if not session_id or not tool_call_id:
+            return False
+
+        def _do(conn):
+            cursor = conn.execute(
+                """UPDATE messages SET interrupted_tool_tail = 1
+                   WHERE id = (
+                       SELECT id FROM messages
+                       WHERE session_id = ? AND active = 1
+                         AND role = 'tool' AND tool_call_id = ?
+                       ORDER BY id DESC LIMIT 1
+                   )""",
+                (session_id, tool_call_id),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
 
     def append_delegation_delivery(self, session_id: str, content: str, metadata: Dict[str, Any]) -> int:
         """Record a detached API result once, between client turns, including replay after rotation.
@@ -961,6 +986,8 @@ class SessionMessagesMixin:
                 msg["_compressed_summary"] = True
             msg.update(
                 (col, row[col]) for col in ("timestamp", "tool_call_id", "tool_name", "effect_disposition") if row[col])
+            if row["interrupted_tool_tail"]:
+                msg["_interrupted_tool_tail"] = True
             if row["tool_calls"]:
                 msg["tool_calls"] = _json_or(
                     row["tool_calls"], [], "Failed to deserialize tool_calls in conversation replay, falling back to []")

--- a/tests/agent/test_empty_tool_name_loop_dampening.py
+++ b/tests/agent/test_empty_tool_name_loop_dampening.py
@@ -249,9 +249,10 @@ def test_invalid_tool_exhaustion_closes_tool_tail(agent_env):
     """Invalid-tool 3-strike partial must not leave a durable tool→user tail (#48879 class).
 
     Retries <3 append assistant+error tool rows, so the transcript already ends
-    on ``tool`` before the exhaustion early-return. That return must close the
-    sequence (same contract as interrupt aborts) so the next user turn is not
-    ``tool → user`` for strict providers.
+    on ``tool`` before the exhaustion early-return. That return must stamp
+    interruption provenance on the tool tail (same contract as interrupt aborts,
+    #63292) so the next user turn's API copy — not the durable transcript —
+    carries the synthetic closure for strict providers.
     """
     agent, handler = agent_env
     for _ in range(3):
@@ -262,6 +263,6 @@ def test_invalid_tool_exhaustion_closes_tool_tail(agent_env):
     assert result.get("partial", False)
     msgs = result.get("messages") or []
     assert msgs, "expected persisted conversation messages"
-    assert msgs[-1].get("role") == "assistant"
-    assert "invalid tool call" in (msgs[-1].get("content") or "").lower()
+    assert msgs[-1].get("role") == "tool", "interrupted tool tail is kept, not closed in-place"
+    assert msgs[-1].get("_interrupted_tool_tail") is True, "provenance marker must be stamped on the tool tail"
 

--- a/tests/agent/test_interrupt_tool_tail_api_sanitization.py
+++ b/tests/agent/test_interrupt_tool_tail_api_sanitization.py
@@ -1,0 +1,81 @@
+"""Interrupted tool-tail closure stays API-only."""
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+def _tool_tail(*, interrupted=False):
+    tool_result = {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": "ok edited",
+    }
+    if interrupted:
+        tool_result["_interrupted_tool_tail"] = True
+    return [
+        {"role": "user", "content": "edit the file"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "patch", "arguments": "{}"}}
+            ],
+        },
+        tool_result,
+    ]
+
+
+def test_user_after_interrupted_tool_tail_is_closed_only_in_api_copy():
+    canonical = _tool_tail(interrupted=True) + [
+        {"role": "user", "content": "do something else"}
+    ]
+
+    wire = sanitize_api_messages([dict(message) for message in canonical])
+
+    assert [message["role"] for message in canonical[-2:]] == ["tool", "user"]
+    assert canonical[-2]["_interrupted_tool_tail"] is True
+    assert [message["role"] for message in wire[-3:]] == [
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert wire[-2]["content"] == "Operation interrupted."
+    assert all("_interrupted_tool_tail" not in message for message in wire)
+
+
+def test_normal_user_redirect_reaches_api_copy_unchanged():
+    canonical = _tool_tail() + [{"role": "user", "content": "do something else"}]
+
+    wire = sanitize_api_messages([dict(message) for message in canonical])
+
+    assert wire == canonical
+
+
+def test_real_partial_assistant_text_remains_the_closure():
+    canonical = _tool_tail() + [
+        {"role": "assistant", "content": "Partial answer so far"},
+        {"role": "user", "content": "do something else"},
+    ]
+
+    wire = sanitize_api_messages([dict(message) for message in canonical])
+
+    assert wire == canonical
+    assert wire[-2]["content"] == "Partial answer so far"
+
+
+def test_legacy_synthetic_interrupt_sentinel_remains_compatible():
+    canonical = _tool_tail() + [
+        {"role": "assistant", "content": "Operation interrupted."},
+        {"role": "user", "content": "do something else"},
+    ]
+
+    wire = sanitize_api_messages([dict(message) for message in canonical])
+
+    assert wire == canonical
+
+
+def test_tool_tail_without_followup_is_unchanged():
+    canonical = _tool_tail()
+
+    wire = sanitize_api_messages([dict(message) for message in canonical])
+
+    assert wire == canonical

--- a/tests/agent/test_interrupt_tool_tail_api_sanitization.py
+++ b/tests/agent/test_interrupt_tool_tail_api_sanitization.py
@@ -79,3 +79,53 @@ def test_tool_tail_without_followup_is_unchanged():
     wire = sanitize_api_messages([dict(message) for message in canonical])
 
     assert wire == canonical
+
+
+# ---------------------------------------------------------------------------
+# Durable provenance round-trip (quad-review gap: the DB layer had zero
+# coverage — a mutant binding 0 / skipping replay passed the whole suite).
+# ---------------------------------------------------------------------------
+def test_interrupted_tool_tail_survives_db_roundtrip(tmp_path):
+    """Flush → persist → reload must carry interrupted_tool_tail=True: the
+    provenance is DURABLE canonical state, not an in-memory-only flag."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="tui")
+    db.append_message(
+        "s1", role="tool", content="partial result", tool_call_id="call-1",
+    )
+    assert db.mark_tool_tail_interrupted("s1", "call-1") is True
+
+    # Zero-row match returns False (unknown id / not-yet-flushed row) —
+    # the flush-side guard relies on this to stay eligible for back-stamp.
+    assert db.mark_tool_tail_interrupted("s1", "missing-call") is False
+
+    reloaded = db.get_messages_as_conversation("s1", include_ancestors=False)
+    assert reloaded and reloaded[0].get("_interrupted_tool_tail") is True
+
+
+def test_interrupted_tool_tail_column_upgrades_legacy_db(tmp_path):
+    """A state.db written BEFORE this PR (no interrupted_tool_tail column)
+    reconciles on open: the column is added and legacy rows default to 0."""
+    from hermes_state import SessionDB
+
+    path = tmp_path / "legacy.db"
+    db = SessionDB(path)
+    db.create_session("s1", source="tui")
+    db.append_message("s1", role="user", content="hi")
+    db.close()
+
+    # Simulate the pre-PR on-disk shape: drop the column the DDL just added
+    # (a plain DROP COLUMN keeps triggers/indexes intact, unlike a rebuild).
+    con = __import__("sqlite3").connect(path)
+    con.execute("PRAGMA writable_schema = OFF")
+    con.execute("ALTER TABLE messages DROP COLUMN interrupted_tool_tail")
+    con.commit()
+    con.close()
+
+    reopened = SessionDB(path)  # _reconcile_columns must re-ADD the column
+    cols = {row[1] for row in reopened._conn.execute("PRAGMA table_info(messages)")}
+    assert "interrupted_tool_tail" in cols
+    reloaded = reopened.get_messages("s1")
+    assert reloaded and reloaded[0].get("_interrupted_tool_tail") in (None, False)

--- a/tests/agent/test_turn_finalizer_interrupt_alternation.py
+++ b/tests/agent/test_turn_finalizer_interrupt_alternation.py
@@ -1,20 +1,11 @@
-"""Regression test for #48879.
+"""Regression tests for interrupted tool-tail persistence and replay.
 
-When a turn is interrupted via ``/stop`` right after a tool completes — but
-before the assistant streams any final text — the transcript tail is a raw
-``tool`` message. Persisting that tail unmodified means the next user message
-lands as ``... tool → user``, a role-alternation violation that strict
-providers (Gemini, Claude) react to by hallucinating a continuation of the
-user's message before transitioning into the assistant persona.
-
-``finalize_turn`` closes the tool-call sequence on interrupt by appending a
-synthetic ``assistant`` message before persistence. ``final_response`` is
-typically empty on an interrupt, so the placeholder text is used rather than
-an empty-content assistant turn.
+An interrupt after a tool result must not turn cancellation metadata into a
+user-visible assistant row. The canonical transcript keeps the real tool tail;
+the per-request API copy closes ``tool → user`` before strict-provider replay.
 """
 
-import pytest
-
+from agent.agent_runtime_helpers import sanitize_api_messages
 from agent.turn_finalizer import finalize_turn
 
 
@@ -145,27 +136,58 @@ def _assert_no_tool_then_user(messages):
             )
 
 
-def test_interrupt_after_tool_closes_sequence_with_placeholder():
+def test_interrupt_after_tool_keeps_transcript_clean_and_closes_api_copy():
     agent = _StubAgent()
     messages = _interrupted_tool_tail()
-    _finalize(agent, messages, interrupted=True, final_response=None)
+    _finalize(agent, messages, interrupted=True, final_response="")
 
-    # Tail must now be an assistant message, not a raw tool result.
-    assert messages[-1]["role"] == "assistant"
-    # Empty final_response falls back to the explicit placeholder rather
-    # than persisting an empty-content assistant turn.
-    assert messages[-1]["content"] == "Operation interrupted."
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["_interrupted_tool_tail"] is True
+    assert agent.persisted_messages == messages
+    assert not any(
+        message.get("role") == "assistant"
+        and str(message.get("content") or "").startswith("Operation interrupted")
+        for message in agent.persisted_messages
+    )
 
-    # The persisted snapshot is alternation-safe: appending a new user
-    # message would follow an assistant, not an orphan tool.
-    assert agent.persisted_messages is not None
-    assert agent.persisted_messages[-1]["role"] == "assistant"
-    follow_on = agent.persisted_messages + [{"role": "user", "content": "forget it"}]
-    _assert_no_tool_then_user(follow_on)
+    canonical_follow_on = agent.persisted_messages + [
+        {"role": "user", "content": "forget it"}
+    ]
+    wire_messages = sanitize_api_messages([dict(message) for message in canonical_follow_on])
+
+    assert canonical_follow_on[-2]["role"] == "tool"
+    assert canonical_follow_on[-1]["role"] == "user"
+    _assert_no_tool_then_user(wire_messages)
+    assert [message["role"] for message in wire_messages[-3:]] == [
+        "tool",
+        "assistant",
+        "user",
+    ]
 
 
+def test_interrupt_after_tool_keeps_delivered_text_when_present():
+    agent = _StubAgent()
+    messages = _interrupted_tool_tail() + [
+        {"role": "assistant", "content": "Partial answer so far"}
+    ]
+    _finalize(agent, messages, interrupted=True, final_response="Partial answer so far")
+
+    assert messages[-1] == {
+        "role": "assistant",
+        "content": "Partial answer so far",
+    }
+    assert agent.persisted_messages[-1] == messages[-1]
 
 
+def test_non_interrupted_tool_tail_is_left_untouched():
+    # A turn that ends on a tool tail WITHOUT an interrupt (mid-progress
+    # tool loop) must not get a synthetic close — that is normal dialog
+    # state handled elsewhere.
+    agent = _StubAgent()
+    messages = _interrupted_tool_tail()
+    _finalize(agent, messages, interrupted=False, final_response=None)
+    assert messages[-1]["role"] == "tool"
+    assert "_interrupted_tool_tail" not in messages[-1]
 
 
 def test_interrupt_without_tool_tail_adds_nothing():

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4609,8 +4609,11 @@ class TestRunConversation:
 
         assert result.get("partial") is True
         msgs = result.get("messages") or []
-        assert msgs[-1].get("role") == "assistant"
-        assert "truncated" in (msgs[-1].get("content") or "").lower()
+        # Truncated-args partial exits stamp interruption provenance on the tool
+        # tail (#63292): the durable transcript keeps the real ``tool`` row and the
+        # API-copy sanitizer synthesizes the closure at the next user turn.
+        assert msgs[-1].get("role") == "tool", "interrupted tool tail is kept, not closed in-place"
+        assert msgs[-1].get("_interrupted_tool_tail") is True, "provenance marker must be stamped on the tool tail"
         assert any(isinstance(m, dict) and m.get("role") == "tool" for m in msgs)
 
 


### PR DESCRIPTION
## Summary

- represent cancelled model waits as `interrupted` status with an empty final response instead of assistant prose
- preserve real partial assistant text while keeping cancellation-only turns out of canonical session history
- close interrupted `tool -> user` tails only in the per-request API copy so strict providers still receive valid ordering
- settle Desktop interruption events without completion sounds, celebration/unread cues, or native completion notifications
- keep narrow compatibility filtering for interruption sentinels emitted by older workers

## Root cause

The core loop returned local cancellation status strings such as `Operation interrupted: waiting for model response (...)` as `final_response`, and the turn finalizer could persist a synthetic `Operation interrupted.` assistant row after a tool result. Desktop then handled every `message.complete` as a successful completion, so cancellation metadata appeared as a reply and triggered completion UX.

The fix makes structured `interrupted` state authoritative. Empty cancellations stay metadata-only; actual streamed partial text is still returned and persisted. Provider role repair now happens on the API copy rather than rewriting the durable transcript.

## Verification

- `pytest -q tests/run_agent/test_message_sequence_repair.py tests/agent/test_turn_finalizer*.py tests/agent/test_interrupt_tool_tail_api_sanitization.py tests/run_agent/test_run_agent.py -k 'interrupt or tool_tail or sanitize'` — 37 passed
- `npx vitest run src/app/session/hooks/use-message-stream --environment jsdom` — 12 passed
- `npm run typecheck` in `apps/desktop` — passed
- focused Desktop ESLint — passed
- `uv run --frozen --extra dev --extra acp pytest -q tests/acp/test_server.py -k interrupt` — 1 passed
- `npx vitest run src/__tests__/createGatewayEventHandler.test.ts -t 'interrupt'` in `ui-tui` — 2 passed
- focused Ruff and `git diff --check` — passed

## Related work

This is complementary to #55317: that PR surfaces **non-interrupted** tool-result-only endings, while this PR keeps **interrupted** cancellation paths metadata-only.
