### PR TITLE
fix(tools): normalize loose clarify choices

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -10,6 +10,7 @@ from tools.clarify_tool import (
     MAX_CHOICES,
     CLARIFY_SCHEMA,
     _flatten_choice,
+    _normalize_choices,
 )
 
 
@@ -103,10 +104,10 @@ class TestClarifyToolChoicesValidation:
         assert choices_received == ["valid", "also valid"]
 
     def test_invalid_choices_type_returns_error(self):
-        """Non-list choices should return error."""
+        """Scalar non-collection choices should still return error."""
         result = json.loads(clarify_tool(
             "Question?",
-            choices="not a list",  # type: ignore
+            choices=7,  # type: ignore
             callback=lambda q, c: "ignored"
         ))
         assert "error" in result
@@ -122,6 +123,49 @@ class TestClarifyToolChoicesValidation:
 
         clarify_tool("Pick", choices=[1, 2, 3], callback=mock_callback)  # type: ignore
         assert choices_received == ["1", "2", "3"]
+
+    def test_numbered_multiline_string_choices_are_coerced(self):
+        """Weak structured-output models often emit numbered text, not arrays."""
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "answer"
+
+        clarify_tool(
+            "Pick",
+            choices="1. PowerShell\n2. Python\n3. Bash",  # type: ignore
+            callback=mock_callback,
+        )
+        assert choices_received == ["PowerShell", "Python", "Bash"]
+
+    def test_json_string_choices_are_coerced(self):
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "answer"
+
+        clarify_tool(
+            "Pick",
+            choices='["PowerShell", "Python"]',  # type: ignore
+            callback=mock_callback,
+        )
+        assert choices_received == ["PowerShell", "Python"]
+
+    def test_object_wrapped_choices_are_coerced(self):
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "answer"
+
+        clarify_tool(
+            "Pick",
+            choices={"options": ["PowerShell", "Python"]},  # type: ignore
+            callback=mock_callback,
+        )
+        assert choices_received == ["PowerShell", "Python"]
 
 
 class TestClarifyToolCallbackHandling:
@@ -227,6 +271,16 @@ class TestClarifyDictChoices:
         assert result["user_response"] == "Tight, covers all 3 points"
         assert "{" not in result["user_response"]
         assert all("{" not in c for c in result["choices_offered"])
+
+
+class TestClarifyChoicesNormalizationHelpers:
+    def test_normalize_rejects_scalar(self):
+        assert _normalize_choices(7) == (False, None)
+
+    def test_normalize_unwraps_nested_json_object_string(self):
+        ok, choices = _normalize_choices('{"options": [{"label": "Python"}, {"text": "PowerShell"}]}')
+        assert ok is True
+        assert choices == ["Python", "PowerShell"]
 
 
 class TestClarifySchema:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,12 +12,14 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+import re
+from typing import Any, Callable, List, Optional
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+_CHOICE_CONTAINER_KEYS = ("choices", "options", "items", "values")
 
 
 def _flatten_choice(c) -> str:
@@ -53,6 +55,73 @@ def _flatten_choice(c) -> str:
     return str(c).strip()
 
 
+def _strip_choice_prefix(value: str) -> str:
+    """Drop lightweight numbering/bullets from loose text choices."""
+    return re.sub(r"^\s*(?:[-*]|\d+[\).\:-])\s*", "", value).strip()
+
+
+def _coerce_choices_string(raw: str) -> List[str]:
+    """Accept numbered lines / CSV-ish strings from weak tool-call emitters."""
+    stripped = raw.strip()
+    if not stripped:
+        return []
+
+    numbered_lines = [
+        _strip_choice_prefix(line)
+        for line in stripped.splitlines()
+        if line.strip()
+    ]
+    numbered_lines = [line for line in numbered_lines if line]
+    if len(numbered_lines) > 1:
+        return numbered_lines
+
+    if any(sep in stripped for sep in (",", ";", "|")):
+        parts = re.split(r"\s*[,;|]\s*", stripped)
+        return [_strip_choice_prefix(part) for part in parts if _strip_choice_prefix(part)]
+
+    cleaned = _strip_choice_prefix(stripped)
+    return [cleaned] if cleaned else []
+
+
+def _normalize_choices(choices: Any) -> tuple[bool, Optional[List[str]]]:
+    """Coerce common loose tool-call payloads into list[str]."""
+    candidate: Any = choices
+
+    if isinstance(candidate, str):
+        stripped = candidate.strip()
+        if not stripped:
+            return True, None
+        if stripped[:1] in "[{":
+            try:
+                candidate = json.loads(stripped)
+            except Exception:
+                candidate = stripped
+        if isinstance(candidate, str):
+            candidate = _coerce_choices_string(candidate)
+
+    if isinstance(candidate, dict):
+        for key in _CHOICE_CONTAINER_KEYS:
+            value = candidate.get(key)
+            if value is not None:
+                candidate = value
+                break
+        else:
+            candidate = list(candidate.values())
+
+    if isinstance(candidate, (tuple, set)):
+        candidate = list(candidate)
+
+    if candidate is None:
+        return True, None
+    if not isinstance(candidate, list):
+        return False, None
+
+    normalized = [s for s in (_flatten_choice(c) for c in candidate) if s]
+    if len(normalized) > MAX_CHOICES:
+        normalized = normalized[:MAX_CHOICES]
+    return True, normalized or None
+
+
 def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
@@ -79,18 +148,14 @@ def clarify_tool(
 
     # Validate and trim choices
     if choices is not None:
-        if not isinstance(choices, list):
+        valid_choices, normalized_choices = _normalize_choices(choices)
+        if not valid_choices:
             return tool_error("choices must be a list of strings.")
-        # LLMs sometimes emit dict-shaped choices (e.g. [{"description": "..."}])
-        # instead of bare strings. _flatten_choice unwraps them to their
-        # user-facing text here — the single platform-agnostic entry point —
-        # so the CLI panel, Discord buttons, and Telegram list all render clean
-        # text and the resolved answer is never a raw Python dict repr.
-        choices = [s for s in (_flatten_choice(c) for c in choices) if s]
-        if len(choices) > MAX_CHOICES:
-            choices = choices[:MAX_CHOICES]
-        if not choices:
-            choices = None  # empty list → open-ended
+        # Weak structured-output providers sometimes serialize choices as
+        # a JSON string, numbered text block, or {"options": [...]} object.
+        # Normalize once here so the existing platform adapters still get the
+        # clean list[str] shape they already know how to render.
+        choices = normalized_choices
 
     if callback is None:
         return json.dumps(


### PR DESCRIPTION
## What does this PR do?

Normalizes loose `clarify` tool choice payloads before they reach the gateway UI.
MiniMax M3 and similar providers sometimes emit `choices` as numbered text,
JSON-string arrays, or object-wrapped lists instead of a strict `list[str]`.
Before this change, `clarify_tool` rejected those payloads early, so Telegram
never rendered the clarify prompt. This patch coerces the common loose shapes
back into the existing `list[str]` contract and adds targeted regressions.

## Related Issue

Fixes #59065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalized loose `choices` payloads in `tools/clarify_tool.py`.
- Accepted numbered multiline strings, JSON-string payloads, and object-wrapped arrays such as `{"options": [...]}`.
- Added regression coverage in `tests/tools/test_clarify_tool.py` for the new coercion paths.

## How to Test

1. `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest tests/tools/test_clarify_tool.py`
2. `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile tools/clarify_tool.py tests/tools/test_clarify_tool.py`
3. Reproduce a gateway clarify call with a provider that emits loose `choices` payloads and confirm the prompt reaches Telegram instead of failing at tool validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- `pytest tests/tools/test_clarify_tool.py` -> `33 passed in 2.49s`
- `python -m py_compile tools/clarify_tool.py tests/tools/test_clarify_tool.py` -> passed
- `git diff --check` -> passed
