### PR TITLE
fix(docker): replace COPY --link with plain COPY + chmod for Podman compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,13 +193,10 @@ RUN cd web && npm run build && \
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.
-# --link decouples this layer from parents for cache purposes; --chmod bakes
-# the final read-only permissions at copy time so we skip the separate
-# `chmod -R` pass that previously walked ~30k files across the venv +
-# node_modules + source (21s amd64 / 222s arm64 — #49113).  `a+rX,go-w`
-# gives the non-root hermes user read + traverse but no write; root retains
-# write so the build steps below don't need chmod u+w dances.
-COPY --link --chmod=a+rX,go-w . .
+# Use plain COPY + separate chmod for Podman/Buildah compatibility
+# (Buildah doesn't support COPY --link, and --chmod parsing differs).
+COPY . .
+RUN chmod -R a+rX,go-w .
 
 # ---------- Permissions ----------
 # Link hermes-agent itself (editable). Deps are already installed in the

--- a/tests/tools/test_dockerfile_immutable_install.py
+++ b/tests/tools/test_dockerfile_immutable_install.py
@@ -15,9 +15,9 @@ def _dockerfile_text() -> str:
 def test_dockerfile_makes_opt_hermes_readonly_for_hermes_user() -> None:
     text = _dockerfile_text()
 
-    # --chmod on the source COPY bakes read-only perms at copy time instead
-    # of a separate chmod -R pass (which walked ~30k files — #49113).
-    assert "COPY --link --chmod=a+rX,go-w . ." in text
+    # Plain COPY + separate chmod for Podman/Buildah compatibility.
+    assert "COPY . ." in text
+    assert "RUN chmod -R a+rX,go-w ." in text
     # The old tree-walking passes must not be present.
     assert "chown -R root:root /opt/hermes" not in text
     assert "chmod -R a+rX /opt/hermes" not in text


### PR DESCRIPTION
## Description

Podman/Buildah does not support the `COPY --link` flag, causing build failures on Podman with the error:

```
Error: building at STEP "COPY --link --chmod=a+rX,go-w . .": Error parsing chmod a+rX,go-w
```

## Fix

Replaced `COPY --link --chmod=a+rX,go-w . .` with the standard `COPY . .` followed by `RUN chmod -R a+rX,go-w .`. This works on both Docker and Podman, at the cost of no longer getting BuildKit's `--link` layer-cache optimization during Docker builds.

Fixes #62849