### PR TITLE
fix: gate Ollama think/reasoning_effort on model's declared capabilities

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -8,12 +8,70 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
+  - Ollama backends are additionally gated on the model's declared
+    /api/show capabilities: non-thinking models (e.g. llama3.3:70b)
+    400 with "does not support thinking" if think/reasoning_effort is
+    sent at all, so we probe and skip both fields when unsupported.
 """
 
+import json
+import time as _time
+import urllib.request
 from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+# Cache of (model, base_url) -> (capabilities list, timestamp). Non-empty
+# results are cached indefinitely (a model's declared capabilities don't
+# change at runtime); empty/failed probes get a short TTL so a transient
+# network hiccup doesn't wedge the model into "no thinking support" forever.
+_OLLAMA_CAPS_CACHE: dict[tuple[str, str], tuple[list[str], float]] = {}
+_OLLAMA_CAPS_TTL = 300  # seconds
+
+
+def _is_ollama_base_url(base_url: str | None) -> bool:
+    b = (base_url or "").lower()
+    return "ollama" in b or ":11434" in b
+
+
+def _ollama_model_capabilities(model: str | None, base_url: str | None, timeout: float = 3.0) -> list[str]:
+    """Fetch Ollama's declared capabilities for `model` via /api/show.
+
+    Ollama publishes per-model capabilities (e.g. ["completion","tools"] or
+    ["completion","tools","thinking"]) at POST {root}/api/show. Only models
+    that list "thinking" accept the think / reasoning_effort request fields —
+    sending them to a non-thinking model 400s with
+    '"<model>" does not support thinking'. Cached per (model, base_url).
+    """
+    if not base_url or not model:
+        return []
+    key = (model, base_url)
+    cached = _OLLAMA_CAPS_CACHE.get(key)
+    if cached is not None:
+        caps, ts = cached
+        if caps or (_time.monotonic() - ts) < _OLLAMA_CAPS_TTL:
+            return caps
+
+    caps: list[str] = []
+    try:
+        root = base_url.rstrip("/")
+        if root.endswith("/v1"):
+            root = root[: -len("/v1")]
+        req = urllib.request.Request(
+            root + "/api/show",
+            data=json.dumps({"model": model}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+        caps = list(data.get("capabilities") or [])
+    except Exception:
+        caps = []
+
+    _OLLAMA_CAPS_CACHE[key] = (caps, _time.monotonic())
+    return caps
 
 
 class CustomProfile(ProviderProfile):
@@ -45,17 +103,30 @@ class CustomProfile(ProviderProfile):
         #   - enabled + no effort  → omit both, so the endpoint applies its own
         #     server-side default (do NOT force a level the user didn't pick).
         #
-        # We deliberately do NOT emit ``think=True`` on enable: it is an
+        # We deliberately do NOT emit think=True on enable: it is an
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
         # recognize it. Mirrors the DeepSeek/Zai profile precedent.
+        #
+        # For Ollama specifically, gate on the model's declared capabilities:
+        # non-thinking models (e.g. llama3.3:70b — ["completion","tools"])
+        # 400 with "does not support thinking" if think/reasoning_effort is
+        # sent at all, so probe /api/show and skip emitting either field when
+        # the model doesn't advertise "thinking". Non-Ollama custom backends
+        # (vLLM/GLM/llama.cpp) keep the unconditional behavior since they
+        # don't expose an equivalent capability probe.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
-            if _effort == "none" or _enabled is False:
-                extra_body["think"] = False
-            elif _effort:
-                top_level["reasoning_effort"] = _effort
+            _base_url = ctx.get("base_url")
+            _emit = True
+            if _is_ollama_base_url(_base_url):
+                _emit = "thinking" in _ollama_model_capabilities(ctx.get("model"), _base_url)
+            if _emit:
+                if _effort == "none" or _enabled is False:
+                    extra_body["think"] = False
+                elif _effort:
+                    top_level["reasoning_effort"] = _effort
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -37,6 +37,28 @@ def custom_profile():
     return profile
 
 
+@pytest.fixture
+def custom_mod():
+    """Resolve the dynamically-loaded ``custom`` provider module.
+
+    ``plugins/model-providers/custom`` is a hyphenated directory loaded via
+    importlib.util.spec_from_file_location, not a real importable package —
+    ``import plugins.model_providers.custom`` fails even after discovery has
+    run. Pull it out of sys.modules by the profile class's ``__module__``
+    instead, which is how the interpreter actually knows it.
+    """
+    import sys
+
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("custom")
+    assert profile is not None, "custom provider profile must be registered"
+    mod = sys.modules.get(type(profile).__module__)
+    assert mod is not None, f"module {type(profile).__module__!r} not found in sys.modules"
+    return mod
+
+
 class TestCustomReasoningWireShape:
     """``build_api_kwargs_extras`` produces the correct wire format."""
 
@@ -116,3 +138,165 @@ class TestCustomReasoningWithNumCtx:
         )
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {"reasoning_effort": "high"}
+
+
+class TestOllamaThinkingCapabilityGate:
+    """Ollama backends must probe /api/show and skip think/reasoning_effort
+    entirely for models that don't declare "thinking" support (#57601 follow-up).
+
+    Non-Ollama custom backends (no base_url, or a base_url that doesn't look
+    like Ollama) are untouched — they keep unconditionally emitting the field,
+    matching every test above.
+    """
+
+    def test_non_thinking_model_emits_nothing(self, custom_profile, custom_mod, monkeypatch):
+        """llama3.3:70b-style capabilities (no "thinking") → omit both fields."""
+
+        monkeypatch.setattr(
+            custom_mod, "_ollama_model_capabilities", lambda model, base_url, timeout=3.0: ["completion", "tools"]
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="llama3.3:70b",
+            base_url="http://chrysalis:11434/v1",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_thinking_model_still_emits(self, custom_profile, monkeypatch, custom_mod):
+        """Model that DOES declare "thinking" → behaves like before (top-level effort)."""
+
+        monkeypatch.setattr(
+            custom_mod, "_ollama_model_capabilities", lambda model, base_url, timeout=3.0: ["completion", "tools", "thinking"]
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="qwen3:32b",
+            base_url="http://chrysalis:11434/v1",
+        )
+        assert tl == {"reasoning_effort": "medium"}
+        assert eb == {}
+
+    def test_non_thinking_model_disabled_also_emits_nothing(self, custom_profile, monkeypatch, custom_mod):
+        """Even the disable path (think=False) is gated — a non-thinking model
+        doesn't recognize the think field at all, so sending False also 400s."""
+
+        monkeypatch.setattr(
+            custom_mod, "_ollama_model_capabilities", lambda model, base_url, timeout=3.0: ["completion", "tools"]
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="llama3.3:70b",
+            base_url="http://chrysalis:11434/v1",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_non_ollama_base_url_bypasses_probe(self, custom_profile, monkeypatch, custom_mod):
+        """A non-Ollama custom base_url (e.g. GLM/ARK) never triggers the probe
+        and keeps the original unconditional emit behavior."""
+
+        def _fail(*a, **kw):
+            raise AssertionError("should not probe non-Ollama base_url")
+
+        monkeypatch.setattr(custom_mod, "_ollama_model_capabilities", _fail)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="glm-5.2",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+        )
+        assert tl == {"reasoning_effort": "max"}
+
+    def test_no_base_url_bypasses_probe(self, custom_profile, monkeypatch, custom_mod):
+        """No base_url passed at all (matches every pre-existing test above) →
+        original unconditional behavior, no probe attempted."""
+
+        def _fail(*a, **kw):
+            raise AssertionError("should not probe when base_url is unset")
+
+        monkeypatch.setattr(custom_mod, "_ollama_model_capabilities", _fail)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model="glm-5.2"
+        )
+        assert tl == {"reasoning_effort": "high"}
+
+
+class TestOllamaCapabilityProbe:
+    """Unit tests for the /api/show capability fetch + cache helper itself."""
+
+    def test_fetches_and_parses_capabilities(self, monkeypatch, custom_mod):
+        import json as _json
+
+        custom_mod._OLLAMA_CAPS_CACHE.clear()
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return _json.dumps({"capabilities": ["completion", "tools"]}).encode()
+
+        monkeypatch.setattr(custom_mod.urllib.request, "urlopen", lambda req, timeout=3.0: _FakeResp())
+        caps = custom_mod._ollama_model_capabilities("llama3.3:70b", "http://chrysalis:11434/v1")
+        assert caps == ["completion", "tools"]
+
+    def test_strips_v1_suffix_from_base_url(self, monkeypatch, custom_mod):
+        import json as _json
+
+        custom_mod._OLLAMA_CAPS_CACHE.clear()
+        seen = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return _json.dumps({"capabilities": []}).encode()
+
+        def _fake_urlopen(req, timeout=3.0):
+            seen["url"] = req.full_url
+            return _FakeResp()
+
+        monkeypatch.setattr(custom_mod.urllib.request, "urlopen", _fake_urlopen)
+        custom_mod._ollama_model_capabilities("m", "http://chrysalis:11434/v1")
+        assert seen["url"] == "http://chrysalis:11434/api/show"
+
+    def test_failed_probe_returns_empty_and_is_cached_short_ttl(self, monkeypatch, custom_mod):
+
+        custom_mod._OLLAMA_CAPS_CACHE.clear()
+
+        def _boom(req, timeout=3.0):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(custom_mod.urllib.request, "urlopen", _boom)
+        caps = custom_mod._ollama_model_capabilities("m", "http://chrysalis:11434/v1")
+        assert caps == []
+        # cached negative result present
+        assert ("m", "http://chrysalis:11434/v1") in custom_mod._OLLAMA_CAPS_CACHE
+
+    def test_missing_model_or_base_url_short_circuits(self, custom_profile, custom_mod):
+
+        assert custom_mod._ollama_model_capabilities(None, "http://chrysalis:11434/v1") == []
+        assert custom_mod._ollama_model_capabilities("m", None) == []
+
+
+class TestIsOllamaBaseUrl:
+    def test_matches_port_11434(self, custom_mod):
+
+        assert custom_mod._is_ollama_base_url("http://chrysalis:11434/v1") is True
+        assert custom_mod._is_ollama_base_url("http://localhost:11434") is True
+
+    def test_matches_ollama_in_host(self, custom_mod):
+
+        assert custom_mod._is_ollama_base_url("https://my-ollama-box.local/v1") is True
+
+    def test_does_not_match_other_hosts(self, custom_mod):
+
+        assert custom_mod._is_ollama_base_url("https://ark.cn-beijing.volces.com/api/v3") is False
+        assert custom_mod._is_ollama_base_url(None) is False


### PR DESCRIPTION
## Problem

The `custom` provider profile (`provider=custom`, covers local Ollama, vLLM, GLM/ARK, llama.cpp) unconditionally sends `think`/`reasoning_effort` on every request once `agent.reasoning_effort` is set to anything other than `none`.

Ollama models that don't declare thinking support — e.g. `llama3.3:70b`, whose `/api/tags` and `/api/show` capabilities are `["completion", "tools"]` with no `"thinking"` entry — reject both fields outright:

```
HTTP 400: "llama3.3:70b" does not support thinking
```

This breaks every single turn for any non-thinking model as soon as the user configures a non-`none` `reasoning_effort`, which is the default for most setups. The only workaround today is disabling reasoning globally, even though the model works fine otherwise (including tool calling).

## Fix

Ollama already publishes per-model capabilities via `POST /api/show`. This adds a small cached probe (`_ollama_model_capabilities`, permanent cache on success, 5-minute TTL on failure/empty) and gates `think`/`reasoning_effort` emission on `"thinking"` being present in that list.

The gate is scoped tightly:
- Only triggers when the configured `base_url` looks like Ollama (port `11434` or `"ollama"` in the host) — mirrors the existing `_is_ollama_glm_backend` detection pattern already used elsewhere in `run_agent.py`.
- Non-Ollama custom backends (vLLM / GLM on Volcengine ARK / llama.cpp) keep the original unconditional behavior — they don't expose an equivalent capability endpoint, and the existing wire-shape tests for those pin that contract.
- When no `base_url` is passed at all (e.g. delegation/summary paths that don't thread it through), behavior is unchanged from before this patch.

## Testing

```
PYTHONPATH=$(pwd) venv/bin/python3.11 -m pytest tests/plugins/model_providers/ tests/providers/ -v
# 293 passed
```

Added 12 new tests in `tests/plugins/model_providers/test_custom_profile.py`:
- `TestOllamaThinkingCapabilityGate` — thinking vs non-thinking models, disabled path also gated, non-Ollama base_url bypasses the probe, no base_url bypasses the probe.
- `TestOllamaCapabilityProbe` — fetch/parse `/api/show`, `/v1` suffix stripping so the probe hits the Ollama root not the OpenAI-compat path, failure caching, missing model/base_url short-circuits.
- `TestIsOllamaBaseUrl` — port `11434` matching, hostname matching, negative cases.

All 13 pre-existing tests in that file continue to pass unchanged (they don't pass `base_url`, so the new gate is a no-op for them — confirms the change is additive, not a behavior change for the documented GLM/ARK contract).

Also manually verified end-to-end against a real Ollama instance serving `llama3.3:70b`: confirmed `/api/show` reports `["completion", "tools"]` (no thinking), confirmed the pre-patch 400 reproduces with `agent.reasoning_effort: medium`, confirmed post-patch `hermes chat` succeeds with reasoning enabled including a tool-calling round-trip.

## Related

Builds on the reasoning wiring introduced for the custom provider in #57601 — see the docstring reference in the test file.