### PR TITLE
fix(auth): send Azure api-key header on OpenAI-wire routes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -50,7 +50,11 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import (
+    base_url_host_matches,
+    build_azure_openai_api_key_headers,
+    is_truthy_value,
+)
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -960,6 +964,15 @@ def init_agent(
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
                 except Exception:
                     pass
+            _azure_headers = build_azure_openai_api_key_headers(
+                effective_base,
+                api_key,
+                provider=agent.provider,
+            )
+            if _azure_headers:
+                merged_headers = dict(client_kwargs.get("default_headers") or {})
+                merged_headers.update(_azure_headers)
+                client_kwargs["default_headers"] = merged_headers
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -105,7 +105,14 @@ from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_lengt
 from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    build_azure_openai_api_key_headers,
+    env_float,
+    model_forces_max_completion_tokens,
+    normalize_proxy_env_vars,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2584,6 +2591,13 @@ def _try_azure_foundry(
     _clean_base, _dq = _extract_url_query_params(base_url)
     if _dq:
         extra["default_query"] = _dq
+    _azure_headers = build_azure_openai_api_key_headers(
+        _clean_base,
+        api_key,
+        provider="azure-foundry",
+    )
+    if _azure_headers:
+        extra["default_headers"] = _azure_headers
 
     client = _create_openai_client(api_key=api_key, base_url=_clean_base, **extra)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -210,7 +210,15 @@ from agent.tool_dispatch_helpers import (
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
+from utils import (
+    atomic_json_write,
+    base_url_host_matches,
+    base_url_hostname,
+    build_azure_openai_api_key_headers,
+    env_float,
+    is_truthy_value,
+    model_forces_max_completion_tokens,
+)
 
 
 # Internal flags that mark a message as ephemeral empty-response/prefill
@@ -4461,6 +4469,16 @@ class AIAgent:
                 self._client_kwargs["default_headers"] = _ph_headers
             else:
                 self._client_kwargs.pop("default_headers", None)
+
+        _azure_headers = build_azure_openai_api_key_headers(
+            base_url,
+            self._client_kwargs.get("api_key", ""),
+            provider=self.provider,
+        )
+        if _azure_headers:
+            headers = dict(self._client_kwargs.get("default_headers") or {})
+            headers.update(_azure_headers)
+            self._client_kwargs["default_headers"] = headers
 
         # User-configured overrides win over URL/profile defaults — keep them
         # applied across credential swaps and client rebuilds, not just at

--- a/tests/agent/test_auxiliary_client_azure_foundry.py
+++ b/tests/agent/test_auxiliary_client_azure_foundry.py
@@ -99,6 +99,32 @@ class TestAuxAzureFoundryApiKey:
         assert isinstance(client, _OpenAI)
         assert client.api_key == "sk-azure-static-key"
 
+    def test_chat_completions_apim_domain_adds_api_key_header(
+        self, monkeypatch, patch_load_config,
+    ):
+        from agent import auxiliary_client as _aux
+
+        captured = {}
+
+        class _FakeOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.api_key = kwargs.get("api_key", "")
+                self.base_url = kwargs.get("base_url", "")
+
+        monkeypatch.setattr(_aux, "_create_openai_client", lambda **kwargs: _FakeOpenAI(**kwargs))
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-azure-static-key")
+        patch_load_config({
+            "provider": "azure-foundry",
+            "base_url": "https://apim-n1ai-usw2-89fbd882c.azure-api.net/openai/v1",
+            "api_mode": "chat_completions",
+            "default": "gpt-4o",
+        })
+        client, resolved = _aux._try_azure_foundry(model="gpt-4o")
+        assert client is not None
+        assert resolved == "gpt-4o"
+        assert captured["default_headers"]["api-key"] == "sk-azure-static-key"
+
     def test_codex_responses_wraps_in_codex_aux_client(self, monkeypatch, patch_load_config):
         from agent.auxiliary_client import _try_azure_foundry, CodexAuxiliaryClient
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -323,6 +323,40 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_azure_foundry_apim_base_url_adds_api_key_header(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="azure-static-key",
+        base_url="https://apim-n1ai-usw2-89fbd882c.azure-api.net/openai/v1",
+        model="gpt-5.4",
+        provider="azure-foundry",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["api-key"] == "azure-static-key"
+
+
+@patch("run_agent.OpenAI")
+def test_custom_azure_apim_base_url_adds_api_key_header(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="azure-static-key",
+        base_url="https://apim-n1ai-usw2-89fbd882c.azure-api.net/openai/v1",
+        model="gpt-5.4",
+        provider="custom",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["api-key"] == "azure-static-key"
+
+
+@patch("run_agent.OpenAI")
 def test_copilot_enterprise_base_url_applies_copilot_default_headers(mock_openai):
     """Enterprise Copilot endpoints (api.<tenant>.githubcopilot.com) must apply
     the same default_headers — including Copilot-Integration-Id: vscode-chat —

--- a/utils.py
+++ b/utils.py
@@ -544,3 +544,41 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+def build_azure_openai_api_key_headers(
+    base_url: str,
+    api_key: Any,
+    *,
+    provider: str | None = None,
+) -> dict[str, str]:
+    """Return Azure-compatible static-key headers for OpenAI-wire endpoints."""
+    if callable(api_key) and not isinstance(api_key, str):
+        return {}
+
+    key = str(api_key or "").strip()
+    if not key:
+        return {}
+
+    normalized_provider = str(provider or "").strip().lower()
+    if normalized_provider == "azure-foundry":
+        return {"api-key": key}
+
+    raw = (base_url or "").strip()
+    if not raw:
+        return {}
+
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        return {}
+
+    path = (parsed.path or "").lower()
+    host_padded = f".{host}."
+    if ".openai.azure." in host_padded:
+        return {"api-key": key}
+    if ".azure-api.net." in host_padded and "/openai" in path:
+        return {"api-key": key}
+    if ".services.ai.azure." in host_padded and "/openai" in path:
+        return {"api-key": key}
+    return {}


### PR DESCRIPTION
## What does this PR do?

Fixes Azure OpenAI-style `chat_completions` auth for static API-key deployments that require the literal `api-key` header instead of bearer-only auth.

The OpenAI SDK still sends `Authorization: Bearer <key>` for string `api_key` values. That breaks Azure APIM front doors such as `*.azure-api.net/openai/v1`, which reject the request unless `api-key` is present. This PR layers `api-key` on top of the existing OpenAI-wire client setup for:

- `provider: azure-foundry` static-key runtimes
- custom OpenAI-compatible endpoints hosted behind Azure APIM / Azure OpenAI host families

Callable Entra ID token-provider paths are explicitly left alone, so bearer JWTs are not mirrored into `api-key`.

## Related Issue

Fixes #63303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `build_azure_openai_api_key_headers(...)` in `utils.py` to decide when OpenAI-wire clients should also send `api-key`
- Applied that helper in the main `AIAgent` initialization path in `agent/agent_init.py`
- Applied the same header injection during client-header rebuilds in `run_agent.py`
- Applied the same behavior to Azure auxiliary-client resolution in `agent/auxiliary_client.py`
- Added regression coverage for both `azure-foundry` and `custom + *.azure-api.net/openai/v1` in:
  - `tests/run_agent/test_provider_attribution_headers.py`
  - `tests/agent/test_auxiliary_client_azure_foundry.py`

## How to Test

1. Reproduce the issue with an Azure APIM OpenAI-compatible endpoint like `https://<name>.azure-api.net/openai/v1` and a static API key.
2. Run:
   - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/run_agent/test_provider_attribution_headers.py`
   - `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/agent/test_auxiliary_client_azure_foundry.py`
3. Confirm OpenAI-wire clients for Azure static-key paths now include `api-key`, while callable Entra ID auth still uses bearer-only semantics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `tests/run_agent/test_provider_attribution_headers.py`: `17 passed in 25.17s`
- `tests/agent/test_auxiliary_client_azure_foundry.py`: `10 passed in 0.61s`
- `py_compile` on touched files: passed
- `git diff --check`: passed
