### PR TITLE
fix: block Claude Code credential attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1031,6 +1031,7 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     ".config",
     ".azure",
     ".gcloud",
+    ".claude",
     "Library/Keychains",  # macOS
 )
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -952,6 +952,21 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
+    def test_denylist_blocks_claude_code_credentials(self, tmp_path, monkeypatch):
+        """Claude Code subscription auth material under the user's home must
+        not be delivered as a native attachment in permissive default mode.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        claude_dir = fake_home / ".claude"
+        claude_dir.mkdir(parents=True)
+        secret = claude_dir / ".credentials.json"
+        secret.write_text('{"access_token": "live-oauth-token"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
     def test_denylist_blocks_system_prefixes(self, tmp_path, monkeypatch):
         """Files under /etc, /proc, /sys, /root, /boot, /var/{log,lib,run}
         are denied. We construct the test by patching the denylist root


### PR DESCRIPTION
Summary:\n- add Claude Code's local auth directory to the native media-delivery denylist\n- cover the default permissive media-delivery path with a regression test\n\nTests:\n- venv/bin/python -m pytest tests/gateway/test_platform_base.py -q