### PR TITLE
fix: skip ollama vision probe for remote API hosts; add IPv4 fallback for broken IPv6

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -325,6 +325,13 @@ def _should_probe_ollama_vision(provider: str, base_url: str) -> bool:
         return True
     if not base_url:
         return False
+    # Skip probing for remote API providers — SSL handshake can hang on
+    # some platforms (e.g. ARM boards with IPv6 connectivity issues).
+    # Only probe when the base URL points to a local address.
+    import re
+    host = base_url.split("://")[-1].split("/")[0].split(":")[0]
+    if host not in ("localhost", "127.0.0.1", "::1", "0.0.0.0") and not host.startswith("192.168."):
+        return False
     try:
         from agent.model_metadata import detect_local_server_type
 

--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -183,11 +183,75 @@ def activate_durable_lazy_target() -> None:
         pass
 
 
+def apply_ipv4_fallback() -> bool:
+    """Prefer IPv4 when the system has IPv6 enabled but no working route.
+
+    On some Linux distributions (notably ARM single-board computers), IPv6
+    is enabled in the kernel but no default IPv6 route exists.  Python's
+    ``socket.getaddrinfo()`` returns IPv6 addresses first, causing httpx
+    and other HTTP libraries to hang on SSL handshake when connecting to
+    dual-stack servers.
+
+    This function probes IPv6 reachability once at startup by attempting a
+    connection to a well-known IPv6 host.  If the probe fails within two
+    seconds, ``socket.getaddrinfo`` is patched to return only IPv4
+    addresses for all subsequent calls.
+
+    Users who need IPv6 can opt out by setting ``HERMES_DISABLE_IPV4_FALLBACK=1``
+    or by ensuring a working default IPv6 route.
+
+    Returns True if the IPv4-only patch was applied, False otherwise.
+    """
+    if os.environ.get("HERMES_DISABLE_IPV4_FALLBACK"):
+        return False
+
+    import socket
+
+    _orig_getaddrinfo = socket.getaddrinfo
+
+    def _probe_ipv6_connectivity() -> bool:
+        try:
+            import ssl
+            infos = _orig_getaddrinfo("opencode.ai", 443, socket.AF_INET6, socket.SOCK_STREAM)
+            if not infos:
+                return False
+            addr = infos[0][4]
+            s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            s.settimeout(4.0)
+            try:
+                s.connect(addr)
+                ctx = ssl.create_default_context()
+                ss = ctx.wrap_socket(s, server_hostname="opencode.ai")
+                ss.close()
+                return True
+            except (socket.timeout, OSError, ConnectionError, ssl.SSLError):
+                return False
+            finally:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+        except (socket.gaierror, OSError):
+            return False
+
+    if _probe_ipv6_connectivity():
+        return False
+
+    def _patched_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return _orig_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)
+
+    socket.getaddrinfo = _patched_getaddrinfo
+    return True
+
+
 # Apply on import — entry points just need ``import hermes_bootstrap``
 # (or ``from hermes_bootstrap import apply_windows_utf8_bootstrap``) at
 # the very top of their module, before importing anything else.  The
 # import side effect does the right thing.
 apply_windows_utf8_bootstrap()
+
+# Apply IPv4 fallback on systems with broken IPv6 connectivity.
+apply_ipv4_fallback()
 
 # Activate the durable lazy-install target (immutable Docker images) so
 # packages installed into the data volume on a previous run are importable


### PR DESCRIPTION
## Problem

Two issues affecting Hermes on ARM single-board computers (e.g. Raspberry Pi, Orange Pi) and other systems with broken IPv6 connectivity:

### 1. Startup hang due to remote server probing

During startup, `_should_probe_ollama_vision()` calls `detect_local_server_type()` which makes HTTP requests to the configured `base_url` probing for local server endpoints (`/api/tags`, `/v1/props`, `/version`). When the base URL points to a remote API (e.g. opencode.ai), these probes have no purpose and can hang on systems with connectivity issues.

### 2. SSL handshake hang on broken IPv6

Many Linux distributions on ARM hardware have IPv6 enabled in the kernel but no working IPv6 route. Python's `socket.getaddrinfo()` returns IPv6 addresses first, causing httpx and other HTTP libraries to hang during SSL handshake when connecting to dual-stack servers. curl handles this gracefully via Happy Eyeballs (RFC 8305), but Python's httpcore does not.

## Changes

### `agent/image_routing.py`
- `_should_probe_ollama_vision()` now checks if the host in `base_url` is a local address (localhost, 127.0.0.1, ::1, 0.0.0.0, 192.168.x.x). Remote hosts are skipped entirely, preventing pointless probe requests.

### `hermes_bootstrap.py`
- New `apply_ipv4_fallback()` function that probes IPv6 reachability once at startup. If connecting to a well-known IPv6 host fails within 2 seconds, `socket.getaddrinfo` is patched to return IPv4 addresses only.
- Users with working IPv6 can opt out via `HERMES_DISABLE_IPV4_FALLBACK=1`.

## Testing

Tested on Orange Pi (ARM64, Debian) with broken IPv6. Before the fix, Hermes hung on startup for 60+ seconds and every API call timed out. After the fix, Hermes starts instantly and API calls complete normally.