### PR TITLE
fix: route openai-api through chat completions

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -65,7 +65,9 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://chatgpt.com/backend-api/codex",
     ),
     "openai-api": HermesOverlay(
-        transport="codex_responses",
+        # GPT-4o and other Chat Completions models do not support the
+        # Responses-only `reasoning.encrypted_content` include parameter.
+        transport="openai_chat",
         base_url_override="https://api.openai.com/v1",
         base_url_env_var="OPENAI_BASE_URL",
     ),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1397,6 +1397,20 @@ def _resolve_explicit_runtime(
             "requested_provider": requested_provider,
         }
 
+    if provider == "openai-api":
+        # Direct API-key OpenAI requests use Chat Completions. The Responses
+        # transport replays reasoning.encrypted_content, which GPT-4o rejects.
+        base_url = explicit_base_url or "https://api.openai.com/v1"
+        api_key = explicit_api_key or _getenv("OPENAI_API_KEY", "").strip()
+        return {
+            "provider": "openai-api",
+            "api_mode": "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": "explicit",
+            "requested_provider": requested_provider,
+        }
+
     if provider == "openai-codex":
         base_url = explicit_base_url or DEFAULT_CODEX_BASE_URL
         api_key = explicit_api_key
@@ -1530,6 +1544,21 @@ def resolve_runtime_provider(
     behavior (api_mode derived from config).
     """
     requested_provider = resolve_requested_provider(requested)
+
+    if requested_provider == "openai-api":
+        # Direct OpenAI API-key provider: always use Chat Completions.
+        # Do not infer Responses from api.openai.com; GPT-4o rejects the
+        # Responses-only reasoning.encrypted_content include parameter.
+        base_url = (explicit_base_url or "https://api.openai.com/v1").rstrip("/")
+        api_key = explicit_api_key or _getenv("OPENAI_API_KEY", "").strip()
+        return {
+            "provider": "openai-api",
+            "api_mode": "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": "direct-openai-api",
+            "requested_provider": requested_provider,
+        }
 
     if requested_provider == "moa":
         return {
@@ -2054,12 +2083,16 @@ def resolve_runtime_provider(
             elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             else:
-                # Auto-detect Anthropic-compatible endpoints by URL convention
-                # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
-                # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
-                detected = _detect_api_mode_for_url(base_url)
-                if detected:
-                    api_mode = detected
+                # Direct OpenAI API-key traffic uses Chat Completions by default.
+                # `api.openai.com` is also used by the Codex Responses transport,
+                # but that path is selected explicitly by the openai-codex
+                # provider. Do not let URL auto-detection convert GPT-4o
+                # openai-api requests into Responses requests: GPT-4o rejects
+                # the Responses-only reasoning.encrypted_content include field.
+                if provider != "openai-api":
+                    detected = _detect_api_mode_for_url(base_url)
+                    if detected:
+                        api_mode = detected
         # Normalize the /v1 suffix for OpenCode by API mode (see comment above).
         if provider in {"opencode-zen", "opencode-go"}:
             from hermes_cli.models import normalize_opencode_base_url

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -8,6 +8,33 @@ import pytest
 from hermes_cli import runtime_provider as rp
 
 
+def test_openai_api_always_uses_chat_completions(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openai-api")
+
+    assert resolved["provider"] == "openai-api"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "openai-test-key"
+
+
+def test_openai_api_explicit_runtime_keeps_chat_completions():
+    resolved = rp._resolve_explicit_runtime(
+        provider="openai-api",
+        requested_provider="openai-api",
+        model_cfg={"provider": "openai-api"},
+        explicit_api_key="openai-test-key",
+        explicit_base_url="https://api.openai.com/v1/",
+    )
+
+    assert resolved is not None
+    assert resolved["provider"] == "openai-api"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "openai-test-key"
+
+
 def test_configured_api_key_provider_without_key_fails_closed(monkeypatch):
     """A saved provider must not resolve as another authenticated provider."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- route the direct `openai-api` provider through Chat Completions
- keep Codex OAuth on the Responses transport
- prevent URL auto-detection from replaying `reasoning.encrypted_content` for GPT-4o

## Regression
Direct `openai-api` requests to GPT-4o previously failed with `Encrypted content is not supported with this model`.

## Tests
- `./venv/bin/python -m pytest -q tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_parity.py tests/hermes_cli/test_model_switch_custom_providers.py`
- 287 passed