### PR TITLE
fix(docker): surface sandbox startup failures truthfully

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -863,13 +863,52 @@ def test_docker_run_timeout_cleans_up_orphaned_container(monkeypatch):
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
 
-    with pytest.raises(subprocess.TimeoutExpired):
+    with pytest.raises(RuntimeError) as excinfo:
         _make_dummy_env()
 
+    assert "Docker sandbox startup timed out after 120 seconds" in str(excinfo.value)
+    assert "Docker is installed" in str(excinfo.value)
     assert len(cleanup_calls) == 1, "docker rm should be called once for the orphaned container"
     rm_cmd = cleanup_calls[0]
     assert rm_cmd[1] == "rm" and rm_cmd[2] == "-f"
     assert rm_cmd[3].startswith("hermes-"), "should remove the container by its generated name"
+
+
+def test_docker_run_failure_surfaces_docker_run_stderr(monkeypatch):
+    """Container startup failures should report the real docker run error."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+
+    cleanup_calls = []
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "ps":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if sub == "run":
+                raise subprocess.CalledProcessError(
+                    125,
+                    cmd,
+                    output="",
+                    stderr="context deadline exceeded",
+                )
+            if sub == "rm":
+                cleanup_calls.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _make_dummy_env(image="nikolaik/python-nodejs:python3.11-nodejs20")
+
+    assert "Docker sandbox startup failed while running `docker run`" in str(excinfo.value)
+    assert "exit code 125" in str(excinfo.value)
+    assert "context deadline exceeded" in str(excinfo.value)
+    assert len(cleanup_calls) == 1, "docker rm should still clean up the orphaned container"
 
 
 def test_no_reuse_when_persist_across_processes_disabled(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -565,6 +565,29 @@ def _ensure_docker_available() -> None:
             )
 
 
+def _format_docker_run_failure(
+    error: subprocess.CalledProcessError | subprocess.TimeoutExpired,
+    *,
+    image: str,
+    timeout_s: int,
+) -> str:
+    """Render a truthful docker sandbox startup failure message."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return (
+            f"Docker sandbox startup timed out after {timeout_s} seconds while "
+            f"starting image '{image}'. Docker is installed, but the Hermes "
+            "sandbox container did not become ready in time."
+        )
+
+    stderr = (error.stderr or "").strip()
+    stdout = (error.output or "").strip()
+    detail = stderr or stdout or str(error)
+    return (
+        "Docker sandbox startup failed while running `docker run` "
+        f"(exit code {error.returncode}): {detail}"
+    )
+
+
 class DockerEnvironment(BaseEnvironment):
     """Hardened Docker container execution with resource limits and persistence.
 
@@ -1005,7 +1028,9 @@ class DockerEnvironment(BaseEnvironment):
                     capture_output=True, timeout=10,
                     stdin=subprocess.DEVNULL,
                 )
-                raise
+                raise RuntimeError(
+                    _format_docker_run_failure(e, image=image, timeout_s=120)
+                ) from e
             self._container_id = result.stdout.strip()
             logger.info(f"Started container {container_name} ({self._container_id[:12]})")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker backend startup error path so Hermes reports the real sandbox startup failure instead of collapsing distinct `docker run` failures into an opaque subprocess exception.

When the sandbox container times out or `docker run` exits non-zero, Hermes now raises a clear `RuntimeError` that says Docker is installed and identifies the actual startup failure. This matches the evidence in #63356, where `docker version` worked but container startup stalled.

## Related Issue

Fixes #63356

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_format_docker_run_failure(...)` in `tools/environments/docker.py` to turn `docker run` startup timeouts and non-zero exits into truthful `RuntimeError` messages.
- Kept the existing orphaned-container cleanup path, but now re-raise a user-meaningful startup error after cleanup.
- Added regression tests in `tests/tools/test_docker_environment.py` covering timeout messaging and stderr propagation for failed `docker run` startup.

## How to Test

1. Run `python3 -m pytest tests/tools/test_docker_environment.py -k 'ensure_docker_available or docker_run_timeout_cleans_up_orphaned_container or docker_run_failure_surfaces_docker_run_stderr'`.
2. Confirm the targeted test suite passes, including the new timeout/stderr regression coverage.
3. Optionally reproduce a slow or failing Docker sandbox startup and verify Hermes now reports a `docker run` startup failure rather than implying `docker version` is broken.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 12.7.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted proof:

- `python3 -m pytest tests/tools/test_docker_environment.py -k 'ensure_docker_available or docker_run_timeout_cleans_up_orphaned_container or docker_run_failure_surfaces_docker_run_stderr'` -> `5 passed, 65 deselected`
- `python3 -m py_compile tools/environments/docker.py tests/tools/test_docker_environment.py`
- `git diff --check origin/main...HEAD`
