### PR TITLE
fix(runs): load SessionDB history when session_id is provided

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4286,6 +4286,17 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
+        # If still no conversation_history but a session_id was explicitly
+        # provided, restore history from SessionDB — matches the behavior of
+        # POST /api/sessions/{session_id}/chat/stream.
+        if not conversation_history and body.get("session_id"):
+            try:
+                loaded = self._conversation_history_for_session(body["session_id"])
+                if loaded:
+                    conversation_history = loaded
+            except Exception:
+                pass
+
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated


### PR DESCRIPTION
## Description

`POST /v1/runs` accepted a `session_id` parameter but never loaded the conversation history from SessionDB when no explicit `conversation_history` was provided. This meant runs could not reference previous conversation context, unlike `POST /api/sessions/{session_id}/chat/stream` which automatically loads history.

## Fix

Added a SessionDB history lookup in `_handle_runs()`: when `conversation_history` is still empty after checking the body, `previous_response_id`, and multi-message input array, and a `session_id` was explicitly provided, load the history using the existing `_conversation_history_for_session()` method.

Fixes #62732