### PR TITLE
fix: filter invalid MoA slot providers

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -29,7 +29,10 @@ def _prompt_choice(title: str, rows: list[str], default: int = 0) -> int:
 def _model_options() -> list[dict[str, Any]]:
     payload = build_models_payload(
         load_picker_context(),
-        include_unconfigured=True,
+        # Slot pickers must only offer providers the user can actually call.
+        # Including setup-only rows makes an unconfigured canonical provider
+        # (usually OpenRouter, due to catalog ordering) become the default.
+        include_unconfigured=False,
         picker_hints=True,
         canonical_order=True,
         pricing=True,
@@ -37,7 +40,13 @@ def _model_options() -> list[dict[str, Any]]:
         max_models=200,
     )
     providers = payload.get("providers") or []
-    return [p for p in providers if p.get("slug") and p.get("models")]
+    return [
+        p
+        for p in providers
+        if p.get("slug")
+        and str(p.get("slug")).strip().lower() != "moa"
+        and p.get("models")
+    ]
 
 
 def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -11,6 +11,27 @@ from hermes_cli.moa_config import (
 )
 
 
+def test_moa_slot_picker_excludes_unconfigured_providers(monkeypatch):
+    from hermes_cli import moa_cmd
+
+    captured = {}
+    monkeypatch.setattr(moa_cmd, "load_picker_context", lambda: object())
+
+    def fake_build(_context, **kwargs):
+        captured.update(kwargs)
+        return {
+            "providers": [
+                {"slug": "moa", "models": ["default"]},
+                {"slug": "opencode-go", "models": ["deepseek-v4-pro"]},
+            ]
+        }
+
+    monkeypatch.setattr(moa_cmd, "build_models_payload", fake_build)
+
+    assert [row["slug"] for row in moa_cmd._model_options()] == ["opencode-go"]
+    assert captured["include_unconfigured"] is False
+
+
 def test_normalize_moa_config_uses_default_named_preset():
     cfg = normalize_moa_config({})
 


### PR DESCRIPTION
## Summary
- exclude unconfigured providers from the CLI MoA slot picker
- exclude the virtual moa provider so an aggregator cannot accidentally recurse and fall back to OpenRouter
- add regression coverage for picker filtering

## Root cause
The CLI MoA picker included setup-only providers and the virtual moa provider. Selecting the latter is rejected as recursive MoA and falls back to the default aggregator, which can route users to OpenRouter unexpectedly.

## Validation
- exercised the picker against the local authenticated-provider inventory
- verified the configured OpenCode Go slot remains selected
- pytest was unavailable in the bundled Hermes virtualenv