### PR TITLE
fix(desktop): submit first prompt after session creation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -298,6 +298,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
+        // createBackendSessionForSend atomically claims the new runtime/stored
+        // session and may navigate to its route. Treat that as continuation
+        // of this submit, not drift that aborts the first prompt.
+        expectedRuntimeSessionId = sessionId
+        startingStoredSessionId = selectedStoredSessionIdRef.current
+        startingRouteToken = getRouteToken()
+
         if (sessionContextDrifted()) {
           return abortForSessionSwitch(sessionId)
         }
@@ -309,13 +316,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
           return false
         }
-
-        // createBackendSessionForSend atomically claims the new runtime/stored
-        // session and may navigate to its route. Treat that as continuation
-        // of this submit, not drift that aborts the first prompt.
-        expectedRuntimeSessionId = sessionId
-        startingStoredSessionId = selectedStoredSessionIdRef.current
-        startingRouteToken = getRouteToken()
 
         seedOptimistic(sessionId)
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -119,8 +119,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
       const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
-      const startingRouteToken = getRouteToken()
+      // Session creation is part of this submit flow. These baselines are
+      // refreshed after creating a new session so the expected transition to
+      // its stored id/route is not mistaken for an external session switch.
+      let startingStoredSessionId = selectedStoredSessionIdRef.current
+      let startingRouteToken = getRouteToken()
 
       const sessionContextDrifted = (): boolean =>
         selectedStoredSessionIdRef.current !== startingStoredSessionId ||
@@ -292,6 +295,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
           return false
         }
+
+        // createBackendSessionForSend atomically claims the new runtime/stored
+        // session and may navigate to its route. Treat that as continuation
+        // of this submit, not drift that aborts the first prompt.
+        startingStoredSessionId = selectedStoredSessionIdRef.current
+        startingRouteToken = getRouteToken()
 
         seedOptimistic(sessionId)
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -124,10 +124,24 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // its stored id/route is not mistaken for an external session switch.
       let startingStoredSessionId = selectedStoredSessionIdRef.current
       let startingRouteToken = getRouteToken()
+      let expectedRuntimeSessionId = startingActiveSessionId
 
-      const sessionContextDrifted = (): boolean =>
-        selectedStoredSessionIdRef.current !== startingStoredSessionId ||
-        getRouteToken() !== startingRouteToken
+      const sessionContextDrifted = (): boolean => {
+        // Once this submit created its runtime session, title/navigation and
+        // stored-id refs may briefly synchronize in a different order. The
+        // authoritative signal for an external switch is a different live
+        // runtime session; a transient null is still part of the handoff.
+        if (expectedRuntimeSessionId) {
+          const currentRuntimeSessionId = activeSessionIdRef.current
+
+          return Boolean(currentRuntimeSessionId && currentRuntimeSessionId !== expectedRuntimeSessionId)
+        }
+
+        return (
+          selectedStoredSessionIdRef.current !== startingStoredSessionId ||
+          getRouteToken() !== startingRouteToken
+        )
+      }
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
@@ -299,6 +313,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // createBackendSessionForSend atomically claims the new runtime/stored
         // session and may navigate to its route. Treat that as continuation
         // of this submit, not drift that aborts the first prompt.
+        expectedRuntimeSessionId = sessionId
         startingStoredSessionId = selectedStoredSessionIdRef.current
         startingRouteToken = getRouteToken()
 


### PR DESCRIPTION
## What changed

Fix the desktop composer path for the first prompt in a newly created session.

## Root cause

Creating a new session updates the stored-session ID and route as part of the same submit flow. The prompt submit pipeline treated that expected handoff as an external session switch and aborted before sending `prompt.submit`. The first message remained in the composer while the new session received a title.

## Fix

- Track the expected runtime session ID during the handoff.
- Rebase the stored-session and route baselines after session creation.
- Perform the drift check only after the new-session baseline is established.
- Preserve rejection of genuine user-driven session switches.

## Validation

- `npm run build` passed from `apps/desktop`.
- The fix was reproduced on the packaged Windows desktop app and the patched build was manually verified with a new session.
- Only `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` is included in this PR; unrelated local changes were excluded.

## Note

This PR is based on the existing first-submit fix commits and adds the ordering correction needed for the actual Windows reproduction.