### PR TITLE
fix(model-picker): clear disconnected provider env state

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7348,6 +7348,33 @@ def test_browser_manage_disconnect_drops_env_and_cleans(monkeypatch):
     assert cleanup_count["n"] == 2
 
 
+def test_model_disconnect_clears_process_env_for_api_key_provider(monkeypatch):
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    monkeypatch.setitem(
+        PROVIDER_REGISTRY,
+        "openai",
+        types.SimpleNamespace(name="OpenAI", api_key_env_vars=("OPENAI_API_KEY",)),
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    with patch("hermes_cli.config.remove_env_value", return_value=False) as remove_env:
+        with patch("hermes_cli.auth.clear_provider_auth", return_value=False) as clear_auth:
+            resp = server._methods["model.disconnect"](
+                "1",
+                {"slug": "openai"},
+            )
+
+    assert resp["result"] == {
+        "slug": "openai",
+        "name": "OpenAI",
+        "disconnected": True,
+    }
+    assert "OPENAI_API_KEY" not in os.environ
+    remove_env.assert_called_once_with("OPENAI_API_KEY")
+    clear_auth.assert_called_once_with("openai")
+
+
 # ── config.get indicator normalization ───────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13019,7 +13019,9 @@ def _(rid, params: dict) -> dict:
         # Remove API key env vars from .env and process
         if pconfig and pconfig.api_key_env_vars:
             for ev in pconfig.api_key_env_vars:
-                if remove_env_value(ev):
+                removed_from_file = remove_env_value(ev)
+                removed_from_process = os.environ.pop(ev, None) is not None
+                if removed_from_file or removed_from_process:
                     cleared_env = True
 
         # Clear OAuth / credential pool state


### PR DESCRIPTION
## What does this PR do?

This narrows `#63211` to the remaining stale-provider bug in the gateway model picker path.

`model.disconnect` already removes API-key entries from `.env`, but it left the same env var in the live gateway process. The picker's authenticated-provider listing still read that in-memory env state, so a provider with a removed key could remain visible until the process restarted. This change clears the process env var during disconnect and adds a regression test for that path.

The separate "`model.base_url` custom models require manual refresh" symptom described in the issue appears to already be implemented on current `main`, so this PR intentionally does not claim to fix that part again.

## Related Issue

#63211

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Clear disconnected provider API key env vars from the live process in [tui_gateway/server.py](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-63211-custom-picker-freshness/tui_gateway/server.py)
- Add a regression test for `model.disconnect` stale env cleanup in [tests/test_tui_gateway_server.py](/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-63211-custom-picker-freshness/tests/test_tui_gateway_server.py)

## How to Test

1. Set a provider API key in the running gateway process, then call `model.disconnect` for that provider.
2. Re-open the model picker and confirm the disconnected provider no longer remains visible from stale process env state.
3. Run `uv run --python 3.11 --extra dev pytest tests/test_tui_gateway_server.py -k 'model_disconnect_clears_process_env_for_api_key_provider or model_options_refresh_allows_custom_provider_probes or model_options_hides_unconfigured_providers_by_default'`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused proof: `uv run --python 3.11 --extra dev pytest tests/test_tui_gateway_server.py -k 'model_disconnect_clears_process_env_for_api_key_provider or model_options_refresh_allows_custom_provider_probes or model_options_hides_unconfigured_providers_by_default'` -> `3 passed, 314 deselected in 4.89s`
