### PR TITLE
fix(desktop): replay pending composer draft after bind

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-text-guard.test.tsx
+++ b/apps/desktop/src/app/chat/composer/composer-text-guard.test.tsx
@@ -1,9 +1,16 @@
 // @vitest-environment jsdom
 import { act, cleanup, render } from '@testing-library/react'
-import { useCallback, useRef } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCallback, useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 afterEach(cleanup)
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 // Regression repro for #49903: on desktop v0.17.0 the composer threw an
 // uncaught `Error: Composer is not available` at startup and the input went
@@ -16,12 +23,10 @@ afterEach(cleanup)
 // before the core binds, and the popout refactor (#49488) widened that window,
 // so the throw surfaced as an uncaught error that wedged the input.
 //
-// The fix wraps every `aui.composer().setText` call in a `setComposerText`
-// helper that swallows the unbound-core throw — the contentEditable DOM +
-// draftRef already hold the text and the draft⇄editor sync re-applies it once
-// the core attaches, so nothing is lost. This Harness mirrors that helper
-// faithfully (same try/catch shape) over a fake `aui` whose composer can be
-// toggled bound/unbound, the way the assistant-ui runtime behaves across mount.
+// The fix keeps the latest desired draft on file and retries `setText` on
+// animation frames until the composer core binds. That preserves the no-crash
+// startup behavior while also preventing a stale runtime draft from leaking
+// into the next session after a scope swap.
 
 interface FakeComposer {
   setText: (value: string) => void
@@ -44,6 +49,7 @@ function makeFakeAui(bound: { current: boolean }, applied: string[]) {
 }
 
 function Harness({
+  writes,
   bound,
   applied,
   onError
@@ -51,28 +57,78 @@ function Harness({
   applied: string[]
   bound: { current: boolean }
   onError: (err: unknown) => void
+  writes: string[]
 }) {
   const aui = useRef(makeFakeAui(bound, applied)).current
+  const pendingComposerTextRef = useRef<string | null>(null)
+  const pendingComposerTextRafRef = useRef<number | undefined>(undefined)
 
-  // Verbatim mirror of the production `setComposerText` helper in index.tsx.
+  const flushPendingComposerText = useCallback(() => {
+    const pending = pendingComposerTextRef.current
+
+    if (pending === null) {
+      return true
+    }
+
+    try {
+      aui.composer().setText(pending)
+      pendingComposerTextRef.current = null
+
+      return true
+    } catch {
+      return false
+    }
+  }, [aui])
+
+  const schedulePendingComposerTextFlush = useCallback(() => {
+    if (pendingComposerTextRafRef.current !== undefined) {
+      return
+    }
+
+    const retry = () => {
+      pendingComposerTextRafRef.current = undefined
+
+      if (pendingComposerTextRef.current === null) {
+        return
+      }
+
+      if (!flushPendingComposerText()) {
+        pendingComposerTextRafRef.current = window.requestAnimationFrame(retry)
+      }
+    }
+
+    pendingComposerTextRafRef.current = window.requestAnimationFrame(retry)
+  }, [flushPendingComposerText])
+
   const setComposerText = useCallback(
     (value: string) => {
-      try {
-        aui.composer().setText(value)
-      } catch {
-        // Composer core not bound yet — swallow so the input stays usable.
+      pendingComposerTextRef.current = value
+
+      if (!flushPendingComposerText()) {
+        schedulePendingComposerTextFlush()
       }
     },
-    [aui]
+    [flushPendingComposerText, schedulePendingComposerTextFlush]
   )
 
-  // A draft-restore-on-mount that fires while the core may still be unbound,
-  // exactly like loadIntoComposer/clearDraft do on startup.
-  try {
-    setComposerText('restored draft')
-  } catch (err) {
-    onError(err)
-  }
+  useEffect(() => {
+    for (const value of writes) {
+      try {
+        setComposerText(value)
+      } catch (err) {
+        onError(err)
+      }
+    }
+  }, [onError, setComposerText, writes])
+
+  useEffect(
+    () => () => {
+      if (pendingComposerTextRafRef.current !== undefined) {
+        window.cancelAnimationFrame(pendingComposerTextRafRef.current)
+      }
+    },
+    []
+  )
 
   return null
 }
@@ -83,7 +139,7 @@ describe('setComposerText guard (#49903)', () => {
     const bound = { current: false }
     const onError = vi.fn()
 
-    expect(() => render(<Harness applied={applied} bound={bound} onError={onError} />)).not.toThrow()
+    expect(() => render(<Harness applied={applied} bound={bound} onError={onError} writes={['restored draft']} />)).not.toThrow()
 
     // The guard absorbed the throw — nothing escaped to the renderer, and no
     // assistant-ui write landed (core was unbound).
@@ -97,10 +153,48 @@ describe('setComposerText guard (#49903)', () => {
     const onError = vi.fn()
 
     act(() => {
-      render(<Harness applied={applied} bound={bound} onError={onError} />)
+      render(<Harness applied={applied} bound={bound} onError={onError} writes={['restored draft']} />)
     })
 
     expect(onError).not.toHaveBeenCalled()
     expect(applied).toEqual(['restored draft'])
+  })
+
+  it('replays the latest pending draft once the core binds', () => {
+    const applied: string[] = []
+    const bound = { current: false }
+
+    render(<Harness applied={applied} bound={bound} onError={vi.fn()} writes={['restored draft']} />)
+
+    act(() => {
+      vi.advanceTimersByTime(16)
+    })
+    expect(applied).toEqual([])
+
+    bound.current = true
+    act(() => {
+      vi.advanceTimersByTime(16)
+    })
+
+    expect(applied).toEqual(['restored draft'])
+  })
+
+  it('flushes only the newest pending value across an unbound session swap', () => {
+    const applied: string[] = []
+    const bound = { current: false }
+
+    render(<Harness applied={applied} bound={bound} onError={vi.fn()} writes={['previous session draft', '']} />)
+
+    act(() => {
+      vi.advanceTimersByTime(16)
+    })
+    expect(applied).toEqual([])
+
+    bound.current = true
+    act(() => {
+      vi.advanceTimersByTime(16)
+    })
+
+    expect(applied).toEqual([''])
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -62,22 +62,10 @@ export function useComposerDraft({
     return trimmed.length > 0 && !SLASH_COMMAND_RE.test(trimmed)
   })
 
-  // assistant-ui's composer mutators throw when the core isn't bound yet (a
-  // startup/thread-swap window); the DOM + draftRef hold the text and the
-  // subscription reconciles once it binds, so swallow the premature write.
-  const setComposerText = useCallback(
-    (value: string) => {
-      try {
-        aui.composer().setText(value)
-      } catch {
-        // Composer core not bound yet — DOM/draftRef carry the text.
-      }
-    },
-    [aui]
-  )
-
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef('')
+  const pendingComposerTextRef = useRef<string | null>(null)
+  const pendingComposerTextRafRef = useRef<number | undefined>(undefined)
   const pendingDraftPersistRef = useRef<{ scope: string | null; text: string } | null>(null)
   const draftPersistTimerRef = useRef<number | undefined>(undefined)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
@@ -95,6 +83,57 @@ export function useComposerDraft({
   queueEditStateRef.current = queueEditRef.current
 
   const [focusRequestId, setFocusRequestId] = useState(0)
+
+  const flushPendingComposerText = useCallback(() => {
+    const pending = pendingComposerTextRef.current
+
+    if (pending === null) {
+      return true
+    }
+
+    try {
+      aui.composer().setText(pending)
+      pendingComposerTextRef.current = null
+
+      return true
+    } catch {
+      return false
+    }
+  }, [aui])
+
+  const schedulePendingComposerTextFlush = useCallback(() => {
+    if (pendingComposerTextRafRef.current !== undefined) {
+      return
+    }
+
+    const retry = () => {
+      pendingComposerTextRafRef.current = undefined
+
+      if (pendingComposerTextRef.current === null) {
+        return
+      }
+
+      if (!flushPendingComposerText()) {
+        pendingComposerTextRafRef.current = window.requestAnimationFrame(retry)
+      }
+    }
+
+    pendingComposerTextRafRef.current = window.requestAnimationFrame(retry)
+  }, [flushPendingComposerText])
+
+  // assistant-ui's composer mutators throw when the core isn't bound yet (a
+  // startup/thread-swap window). Keep the latest desired draft on file and
+  // replay it once the core binds so stale session text cannot leak back in.
+  const setComposerText = useCallback(
+    (value: string) => {
+      pendingComposerTextRef.current = value
+
+      if (!flushPendingComposerText()) {
+        schedulePendingComposerTextFlush()
+      }
+    },
+    [flushPendingComposerText, schedulePendingComposerTextFlush]
+  )
 
   const focusInput = useCallback(() => {
     focusComposerInput(editorRef.current)
@@ -149,6 +188,15 @@ export function useComposerDraft({
       focusInput()
     }
   }, [focusInput, focusKey, focusRequestId, inputDisabled])
+
+  useEffect(
+    () => () => {
+      if (pendingComposerTextRafRef.current !== undefined) {
+        window.cancelAnimationFrame(pendingComposerTextRafRef.current)
+      }
+    },
+    []
+  )
 
   useEffect(() => {
     if (inputDisabled) {


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop composer race behind issue #63210 by preserving the latest pending draft while the assistant-ui composer core is still unbound, then replaying that value once the core attaches. This keeps the first send from disappearing on a new session and avoids restoring stale draft text from the previous session after a scope swap.

## Related Issue

Fixes #63210

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts` to queue the most recent pending composer value and retry `aui.composer().setText(...)` on animation frames until the core binds.
- Clear the queued value after a successful write so only the newest pending draft survives thread/session swaps.
- Extend `apps/desktop/src/app/chat/composer/composer-text-guard.test.tsx` with regressions for the delayed-bind replay path and stale-draft replacement.

## How to Test

1. Reproduce the bug on desktop by opening a fresh session where the composer binds after the draft restore path starts; verify the first Enter no longer leaves the message stranded in the input.
2. Run `npm run test:ui -- src/app/chat/composer/composer-text-guard.test.tsx` from `apps/desktop`.
3. Run `npx eslint src/app/chat/composer/composer-text-guard.test.tsx src/app/chat/composer/hooks/use-composer-draft.ts` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 / Darwin 25.4.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `npm run test:ui -- src/app/chat/composer/composer-text-guard.test.tsx` => 4 tests passed
- `npx eslint src/app/chat/composer/composer-text-guard.test.tsx src/app/chat/composer/hooks/use-composer-draft.ts` => passed
- `git diff --check origin/main...HEAD` => passed
