### PR TITLE
fix(nous): restore inference-api.nousresearch.com base_url

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -194,7 +194,6 @@ def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     base = str(base_url or "")
     return (
         base_url_host_matches(base, "inference-api.nousresearch.com")
-        or base_url_host_matches(base, "inference.nousresearch.com")
     )
 
 

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -51,7 +51,7 @@ nous = NousProfile(
         "hermes-3-405b",
         "hermes-3-70b",
     ),
-    base_url="https://inference.nousresearch.com/v1",
+    base_url="https://inference-api.nousresearch.com/v1",
     auth_type="oauth_device_code",
 )
 


### PR DESCRIPTION
## Description

Restores the correct Nous Portal inference API base URL (`inference-api.nousresearch.com`). The upstream migration to `inference.nousresearch.com` broke routing for the correct inference endpoint.

### Changes

1. **`plugins/model-providers/nous/__init__.py`**: Changed `base_url` back to `https://inference-api.nousresearch.com/v1`
2. **`agent/conversation_loop.py`**: Removed stale `inference.nousresearch.com` host match from `_is_nous_inference_route()`, which was added as a workaround during the migration

Fixes #60715