### PR TITLE
fix(skills): trust reserved markers only from provenance

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -42,6 +42,20 @@ def _display_source(r) -> str:
     return r.source
 
 
+def _scan_provenance_for_source(
+    source: str,
+    identifier: str = "",
+    fallback: str = "",
+) -> tuple[str, bool]:
+    """Return scanner source identity plus whether reserved origin markers apply."""
+    if source in {"official", "agent-created"}:
+        return source, True
+    return (
+        identifier or fallback,
+        False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared do_* functions
 # ---------------------------------------------------------------------------
@@ -640,18 +654,16 @@ def do_install(identifier: str, category: str = "", force: bool = False,
 
     # Scan
     c.print("[bold]Running security scan...[/]")
-    if bundle.source == "official":
-        scan_source = "official"
-    else:
-        scan_source = (
-            getattr(bundle, "identifier", "")
-            or getattr(meta, "identifier", "")
-            or identifier
-        )
+    scan_source, allow_origin_markers = _scan_provenance_for_source(
+        bundle.source,
+        getattr(bundle, "identifier", "") or getattr(meta, "identifier", ""),
+        identifier,
+    )
     from tools.skills_hub import HUB_DIR, source_url_for_bundle
     result, scan_provenance = scan_skill_cached(
         q_path,
         source=scan_source,
+        allow_origin_markers=allow_origin_markers,
         source_url=source_url_for_bundle(bundle),
         cache_dir=HUB_DIR / "scan-cache",
     )
@@ -1100,7 +1112,16 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+        scan_source, allow_origin_markers = _scan_provenance_for_source(
+            entry["source"],
+            entry.get("identifier", ""),
+            entry["name"],
+        )
+        result = scan_skill(
+            skill_path,
+            source=scan_source,
+            allow_origin_markers=allow_origin_markers,
+        )
         c.print(format_scan_report(result))
 
         if deep:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12448,19 +12448,21 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
         if not bundle:
             return None
 
-        if bundle.source == "official":
-            scan_source = "official"
-        else:
-            scan_source = (
-                getattr(bundle, "identifier", "")
-                or getattr(meta, "identifier", "")
-                or ident
-            )
+        from hermes_cli.skills_hub import _scan_provenance_for_source
+        scan_source, allow_origin_markers = _scan_provenance_for_source(
+            bundle.source,
+            getattr(bundle, "identifier", "") or getattr(meta, "identifier", ""),
+            ident,
+        )
 
         q_path = None
         try:
             q_path = quarantine_bundle(bundle)
-            result = scan_skill(q_path, source=scan_source)
+            result = scan_skill(
+                q_path,
+                source=scan_source,
+                allow_origin_markers=allow_origin_markers,
+            )
         finally:
             if q_path is not None:
                 _shutil.rmtree(q_path, ignore_errors=True)

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -292,8 +292,9 @@ def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_en
 
     scanned = {}
 
-    def _scan_skill(skill_path, source="community"):
+    def _scan_skill(skill_path, source="community", allow_origin_markers=True):
         scanned["source"] = source
+        scanned["allow_origin_markers"] = allow_origin_markers
         return guard.ScanResult(
             skill_name="frontend-design",
             source=source,
@@ -315,6 +316,7 @@ def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_en
     do_install("skils-sh/anthropics/skills/frontend-design", console=console, skip_confirm=True)
 
     assert scanned["source"] == canonical_identifier
+    assert scanned["allow_origin_markers"] is False
 
 
 def test_do_install_scans_official_bundles_with_source_provenance(
@@ -346,8 +348,9 @@ def test_do_install_scans_official_bundles_with_source_provenance(
 
     scanned = {}
 
-    def _scan_skill(skill_path, source="community"):
+    def _scan_skill(skill_path, source="community", allow_origin_markers=True):
         scanned["source"] = source
+        scanned["allow_origin_markers"] = allow_origin_markers
         return guard.ScanResult(
             skill_name="prunus-gaia",
             source=source,
@@ -369,6 +372,108 @@ def test_do_install_scans_official_bundles_with_source_provenance(
     do_install("official/agent/prunus-gaia", console=console, skip_confirm=True)
 
     assert scanned["source"] == "official"
+    assert scanned["allow_origin_markers"] is True
+
+
+def test_do_install_does_not_treat_marketplace_slug_official_as_builtin(
+    monkeypatch, tmp_path, hub_env
+):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    class _SlugSource:
+        def inspect(self, identifier):
+            return type("Meta", (), {
+                "extra": {},
+                "identifier": "official",
+            })()
+
+        def fetch(self, identifier):
+            return type("Bundle", (), {
+                "name": "official",
+                "files": {"SKILL.md": "# Official"},
+                "source": "skills.sh",
+                "identifier": "official",
+                "trust_level": "community",
+                "metadata": {},
+            })()
+
+    q_path = tmp_path / "skills" / ".hub" / "quarantine" / "official"
+    q_path.mkdir(parents=True)
+    (q_path / "SKILL.md").write_text("# Official")
+
+    scanned = {}
+
+    def _scan_skill(skill_path, source="community", allow_origin_markers=True):
+        scanned["source"] = source
+        scanned["allow_origin_markers"] = allow_origin_markers
+        return guard.ScanResult(
+            skill_name="official",
+            source=source,
+            trust_level="community",
+            verdict="safe",
+        )
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(hub, "create_source_router", lambda auth: [_SlugSource()])
+    monkeypatch.setattr(hub, "quarantine_bundle", lambda bundle: q_path)
+    monkeypatch.setattr(hub, "HubLockFile", lambda: type("Lock", (), {"get_installed": lambda self, name: None})())
+    monkeypatch.setattr(guard, "scan_skill", _scan_skill)
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (False, "stop after scan"))
+    monkeypatch.setattr("hermes_cli.skills_hub._resolve_short_name", lambda name, sources, console: "official")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    do_install("official", console=console, skip_confirm=True)
+
+    assert scanned["source"] == "official"
+    assert scanned["allow_origin_markers"] is False
+
+
+def test_do_audit_does_not_treat_identifier_official_as_builtin(monkeypatch, tmp_path, hub_env):
+    import hermes_cli.skills_hub as cli_hub
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    skill_dir = tmp_path / "skills" / "community" / "official"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Official")
+
+    scanned = {}
+
+    def _scan_skill(skill_path, source="community", allow_origin_markers=True):
+        scanned["source"] = source
+        scanned["allow_origin_markers"] = allow_origin_markers
+        return guard.ScanResult(
+            skill_name="official",
+            source=source,
+            trust_level="community",
+            verdict="safe",
+        )
+
+    monkeypatch.setattr(
+        hub,
+        "HubLockFile",
+        lambda: type("Lock", (), {
+            "list_installed": lambda self: [{
+                "name": "official",
+                "install_path": "community/official",
+                "source": "skills.sh",
+                "identifier": "official",
+            }],
+        })(),
+    )
+    monkeypatch.setattr(guard, "scan_skill", _scan_skill)
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    cli_hub.do_audit(name="official", console=console)
+
+    assert scanned["source"] == "official"
+    assert scanned["allow_origin_markers"] is False
 
 
 def test_do_install_preserves_nested_official_optional_path(
@@ -462,8 +567,11 @@ def _install_mocks(monkeypatch, tmp_path, source_factory, category_hint=""):
     )
     monkeypatch.setattr(
         guard, "scan_skill",
-        lambda skill_path, source="community": guard.ScanResult(
-            skill_name="pending", source=source, trust_level="community", verdict="safe",
+        lambda skill_path, source="community", allow_origin_markers=True: guard.ScanResult(
+            skill_name="pending",
+            source=source,
+            trust_level="community",
+            verdict="safe",
         ),
     )
     monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
@@ -780,4 +888,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -46,6 +46,11 @@ class TestResolveTrustLevel:
     def test_official_source_provenance_resolves_to_builtin(self):
         assert _resolve_trust_level("official") == "builtin"
 
+    def test_official_marker_does_not_elevate_without_provenance(self):
+        assert _resolve_trust_level("official", allow_origin_markers=False) == "community"
+        assert _resolve_trust_level("agent-created", allow_origin_markers=False) == "community"
+        assert _resolve_trust_level("skills-sh/official", allow_origin_markers=False) == "community"
+
     def test_trusted_repos(self):
         assert _resolve_trust_level("openai/skills") == "trusted"
         assert _resolve_trust_level("anthropics/skills") == "trusted"

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -629,7 +629,12 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     return findings
 
 
-def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
+def scan_skill(
+    skill_path: Path,
+    source: str = "community",
+    *,
+    allow_origin_markers: bool = True,
+) -> ScanResult:
     """
     Scan all files in a skill directory for security threats.
 
@@ -649,12 +654,17 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
     Args:
         skill_path: Path to the skill directory (must contain SKILL.md)
         source: Source identifier for trust level resolution (e.g. "openai/skills")
+        allow_origin_markers: Whether reserved provenance markers like
+            "official" and "agent-created" may elevate trust.
 
     Returns:
         ScanResult with verdict, findings, and trust metadata
     """
     skill_name = skill_path.name
-    trust_level = _resolve_trust_level(source)
+    trust_level = _resolve_trust_level(
+        source,
+        allow_origin_markers=allow_origin_markers,
+    )
 
     all_findings: List[Finding] = []
 
@@ -717,13 +727,16 @@ def scan_skill_cached(
     skill_path: Path,
     source: str = "community",
     *,
+    allow_origin_markers: bool = True,
     source_url: str = "",
     cache_dir: Path | None = None,
 ) -> Tuple[ScanResult, dict]:
     """Return a scan plus attestation, caching only exact current content."""
     bundle_hash = full_content_hash(skill_path)
     cache_root = cache_dir or skill_path.parent / ".scan-cache"
-    source_identity = hashlib.sha256(f"{source}\0{source_url}".encode("utf-8")).hexdigest()[:16]
+    source_identity = hashlib.sha256(
+        f"{source}\0{int(allow_origin_markers)}\0{source_url}".encode("utf-8")
+    ).hexdigest()[:16]
     cache_file = cache_root / f"{bundle_hash.split(':', 1)[1]}-{source_identity}.json"
     try:
         cached = json.loads(cache_file.read_text(encoding="utf-8"))
@@ -733,6 +746,7 @@ def scan_skill_cached(
             and cached.get("bundle_hash") == bundle_hash
             and cached.get("scanner_version") == SCANNER_VERSION
             and cached.get("source") == source
+            and cached.get("allow_origin_markers", True) == allow_origin_markers
             and cached.get("source_url") == source_url):
         result = ScanResult(
             skill_name=skill_path.name, source=source,
@@ -745,10 +759,17 @@ def scan_skill_cached(
         result.scan_provenance = provenance
         return result, provenance
 
-    result = scan_skill(skill_path, source=source)
+    result = scan_skill(
+        skill_path,
+        source=source,
+        allow_origin_markers=allow_origin_markers,
+    )
     findings = [_finding_dict(item) for item in result.findings]
     provenance = {
-        "source": source, "source_url": source_url, "bundle_hash": bundle_hash,
+        "source": source,
+        "allow_origin_markers": allow_origin_markers,
+        "source_url": source_url,
+        "bundle_hash": bundle_hash,
         "scanner_version": SCANNER_VERSION, "verdict": result.verdict,
         "trust_level": result.trust_level, "findings": findings,
         "rules": sorted({item["pattern_id"] for item in findings}),
@@ -1099,7 +1120,7 @@ def _load_skill_ignore(skill_dir: Path):
     return ignore
 
 
-def _resolve_trust_level(source: str) -> str:
+def _resolve_trust_level(source: str, *, allow_origin_markers: bool = True) -> str:
     """Map a source identifier to a trust level."""
     prefix_aliases = (
         "skills-sh/",
@@ -1114,11 +1135,11 @@ def _resolve_trust_level(source: str) -> str:
             break
 
     # Agent-created skills get their own permissive trust level
-    if normalized_source == "agent-created":
+    if allow_origin_markers and normalized_source == "agent-created":
         return "agent-created"
     # Official optional skills must be identified by source provenance, not by
     # user-controlled GitHub identifiers such as "official/<repo>".
-    if normalized_source == "official":
+    if allow_origin_markers and normalized_source == "official":
         return "builtin"
     # Check if source matches any trusted repo exactly, or a skill path inside
     # that repo. Do not trust sibling repositories that merely share a prefix.


### PR DESCRIPTION
## What does this PR do?

Fixes a trust-resolution bug in the skill scanner: reserved trust markers like `official` and `agent-created` were being derived from the scanned identifier string, which is attacker-controlled for third-party marketplace installs and installed-skill audit records. A malicious skill could therefore scan as builtin/trusted by choosing a misleading identifier. This PR makes those markers depend on real bundle provenance, not on the slug being scanned.

## Related Issue

Fixes #63306

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an `allow_origin_markers` gate in [`tools/skills_guard.py`] so `_resolve_trust_level()` only treats `official` / `agent-created` as elevated when the caller confirms provenance.
- Updated `scan_skill_cached()` cache identity to include the provenance-elevation flag so cached results cannot reuse the wrong trust mode.
- Centralized scan provenance selection in [`hermes_cli/skills_hub.py`] and applied it to install-time scans and installed-skill audits.
- Updated [`hermes_cli/web_server.py`] to use the same provenance-aware scan path for dashboard skill scans.
- Added regression tests in [`tests/tools/test_skills_guard.py`] and [`tests/hermes_cli/test_skills_hub.py`] for misleading `official` slugs and for real official bundles.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/tools/test_skills_guard.py tests/hermes_cli/test_skills_hub.py`
2. Confirm a third-party skill whose identifier is literally `official` still scans as community, while an actual `official/...` bundle scans as builtin.
3. Run `git diff --check` to verify the patch is clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```
$ /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/tools/test_skills_guard.py tests/hermes_cli/test_skills_hub.py
111 passed in 2.25s

$ git diff --check
# no output
```
