### PR TITLE
fix(gateway): harden Telegram voice and callbacks

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,7 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from hermes_cli.config import load_config_readonly
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,15 @@ def generate_title(
     ``AIAgent._emit_auxiliary_failure`` so the user sees a warning instead
     of silently accumulating untitled sessions.
     """
+    try:
+        cfg = load_config_readonly() or {}
+        title_cfg = ((cfg.get("auxiliary") or {}).get("title_generation") or {})
+        if str(title_cfg.get("provider", "")).strip().lower() in {"off", "false", "none", "disabled"}:
+            logger.debug("Title generation disabled by auxiliary.title_generation.provider=%s", title_cfg.get("provider"))
+            return None
+    except Exception:
+        logger.debug("Could not read title generation config", exc_info=True)
+
     # Truncate long messages to keep the request small
     user_snippet = user_message[:500] if user_message else ""
     assistant_snippet = assistant_response[:500] if assistant_response else ""

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2384,8 +2384,10 @@ class BasePlatformAdapter(ABC):
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
         #   - ``_auto_tts_enabled_chats``: chat explicitly opted in via ``/voice on``
-        #     or ``/voice tts`` (mode is ``voice_only`` or ``all``). Fires even when
-        #     the global default is False.
+        #     or ``/voice tts`` (mode is ``voice_only`` or ``all``). Fires for voice
+        #     input even when the global default is False.
+        #   - ``_auto_tts_all_chats``: chat explicitly opted in via ``/voice tts``
+        #     (mode is ``all``). Fires for both text and voice input.
         #   - ``_auto_tts_disabled_chats``: chat explicitly opted out via
         #     ``/voice off`` (mode is ``off``). Suppresses auto-TTS even when the
         #     global default is True.
@@ -2394,6 +2396,7 @@ class BasePlatformAdapter(ABC):
         #     OR (_auto_tts_default and chat not in _auto_tts_disabled_chats)
         self._auto_tts_default: bool = False
         self._auto_tts_enabled_chats: set = set()
+        self._auto_tts_all_chats: set = set()
         self._auto_tts_disabled_chats: set = set()
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
@@ -4949,13 +4952,19 @@ class BasePlatformAdapter(ABC):
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
 
-                # Auto-TTS: if voice message, generate audio FIRST (before sending text)
-                # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
-                # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
-                # True globally and no ``/voice off`` has been issued.
+                # Auto-TTS: generate audio FIRST (before sending text). ``/voice on``
+                # and ``voice.auto_tts`` apply to voice inputs; ``/voice tts`` applies
+                # to both text and voice inputs for users who want automatic voice
+                # memos even when they type.
                 _tts_path = None
-                if (self._should_auto_tts_for_chat(event.source.chat_id)
-                        and event.message_type == MessageType.VOICE
+                _auto_tts_for_this_message = (
+                    event.source.chat_id in self._auto_tts_all_chats
+                    or (
+                        event.message_type == MessageType.VOICE
+                        and self._should_auto_tts_for_chat(event.source.chat_id)
+                    )
+                )
+                if (_auto_tts_for_this_message
                         and text_content
                         and not media_files):
                     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3260,6 +3260,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _set_adapter_auto_tts_disabled(self, adapter, chat_id: str, disabled: bool) -> None:
         """Update an adapter's in-memory auto-TTS suppression set if present."""
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
+        all_chats = getattr(adapter, "_auto_tts_all_chats", None)
         if not isinstance(disabled_chats, set):
             return
         if disabled:
@@ -3268,16 +3269,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
             if isinstance(enabled_chats, set):
                 enabled_chats.discard(chat_id)
+            if isinstance(all_chats, set):
+                all_chats.discard(chat_id)
         else:
             disabled_chats.discard(chat_id)
 
-    def _set_adapter_auto_tts_enabled(self, adapter, chat_id: str, enabled: bool) -> None:
+    def _set_adapter_auto_tts_enabled(
+        self,
+        adapter,
+        chat_id: str,
+        enabled: bool,
+        *,
+        all_messages: bool = False,
+    ) -> None:
         """Update an adapter's per-chat auto-TTS opt-in set if present.
 
         Used for ``/voice on``/``/voice tts`` where the user explicitly wants
         auto-TTS even when ``voice.auto_tts`` is False globally.
         """
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
+        all_chats = getattr(adapter, "_auto_tts_all_chats", None)
         if not isinstance(enabled_chats, set):
             return
         if enabled:
@@ -3286,15 +3297,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
             if isinstance(disabled_chats, set):
                 disabled_chats.discard(chat_id)
+            if isinstance(all_chats, set):
+                if all_messages:
+                    all_chats.add(chat_id)
+                else:
+                    all_chats.discard(chat_id)
         else:
             enabled_chats.discard(chat_id)
+            if isinstance(all_chats, set):
+                all_chats.discard(chat_id)
 
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
         """Restore persisted /voice state into a live platform adapter.
 
-        Populates three fields from config + ``self._voice_mode``:
+        Populates fields from config + ``self._voice_mode``:
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
+          - ``_auto_tts_all_chats``: chats with mode ``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
         """
         platform = getattr(adapter, "platform", None)
@@ -3303,7 +3322,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-        if not isinstance(disabled_chats, set) and not isinstance(enabled_chats, set):
+        all_chats = getattr(adapter, "_auto_tts_all_chats", None)
+        if (
+            not isinstance(disabled_chats, set)
+            and not isinstance(enabled_chats, set)
+            and not isinstance(all_chats, set)
+        ):
             return
 
         # Push the global voice.auto_tts default (config.yaml) onto the adapter.
@@ -3331,6 +3355,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_chats.update(
                 key[len(prefix):] for key, mode in self._voice_mode.items()
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
+            )
+        if isinstance(all_chats, set):
+            all_chats.clear()
+            all_chats.update(
+                key[len(prefix):] for key, mode in self._voice_mode.items()
+                if mode == "all" and key.startswith(prefix)
             )
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
@@ -12880,6 +12910,77 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return raw.guild.id
         return None
 
+    async def _handle_voice_command(self, event: MessageEvent) -> str:
+        """Handle /voice [on|off|tts|channel|leave|status] command."""
+        args = event.get_command_args().strip().lower()
+        chat_id = event.source.chat_id
+        platform = event.source.platform
+        voice_key = self._voice_key(platform, chat_id)
+
+        adapter = self.adapters.get(platform)
+
+        if args in {"on", "enable"}:
+            self._voice_mode[voice_key] = "voice_only"
+            self._save_voice_modes()
+            if adapter:
+                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+            return t("gateway.voice.enabled_voice_only")
+        elif args in {"off", "disable"}:
+            self._voice_mode[voice_key] = "off"
+            self._save_voice_modes()
+            if adapter:
+                self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+            return t("gateway.voice.disabled_text")
+        elif args == "tts":
+            self._voice_mode[voice_key] = "all"
+            self._save_voice_modes()
+            if adapter:
+                self._set_adapter_auto_tts_enabled(
+                    adapter, chat_id, enabled=True, all_messages=True
+                )
+            return t("gateway.voice.tts_enabled")
+        elif args in {"channel", "join"}:
+            return await self._handle_voice_channel_join(event)
+        elif args == "leave":
+            return await self._handle_voice_channel_leave(event)
+        elif args == "status":
+            mode = self._voice_mode.get(voice_key, "off")
+            labels = {
+                "off": t("gateway.voice.label_off"),
+                "voice_only": t("gateway.voice.label_voice_only"),
+                "all": t("gateway.voice.label_all"),
+            }
+            # Append voice channel info if connected
+            adapter = self.adapters.get(event.source.platform)
+            guild_id = self._get_guild_id(event)
+            if guild_id and hasattr(adapter, "get_voice_channel_info"):
+                info = adapter.get_voice_channel_info(guild_id)
+                if info:
+                    lines = [
+                        t("gateway.voice.status_mode", label=labels.get(mode, mode)),
+                        t("gateway.voice.status_channel", channel=info['channel_name']),
+                        t("gateway.voice.status_participants", count=info['member_count']),
+                    ]
+                    for m in info["members"]:
+                        status = t("gateway.voice.speaking") if m.get("is_speaking") else ""
+                        lines.append(t("gateway.voice.status_member", name=m['display_name'], status=status))
+                    return "\n".join(lines)
+            return t("gateway.voice.status_mode", label=labels.get(mode, mode))
+        else:
+            # Toggle: off → on, on/all → off
+            current = self._voice_mode.get(voice_key, "off")
+            if current == "off":
+                self._voice_mode[voice_key] = "voice_only"
+                self._save_voice_modes()
+                if adapter:
+                    self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                return t("gateway.voice.enabled_short")
+            else:
+                self._voice_mode[voice_key] = "off"
+                self._save_voice_modes()
+                if adapter:
+                    self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+                return t("gateway.voice.disabled_short")
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
@@ -12929,7 +13030,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter._voice_sources[guild_id] = event.source.to_dict()
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            self._set_adapter_auto_tts_enabled(
+                adapter, event.source.chat_id, enabled=True, all_messages=True
+            )
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -241,6 +241,18 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".gif": "image/gif",
 }
 
+# Telegram can deliver iOS Voice Memo uploads as generic documents instead of
+# native audio/voice messages.  Keep this narrow: route only CAF files into the
+# audio-file attachment path so they become available to the agent without
+# automatically treating them like voice-message STT input.
+_TELEGRAM_AUDIO_DOCUMENT_TYPES = {
+    ".caf": "audio/x-caf",
+}
+_TELEGRAM_AUDIO_MIME_TO_EXT = {
+    "audio/x-caf": ".caf",
+    "audio/caf": ".caf",
+}
+
 
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
@@ -905,6 +917,32 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or user_id in allowed_ids
+
+    @staticmethod
+    def _session_owner_user_id(session_key: Optional[str]) -> Optional[str]:
+        """Extract the owner user id from a Telegram session key, when present."""
+        if not session_key:
+            return None
+        parts = str(session_key).split(":")
+        if len(parts) < 5 or parts[:3] != ["agent", "main", "telegram"]:
+            return None
+
+        chat_type = parts[3].strip().lower()
+        if chat_type in {"dm", "private"}:
+            return None
+
+        # Shape: agent:main:telegram:<chat_type>:<chat_id>[:<thread_id>][:<user_id>]
+        # Regular group sessions append user_id directly after chat_id. Forum/thread
+        # sessions intentionally share state unless a seventh part is present.
+        if len(parts) >= 7:
+            return parts[-1] or None
+        if len(parts) == 6 and chat_type in {"group", "supergroup"}:
+            return parts[5] or None
+        return None
+
+    def _callback_matches_session_owner(self, session_key: Optional[str], user_id: str) -> bool:
+        owner_id = self._session_owner_user_id(session_key)
+        return owner_id is None or str(owner_id) == str(user_id or "").strip()
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -5370,10 +5408,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                session_key = self._approval_state.get(approval_id)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
+                if not self._callback_matches_session_owner(session_key, caller_id):
+                    await query.answer(text="This prompt belongs to another user.")
+                    return
+                self._approval_state.pop(approval_id, None)
 
                 # Map choice to human-readable label
                 label_map = {
@@ -5436,10 +5478,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to answer this prompt.")
                     return
 
-                session_key = self._slash_confirm_state.pop(confirm_id, None)
+                session_key = self._slash_confirm_state.get(confirm_id)
                 if not session_key:
                     await query.answer(text="This prompt has already been resolved.")
                     return
+                if not self._callback_matches_session_owner(session_key, caller_id):
+                    await query.answer(text="This prompt belongs to another user.")
+                    return
+                self._slash_confirm_state.pop(confirm_id, None)
 
                 label_map = {
                     "once": "✅ Approved once",
@@ -5539,6 +5585,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 session_key = self._clarify_state.get(clarify_id)
                 if not session_key:
                     await query.answer(text="This prompt has already been resolved.")
+                    return
+                if not self._callback_matches_session_owner(session_key, caller_id):
+                    await query.answer(text="This prompt belongs to another user.")
                     return
 
                 user_display = getattr(query.from_user, "first_name", "User")
@@ -7916,6 +7965,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 if not ext and doc_mime:
                     ext = _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, "")
                     if not ext:
+                        ext = _TELEGRAM_AUDIO_MIME_TO_EXT.get(doc_mime, "")
+                    if not ext:
                         mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
                         ext = mime_to_ext.get(doc_mime, "")
 
@@ -7960,6 +8011,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     else:
                         batch_key = self._photo_batch_key(event, msg)
                         self._enqueue_photo_event(batch_key, event)
+                    return
+
+                # iOS Voice Memos may arrive as .caf documents. Treat those as
+                # audio-file attachments (not voice messages) so the agent sees
+                # a usable cached audio path and can decide whether to analyze
+                # or transcribe it on request.
+                if ext in _TELEGRAM_AUDIO_DOCUMENT_TYPES or doc_mime in _TELEGRAM_AUDIO_MIME_TO_EXT:
+                    audio_ext = ext if ext in _TELEGRAM_AUDIO_DOCUMENT_TYPES else _TELEGRAM_AUDIO_MIME_TO_EXT.get(doc_mime, ".caf")
+                    file_obj = await doc.get_file()
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=audio_ext)
+                    event.message_type = MessageType.AUDIO
+                    event.media_urls = [cached_path]
+                    event.media_types = [_TELEGRAM_AUDIO_DOCUMENT_TYPES.get(audio_ext, doc_mime or "audio/x-caf")]
+                    logger.info("[Telegram] Cached user audio document at %s", cached_path)
+                    await self.handle_message(event)
                     return
 
                 if not ext and doc.mime_type:

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -238,6 +238,18 @@ class TestTelegramExecApproval:
 class TestTelegramApprovalCallback:
     """Test the approval callback handling in _handle_callback_query."""
 
+    def test_session_owner_parser_preserves_shared_and_dm_sessions(self):
+        assert TelegramAdapter._session_owner_user_id("agent:main:telegram:dm:111") is None
+        assert TelegramAdapter._session_owner_user_id("agent:main:telegram:forum:-10012345:777") is None
+        assert (
+            TelegramAdapter._session_owner_user_id("agent:main:telegram:group:-10012345:111")
+            == "111"
+        )
+        assert (
+            TelegramAdapter._session_owner_user_id("agent:main:telegram:forum:-10012345:777:111")
+            == "111"
+        )
+
     @pytest.mark.asyncio
     async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
@@ -257,7 +269,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
@@ -289,7 +301,7 @@ class TestTelegramApprovalCallback:
         query.message.chat_id = 12345
         query.from_user = MagicMock()
         query.from_user.first_name = "Norbert"
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
@@ -317,7 +329,7 @@ class TestTelegramApprovalCallback:
         query.message.chat_id = 12345
         query.from_user = MagicMock()
         query.from_user.first_name = "Norbert"
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
@@ -348,7 +360,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval", return_value=1):
@@ -420,6 +432,93 @@ class TestTelegramApprovalCallback:
         assert runner.last_source.platform == Platform.TELEGRAM
         assert runner.last_source.user_id == "222"
         assert runner.last_source.chat_id == "12345"
+
+    @pytest.mark.asyncio
+    async def test_approval_callback_rejects_allowed_user_who_does_not_own_session(self):
+        adapter = _make_adapter()
+        adapter._approval_state[8] = "agent:main:telegram:group:-10012345:111"
+
+        query = AsyncMock()
+        query.data = "ea:once:8"
+        query.message = MagicMock()
+        query.message.chat_id = -10012345
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = "222"
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        query.answer.assert_called_once()
+        assert "belongs to another user" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        assert adapter._approval_state[8] == "agent:main:telegram:group:-10012345:111"
+
+    @pytest.mark.asyncio
+    async def test_approval_callback_allows_session_owner_in_allowlisted_group(self):
+        adapter = _make_adapter()
+        adapter._approval_state[9] = "agent:main:telegram:group:-10012345:111"
+
+        query = AsyncMock()
+        query.data = "ea:once:9"
+        query.message = MagicMock()
+        query.message.chat_id = -10012345
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = "111"
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once_with("agent:main:telegram:group:-10012345:111", "once")
+        assert 9 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_slash_confirm_callback_rejects_allowed_user_who_does_not_own_session(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["confirm-1"] = "agent:main:telegram:group:-10012345:111"
+
+        query = AsyncMock()
+        query.data = "sc:once:confirm-1"
+        query.message = MagicMock()
+        query.message.chat_id = -10012345
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = "222"
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        query.answer.assert_called_once()
+        assert "belongs to another user" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        assert adapter._slash_confirm_state["confirm-1"] == "agent:main:telegram:group:-10012345:111"
 
     @pytest.mark.asyncio
     async def test_already_resolved(self):

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -391,7 +391,7 @@ class TestTelegramClarifyCallback:
         prompt expired instead of silently entering text-capture mode."""
         adapter = _make_adapter()
         # No clarify primitive entry → mark_awaiting_text returns False.
-        adapter._clarify_state["cidOtherExpired"] = "sk-other-expired"
+        adapter._clarify_state["cidOtherExpired"] = "***"
 
         query = AsyncMock()
         query.data = "cl:cidOtherExpired:other"
@@ -415,6 +415,43 @@ class TestTelegramClarifyCallback:
         assert "expired" in answer_text
         # State popped so a subsequent typed message is not mis-captured.
         assert "cidOtherExpired" not in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_who_does_not_own_session_cannot_resolve(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        session_key = "agent:main:telegram:group:-10012345:111"
+        cm.register("cidOwner", session_key, "Pick", ["a", "b"])
+        adapter._clarify_state["cidOwner"] = session_key
+
+        query = AsyncMock()
+        query.data = "cl:cidOwner:0"
+        query.message = MagicMock()
+        query.message.chat_id = -10012345
+        query.message.chat.type = "group"
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "222"
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        with cm._lock:
+            entry = cm._entries.get("cidOwner")
+        assert entry is not None
+        assert not entry.event.is_set()
+        query.answer.assert_called_once()
+        assert "belongs to another user" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        assert adapter._clarify_state["cidOwner"] == session_key
 
     @pytest.mark.asyncio
     async def test_invalid_choice_token(self):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -67,9 +67,9 @@ def _make_file_obj(data: bytes = b"hello"):
 
 
 def _make_document(
-    file_name="report.pdf",
-    mime_type="application/pdf",
-    file_size=1024,
+    file_name: str | None = "report.pdf",
+    mime_type: str | None = "application/pdf",
+    file_size: int | None = 1024,
     file_obj=None,
 ):
     """Create a mock Telegram Document object."""
@@ -149,6 +149,9 @@ def _redirect_cache(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
     )
 
 
@@ -297,6 +300,48 @@ class TestDocumentDownloadBlock:
         enqueue_mock.assert_not_called()
         event = adapter.handle_message.call_args[0][0]
         assert "could not be read as an image" in event.text
+
+    @pytest.mark.asyncio
+    async def test_caf_document_is_routed_as_audio_attachment(self, adapter):
+        """iOS Voice Memo .caf uploads should cache as audio, not be rejected."""
+        caf_bytes = b"caff\x00\x01fake-caf-audio"
+        file_obj = _make_file_obj(caf_bytes)
+        doc = _make_document(
+            file_name="voice-sample.caf",
+            mime_type="audio/x-caf",
+            file_size=len(caf_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].endswith(".caf")
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["audio/x-caf"]
+
+    @pytest.mark.asyncio
+    async def test_caf_document_detected_by_mime_without_filename(self, adapter):
+        """CAF uploads without a filename should still resolve from audio/x-caf."""
+        caf_bytes = b"caff\x00\x01fake-caf-audio"
+        file_obj = _make_file_obj(caf_bytes)
+        doc = _make_document(
+            file_name=None,
+            mime_type="audio/x-caf",
+            file_size=len(caf_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert event.media_urls[0].endswith(".caf")
+        assert event.media_types == ["audio/x-caf"]
 
     @pytest.mark.asyncio
     async def test_oversized_file_rejected(self, adapter):


### PR DESCRIPTION
## Summary
- route Telegram/iOS .caf document uploads as audio attachments
- scope Telegram inline approval, slash confirm, and clarify callbacks to the session owner in group sessions
- make /voice tts opt-in speak typed replies, while /voice on remains voice-input-only
- allow auxiliary title generation to be disabled via config

## Tests
- ✅ python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/agent/test_title_generator.py tests/hermes_cli/test_aux_config.py -q
- ⚠️ python -m pytest tests/tools/test_voice_mode.py -q currently has 2 environment-dependent failures unrelated to this diff (audio environment availability checks)