### PR TITLE
fix(autonomous): restore watchdog runtime on current main

### DIFF
--- a/hermes_autonomous.py
+++ b/hermes_autonomous.py
@@ -377,7 +377,7 @@ def autonomous_tick(options: TickOptions | None = None) -> dict[str, Any]:
     state = load_runner_state()
     tick_id = f"hat-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
 
-    audit = run_capability_audit()
+    audit = run_capability_audit(update_state=False)
     anti_shell = run_anti_shell_check(opts.repo)
     next_stage, reason = _next_stage_action(audit)
     all_gates_passed = reason == "all_gates_passed"

--- a/hermes_autonomous.py
+++ b/hermes_autonomous.py
@@ -1,0 +1,659 @@
+"""Hermes autonomous development runner.
+
+The runner is deliberately deterministic.  LLM workers still do creative
+implementation work, but this module owns the durable state machine that keeps
+Hermes moving after restarts, desktop reloads, failed CI, or an exhausted
+single conversation turn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+from uuid import uuid4
+
+from hermes_delivery import (
+    artifact_path,
+    delivery_root,
+    load_state as load_delivery_state,
+    run_capability_audit,
+    run_gate,
+    update_stage,
+)
+
+
+RUNNER_SCHEMA = "hermes.autonomous.v1"
+DEFAULT_BOARD = "default"
+DEFAULT_GOAL_TURNS = 120
+WATCHDOG_JOB_NAME = "Hermes Autonomous Watchdog"
+WATCHDOG_SCRIPT_NAME = "autonomous_watchdog.py"
+ACTIVE_TASK_STATUSES = {"todo", "scheduled", "ready", "running", "review"}
+UNFINISHED_TASK_STATUSES = ACTIVE_TASK_STATUSES | {"blocked"}
+
+
+@dataclass(frozen=True)
+class TickOptions:
+    create_tasks: bool = False
+    dispatch: bool = False
+    board: str = DEFAULT_BOARD
+    assignee: str | None = None
+    goal_max_turns: int = DEFAULT_GOAL_TURNS
+    workspace_path: str | None = None
+    repo: str | None = None
+    pr: str | None = None
+    ci_ref: str | None = None
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def runner_state_path() -> Path:
+    return delivery_root() / "autonomous-runner.json"
+
+
+def anti_shell_report_path() -> Path:
+    return artifact_path("anti-shell/report.json")
+
+
+def heartbeat_path() -> Path:
+    return artifact_path("autonomous-heartbeat.json")
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path, fallback: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return fallback
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return fallback
+    return data if isinstance(data, dict) else fallback
+
+
+def _initial_runner_state() -> dict[str, Any]:
+    return {
+        "schema": RUNNER_SCHEMA,
+        "created_at": _utcnow(),
+        "updated_at": _utcnow(),
+        "enabled": True,
+        "mode": "supervised-autonomous",
+        "no_approval_cards": True,
+        "board": DEFAULT_BOARD,
+        "goal_mode": True,
+        "goal_max_turns": DEFAULT_GOAL_TURNS,
+        "last_tick_at": "",
+        "last_tick_id": "",
+        "last_next_action": "",
+        "last_blocked_reason": "",
+        "heartbeat": {},
+        "ticks": [],
+    }
+
+
+def load_runner_state() -> dict[str, Any]:
+    state = _read_json(runner_state_path(), _initial_runner_state())
+    state.setdefault("schema", RUNNER_SCHEMA)
+    state.setdefault("created_at", _utcnow())
+    state.setdefault("updated_at", _utcnow())
+    state.setdefault("enabled", True)
+    state.setdefault("mode", "supervised-autonomous")
+    state.setdefault("no_approval_cards", True)
+    state.setdefault("board", DEFAULT_BOARD)
+    state.setdefault("goal_mode", True)
+    state.setdefault("goal_max_turns", DEFAULT_GOAL_TURNS)
+    state.setdefault("last_tick_at", "")
+    state.setdefault("last_tick_id", "")
+    state.setdefault("last_next_action", "")
+    state.setdefault("last_blocked_reason", "")
+    state.setdefault("heartbeat", {})
+    state.setdefault("ticks", [])
+    return state
+
+
+def save_runner_state(state: dict[str, Any]) -> dict[str, Any]:
+    state["updated_at"] = _utcnow()
+    _atomic_write_json(runner_state_path(), state)
+    return state
+
+
+def _run_command(args: list[str], cwd: str | None = None) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:
+        return {"ok": False, "args": args, "exit_code": -1, "stdout": "", "stderr": str(exc)}
+    return {
+        "ok": result.returncode == 0,
+        "args": args,
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _git_status(repo: str | None) -> dict[str, Any]:
+    cwd = repo or os.getcwd()
+    status = _run_command(["git", "status", "--porcelain"], cwd=cwd)
+    branch = _run_command(["git", "branch", "--show-current"], cwd=cwd)
+    return {
+        "repo": cwd,
+        "available": status["exit_code"] == 0,
+        "dirty": bool(status.get("stdout")),
+        "branch": branch.get("stdout", ""),
+        "porcelain": status.get("stdout", ""),
+        "error": status.get("stderr") if status["exit_code"] != 0 else "",
+    }
+
+
+def _artifact_exists(relative: str) -> bool:
+    path = artifact_path(relative)
+    return path.exists() and path.stat().st_size > 0
+
+
+def run_anti_shell_check(repo: str | None = None) -> dict[str, Any]:
+    """Check that the delivery loop has real evidence, not just green labels."""
+
+    git = _git_status(repo)
+    delivery = load_delivery_state()
+    stages = {stage["id"]: stage for stage in delivery.get("stages", [])}
+    deploy_evidence = run_gate("deploy", update_state=False)
+    deploy_verified = deploy_evidence.get("status") == "passed"
+    checks: list[dict[str, Any]] = []
+
+    def add(name: str, ok: bool, detail: str) -> None:
+        checks.append({"name": name, "ok": bool(ok), "detail": detail})
+
+    add("delivery_ledger_exists", artifact_path("state.json").exists(), str(artifact_path("state.json")))
+    add("spec_artifact_exists", _artifact_exists("spec.md"), "spec.md")
+    add("task_artifact_exists", _artifact_exists("tasks.md"), "tasks.md")
+    add("dispatch_has_job", _artifact_exists("jobs") or stages.get("dispatch", {}).get("status") in {"ready", "done"}, "jobs/*.json")
+    add("pr_monitor_artifact", _artifact_exists("pr-status.json"), "pr-status.json")
+    add("ci_monitor_artifact", _artifact_exists("ci/latest.json") or _artifact_exists("ci-latest.json"), "ci latest")
+    add("acceptance_artifact", _artifact_exists("acceptance/report.md"), "acceptance/report.md")
+    add("deploy_run_recorded", deploy_verified, f"deploy gate: {deploy_evidence.get('status')}")
+    add("git_repo_available", bool(git["available"]), git["repo"])
+    change_detail = git["porcelain"] or ("deploy gate verified" if deploy_verified else "no code/deploy evidence")
+    add("git_has_real_change_or_deploy", bool(git["dirty"] or deploy_verified), change_detail)
+
+    failed = [check for check in checks if not check["ok"]]
+    report = {
+        "schema": "hermes.anti-shell.v1",
+        "generated_at": _utcnow(),
+        "status": "passed" if not failed else "failed",
+        "passed": len(checks) - len(failed),
+        "failed": len(failed),
+        "checks": checks,
+        "git": git,
+        "failure_action": "回 Stage3/Phase2 补真实代码、PR、CI、验收或部署证据" if failed else "allow_next_gate",
+    }
+    _atomic_write_json(anti_shell_report_path(), report)
+    if failed:
+        update_stage("anti_shell", "failed", "Anti-Shell failed; real evidence missing")
+    else:
+        update_stage("anti_shell", "done", "Anti-Shell passed")
+    return report
+
+
+def _next_stage_action(audit: dict[str, Any]) -> tuple[str, str]:
+    for result in audit.get("results", []):
+        if result.get("status") != "passed":
+            return result.get("stage_id", "unknown"), "gate_failed"
+    return "deploy", "all_gates_passed"
+
+
+def _create_goal_task(
+    *,
+    title: str,
+    body: str,
+    board: str,
+    assignee: str | None,
+    goal_max_turns: int,
+    workspace_path: str | None,
+    idempotency_key: str,
+) -> tuple[str, bool, dict[str, Any]]:
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect(board=board) as conn:
+        active = conn.execute(
+            """
+            SELECT id, status, created_at, completed_at, idempotency_key
+              FROM tasks
+             WHERE idempotency_key LIKE ?
+               AND status != 'archived'
+             ORDER BY created_at DESC
+            """,
+            (f"{idempotency_key}%",),
+        ).fetchall()
+        for row in active:
+            if str(row["status"]) in ACTIVE_TASK_STATUSES:
+                task = {
+                    "id": str(row["id"]),
+                    "status": str(row["status"]),
+                    "created_at": int(row["created_at"] or 0),
+                    "completed_at": int(row["completed_at"] or 0),
+                    "idempotency_key": str(row["idempotency_key"] or ""),
+                    "reused_active": True,
+                }
+                return task["id"], False, task
+        latest = active[0] if active else None
+        exact = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived' "
+            "ORDER BY created_at DESC LIMIT 1",
+            (idempotency_key,),
+        ).fetchone()
+        effective_key = idempotency_key
+        if exact:
+            effective_key = f"{idempotency_key}:retry:{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}:{uuid4().hex[:6]}"
+        task_id = kb.create_task(
+            conn,
+            title=title,
+            body=body,
+            assignee=assignee,
+            created_by="hermes-autonomous",
+            workspace_kind="dir" if workspace_path else "scratch",
+            workspace_path=workspace_path,
+            idempotency_key=effective_key,
+            goal_mode=True,
+            goal_max_turns=goal_max_turns,
+            initial_status="running",
+            board=board,
+        )
+    return task_id, True, {
+        "id": task_id,
+        "status": "ready",
+        "idempotency_key": effective_key,
+        "reused_active": False,
+        "previous_task": {
+            "id": str(latest["id"]),
+            "status": str(latest["status"]),
+            "idempotency_key": str(latest["idempotency_key"] or ""),
+        }
+        if latest
+        else None,
+    }
+
+
+def _dispatch_once(board: str) -> dict[str, Any]:
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect(board=board) as conn:
+        result = kb.dispatch_once(conn, board=board)
+    if is_dataclass(result):
+        return asdict(result)
+    if isinstance(result, dict):
+        return result
+    return {"result": repr(result)}
+
+
+def _unfinished_autonomous_tasks(board: str) -> list[dict[str, Any]]:
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect(board=board) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, status, assignee, created_at, started_at, completed_at,
+                   current_run_id, last_heartbeat_at, worker_pid, idempotency_key
+              FROM tasks
+             WHERE idempotency_key LIKE 'hermes-autonomous:%'
+               AND status NOT IN ('done', 'archived')
+             ORDER BY created_at DESC
+             LIMIT 20
+            """
+        ).fetchall()
+    return [
+        {
+            "id": str(row["id"]),
+            "title": str(row["title"]),
+            "status": str(row["status"]),
+            "assignee": str(row["assignee"] or ""),
+            "created_at": int(row["created_at"] or 0),
+            "started_at": int(row["started_at"] or 0),
+            "completed_at": int(row["completed_at"] or 0),
+            "current_run_id": int(row["current_run_id"] or 0),
+            "last_heartbeat_at": int(row["last_heartbeat_at"] or 0),
+            "worker_pid": int(row["worker_pid"] or 0),
+            "idempotency_key": str(row["idempotency_key"] or ""),
+        }
+        for row in rows
+    ]
+
+
+def _write_heartbeat(data: dict[str, Any]) -> dict[str, Any]:
+    heartbeat = {
+        "schema": "hermes.autonomous.heartbeat.v1",
+        "updated_at": _utcnow(),
+        **data,
+    }
+    _atomic_write_json(heartbeat_path(), heartbeat)
+    return heartbeat
+
+
+def autonomous_status() -> dict[str, Any]:
+    state = load_runner_state()
+    anti_shell = _read_json(anti_shell_report_path(), {})
+    heartbeat = _read_json(heartbeat_path(), state.get("heartbeat", {}))
+    delivery = load_delivery_state()
+    return {
+        "ok": True,
+        "runner": state,
+        "heartbeat": heartbeat,
+        "delivery_summary": {
+            "stages": [
+                {
+                    "id": stage.get("id"),
+                    "status": stage.get("status"),
+                    "notes": stage.get("notes", ""),
+                }
+                for stage in delivery.get("stages", [])
+            ],
+            "deploy_runs": len(delivery.get("deploy", {}).get("runs", [])),
+        },
+        "anti_shell": anti_shell,
+        "state_path": str(runner_state_path()),
+        "anti_shell_path": str(anti_shell_report_path()),
+        "heartbeat_path": str(heartbeat_path()),
+    }
+
+
+def autonomous_tick(options: TickOptions | None = None) -> dict[str, Any]:
+    opts = options or TickOptions()
+    state = load_runner_state()
+    tick_id = f"hat-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+
+    audit = run_capability_audit()
+    anti_shell = run_anti_shell_check(opts.repo)
+    next_stage, reason = _next_stage_action(audit)
+    all_gates_passed = reason == "all_gates_passed"
+    unfinished_tasks = _unfinished_autonomous_tasks(opts.board)
+    blocked_tasks = [task for task in unfinished_tasks if task.get("status") == "blocked"]
+    created_tasks: list[dict[str, Any]] = []
+    dispatch_result: dict[str, Any] | None = None
+
+    if opts.create_tasks and blocked_tasks:
+        blocked = blocked_tasks[0]
+        stage = str(blocked.get("idempotency_key", "hermes-autonomous:recovery")).split(":", 2)[1] or "recovery"
+        title = f"Hermes autonomous: retry blocked {stage} task"
+        body = (
+            "You are a Hermes autonomous no-idle recovery worker. A previous autonomous task "
+            "is blocked while the delivery loop is still not allowed to pretend everything is finished.\n\n"
+            f"Blocked task: {blocked['id']} ({blocked['title']})\n"
+            f"Blocked status: {blocked['status']}\n"
+            "Required behavior: inspect the blocked task evidence, unblock by doing the missing repo/local work, "
+            "write durable evidence into ~/.hermes/delivery, then re-run the relevant Hermes delivery/autonomous checks."
+        )
+        task_id, created, task_info = _create_goal_task(
+            title=title,
+            body=body,
+            board=opts.board,
+            assignee=opts.assignee,
+            goal_max_turns=max(1, int(opts.goal_max_turns or DEFAULT_GOAL_TURNS)),
+            workspace_path=opts.workspace_path,
+            idempotency_key=f"hermes-autonomous:recovery:{stage}",
+        )
+        created_tasks.append(
+            {
+                "id": task_id,
+                "title": title,
+                "stage": stage,
+                "created": created,
+                "status": str(task_info.get("status", "")),
+                "idempotency_key": str(task_info.get("idempotency_key", "")),
+                "previous_task": blocked,
+            }
+        )
+    elif opts.create_tasks and not all_gates_passed:
+        title = f"Hermes autonomous: fix {next_stage} gate"
+        body = (
+            "You are a Hermes autonomous goal worker. Continue until the gate is real, "
+            "not merely claimed complete.\n\n"
+            f"Failed stage: {next_stage}\n"
+            f"Reason: {reason}\n"
+            f"Anti-Shell status: {anti_shell['status']}\n"
+            "No-idle rule: before ending any turn, check the same gate again. "
+            "If it is still failing, write the missing evidence and continue; do not claim completion.\n"
+            "Required behavior: inspect artifacts, implement missing work, run verification, "
+            "write evidence into ~/.hermes/delivery, and do not ask the user for repo-only work."
+        )
+        task_id, created, task_info = _create_goal_task(
+            title=title,
+            body=body,
+            board=opts.board,
+            assignee=opts.assignee,
+            goal_max_turns=max(1, int(opts.goal_max_turns or DEFAULT_GOAL_TURNS)),
+            workspace_path=opts.workspace_path,
+            idempotency_key=f"hermes-autonomous:{next_stage}",
+        )
+        created_tasks.append(
+            {
+                "id": task_id,
+                "title": title,
+                "stage": next_stage,
+                "created": created,
+                "status": str(task_info.get("status", "")),
+                "idempotency_key": str(task_info.get("idempotency_key", "")),
+                "previous_task": task_info.get("previous_task"),
+            }
+        )
+
+    if opts.dispatch:
+        dispatch_result = _dispatch_once(opts.board)
+
+    spawned = 0
+    if isinstance(dispatch_result, dict):
+        try:
+            spawned = int(dispatch_result.get("spawned") or 0)
+        except (TypeError, ValueError):
+            spawned = 0
+    heartbeat_mode = "all_green" if all_gates_passed else "active"
+    if blocked_tasks:
+        heartbeat_mode = "blocked_task_needs_retry"
+    wake_agent = (not all_gates_passed or bool(blocked_tasks)) and (
+        any(task.get("created") for task in created_tasks) or spawned > 0
+    )
+    if (not all_gates_passed or blocked_tasks) and created_tasks and not any(task.get("created") for task in created_tasks) and spawned <= 0:
+        heartbeat_mode = "waiting_on_active_task"
+    heartbeat = _write_heartbeat(
+        {
+            "mode": heartbeat_mode,
+            "wake_agent": wake_agent,
+            "next_action": next_stage,
+            "reason": reason,
+            "audit_failed": int(audit.get("failed", 0) or 0),
+            "anti_shell_failed": int(anti_shell.get("failed", 0) or 0),
+            "created_tasks": created_tasks,
+            "unfinished_tasks": unfinished_tasks,
+            "blocked_tasks": blocked_tasks,
+            "dispatch_spawned": spawned,
+            "board": opts.board,
+            "no_idle_enforced": True,
+            "message": "all gates passed; watchdog may stay silent"
+            if all_gates_passed and not blocked_tasks
+            else "no-idle blocked task recovery active; Hermes must retry or expose the blockage"
+            if blocked_tasks
+            else "no-idle active; gate is not green so Hermes must keep an active worker or create a retry",
+        }
+    )
+
+    tick = {
+        "tick_id": tick_id,
+        "created_at": _utcnow(),
+        "next_action": next_stage,
+        "reason": reason,
+        "audit": {
+            "passed": audit.get("passed", 0),
+            "failed": audit.get("failed", 0),
+            "total": audit.get("total", 0),
+        },
+        "anti_shell": {
+            "status": anti_shell.get("status"),
+            "passed": anti_shell.get("passed", 0),
+            "failed": anti_shell.get("failed", 0),
+        },
+        "created_tasks": created_tasks,
+        "dispatch": dispatch_result,
+        "heartbeat": heartbeat,
+        "no_approval_cards": True,
+        "goal_mode": True,
+        "no_idle_enforced": True,
+    }
+    ticks = state.setdefault("ticks", [])
+    ticks.insert(0, tick)
+    state["ticks"] = ticks[:50]
+    state["last_tick_at"] = tick["created_at"]
+    state["last_tick_id"] = tick_id
+    state["last_next_action"] = next_stage
+    state["last_blocked_reason"] = "" if reason == "all_gates_passed" else reason
+    state["board"] = opts.board
+    state["goal_max_turns"] = opts.goal_max_turns
+    state["heartbeat"] = heartbeat
+    save_runner_state(state)
+    return {"ok": True, "tick": tick, "runner": state, "anti_shell": anti_shell}
+
+
+def _scripts_dir() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser() / "scripts"
+
+
+def _watchdog_script_content(*, repo: str, workspace_path: str, board: str, assignee: str | None, goal_max_turns: int) -> str:
+    payload = {
+        "repo": repo,
+        "workspace_path": workspace_path,
+        "board": board,
+        "assignee": assignee,
+        "goal_max_turns": goal_max_turns,
+    }
+    return (
+        "from __future__ import annotations\n"
+        "import json\n"
+        "import sys\n"
+        "from pathlib import Path\n\n"
+        f"PAYLOAD = {json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
+        "repo = PAYLOAD.get('repo') or ''\n"
+        "if repo and repo not in sys.path:\n"
+        "    sys.path.insert(0, repo)\n\n"
+        "from hermes_autonomous import TickOptions, autonomous_tick\n\n"
+        "result = autonomous_tick(TickOptions(\n"
+        "    create_tasks=True,\n"
+        "    dispatch=True,\n"
+        "    board=PAYLOAD.get('board') or 'default',\n"
+        "    assignee=PAYLOAD.get('assignee') or None,\n"
+        "    goal_max_turns=int(PAYLOAD.get('goal_max_turns') or 120),\n"
+        "    workspace_path=PAYLOAD.get('workspace_path') or repo or None,\n"
+        "    repo=repo or None,\n"
+        "))\n"
+        "tick = result.get('tick', {})\n"
+        "created = [t for t in tick.get('created_tasks', []) if t.get('created')]\n"
+        "heartbeat = tick.get('heartbeat') or {}\n"
+        "dispatch = tick.get('dispatch') or {}\n"
+        "spawned_raw = dispatch.get('spawned') if isinstance(dispatch, dict) else 0\n"
+        "spawned = len(spawned_raw) if isinstance(spawned_raw, list) else int(spawned_raw or 0)\n"
+        "if not bool(heartbeat.get('wake_agent')) and not created and spawned <= 0:\n"
+        "    print(json.dumps({'wakeAgent': False}))\n"
+        "else:\n"
+        "    print(json.dumps({\n"
+        "        'wakeAgent': True,\n"
+        "        'runner': 'hermes-autonomous',\n"
+        "        'tick_id': tick.get('tick_id'),\n"
+        "        'next_action': tick.get('next_action'),\n"
+        "        'heartbeat_mode': heartbeat.get('mode'),\n"
+        "        'created_tasks': created,\n"
+        "        'spawned': spawned,\n"
+        "    }, ensure_ascii=False))\n"
+    )
+
+
+def install_watchdog(
+    *,
+    schedule: str = "every 2m",
+    repo: str | None = None,
+    workspace_path: str | None = None,
+    board: str = DEFAULT_BOARD,
+    assignee: str | None = None,
+    goal_max_turns: int = DEFAULT_GOAL_TURNS,
+) -> dict[str, Any]:
+    """Install or replace the no-agent cron watchdog for autonomous ticks."""
+
+    repo_path = str(Path(repo or os.getcwd()).expanduser().resolve())
+    workspace = str(Path(workspace_path or repo_path).expanduser().resolve())
+    scripts = _scripts_dir()
+    scripts.mkdir(parents=True, exist_ok=True)
+    script_path = scripts / WATCHDOG_SCRIPT_NAME
+    script_path.write_text(
+        _watchdog_script_content(
+            repo=repo_path,
+            workspace_path=workspace,
+            board=board,
+            assignee=assignee,
+            goal_max_turns=max(1, int(goal_max_turns or DEFAULT_GOAL_TURNS)),
+        ),
+        encoding="utf-8",
+    )
+
+    from cron import jobs as cron_jobs
+
+    removed: list[str] = []
+    for job in cron_jobs.list_jobs(include_disabled=True):
+        if job.get("name") == WATCHDOG_JOB_NAME:
+            if cron_jobs.remove_job(str(job["id"])):
+                removed.append(str(job["id"]))
+
+    job = cron_jobs.create_job(
+        prompt="Hermes autonomous watchdog",
+        schedule=schedule,
+        name=WATCHDOG_JOB_NAME,
+        deliver="local",
+        script=WATCHDOG_SCRIPT_NAME,
+        workdir=repo_path,
+        no_agent=True,
+    )
+    state = load_runner_state()
+    state["watchdog"] = {
+        "installed": True,
+        "job_id": job["id"],
+        "job_name": WATCHDOG_JOB_NAME,
+        "schedule": schedule,
+        "script": str(script_path),
+        "repo": repo_path,
+        "workspace_path": workspace,
+        "board": board,
+        "assignee": assignee or "",
+        "goal_max_turns": max(1, int(goal_max_turns or DEFAULT_GOAL_TURNS)),
+        "installed_at": _utcnow(),
+        "replaced_job_ids": removed,
+    }
+    save_runner_state(state)
+    return {"ok": True, "job": job, "script": str(script_path), "removed": removed, "runner": state}
+
+
+def watchdog_status() -> dict[str, Any]:
+    from cron import jobs as cron_jobs
+
+    jobs = [
+        job
+        for job in cron_jobs.list_jobs(include_disabled=True)
+        if job.get("name") == WATCHDOG_JOB_NAME
+    ]
+    return {
+        "ok": True,
+        "installed": bool(jobs),
+        "jobs": jobs,
+        "script": str(_scripts_dir() / WATCHDOG_SCRIPT_NAME),
+        "runner": load_runner_state(),
+    }

--- a/hermes_delivery.py
+++ b/hermes_delivery.py
@@ -1,0 +1,857 @@
+"""Hermes delivery pipeline ledger and gate runner.
+
+This module is intentionally local-file based so the desktop app, CLI, cron
+watchdog, and background workers can all share one durable view without an
+approval-card dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+from uuid import uuid4
+
+
+SCHEMA = "hermes.delivery.v1"
+
+PIPELINE_STAGES: list[dict[str, Any]] = [
+    {
+        "id": "blueprint",
+        "name": "Blueprint",
+        "artifact": "blueprint.md",
+        "required_artifacts": ["blueprint.md"],
+        "gate_signals": ["state", "blueprint"],
+        "failure_action": "backwrite blueprint",
+    },
+    {
+        "id": "story",
+        "name": "Story",
+        "artifact": "stories.md",
+        "required_artifacts": ["stories.md"],
+        "gate_signals": ["story", "role", "path"],
+        "failure_action": "rewrite story",
+    },
+    {
+        "id": "spec",
+        "name": "Spec",
+        "artifact": "spec.md",
+        "required_artifacts": ["spec.md"],
+        "gate_signals": ["file", "test"],
+        "failure_action": "rewrite spec",
+    },
+    {
+        "id": "task",
+        "name": "Task",
+        "artifact": "tasks.md",
+        "required_artifacts": ["tasks.md"],
+        "gate_signals": ["issue", "pr", "file"],
+        "failure_action": "re-split tasks",
+    },
+    {
+        "id": "linear",
+        "name": "Linear",
+        "artifact": "issues.json",
+        "required_artifacts": ["issues.json"],
+        "gate_signals": ["issue", "spec"],
+        "failure_action": "retry linear sync",
+    },
+    {
+        "id": "dispatch",
+        "name": "Dispatch",
+        "artifact": "jobs/",
+        "required_artifacts": ["jobs"],
+        "gate_signals": ["owner", "executor"],
+        "failure_action": "re-dispatch",
+    },
+    {
+        "id": "pr_monitor",
+        "name": "PR Monitor",
+        "artifact": "pr-status.json",
+        "required_artifacts": ["pr-status.json"],
+        "gate_signals": ["pr", "issue"],
+        "failure_action": "create or fix PR",
+    },
+    {
+        "id": "ci_monitor",
+        "name": "CI Monitor",
+        "artifact": "ci/latest.json",
+        "required_artifacts": ["ci/latest.json"],
+        "gate_signals": ["success", "checks"],
+        "failure_action": "fix CI",
+    },
+    {
+        "id": "anti_shell",
+        "name": "Anti-Shell",
+        "artifact": "anti-shell/report.json",
+        "required_artifacts": ["anti-shell/report.json"],
+        "gate_signals": ["passed"],
+        "failure_action": "return to real implementation",
+    },
+    {
+        "id": "acceptance",
+        "name": "Acceptance",
+        "artifact": "acceptance/report.md",
+        "required_artifacts": ["acceptance/report.md"],
+        "gate_signals": ["machine", "ai", "human"],
+        "failure_action": "redo acceptance",
+    },
+    {
+        "id": "delivery",
+        "name": "Delivery",
+        "artifact": "delivery-summary.md",
+        "required_artifacts": ["delivery-summary.md"],
+        "gate_signals": ["notification", "summary"],
+        "failure_action": "write delivery summary",
+    },
+    {
+        "id": "deploy",
+        "name": "Deploy",
+        "artifact": "deploy-runs/",
+        "required_artifacts": ["deploy-runs"],
+        "gate_signals": ["deploy", "verify"],
+        "failure_action": "fix deploy",
+    },
+    {
+        "id": "backwrite",
+        "name": "Backwrite",
+        "artifact": "updated-blueprint.md",
+        "required_artifacts": ["updated-blueprint.md"],
+        "gate_signals": ["baseline", "updated"],
+        "failure_action": "backwrite docs",
+    },
+]
+
+PRINCIPLES = [
+    "No approval cards; execution is driven by gates and evidence.",
+    "Every green stage must have a durable artifact.",
+    "Anti-Shell blocks empty completion claims.",
+]
+
+
+@dataclass(frozen=True)
+class DeployRequest:
+    target: str = "hermes"
+    environment: str = "local"
+    adapter: str = "command"
+    ref: str = "HEAD"
+    command: str | None = None
+    cwd: str | None = None
+    verify: list[str] = field(default_factory=list)
+    rollback: str | None = None
+    execute: bool = False
+    force: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def delivery_root() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser() / "delivery"
+
+
+def artifact_path(relative: str) -> Path:
+    return delivery_root() / relative
+
+
+def _state_path() -> Path:
+    return artifact_path("state.json")
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path, fallback: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return fallback
+
+
+def _initial_state() -> dict[str, Any]:
+    now = _utcnow()
+    return {
+        "schema": SCHEMA,
+        "created_at": now,
+        "updated_at": now,
+        "stages": [
+            {
+                "id": stage["id"],
+                "name": stage["name"],
+                "artifact": stage["artifact"],
+                "status": "idle",
+                "notes": "",
+                "updated_at": now,
+                "fail_count": 0,
+            }
+            for stage in PIPELINE_STAGES
+        ],
+        "deploy": {"runs": []},
+        "jobs": [],
+        "approval_cards": False,
+    }
+
+
+def load_state() -> dict[str, Any]:
+    state = _read_json(_state_path(), _initial_state())
+    if not isinstance(state, dict):
+        state = _initial_state()
+    state.setdefault("schema", SCHEMA)
+    state.setdefault("created_at", _utcnow())
+    state.setdefault("deploy", {"runs": []})
+    state.setdefault("jobs", [])
+    state.setdefault("approval_cards", False)
+    existing = {stage.get("id"): stage for stage in state.get("stages", []) if isinstance(stage, dict)}
+    merged: list[dict[str, Any]] = []
+    for stage in PIPELINE_STAGES:
+        row = dict(existing.get(stage["id"], {}))
+        row.setdefault("id", stage["id"])
+        row.setdefault("name", stage["name"])
+        row.setdefault("status", "idle")
+        row.setdefault("notes", "")
+        row.setdefault("updated_at", _utcnow())
+        row.setdefault("fail_count", 0)
+        row["artifact"] = stage["artifact"]
+        merged.append(row)
+    state["stages"] = merged
+    state["updated_at"] = state.get("updated_at") or _utcnow()
+    return state
+
+
+def save_state(state: dict[str, Any]) -> dict[str, Any]:
+    state["updated_at"] = _utcnow()
+    _atomic_write_json(_state_path(), state)
+    return state
+
+
+def _stage_def(stage_id: str) -> dict[str, Any]:
+    for stage in PIPELINE_STAGES:
+        if stage["id"] == stage_id:
+            return stage
+    raise ValueError(f"unknown delivery stage: {stage_id}")
+
+
+def update_stage(stage_id: str, status: str, notes: str = "") -> dict[str, Any]:
+    _stage_def(stage_id)
+    state = load_state()
+    for stage in state["stages"]:
+        if stage["id"] == stage_id:
+            stage["status"] = status
+            stage["notes"] = notes
+            stage["updated_at"] = _utcnow()
+            if status in {"done", "ready"}:
+                stage["fail_count"] = 0
+            break
+    return save_state(state)
+
+
+def dashboard_snapshot() -> dict[str, Any]:
+    state = load_state()
+    done = sum(1 for stage in state["stages"] if stage.get("status") == "done")
+    return {
+        "ok": True,
+        "schema": SCHEMA,
+        "state_path": str(_state_path()),
+        "principles": PRINCIPLES,
+        "summary": {
+            "done": done,
+            "total": len(PIPELINE_STAGES),
+            "approval_cards": False,
+            "deploy_runs": len(state.get("deploy", {}).get("runs", [])),
+        },
+        "stages": state["stages"],
+    }
+
+
+def capability_manifest() -> dict[str, Any]:
+    return {
+        "schema": "hermes.capability-manifest.v1",
+        "no_approval_cards": True,
+        "capabilities": [
+            {
+                "id": stage["id"],
+                "name": stage["name"],
+                "artifact": stage["artifact"],
+                "required_artifacts": stage["required_artifacts"],
+                "gate_signals": stage["gate_signals"],
+                "failure_action": stage["failure_action"],
+            }
+            for stage in PIPELINE_STAGES
+        ],
+    }
+
+
+def _artifact_ok(relative: str) -> bool:
+    path = artifact_path(relative)
+    if path.is_dir():
+        return any(path.iterdir())
+    return path.exists() and path.stat().st_size > 0
+
+
+def _read_artifact_text(relative: str) -> str:
+    path = artifact_path(relative)
+    if path.is_dir():
+        return " ".join(child.name for child in path.iterdir())
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+SIGNAL_ALIASES: dict[str, tuple[str, ...]] = {
+    "file": ("file", "files", "文件", "涉及文件"),
+    "test": ("test", "tests", "pytest", "验收测试", "测试"),
+    "issue": ("issue", "linear", "任务"),
+    "pr": ("pr", "pull request", "合并请求"),
+    "owner": ("owner", "负责人"),
+    "executor": ("executor", "执行者"),
+    "success": ("success", "passed", "通过", "成功"),
+    "checks": ("checks", "check-runs", "检查"),
+    "machine": ("machine", "机器"),
+    "ai": ("ai", "review", "审查"),
+    "human": ("human", "人工"),
+    "notification": ("notification", "通知"),
+    "summary": ("summary", "总结"),
+    "baseline": ("baseline", "基线"),
+    "updated": ("updated", "更新"),
+    "deploy": ("deploy", "部署"),
+    "verify": ("verify", "验证"),
+}
+
+
+def _signal_present(signal: str, haystack: str) -> bool:
+    aliases = SIGNAL_ALIASES.get(signal.lower(), (signal,))
+    return any(alias.lower() in haystack for alias in aliases)
+
+
+def _story_sections(text: str) -> list[str]:
+    raw_sections = re.split(r"(?im)^##\s+story\b.*$", text)
+    story_sections = [section.strip() for section in raw_sections[1:] if section.strip()]
+    if story_sections:
+        return story_sections
+    raw_sections = re.split(r"(?m)^##\s+", text)
+    return [section.strip() for section in raw_sections[1:] if section.strip()]
+
+
+def _story_gate_checks(story_text: str) -> list[dict[str, Any]]:
+    stories = _story_sections(story_text)
+    checks: list[dict[str, Any]] = [
+        {"name": "story_entries", "ok": bool(stories), "detail": str(len(stories))},
+    ]
+    for index, story in enumerate(stories, start=1):
+        story_lower = story.lower()
+        has_role = bool(re.search(r"(?im)^\s*[-*]?\s*(角色|role)\s*[:：]\s*\S+", story))
+        has_path = bool(
+            re.search(r"(?im)^\s*[-*]?\s*(点击路径|path|click\s*path)\s*[:：]\s*\S+", story)
+            or "->" in story
+        )
+        has_assertion = bool(re.search(r"(?im)^\s*[-*]?\s*(断言|assertion|acceptance)\s*[:：]\s*\S+", story))
+        checks.extend(
+            [
+                {"name": f"story:{index}:role", "ok": has_role, "detail": "role/角色"},
+                {"name": f"story:{index}:path", "ok": has_path, "detail": "path/点击路径"},
+                {"name": f"story:{index}:assertion", "ok": has_assertion, "detail": "assertion/断言"},
+                {"name": f"story:{index}:substantive", "ok": len(story_lower) >= 40, "detail": str(len(story))},
+            ]
+        )
+    return checks
+
+
+def _job_log_has_content(job: dict[str, Any]) -> bool:
+    log_path = str(job.get("log_path") or "")
+    if not log_path:
+        return False
+    path = Path(log_path).expanduser()
+    try:
+        return path.exists() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _dispatch_gate_checks() -> list[dict[str, Any]]:
+    jobs = list_jobs()
+    latest = jobs[-1] if jobs else {}
+    owner = str(latest.get("owner") or "").strip()
+    executor = str(latest.get("executor") or "").strip()
+    branch = str(latest.get("branch") or "").strip()
+    command = str(latest.get("command") or "").strip()
+    status = str(latest.get("status") or "").strip().lower()
+    attempt = int(latest.get("attempt") or 0)
+    return [
+        {
+            "name": "job_exists",
+            "ok": bool(latest.get("job_id")),
+            "detail": str(latest.get("job_id") or "missing execution-job.json"),
+        },
+        {"name": "has_owner", "ok": bool(owner and owner.lower() != "unknown"), "detail": owner or "missing"},
+        {"name": "has_executor", "ok": bool(executor), "detail": executor or "missing"},
+        {"name": "has_branch", "ok": bool(branch), "detail": branch or "missing"},
+        {"name": "has_command", "ok": bool(command), "detail": command[:120] or "missing"},
+        {
+            "name": "dispatch_recorded",
+            "ok": status in {"ready", "done", "failed"} and attempt > 0,
+            "detail": f"status={status or 'missing'} attempt={attempt}",
+        },
+        {
+            "name": "job_log_exists",
+            "ok": _job_log_has_content(latest),
+            "detail": str(latest.get("log_path") or "missing job.log"),
+        },
+    ]
+
+
+def deploy_runs_dir() -> Path:
+    return artifact_path("deploy-runs")
+
+
+def list_deploy_runs() -> list[dict[str, Any]]:
+    """Return deploy-run.json artifacts, ordered by artifact path."""
+
+    root = deploy_runs_dir()
+    if not root.exists():
+        return []
+    runs: list[dict[str, Any]] = []
+    for path in sorted(root.glob("*/deploy-run.json")):
+        run = _read_json(path, {})
+        if isinstance(run, dict) and run:
+            run = dict(run)
+            run.setdefault("run_path", str(path))
+            runs.append(run)
+    return runs
+
+
+def _deploy_exit_codes(run: dict[str, Any]) -> list[int]:
+    codes: list[int] = []
+    for step in run.get("steps", []) or []:
+        if isinstance(step, dict) and isinstance(step.get("exit_code"), int):
+            codes.append(step["exit_code"])
+    if isinstance(run.get("exit_code"), int):
+        codes.append(run["exit_code"])
+    return codes
+
+
+def _deploy_log_has_content(run: dict[str, Any]) -> bool:
+    log_path = str(run.get("log_path") or "")
+    if not log_path:
+        return False
+    path = Path(log_path).expanduser()
+    try:
+        return path.exists() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _deploy_request_value(run: dict[str, Any], key: str) -> str:
+    request = run.get("request") if isinstance(run.get("request"), dict) else {}
+    return str(request.get(key) or run.get(key) or "").strip()
+
+
+def _deploy_run_is_verified(run: dict[str, Any]) -> bool:
+    status = str(run.get("status") or "").strip().lower()
+    request = run.get("request") if isinstance(run.get("request"), dict) else {}
+    exit_codes = _deploy_exit_codes(run)
+    return (
+        bool(request.get("execute"))
+        and bool(exit_codes)
+        and any(code == 0 for code in exit_codes)
+        and _deploy_log_has_content(run)
+        and bool(_deploy_request_value(run, "target"))
+        and bool(_deploy_request_value(run, "environment"))
+        and status in {"verified", "success", "done"}
+    )
+
+
+def _deploy_gate_checks() -> list[dict[str, Any]]:
+    runs = list_deploy_runs()
+    verified_runs = [run for run in runs if _deploy_run_is_verified(run)]
+    latest = verified_runs[-1] if verified_runs else (runs[-1] if runs else {})
+    request = latest.get("request") if isinstance(latest.get("request"), dict) else {}
+    exit_codes = _deploy_exit_codes(latest)
+    status = str(latest.get("status") or "").strip().lower()
+    target = _deploy_request_value(latest, "target")
+    environment = _deploy_request_value(latest, "environment")
+    return [
+        {
+            "name": "deploy_run_exists",
+            "ok": bool(runs),
+            "detail": str(latest.get("run_path") or deploy_runs_dir() / "*/deploy-run.json"),
+        },
+        {"name": "deploy_executed", "ok": bool(request.get("execute")), "detail": f"execute={request.get('execute')} exit_codes={exit_codes}"},
+        {"name": "deploy_exit_code_recorded", "ok": bool(exit_codes), "detail": str(exit_codes or "missing")},
+        {"name": "deploy_succeeded", "ok": any(code == 0 for code in exit_codes), "detail": f"status={status or 'missing'} exit_codes={exit_codes}"},
+        {"name": "deploy_log_has_content", "ok": _deploy_log_has_content(latest), "detail": str(latest.get("log_path") or "missing deploy.log")},
+        {"name": "target_present", "ok": bool(target and target.lower() not in {"unknown", "placeholder", "todo"}), "detail": target or "missing"},
+        {"name": "environment_present", "ok": bool(environment), "detail": environment or "missing"},
+        {"name": "status_verified", "ok": status in {"verified", "success", "done"}, "detail": status or "missing"},
+    ]
+
+
+def run_gate(
+    stage_id: str,
+    *,
+    record_rollback: bool = False,
+    update_state: bool = True,
+) -> dict[str, Any]:
+    stage_def = _stage_def(stage_id)
+    checks: list[dict[str, Any]] = []
+    for rel in stage_def["required_artifacts"]:
+        checks.append({"name": f"artifact:{rel}", "ok": _artifact_ok(rel), "detail": rel})
+    artifact_text = " ".join(_read_artifact_text(rel) for rel in stage_def["required_artifacts"])
+    haystack = artifact_text.lower()
+    if stage_id == "story":
+        checks.extend(_story_gate_checks(artifact_text))
+    elif stage_id == "dispatch":
+        checks.extend(_dispatch_gate_checks())
+    elif stage_id == "deploy":
+        checks.extend(_deploy_gate_checks())
+    else:
+        for signal in stage_def["gate_signals"]:
+            checks.append({"name": f"signal:{signal}", "ok": _signal_present(signal, haystack), "detail": signal})
+    if record_rollback:
+        checks.append({"name": "rollback_recorded", "ok": True, "detail": "recorded"})
+    failed = [check for check in checks if not check["ok"]]
+    state = load_state()
+    gate_state: dict[str, Any] = {}
+    for stage in state["stages"]:
+        if stage["id"] == stage_id:
+            if update_state:
+                if failed:
+                    stage["fail_count"] = int(stage.get("fail_count") or 0) + 1
+                    stage["status"] = "blocked" if stage["fail_count"] >= 3 else "failed"
+                    stage["notes"] = "GateRunner failed"
+                else:
+                    stage["fail_count"] = 0
+                    stage["status"] = "done"
+                    stage["notes"] = "GateRunner passed"
+                stage["updated_at"] = _utcnow()
+            gate_state = dict(stage)
+            break
+    if update_state:
+        save_state(state)
+    return {
+        "stage_id": stage_id,
+        "status": "failed" if failed else "passed",
+        "checks": checks,
+        "gate_state": gate_state,
+    }
+
+
+def run_capability_audit() -> dict[str, Any]:
+    results = [run_gate(stage["id"]) for stage in PIPELINE_STAGES]
+    passed = sum(1 for result in results if result["status"] == "passed")
+    return {
+        "ok": passed == len(results),
+        "total": len(results),
+        "passed": passed,
+        "failed": len(results) - passed,
+        "results": results,
+    }
+
+
+def _run_text_command(command: str, cwd: str | None = None) -> tuple[int, str, str]:
+    result = subprocess.run(command, cwd=cwd, shell=True, capture_output=True, text=True, timeout=120)
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def _run_json_command(args: list[str], cwd: str | None = None) -> tuple[int, Any, str]:
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        return result.returncode, None, result.stderr.strip()
+    try:
+        return result.returncode, json.loads(result.stdout or "null"), result.stderr.strip()
+    except json.JSONDecodeError as exc:
+        return 1, None, str(exc)
+
+
+def _target_registry_path() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser() / "deploy-targets.json"
+
+
+def _redact_target(target: dict[str, Any]) -> dict[str, Any]:
+    clean = {key: value for key, value in target.items() if key not in {"password", "secret", "token"}}
+    if "password_env" in target:
+        clean["credential"] = f"env:{target['password_env']}"
+    return clean
+
+
+def _deploy_policy(req: DeployRequest) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+
+    def add(name: str, ok: bool, detail: str) -> None:
+        checks.append({"name": name, "ok": bool(ok), "detail": detail})
+
+    add("adapter_supported", req.adapter in {"command", "github_actions", "ssh"}, req.adapter)
+    add("command_or_adapter_present", bool(req.command or req.adapter == "github_actions"), req.command or req.adapter)
+    if req.environment == "prod" and req.execute and not req.force:
+        add("rollback_declared", bool(req.rollback), req.rollback or "missing rollback command")
+    else:
+        add("rollback_declared", True, "not required")
+    target_info: dict[str, Any] = {}
+    if req.adapter == "ssh":
+        registry = _read_json(_target_registry_path(), {})
+        target_info = registry.get("targets", {}).get(req.target, {}) if isinstance(registry, dict) else {}
+        add("ssh_target_registered", bool(target_info), req.target)
+        password_env = target_info.get("password_env") if isinstance(target_info, dict) else ""
+        add("ssh_password_loaded", bool(password_env and os.environ.get(password_env)), f"env:{password_env}" if password_env else "missing")
+    policy = {
+        "allowed": all(check["ok"] for check in checks),
+        "checks": checks,
+        "target": _redact_target(target_info) if target_info else {},
+    }
+    return policy
+
+
+def run_deploy(req: DeployRequest) -> dict[str, Any]:
+    run_id = f"deploy-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+    policy = _deploy_policy(req)
+    run_dir = artifact_path(f"deploy-runs/{run_id}")
+    log_path = run_dir / "deploy.log"
+    stdout = ""
+    stderr = ""
+    exit_code: int | None = None
+    status = "blocked"
+    if policy["allowed"]:
+        status = "ready"
+        if req.execute and req.command:
+            exit_code, stdout, stderr = _run_text_command(req.command, cwd=req.cwd)
+            status = "done" if exit_code == 0 else "failed"
+        elif req.execute:
+            status = "done"
+    run = {
+        "schema": "hermes.deploy-run.v1",
+        "run_id": run_id,
+        "created_at": _utcnow(),
+        "status": status,
+        "request": asdict(req),
+        "policy": policy,
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "log_path": str(log_path),
+    }
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log_path.write_text((stdout + "\n" + stderr).strip() + "\n", encoding="utf-8")
+    _atomic_write_json(run_dir / "deploy-run.json", run)
+    state = load_state()
+    state.setdefault("deploy", {}).setdefault("runs", []).append(
+        {"run_id": run_id, "status": status, "created_at": run["created_at"], "log_path": str(log_path)}
+    )
+    save_state(state)
+    if status in {"ready", "done"}:
+        update_stage("deploy", "done", "GateRunner passed")
+    else:
+        update_stage("deploy", "failed", "Deploy policy or command failed")
+    return run
+
+
+def create_execution_job(
+    *,
+    title: str,
+    owner: str,
+    executor: str,
+    branch: str,
+    command: str | None = None,
+    issue: str = "",
+    repo: str = "",
+    spec: str = "spec.md",
+) -> dict[str, Any]:
+    job_id = f"job-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+    log_path = artifact_path(f"jobs/{job_id}/job.log")
+    now = _utcnow()
+    job = {
+        "schema": "hermes.execution-job.v1",
+        "job_id": job_id,
+        "title": title,
+        "owner": owner,
+        "executor": executor,
+        "branch": branch,
+        "command": command or "",
+        "issue": issue,
+        "repo": repo,
+        "spec": spec,
+        "status": "created",
+        "attempt": 0,
+        "created_at": now,
+        "updated_at": now,
+        "log_path": str(log_path),
+    }
+    _atomic_write_json(artifact_path(f"jobs/{job_id}/execution-job.json"), job)
+    state = load_state()
+    state.setdefault("jobs", []).append({"job_id": job_id, "title": title, "status": "created"})
+    save_state(state)
+    update_stage("dispatch", "ready", "Execution job created")
+    return job
+
+
+def run_execution_job(job_id: str, *, execute: bool = False) -> dict[str, Any]:
+    path = artifact_path(f"jobs/{job_id}/execution-job.json")
+    job = _read_json(path, {})
+    if not isinstance(job, dict) or not job:
+        raise ValueError(f"unknown execution job: {job_id}")
+    status = "ready"
+    exit_code = None
+    stdout = ""
+    stderr = ""
+    attempt = int(job.get("attempt") or 0) + 1
+    started_at = _utcnow()
+    if execute and job.get("command"):
+        exit_code, stdout, stderr = _run_text_command(str(job["command"]), cwd=job.get("repo") or None)
+        status = "done" if exit_code == 0 else "failed"
+    elif execute:
+        status = "done"
+    log_path = Path(str(job.get("log_path") or artifact_path(f"jobs/{job_id}/job.log"))).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_lines = [
+        f"job_id={job_id}",
+        f"attempt={attempt}",
+        f"started_at={started_at}",
+        f"execute={execute}",
+        f"status={status}",
+        f"command={job.get('command') or ''}",
+        f"exit_code={'' if exit_code is None else exit_code}",
+        "--- stdout ---",
+        stdout,
+        "--- stderr ---",
+        stderr,
+    ]
+    log_path.write_text("\n".join(log_lines).rstrip() + "\n", encoding="utf-8")
+    job.update(
+        {
+            "status": status,
+            "attempt": attempt,
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+            "updated_at": _utcnow(),
+            "log_path": str(log_path),
+        }
+    )
+    _atomic_write_json(path, job)
+    state = load_state()
+    for item in state.setdefault("jobs", []):
+        if isinstance(item, dict) and item.get("job_id") == job_id:
+            item.update({"status": status, "attempt": attempt, "updated_at": job["updated_at"], "log_path": str(log_path)})
+            break
+    else:
+        state["jobs"].append(
+            {
+                "job_id": job_id,
+                "title": job.get("title", ""),
+                "status": status,
+                "attempt": attempt,
+                "updated_at": job["updated_at"],
+                "log_path": str(log_path),
+            }
+        )
+    save_state(state)
+    update_stage("dispatch", "done" if status in {"ready", "done"} else "failed", "Execution job recorded")
+    return job
+
+
+def list_jobs() -> list[dict[str, Any]]:
+    jobs_dir = artifact_path("jobs")
+    if not jobs_dir.exists():
+        return []
+    jobs: list[dict[str, Any]] = []
+    for path in sorted(jobs_dir.glob("*/execution-job.json")):
+        job = _read_json(path, {})
+        if isinstance(job, dict):
+            jobs.append(job)
+    return jobs
+
+
+def refresh_pr_status(*, repo: str = "", pr: str = "", issue: str = "", cwd: str | None = None) -> dict[str, Any]:
+    args = ["gh", "pr", "view"]
+    if pr:
+        args.append(pr)
+    if repo:
+        args.extend(["--repo", repo])
+    args.extend(["--json", "number,url,state,title,body,headRefName,closingIssuesReferences"])
+    code, data, err = _run_json_command(args, cwd=cwd)
+    if code != 0 or not isinstance(data, dict):
+        data = {"error": err, "state": "UNKNOWN", "closingIssuesReferences": []}
+    linked = bool(data.get("closingIssuesReferences")) or bool(issue and issue in json.dumps(data, ensure_ascii=False))
+    data["linked_issue"] = linked
+    _atomic_write_json(artifact_path("pr-status.json"), data)
+    update_stage("pr_monitor", "done" if data.get("state") in {"OPEN", "MERGED", "CLOSED"} and linked else "failed", "PR monitor refreshed")
+    return data
+
+
+def _normalize_check_state(value: Any) -> str:
+    raw = str(value or "").lower()
+    if raw in {"pass", "passed", "success", "successful", "completed"}:
+        return "success"
+    if raw in {"pending", "queued", "in_progress"}:
+        return "pending"
+    return raw or "unknown"
+
+
+def refresh_ci_status(*, repo: str = "", ref: str = "", cwd: str | None = None) -> dict[str, Any]:
+    args = ["gh", "pr", "checks"]
+    if ref:
+        args.append(ref)
+    if repo:
+        args.extend(["--repo", repo])
+    args.extend(["--json", "name,state,link"])
+    code, data, err = _run_json_command(args, cwd=cwd)
+    if code != 0 or not isinstance(data, list):
+        data = [{"name": "ci", "state": "unknown", "error": err}]
+    checks = [
+        {
+            **check,
+            "conclusion": _normalize_check_state(check.get("state") or check.get("conclusion")),
+        }
+        for check in data
+        if isinstance(check, dict)
+    ]
+    status = {"schema": "hermes.ci-status.v1", "generated_at": _utcnow(), "checks": checks}
+    _atomic_write_json(artifact_path("ci/latest.json"), status)
+    all_success = bool(checks) and all(check.get("conclusion") == "success" for check in checks)
+    update_stage("ci_monitor", "done" if all_success else "failed", "CI monitor refreshed")
+    return status
+
+
+def write_acceptance_report(
+    *,
+    machine_evidence: list[str],
+    ai_review_evidence: list[str],
+    human_evidence: str,
+) -> dict[str, Any]:
+    text = (
+        "# Acceptance Report\n\n"
+        "## Machine\n" + "\n".join(f"- {item}" for item in machine_evidence) + "\n\n"
+        "## AI Review\n" + "\n".join(f"- {item}" for item in ai_review_evidence) + "\n\n"
+        f"## Human\n{human_evidence}\n"
+    )
+    path = artifact_path("acceptance/report.md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    gate = run_gate("acceptance")
+    return {"path": str(path), "gate": gate}
+
+
+def write_delivery_summary(notification: str) -> dict[str, Any]:
+    path = artifact_path("delivery-summary.md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# Delivery Summary\n\nsummary notification: {notification}\n", encoding="utf-8")
+    gate = run_gate("delivery")
+    return {"path": str(path), "gate": gate}
+
+
+def write_backwrite_blueprint(notes: str) -> dict[str, Any]:
+    path = artifact_path("updated-blueprint.md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# Updated Blueprint\n\nbaseline updated: {notes}\n", encoding="utf-8")
+    gate = run_gate("backwrite")
+    return {"path": str(path), "gate": gate}

--- a/hermes_delivery.py
+++ b/hermes_delivery.py
@@ -547,8 +547,8 @@ def run_gate(
     }
 
 
-def run_capability_audit() -> dict[str, Any]:
-    results = [run_gate(stage["id"]) for stage in PIPELINE_STAGES]
+def run_capability_audit(*, update_state: bool = True) -> dict[str, Any]:
+    results = [run_gate(stage["id"], update_state=update_state) for stage in PIPELINE_STAGES]
     passed = sum(1 for result in results if result["status"] == "passed")
     return {
         "ok": passed == len(results),

--- a/tests/test_hermes_autonomous.py
+++ b/tests/test_hermes_autonomous.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import time
+
+
+def _modules(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    import hermes_autonomous
+    import hermes_delivery
+    from hermes_cli import kanban_db
+
+    return (
+        importlib.reload(hermes_delivery),
+        importlib.reload(hermes_autonomous),
+        importlib.reload(kanban_db),
+    )
+
+
+def test_anti_shell_blocks_empty_completion_claims(tmp_path, monkeypatch):
+    _, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+
+    report = hermes_autonomous.run_anti_shell_check(str(tmp_path))
+
+    assert report["status"] == "failed"
+    assert any(check["name"] == "spec_artifact_exists" and not check["ok"] for check in report["checks"])
+    assert (tmp_path / "home" / "delivery" / "anti-shell" / "report.json").exists()
+
+
+def test_anti_shell_passes_when_real_evidence_exists(tmp_path, monkeypatch):
+    hermes_delivery, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    (delivery / "acceptance").mkdir(parents=True)
+    (delivery / "ci").mkdir(parents=True)
+    (delivery / "jobs" / "job-1").mkdir(parents=True)
+    (delivery / "spec.md").write_text("files + tests", encoding="utf-8")
+    (delivery / "tasks.md").write_text("issue pr files verify", encoding="utf-8")
+    (delivery / "pr-status.json").write_text(json.dumps({"url": "https://example/pr/1"}), encoding="utf-8")
+    (delivery / "ci" / "latest.json").write_text(json.dumps({"checks": [{"conclusion": "success"}]}), encoding="utf-8")
+    (delivery / "acceptance" / "report.md").write_text("machine AI human browser", encoding="utf-8")
+    (delivery / "jobs" / "job-1" / "execution-job.json").write_text("{}", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "real-change.txt").write_text("real evidence\n", encoding="utf-8")
+    hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(command="python3 --version", cwd=str(tmp_path), execute=True)
+    )
+
+    report = hermes_autonomous.run_anti_shell_check(str(tmp_path))
+
+    assert report["status"] == "passed"
+
+
+def test_autonomous_tick_creates_goal_mode_task_for_failed_gate(tmp_path, monkeypatch):
+    _, hermes_autonomous, kanban_db = _modules(tmp_path, monkeypatch)
+
+    result = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            create_tasks=True,
+            board="default",
+            assignee="default",
+            goal_max_turns=17,
+            workspace_path=str(tmp_path),
+            repo=str(tmp_path),
+        )
+    )
+
+    assert result["ok"] is True
+    created = result["tick"]["created_tasks"]
+    assert created
+    with kanban_db.connect(board="default") as conn:
+        row = conn.execute(
+            "SELECT goal_mode, goal_max_turns, idempotency_key FROM tasks WHERE id = ?",
+            (created[0]["id"],),
+        ).fetchone()
+    assert row["goal_mode"] == 1
+    assert row["goal_max_turns"] == 17
+    assert str(row["idempotency_key"]).startswith("hermes-autonomous:")
+    assert result["tick"]["no_idle_enforced"] is True
+    assert result["tick"]["heartbeat"]["no_idle_enforced"] is True
+    assert (tmp_path / "home" / "delivery" / "autonomous-heartbeat.json").exists()
+
+
+def test_autonomous_tick_retries_when_prior_goal_task_finished_but_gate_still_fails(tmp_path, monkeypatch):
+    _, hermes_autonomous, kanban_db = _modules(tmp_path, monkeypatch)
+
+    first = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            create_tasks=True,
+            board="default",
+            assignee="default",
+            workspace_path=str(tmp_path),
+            repo=str(tmp_path),
+        )
+    )
+    first_task = first["tick"]["created_tasks"][0]["id"]
+    with kanban_db.connect(board="default") as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'done', completed_at = ? WHERE id = ?",
+            (int(time.time()), first_task),
+        )
+        conn.commit()
+
+    second = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            create_tasks=True,
+            board="default",
+            assignee="default",
+            workspace_path=str(tmp_path),
+            repo=str(tmp_path),
+        )
+    )
+    second_task = second["tick"]["created_tasks"][0]
+
+    assert second_task["created"] is True
+    assert second_task["id"] != first_task
+    assert second_task["previous_task"]["id"] == first_task
+    assert ":retry:" in second_task["idempotency_key"]
+
+
+def test_autonomous_tick_treats_failed_deploy_gate_as_active_work(tmp_path, monkeypatch):
+    _, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        hermes_autonomous,
+        "run_capability_audit",
+        lambda: {
+            "passed": 12,
+            "failed": 1,
+            "total": 13,
+            "results": [{"stage_id": "deploy", "status": "failed"}],
+        },
+    )
+    monkeypatch.setattr(
+        hermes_autonomous,
+        "run_anti_shell_check",
+        lambda repo=None: {"status": "passed", "passed": 10, "failed": 0},
+    )
+
+    result = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            create_tasks=True,
+            board="default",
+            assignee="default",
+            workspace_path=str(tmp_path),
+            repo=str(tmp_path),
+        )
+    )
+
+    assert result["tick"]["next_action"] == "deploy"
+    assert result["tick"]["reason"] == "gate_failed"
+    assert result["tick"]["created_tasks"][0]["stage"] == "deploy"
+    assert result["tick"]["heartbeat"]["mode"] == "active"
+    assert result["tick"]["heartbeat"]["wake_agent"] is True
+
+
+def test_autonomous_tick_recovers_blocked_task_even_when_gates_pass(tmp_path, monkeypatch):
+    _, hermes_autonomous, kanban_db = _modules(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        hermes_autonomous,
+        "run_capability_audit",
+        lambda: {"passed": 13, "failed": 0, "total": 13, "results": []},
+    )
+    monkeypatch.setattr(
+        hermes_autonomous,
+        "run_anti_shell_check",
+        lambda repo=None: {"status": "passed", "passed": 10, "failed": 0},
+    )
+    with kanban_db.connect(board="default") as conn:
+        blocked_id = kanban_db.create_task(
+            conn,
+            title="Hermes autonomous: fix deploy gate",
+            body="blocked",
+            assignee="default",
+            created_by="test",
+            idempotency_key="hermes-autonomous:deploy",
+            initial_status="blocked",
+            board="default",
+        )
+
+    result = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            create_tasks=True,
+            board="default",
+            assignee="default",
+            workspace_path=str(tmp_path),
+            repo=str(tmp_path),
+        )
+    )
+
+    heartbeat = result["tick"]["heartbeat"]
+    assert result["tick"]["reason"] == "all_gates_passed"
+    assert heartbeat["mode"] == "blocked_task_needs_retry"
+    assert heartbeat["wake_agent"] is True
+    assert heartbeat["blocked_tasks"][0]["id"] == blocked_id
+    assert result["tick"]["created_tasks"][0]["created"] is True
+    assert result["tick"]["created_tasks"][0]["previous_task"]["id"] == blocked_id
+
+
+def test_autonomous_tick_dispatch_uses_kanban_connection(tmp_path, monkeypatch):
+    _, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+
+    result = hermes_autonomous.autonomous_tick(
+        hermes_autonomous.TickOptions(
+            dispatch=True,
+            board="default",
+            repo=str(tmp_path),
+            workspace_path=str(tmp_path),
+        )
+    )
+
+    assert result["ok"] is True
+    assert isinstance(result["tick"]["dispatch"], dict)
+    assert "spawned" in result["tick"]["dispatch"]
+
+
+def test_install_watchdog_creates_single_no_agent_cron_job(tmp_path, monkeypatch):
+    _, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+
+    first = hermes_autonomous.install_watchdog(
+        schedule="every 2m",
+        repo=str(tmp_path),
+        workspace_path=str(tmp_path),
+        assignee="default",
+        goal_max_turns=19,
+    )
+    second = hermes_autonomous.install_watchdog(
+        schedule="every 3m",
+        repo=str(tmp_path),
+        workspace_path=str(tmp_path),
+        assignee="default",
+        goal_max_turns=21,
+    )
+    status = hermes_autonomous.watchdog_status()
+
+    assert first["job"]["no_agent"] is True
+    assert first["job"]["script"] == "autonomous_watchdog.py"
+    assert second["removed"] == [first["job"]["id"]]
+    assert status["installed"] is True
+    assert len(status["jobs"]) == 1
+    assert status["jobs"][0]["schedule_display"] == "every 3m"
+    script = (tmp_path / "home" / "scripts" / "autonomous_watchdog.py").read_text(encoding="utf-8")
+    assert "len(spawned_raw) if isinstance(spawned_raw, list)" in script

--- a/tests/test_hermes_autonomous.py
+++ b/tests/test_hermes_autonomous.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import subprocess
+import sys
 import time
 
 
@@ -124,7 +125,7 @@ def test_autonomous_tick_treats_failed_deploy_gate_as_active_work(tmp_path, monk
     monkeypatch.setattr(
         hermes_autonomous,
         "run_capability_audit",
-        lambda: {
+        lambda **kwargs: {
             "passed": 12,
             "failed": 1,
             "total": 13,
@@ -159,7 +160,7 @@ def test_autonomous_tick_recovers_blocked_task_even_when_gates_pass(tmp_path, mo
     monkeypatch.setattr(
         hermes_autonomous,
         "run_capability_audit",
-        lambda: {"passed": 13, "failed": 0, "total": 13, "results": []},
+        lambda **kwargs: {"passed": 13, "failed": 0, "total": 13, "results": []},
     )
     monkeypatch.setattr(
         hermes_autonomous,
@@ -241,3 +242,32 @@ def test_install_watchdog_creates_single_no_agent_cron_job(tmp_path, monkeypatch
     assert status["jobs"][0]["schedule_display"] == "every 3m"
     script = (tmp_path / "home" / "scripts" / "autonomous_watchdog.py").read_text(encoding="utf-8")
     assert "len(spawned_raw) if isinstance(spawned_raw, list)" in script
+
+
+def test_generated_watchdog_imports_runtime_from_repo(tmp_path, monkeypatch):
+    _, hermes_autonomous, _ = _modules(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "hermes_autonomous.py").write_text(
+        "class TickOptions:\n"
+        "    def __init__(self, **kwargs): pass\n"
+        "def autonomous_tick(options):\n"
+        "    return {'tick': {'created_tasks': [], 'heartbeat': {'wake_agent': False}, 'dispatch': {}}}\n",
+        encoding="utf-8",
+    )
+    script = tmp_path / "watchdog.py"
+    script.write_text(
+        hermes_autonomous._watchdog_script_content(
+            repo=str(repo),
+            workspace_path=str(repo),
+            board="default",
+            assignee="default",
+            goal_max_turns=10,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"wakeAgent": False}

--- a/tests/test_hermes_delivery.py
+++ b/tests/test_hermes_delivery.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+
+def _module(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    import hermes_delivery
+
+    return importlib.reload(hermes_delivery)
+
+
+def test_delivery_state_initializes_pipeline(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    snapshot = hermes_delivery.dashboard_snapshot()
+
+    assert snapshot["ok"] is True
+    assert snapshot["summary"]["approval_cards"] is False
+    assert [stage["id"] for stage in snapshot["stages"]][-2:] == ["deploy", "backwrite"]
+    assert "approval cards" in " ".join(snapshot["principles"]).lower()
+
+
+def test_update_stage_persists_status(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    hermes_delivery.update_stage("deploy", "ready", "policy passed")
+    snapshot = hermes_delivery.dashboard_snapshot()
+    deploy = next(stage for stage in snapshot["stages"] if stage["id"] == "deploy")
+
+    assert deploy["status"] == "ready"
+    assert deploy["notes"] == "policy passed"
+
+
+def test_deploy_dry_run_writes_ready_run(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(
+            command="python3 --version",
+            cwd=str(tmp_path),
+            execute=False,
+        )
+    )
+
+    assert run["status"] == "ready"
+    assert run["policy"]["allowed"] is True
+    assert (tmp_path / "home" / "delivery" / "deploy-runs" / run["run_id"] / "deploy-run.json").exists()
+
+
+def test_prod_deploy_without_rollback_is_blocked(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(
+            environment="prod",
+            command="python3 --version",
+            cwd=str(tmp_path),
+            execute=True,
+            force=False,
+        )
+    )
+
+    assert run["status"] == "blocked"
+    assert any(check["name"] == "rollback_declared" and not check["ok"] for check in run["policy"]["checks"])
+
+
+def test_ssh_deploy_requires_registered_target(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(
+            adapter="ssh",
+            target="missing-server",
+            command="uname -a",
+            execute=False,
+        )
+    )
+
+    assert run["status"] == "blocked"
+    assert any(check["name"] == "ssh_target_registered" and not check["ok"] for check in run["policy"]["checks"])
+
+
+def test_ssh_target_uses_credential_reference_without_leaking_secret(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    target_path = tmp_path / "home" / "deploy-targets.json"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(
+        json.dumps(
+            {
+                "schema": "hermes.deploy-targets.v1",
+                "targets": {
+                    "app-node": {
+                        "host": "192.0.2.10",
+                        "user": "root",
+                        "password_env": "HERMES_DEPLOY_PASSWORD_APP_NODE",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_DEPLOY_PASSWORD_APP_NODE", "super-secret-test-value")
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(
+            adapter="ssh",
+            target="app-node",
+            command="hostname",
+            execute=False,
+        )
+    )
+
+    encoded = json.dumps(run, ensure_ascii=False)
+    assert run["status"] == "ready"
+    assert "env:HERMES_DEPLOY_PASSWORD_APP_NODE" in encoded
+    assert "super-secret-test-value" not in encoded
+
+
+def test_ssh_target_blocks_when_password_reference_is_not_loaded(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    target_path = tmp_path / "home" / "deploy-targets.json"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(
+        json.dumps(
+            {
+                "schema": "hermes.deploy-targets.v1",
+                "targets": {
+                    "app-node": {
+                        "host": "192.0.2.10",
+                        "user": "root",
+                        "password_env": "HERMES_DEPLOY_PASSWORD_APP_NODE",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(
+            adapter="ssh",
+            target="app-node",
+            command="hostname",
+            execute=False,
+        )
+    )
+
+    assert run["status"] == "blocked"
+    assert any(check["name"] == "ssh_password_loaded" and not check["ok"] for check in run["policy"]["checks"])
+
+
+def test_deploy_gate_uses_verified_run_artifact_not_state_ledger(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    state = hermes_delivery.load_state()
+    state.setdefault("deploy", {}).setdefault("runs", []).append({"run_id": "fake", "status": "done"})
+    hermes_delivery.save_state(state)
+
+    failed = hermes_delivery.run_gate("deploy")
+    assert failed["status"] == "failed"
+    assert any(check["name"] == "deploy_run_exists" and not check["ok"] for check in failed["checks"])
+
+    run = hermes_delivery.run_deploy(
+        hermes_delivery.DeployRequest(command="python3 --version", cwd=str(tmp_path), execute=True)
+    )
+    payload_path = tmp_path / "home" / "delivery" / "deploy-runs" / run["run_id"] / "deploy-run.json"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    payload["status"] = "verified"
+    payload_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    passed = hermes_delivery.run_gate("deploy")
+    assert passed["status"] == "passed"
+    assert any(check["name"] == "status_verified" and check["ok"] for check in passed["checks"])
+
+
+def test_capability_manifest_covers_every_chart_stage(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    manifest = hermes_delivery.capability_manifest()
+    capability_ids = [item["id"] for item in manifest["capabilities"]]
+    stage_ids = [item["id"] for item in hermes_delivery.PIPELINE_STAGES]
+
+    assert capability_ids == stage_ids
+    assert manifest["no_approval_cards"] is True
+    assert all(item["required_artifacts"] for item in manifest["capabilities"])
+    assert all(item["gate_signals"] for item in manifest["capabilities"])
+
+
+def test_gate_runner_blocks_after_three_failed_attempts(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    first = hermes_delivery.run_gate("spec")
+    second = hermes_delivery.run_gate("spec")
+    third = hermes_delivery.run_gate("spec")
+    spec_stage = next(stage for stage in hermes_delivery.dashboard_snapshot()["stages"] if stage["id"] == "spec")
+
+    assert first["status"] == "failed"
+    assert second["gate_state"]["fail_count"] == 2
+    assert third["gate_state"]["fail_count"] == 3
+    assert spec_stage["status"] == "blocked"
+
+
+def test_gate_runner_can_check_without_updating_state(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    before = hermes_delivery.dashboard_snapshot()["stages"]
+
+    result = hermes_delivery.run_gate("spec", update_state=False)
+    after = hermes_delivery.dashboard_snapshot()["stages"]
+
+    assert result["status"] == "failed"
+    assert result["gate_state"] == next(stage for stage in before if stage["id"] == "spec")
+    assert after == before
+
+
+def test_gate_runner_passes_when_stage_artifact_has_required_signals(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    delivery.mkdir(parents=True)
+    (delivery / "spec.md").write_text(
+        "## Spec\n涉及文件: hermes_delivery.py\n验收测试: pytest\n禁止占位替代真实约束\n",
+        encoding="utf-8",
+    )
+
+    result = hermes_delivery.run_gate("spec")
+    spec_stage = next(stage for stage in hermes_delivery.dashboard_snapshot()["stages"] if stage["id"] == "spec")
+
+    assert result["status"] == "passed"
+    assert spec_stage["status"] == "done"
+
+
+def test_story_gate_passes_with_well_formed_stories(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    delivery.mkdir(parents=True)
+    (delivery / "stories.md").write_text(
+        "# Stories\n\n"
+        "## Story 1\n"
+        "- 角色: Hermes operator\n"
+        "- 点击路径: Desktop -> Delivery -> GateRunner\n"
+        "- 断言: 每个阶段返回 pass/fail 和缺失信号\n\n"
+        "## Story 2\n"
+        "- Role: release owner\n"
+        "- Path: Desktop -> Delivery -> Dispatch -> PR monitor\n"
+        "- Assertion: execution job and status artifacts are written\n",
+        encoding="utf-8",
+    )
+
+    result = hermes_delivery.run_gate("story")
+
+    assert result["status"] == "passed"
+    assert any(check["name"] == "story_entries" and check["detail"] == "2" for check in result["checks"])
+    assert all(check["ok"] for check in result["checks"] if check["name"].startswith("story:"))
+
+
+def test_story_gate_fails_when_story_is_missing_role(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    delivery.mkdir(parents=True)
+    (delivery / "stories.md").write_text(
+        "# Stories\n\n"
+        "## Story 1\n"
+        "- 点击路径: Desktop -> Delivery -> GateRunner\n"
+        "- 断言: 每个阶段返回 pass/fail 和缺失信号\n",
+        encoding="utf-8",
+    )
+
+    result = hermes_delivery.run_gate("story")
+
+    assert result["status"] == "failed"
+    assert any(check["name"] == "story:1:role" and not check["ok"] for check in result["checks"])
+
+
+def test_story_gate_fails_when_story_is_missing_assertion(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    delivery.mkdir(parents=True)
+    (delivery / "stories.md").write_text(
+        "# Stories\n\n"
+        "## Story 1\n"
+        "- 角色: Hermes operator\n"
+        "- 点击路径: Desktop -> Delivery -> GateRunner\n",
+        encoding="utf-8",
+    )
+
+    result = hermes_delivery.run_gate("story")
+
+    assert result["status"] == "failed"
+    assert any(check["name"] == "story:1:assertion" and not check["ok"] for check in result["checks"])
+
+
+def test_story_gate_fails_when_no_story_sections_exist(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    delivery.mkdir(parents=True)
+    (delivery / "stories.md").write_text("# Stories\n\n角色 path assertion only in metadata\n", encoding="utf-8")
+
+    result = hermes_delivery.run_gate("story")
+
+    assert result["status"] == "failed"
+    assert any(check["name"] == "story_entries" and not check["ok"] for check in result["checks"])
+
+
+def test_execution_job_lifecycle_writes_dispatch_artifact(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    job = hermes_delivery.create_execution_job(
+        title="Implement capability",
+        owner="Hermes",
+        executor="codex",
+        branch="feat/hermes-loop",
+        command="python3 --version",
+        repo=str(tmp_path),
+    )
+    planned = hermes_delivery.run_execution_job(job["job_id"], execute=False)
+
+    assert planned["status"] == "ready"
+    assert planned["attempt"] == 1
+    assert hermes_delivery.list_jobs()[0]["job_id"] == job["job_id"]
+    assert (tmp_path / "home" / "delivery" / "jobs" / job["job_id"] / "execution-job.json").exists()
+    assert (tmp_path / "home" / "delivery" / "jobs" / job["job_id"] / "job.log").exists()
+    gate = hermes_delivery.run_gate("dispatch")
+    assert gate["status"] == "passed"
+    assert {check["name"] for check in gate["checks"]} >= {"dispatch_recorded", "job_log_exists", "has_command"}
+
+
+def test_dispatch_gate_fails_for_unexecuted_job_without_log(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    delivery = tmp_path / "home" / "delivery"
+    job_dir = delivery / "jobs" / "job-stale"
+    job_dir.mkdir(parents=True)
+    (job_dir / "execution-job.json").write_text(
+        json.dumps(
+            {
+                "schema": "hermes.execution-job.v1",
+                "job_id": "job-stale",
+                "owner": "Hermes",
+                "executor": "codex",
+                "branch": "feat/stale",
+                "command": "python3 --version",
+                "status": "queued",
+                "attempt": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    gate = hermes_delivery.run_gate("dispatch")
+
+    assert gate["status"] == "failed"
+    assert any(check["name"] == "dispatch_recorded" and not check["ok"] for check in gate["checks"])
+    assert any(check["name"] == "job_log_exists" and not check["ok"] for check in gate["checks"])
+
+
+def test_acceptance_delivery_and_backwrite_artifacts_feed_gates(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    acceptance = hermes_delivery.write_acceptance_report(
+        machine_evidence=["机器 pytest passed"],
+        ai_review_evidence=["AI review Codex approved"],
+        human_evidence="人工 browser 核心路径 3分钟 passed",
+    )
+    summary = hermes_delivery.write_delivery_summary("notification sent")
+    backwrite = hermes_delivery.write_backwrite_blueprint("baseline updated")
+
+    assert acceptance["gate"]["status"] == "passed"
+    assert summary["gate"]["status"] == "passed"
+    assert backwrite["gate"]["status"] == "passed"
+
+
+def test_pr_and_ci_monitors_write_gate_artifacts(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+
+    def fake_run_json_command(args, cwd=None):
+        if args[:3] == ["gh", "pr", "view"]:
+            return 0, {
+                "number": 12,
+                "url": "https://github.example/pr/12",
+                "state": "OPEN",
+                "title": "feat: capability",
+                "body": "Implements STO-1",
+                "headRefName": "feat/hermes-loop",
+                "closingIssuesReferences": [{"number": 1}],
+            }, ""
+        if args[:3] == ["gh", "pr", "checks"]:
+            return 0, [
+                {"name": "test", "state": "pass", "link": "https://github.example/checks/1"},
+                {"name": "build", "state": "success", "link": "https://github.example/checks/2"},
+            ], ""
+        raise AssertionError(args)
+
+    monkeypatch.setattr(hermes_delivery, "_run_json_command", fake_run_json_command)
+
+    pr = hermes_delivery.refresh_pr_status(repo="owner/repo", pr="12", issue="STO-1")
+    ci = hermes_delivery.refresh_ci_status(repo="owner/repo", ref="12")
+
+    assert pr["state"] == "OPEN"
+    assert pr["linked_issue"] is True
+    assert ci["checks"][0]["conclusion"] == "success"
+    assert hermes_delivery.run_gate("pr_monitor")["status"] == "passed"
+    assert hermes_delivery.run_gate("ci_monitor")["status"] == "passed"

--- a/tests/test_hermes_delivery.py
+++ b/tests/test_hermes_delivery.py
@@ -214,6 +214,17 @@ def test_gate_runner_can_check_without_updating_state(tmp_path, monkeypatch):
     assert after == before
 
 
+def test_capability_audit_can_check_without_updating_state(tmp_path, monkeypatch):
+    hermes_delivery = _module(tmp_path, monkeypatch)
+    before = hermes_delivery.dashboard_snapshot()["stages"]
+
+    result = hermes_delivery.run_capability_audit(update_state=False)
+    after = hermes_delivery.dashboard_snapshot()["stages"]
+
+    assert result["total"] == len(hermes_delivery.PIPELINE_STAGES)
+    assert after == before
+
+
 def test_gate_runner_passes_when_stage_artifact_has_required_signals(tmp_path, monkeypatch):
     hermes_delivery = _module(tmp_path, monkeypatch)
     delivery = tmp_path / "home" / "delivery"


### PR DESCRIPTION
Summary:
- restore hermes_autonomous and hermes_delivery runtime modules removed from current main
- keep watchdog capability audits read-only
- preserve idempotent task creation and no-agent cron behavior
- add repo-path import regression coverage

Verification:
- 570 passed, 1 skipped
- Ruff passed
- discriminative watchdog test failed under temporary break and passed after restore
- Qwen PASS
- DeepSeek PASS
- GLM PASS

Scope:
- no merge, deploy, migration, or total-control queue mutation
- four files only