### PR TITLE
test(telegram): pin comma-string allow_from / group_allow_from in adapter auth

### DIFF
--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -144,6 +144,62 @@ def test_is_user_authorized_from_message_allow_from():
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
+def test_is_user_authorized_from_message_comma_string_allow_from():
+    """A comma-string allow_from must behave exactly like the equivalent list.
+
+    A comma-string is a canonical wire format for these keys (a list allow_from
+    is ",".join(...)-ed onto TELEGRAM_ALLOWED_USERS, and the env branch of this
+    same method splits it), and scalar YAML ``allow_from: "111,222"`` reaches
+    the adapter as one string. Iterating such a value char-wise would build an
+    allow-set of single characters, rejecting every real id and locking the
+    owner out. The test above covers the list form only, so this pins the
+    string form through the same DM branch.
+    """
+    adapter = _make_adapter(allow_from="111,222")
+
+    msg = _make_message(from_user_id=111, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=222, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    # An unlisted id is still rejected — and not admitted by a stray char match.
+    msg = _make_message(from_user_id=333, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_comma_string_group_allow_from():
+    """The group branch reads group_allow_from and must split a comma-string
+    there too — the two keys are selected by chat type but parsed identically."""
+    adapter = _make_adapter(group_allow_from="111,222")
+
+    msg = _make_message(from_user_id=222, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=333, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_comma_string_with_spaces():
+    """Surrounding whitespace in a comma-string is tolerated (same .strip() the
+    env branch applies)."""
+    adapter = _make_adapter(allow_from=" 111 , 222 ")
+
+    msg = _make_message(from_user_id=222, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=333, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_comma_string_wildcard():
+    """A bare '*' scalar (not a one-element list) still wildcards."""
+    adapter = _make_adapter(allow_from="*")
+
+    msg = _make_message(from_user_id=999, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
 def test_allowlist_dm_with_explicit_pair_behavior_reaches_gateway(monkeypatch):
     """Allowlist + unauthorized_dm_behavior:pair must not early-drop unknown DMs.
 


### PR DESCRIPTION
> **Rebased onto current `main` — scope reduced to tests only.** See the rebase note in the comments: `main` fixed the underlying parsing bug independently via the `_coerce_allow_set` extraction, so this PR's original one-line production change is now redundant and has been dropped. What remains is the regression coverage, which `main` does not have.

## What

Three tests in `tests/gateway/test_telegram_auth_check.py` pinning that a **comma-string** `allow_from` / `group_allow_from` behaves exactly like the equivalent YAML list in `TelegramAdapter._is_user_authorized_from_message`.

No production change.

## Why

`_is_user_authorized_from_message` picks `group_allow_from` for `group`/`forum`/`channel` and `allow_from` for DMs, then parses whichever it chose with `_coerce_allow_set`. Both keys accept either form:

- a list `allow_from` is `",".join(...)`-ed onto `TELEGRAM_ALLOWED_USERS`, and the env branch of this same method splits it;
- scalar YAML — `allow_from: "111,222"` — reaches the adapter as one string.

If such a value were ever iterated directly instead of split, the allow-set would become **single characters**: every real user id rejected, locking the owner out of their own bot. That is a lockout-class failure, and it is the failure this branch originally shipped a fix for.

`_coerce_allow_set` handles it correctly today. But the existing adapter-auth tests (`..._allow_from`, `..._group_allow_from`) exercise the **list** form only — nothing pins the string form through either branch, so the behavior could regress silently.

## Ships

- `..._comma_string_allow_from` — comma-string via `allow_from` on a DM.
- `..._comma_string_group_allow_from` — comma-string via `group_allow_from` in a group.
- `..._comma_string_with_spaces` — `" 111 , 222 "` tolerated (same `.strip()` as the env branch).
- `..._comma_string_wildcard` — a bare `*` scalar still wildcards.

Verified adversarially: reverting `_coerce_allow_set` to the pre-extraction `{str(u).strip() for u in raw}` comprehension makes three of these four fail. (The wildcard case passes either way — iterating `"*"` char-wise still yields `{"*"}` — so it is coverage, not a discriminator.)
