### PR TITLE
fix(custom): support per-model thinking field overrides

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5231,6 +5231,69 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_thinking_field(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, str]]:
+    """Look up per-model thinking field overrides from ``custom_providers``.
+
+    Some models behind custom endpoints use a different field name to disable
+    thinking (e.g. ``chat_template_kwargs.enable_thinking`` instead of the
+    Ollama-style ``think``).  Users configure this via::
+
+        providers:
+          omlx:
+            api: "http://127.0.0.1:8000/v1"
+            models:
+              Qwen3.6-35B-A3B-bf16:
+                thinking_field: chat_template_kwargs
+                thinking_subkey: enable_thinking
+
+    Returns ``{"field": ..., "subkey": ...}`` when a valid override exists,
+    or ``None`` to fall back to the default ``think`` field.
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        thinking_field = model_cfg.get("thinking_field")
+        if not isinstance(thinking_field, str) or not thinking_field.strip():
+            continue
+        result: Dict[str, str] = {"field": thinking_field.strip()}
+        thinking_subkey = model_cfg.get("thinking_subkey")
+        if isinstance(thinking_subkey, str) and thinking_subkey.strip():
+            result["subkey"] = thinking_subkey.strip()
+        return result
+    return None
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5267,14 +5267,14 @@ def get_custom_provider_thinking_field(
     if not isinstance(custom_providers, list):
         return None
 
-    target_url = (base_url or "").rstrip("/")
+    target_url = (base_url or "").rstrip("/").lower()
     if not target_url:
         return None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
-        entry_url = (entry.get("base_url") or "").rstrip("/")
+        entry_url = (entry.get("base_url") or "").rstrip("/").lower()
         if not entry_url or entry_url != target_url:
             continue
         models = entry.get("models")

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -2,12 +2,13 @@
 
 Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
-Volcengine ARK, vLLM, llama.cpp). Key quirks:
-  - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → top-level reasoning_effort="none"
-    (Ollama /v1/chat/completions ignores think=False — ollama#14820)
-    + extra_body.think = False for /api/chat and proxies
-  - reasoning_config enabled + effort → top-level reasoning_effort
+Volcengine ARK, vLLM, llama.cpp, oMLX). Key quirks:
+  - ollama_num_ctx -> extra_body.options.num_ctx (local context window)
+  - reasoning_config disabled -> top-level reasoning_effort="none"
+    (Ollama /v1/chat/completions ignores think=False -- ollama#14820)
+    + model-specific thinking-off field in extra_body (default: think=False;
+    configurable per-model via thinking_field / thinking_subkey)
+  - reasoning_config enabled + effort -> top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
 """
@@ -19,13 +20,15 @@ from providers.base import ProviderProfile
 
 
 class CustomProfile(ProviderProfile):
-    """Custom/Ollama local provider — think=false and num_ctx support."""
+    """Custom/Ollama local provider -- think=false and num_ctx support."""
 
     def build_api_kwargs_extras(
         self,
         *,
         reasoning_config: dict | None = None,
         ollama_num_ctx: int | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
@@ -38,13 +41,17 @@ class CustomProfile(ProviderProfile):
             extra_body["options"] = options
 
         # Reasoning / thinking control for custom OpenAI-compatible endpoints
-        # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
+        # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, oMLX, ...).
         #
-        #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
-        #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
+        #   - disabled  -> top-level reasoning_effort="none" (Ollama's
+        #     /v1/chat/completions ignores think=False -- ollama#14820 --
+        #     but respects the top-level field) + model-specific body field
+        #     (default: extra_body.think = False; configurable per-model via
+        #     thinking_field / thinking_subkey in custom_providers config).
+        #   - enabled + effort set -> TOP-LEVEL reasoning_effort string, the
         #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
         #     expect (GLM documents "high" and "max"; "max" is its default).
-        #   - enabled + no effort  → omit both, so the endpoint applies its own
+        #   - enabled + no effort  -> omit both, so the endpoint applies its own
         #     server-side default (do NOT force a level the user didn't pick).
         #
         # We deliberately do NOT emit ``think=True`` on enable: it is an
@@ -55,18 +62,46 @@ class CustomProfile(ProviderProfile):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                # Ollama's /v1/chat/completions silently ignores
-                # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field, so both
-                # are needed to actually stop a thinking-capable model from
-                # reasoning (#25758). Endpoints that recognize neither simply
-                # ignore them.
                 top_level["reasoning_effort"] = "none"
-                extra_body["think"] = False
+                self._emit_thinking_disabled(extra_body, model, base_url)
             elif _effort:
                 top_level["reasoning_effort"] = _effort
 
         return extra_body, top_level
+
+    @staticmethod
+    def _emit_thinking_disabled(
+        extra_body: dict[str, Any],
+        model: str | None,
+        base_url: str | None,
+    ) -> None:
+        """Set the correct thinking-off field in *extra_body*.
+
+        Checks per-model config for a ``thinking_field`` / ``thinking_subkey``
+        override (e.g. ``chat_template_kwargs.enable_thinking`` for Qwen on
+        oMLX).  Falls back to the Ollama-style ``think = False``.
+        """
+        thinking_cfg = None
+        if model and base_url:
+            try:
+                from hermes_cli.config import get_custom_provider_thinking_field
+                thinking_cfg = get_custom_provider_thinking_field(model, base_url)
+            except Exception:
+                pass
+
+        if thinking_cfg:
+            field = thinking_cfg["field"]
+            subkey = thinking_cfg.get("subkey")
+            if subkey:
+                nested = extra_body.get(field, {})
+                if not isinstance(nested, dict):
+                    nested = {}
+                nested[subkey] = False
+                extra_body[field] = nested
+            else:
+                extra_body[field] = False
+        else:
+            extra_body["think"] = False
 
     def fetch_models(
         self,
@@ -91,12 +126,12 @@ custom = CustomProfile(
         "llama.cpp",
         "llama-cpp",
     ),
-    env_vars=(),  # No fixed key — custom endpoint
+    env_vars=(),  # No fixed key -- custom endpoint
     base_url="",  # User-configured
     # Without this, no max_tokens is sent and Ollama falls back to its internal
     # num_predict=128, truncating responses after a few tokens (#39281). This is
-    # only a floor used when the user hasn't set model.max_tokens — they can
-    # override per-model — so we set it generously rather than lowballing it.
+    # only a floor used when the user hasn't set model.max_tokens -- they can
+    # override per-model -- so we set it generously rather than lowballing it.
     default_max_tokens=65536,
 )
 

--- a/tests/hermes_cli/test_custom_provider_thinking_field.py
+++ b/tests/hermes_cli/test_custom_provider_thinking_field.py
@@ -1,0 +1,118 @@
+"""Tests for per-model thinking field override resolution.
+
+Covers get_custom_provider_thinking_field(), which lets users configure
+model-specific field names for the thinking-off toggle (e.g.
+chat_template_kwargs.enable_thinking instead of the default think=False).
+"""
+from __future__ import annotations
+
+from hermes_cli.config import get_custom_provider_thinking_field
+
+
+class TestGetCustomProviderThinkingField:
+    def test_returns_field_and_subkey(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8000/v1",
+                "models": {
+                    "Qwen3.6-35B-A3B-bf16": {
+                        "thinking_field": "chat_template_kwargs",
+                        "thinking_subkey": "enable_thinking",
+                    }
+                },
+            }
+        ]
+        result = get_custom_provider_thinking_field(
+            "Qwen3.6-35B-A3B-bf16", "http://127.0.0.1:8000/v1", custom
+        )
+        assert result == {"field": "chat_template_kwargs", "subkey": "enable_thinking"}
+
+    def test_returns_field_without_subkey(self):
+        custom = [
+            {
+                "base_url": "http://localhost:11434/v1",
+                "models": {
+                    "my-model": {"thinking_field": "disable_thinking"}
+                },
+            }
+        ]
+        result = get_custom_provider_thinking_field(
+            "my-model", "http://localhost:11434/v1", custom
+        )
+        assert result == {"field": "disable_thinking"}
+
+    def test_trailing_slash_insensitive(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8000/v1/",
+                "models": {
+                    "m": {"thinking_field": "chat_template_kwargs", "thinking_subkey": "enable_thinking"}
+                },
+            }
+        ]
+        assert (
+            get_custom_provider_thinking_field("m", "http://127.0.0.1:8000/v1", custom)
+            == {"field": "chat_template_kwargs", "subkey": "enable_thinking"}
+        )
+
+    def test_returns_none_when_no_thinking_field(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8000/v1",
+                "models": {"m": {"context_length": 32768}},
+            }
+        ]
+        assert get_custom_provider_thinking_field(
+            "m", "http://127.0.0.1:8000/v1", custom
+        ) is None
+
+    def test_returns_none_when_url_mismatch(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8000/v1",
+                "models": {"m": {"thinking_field": "think"}},
+            }
+        ]
+        assert get_custom_provider_thinking_field(
+            "m", "http://other-host:8000/v1", custom
+        ) is None
+
+    def test_returns_none_when_model_mismatch(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8000/v1",
+                "models": {"m": {"thinking_field": "think"}},
+            }
+        ]
+        assert get_custom_provider_thinking_field(
+            "other-model", "http://127.0.0.1:8000/v1", custom
+        ) is None
+
+    def test_empty_inputs_return_none(self):
+        assert get_custom_provider_thinking_field("", "http://x", []) is None
+        assert get_custom_provider_thinking_field("m", "", []) is None
+        assert get_custom_provider_thinking_field("m", "http://x", None) is None
+
+    def test_ignores_malformed_entries(self):
+        custom = [
+            "not a dict",
+            None,
+            {"base_url": "http://x/v1", "models": "not a dict"},
+            {"base_url": "http://x/v1", "models": {"m": "not a dict"}},
+            {"base_url": "http://x/v1", "models": {"m": {"thinking_field": ""}}},
+            {
+                "base_url": "http://x/v1",
+                "models": {"m": {"thinking_field": "chat_template_kwargs"}},
+            },
+        ]
+        result = get_custom_provider_thinking_field("m", "http://x/v1", custom)
+        assert result == {"field": "chat_template_kwargs"}
+
+    def test_ignores_non_string_thinking_field(self):
+        custom = [
+            {
+                "base_url": "http://x/v1",
+                "models": {"m": {"thinking_field": 123}},
+            }
+        ]
+        assert get_custom_provider_thinking_field("m", "http://x/v1", custom) is None

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -1,18 +1,19 @@
 """Unit tests for the custom provider profile's reasoning wiring.
 
 ``provider=custom`` covers any OpenAI-compatible endpoint the user points
-Hermes at — local Ollama, vLLM, llama.cpp, and hosted reasoning APIs like
+Hermes at -- local Ollama, vLLM, llama.cpp, and hosted reasoning APIs like
 GLM-5.2 on Volcengine ARK. Before #57601's salvage, ``CustomProfile`` emitted
 nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
 was silently dropped for every custom endpoint.
 
 These tests pin the wire-shape contract:
-  - disabled            → extra_body.think = False
-  - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
-                          format GLM/ARK expect), passed through verbatim
-                          including ``max``/``xhigh``
-  - enabled + no effort → nothing emitted (endpoint's server default applies)
-  - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
+  - disabled            -> extra_body.think = False (default), or a
+                           per-model override via thinking_field/thinking_subkey
+  - enabled + effort    -> top-level reasoning_effort (native OpenAI-compat
+                           format GLM/ARK expect), passed through verbatim
+                           including ``max``/``xhigh``
+  - enabled + no effort -> nothing emitted (endpoint's server default applies)
+  - ollama_num_ctx      -> extra_body.options.num_ctx, orthogonal to reasoning
 """
 
 from __future__ import annotations
@@ -102,6 +103,62 @@ class TestCustomReasoningWireShape:
             reasoning_config={"enabled": True, "effort": "high"}, model="glm-5.2"
         )
         assert eb.get("think") is not True
+
+
+class TestCustomThinkingFieldOverride:
+    """Per-model thinking_field/thinking_subkey config overrides."""
+
+    def test_thinking_field_with_subkey(self, custom_profile, monkeypatch):
+        """Model with thinking_field + thinking_subkey emits nested structure."""
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_thinking_field",
+            lambda model, base_url, **kw: {"field": "chat_template_kwargs", "subkey": "enable_thinking"},
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="Qwen3.6-35B-A3B-bf16",
+            base_url="http://127.0.0.1:8000/v1",
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_thinking_field_without_subkey(self, custom_profile, monkeypatch):
+        """Model with thinking_field but no subkey emits a flat boolean."""
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_thinking_field",
+            lambda model, base_url, **kw: {"field": "disable_reasoning"},
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "none"},
+            model="some-model",
+            base_url="http://localhost:11434/v1",
+        )
+        assert eb == {"disable_reasoning": False}
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_no_override_falls_back_to_think(self, custom_profile, monkeypatch):
+        """When no per-model override exists, the default think=False is used."""
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_thinking_field",
+            lambda model, base_url, **kw: None,
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="qwen3",
+            base_url="http://localhost:11434/v1",
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_missing_model_or_base_url_falls_back(self, custom_profile):
+        """Without model/base_url the lookup is skipped, default applies."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
 
 
 class TestCustomReasoningWithNumCtx:

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1174,6 +1174,29 @@ custom_providers:
 
 `hermes model` will prompt for context length when configuring a custom endpoint. Leave it blank for auto-detection.
 
+#### Per-model thinking field override
+
+Some models behind custom endpoints use a different field name to disable
+thinking. For example, Qwen3 served via oMLX expects
+`chat_template_kwargs.enable_thinking` instead of the default `think`.
+You can configure this per model:
+
+```yaml
+custom_providers:
+  - name: "oMLX"
+    base_url: "http://127.0.0.1:8000/v1"
+    models:
+      Qwen3.6-35B-A3B-bf16:
+        thinking_field: chat_template_kwargs
+        thinking_subkey: enable_thinking
+```
+
+When `thinking_subkey` is set, Hermes emits
+`extra_body[thinking_field] = {thinking_subkey: false}`.
+When only `thinking_field` is set (no subkey), it emits
+`extra_body[thinking_field] = false`.
+Models without an override keep the default `think = false`.
+
 :::tip When to set this manually
 - You're using Ollama with a custom `num_ctx` that's lower than the model's maximum
 - You want to limit context below the model's maximum (e.g., 8k on a 128k model to save VRAM)


### PR DESCRIPTION
## What does this PR do?

The custom provider profile hardcodes `extra_body["think"] = False` when reasoning is disabled, but some models behind custom endpoints expect different field names. For example, Qwen3 served via oMLX needs `chat_template_kwargs.enable_thinking` instead of `think`.

This adds per-model `thinking_field` / `thinking_subkey` config support so users can specify the correct wire shape for their endpoint. The existing `think = False` default is preserved when no override is configured.

## Related Issue

Fixes #63195

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added `get_custom_provider_thinking_field()` helper following the existing `get_custom_provider_context_length()` pattern. Looks up `thinking_field` / `thinking_subkey` from per-model config in `custom_providers`.
- `plugins/model-providers/custom/__init__.py`: Added `model` and `base_url` as explicit params to `build_api_kwargs_extras()`. Extracted `_emit_thinking_disabled()` static method that checks per-model config before falling back to `think = False`.
- `tests/plugins/model_providers/test_custom_profile.py`: Added `TestCustomThinkingFieldOverride` class with 4 tests covering field+subkey, field-only, no-override fallback, and missing model/base_url.
- `tests/hermes_cli/test_custom_provider_thinking_field.py`: New test file for the config helper with 9 tests covering matching, trailing slash tolerance, missing fields, type mismatches, and malformed entries.

## How to Test

1. Configure a custom provider with per-model thinking field override:
```yaml
providers:
  omlx:
    api: "http://127.0.0.1:8000/v1"
    models:
      Qwen3.6-35B-A3B-bf16:
        thinking_field: chat_template_kwargs
        thinking_subkey: enable_thinking
```
2. Disable thinking via the model picker toggle
3. Verify the request body contains `{"chat_template_kwargs": {"enable_thinking": false}}` instead of `{"think": false}`

Run the tests:
```bash
pytest tests/hermes_cli/test_custom_provider_thinking_field.py tests/plugins/model_providers/test_custom_profile.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A