### PR TITLE
fix(skills): warn on skill slug collisions instead of silently shadowing

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -374,7 +374,23 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    cmd_key = f"/{cmd_name}"
+                    # Distinct skill names can normalize to the same slash slug
+                    # (e.g. "My Skill" and "my_skill" both -> /my-skill). Keep the
+                    # first one discovered — local skills are scanned before
+                    # external dirs, so local wins — and warn, rather than letting
+                    # a later skill silently shadow it. Mirrors the duplicate-slug
+                    # handling in agent/skill_bundles.py::scan_bundles.
+                    existing = _skill_commands.get(cmd_key)
+                    if existing:
+                        logger.warning(
+                            "Duplicate skill slug %s from %s; keeping %s "
+                            "(skill %r is shadowed and unreachable via %s)",
+                            cmd_key, skill_md, existing["skill_md_path"],
+                            name, cmd_key,
+                        )
+                        continue
+                    _skill_commands[cmd_key] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -113,6 +113,25 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
+    def test_slug_collision_warns_and_keeps_first(self, tmp_path, caplog):
+        """Two distinct skill names that normalize to the same slug must not
+        silently shadow each other — one wins, and the collision is logged."""
+        import logging
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "My Skill")   # name "My Skill" -> /my-skill
+            _make_skill(tmp_path, "my_skill")   # distinct name    -> /my-skill
+            with caplog.at_level(logging.WARNING, logger="agent.skill_commands"):
+                result = scan_skill_commands()
+
+        # Both names collapse to a single slash command (not a silent overwrite
+        # that loses one with no trace).
+        assert "/my-skill" in result
+        assert len(result) == 1
+        assert any(
+            "Duplicate skill slug /my-skill" in r.getMessage() for r in caplog.records
+        )
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"


### PR DESCRIPTION
## What

`scan_skill_commands()` (`agent/skill_commands.py`) dedups discovered skills by frontmatter `name` (`seen_names`, ~line 356) but keys the slash-command map by the normalized **slug** (`_skill_commands[f"/{cmd_name}"]`, ~line 377) via a plain assignment.

Two skills whose **distinct names** normalize to the **same slug** — e.g. `My Skill` and `my_skill` both → `/my-skill` — both pass the name-based dedup, then overwrite each other in the map. Whichever is discovered last silently wins; the other becomes unreachable via its `/slash` command, with **no log line**.

## Fix

Keep the first one discovered (local `SKILLS_DIR` is scanned before external dirs, so local wins — a sensible precedence) and emit a `logger.warning` naming the shadowed skill. This mirrors the duplicate-slug handling already present in `agent/skill_bundles.py::scan_bundles` (`if key in out: logger.warning(...)`), so the two sibling discovery paths now behave consistently.

## Testing

```
scripts/run_tests.sh tests/agent/test_skill_commands.py    # 55 passed
```

Adds `test_slug_collision_warns_and_keeps_first`: two distinct names colliding on one slug yield a single command **plus** a warning, rather than a silent overwrite. (On the pre-fix code the single-command assertion still holds — it's the missing warning that the test catches.)

**Platforms tested:** macOS (Apple Silicon), Python 3.11.