### PR TITLE
fix(cron): tolerate null config sections

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2864,18 +2864,21 @@ def run_job(
         except Exception:
             pass
 
+        agent_cfg = _cfg.get("agent")
+        if not isinstance(agent_cfg, dict):
+            agent_cfg = {}
+
         # Reasoning config from config.yaml (raw value — a YAML boolean False
         # means thinking disabled, see parse_reasoning_effort)
         from hermes_constants import parse_reasoning_effort
         reasoning_config = parse_reasoning_effort(
-            _cfg.get("agent", {}).get("reasoning_effort", "")
+            agent_cfg.get("reasoning_effort", "")
         )
 
         # Prefill messages from env or config.yaml. The top-level
         # prefill_messages_file key is canonical; agent.prefill_messages_file is
         # retained as a legacy fallback for older CLI/godmode configs.
         prefill_messages = None
-        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
         prefill_file = (
             os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
             or _cfg.get("prefill_messages_file", "")
@@ -2896,7 +2899,7 @@ def run_job(
                     prefill_messages = None
 
         # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        max_iterations = agent_cfg.get("max_turns") or _cfg.get("max_turns") or 90
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2040,6 +2040,52 @@ class TestRunJobConfigEnvVarExpansion:
         assert kwargs["model"] == "${_HERMES_TEST_CRON_UNSET_VAR}"
 
 
+class TestRunJobConfigNullSections:
+    _RUNTIME = {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+
+    def test_null_agent_section_does_not_crash_cron_model_chain(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "model: gpt-4o-mini\n"
+            "max_turns: 11\n"
+            "agent:\n"
+            "provider_routing:\n"
+            "fallback_providers:\n"
+            "  - null\n"
+            "  - provider: openrouter\n"
+            "    model: gpt-4o-fallback\n"
+        )
+
+        job = {"id": "null-agent-job", "name": "null agent section", "prompt": "hi"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"
+        assert kwargs["max_iterations"] == 11
+        assert kwargs["fallback_model"] == [
+            {"provider": "openrouter", "model": "gpt-4o-fallback"}
+        ]
+
+
 class TestRunJobModelResolution:
     """Verify defensive model resolution for jobs stored with ``model: null``.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a cron scheduler crash when `config.yaml` contains `agent:` as an explicit null section and the user also has a fallback model chain configured. `run_job()` was still reading `reasoning_effort` and `max_turns` through `_cfg.get("agent", {}).get(...)`, which crashes with `AttributeError: 'NoneType' object has no attribute 'get'` for hand-edited or agent-rewritten configs that serialize `agent:` with no mapping body.

## Related Issue

Fixes #57844

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize `agent` to an empty dict in `cron/scheduler.py` before reading `reasoning_effort`, `prefill_messages_file`, or `max_turns`.
- Reuse that normalized `agent_cfg` across cron runtime setup so `agent: null` behaves like a missing section instead of crashing the job.
- Add a regression test in `tests/cron/test_scheduler.py` covering `agent: null`, `provider_routing: null`, and a mixed `fallback_providers` list.

## How to Test

1. Create a `config.yaml` with `agent:` on its own line, `provider_routing:` on its own line, and a `fallback_providers` chain that includes at least one null/empty entry.
2. Run a cron job through the scheduler path; before this patch it can crash with `AttributeError: 'NoneType' object has no attribute 'get'`.
3. Run `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest tests/cron/test_scheduler.py -k 'null_agent_section_does_not_crash_cron_model_chain or fallback_model_env_ref_in_config_yaml_is_expanded or model_env_ref_in_config_yaml_is_expanded'` and confirm all selected tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / CPython 3.11.14 in the repo venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --python /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python --extra dev pytest tests/cron/test_scheduler.py -k 'null_agent_section_does_not_crash_cron_model_chain or fallback_model_env_ref_in_config_yaml_is_expanded or model_env_ref_in_config_yaml_is_expanded'` -> `3 passed, 213 deselected in 7.54s`
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py` -> passed
- `git diff --check` -> passed
