### PR TITLE
fix(computer-use): surface timeout context and honor raise requests

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -265,6 +265,36 @@ class TestDispatch:
         out = handle_computer_use({"action": "set_value"})
         parsed = json.loads(out)
         assert "error" in parsed
+
+    def test_capture_timeout_includes_exception_metadata(self):
+        from tools.computer_use import tool as cu_tool
+
+        class TimeoutBackend:
+            default_tool_timeout_s = 30.0
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def is_available(self):
+                return True
+
+            def capture(self, mode="som", app=None):
+                raise TimeoutError()
+
+        cu_tool.reset_backend_for_tests()
+        cu_tool._backend = TimeoutBackend()
+
+        out = cu_tool.handle_computer_use({"action": "capture"})
+        parsed = json.loads(out)
+        assert parsed["action"] == "capture"
+        assert parsed["exception_type"] == "TimeoutError"
+        assert parsed["timeout_s"] == 30.0
+        assert parsed["hint_code"] == "stale_or_offscreen_target"
+        assert "timed out waiting for the computer-use backend" in parsed["error"]
+
     def test_capture_after_skipped_when_action_failed(self, noop_backend):
         """capture_after must not fire when res.ok=False (regression guard).
 
@@ -1798,6 +1828,59 @@ class TestFocusAppFilterNoMatch:
         assert backend._active_pid == 200
         assert backend._active_window_id == 2
 
+    def test_focus_app_raise_window_uses_bring_to_front(self):
+        windows = [
+            {"app_name": "Calculator", "pid": 200, "window_id": 2,
+             "is_on_screen": True, "title": "Calculator", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": windows},
+                "isError": False,
+            },
+            {
+                "data": {"message": "raised"},
+                "images": [],
+                "structuredContent": None,
+                "isError": False,
+            },
+        ]
+
+        res = backend.focus_app("Calculator", raise_window=True)
+
+        assert res.ok is True
+        assert res.meta["raise_requested"] is True
+        assert res.meta["raised"] is True
+        assert "raised window" in res.message
+        assert backend._session.call_tool.call_args_list[1].args[0] == "bring_to_front"
+
+    def test_focus_app_raise_window_failure_returns_warning(self):
+        windows = [
+            {"app_name": "Calculator", "pid": 200, "window_id": 2,
+             "is_on_screen": True, "title": "Calculator", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": windows},
+                "isError": False,
+            },
+            TimeoutError(),
+        ]
+
+        res = backend.focus_app("Calculator", raise_window=True)
+
+        assert res.ok is True
+        assert res.meta["raise_requested"] is True
+        assert res.meta["raised"] is False
+        assert res.meta["warning"].startswith("raise_window=True could not bring")
+        assert res.meta["raise_meta"]["exception_type"] == "TimeoutError"
+
 
 class TestCuaEnvironmentScrubbing:
     """Verify that cua-driver subprocess environment is sanitized (issue #37878)."""
@@ -2904,6 +2987,18 @@ class TestCuaToolCoverageExpansion:
         backend.bring_to_front(pid=42, window_id=7)
         name, args = backend._session.call_tool.call_args.args
         assert args["window_id"] == 7
+
+    def test_action_timeout_without_message_is_descriptive(self):
+        backend = self._backend()
+        backend._session.call_tool.side_effect = TimeoutError()
+
+        res = backend._action("click", {"pid": 42, "button": "left"})
+
+        assert res.ok is False
+        assert res.message == "cua-driver error: timed out waiting for the computer-use backend"
+        assert res.meta["exception_type"] == "TimeoutError"
+        assert res.meta["timeout_s"] == 30.0
+        assert res.meta["hint_code"] == "stale_or_offscreen_target"
 
     # ── Pointer + display introspection ─────────────────────────
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1151,6 +1151,8 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 class CuaDriverBackend(ComputerUseBackend):
     """Default computer-use backend. Cross-platform via cua-driver MCP."""
 
+    default_tool_timeout_s = 30.0
+
     def __init__(self) -> None:
         self._bridge = _AsyncBridge()
         self._session = _CuaDriverSession(self._bridge)
@@ -1767,10 +1769,42 @@ class CuaDriverBackend(ComputerUseBackend):
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
             self._last_app = target["app_name"]  # preserve for capture_after= follow-ups
+            meta: Dict[str, Any] = {
+                "raise_requested": bool(raise_window),
+                "raised": False,
+                "pid": self._active_pid,
+                "window_id": self._active_window_id,
+            }
+            base_message = (
+                f"Targeted {target['app_name']} (pid {self._active_pid}, "
+                f"window {self._active_window_id})"
+            )
+            if raise_window:
+                raised = self.bring_to_front(
+                    pid=self._active_pid,
+                    window_id=self._active_window_id,
+                )
+                if raised.ok:
+                    meta["raised"] = True
+                    if raised.message:
+                        meta["raise_message"] = raised.message
+                    return ActionResult(
+                        ok=True,
+                        action="focus_app",
+                        message=f"{base_message} and raised window.",
+                        meta=meta,
+                    )
+                meta["warning"] = (
+                    "raise_window=True could not bring the target window to the "
+                    f"front: {raised.message or 'unknown error'}"
+                )
+                if raised.meta:
+                    meta["raise_meta"] = raised.meta
             return ActionResult(
-                ok=True, action="focus_app",
-                message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
-                        f"window {self._active_window_id}) without raising window.",
+                ok=True,
+                action="focus_app",
+                message=f"{base_message} without raising window.",
+                meta=meta,
             )
         return ActionResult(ok=False, action="focus_app",
                             message=f"No on-screen window found for app '{app}'.")
@@ -2090,7 +2124,20 @@ class CuaDriverBackend(ComputerUseBackend):
             out = self._session.call_tool(name, args)
         except Exception as e:
             logger.exception("cua-driver %s call failed", name)
-            return ActionResult(ok=False, action=name, message=f"cua-driver error: {e}")
+            meta: Dict[str, Any] = {"exception_type": type(e).__name__}
+            if isinstance(e, TimeoutError):
+                meta["timeout_s"] = self.default_tool_timeout_s
+                meta["hint"] = (
+                    "Re-capture the target, avoid stale element indices, and "
+                    "restore any minimized or off-screen window before retrying."
+                )
+                meta["hint_code"] = "stale_or_offscreen_target"
+            return ActionResult(
+                ok=False,
+                action=name,
+                message=f"cua-driver error: {_render_exception_detail(e)}",
+                meta=meta,
+            )
         ok = not out["isError"]
         message = ""
         data = out["data"]
@@ -2100,3 +2147,12 @@ class CuaDriverBackend(ComputerUseBackend):
             message = data
         return ActionResult(ok=ok, action=name, message=message,
                             meta=data if isinstance(data, dict) else {})
+
+
+def _render_exception_detail(exc: Exception) -> str:
+    detail = str(exc).strip()
+    if detail:
+        return detail
+    if isinstance(exc, TimeoutError):
+        return "timed out waiting for the computer-use backend"
+    return type(exc).__name__

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -57,6 +57,11 @@ from tools.computer_use.backend import (
 
 logger = logging.getLogger(__name__)
 
+_TIMEOUT_HINT = (
+    "Re-capture the target, avoid stale element indices, and restore any "
+    "minimized or off-screen window before retrying."
+)
+
 
 # ---------------------------------------------------------------------------
 # Approval & safety
@@ -285,7 +290,44 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
-        return json.dumps({"error": f"{action} failed: {e}"})
+        return json.dumps(
+            _format_tool_error_payload(
+                action,
+                e,
+                timeout_s=getattr(backend, "default_tool_timeout_s", None),
+            )
+        )
+
+
+def _format_tool_error_payload(
+    action: str,
+    exc: Exception,
+    *,
+    timeout_s: Optional[float] = None,
+) -> Dict[str, Any]:
+    detail = str(exc).strip()
+    payload: Dict[str, Any] = {
+        "error": f"{action} failed: {_render_exception_detail(exc)}",
+        "action": action,
+        "exception_type": type(exc).__name__,
+    }
+    if isinstance(exc, TimeoutError):
+        payload["hint"] = _TIMEOUT_HINT
+        payload["hint_code"] = "stale_or_offscreen_target"
+        if timeout_s is not None:
+            payload["timeout_s"] = float(timeout_s)
+    elif detail:
+        payload["detail"] = detail
+    return payload
+
+
+def _render_exception_detail(exc: Exception) -> str:
+    detail = str(exc).strip()
+    if detail:
+        return detail
+    if isinstance(exc, TimeoutError):
+        return "timed out waiting for the computer-use backend"
+    return type(exc).__name__
 
 
 def _request_approval(action: str, args: Dict[str, Any]) -> Optional[str]:


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows-oriented computer-use regression behind #63357 in two places. Empty `TimeoutError()` failures now surface as descriptive tool errors with exception metadata and retry hints instead of blank `capture failed: ` / `cua-driver error: ` strings, and `focus_app(..., raise_window=true)` now attempts `bring_to_front` so the result truthfully reports whether the window was actually raised.

## Related Issue

Fixes #63357

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `tools/computer_use/tool.py` to convert empty exceptions into readable error payloads and attach `exception_type`, `timeout_s`, and retry hints for timeout paths.
- Update `tools/computer_use/cua_backend.py` so `focus_app(..., raise_window=true)` tries `bring_to_front`, records whether the raise succeeded, and never silently treats an explicit raise request as a no-op.
- Extend `tests/tools/test_computer_use.py` with regressions for timeout payload shaping, raise-window success/failure, and empty-message timeout handling inside `_action`.

## How to Test

1. Run `python3 -m pytest tests/tools/test_computer_use.py -k 'capture_timeout_includes_exception_metadata or focus_app_raise_window or action_timeout_without_message_is_descriptive'`.
2. Exercise `computer_use(action="focus_app", app="chrome", raise_window=true)` against a visible target and confirm the response reports `raised=true` behavior instead of silently saying “without raising window.”
3. Exercise a timed-out `computer_use(action="capture", app="chrome")` path and confirm the returned error includes `exception_type`, `timeout_s`, and a non-empty timeout message.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 / Darwin 25.4.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest tests/tools/test_computer_use.py -k 'capture_timeout_includes_exception_metadata or focus_app_raise_window or action_timeout_without_message_is_descriptive'` => 4 passed
- `python3 -m py_compile tools/computer_use/tool.py tools/computer_use/cua_backend.py tests/tools/test_computer_use.py` => passed
- `git diff --check origin/main...HEAD` => passed
