### PR TITLE
feat(agent): pre_persist_user_message hook — agent-path ingress

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -477,6 +477,10 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    # One-shot signal: set by the pre_persist hook below only when its returns
+    # must correct an already-durable staged user row in place (CLI close path).
+    # Reset each turn so a prior turn's flag can never leak forward.
+    agent._persist_user_message_durable_rewrite = None
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
@@ -663,7 +667,19 @@ def build_turn_context(
         # `is not None` so it is a no-op when no override was set.
         _ov = getattr(agent, "_persist_user_message_override", None)
         if _pp and _ov is not None and not isinstance(_ov, list):
-            agent._persist_user_message_override = _compose_pre_persist_returns(_ov, _pp)
+            _composed_override = _compose_pre_persist_returns(_ov, _pp)
+            agent._persist_user_message_override = _composed_override
+            # If this staged user dict was ALREADY written durably (the CLI
+            # close safety-net persists the pending dict and stamps it
+            # `_db_persisted` before this turn's hook runs), the append-only
+            # flush will SKIP it on marker — the recomposed override above never
+            # reaches the durable row. Flag a one-shot in-place correction the
+            # flush applies instead of skipping (see
+            # AIAgent._flush_messages_to_session_db). No-op on the ordinary path
+            # where the dict is not yet persisted (flush writes it fresh).
+            from run_agent import _DB_PERSISTED_MARKER
+            if _pp and user_msg.get(_DB_PERSISTED_MARKER):
+                agent._persist_user_message_durable_rewrite = _composed_override
     except Exception as exc:
         logger.warning("pre_persist_user_message hook failed: %s", exc)
     user_msg["content"] = user_message

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -334,6 +334,39 @@ class TurnContext:
     preflight_compression_blocked: bool = False
 
 
+def _compose_pre_persist_returns(user_message, results):
+    """Compose pre_persist_user_message plugin returns into user_message. Pure.
+
+    Order: (1) winning ``user_message`` replace — highest ``data.priority``,
+    ties → first (stable) — sets the body; (2) ``{"context"}`` dicts and bare
+    strings appended raw at the tail (back-compat, unwrapped). A return of
+    ``None`` is ignored.
+    """
+    replaces, raw_tail = [], []
+    for r in results:
+        if isinstance(r, str):
+            if r.strip():
+                raw_tail.append(r)
+            continue
+        if not isinstance(r, dict):
+            continue
+        if r.get("context"):
+            raw_tail.append(str(r["context"]))
+        if r.get("user_message") is not None:
+            replaces.append((int((r.get("data") or {}).get("priority", 0)),
+                             str(r["user_message"])))
+    if replaces:
+        if len(replaces) > 1:
+            logger.warning("pre_persist_user_message: %d user_message "
+                           "replacements; highest priority (ties->first) wins",
+                           len(replaces))
+        replaces.sort(key=lambda t: -t[0])  # stable: ties keep original order
+        user_message = replaces[0][1]
+    if raw_tail:
+        user_message = user_message + "\n\n" + "\n\n".join(raw_tail)
+    return user_message
+
+
 def build_turn_context(
     agent,
     user_message: Any,
@@ -597,6 +630,43 @@ def build_turn_context(
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             should_review_memory = True
             agent._turns_since_memory = 0
+
+    # Plugin hook: pre_persist_user_message — agent-path ingress. Fragments
+    # returned here are folded into user_message BEFORE the turn's
+    # crash-resilience persist and the API call, so they land on the wire
+    # — the agent-path analogue of the gateway's pre_gateway_dispatch
+    # event.text mutation. Runs after the CLI-staged handoff match and the
+    # original_user_message capture above, both of which must see the raw
+    # (pre-hook) text; user_msg is already in `messages`, so the composed
+    # body is written back into the dict in place.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _pp = _invoke_hook(
+            "pre_persist_user_message",
+            session_id=agent.session_id or "",
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            user_message=user_message,
+            conversation_history=messages[:current_turn_user_idx],
+            platform=getattr(agent, "platform", None) or "",
+            sender_id=getattr(agent, "_user_id", None) or "",
+        )
+        user_message = _compose_pre_persist_returns(user_message, _pp)
+        # Returns are 'pre_persist' by contract — they must reach the persisted
+        # DB row, not only this turn's wire. The gateway may set a persist
+        # override to the pre-hook message (agent._persist_user_message_override,
+        # consumed by _apply_persist_user_message_override); the session flush
+        # writes THAT to the DB row. Without re-composing the returns onto it,
+        # an injected block reaches the API the turn it fires, then vanishes
+        # from replayed history next turn (the row held the raw body). Skip
+        # multimodal (list) content, mirroring the override applier. Guarded on
+        # `is not None` so it is a no-op when no override was set.
+        _ov = getattr(agent, "_persist_user_message_override", None)
+        if _pp and _ov is not None and not isinstance(_ov, list):
+            agent._persist_user_message_override = _compose_pre_persist_returns(_ov, _pp)
+    except Exception as exc:
+        logger.warning("pre_persist_user_message hook failed: %s", exc)
+    user_msg["content"] = user_message
 
     # Cosmetic side-signal: detect an affection "reaction" (ily / <3 / good bot)
     # and notify the host so it can play hearts. Token-free, never touches the

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -427,6 +427,39 @@ class TurnContext:
     preflight_compression_blocked: bool = False
 
 
+def _compose_pre_persist_returns(user_message, results):
+    """Compose pre_persist_user_message plugin returns into user_message. Pure.
+
+    Order: (1) winning ``user_message`` replace — highest ``data.priority``,
+    ties → first (stable) — sets the body; (2) ``{"context"}`` dicts and bare
+    strings appended raw at the tail (back-compat, unwrapped). A return of
+    ``None`` is ignored.
+    """
+    replaces, raw_tail = [], []
+    for r in results:
+        if isinstance(r, str):
+            if r.strip():
+                raw_tail.append(r)
+            continue
+        if not isinstance(r, dict):
+            continue
+        if r.get("context"):
+            raw_tail.append(str(r["context"]))
+        if r.get("user_message") is not None:
+            replaces.append((int((r.get("data") or {}).get("priority", 0)),
+                             str(r["user_message"])))
+    if replaces:
+        if len(replaces) > 1:
+            logger.warning("pre_persist_user_message: %d user_message "
+                           "replacements; highest priority (ties->first) wins",
+                           len(replaces))
+        replaces.sort(key=lambda t: -t[0])  # stable: ties keep original order
+        user_message = replaces[0][1]
+    if raw_tail:
+        user_message = user_message + "\n\n" + "\n\n".join(raw_tail)
+    return user_message
+
+
 def build_turn_context(
     agent,
     user_message: Any,
@@ -690,6 +723,43 @@ def build_turn_context(
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             should_review_memory = True
             agent._turns_since_memory = 0
+
+    # Plugin hook: pre_persist_user_message — agent-path ingress. Fragments
+    # returned here are folded into user_message BEFORE the turn's
+    # crash-resilience persist and the API call, so they land on the wire
+    # — the agent-path analogue of the gateway's pre_gateway_dispatch
+    # event.text mutation. Runs after the CLI-staged handoff match and the
+    # original_user_message capture above, both of which must see the raw
+    # (pre-hook) text; user_msg is already in `messages`, so the composed
+    # body is written back into the dict in place.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _pp = _invoke_hook(
+            "pre_persist_user_message",
+            session_id=agent.session_id or "",
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            user_message=user_message,
+            conversation_history=messages[:current_turn_user_idx],
+            platform=getattr(agent, "platform", None) or "",
+            sender_id=getattr(agent, "_user_id", None) or "",
+        )
+        user_message = _compose_pre_persist_returns(user_message, _pp)
+        # Returns are 'pre_persist' by contract — they must reach the persisted
+        # DB row, not only this turn's wire. The gateway may set a persist
+        # override to the pre-hook message (agent._persist_user_message_override,
+        # consumed by _apply_persist_user_message_override); the session flush
+        # writes THAT to the DB row. Without re-composing the returns onto it,
+        # an injected block reaches the API the turn it fires, then vanishes
+        # from replayed history next turn (the row held the raw body). Skip
+        # multimodal (list) content, mirroring the override applier. Guarded on
+        # `is not None` so it is a no-op when no override was set.
+        _ov = getattr(agent, "_persist_user_message_override", None)
+        if _pp and _ov is not None and not isinstance(_ov, list):
+            agent._persist_user_message_override = _compose_pre_persist_returns(_ov, _pp)
+    except Exception as exc:
+        logger.warning("pre_persist_user_message hook failed: %s", exc)
+    user_msg["content"] = user_message
 
     # Cosmetic side-signal: detect an affection "reaction" (ily / <3 / good bot)
     # and notify the host so it can play hearts. Token-free, never touches the

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -570,6 +570,10 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    # One-shot signal: set by the pre_persist hook below only when its returns
+    # must correct an already-durable staged user row in place (CLI close path).
+    # Reset each turn so a prior turn's flag can never leak forward.
+    agent._persist_user_message_durable_rewrite = None
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
@@ -756,7 +760,19 @@ def build_turn_context(
         # `is not None` so it is a no-op when no override was set.
         _ov = getattr(agent, "_persist_user_message_override", None)
         if _pp and _ov is not None and not isinstance(_ov, list):
-            agent._persist_user_message_override = _compose_pre_persist_returns(_ov, _pp)
+            _composed_override = _compose_pre_persist_returns(_ov, _pp)
+            agent._persist_user_message_override = _composed_override
+            # If this staged user dict was ALREADY written durably (the CLI
+            # close safety-net persists the pending dict and stamps it
+            # `_db_persisted` before this turn's hook runs), the append-only
+            # flush will SKIP it on marker — the recomposed override above never
+            # reaches the durable row. Flag a one-shot in-place correction the
+            # flush applies instead of skipping (see
+            # AIAgent._flush_messages_to_session_db). No-op on the ordinary path
+            # where the dict is not yet persisted (flush writes it fresh).
+            from run_agent import _DB_PERSISTED_MARKER
+            if _pp and user_msg.get(_DB_PERSISTED_MARKER):
+                agent._persist_user_message_durable_rewrite = _composed_override
     except Exception as exc:
         logger.warning("pre_persist_user_message hook failed: %s", exc)
     user_msg["content"] = user_message

--- a/docs/pre-persist-user-message-hook.md
+++ b/docs/pre-persist-user-message-hook.md
@@ -1,0 +1,117 @@
+# `pre_persist_user_message` hook
+
+Agent-path ingress seam. Fires once per user turn in `build_turn_context`, **before**
+the inbound user message is appended and persisted. It is the agent-path analogue of
+the gateway's `pre_gateway_dispatch` (which mutates `event.text`): a plugin can fold
+context into the user turn on paths that never go through the gateway (CLI, subagent,
+agent-to-agent). Unlike `pre_llm_call` — whose returns are ephemeral — returns here
+reach **both the wire and the persisted session-DB row**.
+
+## Kwargs
+
+The hook is called with:
+
+```
+session_id, task_id, turn_id, user_message, conversation_history, platform, sender_id
+```
+
+## Return contract
+
+Each registered plugin returns one of:
+
+| Return | Effect |
+|--------|--------|
+| `None` | ignored |
+| `{"context": str}` / bare `str` | appended at the tail |
+| `{"user_message": str, "data": {"priority": int}}` | replaces the body |
+
+Composition (`_compose_pre_persist_returns`) is a pure function over all plugin
+returns:
+
+- **Append** — every `{"context"}`/`str` fragment is joined by blank lines and
+  appended at the tail, in plugin-iteration order. Several plugins each adding a note
+  all land, no coordinator needed.
+- **Replace** — among `{"user_message": ...}` returns the highest `data.priority`
+  wins (ties → first, stable); a warning is logged if more than one plugin replaces.
+  This is the escape hatch for a plugin that owns the *whole* body (e.g. it has placed
+  one fragment before the user text and another after). Symmetric to
+  `transform_llm_output` on the egress side.
+- **The two compose** — a winning replace sets the body, and append fragments still
+  stack at the tail *on top of it*. Replace competes only with other replaces, never
+  with appends, so a body-owning plugin and a simple note-appender coexist.
+
+The composed result is also re-applied to `_persist_user_message_override` so an
+injected block survives into replayed history instead of vanishing next turn.
+
+Additive and off by default: with no plugin registered, the compose is a no-op.
+
+## Example 1 — minimal append
+
+```python
+# plugin __init__.py
+"""Append a one-line banner to the persisted user turn ({"context"} shape)."""
+
+def register(ctx):
+    def _on_pre_persist(**wire):
+        if not (wire.get("user_message") or "").strip():
+            return None
+        return {"context": "[example] seen this turn"}
+    ctx.register_hook("pre_persist_user_message", _on_pre_persist)
+```
+
+```yaml
+# plugin.yaml
+name: pre-persist-example
+version: "0.1.0"
+kind: standalone
+description: Minimal example of the pre_persist_user_message hook (append shape).
+provides_hooks: [pre_persist_user_message]
+provides_tools: []
+```
+
+## Example 2 — an ordering hub (why the replace path exists)
+
+A ~25-line hub built on top of the hook. Other plugins register a
+`(priority, producer)` with it; the hub runs them, sorts fragments by priority, and
+returns **one** composed body via the replace path. Append alone cannot do this — it
+can never place a fragment above the user text — which is why the contract needs
+`user_message` replace.
+
+```python
+# plugin __init__.py
+"""Order multi-plugin fragments into one body via the replace path."""
+
+_SUBS = {}  # name -> (priority, producer(wire) -> str | None)
+
+def subscribe(name, priority, producer):
+    """Any plugin calls this (plain import) to contribute a fragment."""
+    _SUBS[name] = (priority, producer)
+
+def register(ctx):
+    def _compose(**wire):
+        base = wire.get("user_message") or ""
+        frags = []
+        for name, (prio, produce) in _SUBS.items():
+            try:
+                out = produce(wire)          # one bad producer never sinks the rest
+            except Exception:
+                continue
+            if out:
+                frags.append((prio, name, out))
+        if not frags:
+            return None
+        frags.sort(key=lambda t: (t[0], t[1]))          # by priority, then name
+        body = base + "\n\n" + "\n\n".join(f[2] for f in frags)
+        return {"user_message": body, "data": {"priority": 100}}   # own the body
+    ctx.register_hook("pre_persist_user_message", _compose)
+```
+
+```yaml
+# plugin.yaml
+name: inject-ordering-hub
+version: "0.1.0"
+kind: standalone
+description: Example hub — orders multi-plugin injects into one body via the replace path.
+provides_hooks: [pre_persist_user_message]
+provides_tools: []
+```

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -175,6 +175,14 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Agent-path ingress hook. Fired once per user turn in build_turn_context,
+    # BEFORE the inbound user message is appended and persisted (unlike
+    # pre_llm_call, which fires after the crash-resilience persist and whose
+    # context is ephemeral). Plugins return {"context": "..."} or a str; the
+    # host joins all non-None returns and appends them to user_message so they
+    # persist to the session DB (and thus onto the wire). Kwargs: session_id,
+    # task_id, turn_id, user_message, conversation_history, platform, sender_id.
+    "pre_persist_user_message",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -174,6 +174,14 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Agent-path ingress hook. Fired once per user turn in build_turn_context,
+    # BEFORE the inbound user message is appended and persisted (unlike
+    # pre_llm_call, which fires after the crash-resilience persist and whose
+    # context is ephemeral). Plugins return {"context": "..."} or a str; the
+    # host joins all non-None returns and appends them to user_message so they
+    # persist to the session DB (and thus onto the wire). Kwargs: session_id,
+    # task_id, turn_id, user_message, conversation_history, platform, sender_id.
+    "pre_persist_user_message",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7225,6 +7225,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def update_active_message_content(
+        self,
+        session_id: str,
+        content: Any,
+        *,
+        role: str = "user",
+    ) -> bool:
+        """Correct the content of the newest active row of *role* in place.
+
+        A ``pre_persist_user_message`` hook can compose durable context onto a
+        user message whose dict was ALREADY written to the store: the CLI close
+        safety-net (:meth:`cli.HermesCLI._persist_active_session_before_close`)
+        persists the staged user dict and stamps it ``_db_persisted`` before the
+        turn's hook runs. The append-only turn flush
+        (:meth:`run_agent.AIAgent._flush_messages_to_session_db`) then skips that
+        marked dict, so the injected context reaches the live prompt but never
+        the durable row.
+
+        This performs a targeted in-place UPDATE of the most recent active row
+        for *role* (ordered by ``id``, i.e. insertion order), correcting the
+        durable body WITHOUT inserting a second row — the exactly-once
+        persistence invariant is preserved (the staged user turn stays a single
+        row). The ``messages_fts*`` triggers re-index the row automatically on
+        UPDATE.
+
+        Returns ``True`` if a row was updated, ``False`` if no matching active
+        row exists.
+        """
+        encoded = self._encode_content(content)
+
+        def _do(conn) -> bool:
+            row = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND role = ? AND active = 1 "
+                "ORDER BY id DESC LIMIT 1",
+                (session_id, role),
+            ).fetchone()
+            if row is None:
+                return False
+            conn.execute(
+                "UPDATE messages SET content = ? WHERE id = ?",
+                (encoded, row[0]),
+            )
+            return True
+
+        return self._execute_write(_do)
+
     def has_archived_messages(self, session_id: str) -> bool:
         """Return True if the session has any soft-archived (``active = 0``) rows.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8269,6 +8269,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def update_active_message_content(
+        self,
+        session_id: str,
+        content: Any,
+        *,
+        role: str = "user",
+    ) -> bool:
+        """Correct the content of the newest active row of *role* in place.
+
+        A ``pre_persist_user_message`` hook can compose durable context onto a
+        user message whose dict was ALREADY written to the store: the CLI close
+        safety-net (:meth:`cli.HermesCLI._persist_active_session_before_close`)
+        persists the staged user dict and stamps it ``_db_persisted`` before the
+        turn's hook runs. The append-only turn flush
+        (:meth:`run_agent.AIAgent._flush_messages_to_session_db`) then skips that
+        marked dict, so the injected context reaches the live prompt but never
+        the durable row.
+
+        This performs a targeted in-place UPDATE of the most recent active row
+        for *role* (ordered by ``id``, i.e. insertion order), correcting the
+        durable body WITHOUT inserting a second row — the exactly-once
+        persistence invariant is preserved (the staged user turn stays a single
+        row). The ``messages_fts*`` triggers re-index the row automatically on
+        UPDATE.
+
+        Returns ``True`` if a row was updated, ``False`` if no matching active
+        row exists.
+        """
+        encoded = self._encode_content(content)
+
+        def _do(conn) -> bool:
+            row = conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND role = ? AND active = 1 "
+                "ORDER BY id DESC LIMIT 1",
+                (session_id, role),
+            ).fetchone()
+            if row is None:
+                return False
+            conn.execute(
+                "UPDATE messages SET content = ? WHERE id = ?",
+                (encoded, row[0]),
+            )
+            return True
+
+        return self._execute_write(_do)
+
     def has_archived_messages(self, session_id: str) -> bool:
         """Return True if the session has any soft-archived (``active = 0``) rows.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2104,6 +2104,41 @@ class AIAgent:
                 ):
                     _scan_start += 1
 
+            # A pre_persist_user_message hook may have composed durable context
+            # onto a staged user dict that was ALREADY written and marked by the
+            # CLI close safety-net (_persist_active_session_before_close), before
+            # this turn's hook ran. The append-only scan below cannot re-write a
+            # marked row, so the injected block would reach the live prompt but
+            # not the durable row. Correct that ONE row in place.
+            #
+            # Deliberately handled HERE, ahead of the scan, rather than off the
+            # marked-row branch inside it: `_scan_start` skips an
+            # identity-matched prefix, and the close safety-net's own flush puts
+            # exactly that staged dict into the prefix — so the loop never visits
+            # the row that needs correcting. The signal is one-shot (set in
+            # build_turn_context only when the staged dict was already persisted)
+            # and consumed here, and update_active_message_content targets the
+            # newest active user row itself, so no positional match is needed and
+            # no second row is ever inserted — the staged user turn stays exactly
+            # one row.
+            _durable_rewrite = getattr(
+                self, "_persist_user_message_durable_rewrite", None
+            )
+            if _durable_rewrite is not None:
+                self._persist_user_message_durable_rewrite = None
+                _session_db = getattr(self, "_session_db", None)
+                if _session_db is not None and current_session_id:
+                    try:
+                        _session_db.update_active_message_content(
+                            current_session_id, _durable_rewrite
+                        )
+                    except Exception:
+                        logger.warning(
+                            "pre_persist durable rewrite failed for session=%s",
+                            current_session_id,
+                            exc_info=True,
+                        )
+
             # Collect this flush's new rows and write them in ONE transaction
             # at the end of the scan (see append_messages_batch).
             _batch_rows: List[Dict[str, Any]] = []

--- a/run_agent.py
+++ b/run_agent.py
@@ -2111,6 +2111,41 @@ class AIAgent:
                 ):
                     _scan_start += 1
 
+            # A pre_persist_user_message hook may have composed durable context
+            # onto a staged user dict that was ALREADY written and marked by the
+            # CLI close safety-net (_persist_active_session_before_close), before
+            # this turn's hook ran. The append-only scan below cannot re-write a
+            # marked row, so the injected block would reach the live prompt but
+            # not the durable row. Correct that ONE row in place.
+            #
+            # Deliberately handled HERE, ahead of the scan, rather than off the
+            # marked-row branch inside it: `_scan_start` skips an
+            # identity-matched prefix, and the close safety-net's own flush puts
+            # exactly that staged dict into the prefix — so the loop never visits
+            # the row that needs correcting. The signal is one-shot (set in
+            # build_turn_context only when the staged dict was already persisted)
+            # and consumed here, and update_active_message_content targets the
+            # newest active user row itself, so no positional match is needed and
+            # no second row is ever inserted — the staged user turn stays exactly
+            # one row.
+            _durable_rewrite = getattr(
+                self, "_persist_user_message_durable_rewrite", None
+            )
+            if _durable_rewrite is not None:
+                self._persist_user_message_durable_rewrite = None
+                _session_db = getattr(self, "_session_db", None)
+                if _session_db is not None and current_session_id:
+                    try:
+                        _session_db.update_active_message_content(
+                            current_session_id, _durable_rewrite
+                        )
+                    except Exception:
+                        logger.warning(
+                            "pre_persist durable rewrite failed for session=%s",
+                            current_session_id,
+                            exc_info=True,
+                        )
+
             # Collect this flush's new rows and write them in ONE transaction
             # at the end of the scan (see append_messages_batch).
             _batch_rows: List[Dict[str, Any]] = []

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -38,6 +38,18 @@ from hermes_state import SessionDB
 # compose_user_api_content — the single source of the injection composition
 # ---------------------------------------------------------------------------
 
+# ``invoke_hook`` fans out by hook NAME — one stub answering every name with the
+# same payload also feeds ``pre_persist_user_message``, whose returns are
+# *durable* and are composed into ``content`` (that hook's whole point). These
+# tests pin the opposite invariant: ``content`` stays clean and the composed
+# body lives in the ``api_content`` sidecar. So scope the stub to the hook it
+# actually models — the ephemeral ``pre_llm_call`` context injection.
+def _pre_llm_call_context(*results):
+    def _stub(hook_name, **_kwargs):
+        return list(results) if hook_name == "pre_llm_call" else []
+    return _stub
+
+
 class TestComposeUserApiContent:
     def test_none_when_nothing_to_inject(self):
         assert compose_user_api_content("hello", "", "") is None
@@ -250,7 +262,7 @@ class TestPrologueStamping:
         agent = _FakeAgent()
         with patch(
             "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
+            _pre_llm_call_context({"context": "PLUGIN-CTX"}),
         ):
             ctx = _build(agent)
         msg = ctx.messages[ctx.current_turn_user_idx]
@@ -276,7 +288,7 @@ class TestPrologueStamping:
         agent.api_mode = "codex_app_server"
         with patch(
             "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
+            _pre_llm_call_context({"context": "PLUGIN-CTX"}),
         ):
             ctx = _build(agent)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
@@ -577,7 +589,7 @@ class TestPrologueMoaAndInPlaceBackfill:
         agent = _FakeAgent()
         with patch(
             "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
+            _pre_llm_call_context({"context": "PLUGIN-CTX"}),
         ):
             ctx = _build(agent, moa_active=True)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
@@ -630,7 +642,7 @@ class TestPrologueMoaAndInPlaceBackfill:
         ]
         with patch(
             "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
+            _pre_llm_call_context({"context": "PLUGIN-CTX"}),
         ):
             ctx = _build(agent, conversation_history=history)
 

--- a/tests/agent/test_compose_pre_persist_returns.py
+++ b/tests/agent/test_compose_pre_persist_returns.py
@@ -1,0 +1,74 @@
+"""Unit tests for ``_compose_pre_persist_returns`` — the pure composer behind the
+``pre_persist_user_message`` hook. No host state needed."""
+
+from agent.turn_context import _compose_pre_persist_returns as compose
+
+
+def test_context_and_bare_str_both_append_at_tail():
+    out = compose("hi", [{"context": "a"}, "b"])
+    assert out == "hi\n\na\n\nb"
+
+
+def test_append_order_follows_result_order():
+    out = compose("base", ["first", {"context": "second"}, "third"])
+    assert out == "base\n\nfirst\n\nsecond\n\nthird"
+
+
+def test_user_message_replaces_body():
+    out = compose("original", [{"user_message": "brand new"}])
+    assert out == "brand new"
+
+
+def test_highest_priority_replace_wins():
+    out = compose(
+        "x",
+        [
+            {"user_message": "low", "data": {"priority": 1}},
+            {"user_message": "high", "data": {"priority": 9}},
+        ],
+    )
+    assert out == "high"
+
+
+def test_replace_ties_keep_first():
+    out = compose(
+        "x",
+        [
+            {"user_message": "first", "data": {"priority": 5}},
+            {"user_message": "second", "data": {"priority": 5}},
+        ],
+    )
+    assert out == "first"
+
+
+def test_multiple_replaces_logs_warning(caplog):
+    with caplog.at_level("WARNING"):
+        compose(
+            "x",
+            [
+                {"user_message": "a", "data": {"priority": 1}},
+                {"user_message": "b", "data": {"priority": 2}},
+            ],
+        )
+    assert any("user_message" in r.message for r in caplog.records)
+
+
+def test_replace_sets_body_then_appends_still_apply():
+    # A replace picks the body (among replaces); context/str appends still stack
+    # at the tail on top of the winning body — they are not discarded.
+    out = compose(
+        "orig",
+        [{"context": "tail note"}, {"user_message": "owned body"}],
+    )
+    assert out == "owned body\n\ntail note"
+
+
+def test_none_and_empty_and_non_dict_ignored():
+    assert compose("keep", [None]) == "keep"
+    assert compose("keep", [{}]) == "keep"
+    assert compose("keep", [{"context": ""}]) == "keep"
+    assert compose("keep", [123]) == "keep"
+
+
+def test_no_returns_is_identity():
+    assert compose("unchanged", []) == "unchanged"

--- a/tests/agent/test_gateway_turn_sidecar.py
+++ b/tests/agent/test_gateway_turn_sidecar.py
@@ -24,6 +24,18 @@ from agent.turn_context import (
 )
 
 
+# ``invoke_hook`` fans out by hook NAME — one stub answering every name with the
+# same payload also feeds ``pre_persist_user_message``, whose returns are
+# *durable* and are composed into ``content`` (that hook's whole point). These
+# tests pin the opposite invariant: ``content`` stays clean and the composed
+# body lives in the ``api_content`` sidecar. So scope the stub to the hook it
+# actually models — the ephemeral ``pre_llm_call`` context injection.
+def _pre_llm_call_context(*results):
+    def _stub(hook_name, **_kwargs):
+        return list(results) if hook_name == "pre_llm_call" else []
+    return _stub
+
+
 class _FakeTodoStore:
     def has_items(self):
         return True
@@ -168,7 +180,7 @@ class TestStringContentSidecarDelivery:
         agent._gateway_turn_context_notes = VC_NOTE
         with patch(
             "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
+            _pre_llm_call_context({"context": "PLUGIN-CTX"}),
         ):
             ctx = _build(agent)
         msg = ctx.messages[ctx.current_turn_user_idx]

--- a/tests/agent/test_pre_persist_durable_row.py
+++ b/tests/agent/test_pre_persist_durable_row.py
@@ -1,0 +1,255 @@
+"""Integration coverage for the pre_persist_user_message hook's durable contract.
+
+The pure composition of hook returns is unit-tested in
+``test_compose_pre_persist_returns.py``. These tests drive the REAL persistence
+seam (``build_turn_context`` -> ``_persist_session`` ->
+``_flush_messages_to_session_db`` -> SQLite) to prove the hook's returns reach
+the *durable* session row, not only this turn's live prompt:
+
+1. The ordinary early-persistence path: a fresh staged user turn is written with
+   the injected block.
+2. The already-close-persisted staged-user path: the CLI close safety-net can
+   persist and mark the staged user dict BEFORE this turn's hook runs. The
+   append-only flush then skips that marked dict, so the durable row must be
+   corrected in place (``update_active_message_content``) without inserting a
+   second row — preserving the exactly-once persistence invariant.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+
+def _real_agent(db, session_id, session_messages):
+    """Build the real persistence seam without the heavyweight LLM client.
+
+    Mirrors the harness in tests/cli/test_cli_shutdown_memory_messages.py.
+    """
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    agent.platform = "cli"
+    agent.model = "test-model"
+    agent._session_messages = session_messages
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_disabled = False
+    agent._cached_system_prompt = "test system prompt"
+    agent._session_init_model_config = None
+    agent._parent_session_id = None
+    agent._session_json_enabled = False
+    agent._pending_cli_user_message = None
+    agent._session_persist_lock = threading.RLock()
+    return agent
+
+
+def _configure_for_turn(agent):
+    """Stub the per-turn setup collaborators build_turn_context touches."""
+    agent.quiet_mode = True
+    agent.max_iterations = 1
+    agent.provider = "test"
+    agent.base_url = ""
+    agent.api_key = ""
+    agent.api_mode = "chat_completions"
+    agent.tools = []
+    agent.valid_tool_names = set()
+    agent.enabled_toolsets = None
+    agent.disabled_toolsets = None
+    agent._skip_mcp_refresh = True
+    agent.compression_enabled = False
+    agent.context_compressor = types.SimpleNamespace(protect_first_n=2, protect_last_n=2)
+    agent._memory_store = None
+    agent._memory_manager = None
+    agent._memory_nudge_interval = 0
+    agent._turns_since_memory = 0
+    agent._user_turn_count = 0
+    agent._todo_store = types.SimpleNamespace(has_items=lambda: True)
+    agent._tool_guardrails = types.SimpleNamespace(reset_for_turn=lambda: None)
+    agent._compression_warning = None
+    agent._interrupt_requested = False
+    agent._memory_write_origin = "assistant_tool"
+    agent._stream_context_scrubber = None
+    agent._stream_think_scrubber = None
+    agent._restore_primary_runtime = lambda: None
+    agent._cleanup_dead_connections = lambda: False
+    agent._emit_status = lambda _message: None
+    agent._replay_compression_warning = lambda: None
+    agent._hydrate_todo_store = lambda *_args: None
+    agent._safe_print = lambda *_args: None
+
+
+def _build_turn(agent, prefix, user_message, persist_user_message):
+    from agent.turn_context import build_turn_context
+
+    return build_turn_context(
+        agent,
+        user_message,
+        None,
+        prefix,
+        "task",
+        None,
+        persist_user_message,
+        None,
+        restore_or_build_system_prompt=lambda *_args: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda value: value,
+        summarize_user_message_for_log=lambda value: value,
+        set_session_context=lambda _session_id: None,
+        set_current_write_origin=lambda _origin: None,
+        ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *_args: None),
+    )
+
+
+def _inject_recall_hook(hook_name, **_kwargs):
+    """Fake plugin dispatcher: a pre_persist plugin that appends a recall block."""
+    if hook_name == "pre_persist_user_message":
+        return [{"context": "[Mem] recall"}]
+    return None
+
+
+def test_pre_persist_returns_reach_durable_row_on_early_persist(tmp_path, monkeypatch):
+    """A fresh staged user turn persists WITH the injected block (early persist)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "pre-persist-early"
+    db.create_session(session_id=session_id, source="cli")
+    prefix = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent = _real_agent(db, session_id, prefix)
+    agent._flush_messages_to_session_db(prefix, [])
+
+    staged = {"role": "user", "content": "new prompt"}
+    agent._pending_cli_user_message = staged
+    _configure_for_turn(agent)
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _inject_recall_hook)
+
+    worker = _build_turn(agent, prefix, "new prompt", "new prompt")
+
+    # The live prompt carries the injection this turn.
+    assert worker.messages[-1] is staged
+    assert worker.messages[-1]["content"] == "new prompt\n\n[Mem] recall"
+
+    # The durable row carries it too — the whole point of a *pre_persist* hook.
+    stored = db.get_messages_as_conversation(session_id)
+    assert [m["content"] for m in stored] == [
+        "old prompt",
+        "old answer",
+        "new prompt\n\n[Mem] recall",
+    ]
+
+
+def test_pre_persist_corrects_close_marked_staged_row_in_place(tmp_path, monkeypatch):
+    """Close-persisted staged user row is corrected in place, not duplicated.
+
+    The CLI close safety-net writes the clean staged dict and stamps it
+    ``_db_persisted`` before this turn's hook runs. The append-only flush would
+    otherwise skip that marked dict, leaving the injected context out of the
+    durable row. The hook path must correct that one row in place.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    import cli as cli_mod
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "pre-persist-close-marked"
+    db.create_session(session_id=session_id, source="cli")
+    prefix = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent = _real_agent(db, session_id, prefix)
+    agent._flush_messages_to_session_db(prefix, [])
+
+    staged = {"role": "user", "content": "new prompt"}
+    agent._pending_cli_user_message = staged
+
+    # CLI close safety-net: persist + mark the clean staged dict.
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.conversation_history = list(prefix) + [staged]
+    cli.session_id = session_id
+    cli.agent = agent
+    cli._persist_active_session_before_close()
+    assert staged["_db_persisted"] is True
+    pre_hook_stored = db.get_messages_as_conversation(session_id)
+    assert [m["content"] for m in pre_hook_stored] == [
+        "old prompt",
+        "old answer",
+        "new prompt",
+    ]
+
+    # Now a worker turn reuses that marked dict; the pre_persist hook injects.
+    _configure_for_turn(agent)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _inject_recall_hook)
+
+    worker = _build_turn(agent, prefix, "new prompt", "new prompt")
+    assert worker.messages[-1] is staged
+    assert worker.messages[-1]["content"] == "new prompt\n\n[Mem] recall"
+
+    # The already-durable row is corrected in place: injection is now durable
+    # AND there is still exactly one row for this user turn (no duplicate).
+    stored = db.get_messages_as_conversation(session_id)
+    assert [m["content"] for m in stored] == [
+        "old prompt",
+        "old answer",
+        "new prompt\n\n[Mem] recall",
+    ]
+
+
+def test_close_marked_staged_row_untouched_when_hook_is_silent(tmp_path, monkeypatch):
+    """No hook returns => no in-place rewrite; the clean durable row is kept.
+
+    Guards the exactly-once/clean-row invariant the correction must not disturb
+    on the ordinary (no-injection) path.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    import cli as cli_mod
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "pre-persist-close-marked-silent"
+    db.create_session(session_id=session_id, source="cli")
+    prefix = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent = _real_agent(db, session_id, prefix)
+    agent._flush_messages_to_session_db(prefix, [])
+
+    staged = {"role": "user", "content": "new prompt"}
+    agent._pending_cli_user_message = staged
+
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.conversation_history = list(prefix) + [staged]
+    cli.session_id = session_id
+    cli.agent = agent
+    cli._persist_active_session_before_close()
+    assert staged["_db_persisted"] is True
+
+    _configure_for_turn(agent)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook", lambda *_a, **_k: None
+    )
+
+    _build_turn(agent, prefix, "new prompt", "new prompt")
+
+    stored = db.get_messages_as_conversation(session_id)
+    assert [m["content"] for m in stored] == [
+        "old prompt",
+        "old answer",
+        "new prompt",
+    ]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -605,7 +605,8 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [ephemeral context injection](#pre_llm_call-context-injection) |
+| [`pre_persist_user_message`](/user-guide/features/hooks#pre_persist_user_message) | Once per turn, before the inbound user message is persisted | `session_id: str, turn_id: str, user_message: str, conversation_history: list, platform: str, sender_id: str` | [durable context injection](/user-guide/features/hooks#pre_persist_user_message) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
@@ -615,7 +616,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which injects **ephemeral** context into the conversation (this turn's prompt only); `pre_persist_user_message`, which injects **durable** context that is written to the persisted user-message row (see the [Event Hooks reference](/user-guide/features/hooks#pre_persist_user_message)); and `pre_tool_call`, which can return a block/approve directive.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
@@ -623,7 +624,7 @@ The kanban lifecycle hooks fire **after** the board DB change commits, so a call
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context. The injection is **ephemeral** — it reaches the API call for this turn only and is never persisted. For context that must survive into the durable transcript, use [`pre_persist_user_message`](/user-guide/features/hooks#pre_persist_user_message) instead.
 
 #### Return format
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -666,7 +666,8 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [ephemeral context injection](#pre_llm_call-context-injection) |
+| [`pre_persist_user_message`](/user-guide/features/hooks#pre_persist_user_message) | Once per turn, before the inbound user message is persisted | `session_id: str, turn_id: str, user_message: str, conversation_history: list, platform: str, sender_id: str` | [durable context injection](/user-guide/features/hooks#pre_persist_user_message) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
@@ -676,7 +677,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which injects **ephemeral** context into the conversation (this turn's prompt only); `pre_persist_user_message`, which injects **durable** context that is written to the persisted user-message row (see the [Event Hooks reference](/user-guide/features/hooks#pre_persist_user_message)); and `pre_tool_call`, which can return a block/approve directive.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
@@ -684,7 +685,7 @@ The kanban lifecycle hooks fire **after** the board DB change commits, so a call
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context. The injection is **ephemeral** — it reaches the API call for this turn only and is never persisted. For context that must survive into the durable transcript, use [`pre_persist_user_message`](/user-guide/features/hooks#pre_persist_user_message) instead.
 
 #### Return format
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -383,7 +383,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Three hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject ephemeral context** into the LLM call, and [`pre_persist_user_message`](#pre_persist_user_message) can **inject durable context** that is written to the persisted user-message row. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -392,7 +392,8 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
-| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
+| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend **ephemeral** context to the user message |
+| [`pre_persist_user_message`](#pre_persist_user_message) | Once per turn, before the inbound user message is persisted | `{"context": str}` / `{"user_message": str, ...}` to fold **durable** context into the persisted row |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -522,7 +523,7 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. Its return value injects **ephemeral** context into the current turn's user message — added at API call time only, never persisted (contrast [`pre_persist_user_message`](#pre_persist_user_message), which injects **durable** context into the persisted row).
 
 **Callback signature:**
 
@@ -598,6 +599,84 @@ def guardrails(**kwargs):
 
 def register(ctx):
     ctx.register_hook("pre_llm_call", guardrails)
+```
+
+---
+
+### `pre_persist_user_message`
+
+Fires **once per turn**, on the agent path, just before the inbound user message is appended and persisted to the session store. Where [`pre_llm_call`](#pre_llm_call) injects **ephemeral** context (added at API-call time only, never written to disk), `pre_persist_user_message` injects **durable** context: its returns are folded into the user message that is written to the session-database row, so the injected block **replays as part of the conversation on later turns and after a restart**.
+
+This is the agent-path analogue of the gateway's [`pre_gateway_dispatch`](#pre_gateway_dispatch) `rewrite`, which mutates the inbound event text before it is dispatched and persisted. Use it when a plugin's context must survive into the durable transcript (e.g. memory recall that should remain visible in replayed history), not just this turn's prompt.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, turn_id: str, user_message: str,
+                conversation_history: list, platform: str,
+                sender_id: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | `str` | Unique identifier for the current session |
+| `turn_id` | `str` | Unique identifier for this turn |
+| `task_id` | `str` | The effective task identifier for this turn |
+| `user_message` | `str` | The user's message for this turn, before this hook's composition |
+| `conversation_history` | `list` | Copy of the message list **before** this turn's user message (OpenAI format) |
+| `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
+| `sender_id` | `str` | The sender's identifier, when the host knows it (else empty) |
+
+**Fires:** In `agent/turn_context.py`, inside `build_turn_context()`, after the staged user message is resolved but before the turn's crash-resilience persist and first API call.
+
+**Return value:** Two composable shapes (see `_compose_pre_persist_returns`):
+
+- **Append** — a dict with a `"context"` key, or a plain non-empty string, is appended to the user message (highest-priority replace body first, then appends). This is the common case, symmetric with `pre_llm_call`.
+- **Replace** — a dict `{"user_message": str, "data": {"priority": int}}` replaces the body outright; the highest `priority` wins, ties resolve to the first plugin in discovery order. A winning replace and any appends both apply.
+
+Return `None` for no change. Injected context reaches **both** this turn's prompt and the persisted row.
+
+```python
+# Append durable recall (most common)
+return {"context": "Recalled context:\n- User prefers Python"}
+
+# Plain string (equivalent append)
+return "Recalled context:\n- User prefers Python"
+
+# Replace the persisted body (highest priority wins)
+return {"user_message": "[redacted]", "data": {"priority": 100}}
+
+# No change
+return None
+```
+
+When **multiple plugins** return context, appends are joined with double newlines in plugin discovery order (alphabetical by directory name), after any winning replace.
+
+**Use cases:** Durable memory recall, inbound message normalization/redaction that must persist, agent-path ingress enrichment mirroring gateway `rewrite`.
+
+**Example — durable memory recall:**
+
+```python
+import httpx
+
+MEMORY_API = "https://your-memory-api.example.com"
+
+def recall(session_id, user_message, **kwargs):
+    try:
+        resp = httpx.post(f"{MEMORY_API}/recall", json={
+            "session_id": session_id,
+            "query": user_message,
+        }, timeout=3)
+        memories = resp.json().get("results", [])
+        if not memories:
+            return None
+        text = "Recalled context:\n" + "\n".join(f"- {m['text']}" for m in memories)
+        return {"context": text}
+    except Exception:
+        return None
+
+def register(ctx):
+    ctx.register_hook("pre_persist_user_message", recall)
 ```
 
 ---

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -398,6 +398,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; first string replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
+| `pre_persist_user_message` | Directive/control | Once per turn on the agent path, before the inbound user message is appended and persisted; a `{"user_message": ...}` return replaces the body (highest `data.priority` wins), and string/`{"context": ...}` returns are appended. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `platform`, `sender_id` | Full user message and conversation history; unlike `pre_llm_call`, returns are written to the durable session-store row. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
 | `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
@@ -534,7 +535,7 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. All valid callback returns are aggregated in plugin order and injected into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. All valid callback returns are aggregated in plugin order and injected into the current turn's user message. The injection is **ephemeral** — added at API-call time only, never written to the persisted row (contrast [`pre_persist_user_message`](#pre_persist_user_message), whose returns are **durable**).
 
 **Callback signature:**
 
@@ -610,6 +611,84 @@ def guardrails(**kwargs):
 
 def register(ctx):
     ctx.register_hook("pre_llm_call", guardrails)
+```
+
+---
+
+### `pre_persist_user_message`
+
+Fires **once per turn**, on the agent path, just before the inbound user message is appended and persisted to the session store. Where [`pre_llm_call`](#pre_llm_call) injects **ephemeral** context (added at API-call time only, never written to disk), `pre_persist_user_message` injects **durable** context: its returns are folded into the user message that is written to the session-database row, so the injected block **replays as part of the conversation on later turns and after a restart**.
+
+This is the agent-path analogue of the gateway's [`pre_gateway_dispatch`](#pre_gateway_dispatch) `rewrite`, which mutates the inbound event text before it is dispatched and persisted. Use it when a plugin's context must survive into the durable transcript (e.g. memory recall that should remain visible in replayed history), not just this turn's prompt.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, turn_id: str, user_message: str,
+                conversation_history: list, platform: str,
+                sender_id: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | `str` | Unique identifier for the current session |
+| `turn_id` | `str` | Unique identifier for this turn |
+| `task_id` | `str` | The effective task identifier for this turn |
+| `user_message` | `str` | The user's message for this turn, before this hook's composition |
+| `conversation_history` | `list` | Copy of the message list **before** this turn's user message (OpenAI format) |
+| `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
+| `sender_id` | `str` | The sender's identifier, when the host knows it (else empty) |
+
+**Fires:** In `agent/turn_context.py`, inside `build_turn_context()`, after the staged user message is resolved but before the turn's crash-resilience persist and first API call.
+
+**Return value:** Two composable shapes (see `_compose_pre_persist_returns`):
+
+- **Append** — a dict with a `"context"` key, or a plain non-empty string, is appended to the user message (highest-priority replace body first, then appends). This is the common case, symmetric with `pre_llm_call`.
+- **Replace** — a dict `{"user_message": str, "data": {"priority": int}}` replaces the body outright; the highest `priority` wins, ties resolve to the first plugin in discovery order. A winning replace and any appends both apply.
+
+Return `None` for no change. Injected context reaches **both** this turn's prompt and the persisted row.
+
+```python
+# Append durable recall (most common)
+return {"context": "Recalled context:\n- User prefers Python"}
+
+# Plain string (equivalent append)
+return "Recalled context:\n- User prefers Python"
+
+# Replace the persisted body (highest priority wins)
+return {"user_message": "[redacted]", "data": {"priority": 100}}
+
+# No change
+return None
+```
+
+When **multiple plugins** return context, appends are joined with double newlines in plugin discovery order (alphabetical by directory name), after any winning replace.
+
+**Use cases:** Durable memory recall, inbound message normalization/redaction that must persist, agent-path ingress enrichment mirroring gateway `rewrite`.
+
+**Example — durable memory recall:**
+
+```python
+import httpx
+
+MEMORY_API = "https://your-memory-api.example.com"
+
+def recall(session_id, user_message, **kwargs):
+    try:
+        resp = httpx.post(f"{MEMORY_API}/recall", json={
+            "session_id": session_id,
+            "query": user_message,
+        }, timeout=3)
+        memories = resp.json().get("results", [])
+        if not memories:
+            return None
+        text = "Recalled context:\n" + "\n".join(f"- {m['text']}" for m in memories)
+        return {"context": text}
+    except Exception:
+        return None
+
+def register(ctx):
+    ctx.register_hook("pre_persist_user_message", recall)
 ```
 
 ---


### PR DESCRIPTION
## What

Adds `pre_persist_user_message` — a plugin hook fired **once per user turn** in `build_turn_context`, **before** the inbound user message is appended and persisted. Returns are folded into `user_message` via a pure composer (`_compose_pre_persist_returns`), then also re-applied to `_persist_user_message_override` so an injected block survives into replayed history.

Additive and off by default: with no plugin registered, the compose is a no-op.

## Why a hook here at all

The gateway already has `pre_gateway_dispatch` for platform ingress — but that only fires on the gateway path. Direct agent invocations (CLI, subagents, agent-to-agent) never go through it, so **there is no supported seam to add per-turn context on the agent path**. Today a plugin that wants this has to monkey-patch `build_turn_context`. This is the symmetric, supported counterpart to `pre_gateway_dispatch`.

## Why *persist*, not `pre_llm_call`

`pre_llm_call` already lets a plugin add context — but its returns are **ephemeral**: they reach the wire for that one call and are never written to the session-DB row. So injected context vanishes from replayed history on the next turn. This hook folds the return into `user_message` *before persistence*, so the context reaches **both the wire and the stored row** and is stable across replays. That durability is the whole point of doing it at persist time.

## Why this contract shape (append **and** replace)

Two return shapes, because there are two genuinely different needs, and several plugins should be able to share a turn with **no coordinator**:

- `{"context": str}` / bare `str` → **appended at the tail**. This is the common case — a few plugins each adding a note. They all stack (joined by blank lines, iteration order); nobody coordinates. Free, weak, sufficient for "add a line."
- `{"user_message": str, "data": {"priority": int}}` → **replaces the body**. Some plugins need to own the *whole* message — e.g. place one fragment *before* the user text and another *after*. Append physically cannot do that (it only ever adds a tail). So a plugin that has already composed the final body needs a way to hand it back. `priority` (highest wins, ties → first) is the minimal tiebreak when two plugins both claim the body — symmetric to `transform_llm_output` on the egress side.
- **They compose**: a winning replace sets the body, and tail appends still stack on top of it. Replace competes only with other replaces, never with appends — so a body-owner and a simple note-appender coexist without stepping on each other.

## Why keep the core generic (no ordering policy)

The host deliberately knows only *append* and *replace-by-priority*. Deterministic multi-plugin **ordering** (slots, "this fragment above that one") is a *policy* — different deployments want different orders — so it does not belong in core. Anything richer is a plugin-space pattern built **on top** of this primitive: the second example (`docs/pre-persist-user-message-hook.md`) is a ~25-line ordering hub that lets several plugins register `(priority, producer)`, sorts their fragments, and returns one composed body via the replace path. The core stays unopinionated; the composition policy lives in a plugin. This is exactly why the replace path matters — it's what lets such a hub own the body.

## History

Supersedes #58814 (closed by us). That first cut was append-only; it was approved as a clean seam, but we closed it because append alone can't do head/tail placement. This reopens the idea with the richer-but-still-generic contract above.

## Ships

- `agent/turn_context.py` — the hook call + pure `_compose_pre_persist_returns` composer.
- `hermes_cli/plugins.py` — `pre_persist_user_message` in `VALID_HOOKS`.
- `docs/pre-persist-user-message-hook.md` — contract doc + two example plugins (minimal `{"context"}` appender; the ordering hub).
- `tests/agent/test_compose_pre_persist_returns.py` — pure-composer coverage: append stacking, replace-by-priority, ties-keep-first, warning on >1 replace, replace+append composition, ignored `None`/empty/non-dict.
