### PR TITLE
fix(tui): enforce notification session ownership across all drain paths

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7712,12 +7712,8 @@ def test_notification_poller_delivers_completion(monkeypatch):
 
     # Isolate the completion queue for the duration of this test. The poller
     # reads process_registry.completion_queue by attribute at runtime; the
-    # event below carries no session_key, so any *other* poller (a leaked
-    # daemon thread from another test, or a concurrent one in the same xdist
-    # worker) is allowed to dequeue and dispatch it to its own session — whose
-    # agent may be a fixture double without run_conversation. A fresh Queue
-    # here fully isolates this test; monkeypatch restores the original on
-    # teardown. (Same pattern as test_notification_poller_requeues_when_busy.)
+    # A fresh Queue fully isolates this test from leaked/concurrent pollers in
+    # the same xdist worker; monkeypatch restores the original on teardown.
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_poller_test")
@@ -7729,6 +7725,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
     isolated_queue.put({
         "type": "completion",
         "session_id": "proc_poller_test",
+        "session_key": "session-key",
         "command": "echo hello",
         "exit_code": 0,
         "output": "hello",
@@ -7779,9 +7776,7 @@ def test_notification_poller_skips_consumed(monkeypatch):
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
     # Isolate the completion queue so a concurrent/leaked poller in the same
-    # xdist worker can't dequeue this session_key-less event before our poller
-    # does. monkeypatch restores the shared singleton on teardown. (Same
-    # pattern as test_notification_poller_requeues_when_busy.)
+    # xdist worker can't dequeue this event before our poller does.
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
 
@@ -7789,6 +7784,7 @@ def test_notification_poller_skips_consumed(monkeypatch):
     isolated_queue.put({
         "type": "completion",
         "session_id": "proc_already_done",
+        "session_key": "session-key",
         "command": "echo x",
         "exit_code": 0,
         "output": "x",
@@ -7831,6 +7827,7 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
     evt = {
         "type": "completion",
         "session_id": "proc_busy_test",
+        "session_key": "session-key",
         "command": "make build",
         "exit_code": 0,
         "output": "ok",
@@ -7855,6 +7852,234 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         server._sessions.pop("sid_busy", None)
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
+
+
+def test_post_turn_drain_preserves_foreign_completion_for_owner(monkeypatch):
+    """B's post-turn drain cannot consume A's process completion."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    session_a = _session(session_key="session-a-drainown")
+    session_b = _session(session_key="session-b-drainown")
+    server._sessions.update({"sid-a-drainown": session_a, "sid-b-drainown": session_b})
+    evt = {
+        "type": "completion",
+        "session_id": "proc-owned-by-a-drainown",
+        "session_key": "session-a-drainown",
+        "command": "echo a",
+        "exit_code": 0,
+        "output": "a",
+    }
+    isolated_queue.put(evt)
+
+    try:
+        drained_b = process_registry.drain_notifications(
+            session_key="session-b-drainown",
+            owns_event=lambda event: server._session_owns_notification_event(
+                "sid-b-drainown", session_b, event
+            ),
+        )
+        assert drained_b == []
+        assert isolated_queue.qsize() == 1
+
+        drained_a = process_registry.drain_notifications(
+            session_key="session-a-drainown",
+            owns_event=lambda event: server._session_owns_notification_event(
+                "sid-a-drainown", session_a, event
+            ),
+        )
+        assert [event[0]["session_id"] for event in drained_a] == ["proc-owned-by-a-drainown"]
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid-a-drainown", None)
+        server._sessions.pop("sid-b-drainown", None)
+
+
+def test_notification_poller_requeues_foreign_completion_then_owner_gets_it(monkeypatch):
+    """B may dequeue A's event, but only A receives the automatic turn."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    turns = {"a": [], "b": []}
+
+    class _Agent:
+        model = "test-model"
+
+        def __init__(self, bucket):
+            self._bucket = bucket
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            self._bucket.append(prompt)
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _StopAfterOneLoop:
+        def __init__(self):
+            self._checks = 0
+
+        def is_set(self):
+            self._checks += 1
+            return self._checks > 1
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    session_a = _session(agent=_Agent(turns["a"]), session_key="session-a-pollreq")
+    session_b = _session(agent=_Agent(turns["b"]), session_key="session-b-pollreq")
+    server._sessions.update({"sid-a-pollreq": session_a, "sid-b-pollreq": session_b})
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc-owned-by-a-pollreq",
+        "session_key": "session-a-pollreq",
+        "command": "echo a",
+        "exit_code": 0,
+        "output": "a",
+    })
+
+    try:
+        server._notification_poller_loop(_StopAfterOneLoop(), "sid-b-pollreq", session_b)
+        assert turns["b"] == []
+        assert isolated_queue.qsize() == 1
+
+        owner_stop = threading.Event()
+        owner_stop.set()
+        server._notification_poller_loop(owner_stop, "sid-a-pollreq", session_a)
+        session_a["_run_thread"].join(timeout=5)
+
+        assert len(turns["a"]) == 1
+        assert "proc-owned-by-a-pollreq completed normally" in turns["a"][0]
+        assert turns["b"] == []
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid-a-pollreq", None)
+        server._sessions.pop("sid-b-pollreq", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_ownerless_completion_is_injected_into_no_conversation(monkeypatch):
+    """An event without ownership metadata is never adopted by a live chat."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    class _StopAfterOneLoop:
+        def __init__(self):
+            self._checks = 0
+
+        def is_set(self):
+            self._checks += 1
+            return self._checks > 1
+
+    session_a = _session(session_key="session-a-ownerless")
+    session_b = _session(session_key="session-b-ownerless")
+    server._sessions.update({"sid-a-ownerless": session_a, "sid-b-ownerless": session_b})
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc-ownerless-ownerless",
+        "session_key": "",
+        "command": "echo orphan",
+        "exit_code": 0,
+        "output": "orphan",
+    })
+    try:
+        server._notification_poller_loop(_StopAfterOneLoop(), "sid-a-ownerless", session_a)
+
+        stop = threading.Event()
+        stop.set()
+        server._notification_poller_loop(stop, "sid-b-ownerless", session_b)
+
+        assert session_a.get("_run_thread") is None
+        assert session_b.get("_run_thread") is None
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid-a-ownerless", None)
+        server._sessions.pop("sid-b-ownerless", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_completion_ownership_follows_compression_lineage(monkeypatch):
+    """A continuation claims an event stamped with its pre-compression key."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    class _Db:
+        def resolve_resume_session_id(self, session_key):
+            assert session_key == "pre-compression"
+            return "continuation"
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: _Db())
+    session = _session(session_key="continuation")
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc-before-compression",
+        "session_key": "pre-compression",
+        "command": "echo lineage",
+        "exit_code": 0,
+        "output": "lineage",
+    })
+
+    drained = process_registry.drain_notifications(
+        session_key="continuation",
+        owns_event=lambda event: server._session_owns_notification_event(
+            "sid-continuation", session, event
+        ),
+    )
+
+    assert [event[0]["session_id"] for event in drained] == ["proc-before-compression"]
+    assert isolated_queue.empty()
+
+
+def test_completion_ownership_db_failure_fails_closed(monkeypatch):
+    """A lineage lookup failure cannot turn an unknown event into ours."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    class _BrokenDb:
+        def resolve_resume_session_id(self, _session_key):
+            raise RuntimeError("database unavailable")
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: _BrokenDb())
+    session = _session(session_key="unrelated-live-session")
+    evt = {
+        "type": "completion",
+        "session_id": "proc-unknown-lineage",
+        "session_key": "unknown-parent",
+        "command": "echo unknown",
+        "exit_code": 0,
+        "output": "unknown",
+    }
+    isolated_queue.put(evt)
+
+    drained = process_registry.drain_notifications(
+        session_key="unrelated-live-session",
+        owns_event=lambda event: server._session_owns_notification_event(
+            "sid-unrelated", session, event
+        ),
+    )
+
+    assert drained == []
+    assert isolated_queue.get_nowait() is evt
 
 
 def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
@@ -7962,6 +8187,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     base = {
         "type": "watch_match",
         "session_id": "proc_watch_dedup",
+        "session_key": "session-key",
         "command": "tail -f app.log",
         "pattern": "READY",
         "output": "READY on port 8000",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1157,18 +1157,18 @@ class ProcessRegistry:
         Skips completion events the agent already consumed via wait/log or
         observed inline via poll() (see ``_drain_should_skip``).
 
-        Async-delegation events carry a conversation payload, so draining one
-        into the wrong session is a cross-chat leak (#58684, #55578). Two
-        filter modes, strongest wins:
+        Notification events are session-scoped, so draining one into the wrong
+        session is a cross-chat leak (#58684, #55578). Two filter modes,
+        strongest wins:
 
         - ``owns_event(evt) -> bool``: positive-proof ownership callback.
-          When provided, an async-delegation event is consumed ONLY if the
-          callback returns True; everything else is re-queued for its owner.
+          When provided, an event is consumed ONLY if the callback returns
+          True; everything else is re-queued for its owner.
           The TUI passes its compression-chain-aware ownership check here so
           a post-compression session still claims its own pre-compression
           dispatches.
         - ``session_key``: plain key equality (CLI and other single-session
-          callers). Non-matching async-delegation events are re-queued.
+          callers). Non-matching events are re-queued.
 
         With neither set, all events are consumed (legacy single-session
         behavior, backward compatible).
@@ -1183,23 +1183,22 @@ class ProcessRegistry:
             _evt_sid = evt.get("session_id", "")
             if evt.get("type") == "completion" and self._drain_should_skip(_evt_sid):
                 continue
-            # Filter async-delegation events so they are not delivered to the
+            # Filter session-scoped events so they are not delivered to the
             # wrong session/thread (#58684). Positive-proof callback beats
             # bare key equality when the caller can provide one.
-            if evt.get("type") == "async_delegation":
-                if owns_event is not None:
-                    try:
-                        owned = bool(owns_event(evt))
-                    except Exception:
-                        owned = False  # fail closed — never leak on a broken check
-                    if not owned:
-                        requeue.append(evt)
-                        continue
-                elif session_key:
-                    evt_session_key = evt.get("session_key", "") or ""
-                    if evt_session_key != session_key:
-                        requeue.append(evt)
-                        continue
+            if owns_event is not None:
+                try:
+                    owned = bool(owns_event(evt))
+                except Exception:
+                    owned = False  # fail closed — never leak on a broken check
+                if not owned:
+                    requeue.append(evt)
+                    continue
+            elif session_key:
+                evt_session_key = evt.get("session_key", "") or ""
+                if evt_session_key != session_key:
+                    requeue.append(evt)
+                    continue
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8556,7 +8556,8 @@ def _notification_event_belongs_elsewhere(sid: str, session: dict, evt: dict) ->
     # Compression can rotate AIAgent.session_id while the detached child is
     # still running. Resolve the event's original key to its continuation tip so
     # an event captured before or after compression still maps to the same live
-    # desktop session instead of becoming an orphan that any poller may consume.
+    # desktop session instead of becoming an ownerless event that no poller may
+    # inject into a conversation.
     resolved_key = evt_key
     try:
         db = _get_db()
@@ -8615,9 +8616,9 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
     minus its orphan-adoption fallback. An event owns-matches when its
     ``origin_ui_session_id`` is this live session, or its ``session_key``
     (raw or resolved through the compression chain) matches this session's
-    key/lineage. Used as a fail-closed gate for async-delegation payloads:
-    "not provably elsewhere" is NOT good enough to inject a conversation
-    payload into this chat (#55578).
+    key/lineage. Used as a fail-closed gate for every process notification:
+    "not provably elsewhere" is NOT good enough to inject an automatic turn
+    into this chat (#55578).
     """
     if session.get("_finalized"):
         return False
@@ -8688,10 +8689,9 @@ def _notification_poller_loop(
     status.update (kind=process) for user visibility, then chains an
     agent turn via _run_prompt_submit if the session is idle.
 
-    NOTE: The completion_queue is global (one per process). If multiple
-    TUI sessions coexist, whichever poller wakes first grabs the event,
-    even if the process was started by a different session. This matches
-    CLI/gateway behavior (single session per process).
+    NOTE: The completion_queue is global (one per process). If multiple TUI
+    sessions coexist, a poller may dequeue another session's event, but it must
+    requeue it; only a positive ownership match may trigger an agent turn.
     """
     from tools.process_registry import process_registry, format_process_notification
 
@@ -8712,26 +8712,22 @@ def _notification_poller_loop(
             time.sleep(0.1)
             continue
 
-        # Fail closed for async-delegation results (#55578): these carry a
-        # conversation payload, and injecting one into any chat other than the
-        # one that commissioned it is a hard cross-session leak. The
+        # Fail closed for every process notification (#55578): injecting an
+        # automatic turn into any chat other than the one that commissioned it
+        # is a hard cross-session leak. The
         # belongs-elsewhere check above already re-queued events owned by
         # another LIVE session; what reaches here is either ours or an
-        # orphan whose owner is gone. Orphaned delegation payloads are
-        # DROPPED, not adopted — the subagent's summary is already persisted
-        # in the delegation records/output store, so nothing is lost, whereas
-        # a wrong-chat injection is unrecoverable. Non-delegation events
-        # (background process completions etc.) keep the historical
-        # adopt-orphans behavior.
-        if evt.get("type") == "async_delegation" and not _session_owns_notification_event(
-            sid, session, evt
-        ):
+        # orphan whose owner is gone. Ownerless events are DROPPED from
+        # conversation injection, not adopted; process/delegation output stays
+        # available in the durable registry, whereas wrong-chat injection is
+        # unrecoverable.
+        if not _session_owns_notification_event(sid, session, evt):
             logger.warning(
-                "async-delegation completion %s has no live owner "
+                "process notification %s has no live owner "
                 "(origin=%r key=%r); dropping from injection instead of "
-                "delivering to session %s (#55578 fail-closed; result "
-                "remains in the delegation records)",
-                evt.get("delegation_id", "?"),
+                "delivering to session %s (#55578 fail-closed; output "
+                "remains in the process/delegation records)",
+                evt.get("delegation_id") or evt.get("session_id", "?"),
                 str(evt.get("origin_ui_session_id") or ""),
                 str(evt.get("session_key") or ""),
                 sid,
@@ -8794,13 +8790,11 @@ def _notification_poller_loop(
         if _notification_event_belongs_elsewhere(sid, session, evt):
             deferred.append(evt)
             continue
-        # Same fail-closed rule as the live loop: an orphaned async-delegation
-        # payload is never adopted by a foreign session — defer it (a later
+        # Same fail-closed rule as the live loop: an ownerless notification is
+        # never adopted by a foreign session — defer it (a later
         # resume of the owner's lineage can still claim it) rather than
-        # injecting another chat's conversation here (#55578).
-        if evt.get("type") == "async_delegation" and not _session_owns_notification_event(
-            sid, session, evt
-        ):
+        # injecting an automatic turn into another chat (#55578).
+        if not _session_owns_notification_event(sid, session, evt):
             deferred.append(evt)
             continue
         _evt_sid = evt.get("session_id", "")
@@ -9363,7 +9357,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             # Positive-proof ownership (compression-chain aware) — the same
             # fail-closed gate the poller uses, so the post-turn drain can't
-            # adopt another session's (or an orphan's) delegation payload,
+            # adopt another session's (or an orphan's) notification,
             # while a post-compression session still claims its own
             # pre-compression dispatches (#55578).
             for _evt, synth in process_registry.drain_notifications(


### PR DESCRIPTION
## Summary

Background-process completion notifications now deliver only to the session that owns them; a multi-session `tui_gateway` process can no longer inject one session's process output into another session's conversation.

Closes #35652.

## Changes

- Apply the ownership filter (`owns_event` callback / `session_key` equality) in `ProcessRegistry.drain_notifications()` to **every** session-scoped notification type — previously only `type == "async_delegation"` was filtered (#58684/#55578 scope), so plain `completion` / `watch_match` / `watch_disabled` events were consumed by whichever session's post-turn drain or poller woke first.
- Require positive ownership (`_session_owns_notification_event`, compression-lineage aware) before the TUI live poller creates a conversation turn from a completion — "not provably elsewhere" is no longer sufficient.
- Mirror the same positive-ownership rule in the shutdown drain.
- Never inject ownerless events into any conversation — they stay retrievable in the process registry (`process` tool log/poll), and callback exceptions fail closed with requeue.
- Preserve legacy consume-everything behavior for single-session callers that pass no filter (classic CLI), and keep compression-lineage resolution so a compacted session still receives its own pre-compression events.

## Behaviour

Before: with two live sessions in one `hermes dashboard`/`--tui` process, session A's `terminal(background=true, notify_on_complete=true)` completion could surface as an `[IMPORTANT: Background process …]` turn in session B while A was live — exactly the residual drain path flagged by @gvago (second unscoped drain site) and reproduced by @Evisolpxe in #35652. On the reporting machine this fired 6 times in one evening, deterministically, from the busiest session's post-turn drain.

After: completions route to their owning session only; foreign events are requeued for their owner; ownerless events surface in the registry, never in a chat. Verified live on the reproduction machine in both directions (own-process → own-session, and the original steal topology with the thief session mid-turn): 6 leaks/evening → 0.

## Validation

| Check | Result |
|---|---|
| Targeted suites (`scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/`) | 667 passed, 0 failed (5× repeat, order-stable) |
| New regressions | 5: two-session post-turn drain, poller requeue-for-owner, ownerless non-injection, compression-lineage delivery, fail-closed on broken ownership callback |
| RED control | Production fix reverted to main with tests kept: regression tests fail (wrong-session adoption reproduced); restored: green |
| Narrowed tests | 4 existing tests that codified ownerless adoption into conversations narrowed to registry/status behavior |
| Live reproduction | 2-session dashboard topology from #35652: before 6 wrong-session injections/evening; after 0 in both directions |
| `git diff --check` | Passed |

Execution-context review of every modified call site: `drain_notifications()` stays synchronous in its caller with non-blocking queue ops; the poller/shutdown/post-turn drains run on their existing per-session daemon threads; a slow lineage DB lookup delays only that session's poller, never the JSON-RPC loop; raw-key matches avoid DB access entirely.

## Infographic

![Notification session ownership — before/after](https://raw.githubusercontent.com/abhibansal-sg/hermes-mobile/pr-assets/assets/tui-notification-ownership.png)
