### PR TITLE
fix(telegram): diagnose blocked-loop init hangs, unbind DoH discovery from system DNS

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9,6 +9,7 @@ Uses python-telegram-bot library for:
 
 import asyncio
 import dataclasses
+import faulthandler
 import inspect
 import json
 import logging
@@ -45,6 +46,35 @@ def _consume_abandoned_task(task: asyncio.Task) -> None:
         logger.debug("Abandoned Telegram init task failed after timeout", exc_info=True)
 
 
+# Grace period after the wall-clock deadline fires: if the event loop still
+# hasn't processed the expiry callback by then, the loop thread itself is
+# blocked in a synchronous call — the exact state in which every asyncio-based
+# timeout (including this helper's own expiry hand-off) goes silent, so the
+# gateway hangs at "attempt 1/8" with no further output (#63309).
+_LOOP_BLOCKED_DUMP_GRACE = 5.0
+
+
+def _dump_loop_blocked_diagnostics(timeout: float, grace: float) -> None:
+    """Emit diagnostics from the deadline timer thread when the loop is stuck.
+
+    Runs OFF the event loop, so it works precisely when the loop cannot. The
+    faulthandler dump names the frame the loop thread is blocked in — the one
+    piece of information #63309-class hangs otherwise never surface.
+    """
+    logger.warning(
+        "[Telegram] init deadline (%.0fs) expired but the event loop has not "
+        "processed the expiry after a further %.0fs — the loop thread appears "
+        "BLOCKED in a synchronous call, which is why no timeout fires (#63309). "
+        "Dumping all thread stacks to stderr to identify the blocking frame.",
+        timeout,
+        grace,
+    )
+    try:
+        faulthandler.dump_traceback(all_threads=True)
+    except Exception:
+        logger.debug("faulthandler traceback dump failed", exc_info=True)
+
+
 async def _await_with_thread_deadline(awaitable, timeout: float, *, on_abandon=None):
     """Await with a wall-clock deadline that does not depend on loop timers.
 
@@ -66,17 +96,34 @@ async def _await_with_thread_deadline(awaitable, timeout: float, *, on_abandon=N
     task = asyncio.ensure_future(awaitable)
     loop = asyncio.get_running_loop()
     deadline = loop.create_future()
+    # Set the moment the loop actually runs the expiry callback (or the helper
+    # exits normally). threading.Event so the watchdog thread can read it
+    # without touching asyncio state from off-loop.
+    loop_processed_expiry = threading.Event()
 
     def _mark_expired() -> None:
+        loop_processed_expiry.set()
         if not deadline.done():
             deadline.set_result(None)
 
     def _expire_from_thread() -> None:
         loop.call_soon_threadsafe(_mark_expired)
 
+    def _watchdog_check() -> None:
+        # The deadline fired _LOOP_BLOCKED_DUMP_GRACE ago but the loop never
+        # ran _mark_expired: the loop thread is stuck in a synchronous call.
+        # Diagnose from this thread — the loop can't.
+        if not loop_processed_expiry.is_set():
+            _dump_loop_blocked_diagnostics(timeout, _LOOP_BLOCKED_DUMP_GRACE)
+
     timer = threading.Timer(max(timeout, 0.0), _expire_from_thread)
     timer.daemon = True
     timer.start()
+    watchdog = threading.Timer(
+        max(timeout, 0.0) + _LOOP_BLOCKED_DUMP_GRACE, _watchdog_check
+    )
+    watchdog.daemon = True
+    watchdog.start()
     try:
         done, _ = await asyncio.wait(
             {task, deadline},
@@ -99,6 +146,11 @@ async def _await_with_thread_deadline(awaitable, timeout: float, *, on_abandon=N
         raise asyncio.TimeoutError()
     finally:
         timer.cancel()
+        watchdog.cancel()
+        # cancel() cannot stop a Timer whose callback is already running;
+        # setting the event closes that race so a completed await can never
+        # be misreported as a blocked loop.
+        loop_processed_expiry.set()
 
 
 async def _run_abandon_cleanup(on_abandon) -> None:

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -205,14 +205,24 @@ async def discover_fallback_ips() -> list[str]:
     """
     async with httpx.AsyncClient(timeout=httpx.Timeout(_DOH_TIMEOUT)) as client:
         doh_tasks = [_query_doh_provider(client, p) for p in _DOH_PROVIDERS]
-        system_dns_task = asyncio.to_thread(_resolve_system_dns)
-        results = await asyncio.gather(system_dns_task, *doh_tasks, return_exceptions=True)
+        system_dns_task = asyncio.ensure_future(asyncio.to_thread(_resolve_system_dns))
+        results = await asyncio.gather(*doh_tasks, return_exceptions=True)
 
-    # results[0] = system DNS IPs (set), results[1:] = DoH IP lists
-    system_ips: set[str] = results[0] if isinstance(results[0], set) else set()
+    # The system-resolver leg runs socket.getaddrinfo in a worker thread with
+    # no timeout of its own — a wedged OS resolver (broken VPN/DNS) can sit for
+    # minutes. Its result only feeds the no-usable-answers log line below, so
+    # it must never gate discovery: bound it and move on (#63309). The DoH legs
+    # are already bounded by the client timeout above.
+    system_ips: set[str] = set()
+    try:
+        system_result = await asyncio.wait_for(system_dns_task, timeout=_DOH_TIMEOUT)
+        if isinstance(system_result, set):
+            system_ips = system_result
+    except Exception:
+        logger.debug("System-DNS resolution for %s did not complete in time", _TELEGRAM_API_HOST)
 
     doh_ips: list[str] = []
-    for r in results[1:]:
+    for r in results:
         if isinstance(r, list):
             doh_ips.extend(r)
 

--- a/tests/gateway/test_telegram_init_deadline.py
+++ b/tests/gateway/test_telegram_init_deadline.py
@@ -199,3 +199,79 @@ async def test_shutdown_abandoned_app_handles_none_and_missing_requests():
     app.shutdown = AsyncMock(side_effect=RuntimeError("still running"))
     app.bot = None
     await tg_adapter._shutdown_abandoned_app(app)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_blocked_loop_after_expiry_dumps_diagnostics(monkeypatch):
+    """#63309: when the loop thread is stuck in a synchronous call, the expiry
+    callback never runs and every asyncio timeout goes silent. The off-loop
+    watchdog must detect that state and emit diagnostics from its own thread."""
+    import asyncio as _asyncio
+    import time as _time
+
+    dumps = []
+    monkeypatch.setattr(
+        tg_adapter,
+        "_dump_loop_blocked_diagnostics",
+        lambda timeout, grace: dumps.append((timeout, grace)),
+    )
+    monkeypatch.setattr(tg_adapter, "_LOOP_BLOCKED_DUMP_GRACE", 0.15)
+
+    hung = _asyncio.get_running_loop().create_future()  # never completes
+    task = _asyncio.ensure_future(
+        tg_adapter._await_with_thread_deadline(hung, timeout=0.05)
+    )
+    # Let the helper start its deadline + watchdog timers…
+    await _asyncio.sleep(0)
+    # …then block the event loop straight through deadline (0.05s) AND the
+    # watchdog grace (0.15s): call_soon_threadsafe stays queued, exactly like
+    # a sync call pinning the loop during Application.initialize().
+    _time.sleep(0.5)
+    with pytest.raises(_asyncio.TimeoutError):
+        await task
+
+    assert dumps == [(0.05, 0.15)]
+    hung.cancel()
+
+
+@pytest.mark.asyncio
+async def test_responsive_loop_expiry_does_not_dump(monkeypatch):
+    """A normal timeout on a responsive loop must not trigger the watchdog."""
+    import asyncio as _asyncio
+
+    dumps = []
+    monkeypatch.setattr(
+        tg_adapter,
+        "_dump_loop_blocked_diagnostics",
+        lambda timeout, grace: dumps.append((timeout, grace)),
+    )
+    monkeypatch.setattr(tg_adapter, "_LOOP_BLOCKED_DUMP_GRACE", 0.1)
+
+    hung = _asyncio.get_running_loop().create_future()
+    with pytest.raises(_asyncio.TimeoutError):
+        await tg_adapter._await_with_thread_deadline(hung, timeout=0.05)
+    # Give the (cancelled) watchdog window time to have fired if it were going to.
+    await _asyncio.sleep(0.3)
+    assert dumps == []
+    hung.cancel()
+
+
+@pytest.mark.asyncio
+async def test_completed_await_never_reports_blocked_loop(monkeypatch):
+    """Success before the deadline must cancel the watchdog (no false dump)."""
+    import asyncio as _asyncio
+
+    dumps = []
+    monkeypatch.setattr(
+        tg_adapter,
+        "_dump_loop_blocked_diagnostics",
+        lambda timeout, grace: dumps.append((timeout, grace)),
+    )
+    monkeypatch.setattr(tg_adapter, "_LOOP_BLOCKED_DUMP_GRACE", 0.05)
+
+    async def _quick():
+        return "ok"
+
+    assert await tg_adapter._await_with_thread_deadline(_quick(), timeout=0.2) == "ok"
+    await _asyncio.sleep(0.4)
+    assert dumps == []

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -705,3 +705,54 @@ class TestDiscoverFallbackIps:
 
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.167.220"]
+
+    @pytest.mark.asyncio
+    async def test_hung_system_dns_does_not_gate_doh_results(self, monkeypatch):
+        """#63309: socket.getaddrinfo has no timeout of its own — a wedged OS
+        resolver must not stall discovery. DoH answers must come back promptly
+        even while the system-DNS worker thread is still hanging."""
+        import time as _time
+
+        self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, _doh_answer("149.154.167.220")),
+            "https://cloudflare-dns.com": (200, _doh_answer()),
+        }, system_dns_ips=["149.154.166.110"])
+        monkeypatch.setattr(tnet, "_DOH_TIMEOUT", 0.2)
+
+        def _hung_getaddrinfo(*a, **kw):
+            _time.sleep(1.5)  # far beyond the discovery bound
+            raise OSError("resolver wedged")
+
+        monkeypatch.setattr(tnet.socket, "getaddrinfo", _hung_getaddrinfo)
+
+        start = _time.monotonic()
+        ips = await tnet.discover_fallback_ips()
+        elapsed = _time.monotonic() - start
+
+        assert ips == ["149.154.167.220"]
+        assert elapsed < 1.0, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
+
+    @pytest.mark.asyncio
+    async def test_hung_system_dns_with_no_doh_answers_bounded_seed_fallback(self, monkeypatch):
+        """Worst case — resolver wedged AND no DoH answers — must still return
+        the seed list within the bound instead of hanging connect()."""
+        import time as _time
+
+        self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, {"Status": 0}),
+            "https://cloudflare-dns.com": (200, {"garbage": True}),
+        }, system_dns_ips=["149.154.166.110"])
+        monkeypatch.setattr(tnet, "_DOH_TIMEOUT", 0.2)
+
+        def _hung_getaddrinfo(*a, **kw):
+            _time.sleep(1.5)
+            raise OSError("resolver wedged")
+
+        monkeypatch.setattr(tnet.socket, "getaddrinfo", _hung_getaddrinfo)
+
+        start = _time.monotonic()
+        ips = await tnet.discover_fallback_ips()
+        elapsed = _time.monotonic() - start
+
+        assert ips == tnet._SEED_FALLBACK_IPS
+        assert elapsed < 1.0, f"seed fallback gated on hung system DNS ({elapsed:.2f}s)"


### PR DESCRIPTION
## What does this PR do?

Addresses the #63309 hang class: gateway stuck at `Connecting to Telegram (attempt 1/8)…` for 9+ minutes with **no** retry line, **no** timeout message, process alive.

### Why every timeout goes silent (mechanism)

Three independent bounds should have produced output within ~30s: the httpx connect timeout (10s), `_await_with_thread_deadline` (30s), and the gateway's per-platform `asyncio.wait_for` (30s). For **all three** to stay silent simultaneously, the event loop thread must be blocked in a synchronous call: the thread-deadline's timer fires off-loop but its expiry hand-off (`loop.call_soon_threadsafe`) still needs the loop to run it, and the gateway `wait_for` is a pure loop timer. A pinned loop also freezes every already-connected platform — matching "15 tasks, ~316 MB, nothing progresses" in the report. (Bootstrap is a sequential `for` over platforms, so one wedged connect holds the whole gateway.)

We audited the entire async path under `Application.initialize()` at the pinned versions (httpx 0.28.1 / PTB 22.6 / anyio 4.12): DNS is executor-based, SSL contexts are built eagerly *before* the attempt-1 log, the `scutil` subprocess has a 3s cap — so the blocking frame is environment-dependent and **cannot be identified from the repo alone**. That's the gap this PR closes: make the process name the frame itself.

### Change 1 — loop-blocked watchdog in `_await_with_thread_deadline`

A second daemon timer fires one grace period (5s) after the deadline. If the loop still hasn't processed the expiry callback by then, the watchdog — running on its own thread, which is exactly where diagnosis must happen when the loop can't run — logs a WARNING and calls `faulthandler.dump_traceback(all_threads=True)`. The next #63309 report comes with a stack trace naming the blocking frame instead of two WARNING lines and silence.

A `threading.Event` set by the expiry callback and on normal exit closes the `Timer.cancel()` race, so a completed await can never be misreported as a blocked loop.

### Change 2 — `discover_fallback_ips` no longer gated by the system resolver

`asyncio.gather` waited unboundedly on `asyncio.to_thread(_resolve_system_dns)` — a bare `socket.getaddrinfo` with **no timeout**. A wedged OS resolver (broken VPN/DNS, the same environments that hit this issue) stalls startup for minutes *between the two observed log lines*. The system-DNS result only feeds a log message, so it must never gate discovery: DoH legs (already bounded by the client timeout) are gathered alone, and the system leg is awaited best-effort with a `_DOH_TIMEOUT` cap.

## Not in scope (follow-ups worth their own issues)

- The direct stderr `StreamHandler` on the gateway root logger is the only synchronous I/O the loop thread performs on this path (file handlers are QueueListener-routed by design); a stalled stderr consumer could pin the loop. Routing it through the queue is a gateway-wide change.
- Sequential platform bootstrap (`gateway/run.py`) means one platform's connect blocks all others; concurrent per-platform connect tasks would bound the blast radius.
- `platform_connect_timeout <= 0` disables the outer guard entirely.

## Overlap

#59336 (webhook deadline), #59618 (`start_polling` timeout), #29196 (`delete_webhook`/bootstrap retries) bound *other* awaits in this path; none address the blocked-loop state where no asyncio timeout can fire, and none touch the unbounded system-DNS leg.

## Verification

- `tests/gateway/test_telegram_init_deadline.py`: +3 regressions — blocked-loop dump fires (loop deliberately pinned with a sync sleep through deadline+grace); responsive-loop timeout does NOT dump; completed await does NOT dump.
- `tests/gateway/test_telegram_network.py`: +2 regressions — hung `getaddrinfo` (1.5s) with DoH answers returns the DoH IPs in <1s; hung resolver with no DoH answers returns the seed list in <1s.
- Both files: 58/58. Full `-k telegram` gateway selection: 1151 passed / 2 skipped; the 8 failures present are identical on pristine HEAD in the same environment (PTB-version-dependent, pre-existing).

Fixes #63309 (diagnosis + the one confirmed unbounded stall; the faulthandler dump is what turns the next occurrence into a one-line root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)