### PR TITLE
fix(curator): abort rollback when safety snapshot fails

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -577,12 +577,19 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
         # Protect the target from this snapshot's prune step: at the steady
         # keep limit, pruning the oldest snapshot would otherwise delete the
         # very snapshot we are about to extract from.
-        snapshot_skills(
+        safety_snapshot = snapshot_skills(
             reason=f"pre-rollback to {target.name}",
             protect_ids={target.name},
         )
     except Exception as e:
         return (False, f"pre-rollback safety snapshot failed: {e}", None)
+    if safety_snapshot is None:
+        return (
+            False,
+            "pre-rollback safety snapshot failed; backups may be disabled "
+            "or unavailable, and current skills were not changed",
+            None,
+        )
 
     # Additionally move current entries into an internal staging dir so
     # the extract happens into an empty skills tree (predictable result).

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -226,6 +226,27 @@ def test_rollback_is_itself_undoable(backup_env):
     )
 
 
+def test_rollback_aborts_when_safety_snapshot_fails(backup_env, monkeypatch):
+    """Rollback must not replace live skills without an undo snapshot."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    skill_file = _write_skill(skills, "alpha", body="snapshot state") / "SKILL.md"
+    target = cb.snapshot_skills(reason="rollback-target")
+    assert target is not None
+
+    skill_file.write_text("current state\n", encoding="utf-8")
+    current_bytes = skill_file.read_bytes()
+    monkeypatch.setattr(cb, "snapshot_skills", lambda *args, **kwargs: None)
+
+    ok, msg, restored = cb.rollback(target.name)
+
+    assert not ok
+    assert "safety snapshot failed" in msg
+    assert restored is None
+    assert skill_file.read_bytes() == current_bytes
+    assert not list((skills / ".curator_backups").glob(".rollback-staging-*"))
+
+
 def test_rollback_no_snapshots_returns_error(backup_env):
     cb = backup_env["cb"]
     ok, msg, _ = cb.rollback()


### PR DESCRIPTION
## What does this PR do?

`rollback()` promises to take a safety snapshot before replacing the live skills tree. However, `snapshot_skills()` reports expected failures by returning `None`, while `rollback()` only handled raised exceptions. A disabled or unavailable backup could therefore let rollback proceed without the undo point its own safety contract requires.

This change captures the snapshot result and fails closed when it is `None`, before staging or modifying any current skill. The existing exception path is unchanged.

## Related Issue

No issue filed; this was found while auditing the rollback safety invariant.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Abort curator rollback when its pre-rollback safety snapshot is unavailable.
- Add a regression test proving the live skill remains byte-for-byte unchanged and no staging directory is created.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/hermes_cli/test_backup.py tests/hermes_cli/test_curator_usage.py tests/hermes_cli/test_curator_status.py tests/hermes_cli/test_curator_run.py tests/hermes_cli/test_curator_recent_run_notice.py tests/hermes_cli/test_curator_archive_prune.py tests/agent/test_curator.py tests/agent/test_curator_backup.py tests/agent/test_curator_activity.py tests/agent/test_curator_reports.py tests/agent/test_curator_classification.py -q` (334 passed).
2. Run `.venv/bin/ruff check agent/curator_backup.py tests/agent/test_curator_backup.py`.
3. Reproduce with a temporary skills directory, a valid rollback target, and `snapshot_skills()` returning `None`; rollback now returns failure and preserves the current file contents.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux, Python 3.13

The focused curator and backup suite passes. The full local suite also exercises machine-specific credentials, services, and gateway timing, so I have left the full-suite item unchecked rather than claiming a clean environment-independent run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is an internal rollback guard with regression coverage.
