### PR TITLE
fix(gateway): verify launchd relaunch after restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1131,6 +1131,61 @@ def _wait_for_systemd_service_restart(
     return False
 
 
+def _wait_for_launchd_service_restart(
+    *,
+    previous_pid: int | None = None,
+    timeout: float = 30.0,
+) -> bool:
+    """Wait for the launchd-managed gateway to come back after a restart."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    printed_runtime_wait = False
+
+    while time.monotonic() < deadline:
+        if not _probe_launchd_service_running():
+            time.sleep(1)
+            continue
+
+        new_pid = None
+        try:
+            from gateway.status import get_running_pid
+
+            new_pid = get_running_pid()
+        except Exception:
+            new_pid = None
+
+        if new_pid and (previous_pid is None or new_pid != previous_pid):
+            runtime_state = _gateway_runtime_status_for_pid(new_pid)
+            gateway_state = (runtime_state or {}).get("gateway_state")
+            if gateway_state == "running":
+                print(f"✓ Launchd service restarted (PID {new_pid})")
+                return True
+            if gateway_state == "startup_failed":
+                reason = (runtime_state or {}).get("exit_reason") or "startup failed"
+                print(
+                    "⚠ Launchd service process restarted "
+                    f"(PID {new_pid}), but gateway startup failed: {reason}"
+                )
+                return False
+            if not printed_runtime_wait:
+                print(
+                    f"⏳ Launchd service process started (PID {new_pid}); "
+                    "waiting for gateway runtime..."
+                )
+                printed_runtime_wait = True
+
+        time.sleep(1)
+
+    print(
+        f"⚠ Launchd service did not relaunch within {int(timeout)}s.\n"
+        "  Check status: hermes gateway status\n"
+        "  Recover manually:\n"
+        f"    launchctl kickstart {_launchd_domain()}/{get_launchd_label()}"
+    )
+    return False
+
+
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
     result = props.get("Result", "").lower()
     sub_state = props.get("SubState", "").lower()
@@ -4326,8 +4381,15 @@ def launchd_restart():
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
-            _clear_launchd_unsupported_marker()
-            return
+            if _wait_for_launchd_service_restart(
+                previous_pid=pid,
+                timeout=max(drain_timeout + 10.0, 15.0),
+            ):
+                _clear_launchd_unsupported_marker()
+                return
+            print(
+                "⚠ launchd did not relaunch after the graceful restart request — forcing kickstart"
+            )
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway
@@ -4350,6 +4412,12 @@ def launchd_restart():
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        if not _wait_for_launchd_service_restart(previous_pid=pid, timeout=20.0):
+            raise subprocess.CalledProcessError(
+                1,
+                ["launchctl", "kickstart", "-k", target],
+                stderr="launchd accepted the restart request, but the gateway did not relaunch",
+            )
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
     except subprocess.CalledProcessError as e:
@@ -4381,6 +4449,12 @@ def launchd_restart():
                 timeout=30,
             )
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+            if not _wait_for_launchd_service_restart(previous_pid=None, timeout=20.0):
+                raise subprocess.CalledProcessError(
+                    1,
+                    ["launchctl", "kickstart", target],
+                    stderr="launchd reloaded the job, but the gateway did not relaunch",
+                )
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -847,6 +847,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -884,6 +885,7 @@ class TestLaunchdServiceRecovery:
             "_request_gateway_self_restart",
             lambda pid: calls.append(("self", pid)) or True,
         )
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: True)
         monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
@@ -894,6 +896,56 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [("self", 321)]
         assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_recovers_stuck_self_restart_with_kickstart(self, monkeypatch, capsys):
+        calls = []
+        waits = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+
+        wait_results = iter([False, True])
+
+        def fake_wait(**kwargs):
+            waits.append(kwargs)
+            return next(wait_results)
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", fake_wait)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert waits == [
+            {"previous_pid": 321, "timeout": 22.0},
+            {"previous_pid": 321, "timeout": 20.0},
+        ]
+        assert calls == [["launchctl", "kickstart", "-k", target]]
+        out = capsys.readouterr().out.lower()
+        assert "forcing kickstart" in out
+
+    def test_launchd_restart_raises_when_gateway_never_relaunches(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: False)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, check=False, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_restart()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
@@ -1142,6 +1194,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(
             gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
         )
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 


### PR DESCRIPTION
## What does this PR do?

It fixes the launchd side of the restart-survivability gap described in `#62128`.

Today `launchd_restart()` prints `✓ Service restart requested` as soon as the running gateway accepts the graceful self-restart signal, but it never verifies that launchd actually spawned a new gateway process. When launchd gets stuck in the `state = not running` / `pended nondemand spawn = semaphore` state from the report, Hermes treats the restart handoff itself as success and the update flow silently moves on with a dead gateway.

This patch makes the launchd path behave more like the already-hardened systemd path:

- wait for a new gateway PID plus runtime state `running` after a graceful self-restart request;
- if that relaunch never materializes, fall back to `launchctl kickstart -k`;
- fail the restart command if launchd still does not produce a healthy gateway after the fallback, so callers stop reporting success for a dead service.

The desktop self-relaunch behavior from `#62128` is not changed here; this PR narrows to the gateway-survivability half of the bug.

## Related Issue

Refs #62128

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - added `_wait_for_launchd_service_restart(...)` to require a new PID and gateway runtime state before declaring a launchd restart successful;
  - changed `launchd_restart()` so the graceful self-restart path waits for relaunch, falls back to `launchctl kickstart -k` when launchd wedges, and raises an error if the fallback still does not bring the gateway back.
- `tests/hermes_cli/test_gateway_service.py`
  - updated existing launchd restart tests for the new verification step;
  - added regression coverage for the “self-restart accepted but never relaunched” recovery path;
  - added a hard-failure test for the case where launchd never relaunches the gateway even after fallback.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -k 'launchd_restart'`.
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`.
3. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — launchd-only runtime path; other platforms unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- `pytest tests/hermes_cli/test_gateway_service.py -k 'launchd_restart'` -> `7 passed, 183 deselected in 12.33s`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` -> passed
- `git diff --check` -> passed
