### PR TITLE
fix(mcp): unblock bridge approval responses

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -29,6 +29,7 @@ MCP client config (e.g. claude_desktop_config.json):
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -281,6 +282,51 @@ def _extract_attachments(msg: dict) -> List[dict]:
     return attachments
 
 
+def _pending_approval_kind(approval: dict) -> str:
+    """Infer a stable approval kind for bridge clients."""
+    kind = approval.get("kind")
+    if kind:
+        return str(kind)
+    return "exec" if approval.get("command") else "plugin"
+
+
+def _pending_approval_id(session_key: str, approval: dict) -> str:
+    """Build a stable approval identifier for MCP round-trips."""
+    fingerprint = {
+        "session_key": session_key,
+        "command": approval.get("command", ""),
+        "description": approval.get("description", ""),
+        "pattern_key": approval.get("pattern_key", ""),
+        "pattern_keys": approval.get("pattern_keys", []),
+        "turn_id": approval.get("turn_id", ""),
+        "tool_call_id": approval.get("tool_call_id", ""),
+        "created_at": approval.get("created_at", ""),
+    }
+    payload = json.dumps(fingerprint, sort_keys=True, default=str)
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+    return f"{session_key}:{digest}"
+
+
+def _normalize_pending_approval(
+    session_key: str,
+    approval: dict,
+    *,
+    existing: Optional[dict] = None,
+) -> dict:
+    """Normalize approval payloads exposed through the MCP bridge."""
+    normalized = dict(approval)
+    normalized.setdefault("session_key", session_key)
+    normalized.setdefault("kind", _pending_approval_kind(normalized))
+    if existing and existing.get("created_at") and not normalized.get("created_at"):
+        normalized["created_at"] = existing["created_at"]
+    normalized.setdefault(
+        "created_at",
+        datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    )
+    normalized["id"] = _pending_approval_id(session_key, normalized)
+    return normalized
+
+
 # ---------------------------------------------------------------------------
 # Event Bridge — polls SessionDB for new messages, maintains event queue
 # ---------------------------------------------------------------------------
@@ -398,21 +444,92 @@ class EventBridge:
             )
 
     def respond_to_approval(self, approval_id: str, decision: str) -> dict:
-        """Resolve a pending approval (best-effort without gateway IPC)."""
+        """Resolve a pending approval and unblock the gateway wait if possible."""
         with self._lock:
-            approval = self._pending_approvals.pop(approval_id, None)
+            approval = self._pending_approvals.get(approval_id)
 
         if not approval:
             return {"error": f"Approval not found: {approval_id}"}
 
+        session_key = approval.get("session_key", "")
+        normalized_decision = {
+            "allow-once": "once",
+            "allow-always": "always",
+            "deny": "deny",
+        }.get(decision, decision)
+
+        if session_key:
+            try:
+                from tools.approval import resolve_gateway_approval
+
+                resolved = resolve_gateway_approval(session_key, normalized_decision)
+            except Exception as exc:
+                return {"error": f"Approval resolution failed: {exc}"}
+            if resolved <= 0:
+                return {"error": f"Approval no longer pending: {approval_id}"}
+
+        with self._lock:
+            self._pending_approvals.pop(approval_id, None)
+
         self._enqueue(QueueEvent(
             cursor=0,  # Will be set by _enqueue
             type="approval_resolved",
-            session_key=approval.get("session_key", ""),
+            session_key=session_key,
             data={"approval_id": approval_id, "decision": decision},
         ))
 
         return {"resolved": True, "approval_id": approval_id, "decision": decision}
+
+    def _sync_pending_approvals(self) -> None:
+        """Mirror live gateway approvals into the bridge event queue."""
+        try:
+            from tools.approval import list_pending_gateway_approvals
+
+            pending = list_pending_gateway_approvals()
+        except Exception as exc:
+            logger.debug("EventBridge approval sync skipped: %s", exc)
+            return
+
+        with self._lock:
+            previous = {
+                approval.get("session_key", ""): dict(approval)
+                for approval in self._pending_approvals.values()
+                if approval.get("session_key")
+            }
+
+        current: Dict[str, dict] = {}
+        for session_key, approval in pending.items():
+            current[session_key] = _normalize_pending_approval(
+                session_key,
+                approval,
+                existing=previous.get(session_key),
+            )
+
+        with self._lock:
+            self._pending_approvals = {
+                approval["id"]: approval for approval in current.values()
+            }
+
+        for session_key, approval in current.items():
+            if previous.get(session_key) != approval:
+                self._enqueue(QueueEvent(
+                    cursor=0,
+                    type="approval_requested",
+                    session_key=session_key,
+                    data=dict(approval),
+                ))
+
+        for session_key, approval in previous.items():
+            if session_key not in current:
+                self._enqueue(QueueEvent(
+                    cursor=0,
+                    type="approval_resolved",
+                    session_key=session_key,
+                    data={
+                        "approval_id": approval.get("id", ""),
+                        "decision": "resolved",
+                    },
+                ))
 
     def _enqueue(self, event: QueueEvent) -> None:
         """Add an event to the queue and wake any waiters."""
@@ -450,6 +567,8 @@ class EventBridge:
         eliminating the old dual-file (sessions.json + state.db) race that
         could drop brand-new conversations (#8925).
         """
+        self._sync_pending_approvals()
+
         try:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -478,7 +478,7 @@ class TestEventBridge:
         b._pending_approvals["a1"] = {
             "id": "a1", "kind": "exec",
             "description": "rm -rf /tmp",
-            "session_key": "test", "created_at": "2026-03-29T12:00:00",
+            "created_at": "2026-03-29T12:00:00",
         }
         assert len(b.list_pending_approvals()) == 1
         result = b.respond_to_approval("a1", "deny")
@@ -489,6 +489,63 @@ class TestEventBridge:
         from mcp_serve import EventBridge
         r = EventBridge().respond_to_approval("nope", "deny")
         assert "error" in r
+
+    def test_sync_pending_approvals_emits_request_and_resolution(self, monkeypatch):
+        import mcp_serve
+
+        pending = {
+            "session-1": {
+                "command": "rm -rf /tmp/demo",
+                "description": "dangerous command",
+                "created_at": "2026-03-29T12:00:00Z",
+            }
+        }
+        monkeypatch.setattr(
+            "tools.approval.list_pending_gateway_approvals",
+            lambda: pending.copy(),
+        )
+
+        bridge = mcp_serve.EventBridge()
+        bridge._sync_pending_approvals()
+
+        approvals = bridge.list_pending_approvals()
+        assert len(approvals) == 1
+        assert approvals[0]["session_key"] == "session-1"
+        assert approvals[0]["kind"] == "exec"
+        events = bridge.poll_events(after_cursor=0)["events"]
+        assert events[0]["type"] == "approval_requested"
+
+        pending.clear()
+        bridge._sync_pending_approvals()
+        events = bridge.poll_events(after_cursor=1)["events"]
+        assert events[-1]["type"] == "approval_resolved"
+        assert bridge.list_pending_approvals() == []
+
+    def test_respond_to_approval_unblocks_gateway_queue(self, monkeypatch):
+        from mcp_serve import EventBridge
+
+        calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False, reason=None):
+            calls.append((session_key, choice, resolve_all, reason))
+            return 1
+
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", fake_resolve)
+
+        bridge = EventBridge()
+        bridge._pending_approvals["a1"] = {
+            "id": "a1",
+            "kind": "plugin",
+            "description": "Approve plugin write",
+            "session_key": "session-1",
+            "created_at": "2026-03-29T12:00:00Z",
+        }
+
+        result = bridge.respond_to_approval("a1", "allow-once")
+
+        assert result["resolved"] is True
+        assert calls == [("session-1", "once", False, None)]
+        assert bridge.list_pending_approvals() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1527,10 +1527,34 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def list_pending_gateway_approvals() -> dict[str, dict]:
+    """Return the oldest blocking gateway approval for each active session."""
+    with _lock:
+        snapshot: dict[str, dict] = {}
+        for session_key, queue in _gateway_queues.items():
+            if not queue:
+                continue
+            approval = dict(queue[0].data or {})
+            for key, value in (_pending.get(session_key) or {}).items():
+                approval.setdefault(key, value)
+            approval.setdefault("session_key", session_key)
+            snapshot[session_key] = approval
+        return snapshot
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
+    record = dict(approval)
+    record.setdefault("session_key", session_key)
+    record.setdefault("created_at", time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+    turn_id = _approval_turn_id.get()
+    tool_call_id = _approval_tool_call_id.get()
+    if turn_id:
+        record.setdefault("turn_id", turn_id)
+    if tool_call_id:
+        record.setdefault("tool_call_id", tool_call_id)
     with _lock:
-        _pending[session_key] = approval
+        _pending[session_key] = record
 
 
 def approve_session(session_key: str, pattern_key: str):


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP bridge approval path for gateway sessions. `mcp_serve` now mirrors live pending approvals from `tools.approval` into the bridge event queue and `permissions_respond` now calls back into `resolve_gateway_approval()` so a bridge approval actually unblocks the waiting tool call instead of timing out after 300 seconds.

## Related Issue

Fixes #59260

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools.approval.list_pending_gateway_approvals()` and enriched `submit_pending()` metadata so bridge clients can see live pending approvals with stable session context.
- Updated `mcp_serve.py` to synthesize stable approval ids, sync approval request / resolution events into the bridge queue, and route `permissions_respond` decisions back into `resolve_gateway_approval()`.
- Added focused regressions in `tests/test_mcp_serve.py` for bridge approval syncing and for unblocking the gateway queue when an MCP client responds.

## How to Test

1. Run `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-59260-mcp-bridge-approval/tests/test_mcp_serve.py`
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m py_compile /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-59260-mcp-bridge-approval/mcp_serve.py /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-59260-mcp-bridge-approval/tools/approval.py /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-59260-mcp-bridge-approval/tests/test_mcp_serve.py`
3. Reproduce a gateway approval through the MCP bridge and confirm `permissions_list_open` surfaces it and `permissions_respond` clears the pending tool wait instead of letting it timeout.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused proof is recorded in `codex-proof/59260-proof.txt`.
