### PR TITLE
fix(kanban): stop stale event streams recreating removed boards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1123,6 +1123,9 @@ def _cmd_boards_rm(args: argparse.Namespace) -> int:
     force_delete = getattr(args, "delete", False) or getattr(args, "boards_action", "") == "delete"
     try:
         res = kb.remove_board(args.slug, archive=not force_delete)
+    except kb.BoardDeleteRecoveryError as exc:
+        print(f"kanban boards rm: {exc}", file=sys.stderr)
+        return 1
     except ValueError as exc:
         print(f"kanban boards rm: {exc}", file=sys.stderr)
         return 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -827,7 +827,18 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         return {"slug": normed, "action": "archived", "new_path": str(target)}
     else:
         import shutil
-        shutil.rmtree(d)
+
+        def _ignore_disappeared_sidecar(_func, _path, exc_info):
+            # A concurrent SQLite reader may close between rmtree's directory
+            # scan and unlink, removing its own -wal/-shm sidecar first. Python
+            # 3.13+ ignores these nested FileNotFoundError races; preserve that
+            # behavior on supported older runtimes without hiding other errors.
+            exc = exc_info[1]
+            if isinstance(exc, FileNotFoundError):
+                return
+            raise exc
+
+        shutil.rmtree(d, onerror=_ignore_disappeared_sidecar)
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
 
@@ -1312,13 +1323,28 @@ def _resolve_busy_timeout_ms() -> int:
     return DEFAULT_BUSY_TIMEOUT_MS
 
 
-def _sqlite_connect(path: Path) -> sqlite3.Connection:
-    """Open a Kanban SQLite connection with consistent lock waiting."""
+def _sqlite_connect(
+    path: Path,
+    *,
+    create_if_missing: bool = True,
+) -> sqlite3.Connection:
+    """Open a Kanban SQLite connection with consistent lock waiting.
+
+    ``create_if_missing=False`` uses SQLite's ``mode=rw`` URI so a stale
+    reader cannot recreate a named board after it has been archived or
+    deleted.
+    """
     busy_timeout_ms = _resolve_busy_timeout_ms()
+    database = str(path)
+    uri = False
+    if not create_if_missing:
+        database = f"{path.resolve().as_uri()}?mode=rw"
+        uri = True
     conn = sqlite3.connect(
-        str(path),
+        database,
         isolation_level=None,
         timeout=busy_timeout_ms / 1000.0,
+        uri=uri,
     )
     # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
     # the PRAGMA explicitly so it is observable and survives future wrapper
@@ -1328,7 +1354,7 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
 
 
 @contextlib.contextmanager
-def _cross_process_init_lock(path: Path):
+def _cross_process_init_lock(path: Path, *, create_parent: bool = True):
     """Serialize first-connect WAL/schema/integrity setup across processes.
 
     ``_INIT_LOCK`` only protects threads inside one Python process. During a
@@ -1351,7 +1377,8 @@ def _cross_process_init_lock(path: Path):
     is redundant work, not corruption. A bounded "proceed anyway" beats an
     unbounded hang that silently stops the board.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    if create_parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
     handle = lock_path.open("a+b")
     acquired = False
@@ -1682,6 +1709,7 @@ def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    create_if_missing: bool = True,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1700,12 +1728,20 @@ def connect(
     * Neither → :func:`kanban_db_path` resolves via
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
+
+    ``create_if_missing=False`` is for stale/read-only consumers such as the
+    dashboard event stream. It atomically refuses to open a DB that was moved
+    away by board archive/delete instead of silently creating an empty board
+    at the old path.
     """
     if db_path is not None:
         path = db_path
     else:
         path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    if create_if_missing:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    elif not path.is_file():
+        raise FileNotFoundError(f"kanban board database does not exist: {path}")
 
     # Fast path: once THIS process has initialized this path, the expensive
     # first-open work (header validation, integrity probe, schema + additive
@@ -1719,7 +1755,7 @@ def connect(
     # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
     resolved = str(path.resolve())
     if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, create_if_missing=create_if_missing)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1735,7 +1771,7 @@ def connect(
             raise
         return conn
 
-    with _cross_process_init_lock(path):
+    with _cross_process_init_lock(path, create_parent=create_if_missing):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
         _validate_sqlite_header(path)
@@ -1744,7 +1780,7 @@ def connect(
         # via _INITIALIZED_PATHS so it only runs once per process per path.
         _guard_existing_db_is_healthy(path)
         resolved = str(path.resolve())
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, create_if_missing=create_if_missing)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -784,6 +785,27 @@ def list_boards(*, include_archived: bool = True) -> list[dict]:
     return entries
 
 
+class BoardDeleteRecoveryError(RuntimeError):
+    """Hard delete failed after detach and rollback could not restore it."""
+
+    def __init__(
+        self,
+        slug: str,
+        recovery_path: Path,
+        cleanup_error: OSError,
+        restore_error: OSError,
+    ) -> None:
+        self.slug = slug
+        self.recovery_path = recovery_path
+        self.cleanup_error = cleanup_error
+        self.restore_error = restore_error
+        super().__init__(
+            f"hard-delete cleanup failed for board {slug!r}, and automatic "
+            "rollback to the public board path also failed; inspect the "
+            f"detached board recovery path: {recovery_path}"
+        )
+
+
 def remove_board(slug: str, *, archive: bool = True) -> dict:
     """Remove or archive a board.
 
@@ -804,41 +826,108 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     if not d.exists():
         raise ValueError(f"board {normed!r} does not exist")
 
+    was_current = get_current_board() == normed
+    db_cache_key = str((d / "kanban.db").resolve())
+    was_initialized = db_cache_key in _INITIALIZED_PATHS
+
     # If the user removed the currently-active board, revert to default.
-    if get_current_board() == normed:
+    if was_current:
         clear_current_board()
 
     # A concurrent connect(board=normed) after the rename/delete recreates
     # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
     # dropped first so the schema init pass re-runs on that fresh file.
-    _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
+    _INITIALIZED_PATHS.discard(db_cache_key)
+
+    def _restore_pre_remove_state(*, restore_init_cache: bool) -> None:
+        if was_current:
+            set_current_board(normed)
+        if restore_init_cache and was_initialized:
+            _INITIALIZED_PATHS.add(db_cache_key)
 
     if archive:
-        archive_root = boards_root() / "_archived"
-        archive_root.mkdir(parents=True, exist_ok=True)
-        ts = int(time.time())
-        target = archive_root / f"{normed}-{ts}"
-        # Avoid collision on rapid double-archives.
-        suffix = 1
-        while target.exists():
-            target = archive_root / f"{normed}-{ts}-{suffix}"
-            suffix += 1
-        d.rename(target)
+        try:
+            archive_root = boards_root() / "_archived"
+            archive_root.mkdir(parents=True, exist_ok=True)
+            ts = int(time.time())
+            target = archive_root / f"{normed}-{ts}"
+            # Avoid collision on rapid double-archives.
+            suffix = 1
+            while target.exists():
+                target = archive_root / f"{normed}-{ts}-{suffix}"
+                suffix += 1
+            d.rename(target)
+        except OSError:
+            _restore_pre_remove_state(restore_init_cache=True)
+            raise
         return {"slug": normed, "action": "archived", "new_path": str(target)}
     else:
         import shutil
 
-        def _ignore_disappeared_sidecar(_func, _path, exc_info):
+        # Detach the public board path atomically before recursive cleanup.
+        # A live SQLite reader can create or remove WAL/SHM sidecars while
+        # rmtree is walking the directory; deleting in place can therefore
+        # lose the race at the final rmdir with ENOTEMPTY. Once renamed, stale
+        # readers still holding the old DB path cannot add entries to the
+        # detached directory, and new named-board readers fail closed.
+        try:
+            delete_target = d.with_name(
+                f".deleting-{normed}-{secrets.token_hex(8)}"
+            )
+            while delete_target.exists():
+                delete_target = d.with_name(
+                    f".deleting-{normed}-{secrets.token_hex(8)}"
+                )
+            d.rename(delete_target)
+        except OSError:
+            _restore_pre_remove_state(restore_init_cache=True)
+            raise
+
+        def _ignore_disappeared_nested_entry(_func, entry_path, exc_info):
             # A concurrent SQLite reader may close between rmtree's directory
             # scan and unlink, removing its own -wal/-shm sidecar first. Python
             # 3.13+ ignores these nested FileNotFoundError races; preserve that
-            # behavior on supported older runtimes without hiding other errors.
+            # behavior on supported older runtimes without hiding a missing
+            # cleanup root or any other error.
             exc = exc_info[1]
-            if isinstance(exc, FileNotFoundError):
+            if (
+                isinstance(exc, FileNotFoundError)
+                and Path(entry_path) != delete_target
+            ):
                 return
             raise exc
 
-        shutil.rmtree(d, onerror=_ignore_disappeared_sidecar)
+        cleanup_error = None
+        for attempt in range(3):
+            try:
+                shutil.rmtree(
+                    delete_target,
+                    onerror=_ignore_disappeared_nested_entry,
+                )
+                break
+            except OSError as exc:
+                if exc.errno == errno.ENOTEMPTY and attempt < 2:
+                    # Let a detached SQLite reader finish closing/unlinking
+                    # sidecars before the bounded retry.
+                    time.sleep(0.01 * (attempt + 1))
+                    continue
+                cleanup_error = exc
+                break
+        if cleanup_error is not None:
+            try:
+                delete_target.rename(d)
+            except OSError as restore_error:
+                raise BoardDeleteRecoveryError(
+                    normed,
+                    delete_target,
+                    cleanup_error,
+                    restore_error,
+                ) from restore_error
+            # Cleanup may already have removed or truncated DB files. Restore
+            # the current-board pointer, but force the next connection to
+            # revalidate and reinitialize instead of trusting stale cache state.
+            _restore_pre_remove_state(restore_init_cache=False)
+            raise cleanup_error
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
 
@@ -1327,18 +1416,21 @@ def _sqlite_connect(
     path: Path,
     *,
     create_if_missing: bool = True,
+    read_only: bool = False,
 ) -> sqlite3.Connection:
     """Open a Kanban SQLite connection with consistent lock waiting.
 
     ``create_if_missing=False`` uses SQLite's ``mode=rw`` URI so a stale
-    reader cannot recreate a named board after it has been archived or
-    deleted.
+    consumer cannot recreate a named board after it has been archived or
+    deleted. ``read_only=True`` uses ``mode=ro`` and is reserved for callers
+    that must not initialize or mutate the database.
     """
     busy_timeout_ms = _resolve_busy_timeout_ms()
     database = str(path)
     uri = False
-    if not create_if_missing:
-        database = f"{path.resolve().as_uri()}?mode=rw"
+    if read_only or not create_if_missing:
+        mode = "ro" if read_only else "rw"
+        database = f"{path.resolve().as_uri()}?mode={mode}"
         uri = True
     conn = sqlite3.connect(
         database,
@@ -1817,6 +1909,45 @@ def connect(
         except Exception:
             conn.close()
             raise
+    return conn
+
+
+def connect_existing_readonly(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> sqlite3.Connection:
+    """Open an existing Kanban DB without initialization or write pragmas.
+
+    This is the event-stream connection path. It intentionally bypasses the
+    init lock, integrity repair, WAL activation, schema migrations, and
+    ``_INITIALIZED_PATHS`` cache so a stale consumer cannot mutate or recreate
+    a board that is being archived or deleted.
+    """
+    path = db_path if db_path is not None else kanban_db_path(board=board)
+    if not path.is_file():
+        raise FileNotFoundError(f"kanban board database does not exist: {path}")
+    try:
+        conn = _sqlite_connect(
+            path,
+            create_if_missing=False,
+            read_only=True,
+        )
+    except sqlite3.OperationalError:
+        # Close the check/open race cleanly when archive/delete moved the board
+        # after ``is_file()`` but before SQLite acquired it. Preserve unrelated
+        # SQLite failures (permissions, malformed URI, I/O) unchanged.
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"kanban board database does not exist: {path}"
+            ) from None
+        raise
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only=ON")
+    except Exception:
+        conn.close()
+        raise
     return conn
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2079,6 +2079,8 @@ def delete_board(slug: str, delete: bool = Query(False, description="Hard-delete
     """Archive (default) or hard-delete a board."""
     try:
         res = kanban_db.remove_board(slug, archive=not delete)
+    except kanban_db.BoardDeleteRecoveryError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return {"result": res, "current": kanban_db.get_current_board()}
@@ -2417,15 +2419,10 @@ async def stream_events(ws: WebSocket):
             ws_board = None
 
         def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
-            # Named boards are explicitly created through create_board(). The
-            # event tail is a stale/read-only consumer and must never recreate
-            # one after Archive/Delete moved its DB away.
-            conn = kanban_db.connect(
-                board=ws_board,
-                create_if_missing=(
-                    ws_board is None or ws_board == kanban_db.DEFAULT_BOARD
-                ),
-            )
+            # The event tail is a stale/read-only consumer. It must not take
+            # the schema-init path or recreate a board after Archive/Delete
+            # atomically moved the public board directory away.
+            conn = kanban_db.connect_existing_readonly(board=ws_board)
             try:
                 rows = conn.execute(
                     "SELECT id, task_id, run_id, kind, payload, created_at "

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2417,7 +2417,15 @@ async def stream_events(ws: WebSocket):
             ws_board = None
 
         def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
-            conn = kanban_db.connect(board=ws_board)
+            # Named boards are explicitly created through create_board(). The
+            # event tail is a stale/read-only consumer and must never recreate
+            # one after Archive/Delete moved its DB away.
+            conn = kanban_db.connect(
+                board=ws_board,
+                create_if_missing=(
+                    ws_board is None or ws_board == kanban_db.DEFAULT_BOARD
+                ),
+            )
             try:
                 rows = conn.execute(
                     "SELECT id, task_id, run_id, kind, payload, created_at "
@@ -2457,6 +2465,10 @@ async def stream_events(ws: WebSocket):
         # CancelledError is a BaseException in 3.8+ so the bare Exception
         # handler below would not catch it; without this clause Uvicorn
         # surfaces the cancellation as an application traceback. Quiet it.
+        return
+    except FileNotFoundError:
+        # Normal board lifecycle: Archive/Delete removed a named board while
+        # this browser tab still had its old event stream open.
         return
     except Exception as exc:  # defensive: never crash the dashboard worker
         log.warning("Kanban event stream error: %s", exc)

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -15,8 +15,12 @@ Covers the pieces added when boards became a first-class concept:
 
 from __future__ import annotations
 
+import argparse
+import errno
 import json
 import os
+import shutil
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -257,6 +261,131 @@ class TestBoardCRUD:
         assert res["action"] == "deleted"
         assert not d.exists()
 
+    def test_remove_hard_delete_retries_transient_detached_cleanup_failure(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("nuke")
+        board_path = kb.board_dir("nuke")
+        real_rmtree = shutil.rmtree
+        attempts = []
+
+        def _fail_once(path, *args, **kwargs):
+            attempts.append(Path(path))
+            if len(attempts) == 1:
+                raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "rmtree", _fail_once)
+
+        result = kb.remove_board("nuke", archive=False)
+
+        assert result["action"] == "deleted"
+        assert len(attempts) == 2
+        assert attempts[0] == attempts[1]
+        assert attempts[0].name.startswith(".deleting-nuke-")
+        assert not board_path.exists()
+        assert not attempts[0].exists()
+
+    def test_remove_hard_delete_restores_board_after_persistent_cleanup_failure(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("nuke")
+        board_path = kb.board_dir("nuke")
+        with kb.connect(board="nuke") as conn:
+            task_id = kb.create_task(
+                conn,
+                title="preserve me",
+                assignee="dev",
+            )
+        kb.set_current_board("nuke")
+        cache_key = str((board_path / "kanban.db").resolve())
+        assert cache_key in kb._INITIALIZED_PATHS
+        attempts = []
+
+        def _always_fail(path, *args, **kwargs):
+            attempts.append(Path(path))
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+
+        monkeypatch.setattr(shutil, "rmtree", _always_fail)
+
+        with pytest.raises(OSError, match="Directory not empty"):
+            kb.remove_board("nuke", archive=False)
+
+        assert len(attempts) == 3
+        assert board_path.exists()
+        assert not list(board_path.parent.glob(".deleting-nuke-*"))
+        assert "nuke" in [board["slug"] for board in kb.list_boards()]
+        assert kb.get_current_board() == "nuke"
+        # Cleanup began before rollback, so the DB may have been partially
+        # removed. The next connect must revalidate it instead of trusting the
+        # stale pre-delete initialization cache entry.
+        assert cache_key not in kb._INITIALIZED_PATHS
+        with kb.connect(board="nuke", create_if_missing=False) as conn:
+            task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.title == "preserve me"
+        assert cache_key in kb._INITIALIZED_PATHS
+
+    def test_remove_hard_delete_surfaces_recovery_path_on_restore_collision(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("nuke")
+        board_path = kb.board_dir("nuke")
+
+        def _fail_after_public_path_is_recreated(path, *args, **kwargs):
+            board_path.mkdir()
+            (board_path / "concurrent-board").write_text("new", encoding="utf-8")
+            raise PermissionError(errno.EACCES, "Permission denied", str(path))
+
+        monkeypatch.setattr(
+            shutil,
+            "rmtree",
+            _fail_after_public_path_is_recreated,
+        )
+
+        with pytest.raises(
+            kb.BoardDeleteRecoveryError,
+            match="inspect the detached board recovery path",
+        ) as exc_info:
+            kb.remove_board("nuke", archive=False)
+
+        recovery_paths = list(board_path.parent.glob(".deleting-nuke-*"))
+        assert len(recovery_paths) == 1
+        assert exc_info.value.recovery_path == recovery_paths[0]
+        assert str(recovery_paths[0]) in str(exc_info.value)
+        assert (board_path / "concurrent-board").read_text(encoding="utf-8") == "new"
+
+    def test_remove_hard_delete_rename_failure_leaves_board_state_untouched(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("nuke")
+        kb.set_current_board("nuke")
+        board_path = kb.board_dir("nuke")
+        db_path = board_path / "kanban.db"
+        with kb.connect(board="nuke") as conn:
+            task_id = kb.create_task(conn, title="still here", assignee="dev")
+        cache_key = str(db_path.resolve())
+        assert cache_key in kb._INITIALIZED_PATHS
+        real_rename = Path.rename
+
+        def _deny_board_detach(path, target):
+            if path == board_path:
+                raise PermissionError(errno.EACCES, "Permission denied", str(path))
+            return real_rename(path, target)
+
+        monkeypatch.setattr(Path, "rename", _deny_board_detach)
+
+        with pytest.raises(PermissionError, match="Permission denied"):
+            kb.remove_board("nuke", archive=False)
+
+        assert board_path.exists()
+        assert kb.get_current_board() == "nuke"
+        assert cache_key in kb._INITIALIZED_PATHS
+        with kb.connect(board="nuke", create_if_missing=False) as conn:
+            task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.title == "still here"
+
     def test_remove_default_forbidden(self, fresh_home):
         with pytest.raises(ValueError, match="default"):
             kb.remove_board("default")
@@ -315,6 +444,93 @@ class TestBoardCRUD:
 # ---------------------------------------------------------------------------
 
 class TestConnectionIsolation:
+    def test_connect_existing_readonly_bypasses_schema_init_and_cache(
+        self, fresh_home,
+    ):
+        db_path = fresh_home / "readonly path # with percent%" / "kanban.db"
+        db_path.parent.mkdir(parents=True)
+        raw = sqlite3.connect(db_path)
+        try:
+            raw.execute("CREATE TABLE marker (value TEXT)")
+            raw.commit()
+        finally:
+            raw.close()
+
+        cache_key = str(db_path.resolve())
+        lock_path = db_path.with_name(db_path.name + ".init.lock")
+        assert cache_key not in kb._INITIALIZED_PATHS
+        assert not lock_path.exists()
+
+        conn = kb.connect_existing_readonly(db_path=db_path)
+        try:
+            assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+            }
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("CREATE TABLE must_not_exist (value TEXT)")
+        finally:
+            conn.close()
+
+        assert tables == {"marker"}
+        assert cache_key not in kb._INITIALIZED_PATHS
+        assert not lock_path.exists()
+
+    def test_connect_existing_readonly_does_not_create_missing_parent(
+        self, fresh_home,
+    ):
+        db_path = fresh_home / "missing readonly path" / "kanban.db"
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            kb.connect_existing_readonly(db_path=db_path)
+
+        assert not db_path.parent.exists()
+
+    @pytest.mark.parametrize(
+        "kanban_root_name",
+        ["plain-home", "kanban home # with percent%"],
+        ids=["plain-path", "uri-escaped-path"],
+    )
+    def test_stale_named_consumer_does_not_recreate_removed_board(
+        self, fresh_home, monkeypatch, kanban_root_name,
+    ):
+        kanban_root = fresh_home / kanban_root_name
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(kanban_root))
+        kb.create_board("ephemeral")
+        board_path = kb.board_dir("ephemeral")
+        db_path = kb.kanban_db_path(board="ephemeral")
+        assert db_path.is_file()
+
+        kb.remove_board("ephemeral", archive=False)
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            kb.connect(board="ephemeral", create_if_missing=False)
+
+        assert not board_path.exists()
+
+    def test_connect_no_create_handles_uri_escaped_existing_path(self, fresh_home):
+        db_path = fresh_home / "kanban path # with percent%" / "kanban.db"
+        with kb.connect(db_path=db_path) as conn:
+            task_id = kb.create_task(conn, title="escaped path", assignee="dev")
+
+        with kb.connect(db_path=db_path, create_if_missing=False) as conn:
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.title == "escaped path"
+
+    def test_connect_no_create_does_not_create_uri_escaped_missing_path(
+        self, fresh_home,
+    ):
+        db_path = fresh_home / "missing path # with percent%" / "kanban.db"
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            kb.connect(db_path=db_path, create_if_missing=False)
+
+        assert not db_path.parent.exists()
+
     def test_tasks_do_not_leak_across_boards(self, fresh_home):
         kb.create_board("alpha")
         kb.create_board("beta")
@@ -484,6 +700,29 @@ def _cli(args: list[str], env_extra: dict | None = None) -> subprocess.Completed
 
 
 class TestCLI:
+    def test_boards_rm_surfaces_recovery_path(self, tmp_path, monkeypatch, capsys):
+        from hermes_cli import kanban as kanban_cli
+
+        recovery_path = tmp_path / ".deleting-nuke-recoverable"
+        error = kb.BoardDeleteRecoveryError(
+            "nuke",
+            recovery_path,
+            PermissionError(errno.EACCES, "Permission denied"),
+            FileExistsError(errno.EEXIST, "File exists"),
+        )
+
+        def _fail_remove_board(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr(kanban_cli.kb, "remove_board", _fail_remove_board)
+
+        result = kanban_cli._cmd_boards_rm(
+            argparse.Namespace(slug="nuke", delete=True, boards_action="rm")
+        )
+
+        assert result == 1
+        assert str(recovery_path) in capsys.readouterr().err
+
     def test_boards_list_default_only(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}
         res = _cli(["boards", "list", "--json"], env_extra=env)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -7,10 +7,14 @@ REST surface without spinning up the whole dashboard.
 
 from __future__ import annotations
 
+import asyncio
+import errno
 import importlib.util
 import os
+import shutil
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -989,6 +993,159 @@ def test_ws_event_poll_does_not_recreate_removed_board(
         # tick, making the Dashboard's Archive button look like a no-op.
         time.sleep(0.75)
         assert not kb.board_dir("ephemeral").exists()
+
+
+def test_ws_event_poll_hard_delete_detaches_before_recursive_cleanup(
+    tmp_path, monkeypatch,
+):
+    """Hard delete succeeds while an event-stream SQLite read is open.
+
+    A synchronized rmtree shim reproduces macOS's ``ENOTEMPTY`` failure when
+    SQLite creates a WAL/SHM sidecar between rmtree's directory scan and final
+    rmdir. The board's public path must be atomically detached before recursive
+    cleanup, then the stale stream must notice the missing path and exit.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    kb.create_board("ephemeral")
+    board_path = kb.board_dir("ephemeral")
+
+    import hermes_cli
+    import types
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _ws_auth_ok=lambda ws: ws.query_params.get("token", "") == "secret-xyz",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    stream_query_open = threading.Event()
+    release_stream_query = threading.Event()
+    wrapped_once = threading.Event()
+    real_connect_existing_readonly = kb.connect_existing_readonly
+
+    class _SynchronizedConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, *args, **kwargs):
+            stream_query_open.set()
+            assert release_stream_query.wait(5), "timed out waiting for board delete"
+            return self._conn.execute(*args, **kwargs)
+
+        def close(self):
+            self._conn.close()
+
+    def _synchronized_connect_existing_readonly(*args, **kwargs):
+        conn = real_connect_existing_readonly(*args, **kwargs)
+        if (
+            kwargs.get("board") == "ephemeral"
+            and not wrapped_once.is_set()
+        ):
+            wrapped_once.set()
+            return _SynchronizedConnection(conn)
+        return conn
+
+    monkeypatch.setattr(
+        kb,
+        "connect_existing_readonly",
+        _synchronized_connect_existing_readonly,
+    )
+
+    real_rmtree = shutil.rmtree
+
+    def _fail_if_live_board_was_not_detached(path, *args, **kwargs):
+        if Path(path) == board_path and stream_query_open.is_set():
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", _fail_if_live_board_was_not_detached)
+
+    router = _load_plugin_router()
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/kanban")
+    c = TestClient(app)
+
+    stream_endpoint = next(
+        route.endpoint for route in router.routes if route.path == "/events"
+    )
+
+    class _FakeWS:
+        query_params = {
+            "token": "secret-xyz",
+            "board": "ephemeral",
+            "since": "0",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_json(self, _data):
+            pass
+
+        async def close(self, code=None):
+            pass
+
+    stream_exited = threading.Event()
+    stream_errors = []
+
+    def _run_stream():
+        try:
+            asyncio.run(stream_endpoint(_FakeWS()))
+        except BaseException as exc:
+            stream_errors.append(exc)
+        finally:
+            stream_exited.set()
+
+    stream_thread = threading.Thread(target=_run_stream, daemon=True)
+    stream_thread.start()
+
+    assert stream_query_open.wait(5), "event stream did not open its DB read"
+    try:
+        response = c.delete(
+            "/api/plugins/kanban/boards/ephemeral?delete=true"
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["result"]["action"] == "deleted"
+        assert not board_path.exists()
+    finally:
+        release_stream_query.set()
+
+    assert stream_exited.wait(5), "stale event stream did not exit"
+    stream_thread.join(timeout=1)
+    assert stream_errors == []
+
+
+def test_hard_delete_restore_collision_surfaces_recovery_path(
+    kanban_home, tmp_path, monkeypatch,
+):
+    recovery_path = tmp_path / ".deleting-ephemeral-recoverable"
+    recovery_path.mkdir()
+    error = kb.BoardDeleteRecoveryError(
+        "ephemeral",
+        recovery_path,
+        PermissionError(errno.EACCES, "Permission denied"),
+        FileExistsError(errno.EEXIST, "File exists"),
+    )
+
+    def _fail_remove_board(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(kb, "remove_board", _fail_remove_board)
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.delete(
+        "/api/plugins/kanban/boards/ephemeral?delete=true"
+    )
+
+    assert response.status_code == 409
+    assert str(recovery_path) in response.json()["detail"]
 
 
 def test_ws_events_swallows_cancellation_on_shutdown(tmp_path, monkeypatch):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -941,6 +941,56 @@ def test_ws_events_board_query_param_default_overrides_current_board_pointer(tmp
     assert other_task not in task_ids
 
 
+@pytest.mark.parametrize("hard_delete", [False, True])
+def test_ws_event_poll_does_not_recreate_removed_board(
+    tmp_path, monkeypatch, hard_delete,
+):
+    """An open dashboard event stream must not resurrect a removed board.
+
+    The stream polls every 300 ms. Archiving or hard-deleting the selected
+    board removes its directory, so the next poll must stop instead of opening
+    SQLite in create mode at the old path.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    kb.create_board("ephemeral")
+
+    import hermes_cli
+    import types
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _ws_auth_ok=lambda ws: ws.query_params.get("token", "") == "secret-xyz",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    c = TestClient(app)
+    delete_url = "/api/plugins/kanban/boards/ephemeral"
+    if hard_delete:
+        delete_url += "?delete=true"
+
+    with c.websocket_connect(
+        "/api/plugins/kanban/events?token=secret-xyz&board=ephemeral&since=0"
+    ):
+        response = c.delete(delete_url)
+        assert response.status_code == 200, response.text
+        assert response.json()["result"]["action"] == (
+            "deleted" if hard_delete else "archived"
+        )
+
+        # Wait for more than two poll intervals. Before the regression fix,
+        # connect(board="ephemeral") recreated an empty directory on the next
+        # tick, making the Dashboard's Archive button look like a no-op.
+        time.sleep(0.75)
+        assert not kb.board_dir("ephemeral").exists()
+
+
 def test_ws_events_swallows_cancellation_on_shutdown(tmp_path, monkeypatch):
     """``asyncio.CancelledError`` while sleeping in the poll loop is the
     normal uvicorn-shutdown path (``BaseException``, so the bare


### PR DESCRIPTION
## Summary

Prevent stale Kanban Dashboard event streams from recreating boards after archive/delete, and make hard deletion race-safe when SQLite WAL readers are still active.

## Root cause

The Dashboard event WebSocket polls the selected board every 300 ms. Its named-board read path used the normal RW/WAL/schema-initializing connection path. If Archive/Delete moved or removed the board while the stream remained open, a stale poll could recreate the old board path or create/remove SQLite WAL/SHM sidecars while `shutil.rmtree()` walked it. On macOS, that race intermittently failed hard delete with `OSError: [Errno 66] Directory not empty`.

## Fix

### Non-creating event-stream access

- Add `connect_existing_readonly()` using SQLite `mode=ro` and `PRAGMA query_only=ON`.
- Bypass parent creation, init-lock creation, WAL activation pragmas, schema/migrations, integrity-repair writes, and `_INITIALIZED_PATHS` mutation.
- Use it for named-board event polling; stale streams fail closed and exit when the public board path disappears.

Read-only WAL access can still require sidecars, so this is hygiene rather than the deletion boundary.

### Race-safe hard delete

- Atomically rename the public board directory to a unique same-parent tombstone before recursive cleanup.
- Retry only post-detach `ENOTEMPTY`, with a short bounded retry limit.
- Continue narrowly tolerating nested `FileNotFoundError` when SQLite removes a sidecar between directory scan and unlink.
- On persistent cleanup failure, restore the public board path when safe and leave the initialization cache discarded for revalidation.
- If rollback collides with a concurrently recreated public path, preserve both locations and raise `BoardDeleteRecoveryError` carrying the detached recovery path.
- Surface that recovery path through the CLI and Dashboard HTTP 409 response.
- Keep archive behavior and default-board protection unchanged.

## Regression coverage

- Existing open-stream archive/delete regression remains.
- Deterministic synchronized test holds an event-stream DB read open while hard DELETE runs and verifies HTTP 200, absent public board path, and clean stream exit.
- Tests cover transient cleanup retry, persistent cleanup rollback, rollback collision, rename failure, current-board/cache restoration semantics, and URI-escaped existing/missing paths.

## Verification

```text
scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/plugins/test_kanban*.py tests/tools/test_kanban*.py tests/gateway/test_kanban*.py -q
988 passed, 0 failed across 37 files
```

Stress verification:

- Original intermittent hard-delete regression: 30/30 passed.
- Deterministic synchronized regression: 20/20 passed.
- Focused changed-file suite: 169 passed, 0 failed.

Also passed:

- `git diff --check`
- Python `compileall` for all changed files
- added-line security scan: no production secret or injection findings

## Related work

Addresses the active-stream/hard-delete case in #43243 and #35211.

Related PRs #56030, #37654, and #35208 cover overlapping resurrection paths. This patch keeps normal `connect()` compatibility, adds an explicit existing-only read path, and tests the already-open stream race directly.
