### PR TITLE
fix(daytona): recreate persistent sandboxes after image changes

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -315,23 +315,19 @@ class TestPersistence:
         env._mock_client.create.assert_called_once()
         assert env._sandbox is replacement
 
-    def test_persistent_creates_new_when_none_found(self, make_env, daytona_sdk):
-        env = make_env(
+    def test_persistent_creation_stamps_image_identity(self, make_env, daytona_sdk):
+        make_env(
             get_side_effect=daytona_sdk.DaytonaError("not found"),
             persistent=True,
             task_id="mytask",
         )
-        env._mock_client.create.assert_called_once()
-        # Verify the name and labels were passed to CreateSandboxFromImageParams
-        # by checking get() was called with the right sandbox name
-        env._mock_client.get.assert_called_with("hermes-mytask")
-        env._mock_client.list.assert_called_with(
-            labels={"hermes_task_id": "mytask"}, limit=1)
+
         create_kwargs = daytona_sdk.CreateSandboxFromImageParams.call_args.kwargs
         assert create_kwargs["labels"] == {
             "hermes_task_id": "mytask",
             "hermes_image": "test-image:latest",
         }
+
     def test_non_persistent_skips_lookup(self, make_env):
         env = make_env(persistent=False)
         env._mock_client.get.assert_not_called()
@@ -349,12 +345,6 @@ class TestCleanup:
         sb = env._sandbox
         env.cleanup()
         sb.stop.assert_called_once()
-
-    def test_non_persistent_cleanup_deletes_sandbox(self, make_env):
-        env = make_env(persistent=False)
-        sb = env._sandbox
-        env.cleanup()
-        env._mock_client.delete.assert_called_once_with(sb)
 
     def test_force_remove_deletes_persistent_sandbox(self, make_env):
         env = make_env(persistent=True)
@@ -378,10 +368,6 @@ class TestCleanup:
         sb.stop.assert_not_called()
         env._mock_client.delete.assert_called_once_with(sb)
 
-    def test_cleanup_idempotent(self, make_env):
-        env = make_env(persistent=True)
-        env.cleanup()
-        env.cleanup()  # should not raise
     def test_cleanup_swallows_errors(self, make_env):
         env = make_env(persistent=True)
         env._sandbox.stop.side_effect = RuntimeError("stop failed")

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -15,10 +15,11 @@ def _make_exec_response(result="", exit_code=0):
     return SimpleNamespace(result=result, exit_code=exit_code)
 
 
-def _make_sandbox(sandbox_id="sb-123", state="started"):
+def _make_sandbox(sandbox_id="sb-123", state="started", labels=None):
     sb = MagicMock()
     sb.id = sandbox_id
     sb.state = state
+    sb.labels = labels or {}
     sb.process.exec.return_value = _make_exec_response()
     return sb
 
@@ -37,7 +38,9 @@ def _patch_daytona_imports(monkeypatch):
 
     daytona_mod = _types.ModuleType("daytona")
     daytona_mod.Daytona = MagicMock
-    daytona_mod.CreateSandboxFromImageParams = MagicMock
+    daytona_mod.CreateSandboxFromImageParams = MagicMock(
+        name="CreateSandboxFromImageParams"
+    )
     daytona_mod.DaytonaError = type("DaytonaError", (Exception,), {})
     daytona_mod.Resources = MagicMock(name="Resources")
     daytona_mod.SandboxState = _SandboxState
@@ -138,7 +141,95 @@ class TestPersistence:
         env._mock_client.get.assert_called_once_with("hermes-mytask")
         env._mock_client.create.assert_not_called()
 
+    def test_persistent_resumes_matching_image_via_get(self, make_env):
+        existing = _make_sandbox(
+            sandbox_id="sb-existing",
+            labels={"hermes_image": "test-image:latest"},
+        )
+        existing.process.exec.return_value = _make_exec_response(result="/root")
 
+        env = make_env(
+            get_side_effect=lambda name: existing,
+            persistent=True,
+            task_id="mytask",
+        )
+
+        existing.start.assert_called_once()
+        env._mock_client.delete.assert_not_called()
+        env._mock_client.create.assert_not_called()
+
+    def test_persistent_recreates_named_sandbox_when_image_changed(self, make_env):
+        stale = _make_sandbox(
+            sandbox_id="sb-stale",
+            labels={"hermes_image": "old-image:latest"},
+        )
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=lambda name: stale,
+            persistent=True,
+            task_id="mytask",
+        )
+
+        stale.start.assert_not_called()
+        env._mock_client.delete.assert_called_once_with(stale)
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
+
+    def test_persistent_resumes_legacy_via_list(self, make_env, daytona_sdk):
+        legacy = _make_sandbox(sandbox_id="sb-legacy")
+        legacy.process.exec.return_value = _make_exec_response(result="/root")
+        env = make_env(
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            list_return=iter([legacy]),
+            persistent=True,
+            task_id="mytask",
+        )
+        legacy.start.assert_called_once()
+        env._mock_client.list.assert_called_once_with(
+            labels={"hermes_task_id": "mytask"}, limit=1)
+        env._mock_client.create.assert_not_called()
+
+    def test_persistent_recreates_legacy_lookup_when_image_changed(
+        self, make_env, daytona_sdk
+    ):
+        stale = _make_sandbox(
+            sandbox_id="sb-legacy-stale",
+            labels={"hermes_image": "old-image:latest"},
+        )
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            list_return=iter([stale]),
+            persistent=True,
+            task_id="mytask",
+        )
+
+        stale.start.assert_not_called()
+        env._mock_client.delete.assert_called_once_with(stale)
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
+
+    def test_persistent_creates_new_when_none_found(self, make_env, daytona_sdk):
+        env = make_env(
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            persistent=True,
+            task_id="mytask",
+        )
+        env._mock_client.create.assert_called_once()
+        # Verify the name and labels were passed to CreateSandboxFromImageParams
+        # by checking get() was called with the right sandbox name
+        env._mock_client.get.assert_called_with("hermes-mytask")
+        env._mock_client.list.assert_called_with(
+            labels={"hermes_task_id": "mytask"}, limit=1)
+        create_kwargs = daytona_sdk.CreateSandboxFromImageParams.call_args.kwargs
+        assert create_kwargs["labels"] == {
+            "hermes_task_id": "mytask",
+            "hermes_image": "test-image:latest",
+        }
     def test_non_persistent_skips_lookup(self, make_env):
         env = make_env(persistent=False)
         env._mock_client.get.assert_not_called()
@@ -157,7 +248,38 @@ class TestCleanup:
         env.cleanup()
         sb.stop.assert_called_once()
 
+    def test_non_persistent_cleanup_deletes_sandbox(self, make_env):
+        env = make_env(persistent=False)
+        sb = env._sandbox
+        env.cleanup()
+        env._mock_client.delete.assert_called_once_with(sb)
 
+    def test_force_remove_deletes_persistent_sandbox(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._sandbox
+
+        env.cleanup(force_remove=True)
+
+        sb.stop.assert_not_called()
+        env._mock_client.delete.assert_called_once_with(sb)
+
+    def test_cleanup_vm_forwards_force_remove(self, make_env, monkeypatch):
+        from tools import terminal_tool
+
+        env = make_env(persistent=True)
+        sb = env._sandbox
+        monkeypatch.setitem(terminal_tool._active_environments, "daytona-task", env)
+        monkeypatch.setitem(terminal_tool._last_activity, "daytona-task", 0.0)
+
+        terminal_tool.cleanup_vm("daytona-task", force_remove=True)
+
+        sb.stop.assert_not_called()
+        env._mock_client.delete.assert_called_once_with(sb)
+
+    def test_cleanup_idempotent(self, make_env):
+        env = make_env(persistent=True)
+        env.cleanup()
+        env.cleanup()  # should not raise
     def test_cleanup_swallows_errors(self, make_env):
         env = make_env(persistent=True)
         env._sandbox.stop.side_effect = RuntimeError("stop failed")

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -73,6 +73,7 @@ def make_env(daytona_sdk, monkeypatch):
         sandbox=None,
         get_side_effect=None,
         list_return=None,
+        delete_side_effect=None,
         home_dir="/root",
         persistent=True,
         **kwargs,
@@ -83,6 +84,8 @@ def make_env(daytona_sdk, monkeypatch):
 
         mock_client = MagicMock()
         mock_client.create.return_value = sandbox
+        if delete_side_effect is not None:
+            mock_client.delete.side_effect = delete_side_effect
 
         if get_side_effect is not None:
             mock_client.get.side_effect = get_side_effect
@@ -132,7 +135,7 @@ class TestCwdResolution:
 # ---------------------------------------------------------------------------
 
 class TestPersistence:
-    def test_persistent_recreates_unlabeled_named_sandbox(self, make_env):
+    def test_persistent_recreates_unlabeled_named_sandbox(self, make_env, caplog):
         existing = _make_sandbox(sandbox_id="sb-existing")
         replacement = _make_sandbox(sandbox_id="sb-replacement")
 
@@ -148,6 +151,7 @@ class TestPersistence:
         env._mock_client.delete.assert_called_once_with(existing)
         env._mock_client.create.assert_called_once()
         assert env._sandbox is replacement
+        assert "hermes-mytask" in caplog.text
 
     def test_persistent_resumes_matching_image_via_get(self, make_env):
         existing = _make_sandbox(
@@ -184,6 +188,46 @@ class TestPersistence:
         env._mock_client.delete.assert_called_once_with(stale)
         env._mock_client.create.assert_called_once()
         assert env._sandbox is replacement
+
+    def test_persistent_recreates_named_sandbox_when_start_fails(self, make_env):
+        existing = _make_sandbox(
+            sandbox_id="sb-existing",
+            labels={"hermes_image": "test-image:latest"},
+        )
+        existing.start.side_effect = RuntimeError("start failed")
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=lambda name: existing,
+            persistent=True,
+            task_id="mytask",
+        )
+
+        existing.start.assert_called_once()
+        env._mock_client.delete.assert_not_called()
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
+
+    def test_persistent_fails_closed_when_stale_delete_fails(
+        self, make_env, daytona_sdk, caplog
+    ):
+        stale = _make_sandbox(
+            sandbox_id="sb-stale",
+            labels={"hermes_image": "old-image:latest"},
+        )
+
+        with pytest.raises(RuntimeError, match="delete failed"):
+            make_env(
+                get_side_effect=lambda name: stale,
+                persistent=True,
+                task_id="mytask",
+                delete_side_effect=RuntimeError("delete failed"),
+            )
+
+        assert "refusing to create replacement" in caplog.text
+        assert "hermes-mytask" in caplog.text
+        daytona_sdk.Daytona.return_value.create.assert_not_called()
 
     def test_persistent_recreates_unlabeled_legacy_sandbox(
         self, make_env, daytona_sdk
@@ -225,6 +269,29 @@ class TestPersistence:
         legacy.start.assert_called_once()
         env._mock_client.delete.assert_not_called()
         env._mock_client.create.assert_not_called()
+
+    def test_persistent_recreates_legacy_sandbox_when_start_fails(
+        self, make_env, daytona_sdk
+    ):
+        legacy = _make_sandbox(
+            sandbox_id="sb-legacy",
+            labels={"hermes_image": "test-image:latest"},
+        )
+        legacy.start.side_effect = RuntimeError("start failed")
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            list_return=iter([legacy]),
+            persistent=True,
+            task_id="mytask",
+        )
+
+        legacy.start.assert_called_once()
+        env._mock_client.delete.assert_not_called()
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
 
     def test_persistent_recreates_legacy_lookup_when_image_changed(
         self, make_env, daytona_sdk

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -132,14 +132,22 @@ class TestCwdResolution:
 # ---------------------------------------------------------------------------
 
 class TestPersistence:
-    def test_persistent_resumes_via_get(self, make_env):
+    def test_persistent_recreates_unlabeled_named_sandbox(self, make_env):
         existing = _make_sandbox(sandbox_id="sb-existing")
-        existing.process.exec.return_value = _make_exec_response(result="/root")
-        env = make_env(get_side_effect=lambda name: existing, persistent=True,
-                       task_id="mytask")
-        existing.start.assert_called_once()
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=lambda name: existing,
+            persistent=True,
+            task_id="mytask",
+        )
+
+        existing.start.assert_not_called()
         env._mock_client.get.assert_called_once_with("hermes-mytask")
-        env._mock_client.create.assert_not_called()
+        env._mock_client.delete.assert_called_once_with(existing)
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
 
     def test_persistent_resumes_matching_image_via_get(self, make_env):
         existing = _make_sandbox(
@@ -177,18 +185,45 @@ class TestPersistence:
         env._mock_client.create.assert_called_once()
         assert env._sandbox is replacement
 
-    def test_persistent_resumes_legacy_via_list(self, make_env, daytona_sdk):
+    def test_persistent_recreates_unlabeled_legacy_sandbox(
+        self, make_env, daytona_sdk
+    ):
         legacy = _make_sandbox(sandbox_id="sb-legacy")
+        replacement = _make_sandbox(sandbox_id="sb-replacement")
+
+        env = make_env(
+            sandbox=replacement,
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            list_return=iter([legacy]),
+            persistent=True,
+            task_id="mytask",
+        )
+
+        legacy.start.assert_not_called()
+        env._mock_client.list.assert_called_once_with(
+            labels={"hermes_task_id": "mytask"}, limit=1)
+        env._mock_client.delete.assert_called_once_with(legacy)
+        env._mock_client.create.assert_called_once()
+        assert env._sandbox is replacement
+
+    def test_persistent_resumes_matching_image_via_legacy_lookup(
+        self, make_env, daytona_sdk
+    ):
+        legacy = _make_sandbox(
+            sandbox_id="sb-legacy",
+            labels={"hermes_image": "test-image:latest"},
+        )
         legacy.process.exec.return_value = _make_exec_response(result="/root")
+
         env = make_env(
             get_side_effect=daytona_sdk.DaytonaError("not found"),
             list_return=iter([legacy]),
             persistent=True,
             task_id="mytask",
         )
+
         legacy.start.assert_called_once()
-        env._mock_client.list.assert_called_once_with(
-            labels={"hermes_task_id": "mytask"}, limit=1)
+        env._mock_client.delete.assert_not_called()
         env._mock_client.create.assert_not_called()
 
     def test_persistent_recreates_legacy_lookup_when_image_changed(

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -158,28 +158,47 @@ class DaytonaEnvironment(BaseEnvironment):
     def _resume_if_image_matches(self, sandbox, *, image: str,
                                  task_id: str, source: str):
         """Resume a sandbox only when its Hermes image label matches."""
+        sandbox_name = f"hermes-{task_id}"
         labels = getattr(sandbox, "labels", None)
         recorded_image = labels.get(_IMAGE_LABEL) if isinstance(labels, dict) else None
         if recorded_image != image:
             if recorded_image is None:
                 logger.warning(
-                    "Daytona: deleting unlabeled %s sandbox %s for task %s; "
-                    "cannot verify requested image %s",
-                    source, sandbox.id, task_id, image,
+                    "Daytona: deleting unlabeled %s sandbox %s (name %s) for "
+                    "task %s; cannot verify requested image %s",
+                    source, sandbox.id, sandbox_name, task_id, image,
                 )
             else:
                 logger.warning(
-                    "Daytona: deleting %s sandbox %s for task %s after image "
-                    "changed from %s to %s",
-                    source, sandbox.id, task_id, recorded_image, image,
+                    "Daytona: deleting %s sandbox %s (name %s) for task %s "
+                    "after image changed from %s to %s",
+                    source, sandbox.id, sandbox_name, task_id, recorded_image, image,
                 )
-            self._daytona.delete(sandbox)
+            try:
+                self._daytona.delete(sandbox)
+            except Exception as exc:
+                # Fail closed: creating a replacement while the stale sandbox
+                # still owns this task identity could resume the wrong image.
+                logger.error(
+                    "Daytona: failed to delete %s sandbox %s (name %s) for "
+                    "task %s; refusing to create replacement: %s",
+                    source, sandbox.id, sandbox_name, task_id, exc,
+                )
+                raise
             return None
 
-        sandbox.start()
+        try:
+            sandbox.start()
+        except Exception as exc:
+            logger.warning(
+                "Daytona: failed to resume %s sandbox %s (name %s) for task "
+                "%s; creating replacement: %s",
+                source, sandbox.id, sandbox_name, task_id, exc,
+            )
+            return None
         logger.info(
-            "Daytona: resumed %s sandbox %s for task %s with image %s",
-            source, sandbox.id, task_id, recorded_image,
+            "Daytona: resumed %s sandbox %s (name %s) for task %s with image %s",
+            source, sandbox.id, sandbox_name, task_id, recorded_image,
         )
         return sandbox
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -157,30 +157,30 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _resume_if_image_matches(self, sandbox, *, image: str,
                                  task_id: str, source: str):
-        """Resume a sandbox unless its Hermes image label proves it is stale."""
+        """Resume a sandbox only when its Hermes image label matches."""
         labels = getattr(sandbox, "labels", None)
         recorded_image = labels.get(_IMAGE_LABEL) if isinstance(labels, dict) else None
-        if recorded_image is not None and recorded_image != image:
-            logger.warning(
-                "Daytona: deleting %s sandbox %s for task %s after image "
-                "changed from %s to %s",
-                source, sandbox.id, task_id, recorded_image, image,
-            )
+        if recorded_image != image:
+            if recorded_image is None:
+                logger.warning(
+                    "Daytona: deleting unlabeled %s sandbox %s for task %s; "
+                    "cannot verify requested image %s",
+                    source, sandbox.id, task_id, image,
+                )
+            else:
+                logger.warning(
+                    "Daytona: deleting %s sandbox %s for task %s after image "
+                    "changed from %s to %s",
+                    source, sandbox.id, task_id, recorded_image, image,
+                )
             self._daytona.delete(sandbox)
             return None
 
         sandbox.start()
-        if recorded_image is None:
-            logger.info(
-                "Daytona: resumed unlabeled %s sandbox %s for task %s; "
-                "use explicit teardown to recreate it with image tracking",
-                source, sandbox.id, task_id,
-            )
-        else:
-            logger.info(
-                "Daytona: resumed %s sandbox %s for task %s with image %s",
-                source, sandbox.id, task_id, recorded_image,
-            )
+        logger.info(
+            "Daytona: resumed %s sandbox %s for task %s with image %s",
+            source, sandbox.id, task_id, recorded_image,
+        )
         return sandbox
 
     def _daytona_upload(self, host_path: str, remote_path: str) -> None:

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -26,6 +26,9 @@ from tools.environments.file_sync import (
 
 logger = logging.getLogger(__name__)
 
+_TASK_LABEL = "hermes_task_id"
+_IMAGE_LABEL = "hermes_image"
+
 
 class DaytonaEnvironment(BaseEnvironment):
     """Daytona cloud sandbox execution backend.
@@ -83,45 +86,46 @@ class DaytonaEnvironment(BaseEnvironment):
             disk_gib = 10
         resources = Resources(cpu=cpu, memory=memory_gib, disk=disk_gib)
 
-        labels = {"hermes_task_id": task_id}
+        lookup_labels = {_TASK_LABEL: task_id}
+        create_labels = {_TASK_LABEL: task_id, _IMAGE_LABEL: image}
         sandbox_name = f"hermes-{task_id}"
 
         if self._persistent:
+            named = None
             try:
-                self._sandbox = self._daytona.get(sandbox_name)
-                self._sandbox.start()
-                logger.info("Daytona: resumed sandbox %s for task %s",
-                            self._sandbox.id, task_id)
+                named = self._daytona.get(sandbox_name)
             except DaytonaError:
-                self._sandbox = None
+                pass
             except Exception as e:
-                logger.warning("Daytona: failed to resume sandbox for task %s: %s",
+                logger.warning("Daytona: failed to find sandbox for task %s: %s",
                                task_id, e)
-                self._sandbox = None
+            if named is not None:
+                self._sandbox = self._resume_if_image_matches(
+                    named, image=image, task_id=task_id, source="named"
+                )
 
-            if self._sandbox is None:
+            if self._sandbox is None and named is None:
+                legacy = None
                 try:
                     # Daytona SDK >=0.108.0 uses cursor-based pagination and
                     # list() returns an iterator. Offset-based pagination
                     # (page=1) is removed on June 10, 2026.
-                    results = self._daytona.list(labels=labels, limit=1)
+                    results = self._daytona.list(labels=lookup_labels, limit=1)
                     legacy = next(iter(results), None)
-                    if legacy is not None:
-                        self._sandbox = legacy
-                        self._sandbox.start()
-                        logger.info("Daytona: resumed legacy sandbox %s for task %s",
-                                    self._sandbox.id, task_id)
                 except Exception as e:
                     logger.debug("Daytona: no legacy sandbox found for task %s: %s",
                                  task_id, e)
-                    self._sandbox = None
+                if legacy is not None:
+                    self._sandbox = self._resume_if_image_matches(
+                        legacy, image=image, task_id=task_id, source="legacy"
+                    )
 
         if self._sandbox is None:
             self._sandbox = self._daytona.create(
                 CreateSandboxFromImageParams(
                     image=image,
                     name=sandbox_name,
-                    labels=labels,
+                    labels=create_labels,
                     auto_stop_interval=0,
                     resources=resources,
                 )
@@ -150,6 +154,34 @@ class DaytonaEnvironment(BaseEnvironment):
         )
         self._sync_manager.sync(force=True)
         self.init_session()
+
+    def _resume_if_image_matches(self, sandbox, *, image: str,
+                                 task_id: str, source: str):
+        """Resume a sandbox unless its Hermes image label proves it is stale."""
+        labels = getattr(sandbox, "labels", None)
+        recorded_image = labels.get(_IMAGE_LABEL) if isinstance(labels, dict) else None
+        if recorded_image is not None and recorded_image != image:
+            logger.warning(
+                "Daytona: deleting %s sandbox %s for task %s after image "
+                "changed from %s to %s",
+                source, sandbox.id, task_id, recorded_image, image,
+            )
+            self._daytona.delete(sandbox)
+            return None
+
+        sandbox.start()
+        if recorded_image is None:
+            logger.info(
+                "Daytona: resumed unlabeled %s sandbox %s for task %s; "
+                "use explicit teardown to recreate it with image tracking",
+                source, sandbox.id, task_id,
+            )
+        else:
+            logger.info(
+                "Daytona: resumed %s sandbox %s for task %s with image %s",
+                source, sandbox.id, task_id, recorded_image,
+            )
+        return sandbox
 
     def _daytona_upload(self, host_path: str, remote_path: str) -> None:
         """Upload a single file via Daytona SDK."""
@@ -241,7 +273,7 @@ class DaytonaEnvironment(BaseEnvironment):
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
 
-    def cleanup(self):
+    def cleanup(self, *, force_remove: bool = False):
         with self._lock:
             if self._sandbox is None:
                 return
@@ -258,13 +290,16 @@ class DaytonaEnvironment(BaseEnvironment):
                     logger.warning("Daytona: sync_back failed: %s", e)
 
             try:
-                if self._persistent:
+                if self._persistent and not force_remove:
                     self._sandbox.stop()
                     logger.info("Daytona: stopped sandbox %s (filesystem preserved)",
                                 self._sandbox.id)
                 else:
                     self._daytona.delete(self._sandbox)
-                    logger.info("Daytona: deleted sandbox %s", self._sandbox.id)
+                    logger.info(
+                        "Daytona: deleted sandbox %s (force_remove=%s)",
+                        self._sandbox.id, force_remove,
+                    )
             except Exception as e:
                 logger.warning("Daytona: cleanup failed: %s", e)
             self._sandbox = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1873,7 +1873,7 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     """Manually clean up a specific environment by task_id.
 
     *force_remove* (default False) is forwarded to backends that accept it
-    — currently only ``DockerEnvironment``. The default of False matches
+    — currently Docker and Daytona. The default of False matches
     session-lifecycle semantics: this function is called from
     ``AIAgent.close()`` (TUI session close, gateway session teardown) and the
     per-turn cleanup branch for non-persistent envs, both of which should
@@ -1915,7 +1915,7 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     try:
         if hasattr(env, 'cleanup'):
             # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
+            # (DockerEnvironment and DaytonaEnvironment; other backends don't).
             import inspect
             sig = inspect.signature(env.cleanup)
             if "force_remove" in sig.parameters:


### PR DESCRIPTION
## Summary
- stamp newly created Daytona sandboxes with the requested image alongside the task label
- resume only sandboxes whose recorded image matches, on both named and legacy lookup paths
- delete mismatched or unlabeled sandboxes before recreation, and fail closed if deletion cannot be verified
- preserve the prior self-healing fallback by creating a replacement when a matching sandbox fails to start
- honor `cleanup(force_remove=True)` for persistent Daytona sandboxes so `cleanup_vm()` can explicitly recreate them

Fixes #63361.

## Compatibility boundary
Unlabeled pre-change sandboxes cannot prove which image created their persistent filesystem. The first persistent resume after this change therefore deletes an unlabeled sandbox before creating an image-labeled replacement. This intentionally fails closed for image isolation, but it also removes the pre-existing persistent filesystem. Operators who need that state should export or back it up in Daytona before the first post-upgrade resume.

If deletion of an unlabeled or mismatched sandbox fails, environment creation aborts rather than creating a replacement with ambiguous task ownership. A matching sandbox that merely fails to start retains its filesystem and falls back to replacement creation, preserving the previous self-healing behavior.

## Release note
**Daytona persistent sandbox migration:** the first post-upgrade resume of an unlabeled pre-change sandbox deletes that sandbox and its persistent filesystem before creating an image-labeled replacement. Back up required Daytona state before upgrading.

## Current-main proof
On untouched `7b5ba20547`, mismatched-image regressions resumed stale sandboxes, creation omitted image identity, and persistent cleanup rejected `force_remove`. Review follow-up tests also proved that the first implementation let `sandbox.start()` failures escape on both lookup paths and lacked an explicit fail-closed diagnostic for delete failures. All regressions pass after the update.

## Validation
- `tests/tools/test_daytona_environment.py` — 36 passed
- Daytona, Docker cleanup-contract, and sync-back suites — 123 passed
- ruff, py_compile, `git diff --check`, publish gate, and pushed-range gitleaks — clean

The pinned Daytona 0.155.0 SDK was inspected locally to verify sandbox `labels` and creation-label support. No Daytona account, credentials, or network sandbox was used.