### PR TITLE
fix(config): preserve providers fallback on malformed custom providers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4946,10 +4946,9 @@ def get_compatible_custom_providers(
 
     custom_providers = config.get("custom_providers")
     if custom_providers is not None:
-        if not isinstance(custom_providers, list):
-            return []
-        for entry in custom_providers:
-            _append_if_new(_normalize_custom_provider_entry(entry))
+        if isinstance(custom_providers, list):
+            for entry in custom_providers:
+                _append_if_new(_normalize_custom_provider_entry(entry))
 
     for entry in providers_dict_to_custom_providers(config.get("providers")):
         _append_if_new(entry)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1287,6 +1287,36 @@ class TestCustomProviderCompatibility:
         models = [e.get("model") for e in compatible]
         assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
 
+    def test_malformed_custom_providers_does_not_hide_providers_dict(self, tmp_path):
+        """A corrupted legacy custom_providers value must not suppress v12+ providers."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": '[{"name":"Broken Legacy"}]',
+                    "providers": {
+                        "openai-direct": {
+                            "api": "https://api.openai.com/v1",
+                            "api_key": "test-key",
+                            "default_model": "gpt-5-mini",
+                            "name": "OpenAI Direct",
+                            "transport": "codex_responses",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 1
+        assert compatible[0]["name"] == "OpenAI Direct"
+        assert compatible[0]["provider_key"] == "openai-direct"
+        assert compatible[0]["api_mode"] == "codex_responses"
+
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""
@@ -1926,5 +1956,4 @@ class TestCodexAppServerAutoConfig:
 
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
-
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1000,6 +1000,47 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
     assert resolved["model"] == "gpt-5-mini"
 
 
+def test_named_custom_provider_uses_providers_dict_when_legacy_list_is_corrupted(monkeypatch):
+    """A malformed legacy custom_providers value must not block providers dict resolution."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": '[{"name":"Broken Legacy"}]',
+            "providers": {
+                "openai-direct-primary": {
+                    "api": "https://api.openai.com/v1",
+                    "api_key": "dir-key",
+                    "default_model": "gpt-5-mini",
+                    "name": "OpenAI Direct (Primary)",
+                    "transport": "codex_responses",
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-direct-primary")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "dir-key"
+    assert resolved["requested_provider"] == "openai-direct-primary"
+    assert resolved["source"] == "custom_provider:OpenAI Direct (Primary)"
+    assert resolved["model"] == "gpt-5-mini"
+
+
 def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     """providers dict entries with key_env should resolve API key from env var."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## What does this PR do?

Preserves the v12+ `providers:` fallback when a legacy `custom_providers` value is malformed. Before this change, `get_compatible_custom_providers()` returned early for any non-list `custom_providers` value, which silently hid valid provider definitions from the Desktop/runtime compatibility path and could surface `Unknown provider` errors.

## Related Issue

Fixes #58907

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adjusted `hermes_cli/config.py` so malformed legacy `custom_providers` values are ignored instead of aborting the combined compatibility view.
- Added a config compatibility regression test covering a string-shaped `custom_providers` value with a valid `providers:` entry.
- Added a runtime resolution regression test proving named custom providers still resolve from `providers:` even when the legacy field is corrupted.

## How to Test

1. Run `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest tests/hermes_cli/test_config.py -k 'providers_dict_resolves_at_runtime or malformed_custom_providers_does_not_hide_providers_dict'`
2. Run `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest tests/hermes_cli/test_runtime_provider_resolution.py -k 'named_custom_provider_uses_providers_dict_when_list_missing or named_custom_provider_uses_providers_dict_when_legacy_list_is_corrupted'`
3. Run `./.venv/bin/python -m py_compile hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py && git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused proof is recorded in `codex-proof/58907-proof.txt`.
