### PR TITLE
fix(whatsapp): add timeout to ffmpeg convert communicate

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1235,7 +1235,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await proc.communicate()
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120.0)
             if proc.returncode != 0 or not Path(out_path).exists():
                 logger.error(
                     "[whatsapp_cloud] ffmpeg opus conversion failed "


### PR DESCRIPTION
## Summary

Add a 120s timeout to the asyncio.subprocess.communicate() call in the WhatsApp voice message ffmpeg opus conversion path.

## Problem

If ffmpeg hangs (e.g. on a corrupted or malformed MP3), await proc.communicate() would block indefinitely, freezing the gateway's async event loop and stalling all message processing.

## Fix

Wrap await proc.communicate() with asyncio.wait_for(..., timeout=120.0). A 120s budget is generous enough for any real media conversion while bounding worst-case damage.

## Testing
- Syntax check passed (py_compile)
- Behavior verified