### PR TITLE
feat: add atomic Kanban terminal handoff

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -72,7 +72,7 @@ _POLISHED_TOOLS = {
     "feishu_doc_read", "feishu_drive_list_comments", "feishu_drive_list_comment_replies",
     "feishu_drive_reply_comment", "feishu_drive_add_comment",
     "kanban_create", "kanban_show", "kanban_comment", "kanban_complete",
-    "kanban_block", "kanban_link", "kanban_heartbeat",
+    "kanban_block", "kanban_link", "kanban_heartbeat", "kanban_handoff",
     "yb_query_group_info", "yb_query_group_members", "yb_search_sticker",
     "yb_send_dm", "yb_send_sticker",
 }

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -92,6 +92,7 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_complete",
     "kanban_block",
     "kanban_comment",
+    "kanban_handoff",
     "kanban_heartbeat",
     "kanban_show",
     "kanban_list",

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -522,6 +522,26 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_comment.add_argument("--max-len", type=int, default=None,
                            help="Trim the stored comment body to this many characters")
 
+    p_handoff = sub.add_parser(
+        "handoff", help="Atomically record a claim-guarded terminal worker handoff",
+    )
+    p_handoff.add_argument("task_id")
+    p_handoff.add_argument("--run-id", type=int, required=True)
+    p_handoff.add_argument("--profile", required=True)
+    p_handoff.add_argument("--workspace", required=True)
+    p_handoff.add_argument("--claim-lock", required=True)
+    p_handoff.add_argument("--idempotency-key", required=True)
+    p_handoff.add_argument("--transition", choices=("complete", "block"), required=True)
+    p_handoff.add_argument("--comment", required=True)
+    p_handoff.add_argument("--summary")
+    p_handoff.add_argument("--metadata", help="Structured handoff metadata as a JSON object")
+    p_handoff.add_argument("--result")
+    p_handoff.add_argument("--reason")
+    p_handoff.add_argument(
+        "--kind", choices=sorted(kb.VALID_BLOCK_KINDS),
+        help="Typed block reason; preserves dependency routing and loop escalation",
+    )
+
     p_complete = sub.add_parser("complete", help="Mark one or more tasks done")
     p_complete.add_argument("task_ids", nargs="+",
                             help="One or more task ids (only --result applies to all of them)")
@@ -951,6 +971,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "unlink":   _cmd_unlink,
             "claim":    _cmd_claim,
             "comment":  _cmd_comment,
+            "handoff":  _cmd_handoff,
             "complete": _cmd_complete,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
@@ -1861,6 +1882,32 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return int(raw)
     except ValueError:
         return None
+
+
+def _cmd_handoff(args: argparse.Namespace) -> int:
+    metadata = None
+    if args.metadata:
+        try:
+            metadata = json.loads(args.metadata)
+            if not isinstance(metadata, dict):
+                raise ValueError("must be a JSON object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            print(f"kanban: --metadata: {exc}", file=sys.stderr)
+            return 2
+    try:
+        with kb.connect_closing() as conn:
+            response = kb.terminal_handoff(
+                conn, args.task_id, run_id=args.run_id, profile=args.profile,
+                workspace=args.workspace, claim_lock=args.claim_lock,
+                idempotency_key=args.idempotency_key, transition=args.transition,
+                comment=args.comment, summary=args.summary, metadata=metadata,
+                result=args.result, reason=args.reason, kind=args.kind,
+            )
+    except kb.TerminalHandoffError as exc:
+        print(f"kanban: handoff rejected: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(response, sort_keys=True))
+    return 0
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1192,6 +1192,17 @@ CREATE TABLE IF NOT EXISTS task_comments (
     created_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS terminal_handoffs (
+    task_id         TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_hash    TEXT NOT NULL,
+    run_id          INTEGER NOT NULL,
+    transition      TEXT NOT NULL,
+    response_json   TEXT NOT NULL,
+    created_at      INTEGER NOT NULL,
+    PRIMARY KEY (task_id, idempotency_key)
+);
+
 CREATE TABLE IF NOT EXISTS task_events (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id    TEXT NOT NULL,
@@ -2956,6 +2967,168 @@ def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
         )
         for r in rows
     ]
+
+
+class TerminalHandoffError(ValueError):
+    """A claim-guarded terminal handoff was rejected without mutation."""
+
+
+def terminal_handoff(
+    conn: sqlite3.Connection, task_id: str, *, run_id: int, profile: str,
+    workspace: str, claim_lock: str, idempotency_key: str, transition: str,
+    comment: str, summary: Optional[str] = None, metadata: Optional[dict] = None,
+    result: Optional[str] = None, reason: Optional[str] = None,
+    kind: Optional[str] = None,
+) -> dict:
+    """Atomically persist an external worker handoff and close its claim."""
+    import hashlib
+
+    required = {"profile": profile, "workspace": workspace, "claim_lock": claim_lock,
+                "idempotency_key": idempotency_key, "comment": comment}
+    missing = [key for key, value in required.items() if not str(value or "").strip()]
+    if missing:
+        raise TerminalHandoffError(f"required field(s) missing: {', '.join(missing)}")
+    if transition not in {"complete", "block"}:
+        raise TerminalHandoffError("transition must be 'complete' or 'block'")
+    if transition == "complete" and not (summary or result):
+        raise TerminalHandoffError("complete requires summary or result")
+    if transition == "block" and not str(reason or "").strip():
+        raise TerminalHandoffError("block requires reason")
+    if kind is not None and kind not in VALID_BLOCK_KINDS:
+        raise TerminalHandoffError(
+            f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
+        )
+    if transition != "block" and kind is not None:
+        raise TerminalHandoffError("kind is only valid for a block transition")
+
+    canonical_workspace = str(Path(workspace).expanduser().resolve())
+    request = {
+        "task_id": task_id, "run_id": int(run_id), "profile": profile.strip(),
+        "workspace": canonical_workspace, "claim_lock": claim_lock.strip(),
+        "transition": transition, "comment": comment.strip(), "summary": summary,
+        "metadata": metadata, "result": result, "reason": reason, "kind": kind,
+    }
+    request_hash = hashlib.sha256(json.dumps(
+        request, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+    ).encode()).hexdigest()
+    now = int(time.time())
+    final_status = "done"
+    outcome = "completed" if transition == "complete" else "blocked"
+    final_summary = summary if transition == "complete" else reason
+
+    with write_txn(conn):
+        replay = conn.execute(
+            "SELECT request_hash, response_json FROM terminal_handoffs "
+            "WHERE task_id = ? AND idempotency_key = ?",
+            (task_id, idempotency_key.strip()),
+        ).fetchone()
+        if replay:
+            if replay["request_hash"] != request_hash:
+                raise TerminalHandoffError("idempotency_key was already used with a different payload")
+            response = json.loads(replay["response_json"])
+            response["replayed"] = True
+            return response
+
+        task = conn.execute(
+            "SELECT assignee, status, workspace_path, claim_lock, claim_expires, current_run_id, "
+            "block_kind, block_recurrences "
+            "FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if task is None:
+            raise TerminalHandoffError(f"unknown task {task_id}")
+        run = conn.execute(
+            "SELECT profile, status, claim_lock, claim_expires, ended_at FROM task_runs "
+            "WHERE id = ? AND task_id = ?", (int(run_id), task_id),
+        ).fetchone()
+        expected_workspace = str(Path(task["workspace_path"]).expanduser().resolve()) if task["workspace_path"] else None
+        mismatches = []
+        if task["status"] != "running": mismatches.append("task is not running")
+        if task["current_run_id"] != int(run_id): mismatches.append("run is stale or superseded")
+        if task["assignee"] != profile.strip(): mismatches.append("profile does not match assignee")
+        if expected_workspace != canonical_workspace: mismatches.append("workspace does not match claim")
+        if task["claim_lock"] != claim_lock.strip(): mismatches.append("claim lock does not match")
+        if task["claim_expires"] is None or int(task["claim_expires"]) <= now: mismatches.append("claim is expired")
+        if run is None or run["status"] != "running" or run["ended_at"] is not None:
+            mismatches.append("run is not active")
+        elif (run["profile"] != profile.strip() or run["claim_lock"] != claim_lock.strip()
+              or run["claim_expires"] is None or int(run["claim_expires"]) <= now):
+            mismatches.append("run claim does not match")
+        if mismatches:
+            raise TerminalHandoffError("handoff rejected: " + "; ".join(mismatches))
+
+        cur = conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, profile.strip(), comment.strip(), now),
+        )
+        comment_id = int(cur.lastrowid or 0)
+        _append_event(conn, task_id, "commented", {
+            "author": profile.strip(), "len": len(comment.strip()), "source": "terminal_handoff",
+        }, run_id=int(run_id))
+        event_kind = "completed"
+        event_payload = {
+            "result_len": len(result) if result else 0,
+            "summary": (final_summary or "").strip().splitlines()[0][:400] or None,
+        }
+        if transition == "complete":
+            conn.execute(
+                "UPDATE tasks SET status = 'done', result = ?, completed_at = ?, "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+                "current_run_id = NULL, block_kind = NULL, block_recurrences = 0 WHERE id = ?",
+                (result, now, task_id),
+            )
+        else:
+            previous_kind = task["block_kind"]
+            previous_recurrences = int(task["block_recurrences"] or 0)
+            if kind == "dependency":
+                # Dependency waits are scheduler routing, not repeated human
+                # blocks. Match block_task(): preserve the loop counter.
+                recurrences = previous_recurrences
+                final_status = "todo"
+                event_kind = "dependency_wait"
+            else:
+                recurrences = previous_recurrences + 1 if previous_kind == kind else 1
+                if recurrences >= BLOCK_RECURRENCE_LIMIT:
+                    final_status = "triage"
+                    event_kind = "block_loop_detected"
+                else:
+                    final_status = "blocked"
+                    event_kind = "blocked"
+            conn.execute(
+                "UPDATE tasks SET status = ?, result = NULL, completed_at = NULL, "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+                "current_run_id = NULL, block_kind = ?, block_recurrences = ? WHERE id = ?",
+                (final_status, kind, recurrences, task_id),
+            )
+            event_payload = {"reason": reason, "kind": kind, "recurrences": recurrences}
+            if event_kind == "block_loop_detected":
+                event_payload["limit"] = BLOCK_RECURRENCE_LIMIT
+        conn.execute(
+            "UPDATE task_runs SET status = ?, outcome = ?, summary = ?, metadata = ?, ended_at = ?, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL WHERE id = ? AND ended_at IS NULL",
+            ("done" if transition == "complete" else "blocked", outcome, final_summary,
+             json.dumps(metadata, ensure_ascii=False) if metadata else None, now, int(run_id)),
+        )
+        event_payload["source"] = "terminal_handoff"
+        _append_event(conn, task_id, event_kind, event_payload, run_id=int(run_id))
+        response = {"task_id": task_id, "run_id": int(run_id), "status": final_status,
+                    "transition": transition, "comment_id": comment_id, "replayed": False}
+        conn.execute(
+            "INSERT INTO terminal_handoffs (task_id, idempotency_key, request_hash, run_id, transition, response_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (task_id, idempotency_key.strip(), request_hash, int(run_id), transition,
+             json.dumps(response, sort_keys=True), now),
+        )
+
+    if transition == "complete":
+        _clear_failure_counter(conn, task_id)
+        recompute_ready(conn)
+        _cleanup_workspace(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_completed" if transition == "complete" else "kanban_task_blocked",
+        task_id, board=get_current_board(), assignee=profile.strip(), run_id=int(run_id),
+        **({"summary": final_summary} if transition == "complete" else {"reason": reason}),
+    )
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_terminal_handoff.py
+++ b/tests/hermes_cli/test_kanban_terminal_handoff.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def claimed(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task_id = kb.create_task(
+        conn, title="external work", assignee="codex-lane",
+        workspace_kind="dir", workspace_path=str(workspace),
+    )
+    task = kb.claim_task(conn, task_id, claimer="claim-123", ttl_seconds=300)
+    assert task is not None
+    current = kb.get_task(conn, task_id)
+    yield conn, task_id, current.current_run_id, workspace
+    conn.close()
+
+
+def _call(claimed, **overrides):
+    conn, task_id, run_id, workspace = claimed
+    args = dict(
+        run_id=run_id, profile="codex-lane", workspace=str(workspace),
+        claim_lock="claim-123", idempotency_key="attempt-1",
+        transition="complete", comment="handoff: tests pass",
+        summary="implemented atomic handoff", metadata={"tests": 6}, result="ok",
+    )
+    args.update(overrides)
+    return kb.terminal_handoff(conn, task_id, **args)
+
+
+def test_complete_commits_comment_result_run_and_events_atomically(claimed):
+    response = _call(claimed)
+    conn, task_id, run_id, _ = claimed
+    task = kb.get_task(conn, task_id)
+    run = kb.latest_run(conn, task_id)
+    assert response == {"task_id": task_id, "run_id": run_id, "status": "done", "transition": "complete", "comment_id": 1, "replayed": False}
+    assert task.status == "done" and task.result == "ok" and task.current_run_id is None
+    assert run.outcome == "completed" and run.summary == "implemented atomic handoff"
+    assert [c.body for c in kb.list_comments(conn, task_id)] == ["handoff: tests pass"]
+    assert [e.kind for e in kb.list_events(conn, task_id)][-2:] == ["commented", "completed"]
+
+
+def test_replay_returns_original_without_duplication(claimed):
+    first = _call(claimed)
+    replay = _call(claimed)
+    conn, task_id, _, _ = claimed
+    assert replay == {**first, "replayed": True}
+    assert len(kb.list_comments(conn, task_id)) == 1
+    assert len([e for e in kb.list_events(conn, task_id) if e.kind == "completed"]) == 1
+
+
+@pytest.mark.parametrize("override, message", [
+    ({"run_id": 999999}, "stale or superseded"),
+    ({"workspace": "/wrong/workspace"}, "workspace does not match"),
+    ({"profile": "wrong-lane"}, "profile does not match"),
+    ({"claim_lock": "reclaimed"}, "claim lock does not match"),
+])
+def test_mismatched_claim_rejects_without_partial_mutation(claimed, override, message):
+    conn, task_id, _, _ = claimed
+    before_events = len(kb.list_events(conn, task_id))
+    with pytest.raises(kb.TerminalHandoffError, match=message):
+        _call(claimed, **override)
+    assert kb.get_task(conn, task_id).status == "running"
+    assert kb.list_comments(conn, task_id) == []
+    assert len(kb.list_events(conn, task_id)) == before_events
+    assert conn.execute("SELECT count(*) FROM terminal_handoffs").fetchone()[0] == 0
+
+
+def test_block_commits_handoff_and_terminal_transition(claimed):
+    response = _call(
+        claimed, transition="block", summary=None, result=None,
+        reason="review-required: inspect diff",
+    )
+    conn, task_id, _, _ = claimed
+    assert response["status"] == "blocked"
+    assert kb.get_task(conn, task_id).status == "blocked"
+    run = kb.latest_run(conn, task_id)
+    assert run.status == "blocked"
+    assert run.outcome == "blocked"
+    assert kb.list_comments(conn, task_id)[0].body == "handoff: tests pass"
+
+
+def test_dependency_block_routes_to_todo_atomically(claimed):
+    response = _call(
+        claimed, transition="block", summary=None, result=None,
+        reason="waiting for parent output", kind="dependency",
+    )
+    conn, task_id, _, _ = claimed
+    task = kb.get_task(conn, task_id)
+    assert response["status"] == "todo"
+    assert task.status == "todo"
+    assert task.block_kind == "dependency"
+    assert task.block_recurrences == 0
+    run = kb.latest_run(conn, task_id)
+    assert run.status == "blocked"
+    assert run.outcome == "blocked"
+    assert [e.kind for e in kb.list_events(conn, task_id)][-2:] == [
+        "commented", "dependency_wait",
+    ]
+
+
+def test_repeated_same_kind_block_escalates_to_triage_atomically(claimed):
+    conn, task_id, _, _ = claimed
+    conn.execute(
+        "UPDATE tasks SET block_kind = ?, block_recurrences = ? WHERE id = ?",
+        ("needs_input", kb.BLOCK_RECURRENCE_LIMIT - 1, task_id),
+    )
+    conn.commit()
+
+    response = _call(
+        claimed, transition="block", summary=None, result=None,
+        reason="still awaiting operator choice", kind="needs_input",
+    )
+    task = kb.get_task(conn, task_id)
+    assert response["status"] == "triage"
+    assert task.status == "triage"
+    assert task.block_kind == "needs_input"
+    assert task.block_recurrences == kb.BLOCK_RECURRENCE_LIMIT
+    assert kb.latest_run(conn, task_id).status == "blocked"
+    assert kb.list_events(conn, task_id)[-1].kind == "block_loop_detected"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -56,7 +56,7 @@ def test_kanban_tools_visible_with_env_var(monkeypatch, tmp_path):
     kanban = {n for n in names if n and n.startswith("kanban_")}
     expected = {
         "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
-        "kanban_comment", "kanban_create", "kanban_link",
+        "kanban_comment", "kanban_handoff", "kanban_create", "kanban_link",
     }
     assert kanban == expected, f"expected {expected}, got {kanban}"
 
@@ -136,7 +136,7 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
     expected = {
         "kanban_list",
         "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
-        "kanban_comment", "kanban_create", "kanban_link",
+        "kanban_comment", "kanban_handoff", "kanban_create", "kanban_link",
         "kanban_unblock",
     }
     assert kanban == expected, f"expected {expected}, got {kanban}"
@@ -730,11 +730,14 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     kb.init_db()
     conn = kb.connect()
     try:
+        workspace = tmp_path / "goal-workspace"
+        workspace.mkdir()
         goal_task_id = kb.create_task(
             conn, title="goal-mode-block-test", assignee="test-worker",
             body="Must achieve X.", goal_mode=True,
+            workspace_kind="dir", workspace_path=str(workspace),
         )
-        kb.claim_task(conn, goal_task_id)
+        kb.claim_task(conn, goal_task_id, claimer="goal-claim")
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
@@ -815,6 +818,80 @@ def test_block_goal_mode_allows_needs_input_kind(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+def _goal_handoff_args(task_id):
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        return {
+            "task_id": task_id, "run_id": task.current_run_id,
+            "profile": "test-worker", "workspace": task.workspace_path,
+            "claim_lock": "goal-claim", "idempotency_key": "goal-handoff-1",
+            "transition": "complete", "comment": "external worker handoff",
+            "summary": "finished",
+        }
+    finally:
+        conn.close()
+
+
+def test_handoff_goal_mode_complete_rejected_by_judge(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(kt, "judge_goal", lambda **kwargs: ("continue", "not done", None))
+    out = json.loads(kt._handle_handoff(_goal_handoff_args(tid)))
+    assert "Goal completion rejected" in out["error"]
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "running"
+        assert kb.list_comments(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_handoff_goal_mode_judge_exception_fails_open(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+
+    def broken_judge(**kwargs):
+        raise RuntimeError("judge unavailable")
+
+    monkeypatch.setattr(kt, "judge_goal", broken_judge)
+    out = json.loads(kt._handle_handoff(_goal_handoff_args(tid)))
+    assert out["ok"] is True
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "done"
+        assert [comment.body for comment in kb.list_comments(conn, tid)] == [
+            "external worker handoff"
+        ]
+    finally:
+        conn.close()
+
+
+def test_handoff_goal_mode_invalid_block_rejected_without_mutation(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    args = _goal_handoff_args(tid)
+    args.update(transition="block", summary=None, reason="giving up", kind="transient")
+    out = json.loads(kt._handle_handoff(args))
+    assert "goal_mode" in out["error"]
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "running"
+        assert kb.list_comments(conn, tid) == []
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -831,6 +831,68 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _handle_handoff(args: dict, **kw) -> str:
+    """Claim-guarded atomic terminal handoff for external worker adapters."""
+    try:
+        kb, conn = _connect(board=args.get("board"))
+        try:
+            transition = str(args.get("transition") or "")
+            kind = args.get("kind")
+            task_id = str(args.get("task_id") or "")
+            task = kb.get_task(conn, task_id)
+            if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
+                return tool_error(
+                    f"kanban_handoff: kind must be one of {sorted(kb.VALID_BLOCK_KINDS)} (or omit it)"
+                )
+            if task and task.goal_mode and transition == "block" and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS:
+                return tool_error(
+                    f"kanban_handoff: goal_mode tasks can only block with kind in "
+                    f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r})"
+                )
+            if task and task.goal_mode and transition == "complete" and _goal_judge_available():
+                verdict = "done"
+                judge_reason = ""
+                try:
+                    judge_result = judge_goal(
+                        goal=f"{task.title}\n\n{task.body or ''}".strip(),
+                        last_response=str(args.get("summary") or args.get("result") or "").strip(),
+                    )
+                    verdict, judge_reason = judge_result[:2]
+                except Exception as judge_exc:
+                    # Mirror kanban_complete: a broken auxiliary judge must
+                    # not wedge an otherwise valid terminal claim.
+                    logger.warning(
+                        "goal judge check failed, allowing atomic handoff: %s",
+                        judge_exc,
+                        exc_info=True,
+                    )
+                if verdict != "done":
+                    return tool_error(
+                        f"kanban_handoff: Goal completion rejected by judge: {judge_reason}"
+                    )
+            response = kb.terminal_handoff(
+                conn, task_id, run_id=int(args.get("run_id")),
+                profile=str(args.get("profile") or ""), workspace=str(args.get("workspace") or ""),
+                claim_lock=str(args.get("claim_lock") or ""),
+                idempotency_key=str(args.get("idempotency_key") or ""),
+                transition=transition,
+                comment=redact_sensitive_text(str(args.get("comment") or ""), force=True),
+                summary=redact_sensitive_text(str(args["summary"]), force=True) if args.get("summary") else None,
+                metadata=args.get("metadata"),
+                result=redact_sensitive_text(str(args["result"]), force=True) if args.get("result") else None,
+                reason=redact_sensitive_text(str(args["reason"]), force=True) if args.get("reason") else None,
+                kind=kind,
+            )
+            return _ok(**response)
+        finally:
+            conn.close()
+    except (TypeError, ValueError) as e:
+        return tool_error(f"kanban_handoff: {e}")
+    except Exception as e:
+        logger.exception("kanban_handoff failed")
+        return tool_error(f"kanban_handoff: {e}")
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -1387,6 +1449,24 @@ KANBAN_COMMENT_SCHEMA = {
     },
 }
 
+KANBAN_HANDOFF_SCHEMA = {
+    "name": "kanban_handoff",
+    "description": "Atomically validate an external worker claim, append its handoff, and complete or block the run. Idempotent retries return the original result.",
+    "parameters": {"type": "object", "properties": {
+        "task_id": {"type": "string"}, "run_id": {"type": "integer"},
+        "profile": {"type": "string"}, "workspace": {"type": "string"},
+        "claim_lock": {"type": "string"}, "idempotency_key": {"type": "string"},
+        "transition": {"type": "string", "enum": ["complete", "block"]},
+        "comment": {"type": "string"}, "summary": {"type": "string"},
+        "metadata": {"type": "object"}, "result": {"type": "string"},
+        "reason": {"type": "string"},
+        "kind": {"type": "string", "enum": ["dependency", "needs_input", "capability", "transient"]},
+        "board": _board_schema_prop(),
+    }, "required": ["task_id", "run_id", "profile", "workspace", "claim_lock",
+                    "idempotency_key", "transition", "comment"]},
+}
+
+
 KANBAN_CREATE_SCHEMA = {
     "name": "kanban_create",
     "description": (
@@ -1642,6 +1722,11 @@ registry.register(
     handler=_handle_comment,
     check_fn=_check_kanban_mode,
     emoji="💬",
+)
+
+registry.register(
+    name="kanban_handoff", toolset="kanban", schema=KANBAN_HANDOFF_SCHEMA,
+    handler=_handle_handoff, check_fn=_check_kanban_mode, emoji="🤝",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -73,7 +73,7 @@ _HERMES_CORE_TOOLS = [
     # tools/kanban_tools.py.
     "kanban_show", "kanban_list",
     "kanban_complete", "kanban_block", "kanban_heartbeat",
-    "kanban_comment", "kanban_create", "kanban_link",
+    "kanban_comment", "kanban_handoff", "kanban_create", "kanban_link",
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
@@ -269,7 +269,7 @@ TOOLSETS = {
         ),
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
-            "kanban_heartbeat", "kanban_comment",
+            "kanban_heartbeat", "kanban_comment", "kanban_handoff",
             "kanban_create", "kanban_link",
             "kanban_unblock",
         ],

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -90,6 +90,32 @@ A specialisation of the profile lane: an orchestrator is a Hermes profile whose 
 
 ## Adding an external CLI worker lane
 
+External adapters should terminate a claim with the atomic handoff interface,
+not separate comment and complete/block calls:
+
+```bash
+hermes kanban handoff "$HERMES_KANBAN_TASK" \
+  --run-id "$HERMES_KANBAN_RUN_ID" \
+  --profile "$HERMES_PROFILE" \
+  --workspace "$HERMES_KANBAN_WORKSPACE" \
+  --claim-lock "$HERMES_KANBAN_CLAIM_LOCK" \
+  --idempotency-key "$ATTEMPT_ID" \
+  --transition complete \
+  --comment 'Structured implementation handoff' \
+  --summary 'Implementation and verification complete' \
+  --metadata '{"changed_files":["src/example.py"],"tests_run":12}'
+```
+
+Use `--transition block --reason 'review-required: ...'` for the blocking
+terminal path. The equivalent agent/MCP operation is `kanban_handoff` with the
+same fields. The kernel validates task id, active run id, assignee/profile,
+canonical workspace, claim lock, and unexpired task/run claims inside one
+SQLite write transaction. That transaction also appends the comment, closes
+the run, writes the terminal event/result, and records the idempotency result.
+A retry with the same key and identical payload returns the original response
+with `replayed: true`; key reuse with a changed payload is rejected. Any stale,
+reclaimed, superseded, or mismatched claim is rejected without partial writes.
+
 Wiring a non-Hermes CLI tool (Codex CLI, Claude Code CLI, OpenCode CLI, a local coding-model runner, etc.) as a kanban worker lane is *not yet a paved path*. The dispatcher's spawn function is pluggable (`spawn_fn` is a parameter on `dispatch_once`), and a plugin could register its own `spawn_fn` for a non-Hermes assignee, but the surrounding integration work — wrapping the CLI's exit code into `kanban_complete` / `kanban_block` calls, mapping the CLI's workspace/sandbox conventions onto the dispatcher's `HERMES_KANBAN_WORKSPACE` env, handling auth and per-CLI policy — is still per-integration design work.
 
 If you're considering adding a CLI lane, open an issue describing the specific CLI and the workflow you're trying to enable. The contract above is the constraints any such lane must satisfy; the implementation shape (one plugin per CLI vs a generic CLI-runner plugin parameterised by config) is open.


### PR DESCRIPTION
## Summary
- add one claim-guarded transactional terminal handoff for complete-or-block worker outcomes
- validate task/run/profile/workspace claims and idempotent replay before mutation
- expose CLI, Kanban tool, ACP/MCP surfaces and document external worker adapter usage

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_terminal_handoff.py tests/tools/test_kanban_tools.py -q` (109 passed)
- focused broader Kanban suite before delivery (978 passed)
- Ruff on all changed Python files
- `git diff --check`

## Review
- independent Claude Opus 4.8/max correctness and security review: APPROVE

Merge remains human-controlled.