### PR TITLE
feat: runtime reasoning_effort tool (clean reimplementation of #7282)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -294,6 +294,7 @@ def init_agent(
     reasoning_callback: callable = None,
     clarify_callback: callable = None,
     read_terminal_callback: callable = None,
+    reasoning_update_callback: callable = None,
     step_callback: callable = None,
     stream_delta_callback: callable = None,
     interim_assistant_callback: callable = None,
@@ -364,6 +365,9 @@ def init_agent(
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
         reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
             If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
+        reasoning_update_callback (callable): Callback function(level, parsed_config, persist) -> bool invoked when
+            the reasoning_effort tool changes the level. Provided by the platform layer to scope the change
+            (gateway session override) and/or persist it to config when persist is True. Returns True when persisted.
         prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
             Useful for injecting a few-shot example or priming the model's response style.
             Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]
@@ -541,6 +545,7 @@ def init_agent(
     agent.reasoning_callback = reasoning_callback
     agent.clarify_callback = clarify_callback
     agent.read_terminal_callback = read_terminal_callback
+    agent.reasoning_update_callback = reasoning_update_callback
     agent.step_callback = step_callback
     agent.stream_delta_callback = stream_delta_callback
     agent.interim_assistant_callback = interim_assistant_callback

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -526,6 +526,7 @@ def init_agent(
     reasoning_callback: callable = None,
     clarify_callback: callable = None,
     read_terminal_callback: callable = None,
+    reasoning_update_callback: callable = None,
     read_preview_callback: callable = None,
     read_window_below_callback: callable = None,
     setup_mcp_callback: callable = None,
@@ -602,6 +603,9 @@ def init_agent(
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
         reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
             If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
+        reasoning_update_callback (callable): Callback function(level, parsed_config, persist) -> bool invoked when
+            the reasoning_effort tool changes the level. Provided by the platform layer to scope the change
+            (gateway session override) and/or persist it to config when persist is True. Returns True when persisted.
         prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
             Useful for injecting a few-shot example or priming the model's response style.
             Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]
@@ -822,6 +826,7 @@ def init_agent(
     agent.reasoning_callback = reasoning_callback
     agent.clarify_callback = clarify_callback
     agent.read_terminal_callback = read_terminal_callback
+    agent.reasoning_update_callback = reasoning_update_callback
     agent.read_preview_callback = read_preview_callback
     agent.read_window_below_callback = read_window_below_callback
     agent.setup_mcp_callback = setup_mcp_callback

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -57,7 +57,8 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task",
+     "reasoning_effort"}
 )
 
 
@@ -2332,6 +2333,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "reasoning_effort":
+        def _execute(next_args: dict) -> Any:
+            return _finish_agent_tool(agent._apply_reasoning_effort(next_args), next_args)
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -99,7 +99,7 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "read_preview", "read_window_below", "setup_mcp", "tour", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "read_terminal", "read_preview", "read_window_below", "setup_mcp", "tour", "delegate_task", "reasoning_effort"}
 )
 
 
@@ -3268,6 +3268,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "reasoning_effort":
+        def _execute(next_args: dict) -> Any:
+            return _finish_agent_tool(agent._apply_reasoning_effort(next_args), next_args)
     else:
         def _execute(next_args: dict) -> Any:
             dispatch_kwargs = dict(

--- a/agent/display.py
+++ b/agent/display.py
@@ -441,6 +441,15 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         "clarify": "question", "skill_manage": "name",
     }
 
+    # reasoning_effort: show the target level (+ persistence marker)
+    if tool_name == "reasoning_effort":
+        level = _oneline(str(args.get("level", "")).strip().lower())
+        if not level:
+            return None
+        if args.get("persist"):
+            level += " (persist)"
+        return level
+
     # delegate_task: show goal (single) or individual task goals (batch)
     if tool_name == "delegate_task":
         tasks = args.get("tasks")
@@ -592,6 +601,7 @@ _TOOL_VERBS: dict[str, str] = {
     "clarify": "Asking",
     "memory": "Updating memory",
     "todo": "Updating tasks",
+    "reasoning_effort": "Adjusting reasoning effort",
 }
 
 # Verbs that read better without the raw argument preview appended.

--- a/agent/display.py
+++ b/agent/display.py
@@ -556,6 +556,15 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
             return f"-{target}: \"{old[:20]}\""
         return action
 
+    # reasoning_effort: show the target level (+ persistence marker)
+    if tool_name == "reasoning_effort":
+        level = _oneline(str(args.get("level", "")).strip().lower())
+        if not level:
+            return None
+        if args.get("persist"):
+            level += " (persist)"
+        return level
+
     if tool_name == "send_message":
         target = args.get("target", "?")
         msg = _oneline(args.get("message", ""))
@@ -661,6 +670,7 @@ _TOOL_VERBS: dict[str, str] = {
     "clarify": "Asking",
     "memory": "Updating memory",
     "todo": "Updating tasks",
+    "reasoning_effort": "Adjusting reasoning effort",
 }
 
 # Verbs that read better without the raw argument preview appended.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -186,6 +186,20 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+# NOTE: deliberately static text — the system prompt is byte-stable for the
+# lifetime of the agent (see agent/system_prompt.py), so the CURRENT level is
+# never rendered here. The model learns the active level from the
+# reasoning_effort tool result; request construction reads
+# agent.reasoning_config live on every API call.
+REASONING_EFFORT_GUIDANCE = (
+    "You can adjust your own reasoning depth with the reasoning_effort tool: "
+    "raise it for ambiguity, debugging, risky changes, or multi-step synthesis; "
+    "lower it for trivial, mechanical, or routine turns. "
+    "Changes apply from your next model request onward and last for the rest of "
+    "the session unless changed again; pass persist=true only when the user asks "
+    "for a permanent default."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -223,6 +223,20 @@ SKILLS_GUIDANCE = (
     "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )
 
+# NOTE: deliberately static text — the system prompt is byte-stable for the
+# lifetime of the agent (see agent/system_prompt.py), so the CURRENT level is
+# never rendered here. The model learns the active level from the
+# reasoning_effort tool result; request construction reads
+# agent.reasoning_config live on every API call.
+REASONING_EFFORT_GUIDANCE = (
+    "You can adjust your own reasoning depth with the reasoning_effort tool: "
+    "raise it for ambiguity, debugging, risky changes, or multi-step synthesis; "
+    "lower it for trivial, mechanical, or routine turns. "
+    "Changes apply from your next model request onward and last for the rest of "
+    "the session unless changed again; pass persist=true only when the user asks "
+    "for a permanent default."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -36,6 +36,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
+    REASONING_EFFORT_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -224,6 +225,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    # Static text only — the current level is NOT rendered here, so the
+    # prompt stays byte-stable when the tool changes reasoning_config.
+    if "reasoning_effort" in agent.valid_tool_names:
+        tool_guidance.append(REASONING_EFFORT_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -40,6 +40,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
+    REASONING_EFFORT_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -420,6 +421,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    # Static text only — the current level is NOT rendered here, so the
+    # prompt stays byte-stable when the tool changes reasoning_config.
+    if "reasoning_effort" in agent.valid_tool_names:
+        tool_guidance.append(REASONING_EFFORT_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1337,6 +1337,20 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "reasoning_effort":
+            def _execute(next_args: dict) -> Any:
+                return agent._apply_reasoning_effort(next_args)
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('reasoning_effort', function_args, tool_duration, result=function_result)}")
         elif function_name == "read_terminal":
             def _execute(next_args: dict) -> Any:
                 from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2136,6 +2136,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "reasoning_effort":
+            def _execute(next_args: dict) -> Any:
+                return agent._apply_reasoning_effort(next_args)
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+                scope_block=_ts_scope_block,
+                display_index=i,
+            ))
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('reasoning_effort', function_args, tool_duration, result=function_result)}")
         elif function_name == "read_terminal":
             def _execute(next_args: dict) -> Any:
                 from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool

--- a/cli.py
+++ b/cli.py
@@ -5407,6 +5407,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         symmetrically with the show callback (and so future REPL UIs can hook it)."""
         return
 
+    def _on_reasoning_update(self, level: str, parsed_config: dict, persist: bool = False) -> bool:
+        """Platform hook for the reasoning_effort tool.
+
+        Keeps the CLI's own ``reasoning_config`` in sync so later agent
+        re-inits (e.g. /model switches) retain the tool-set level, and
+        persists to config.yaml only when the model passed ``persist=true``.
+        Returns True when the value was durably saved.
+        """
+        self.reasoning_config = parsed_config
+        if not persist:
+            return False
+        return save_config_value("agent.reasoning_effort", level)
+
     # ── Streaming display ────────────────────────────────────────────────
 
     def _current_reasoning_callback(self):

--- a/cli.py
+++ b/cli.py
@@ -7352,6 +7352,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         symmetrically with the show callback (and so future REPL UIs can hook it)."""
         return
 
+    def _on_reasoning_update(self, level: str, parsed_config: dict, persist: bool = False) -> bool:
+        """Platform hook for the reasoning_effort tool.
+
+        Keeps the CLI's own ``reasoning_config`` in sync so later agent
+        re-inits (e.g. /model switches) retain the tool-set level, and
+        persists to config.yaml only when the model passed ``persist=true``.
+        Returns True when the value was durably saved.
+        """
+        self.reasoning_config = parsed_config
+        if not persist:
+            return False
+        return save_config_value("agent.reasoning_effort", level)
+
     # ── Streaming display ────────────────────────────────────────────────
 
     def _current_reasoning_callback(self):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4866,6 +4866,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             self._session_reasoning_overrides[session_key] = dict(reasoning_config)
 
+    def _persist_reasoning_effort_config(self, level: str) -> bool:
+        """Persist agent.reasoning_effort to config.yaml. Returns True on success."""
+        try:
+            from hermes_cli.config import atomic_config_write
+            import yaml
+
+            config_path = _hermes_home / "config.yaml"
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            agent_cfg = user_config.get("agent")
+            if not isinstance(agent_cfg, dict):
+                agent_cfg = {}
+                user_config["agent"] = agent_cfg
+            agent_cfg["reasoning_effort"] = level
+            atomic_config_write(config_path, user_config)
+            return True
+        except Exception as e:
+            logger.error("Failed to persist reasoning_effort from tool: %s", e)
+            return False
+
+    def _make_reasoning_update_callback(self, session_key: str):
+        """Build the reasoning_update_callback for an agent bound to *session_key*.
+
+        The tool's in-process mutation of ``agent.reasoning_config`` does not
+        survive the cached-agent path — every message re-applies the resolved
+        config (``agent.reasoning_config = reasoning_config``). Storing the new
+        level as a session override keeps ``_resolve_session_reasoning_config``
+        returning it on subsequent messages, mirroring ``/reasoning <level>``.
+        ``persist=True`` mirrors ``/reasoning <level> --global``: write
+        config.yaml and drop the (now redundant) session override.
+        """
+
+        def _callback(level: str, parsed_config: dict, persist: bool = False) -> bool:
+            if persist and self._persist_reasoning_effort_config(level):
+                self._set_session_reasoning_override(session_key, None)
+                self._reasoning_config = dict(parsed_config)
+                return True
+            self._set_session_reasoning_override(session_key, parsed_config)
+            self._reasoning_config = dict(parsed_config)
+            return False
+
+        return _callback
+
     @staticmethod
     def _load_service_tier() -> str | None:
         """Load Priority Processing setting from config.yaml.
@@ -13384,6 +13429,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             max_iterations = _current_max_iterations()
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
+            try:
+                _reasoning_session_key = self._session_key_for_source(source)
+            except Exception:
+                _reasoning_session_key = ""
+            reasoning_update_callback = self._make_reasoning_update_callback(_reasoning_session_key)
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
@@ -13414,6 +13464,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
+                    reasoning_update_callback=reasoning_update_callback,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
@@ -18390,6 +18441,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.notice_clear_callback = None
             agent.event_callback = _event_callback_sync
             agent.reasoning_config = reasoning_config
+            # Session-scoped hook for the reasoning_effort tool. Without it,
+            # the tool's mutation of agent.reasoning_config would be undone by
+            # the reset one line above on the very next message; the callback
+            # records the change as a session override so
+            # _resolve_session_reasoning_config keeps returning it.
+            agent.reasoning_update_callback = self._make_reasoning_update_callback(session_key)
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5272,6 +5272,9 @@ class TurnRunner:
             session_key=ctx.session_key,
             model=model,
         )
+        reasoning_update_callback = self._runner._make_reasoning_update_callback(
+            ctx.session_key
+        )
         self._runner._reasoning_config = reasoning_config
         self._runner._service_tier = self._runner._resolve_session_service_tier(
             source=ctx.source, session_key=ctx.session_key
@@ -5616,6 +5619,7 @@ class TurnRunner:
                 ephemeral_system_prompt=combined_ephemeral or None,
                 prefill_messages=self._runner._prefill_messages or None,
                 reasoning_config=reasoning_config,
+                reasoning_update_callback=reasoning_update_callback,
                 service_tier=self._runner._service_tier,
                 request_overrides=turn_route.get("request_overrides"),
                 providers_allowed=pr.get("only"),
@@ -5729,6 +5733,7 @@ class TurnRunner:
         agent.notice_clear_callback = None
         agent.event_callback = ctx._event_callback_sync
         agent.reasoning_config = reasoning_config
+        agent.reasoning_update_callback = reasoning_update_callback
         agent.service_tier = self._runner._service_tier
         agent.request_overrides = turn_route.get("request_overrides") or {}
         # Must-deliver notes for THIS turn ride the current user message
@@ -9287,6 +9292,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._session_state(session_key).conversation.reasoning_override = (
             None if reasoning_config is None else dict(reasoning_config)
         )
+
+    def _persist_reasoning_effort_config(self, level: str) -> bool:
+        """Persist agent.reasoning_effort to config.yaml. Returns True on success."""
+        try:
+            from hermes_cli.config import atomic_config_write
+            import yaml
+
+            config_path = _hermes_home / "config.yaml"
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            agent_cfg = user_config.get("agent")
+            if not isinstance(agent_cfg, dict):
+                agent_cfg = {}
+                user_config["agent"] = agent_cfg
+            agent_cfg["reasoning_effort"] = level
+            atomic_config_write(config_path, user_config)
+            return True
+        except Exception as e:
+            logger.error("Failed to persist reasoning_effort from tool: %s", e)
+            return False
+
+    def _make_reasoning_update_callback(self, session_key: str):
+        """Keep tool updates durable across cached-agent message resets."""
+        def _callback(level: str, parsed_config: dict, persist: bool = False) -> bool:
+            if persist and self._persist_reasoning_effort_config(level):
+                self._set_session_reasoning_override(session_key, None)
+                self._reasoning_config = dict(parsed_config)
+                return True
+            self._set_session_reasoning_override(session_key, parsed_config)
+            self._reasoning_config = dict(parsed_config)
+            return False
+
+        return _callback
 
     def _resolve_session_service_tier(
         self,
@@ -22225,6 +22265,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reasoning_config = self._resolve_session_reasoning_config(
                 source=source, model=model
             )
+            reasoning_update_callback = self._make_reasoning_update_callback(
+                self._session_key_for_source(source)
+            )
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
@@ -22257,6 +22300,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
+                    reasoning_update_callback=reasoning_update_callback,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -373,6 +373,7 @@ class CLIAgentSetupMixin:
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
+                reasoning_update_callback=self._on_reasoning_update,
 
                 fallback_model=self._fallback_model,
                 thinking_callback=self._on_thinking,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -522,6 +522,7 @@ class CLIAgentSetupMixin:
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
+                reasoning_update_callback=self._on_reasoning_update,
 
                 fallback_model=self._fallback_model,
                 thinking_callback=self._on_thinking,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1650,6 +1650,7 @@ class CLICommandsMixin:
                     platform="cli",
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
+                    reasoning_update_callback=self._on_reasoning_update,
                     service_tier=self.service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2165,6 +2165,7 @@ class CLICommandsMixin:
                     platform="cli",
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
+                    reasoning_update_callback=self._on_reasoning_update,
                     service_tier=self.service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -75,6 +75,7 @@ CONFIGURABLE_TOOLSETS = [
     ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
+    ("reasoning",       "🧠 Reasoning Effort",          "reasoning_effort"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -116,7 +116,12 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+#
+# Reasoning effort is opt-in: it is deliberately NOT in _HERMES_CORE_TOOLS
+# (a new default core schema entry is permanent footprint on every request —
+# see AGENTS.md footprint ladder), so users enable it per platform via
+# `hermes tools` → Reasoning Effort.
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "reasoning"}
 
 
 def _xai_credentials_present() -> bool:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -113,6 +113,7 @@ CONFIGURABLE_TOOLSETS = [
     ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
+    ("reasoning",       "🧠 Reasoning Effort",          "reasoning_effort"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
@@ -140,8 +141,10 @@ def gui_toolset_label(label: str) -> str:
 
 
 # Toolsets that are OFF by default for new installs.
-# They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
-# but the setup checklist won't pre-select them for first-time users.
+# Most are still in _HERMES_CORE_TOOLS (available at runtime if enabled), but
+# the setup checklist won't pre-select them for first-time users. Reasoning is
+# different by design: it is also outside _HERMES_CORE_TOOLS, so it has zero
+# schema footprint until explicitly enabled.
 #
 # Video gen is off by default — it's a niche, paid, slow feature. Users
 # who want it opt in via `hermes tools` → Video Generation, which walks
@@ -153,7 +156,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a", "reasoning"}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key

--- a/model_tools.py
+++ b/model_tools.py
@@ -603,7 +603,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "reasoning_effort"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -740,7 +740,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "reasoning_effort"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -450,6 +450,7 @@ class AIAgent:
         reasoning_callback: callable = None,
         clarify_callback: callable = None,
         read_terminal_callback: callable = None,
+        reasoning_update_callback: callable = None,
         step_callback: callable = None,
         stream_delta_callback: callable = None,
         interim_assistant_callback: callable = None,
@@ -526,6 +527,7 @@ class AIAgent:
             reasoning_callback=reasoning_callback,
             clarify_callback=clarify_callback,
             read_terminal_callback=read_terminal_callback,
+            reasoning_update_callback=reasoning_update_callback,
             step_callback=step_callback,
             stream_delta_callback=stream_delta_callback,
             interim_assistant_callback=interim_assistant_callback,
@@ -5723,6 +5725,62 @@ class AIAgent:
             role=function_args.get("role"),
             background=(not _is_subagent),
             parent_agent=self,
+        )
+
+    def _apply_reasoning_effort(self, function_args: dict) -> str:
+        """Apply a runtime reasoning-effort update to the live agent.
+
+        Mutates ``self.reasoning_config`` only — request construction reads it
+        on every API call, so the change takes effect on the next request. The
+        cached system prompt is deliberately left untouched: it must stay
+        byte-stable for the lifetime of the agent to keep provider prompt
+        caches warm (see agent/system_prompt.py).
+
+        ``reasoning_update_callback(level, parsed_config, persist)`` lets the
+        platform layer scope the change beyond this process — the gateway
+        stores a session override so the level survives its per-message
+        ``agent.reasoning_config`` reset, and both CLI and gateway persist to
+        config.yaml when ``persist`` is true. Returns True when the change was
+        durably persisted.
+        """
+        from tools.reasoning_effort_tool import reasoning_effort_tool as _reasoning_effort_tool
+
+        def _callback(parsed_config, *, level: str, persist: bool = False):
+            current_config = self.reasoning_config if isinstance(self.reasoning_config, dict) else None
+            no_change = current_config == parsed_config
+            persisted = False
+            if self.reasoning_update_callback:
+                try:
+                    persisted = bool(
+                        self.reasoning_update_callback(level, parsed_config, persist)
+                    )
+                except Exception as cb_err:
+                    logger.warning("reasoning_update_callback failed: %s", cb_err)
+            if not no_change:
+                self.reasoning_config = parsed_config
+            enabled = parsed_config.get("enabled") is not False
+            message = (
+                f"Reasoning effort already at {level}"
+                if no_change
+                else f"Reasoning effort set to {level}"
+            )
+            message += " and saved as the default." if persisted else " for this session."
+            if not no_change:
+                message += " The new level applies from your next model request."
+            return {
+                "success": True,
+                "level": level,
+                "enabled": enabled,
+                "reasoning_config": parsed_config,
+                "persisted": persisted,
+                "no_change": no_change,
+                "message": message,
+            }
+
+        return _reasoning_effort_tool(
+            level=function_args.get("level", ""),
+            persist=function_args.get("persist", False),
+            callback=_callback,
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -469,6 +469,7 @@ class AIAgent:
         reasoning_callback: callable = None,
         clarify_callback: callable = None,
         read_terminal_callback: callable = None,
+        reasoning_update_callback: callable = None,
         read_preview_callback: callable = None,
         read_window_below_callback: callable = None,
         setup_mcp_callback: callable = None,
@@ -558,6 +559,7 @@ class AIAgent:
             reasoning_callback=reasoning_callback,
             clarify_callback=clarify_callback,
             read_terminal_callback=read_terminal_callback,
+            reasoning_update_callback=reasoning_update_callback,
             read_preview_callback=read_preview_callback,
             read_window_below_callback=read_window_below_callback,
             setup_mcp_callback=setup_mcp_callback,
@@ -8244,6 +8246,62 @@ class AIAgent:
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
             parent_agent=self,
+        )
+
+    def _apply_reasoning_effort(self, function_args: dict) -> str:
+        """Apply a runtime reasoning-effort update to the live agent.
+
+        Mutates ``self.reasoning_config`` only — request construction reads it
+        on every API call, so the change takes effect on the next request. The
+        cached system prompt is deliberately left untouched: it must stay
+        byte-stable for the lifetime of the agent to keep provider prompt
+        caches warm (see agent/system_prompt.py).
+
+        ``reasoning_update_callback(level, parsed_config, persist)`` lets the
+        platform layer scope the change beyond this process — the gateway
+        stores a session override so the level survives its per-message
+        ``agent.reasoning_config`` reset, and both CLI and gateway persist to
+        config.yaml when ``persist`` is true. Returns True when the change was
+        durably persisted.
+        """
+        from tools.reasoning_effort_tool import reasoning_effort_tool as _reasoning_effort_tool
+
+        def _callback(parsed_config, *, level: str, persist: bool = False):
+            current_config = self.reasoning_config if isinstance(self.reasoning_config, dict) else None
+            no_change = current_config == parsed_config
+            persisted = False
+            if self.reasoning_update_callback:
+                try:
+                    persisted = bool(
+                        self.reasoning_update_callback(level, parsed_config, persist)
+                    )
+                except Exception as cb_err:
+                    logger.warning("reasoning_update_callback failed: %s", cb_err)
+            if not no_change:
+                self.reasoning_config = parsed_config
+            enabled = parsed_config.get("enabled") is not False
+            message = (
+                f"Reasoning effort already at {level}"
+                if no_change
+                else f"Reasoning effort set to {level}"
+            )
+            message += " and saved as the default." if persisted else " for this session."
+            if not no_change:
+                message += " The new level applies from your next model request."
+            return {
+                "success": True,
+                "level": level,
+                "enabled": enabled,
+                "reasoning_config": parsed_config,
+                "persisted": persisted,
+                "no_change": no_change,
+                "message": message,
+            }
+
+        return _reasoning_effort_tool(
+            level=function_args.get("level", ""),
+            persist=function_args.get("persist", False),
+            callback=_callback,
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -90,6 +90,21 @@ class TestBuildToolPreview:
         assert result is not None
         assert "hello world" in result
 
+    def test_reasoning_effort_preview_shows_target_level(self):
+        assert build_tool_preview("reasoning_effort", {"level": "high"}) == "high"
+
+    def test_reasoning_effort_preview_normalizes_case(self):
+        assert build_tool_preview("reasoning_effort", {"level": " HIGH "}) == "high"
+
+    def test_reasoning_effort_preview_marks_persist(self):
+        result = build_tool_preview(
+            "reasoning_effort", {"level": "low", "persist": True}
+        )
+        assert result == "low (persist)"
+
+    def test_reasoning_effort_preview_empty_level_returns_none(self):
+        assert build_tool_preview("reasoning_effort", {"level": ""}) is None
+
     def test_read_file_preview(self):
         result = build_tool_preview("read_file", {"path": "/tmp/test.py", "offset": 1})
         assert result is not None

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -77,6 +77,21 @@ class TestBuildToolPreview:
         assert safe_args["ref"] == "@e3"
         assert safe_args["text"].startswith("ghp_AB")
 
+    def test_reasoning_effort_preview_shows_target_level(self):
+        assert build_tool_preview("reasoning_effort", {"level": "high"}) == "high"
+
+    def test_reasoning_effort_preview_normalizes_case(self):
+        assert build_tool_preview("reasoning_effort", {"level": " HIGH "}) == "high"
+
+    def test_reasoning_effort_preview_marks_persist(self):
+        result = build_tool_preview(
+            "reasoning_effort", {"level": "low", "persist": True}
+        )
+        assert result == "low (persist)"
+
+    def test_reasoning_effort_preview_empty_level_returns_none(self):
+        assert build_tool_preview("reasoning_effort", {"level": ""}) is None
+
 
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -30,6 +30,7 @@ from agent.prompt_builder import (
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
+    REASONING_EFFORT_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
@@ -53,6 +54,19 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_reasoning_effort_guidance_gives_raise_and_lower_triggers(self):
+        assert "reasoning_effort tool" in REASONING_EFFORT_GUIDANCE
+        assert "raise it for ambiguity" in REASONING_EFFORT_GUIDANCE
+        assert "lower it for trivial, mechanical, or routine turns" in REASONING_EFFORT_GUIDANCE
+        assert "persist=true" in REASONING_EFFORT_GUIDANCE
+
+    def test_reasoning_effort_guidance_is_static_no_level_placeholder(self):
+        # The guidance lives in the STABLE prompt tier — it must never embed
+        # the current level (which would force a prompt rebuild per change).
+        assert "Current reasoning effort" not in REASONING_EFFORT_GUIDANCE
+        assert "{" not in REASONING_EFFORT_GUIDANCE
+        assert "%s" not in REASONING_EFFORT_GUIDANCE
 
 
 # =========================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -31,6 +31,7 @@ from agent.prompt_builder import (
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
+    REASONING_EFFORT_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
@@ -54,6 +55,19 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_reasoning_effort_guidance_gives_raise_and_lower_triggers(self):
+        assert "reasoning_effort tool" in REASONING_EFFORT_GUIDANCE
+        assert "raise it for ambiguity" in REASONING_EFFORT_GUIDANCE
+        assert "lower it for trivial, mechanical, or routine turns" in REASONING_EFFORT_GUIDANCE
+        assert "persist=true" in REASONING_EFFORT_GUIDANCE
+
+    def test_reasoning_effort_guidance_is_static_no_level_placeholder(self):
+        # The guidance lives in the STABLE prompt tier — it must never embed
+        # the current level (which would force a prompt rebuild per change).
+        assert "Current reasoning effort" not in REASONING_EFFORT_GUIDANCE
+        assert "{" not in REASONING_EFFORT_GUIDANCE
+        assert "%s" not in REASONING_EFFORT_GUIDANCE
 
 
 # =========================================================================

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -475,3 +475,95 @@ class TestLoadShowReasoningCoercion:
             tmp_path, monkeypatch,
             'display: {}\n',
         ) is False
+
+
+class TestReasoningUpdateCallback:
+    """The reasoning_effort tool's platform hook must survive the cached-agent
+    path: every gateway message re-applies _resolve_session_reasoning_config()
+    to agent.reasoning_config, so a tool change is only durable if the callback
+    records it as a session override (or persists it globally)."""
+
+    def _runner_with_home(self, tmp_path, monkeypatch, yaml_body="agent:\n  reasoning_effort: medium\n"):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        return _make_runner(), hermes_home
+
+    def test_non_persistent_update_survives_per_message_reset(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+
+        callback = runner._make_reasoning_update_callback(session_key)
+        persisted = callback("xhigh", {"enabled": True, "effort": "xhigh"}, False)
+
+        assert persisted is False
+        # The next message resolves reasoning config through the session
+        # override — this is what keeps the tool's change alive.
+        assert runner._resolve_session_reasoning_config(source=source) == {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+
+    def test_non_persistent_update_does_not_touch_config(self, tmp_path, monkeypatch):
+        runner, hermes_home = self._runner_with_home(tmp_path, monkeypatch)
+        callback = runner._make_reasoning_update_callback("session-a")
+
+        callback("high", {"enabled": True, "effort": "high"}, False)
+
+        saved = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "medium"
+
+    def test_persistent_update_writes_config_and_clears_override(self, tmp_path, monkeypatch):
+        runner, hermes_home = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "low"}
+
+        callback = runner._make_reasoning_update_callback(session_key)
+        persisted = callback("high", {"enabled": True, "effort": "high"}, True)
+
+        assert persisted is True
+        saved = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "high"
+        assert session_key not in runner._session_reasoning_overrides
+        assert runner._resolve_session_reasoning_config(source=source) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_persist_failure_falls_back_to_session_override(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+        monkeypatch.setattr(
+            runner, "_persist_reasoning_effort_config", lambda level: False
+        )
+
+        callback = runner._make_reasoning_update_callback(session_key)
+        persisted = callback("high", {"enabled": True, "effort": "high"}, True)
+
+        assert persisted is False
+        # Config write failed, but the session still gets the new level.
+        assert runner._resolve_session_reasoning_config(source=source) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_isolated_between_sessions(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source_a = _make_event("hello", chat_id="chat-a").source
+        source_b = _make_event("hello", chat_id="chat-b").source
+        key_a = runner._session_key_for_source(source_a)
+
+        runner._make_reasoning_update_callback(key_a)("xhigh", {"enabled": True, "effort": "xhigh"}, False)
+
+        assert runner._resolve_session_reasoning_config(source=source_a) == {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+        assert runner._resolve_session_reasoning_config(source=source_b) == {
+            "enabled": True,
+            "effort": "medium",
+        }

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -218,3 +218,56 @@ class TestLoadShowReasoningCoercion:
             'display:\n  show_reasoning: true\n',
         ) is True
 
+
+class TestReasoningUpdateCallback:
+    def _runner_with_home(self, tmp_path, monkeypatch, yaml_body="agent:\n  reasoning_effort: medium\n"):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        return _make_runner(), hermes_home
+
+    def test_non_persistent_update_survives_per_message_reset(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+        persisted = runner._make_reasoning_update_callback(session_key)("xhigh", {"enabled": True, "effort": "xhigh"}, False)
+        assert persisted is False
+        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "xhigh"}
+
+    def test_non_persistent_update_does_not_touch_config(self, tmp_path, monkeypatch):
+        runner, hermes_home = self._runner_with_home(tmp_path, monkeypatch)
+        runner._make_reasoning_update_callback("session-a")("high", {"enabled": True, "effort": "high"}, False)
+        saved = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "medium"
+
+    def test_persistent_update_writes_config_and_clears_override(self, tmp_path, monkeypatch):
+        runner, hermes_home = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "low"}
+        persisted = runner._make_reasoning_update_callback(session_key)("high", {"enabled": True, "effort": "high"}, True)
+        assert persisted is True
+        saved = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "high"
+        assert session_key not in runner._session_reasoning_overrides
+        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "high"}
+
+    def test_persist_failure_falls_back_to_session_override(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source = _make_event("hello").source
+        session_key = runner._session_key_for_source(source)
+        monkeypatch.setattr(runner, "_persist_reasoning_effort_config", lambda level: False)
+        persisted = runner._make_reasoning_update_callback(session_key)("high", {"enabled": True, "effort": "high"}, True)
+        assert persisted is False
+        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "high"}
+
+    def test_isolated_between_sessions(self, tmp_path, monkeypatch):
+        runner, _ = self._runner_with_home(tmp_path, monkeypatch)
+        source_a = _make_event("hello", chat_id="chat-a").source
+        source_b = _make_event("hello", chat_id="chat-b").source
+        key_a = runner._session_key_for_source(source_a)
+        runner._make_reasoning_update_callback(key_a)("xhigh", {"enabled": True, "effort": "xhigh"}, False)
+        assert runner._resolve_session_reasoning_config(source=source_a) == {"enabled": True, "effort": "xhigh"}
+        assert runner._resolve_session_reasoning_config(source=source_b) == {"enabled": True, "effort": "medium"}
+

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1267,6 +1267,65 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
+    def test_reasoning_effort_guidance_when_tool_loaded(self):
+        from agent.prompt_builder import REASONING_EFFORT_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "reasoning_effort"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        prompt = agent._build_system_prompt()
+        assert REASONING_EFFORT_GUIDANCE in prompt
+
+    def test_no_reasoning_effort_guidance_without_tool(self, agent):
+        from agent.prompt_builder import REASONING_EFFORT_GUIDANCE
+
+        prompt = agent._build_system_prompt()
+        assert REASONING_EFFORT_GUIDANCE not in prompt
+
+    def test_system_prompt_stays_stable_after_reasoning_effort_change(self):
+        """The cached system prompt must remain byte-identical across a
+        reasoning_effort tool call — invalidating it mid-session breaks
+        provider prefix caching (see agent/system_prompt.py)."""
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "reasoning_effort"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        original_prompt = agent._build_system_prompt()
+        cached_before = agent._cached_system_prompt
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "high"}))
+        assert result["success"] is True
+
+        assert agent._cached_system_prompt is cached_before
+        assert agent._build_system_prompt() == original_prompt
+        # The runtime config DID change — only the prompt is stable.
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()
         # Should contain current date info like "Conversation started:"
@@ -2031,6 +2090,116 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+
+
+class TestApplyReasoningEffort:
+    def test_updates_reasoning_config(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "low"}))
+
+        assert result["success"] is True
+        assert result["level"] == "low"
+        assert result["reasoning_config"] == {"enabled": True, "effort": "low"}
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_new_level_reaches_next_api_request(self, agent):
+        """The changed level must flow into request construction — that is
+        the mechanism that replaces mutating the system prompt."""
+        agent.provider = "openrouter"
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        json.loads(agent._apply_reasoning_effort({"level": "high"}))
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs.get("extra_body", {}).get("reasoning", {}).get("effort") == "high"
+
+    def test_can_disable_reasoning(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "none"}))
+
+        assert result["success"] is True
+        assert result["enabled"] is False
+        assert agent.reasoning_config == {"enabled": False}
+
+    def test_rejects_invalid_level(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "galaxy-brain"}))
+
+        assert "error" in result
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
+    def test_rejects_missing_level(self, agent):
+        result = json.loads(agent._apply_reasoning_effort({}))
+        assert "error" in result
+
+    def test_callback_receives_session_scope_by_default(self, agent):
+        calls = []
+
+        def _update(level, parsed_config, persist=False):
+            calls.append((level, parsed_config, persist))
+            return False
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "high"}))
+
+        assert result["success"] is True
+        assert result["persisted"] is False
+        assert calls == [("high", {"enabled": True, "effort": "high"}, False)]
+
+    def test_persist_flag_reaches_callback(self, agent):
+        calls = []
+
+        def _update(level, parsed_config, persist=False):
+            calls.append((level, parsed_config, persist))
+            return True
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(
+            agent._apply_reasoning_effort({"level": "high", "persist": True})
+        )
+
+        assert result["success"] is True
+        assert result["persisted"] is True
+        assert calls == [("high", {"enabled": True, "effort": "high"}, True)]
+
+    def test_reports_no_change_for_same_level(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "medium"}))
+
+        assert result["success"] is True
+        assert result["no_change"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
+    def test_callback_failure_does_not_block_runtime_change(self, agent):
+        def _update(level, parsed_config, persist=False):
+            raise RuntimeError("disk full")
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "low"}))
+
+        assert result["success"] is True
+        assert result["persisted"] is False
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_invoke_tool_routes_reasoning_effort(self, agent):
+        """The agent-loop interception must handle reasoning_effort — the
+        registry dispatcher only returns a stub error for loop tools."""
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(
+            agent._invoke_tool("reasoning_effort", {"level": "xhigh"}, "task-1")
+        )
+
+        assert result["success"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
 
 
 class TestBuildAssistantMessage:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1253,6 +1253,36 @@ class TestEnvironmentProbeIntegration:
 
 
 class TestInvalidateSystemPrompt:
+    def test_reasoning_effort_guidance_when_tool_loaded(self):
+        from agent.prompt_builder import REASONING_EFFORT_GUIDANCE
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search", "reasoning_effort")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(api_key="test-key-1234567890", base_url="https://openrouter.ai/api/v1", quiet_mode=True, skip_context_files=True, skip_memory=True)
+        assert REASONING_EFFORT_GUIDANCE in agent._build_system_prompt()
+
+    def test_no_reasoning_effort_guidance_without_tool(self, agent):
+        from agent.prompt_builder import REASONING_EFFORT_GUIDANCE
+        assert REASONING_EFFORT_GUIDANCE not in agent._build_system_prompt()
+
+    def test_system_prompt_stays_stable_after_reasoning_effort_change(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search", "reasoning_effort")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(api_key="test-key-1234567890", base_url="https://openrouter.ai/api/v1", quiet_mode=True, skip_context_files=True, skip_memory=True)
+        original_prompt = agent._build_system_prompt()
+        cached_before = agent._cached_system_prompt
+        result = json.loads(agent._apply_reasoning_effort({"level": "high"}))
+        assert result["success"] is True
+        assert agent._cached_system_prompt is cached_before
+        assert agent._build_system_prompt() == original_prompt
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
     def test_clears_cache(self, agent):
         agent._cached_system_prompt = "cached value"
         agent._invalidate_system_prompt()
@@ -1450,6 +1480,116 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+
+
+class TestApplyReasoningEffort:
+    def test_updates_reasoning_config(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "low"}))
+
+        assert result["success"] is True
+        assert result["level"] == "low"
+        assert result["reasoning_config"] == {"enabled": True, "effort": "low"}
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_new_level_reaches_next_api_request(self, agent):
+        """The changed level must flow into request construction — that is
+        the mechanism that replaces mutating the system prompt."""
+        agent.provider = "openrouter"
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        json.loads(agent._apply_reasoning_effort({"level": "high"}))
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs.get("extra_body", {}).get("reasoning", {}).get("effort") == "high"
+
+    def test_can_disable_reasoning(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "none"}))
+
+        assert result["success"] is True
+        assert result["enabled"] is False
+        assert agent.reasoning_config == {"enabled": False}
+
+    def test_rejects_invalid_level(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "galaxy-brain"}))
+
+        assert "error" in result
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
+    def test_rejects_missing_level(self, agent):
+        result = json.loads(agent._apply_reasoning_effort({}))
+        assert "error" in result
+
+    def test_callback_receives_session_scope_by_default(self, agent):
+        calls = []
+
+        def _update(level, parsed_config, persist=False):
+            calls.append((level, parsed_config, persist))
+            return False
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "high"}))
+
+        assert result["success"] is True
+        assert result["persisted"] is False
+        assert calls == [("high", {"enabled": True, "effort": "high"}, False)]
+
+    def test_persist_flag_reaches_callback(self, agent):
+        calls = []
+
+        def _update(level, parsed_config, persist=False):
+            calls.append((level, parsed_config, persist))
+            return True
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(
+            agent._apply_reasoning_effort({"level": "high", "persist": True})
+        )
+
+        assert result["success"] is True
+        assert result["persisted"] is True
+        assert calls == [("high", {"enabled": True, "effort": "high"}, True)]
+
+    def test_reports_no_change_for_same_level(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "medium"}))
+
+        assert result["success"] is True
+        assert result["no_change"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
+    def test_callback_failure_does_not_block_runtime_change(self, agent):
+        def _update(level, parsed_config, persist=False):
+            raise RuntimeError("disk full")
+
+        agent.reasoning_update_callback = _update
+
+        result = json.loads(agent._apply_reasoning_effort({"level": "low"}))
+
+        assert result["success"] is True
+        assert result["persisted"] is False
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_invoke_tool_routes_reasoning_effort(self, agent):
+        """The agent-loop interception must handle reasoning_effort — the
+        registry dispatcher only returns a stub error for loop tools."""
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        result = json.loads(
+            agent._invoke_tool("reasoning_effort", {"level": "xhigh"}, "task-1")
+        )
+
+        assert result["success"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
 
 
 class TestBuildAssistantMessage:
@@ -2323,6 +2463,7 @@ class TestAgentRuntimePostHookOwnershipSync:
         ("setup_mcp", {"server": "linear", "action": "install"}),
         ("tour", {"action": "stop"}),
         ("delegate_task", {"goal": "Check the child path"}),
+        ("reasoning_effort", {"level": "high"}),
     )
 
     @pytest.mark.parametrize(("tool_name", "tool_args"), _CASES)

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -212,6 +212,7 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "reasoning_effort" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -231,6 +231,7 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "reasoning_effort" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS

--- a/tests/tools/test_reasoning_effort_tool.py
+++ b/tests/tools/test_reasoning_effort_tool.py
@@ -1,0 +1,102 @@
+"""Tests for tools/reasoning_effort_tool.py — validation and dispatch."""
+
+import json
+
+from tools.reasoning_effort_tool import (
+    REASONING_EFFORT_SCHEMA,
+    check_reasoning_effort_requirements,
+    reasoning_effort_tool,
+)
+
+
+class TestReasoningEffortTool:
+    def test_requirements_always_met(self):
+        assert check_reasoning_effort_requirements() is True
+
+    def test_missing_level_errors(self):
+        result = json.loads(reasoning_effort_tool("", callback=lambda *a, **k: None))
+        assert result["error"] == "level is required"
+
+    def test_invalid_level_errors_with_valid_levels(self):
+        result = json.loads(
+            reasoning_effort_tool("galaxy-brain", callback=lambda *a, **k: None)
+        )
+        assert "invalid level" in result["error"]
+        assert "none" in result["valid_levels"]
+        assert "medium" in result["valid_levels"]
+
+    def test_no_callback_errors(self):
+        result = json.loads(reasoning_effort_tool("high"))
+        assert "not available" in result["error"]
+
+    def test_level_is_normalized_before_dispatch(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(parsed=parsed, level=level, persist=persist)
+            return {"success": True}
+
+        reasoning_effort_tool("  HIGH  ", callback=_cb)
+        assert seen["level"] == "high"
+        assert seen["parsed"] == {"enabled": True, "effort": "high"}
+        assert seen["persist"] is False
+
+    def test_none_parses_to_disabled(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(parsed=parsed)
+            return {"success": True}
+
+        reasoning_effort_tool("none", callback=_cb)
+        assert seen["parsed"] == {"enabled": False}
+
+    def test_persist_flag_forwarded(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(persist=persist)
+            return {"success": True}
+
+        reasoning_effort_tool("low", persist=True, callback=_cb)
+        assert seen["persist"] is True
+
+    def test_dict_result_serialized(self):
+        result = reasoning_effort_tool(
+            "low", callback=lambda parsed, *, level, persist: {"success": True, "level": level}
+        )
+        assert json.loads(result) == {"success": True, "level": "low"}
+
+    def test_string_result_passthrough(self):
+        result = reasoning_effort_tool(
+            "low", callback=lambda parsed, *, level, persist: '{"raw": true}'
+        )
+        assert result == '{"raw": true}'
+
+    def test_callback_exception_becomes_error(self):
+        def _cb(parsed, *, level, persist):
+            raise RuntimeError("boom")
+
+        result = json.loads(reasoning_effort_tool("low", callback=_cb))
+        assert "Failed to set reasoning effort: boom" in result["error"]
+
+    def test_schema_levels_match_parser(self):
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        schema_levels = REASONING_EFFORT_SCHEMA["parameters"]["properties"]["level"]["enum"]
+        assert schema_levels == ["none", *VALID_REASONING_EFFORTS]
+
+    def test_registered_in_registry(self):
+        # Other tests may reset the global registry; reload the module so its
+        # import-time registry.register(...) runs against the current registry.
+        import importlib
+
+        import tools.reasoning_effort_tool as _mod
+        from tools.registry import registry
+
+        if registry.get_entry("reasoning_effort") is None:
+            importlib.reload(_mod)
+
+        entry = registry.get_entry("reasoning_effort")
+        assert entry is not None
+        assert entry.toolset == "reasoning"

--- a/tests/tools/test_reasoning_effort_tool.py
+++ b/tests/tools/test_reasoning_effort_tool.py
@@ -1,0 +1,149 @@
+"""Tests for tools/reasoning_effort_tool.py — validation and dispatch."""
+
+import json
+
+from tools.reasoning_effort_tool import (
+    REASONING_EFFORT_SCHEMA,
+    check_reasoning_effort_requirements,
+    reasoning_effort_tool,
+)
+
+
+class TestReasoningEffortTool:
+    def test_requirements_always_met(self):
+        assert check_reasoning_effort_requirements() is True
+
+    def test_missing_level_errors(self):
+        result = json.loads(reasoning_effort_tool("", callback=lambda *a, **k: None))
+        assert result["error"] == "level is required"
+
+    def test_invalid_level_errors_with_valid_levels(self):
+        result = json.loads(
+            reasoning_effort_tool("galaxy-brain", callback=lambda *a, **k: None)
+        )
+        assert "invalid level" in result["error"]
+        assert "none" in result["valid_levels"]
+        assert "medium" in result["valid_levels"]
+
+    def test_no_callback_errors(self):
+        result = json.loads(reasoning_effort_tool("high"))
+        assert "not available" in result["error"]
+
+    def test_level_is_normalized_before_dispatch(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(parsed=parsed, level=level, persist=persist)
+            return {"success": True}
+
+        reasoning_effort_tool("  HIGH  ", callback=_cb)
+        assert seen["level"] == "high"
+        assert seen["parsed"] == {"enabled": True, "effort": "high"}
+        assert seen["persist"] is False
+
+    def test_none_parses_to_disabled(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(parsed=parsed)
+            return {"success": True}
+
+        reasoning_effort_tool("none", callback=_cb)
+        assert seen["parsed"] == {"enabled": False}
+
+    def test_persist_flag_forwarded(self):
+        seen = {}
+
+        def _cb(parsed, *, level, persist):
+            seen.update(persist=persist)
+            return {"success": True}
+
+        reasoning_effort_tool("low", persist=True, callback=_cb)
+        assert seen["persist"] is True
+
+    def test_dict_result_serialized(self):
+        result = reasoning_effort_tool(
+            "low", callback=lambda parsed, *, level, persist: {"success": True, "level": level}
+        )
+        assert json.loads(result) == {"success": True, "level": "low"}
+
+    def test_string_result_passthrough(self):
+        result = reasoning_effort_tool(
+            "low", callback=lambda parsed, *, level, persist: '{"raw": true}'
+        )
+        assert result == '{"raw": true}'
+
+    def test_callback_exception_becomes_error(self):
+        def _cb(parsed, *, level, persist):
+            raise RuntimeError("boom")
+
+        result = json.loads(reasoning_effort_tool("low", callback=_cb))
+        assert "Failed to set reasoning effort: boom" in result["error"]
+
+    def test_schema_levels_match_parser(self):
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        schema_levels = REASONING_EFFORT_SCHEMA["parameters"]["properties"]["level"]["enum"]
+        assert schema_levels == ["none", *VALID_REASONING_EFFORTS]
+
+    def test_registered_in_registry(self):
+        # Other tests may reset the global registry; reload the module so its
+        # import-time registry.register(...) runs against the current registry.
+        import importlib
+
+        import tools.reasoning_effort_tool as _mod
+        from tools.registry import registry
+
+        if registry.get_entry("reasoning_effort") is None:
+            importlib.reload(_mod)
+
+        entry = registry.get_entry("reasoning_effort")
+        assert entry is not None
+        assert entry.toolset == "reasoning"
+
+
+class TestOptInFootprint:
+    """reasoning_effort is opt-in — zero default core-schema footprint.
+
+    Review #63316 (toolsets.py thread): core tools are never deferred by
+    tool_search, so membership in _HERMES_CORE_TOOLS is a permanent schema
+    cost on every default platform request. The tool must stay out of the
+    core bundle and off by default; users enable it via `hermes tools` →
+    Reasoning Effort.
+    """
+
+    def test_not_in_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "reasoning_effort" not in _HERMES_CORE_TOOLS
+
+    def test_reasoning_toolset_off_by_default(self):
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        assert "reasoning" in _DEFAULT_OFF_TOOLSETS
+
+    def test_reasoning_toolset_configurable(self):
+        from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
+
+        assert any(key == "reasoning" for key, _, _ in CONFIGURABLE_TOOLSETS)
+
+    def test_unconfigured_platform_resolution_excludes_reasoning(self):
+        """Default (no saved toolset list) platform resolution must not
+        enable the reasoning toolset."""
+        from hermes_cli.tools_config import _get_platform_tools
+
+        enabled = _get_platform_tools(
+            {}, "cli", include_default_mcp_servers=False
+        )
+        assert "reasoning" not in enabled
+
+    def test_explicit_opt_in_enables_reasoning(self):
+        """A user-saved toolset list naming `reasoning` must survive
+        resolution (explicit opt-ins are never stripped by default-off)."""
+        from hermes_cli.tools_config import _get_platform_tools
+
+        config = {"platform_toolsets": {"cli": ["hermes-cli", "reasoning"]}}
+        enabled = _get_platform_tools(
+            config, "cli", include_default_mcp_servers=False
+        )
+        assert "reasoning" in enabled

--- a/tests/tools/test_reasoning_effort_tool.py
+++ b/tests/tools/test_reasoning_effort_tool.py
@@ -100,3 +100,50 @@ class TestReasoningEffortTool:
         entry = registry.get_entry("reasoning_effort")
         assert entry is not None
         assert entry.toolset == "reasoning"
+
+
+class TestOptInFootprint:
+    """reasoning_effort is opt-in — zero default core-schema footprint.
+
+    Review #63316 (toolsets.py thread): core tools are never deferred by
+    tool_search, so membership in _HERMES_CORE_TOOLS is a permanent schema
+    cost on every default platform request. The tool must stay out of the
+    core bundle and off by default; users enable it via `hermes tools` →
+    Reasoning Effort.
+    """
+
+    def test_not_in_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "reasoning_effort" not in _HERMES_CORE_TOOLS
+
+    def test_reasoning_toolset_off_by_default(self):
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        assert "reasoning" in _DEFAULT_OFF_TOOLSETS
+
+    def test_reasoning_toolset_configurable(self):
+        from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
+
+        assert any(key == "reasoning" for key, _, _ in CONFIGURABLE_TOOLSETS)
+
+    def test_unconfigured_platform_resolution_excludes_reasoning(self):
+        """Default (no saved toolset list) platform resolution must not
+        enable the reasoning toolset."""
+        from hermes_cli.tools_config import _get_platform_tools
+
+        enabled = _get_platform_tools(
+            {}, "cli", include_default_mcp_servers=False
+        )
+        assert "reasoning" not in enabled
+
+    def test_explicit_opt_in_enables_reasoning(self):
+        """A user-saved toolset list naming `reasoning` must survive
+        resolution (explicit opt-ins are never stripped by default-off)."""
+        from hermes_cli.tools_config import _get_platform_tools
+
+        config = {"platform_toolsets": {"cli": ["hermes-cli", "reasoning"]}}
+        enabled = _get_platform_tools(
+            config, "cli", include_default_mcp_servers=False
+        )
+        assert "reasoning" in enabled

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -119,3 +119,188 @@ class TestLoadReasoningConfigYamlBoolean:
     def test_unset_returns_default(self) -> None:
         with patch.object(server, "_load_cfg", return_value={"agent": {}}):
             assert server._load_reasoning_config() is None
+
+
+class TestReasoningUpdateCallback:
+    """The reasoning_effort tool's platform hook on the TUI/desktop surface.
+
+    The agent's in-process ``reasoning_config`` mutation does not survive a
+    session rebuild (resume / deferred build re-applies the resolved config),
+    so the callback must land session scope on ``create_reasoning_override``
+    and route ``persist=True`` to config.yaml — mirroring the session-scoped
+    ``config.set key=reasoning`` handler above.
+    """
+
+    def _session(self, sid: str, agent=None) -> dict:
+        return {"session_key": f"key-{sid}", "agent": agent}
+
+    def test_session_scope_lands_on_create_override(self) -> None:
+        session = self._session("s1")
+        with patch.dict(server._sessions, {"s1": session}, clear=False), \
+                patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("s1")(
+                "high", {"enabled": True, "effort": "high"}, False
+            )
+        assert persisted is False
+        assert session["create_reasoning_override"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+        write_key.assert_not_called()
+
+    def test_persist_writes_config_and_clears_override(self) -> None:
+        session = self._session("s2")
+        session["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+        with patch.dict(server._sessions, {"s2": session}, clear=False), \
+                patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("s2")(
+                "high", {"enabled": True, "effort": "high"}, True
+            )
+        assert persisted is True
+        write_key.assert_called_once_with("agent.reasoning_effort", "high")
+        assert "create_reasoning_override" not in session
+
+    def test_persist_failure_falls_back_to_session_override(self) -> None:
+        session = self._session("s3")
+        with patch.dict(server._sessions, {"s3": session}, clear=False), \
+                patch.object(
+                    server, "_write_config_key", side_effect=OSError("disk full")
+                ):
+            persisted = server._make_reasoning_update_callback("s3")(
+                "high", {"enabled": True, "effort": "high"}, True
+            )
+        assert persisted is False
+        assert session["create_reasoning_override"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_live_agent_gets_config_and_footer_update(self) -> None:
+        agent = _agent(None)
+        session = self._session("s4", agent=agent)
+        with patch.dict(server._sessions, {"s4": session}, clear=False), \
+                patch.object(server, "_persist_live_session_runtime") as persist_rt, \
+                patch.object(server, "_emit") as emit:
+            server._make_reasoning_update_callback("s4")(
+                "xhigh", {"enabled": True, "effort": "xhigh"}, False
+            )
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+        persist_rt.assert_called_once_with(session)
+        assert emit.call_args.args[0] == "session.info"
+
+    def test_unknown_session_is_noop_but_persist_still_works(self) -> None:
+        with patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("gone")(
+                "low", {"enabled": True, "effort": "low"}, True
+            )
+        assert persisted is True
+        write_key.assert_called_once_with("agent.reasoning_effort", "low")
+
+
+class TestPersistTrueEndToEnd:
+    """persist=true from the reasoning_effort tool must reach config.yaml.
+
+    Drives the REAL agent-side dispatch (``AIAgent._apply_reasoning_effort``)
+    through the REAL TUI callback and the REAL ``_write_config_key`` /
+    ``_save_cfg`` path against a temp HERMES home — the exact surface the
+    #63316 review flagged as unwired.
+    """
+
+    def test_persist_true_saves_tui_default(self, tmp_path, monkeypatch) -> None:
+        import yaml
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(server, "_hermes_home", home)
+        # Invalidate the module-level config cache (keyed on path, but keep
+        # this test independent of prior cache state).
+        monkeypatch.setattr(server, "_cfg_cache", None)
+        monkeypatch.setattr(server, "_cfg_mtime", None)
+        monkeypatch.setattr(server, "_cfg_path", None)
+
+        tool_defs = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "reasoning_effort",
+                    "description": "reasoning_effort tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with (
+            patch("run_agent.get_tool_definitions", return_value=tool_defs),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                reasoning_config={"enabled": True, "effort": "medium"},
+                reasoning_update_callback=server._make_reasoning_update_callback(
+                    "sid-e2e"
+                ),
+            )
+
+        session = {"session_key": "key-e2e", "agent": agent}
+        session["create_reasoning_override"] = {"enabled": True, "effort": "medium"}
+        with patch.dict(server._sessions, {"sid-e2e": session}, clear=False), \
+                patch.object(server, "_persist_live_session_runtime"), \
+                patch.object(server, "_emit"):
+            import json as _json
+
+            result = _json.loads(
+                agent._apply_reasoning_effort({"level": "high", "persist": True})
+            )
+
+        assert result["success"] is True
+        assert result["persisted"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+        # The durable TUI/desktop default actually landed on disk.
+        saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "high"
+        # Session override cleared — the global value now owns rebuilds.
+        assert "create_reasoning_override" not in session
+
+
+class TestMakeAgentWiresReasoningCallback:
+    """_make_agent must construct agents with the reasoning_update_callback —
+    the exact gap flagged in the #63316 review (toolsets.py thread)."""
+
+    def test_make_agent_passes_callback(self) -> None:
+        from unittest.mock import MagicMock
+
+        fake_runtime = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        }
+        with (
+            patch.object(server, "_load_cfg", return_value={"agent": {}}),
+            patch.object(server, "_get_db", return_value=MagicMock()),
+            patch.object(server, "_load_tool_progress_mode", return_value="compact"),
+            patch.object(server, "_load_reasoning_config", return_value=None),
+            patch.object(server, "_load_service_tier", return_value=None),
+            patch.object(server, "_load_enabled_toolsets", return_value=None),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=fake_runtime,
+            ),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            server._make_agent("sid-cb", "key-cb")
+
+        cb = mock_agent.call_args.kwargs.get("reasoning_update_callback")
+        assert callable(cb)

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -101,3 +101,132 @@ class TestLoadReasoningConfigYamlBoolean:
         ):
             assert server._load_reasoning_config() == {"enabled": False}
 
+
+class TestReasoningUpdateCallback:
+    def _session(self, sid: str, agent=None) -> dict:
+        return {"session_key": f"key-{sid}", "agent": agent}
+
+    def test_session_scope_lands_on_create_override(self) -> None:
+        session = self._session("s1")
+        with patch.dict(server._sessions, {"s1": session}, clear=False), \
+                patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("s1")(
+                "high", {"enabled": True, "effort": "high"}, False
+            )
+        assert persisted is False
+        assert session["create_reasoning_override"] == {"enabled": True, "effort": "high"}
+        write_key.assert_not_called()
+
+    def test_persist_writes_config_and_clears_override(self) -> None:
+        session = self._session("s2")
+        session["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+        with patch.dict(server._sessions, {"s2": session}, clear=False), \
+                patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("s2")(
+                "high", {"enabled": True, "effort": "high"}, True
+            )
+        assert persisted is True
+        write_key.assert_called_once_with("agent.reasoning_effort", "high")
+        assert "create_reasoning_override" not in session
+
+    def test_persist_failure_falls_back_to_session_override(self) -> None:
+        session = self._session("s3")
+        with patch.dict(server._sessions, {"s3": session}, clear=False), \
+                patch.object(server, "_write_config_key", side_effect=OSError("disk full")):
+            persisted = server._make_reasoning_update_callback("s3")(
+                "high", {"enabled": True, "effort": "high"}, True
+            )
+        assert persisted is False
+        assert session["create_reasoning_override"] == {"enabled": True, "effort": "high"}
+
+    def test_live_agent_gets_config_and_footer_update(self) -> None:
+        agent = _agent(None)
+        session = self._session("s4", agent=agent)
+        with patch.dict(server._sessions, {"s4": session}, clear=False), \
+                patch.object(server, "_persist_live_session_runtime") as persist_rt, \
+                patch.object(server, "_emit") as emit:
+            server._make_reasoning_update_callback("s4")(
+                "xhigh", {"enabled": True, "effort": "xhigh"}, False
+            )
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+        persist_rt.assert_called_once_with(session)
+        assert emit.call_args.args[0] == "session.info"
+
+    def test_unknown_session_is_noop_but_persist_still_works(self) -> None:
+        with patch.object(server, "_write_config_key") as write_key:
+            persisted = server._make_reasoning_update_callback("gone")(
+                "low", {"enabled": True, "effort": "low"}, True
+            )
+        assert persisted is True
+        write_key.assert_called_once_with("agent.reasoning_effort", "low")
+
+
+class TestPersistTrueEndToEnd:
+    def test_persist_true_saves_tui_default(self, tmp_path, monkeypatch) -> None:
+        import json as _json
+        import yaml
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+        monkeypatch.setattr(server, "_hermes_home", home)
+        monkeypatch.setattr(server, "_cfg_cache", None)
+        monkeypatch.setattr(server, "_cfg_mtime", None)
+        monkeypatch.setattr(server, "_cfg_path", None)
+        tool_defs = [{"type": "function", "function": {
+            "name": "reasoning_effort", "description": "reasoning_effort tool",
+            "parameters": {"type": "object", "properties": {}}
+        }}]
+        with (
+            patch("run_agent.get_tool_definitions", return_value=tool_defs),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                reasoning_config={"enabled": True, "effort": "medium"},
+                reasoning_update_callback=server._make_reasoning_update_callback("sid-e2e"),
+            )
+        session = {
+            "session_key": "key-e2e", "agent": agent,
+            "create_reasoning_override": {"enabled": True, "effort": "medium"},
+        }
+        with patch.dict(server._sessions, {"sid-e2e": session}, clear=False), \
+                patch.object(server, "_persist_live_session_runtime"), \
+                patch.object(server, "_emit"):
+            result = _json.loads(agent._apply_reasoning_effort({"level": "high", "persist": True}))
+        assert result["success"] is True
+        assert result["persisted"] is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+        saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agent"]["reasoning_effort"] == "high"
+        assert "create_reasoning_override" not in session
+
+
+class TestMakeAgentWiresReasoningCallback:
+    def test_make_agent_passes_callback(self) -> None:
+        from unittest.mock import MagicMock
+
+        fake_runtime = {
+            "provider": "openrouter", "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test", "api_mode": "chat_completions", "command": None,
+            "args": None, "credential_pool": None,
+        }
+        with (
+            patch.object(server, "_load_cfg", return_value={"agent": {}}),
+            patch.object(server, "_get_db", return_value=MagicMock()),
+            patch.object(server, "_load_tool_progress_mode", return_value="compact"),
+            patch.object(server, "_load_reasoning_config", return_value=None),
+            patch.object(server, "_load_service_tier", return_value=None),
+            patch.object(server, "_load_enabled_toolsets", return_value=None),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            server._make_agent("sid-cb", "key-cb")
+        assert callable(mock_agent.call_args.kwargs.get("reasoning_update_callback"))
+

--- a/tools/reasoning_effort_tool.py
+++ b/tools/reasoning_effort_tool.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Reasoning effort tool — adjust the agent's reasoning effort at runtime.
+
+The tool itself is a thin validation + dispatch layer: the actual state
+change lives in the agent loop (``AIAgent._apply_reasoning_effort``), which
+mutates the live agent's ``reasoning_config`` and, when the platform provides
+one, routes scope handling through ``reasoning_update_callback`` (session
+override on the gateway, config persistence on request). Request construction
+reads ``agent.reasoning_config`` on every API call, so a change takes effect
+on the next request without touching the lifetime-stable system prompt.
+"""
+
+import json
+
+from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+from tools.registry import registry
+
+
+def check_reasoning_effort_requirements() -> bool:
+    """Reasoning effort has no external requirements."""
+    return True
+
+
+def reasoning_effort_tool(level: str, persist: bool = False, callback=None) -> str:
+    """Validate and dispatch a reasoning-effort update through a runtime callback."""
+    if not level or not str(level).strip():
+        return json.dumps({"error": "level is required"}, ensure_ascii=False)
+
+    normalized = str(level).strip().lower()
+    parsed = parse_reasoning_effort(normalized)
+    if parsed is None:
+        return json.dumps(
+            {
+                "error": f"invalid level '{normalized}'",
+                "valid_levels": ["none", *VALID_REASONING_EFFORTS],
+            },
+            ensure_ascii=False,
+        )
+
+    if callback is None:
+        return json.dumps(
+            {"error": "reasoning_effort tool is not available in this execution context"},
+            ensure_ascii=False,
+        )
+
+    try:
+        result = callback(parsed, level=normalized, persist=bool(persist))
+    except Exception as exc:
+        return json.dumps(
+            {"error": f"Failed to set reasoning effort: {exc}"},
+            ensure_ascii=False,
+        )
+
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, ensure_ascii=False)
+
+
+REASONING_EFFORT_SCHEMA = {
+    "name": "reasoning_effort",
+    "description": (
+        "Adjust your own reasoning effort for the current session. "
+        "Use it when the task at hand needs materially more or less thinking "
+        "depth. The change applies from the next model request onward. "
+        "Levels from lowest to highest: none, "
+        + ", ".join(VALID_REASONING_EFFORTS)
+        + "."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "enum": ["none", *VALID_REASONING_EFFORTS],
+                "description": "Desired reasoning effort level.",
+            },
+            "persist": {
+                "type": "boolean",
+                "description": (
+                    "If true, also persist the level as the global default "
+                    "via the platform layer. Only use when the user asked "
+                    "for a permanent change."
+                ),
+                "default": False,
+            },
+        },
+        "required": ["level"],
+    },
+}
+
+
+registry.register(
+    name="reasoning_effort",
+    toolset="reasoning",
+    schema=REASONING_EFFORT_SCHEMA,
+    handler=lambda args, **kw: reasoning_effort_tool(
+        level=args.get("level", ""),
+        persist=args.get("persist", False),
+        callback=kw.get("callback"),
+    ),
+    check_fn=check_reasoning_effort_requirements,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -61,6 +61,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Runtime reasoning-effort control
+    "reasoning_effort",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -235,7 +237,13 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
-    
+
+    "reasoning": {
+        "description": "Adjust runtime reasoning effort for the active session",
+        "tools": ["reasoning_effort"],
+        "includes": []
+    },
+
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
         "tools": ["execute_code"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -61,8 +61,6 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
-    # Runtime reasoning-effort control
-    "reasoning_effort",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -239,7 +237,12 @@ TOOLSETS = {
     },
 
     "reasoning": {
-        "description": "Adjust runtime reasoning effort for the active session",
+        "description": (
+            "Adjust runtime reasoning effort for the active session. "
+            "Off by default (deliberately not in _HERMES_CORE_TOOLS — zero "
+            "schema footprint unless wanted); enable in `hermes tools` → "
+            "Reasoning Effort."
+        ),
         "tools": ["reasoning_effort"],
         "includes": []
     },

--- a/toolsets.py
+++ b/toolsets.py
@@ -289,6 +289,17 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "reasoning": {
+        "description": (
+            "Adjust runtime reasoning effort for the active session. "
+            "Off by default (deliberately not in _HERMES_CORE_TOOLS — zero "
+            "schema footprint unless wanted); enable in `hermes tools` → "
+            "Reasoning Effort."
+        ),
+        "tools": ["reasoning_effort"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3867,6 +3867,49 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             _child_mirrors.pop(child_key, None)
 
 
+def _make_reasoning_update_callback(sid: str):
+    """Platform hook for the reasoning_effort tool (TUI/desktop surface).
+
+    Mirrors the ``config.set key=reasoning`` handler: session scope lands on
+    ``create_reasoning_override`` so lazily-built/resumed sessions keep the
+    level (the agent's own ``reasoning_config`` mutation would be dropped on
+    rebuild), and ``persist=True`` writes ``agent.reasoning_effort`` to
+    config.yaml — clearing the now-redundant session override so the global
+    value takes effect on rebuild. Returns True only when durably persisted.
+    """
+
+    def _callback(level: str, parsed_config: dict, persist: bool = False) -> bool:
+        persisted = False
+        if persist:
+            try:
+                _write_config_key("agent.reasoning_effort", level)
+                persisted = True
+            except Exception:
+                logger.error("failed to persist reasoning_effort from tool", exc_info=True)
+
+        with _sessions_lock:
+            session = _sessions.get(sid)
+        if session is not None:
+            if persisted:
+                session.pop("create_reasoning_override", None)
+            else:
+                session["create_reasoning_override"] = parsed_config
+            agent = session.get("agent")
+            if agent is not None:
+                # Set eagerly (the agent loop re-applies it right after) so the
+                # footer emit below and the durable session row both see the
+                # new level, not the pre-tool one.
+                agent.reasoning_config = parsed_config
+                try:
+                    _persist_live_session_runtime(session)
+                    _emit("session.info", sid, _session_info(agent, session))
+                except Exception:
+                    logger.debug("failed to publish reasoning update", exc_info=True)
+        return persisted
+
+    return _callback
+
+
 def _agent_cbs(sid: str) -> dict:
     return {
         "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
@@ -4643,6 +4686,10 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        # Session-scoped hook for the reasoning_effort tool — without it a
+        # TUI/desktop `persist: true` (or any tool-set level on a rebuilt
+        # session) is silently dropped. See _make_reasoning_update_callback.
+        reasoning_update_callback=_make_reasoning_update_callback(sid),
         **_agent_cbs(sid),
     )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6236,6 +6236,37 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             _child_mirrors.pop(child_key, None)
 
 
+def _make_reasoning_update_callback(sid: str):
+    """Persist or session-scope reasoning updates for TUI/desktop agents."""
+    def _callback(level: str, parsed_config: dict, persist: bool = False) -> bool:
+        persisted = False
+        if persist:
+            try:
+                _write_config_key("agent.reasoning_effort", level)
+                persisted = True
+            except Exception:
+                logger.error("failed to persist reasoning_effort from tool", exc_info=True)
+
+        with _sessions_lock:
+            session = _sessions.get(sid)
+        if session is not None:
+            if persisted:
+                session.pop("create_reasoning_override", None)
+            else:
+                session["create_reasoning_override"] = dict(parsed_config)
+            agent = session.get("agent")
+            if agent is not None:
+                agent.reasoning_config = dict(parsed_config)
+                try:
+                    _persist_live_session_runtime(session)
+                    _emit("session.info", sid, _session_info(agent, session))
+                except Exception:
+                    logger.debug("failed to publish reasoning update", exc_info=True)
+        return persisted
+
+    return _callback
+
+
 def _agent_cbs(sid: str) -> dict:
     callbacks = {
         "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
@@ -7119,6 +7150,10 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        # Session-scoped hook for the reasoning_effort tool — without it a
+        # TUI/desktop `persist: true` (or any tool-set level on a rebuilt
+        # session) is silently dropped. See _make_reasoning_update_callback.
+        reasoning_update_callback=_make_reasoning_update_callback(sid),
         **_agent_cbs(sid),
     )
 


### PR DESCRIPTION
I implemented it for my personal needs, sharing in case useful upstream.

## Summary

Adds a first-class `reasoning_effort` tool so agents can adjust their own reasoning depth mid-session. This is a clean reimplementation of #7282 (credit to @ian-pascoe for the original design), rebuilt on current `main` to address the review blockers in https://github.com/NousResearch/hermes-agent/pull/7282#pullrequestreview-4679846108 and to drop the unrelated browser/SearXNG/update-command/lockfile changes bundled there.

## What changed

- **`tools/reasoning_effort_tool.py`** — validation + dispatch layer, registered under a new `reasoning` toolset; exposed in `toolsets.py`, `model_tools._AGENT_LOOP_TOOLS`, and the `hermes tools` configurator.
- **Agent loop** (`run_agent.py`, `agent/agent_runtime_helpers.py`, `agent/tool_executor.py`) — intercepts the tool on both sequential and concurrent dispatch paths via `AIAgent._apply_reasoning_effort`, which mutates `agent.reasoning_config` only.
- **Prompt** (`agent/prompt_builder.py`, `agent/system_prompt.py`) — a **static** `REASONING_EFFORT_GUIDANCE` block, injected only when the tool is loaded.
- **Platform wiring** — new `reasoning_update_callback(level, parsed_config, persist)` constructor hook; CLI syncs its `reasoning_config` and persists on `persist=true`; gateway binds the session key into the callback at agent-attach time.
- **Display** (`agent/display.py`) — tool preview (`high`, `low (persist)`) and progress verb.

## How the #7282 review blockers are addressed

1. **System prompt stays lifetime-stable.** The level-dependent status line is gone and `_cached_system_prompt` is never invalidated. Request construction already reads `agent.reasoning_config` per API call, so the change applies from the next request without touching the prompt. A test asserts the prompt is byte-identical across a level change *and* that the new level reaches `_build_api_kwargs`.
2. **Gateway non-persistent updates survive.** The cached-agent path resets `agent.reasoning_config` from `_resolve_session_reasoning_config()` every message, so the callback routes non-persistent updates through the existing `_session_reasoning_overrides` mechanism (same rail as `/reasoning <level>`). `persist=true` writes `agent.reasoning_effort` to config.yaml and clears the override; a failed config write degrades to a session override.
3. **Tests match the shipped guidance text** — assertions are written against the actual `REASONING_EFFORT_GUIDANCE` constant, plus a guard that the guidance never embeds the current level.
4. **Unrelated work split out** — browser CDP, SearXNG, `hermes update` rework, and the package-lock regen are not in this PR.

## Testing

- New: `tests/tools/test_reasoning_effort_tool.py` (12), `TestApplyReasoningEffort` in run_agent (10), `TestReasoningUpdateCallback` gateway tests (5), display preview tests, prompt-builder guidance tests.
- `tests/agent/` + `tests/run_agent/` + `tests/test_model_tools.py` + gateway/CLI suites: failure set is byte-identical to a clean `main` baseline (order-dependent pre-existing failures only; verified with `diff` of the two FAILED lists) — zero new failures, ~7,700 passing.
- Live smoke: real `AIAgent` → `_invoke_tool("reasoning_effort", …)` → config mutated, prompt cache object untouched, level present in API kwargs, persist callback fired.

Supersedes #7282.

