### PR TITLE
fix(tui): browser paste, copy/cut, and word-delete shortcuts

### DIFF
--- a/ui-tui/src/__tests__/inputSelectionClipboard.test.ts
+++ b/ui-tui/src/__tests__/inputSelectionClipboard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleInputSelectionClipboard } from '../app/useInputHandlers.js'
+
+const selection = (start = 1, end = 4) => ({
+  clear: vi.fn(),
+  collapseToEnd: vi.fn(),
+  copy: vi.fn(),
+  cut: vi.fn(),
+  end,
+  start,
+  value: 'hello'
+})
+
+describe('handleInputSelectionClipboard', () => {
+  it('copies an active composer selection', () => {
+    const active = selection()
+
+    expect(handleInputSelectionClipboard(active, 'copy')).toBe(true)
+    expect(active.copy).toHaveBeenCalledOnce()
+    expect(active.cut).not.toHaveBeenCalled()
+  })
+
+  it('cuts an active composer selection', () => {
+    const active = selection()
+
+    expect(handleInputSelectionClipboard(active, 'cut')).toBe(true)
+    expect(active.cut).toHaveBeenCalledOnce()
+    expect(active.copy).not.toHaveBeenCalled()
+  })
+
+  it('leaves shortcuts available when there is no active selection', () => {
+    expect(handleInputSelectionClipboard(null, 'copy')).toBe(false)
+    expect(handleInputSelectionClipboard(selection(2, 2), 'cut')).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/textInputCut.test.ts
+++ b/ui-tui/src/__tests__/textInputCut.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { cutSelection } from '../components/textInput.js'
+
+describe('cutSelection (transactional cut)', () => {
+  it('removes the selection only after the clipboard write succeeds', async () => {
+    const write = vi.fn().mockResolvedValue(true)
+    const removeSelection = vi.fn()
+
+    const ok = await cutSelection('hello', write, removeSelection)
+
+    expect(ok).toBe(true)
+    expect(write).toHaveBeenCalledWith('hello')
+    expect(removeSelection).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the text intact when the clipboard write fails (headless/SSH)', async () => {
+    const write = vi.fn().mockResolvedValue(false)
+    const removeSelection = vi.fn()
+
+    const ok = await cutSelection('hello', write, removeSelection)
+
+    expect(ok).toBe(false)
+    expect(write).toHaveBeenCalledWith('hello')
+    // Text must NOT be removed. A failed write would otherwise destroy it with no
+    // clipboard copy to paste back.
+    expect(removeSelection).not.toHaveBeenCalled()
+  })
+
+  it('awaits the write before removing (no fire-and-forget removal)', async () => {
+    let resolveWrite: (value: boolean) => void = () => {}
+
+    const write = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveWrite = resolve
+        })
+    )
+
+    const removeSelection = vi.fn()
+
+    const pending = cutSelection('hello', write, removeSelection)
+
+    // While the write is still pending the selection must remain untouched.
+    await Promise.resolve()
+    expect(removeSelection).not.toHaveBeenCalled()
+
+    resolveWrite(true)
+    await pending
+
+    expect(removeSelection).toHaveBeenCalledOnce()
+  })
+})

--- a/ui-tui/src/__tests__/textInputWordDelete.test.ts
+++ b/ui-tui/src/__tests__/textInputWordDelete.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { InputEvent } from '../../packages/hermes-ink/src/ink/events/input-event.js'
+import { INITIAL_STATE, parseMultipleKeypresses } from '../../packages/hermes-ink/src/ink/parse-keypress.js'
+import { deleteWordForward } from '../components/textInput.js'
+
+function parseOne(sequence: string) {
+  const [keys] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+  expect(keys).toHaveLength(1)
+
+  return keys[0]!
+}
+
+// The web dashboard maps Ctrl+Delete to ESC d (see
+// web/src/lib/pty-keyboard-shortcuts.ts). hermes-ink decodes that bare
+// meta-letter form via META_KEY_CODE_RE. If this contract ever changes the
+// `wordMod && inp === 'd'` binding in textInput.tsx stops firing and
+// Ctrl+Delete regresses to typing a literal "d".
+describe('Ctrl+Delete → ESC d decode contract', () => {
+  it('decodes ESC d as meta+"d" so the composer binding is reached', () => {
+    const event = new InputEvent(parseOne('\x1bd'))
+
+    expect(event.key.meta).toBe(true)
+    expect(event.key.ctrl).toBe(false)
+    expect(event.input).toBe('d')
+  })
+})
+
+describe('deleteWordForward', () => {
+  it('deletes the word to the right of the cursor', () => {
+    // cursor before "hello" → removes "hello" and the trailing space.
+    expect(deleteWordForward('foo hello world', 4)).toEqual({ cursor: 4, value: 'foo world' })
+  })
+
+  it('deletes from mid-word to the next word boundary', () => {
+    // cursor inside "hello" (after "he") → removes "llo" + trailing space.
+    expect(deleteWordForward('foo hello world', 6)).toEqual({ cursor: 6, value: 'foo heworld' })
+  })
+
+  it('keeps the cursor fixed while removing text', () => {
+    const result = deleteWordForward('alpha beta', 0)
+
+    expect(result.cursor).toBe(0)
+    expect(result.value).toBe('beta')
+  })
+
+  it('is a no-op when the cursor is already at the end', () => {
+    expect(deleteWordForward('foo bar', 7)).toEqual({ cursor: 7, value: 'foo bar' })
+  })
+
+  it('handles an empty string', () => {
+    expect(deleteWordForward('', 0)).toEqual({ cursor: 0, value: '' })
+  })
+})

--- a/ui-tui/src/app/inputSelectionStore.ts
+++ b/ui-tui/src/app/inputSelectionStore.ts
@@ -3,6 +3,8 @@ import { atom } from 'nanostores'
 export interface InputSelection {
   clear: () => void
   collapseToEnd: () => void
+  copy: () => void
+  cut: () => void
   end: number
   start: number
   value: string

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -33,6 +33,19 @@ const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
+export function handleInputSelectionClipboard(
+  selection: ReturnType<typeof getInputSelection>,
+  action: 'copy' | 'cut'
+): boolean {
+  if (!selection || selection.end <= selection.start) {
+    return false
+  }
+
+  selection[action]()
+
+  return true
+}
+
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
@@ -516,9 +529,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       const inputSel = getInputSelection()
 
-      if (inputSel && inputSel.end > inputSel.start) {
-        inputSel.clear()
-
+      if (handleInputSelectionClipboard(inputSel, 'copy')) {
         return
       }
 
@@ -527,6 +538,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (isMac) {
         return
       }
+    }
+
+    if (isCtrl(key, ch, 'x') && handleInputSelectionClipboard(getInputSelection(), 'cut')) {
+      return
     }
 
     if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -601,6 +601,23 @@ export function TextInput({
         setCur(vRef.current.length)
         curRef.current = vRef.current.length
       },
+      copy: () => {
+        const range = selRange()
+
+        if (range) {
+          void writeClipboardText(vRef.current.slice(range.start, range.end))
+        }
+      },
+      cut: () => {
+        const range = selRange()
+
+        if (!range) {
+          return
+        }
+
+        void writeClipboardText(vRef.current.slice(range.start, range.end))
+        commit(vRef.current.slice(0, range.start) + vRef.current.slice(range.end), range.start)
+      },
       end: selected?.end ?? curRef.current,
       start: selected?.start ?? curRef.current,
       value: vRef.current

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -125,6 +125,27 @@ export function applyPrintableInsert(
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
 
+/**
+ * Transactional cut. Writes `text` to the clipboard and only invokes
+ * `removeSelection` once the write actually succeeds. On failure (e.g. a
+ * headless/SSH box with no clipboard backend) the selection is left untouched
+ * so the text is never destroyed without a copy to paste back. Returns whether
+ * the clipboard write succeeded.
+ */
+export async function cutSelection(
+  text: string,
+  write: (text: string) => Promise<boolean>,
+  removeSelection: () => void
+): Promise<boolean> {
+  const ok = await write(text)
+
+  if (ok) {
+    removeSelection()
+  }
+
+  return ok
+}
+
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
     return true
@@ -202,6 +223,16 @@ function wordRight(s: string, p: number) {
   }
 
   return i
+}
+
+/**
+ * Delete the word to the RIGHT of the cursor (readline meta+d / kill-word).
+ * The cursor stays put; the text from the cursor to the next word boundary is
+ * removed. Callers guard against `cursor >= value.length` themselves; when the
+ * cursor is already at the end this is a no-op.
+ */
+export function deleteWordForward(value: string, cursor: number): TextInsertResult {
+  return { cursor, value: value.slice(0, cursor) + value.slice(wordRight(value, cursor)) }
 }
 
 /**
@@ -615,8 +646,24 @@ export function TextInput({
           return
         }
 
-        void writeClipboardText(vRef.current.slice(range.start, range.end))
-        commit(vRef.current.slice(0, range.start) + vRef.current.slice(range.end), range.start)
+        // Transactional cut: only remove the selection once the clipboard
+        // write actually succeeds. A fire-and-forget write on a headless/SSH
+        // box (no clipboard backend) would otherwise destroy the text with no
+        // copy to paste back. On failure the selection is left intact.
+        const text = vRef.current.slice(range.start, range.end)
+
+        void cutSelection(text, writeClipboardText, () => {
+          // Re-read the selection: the awaited clipboard write opens a window
+          // in which the user could have moved/changed the selection. Only
+          // remove when it still matches what we copied.
+          const current = selRange()
+
+          if (!current || current.start !== range.start || current.end !== range.end) {
+            return
+          }
+
+          commit(vRef.current.slice(0, current.start) + vRef.current.slice(current.end), current.start)
+        })
       },
       end: selected?.end ?? curRef.current,
       start: selected?.start ?? curRef.current,
@@ -1088,6 +1135,21 @@ export function TextInput({
       } else if (wordMod && inp === 'f') {
         clearSel()
         c = wordRight(v, c)
+      } else if (wordMod && inp === 'd') {
+        // meta+d (readline kill-word). The web dashboard maps Ctrl+Delete to
+        // ESC d, which hermes-ink decodes as meta+'d'; without this branch it
+        // fell through to the printable path and typed a literal "d".
+        if (range) {
+          v = v.slice(0, range.start) + v.slice(range.end)
+          c = range.start
+        } else if (c < v.length) {
+          clearSel()
+          const next = deleteWordForward(v, c)
+          v = next.value
+          c = next.cursor
+        } else {
+          return
+        }
       } else if (range && (k.backspace || delFwd)) {
         v = v.slice(0, range.start) + v.slice(range.end)
         c = range.start
@@ -1117,8 +1179,7 @@ export function TextInput({
         }
       } else if (delFwd && c < v.length) {
         if (wordMod) {
-          const t = wordRight(v, c)
-          v = v.slice(0, c) + v.slice(t)
+          v = deleteWordForward(v, c).value
         } else {
           v = v.slice(0, c) + v.slice(nextPos(v, c))
         }

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePtyKeyboardShortcut } from './pty-keyboard-shortcuts'
+
+const key = (overrides: Partial<KeyboardEvent> = {}) =>
+  ({
+    altKey: false,
+    ctrlKey: false,
+    key: '',
+    metaKey: false,
+    shiftKey: false,
+    ...overrides,
+  }) as KeyboardEvent
+
+describe('resolvePtyKeyboardShortcut', () => {
+  it('copies terminal selection with bare Ctrl+C on non-macOS', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'c' }), false, true),
+    ).toBe('copy')
+  })
+
+  it('preserves Ctrl+C interrupt when nothing is selected', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'c' }), false, false),
+    ).toBe('pass')
+  })
+
+  it('maps Ctrl+Backspace to backward word deletion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(
+        key({ ctrlKey: true, key: 'Backspace' }),
+        false,
+        false,
+      ),
+    ).toBe('delete-word-backward')
+  })
+
+  it('maps Ctrl+Delete to forward word deletion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
+    ).toBe('delete-word-forward')
+  })
+})

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { resolvePtyKeyboardShortcut } from './pty-keyboard-shortcuts'
+import {
+  resolvePtyKeyboardShortcut,
+  sendPtyShortcutSequence,
+} from './pty-keyboard-shortcuts'
+import type { PtyConnectionState } from './pty-reconnect'
 
 const key = (overrides: Partial<KeyboardEvent> = {}) =>
   ({
@@ -39,5 +43,38 @@ describe('resolvePtyKeyboardShortcut', () => {
     expect(
       resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
     ).toBe('delete-word-forward')
+  })
+})
+
+describe('sendPtyShortcutSequence', () => {
+  const socket = (readyState: number = WebSocket.OPEN) => ({
+    readyState,
+    send: vi.fn(),
+  })
+
+  it('sends the sequence when the socket and PTY state are open', () => {
+    const ws = socket()
+
+    expect(sendPtyShortcutSequence(ws, 'open', '\x17')).toBe(true)
+    expect(ws.send).toHaveBeenCalledOnce()
+    expect(ws.send).toHaveBeenCalledWith('\x17')
+  })
+
+  it.each<PtyConnectionState>(['connecting', 'reconnecting', 'closed', 'ended'])(
+    'blocks shortcut bytes while the PTY state is %s',
+    (state) => {
+      const ws = socket()
+
+      expect(sendPtyShortcutSequence(ws, state, '\x1bd')).toBe(false)
+      expect(ws.send).not.toHaveBeenCalled()
+    },
+  )
+
+  it('blocks shortcut bytes when the socket is missing or not open', () => {
+    const ws = socket(WebSocket.CLOSING)
+
+    expect(sendPtyShortcutSequence(null, 'open', '\x17')).toBe(false)
+    expect(sendPtyShortcutSequence(ws, 'open', '\x17')).toBe(false)
+    expect(ws.send).not.toHaveBeenCalled()
   })
 })

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -1,0 +1,42 @@
+export type PtyKeyboardShortcut =
+  | "copy"
+  | "delete-word-backward"
+  | "delete-word-forward"
+  | "pass";
+
+export function resolvePtyKeyboardShortcut(
+  ev: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+  isMac: boolean,
+  hasTerminalSelection: boolean,
+): PtyKeyboardShortcut {
+  const key = ev.key.toLowerCase();
+  const copyPressed = isMac
+    ? ev.metaKey && !ev.ctrlKey
+    : ev.ctrlKey && !ev.altKey && !ev.metaKey;
+
+  if (copyPressed && key === "c" && hasTerminalSelection) {
+    return "copy";
+  }
+
+  if (
+    ev.ctrlKey &&
+    !ev.shiftKey &&
+    !ev.altKey &&
+    !ev.metaKey &&
+    ev.key === "Backspace"
+  ) {
+    return "delete-word-backward";
+  }
+
+  if (
+    ev.ctrlKey &&
+    !ev.shiftKey &&
+    !ev.altKey &&
+    !ev.metaKey &&
+    ev.key === "Delete"
+  ) {
+    return "delete-word-forward";
+  }
+
+  return "pass";
+}

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -1,3 +1,7 @@
+import { shouldBlockPtyInput, type PtyConnectionState } from "./pty-reconnect";
+
+const WS_OPEN = 1;
+
 export type PtyKeyboardShortcut =
   | "copy"
   | "delete-word-backward"
@@ -39,4 +43,21 @@ export function resolvePtyKeyboardShortcut(
   }
 
   return "pass";
+}
+
+// Guarded sender for shortcut escape sequences. Applies the same gate as the
+// term.onData path (socket OPEN + shouldBlockPtyInput) so a reconnecting or
+// closed session never receives shortcut bytes.
+export function sendPtyShortcutSequence(
+  ws: Pick<WebSocket, "readyState" | "send"> | null,
+  ptyState: PtyConnectionState,
+  sequence: string,
+): boolean {
+  if (!ws || ws.readyState !== WS_OPEN || shouldBlockPtyInput(ptyState)) {
+    return false;
+  }
+
+  ws.send(sequence);
+
+  return true;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -620,7 +620,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // react to the keypress.
       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
-      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      // Paste on BARE Ctrl+V too (not only Ctrl+Shift+V). Bare Ctrl+V otherwise
+      // falls through to the TUI, whose server-side clipboard read can't see the
+      // browser/OS clipboard → "No image found in clipboard". Routing Ctrl+V
+      // through the same navigator.clipboard path below makes it paste
+      // image-or-text correctly, like Ctrl+Shift+V.
+      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey;
 
       if (copyModifier && ev.key.toLowerCase() === "c") {
         const sel = term.getSelection();
@@ -638,6 +643,40 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         }
         // No selection → fall through so the TUI receives Ctrl+Shift+C
         // (or the bare ev if the user used a different modifier).
+      }
+
+      // Ctrl+Backspace → delete previous word. xterm.js sends bare DEL
+      // regardless of modifier, so word-delete never reaches the TUI on its
+      // own. Send ^W (0x17), which readline / prompt_toolkit treat as
+      // delete-word-backward. (Ctrl+W can't be used in a browser tab — it's a
+      // reserved shortcut that closes the tab and preventDefault has no effect;
+      // for Ctrl+W muscle memory use the Electron desktop app.)
+      if (
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key === "Backspace"
+      ) {
+        ev.preventDefault();
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
+        return false;
+      }
+
+      // Ctrl+Delete → delete next word. Mirror of Ctrl+Backspace; sends Alt+d
+      // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
+      if (
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key === "Delete"
+      ) {
+        ev.preventDefault();
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");
+        return false;
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -49,6 +49,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { resolvePtyKeyboardShortcut } from "@/lib/pty-keyboard-shortcuts";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -613,13 +614,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
-      // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
-      // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
-      // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
-      // without a selection it passes through to the TUI so agents can still
-      // react to the keypress.
+      // Copy: Cmd+C on macOS, Ctrl+C or Ctrl+Shift+C elsewhere. Copy only
+      // when xterm has a selection; without one Ctrl+C still reaches the TUI
+      // as SIGINT.
       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
-      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey;
       // Paste on BARE Ctrl+V too (not only Ctrl+Shift+V). Bare Ctrl+V otherwise
       // falls through to the TUI, whose server-side clipboard read can't see the
       // browser/OS clipboard → "No image found in clipboard". Routing Ctrl+V
@@ -627,22 +626,28 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // image-or-text correctly, like Ctrl+Shift+V.
       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey;
 
-      if (copyModifier && ev.key.toLowerCase() === "c") {
-        const sel = term.getSelection();
-        if (sel) {
-          // Direct writeText inside the keydown handler preserves the user
-          // gesture — async round-trips through OSC 52 can lose activation
-          // and fail with "Document is not focused".
-          navigator.clipboard.writeText(sel).catch((err) => {
-            console.warn("[dashboard clipboard] direct copy failed:", err.message);
-          });
-          // Clear xterm.js's highlight after copy (matches gnome-terminal).
-          term.clearSelection();
-          ev.preventDefault();
-          return false;
-        }
-        // No selection → fall through so the TUI receives Ctrl+Shift+C
-        // (or the bare ev if the user used a different modifier).
+      const terminalSelection = term.getSelection();
+      const shortcut = resolvePtyKeyboardShortcut(
+        ev,
+        isMac,
+        Boolean(terminalSelection),
+      );
+
+      if (
+        (shortcut === "copy" ||
+          (copyModifier && ev.shiftKey && ev.key.toLowerCase() === "c")) &&
+        terminalSelection
+      ) {
+        // Direct writeText inside the keydown handler preserves the user
+        // gesture — async round-trips through OSC 52 can lose activation
+        // and fail with "Document is not focused".
+        navigator.clipboard.writeText(terminalSelection).catch((err) => {
+          console.warn("[dashboard clipboard] direct copy failed:", err.message);
+        });
+        // Clear xterm.js's highlight after copy (matches gnome-terminal).
+        term.clearSelection();
+        ev.preventDefault();
+        return false;
       }
 
       // Ctrl+Backspace → delete previous word. xterm.js sends bare DEL
@@ -651,13 +656,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // delete-word-backward. (Ctrl+W can't be used in a browser tab — it's a
       // reserved shortcut that closes the tab and preventDefault has no effect;
       // for Ctrl+W muscle memory use the Electron desktop app.)
-      if (
-        ev.ctrlKey &&
-        !ev.shiftKey &&
-        !ev.altKey &&
-        !ev.metaKey &&
-        ev.key === "Backspace"
-      ) {
+      if (shortcut === "delete-word-backward") {
         ev.preventDefault();
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
@@ -666,13 +665,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       // Ctrl+Delete → delete next word. Mirror of Ctrl+Backspace; sends Alt+d
       // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
-      if (
-        ev.ctrlKey &&
-        !ev.shiftKey &&
-        !ev.altKey &&
-        !ev.metaKey &&
-        ev.key === "Delete"
-      ) {
+      if (shortcut === "delete-word-forward") {
         ev.preventDefault();
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -49,7 +49,10 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
-import { resolvePtyKeyboardShortcut } from "@/lib/pty-keyboard-shortcuts";
+import {
+  resolvePtyKeyboardShortcut,
+  sendPtyShortcutSequence,
+} from "@/lib/pty-keyboard-shortcuts";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -658,8 +661,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // for Ctrl+W muscle memory use the Electron desktop app.)
       if (shortcut === "delete-word-backward") {
         ev.preventDefault();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
+        sendPtyShortcutSequence(wsRef.current, ptyStateRef.current, "\x17");
         return false;
       }
 
@@ -667,8 +669,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
       if (shortcut === "delete-word-forward") {
         ev.preventDefault();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");
+        sendPtyShortcutSequence(wsRef.current, ptyStateRef.current, "\x1bd");
         return false;
       }
 


### PR DESCRIPTION
## Summary

The dashboard chat is an xterm.js terminal running a real Hermes TUI, so browser and terminal shortcut handling must cooperate.

- Ctrl+V and Ctrl+Shift+V paste browser clipboard images or text.
- Ctrl+C copies an xterm selection. With no selection it still reaches the TUI as interrupt.
- Ctrl+Backspace sends Ctrl+W for backward word deletion.
- Ctrl+Delete sends Alt+D for forward word deletion.
- Ctrl+C now copies an active composer selection instead of only clearing it.
- Ctrl+X cuts an active composer selection. With no selection, existing queue and session behavior is preserved.

## Tests

- Added focused dashboard shortcut routing tests.
- Added TUI composer copy/cut routing tests.
- Dashboard tests: 72 passed.
- Focused TUI tests: 9 passed.
- TypeScript checks pass for both web and ui-tui.
