### PR TITLE
fix(auth): add azure api-key headers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -50,7 +50,11 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import (
+    azure_openai_api_key_headers,
+    base_url_host_matches,
+    is_truthy_value,
+)
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -960,6 +964,11 @@ def init_agent(
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
                 except Exception:
                     pass
+            azure_headers = azure_openai_api_key_headers(effective_base, api_key)
+            if azure_headers:
+                merged_headers = dict(client_kwargs.get("default_headers") or {})
+                merged_headers.update(azure_headers)
+                client_kwargs["default_headers"] = merged_headers
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -105,7 +105,14 @@ from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_lengt
 from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
+from utils import (
+    azure_openai_api_key_headers,
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    model_forces_max_completion_tokens,
+    normalize_proxy_env_vars,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +190,11 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     # by default and let Hermes control the budget; explicit callers can still
     # override via kwargs.
     kwargs.setdefault("max_retries", 0)
+    azure_headers = azure_openai_api_key_headers(base_url, api_key)
+    if azure_headers:
+        merged_headers = dict(kwargs.get("default_headers") or {})
+        merged_headers.update(azure_headers)
+        kwargs["default_headers"] = merged_headers
     return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
 
 
@@ -4364,6 +4376,11 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
+    azure_headers = azure_openai_api_key_headers(sync_base_url, sync_client.api_key)
+    if azure_headers:
+        merged_headers = dict(async_kwargs.get("default_headers") or {})
+        merged_headers.update(azure_headers)
+        async_kwargs["default_headers"] = merged_headers
     _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"))
     if _merged_async:
         async_kwargs["default_headers"] = _merged_async

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -17,7 +17,12 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname
+from utils import (
+    atomic_json_write,
+    azure_openai_api_key_headers,
+    base_url_host_matches,
+    base_url_hostname,
+)
 
 from hermes_constants import OPENROUTER_MODELS_URL
 
@@ -925,6 +930,7 @@ def fetch_endpoint_model_metadata(
         candidates.append(alternate)
 
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    headers.update(azure_openai_api_key_headers(normalized, api_key))
     last_error: Optional[Exception] = None
 
     if is_local_endpoint(normalized):

--- a/run_agent.py
+++ b/run_agent.py
@@ -210,7 +210,15 @@ from agent.tool_dispatch_helpers import (
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
+from utils import (
+    atomic_json_write,
+    azure_openai_api_key_headers,
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    is_truthy_value,
+    model_forces_max_completion_tokens,
+)
 
 
 # Internal flags that mark a message as ephemeral empty-response/prefill
@@ -4461,6 +4469,15 @@ class AIAgent:
                 self._client_kwargs["default_headers"] = _ph_headers
             else:
                 self._client_kwargs.pop("default_headers", None)
+
+        azure_headers = azure_openai_api_key_headers(
+            base_url,
+            self._client_kwargs.get("api_key", ""),
+        )
+        if azure_headers:
+            merged_headers = dict(self._client_kwargs.get("default_headers") or {})
+            merged_headers.update(azure_headers)
+            self._client_kwargs["default_headers"] = merged_headers
 
         # User-configured overrides win over URL/profile defaults — keep them
         # applied across credential swaps and client rebuilds, not just at

--- a/tests/agent/test_auxiliary_client_azure_foundry.py
+++ b/tests/agent/test_auxiliary_client_azure_foundry.py
@@ -99,6 +99,32 @@ class TestAuxAzureFoundryApiKey:
         assert isinstance(client, _OpenAI)
         assert client.api_key == "sk-azure-static-key"
 
+    def test_apim_chat_completions_adds_api_key_default_header(self, monkeypatch, patch_load_config):
+        from agent import auxiliary_client as _aux
+
+        received = {}
+
+        class _FakeOpenAI:
+            def __init__(self, **kwargs):
+                received.update(kwargs)
+                self.api_key = kwargs.get("api_key", "")
+                self.base_url = kwargs.get("base_url", "")
+
+        monkeypatch.setattr(_aux, "OpenAI", _FakeOpenAI)
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-azure-static-key")
+        patch_load_config({
+            "provider": "azure-foundry",
+            "base_url": "https://campus-gateway.azure-api.net/openai/v1",
+            "api_mode": "chat_completions",
+            "default": "gpt-4o",
+        })
+
+        client, resolved = _aux._try_azure_foundry(model="gpt-4o")
+
+        assert client is not None
+        assert resolved == "gpt-4o"
+        assert received["default_headers"]["api-key"] == "sk-azure-static-key"
+
     def test_codex_responses_wraps_in_codex_aux_client(self, monkeypatch, patch_load_config):
         from agent.auxiliary_client import _try_azure_foundry, CodexAuxiliaryClient
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -638,6 +638,41 @@ class TestFetchEndpointModelMetadataLmStudio:
         assert result["publisher/model-a"]["context_length"] == 65536
 
 
+class TestFetchEndpointModelMetadataAzureApim:
+    """Azure APIM-fronted OpenAI endpoints need the native api-key header."""
+
+    def _make_resp(self, body):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = body
+        return resp
+
+    def test_adds_api_key_header_for_azure_apim(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        response = self._make_resp(
+            {
+                "data": [
+                    {"id": "gpt-5.4", "context_length": 400000},
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("agent.model_metadata.requests.get", return_value=response) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "https://campus-gateway.azure-api.net/openai/v1",
+                api_key="azure-static-key",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_args.kwargs["headers"] == {
+            "Authorization": "Bearer azure-static-key",
+            "api-key": "azure-static-key",
+        }
+        assert "gpt-5.4" in result
+
+
 class TestQueryLocalContextLengthNetworkError:
     """_query_local_context_length handles network failures gracefully."""
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -178,6 +178,25 @@ def test_unknown_base_url_clears_default_headers(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_azure_apim_base_url_adds_api_key_header(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="azure-static-key",
+        base_url="https://campus-gateway.azure-api.net/openai/v1",
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent._client_kwargs["default_headers"]["api-key"] == "azure-static-key"
+
+    agent._apply_client_headers_for_base_url("https://campus-gateway.azure-api.net/openai/v1")
+
+    assert agent._client_kwargs["default_headers"]["api-key"] == "azure-static-key"
+
+
+@patch("run_agent.OpenAI")
 def test_openrouter_headers_include_response_cache_when_enabled(mock_openai):
     """When openrouter.response_cache is True, the cache header is injected."""
     mock_openai.return_value = MagicMock()

--- a/tests/test_base_url_hostname.py
+++ b/tests/test_base_url_hostname.py
@@ -8,7 +8,11 @@ tests/agent/test_direct_provider_url_detection.py.
 
 from __future__ import annotations
 
-from utils import base_url_hostname, base_url_host_matches
+from utils import (
+    azure_openai_api_key_headers,
+    base_url_hostname,
+    base_url_host_matches,
+)
 
 
 # ─── base_url_hostname ────────────────────────────────────────────────────
@@ -158,3 +162,33 @@ class TestOllamaUrlHostCheck:
         assert base_url_host_matches(
             "https://api.ollama.com/v1", "ollama.com"
         ) is True
+
+
+class TestAzureOpenaiApiKeyHeaders:
+    def test_openai_azure_resource_host_gets_api_key_header(self):
+        assert azure_openai_api_key_headers(
+            "https://resource.openai.azure.com/openai/v1",
+            "azure-key",
+        ) == {"api-key": "azure-key"}
+
+    def test_azure_apim_host_gets_api_key_header(self):
+        assert azure_openai_api_key_headers(
+            "https://campus-gateway.azure-api.net/openai/v1",
+            "azure-key",
+        ) == {"api-key": "azure-key"}
+
+    def test_non_azure_host_returns_empty(self):
+        assert azure_openai_api_key_headers(
+            "https://api.openai.com/v1",
+            "openai-key",
+        ) == {}
+
+    def test_callable_or_placeholder_key_returns_empty(self):
+        assert azure_openai_api_key_headers(
+            "https://resource.openai.azure.com/openai/v1",
+            lambda: "jwt",
+        ) == {}
+        assert azure_openai_api_key_headers(
+            "https://campus-gateway.azure-api.net/openai/v1",
+            "no-key-required",
+        ) == {}

--- a/utils.py
+++ b/utils.py
@@ -544,3 +544,29 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+def azure_openai_api_key_headers(base_url: str, api_key: Any) -> dict[str, str]:
+    """Return Azure OpenAI-compatible static-key headers for *base_url*.
+
+    Azure OpenAI's native API-key contract uses the literal ``api-key``
+    header. Most OpenAI-compatible clients send only
+    ``Authorization: Bearer <key>`` when given a static key, which fails on
+    Azure API Management gateways fronting Azure OpenAI / Foundry resources.
+
+    For Azure OpenAI resource hosts (``*.openai.azure.com``) and APIM hosts
+    (``*.azure-api.net``), attach the additional ``api-key`` header when the
+    credential is a static string. Callable token providers (Microsoft Entra
+    ID) intentionally return ``{}`` so bearer-only auth remains unchanged.
+    """
+    if not isinstance(api_key, str):
+        return {}
+    token = api_key.strip()
+    if not token or token == "no-key-required":
+        return {}
+    if not (
+        base_url_host_matches(base_url, "openai.azure.com")
+        or base_url_host_matches(base_url, "azure-api.net")
+    ):
+        return {}
+    return {"api-key": token}


### PR DESCRIPTION
## What does this PR do?

Adds Azure OpenAI-compatible `api-key` headers for static-key requests sent to
Azure OpenAI resource hosts and Azure API Management gateways. Hermes was only
sending `Authorization: Bearer <key>` on OpenAI-compatible paths, which causes
APIM-fronted Azure OpenAI / Foundry deployments to reject requests with HTTP
401 even though the same endpoint succeeds with `api-key: <key>`.

## Related Issue

Fixes #63303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `utils.azure_openai_api_key_headers(...)` to detect Azure OpenAI /
  Azure APIM hosts and produce the native `api-key` header for static keys.
- Applied that helper in the main agent client setup paths:
  `run_agent.py`, `agent/agent_init.py`, and auxiliary OpenAI client creation
  in `agent/auxiliary_client.py`, including async rebuilds.
- Updated `agent/model_metadata.py` so `/models` metadata probes against Azure
  APIM/OpenAI-compatible endpoints also send `api-key`.
- Added focused regressions in:
  `tests/test_base_url_hostname.py`,
  `tests/run_agent/test_provider_attribution_headers.py`,
  `tests/agent/test_auxiliary_client_azure_foundry.py`,
  `tests/agent/test_model_metadata_local_ctx.py`.

## How to Test

1. Configure `provider: azure-foundry` or a custom OpenAI-compatible base URL
   that points at `https://<gateway>.azure-api.net/openai/v1` with a static API key.
2. Run a Hermes request or metadata probe; Hermes should now send both the
   existing Authorization bearer header and the Azure-native `api-key` header.
3. Verify the focused regressions still pass:
   `uv run --python ./.venv/bin/python --extra dev pytest tests/test_base_url_hostname.py -k 'AzureOpenaiApiKeyHeaders'`
   plus the three targeted Azure/APIM tests recorded in the proof file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused proof is recorded in `codex-proof/63303-proof.txt`.
