### PR TITLE
fix(acp): honor edit approval timeout

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -33,7 +33,13 @@ class EditProposal:
     arguments: dict[str, Any]
 
 
-EditApprovalRequester = Callable[[EditProposal], bool]
+@dataclass(frozen=True)
+class EditApprovalDecision:
+    approved: bool
+    reason: str = "denied"
+
+
+EditApprovalRequester = Callable[[EditProposal], bool | EditApprovalDecision]
 
 _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
     "ACP_EDIT_APPROVAL_REQUESTER",
@@ -251,12 +257,22 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
         return None
 
     try:
-        approved = bool(requester(proposal))
+        decision = requester(proposal)
     except Exception as exc:
         logger.warning("ACP edit approval requester failed: %s", exc)
-        approved = False
+        decision = EditApprovalDecision(False, "denied")
 
-    if approved:
+    if isinstance(decision, EditApprovalDecision):
+        if decision.approved:
+            return None
+        if decision.reason == "timed_out":
+            return json.dumps(
+                {"error": "Edit approval timed out before the ACP client responded; file was not modified."},
+                ensure_ascii=False,
+            )
+        return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
+
+    if bool(decision):
         return None
     return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
 
@@ -322,17 +338,18 @@ def make_acp_edit_approval_requester(
             log_message="Edit approval request: failed to schedule on loop",
         )
         if future is None:
-            return False
+            return EditApprovalDecision(False, "denied")
         try:
             response = future.result(timeout=timeout)
         except (FutureTimeout, Exception) as exc:
             future.cancel()
             logger.warning("Edit approval request timed out or failed: %s", exc)
-            return False
+            return EditApprovalDecision(False, "timed_out" if isinstance(exc, FutureTimeout) else "denied")
         outcome = getattr(response, "outcome", None)
-        return (
+        approved = (
             getattr(outcome, "outcome", None) == "selected"
             and getattr(outcome, "option_id", None) == "allow_once"
         )
+        return EditApprovalDecision(approved, "denied")
 
     return _requester

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -75,6 +75,7 @@ from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from tools.approval import (
+    _get_approval_timeout,
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
 )
@@ -1426,6 +1427,7 @@ class HermesACPAgent(acp.Agent):
                     conn.request_permission,
                     loop,
                     session_id,
+                    timeout=float(_get_approval_timeout()),
                     auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from acp_adapter.edit_approval import (
+    EditApprovalDecision,
     EditProposal,
     build_acp_edit_tool_call,
     clear_edit_approval_requester,
+    make_acp_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
 )
@@ -128,6 +131,25 @@ def test_requester_exception_denies_and_does_not_mutate(tmp_path):
 
     assert "error" in result
     assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_timeout_decision_surfaces_timeout_error_and_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: EditApprovalDecision(False, "timed_out"))
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-timeout",
+        )
+    )
+
+    assert "error" in result
+    assert "timed out" in result["error"]
     assert target.read_text(encoding="utf-8") == "before\n"
 
 
@@ -267,3 +289,41 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def test_make_requester_timeout_returns_timeout_decision():
+    class _Future:
+        def result(self, timeout=None):
+            raise TimeoutError("timed out")
+
+        def cancel(self):
+            return None
+
+    async def _request_permission(**kwargs):
+        return None
+
+    requester = make_acp_edit_approval_requester(
+        _request_permission,
+        MagicMock(),
+        "session-1",
+        timeout=12.0,
+    )
+
+    proposal = EditProposal(
+        tool_name="write_file",
+        path="demo.txt",
+        old_text="before\n",
+        new_text="after\n",
+        arguments={"path": "demo.txt", "content": "after\n"},
+    )
+
+    def _schedule(coro, loop, logger=None, log_message=None):
+        coro.close()
+        return _Future()
+
+    with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_schedule):
+        decision = requester(proposal)
+
+    assert isinstance(decision, EditApprovalDecision)
+    assert decision.approved is False
+    assert decision.reason == "timed_out"

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1051,6 +1051,43 @@ class TestPrompt:
         assert state.agent.thinking_callback is None
 
     @pytest.mark.asyncio
+    async def test_prompt_uses_configured_edit_approval_timeout(self, agent, monkeypatch):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok",
+            "messages": [],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        mock_conn.request_permission = AsyncMock(return_value=None)
+        agent._conn = mock_conn
+
+        captured: dict[str, object] = {}
+
+        def fake_make_requester(request_permission, loop, session_id, timeout, auto_approve_getter):
+            captured["request_permission"] = request_permission
+            captured["session_id"] = session_id
+            captured["timeout"] = timeout
+            captured["policy"] = auto_approve_getter()
+            return None
+
+        monkeypatch.setattr("acp_adapter.server._get_approval_timeout", lambda: 123)
+        monkeypatch.setattr("acp_adapter.edit_approval.make_acp_edit_approval_requester", fake_make_requester)
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "end_turn"
+        assert captured["request_permission"] is mock_conn.request_permission
+        assert captured["session_id"] == new_resp.session_id
+        assert captured["timeout"] == 123.0
+        assert captured["policy"] == ("ask", ".")
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## What does this PR do?

Fixes ACP edit approval so it honors the configured `approvals.timeout` value and reports an unanswered edit prompt as a timeout instead of an explicit denial.

## Related Issue

Fixes #63302

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Thread `tools.approval._get_approval_timeout()` into the ACP edit approval requester in `acp_adapter/server.py`
- Return a structured ACP edit approval decision so timeout and explicit deny are distinguishable in `acp_adapter/edit_approval.py`
- Surface a timeout-specific tool error when the ACP client never answers the edit prompt
- Add ACP regression tests covering timeout result mapping and server-side timeout wiring

## How to Test

1. Set a long timeout such as `hermes config set approvals.timeout 86400`
2. Start an ACP client that asks before edits, trigger a `write_file` or `patch`, and leave the prompt unanswered
3. Confirm the prompt no longer hard-stops at 60 seconds and that timeout failures report a timeout-specific error instead of `Edit approval denied by ACP client`
4. Run:
   `uv run --python 3.11 --extra dev --extra acp pytest tests/acp/test_edit_approval.py::test_timeout_decision_surfaces_timeout_error_and_does_not_mutate tests/acp/test_edit_approval.py::test_make_requester_timeout_returns_timeout_decision tests/acp/test_server.py::TestPrompt::test_prompt_uses_configured_edit_approval_timeout tests/acp/test_permissions.py::TestApprovalBridge::test_timeout_returns_deny_and_cancels_future`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted ACP timeout proof is recorded in `codex-proof/63302-proof.txt`
