### PR TITLE
fix(gateway): retry stale dead delivery targets

### DIFF
--- a/gateway/dead_targets.py
+++ b/gateway/dead_targets.py
@@ -6,8 +6,9 @@ or a deactivated user — re-sending to it on every cron tick or every fan-out
 delivery wastes a send attempt against the platform's flood-control envelope and
 spams the logs.  This registry lets the delivery layer short-circuit a target it
 has already proven dead, while staying self-healing: any successful send to that
-target clears the flag, so a user who re-adds the bot (or restores the chat)
-recovers automatically with no manual cleanup.
+target clears the flag, and old dead flags periodically allow one retry so a
+user who re-adds the bot (or restores the chat) recovers automatically with no
+manual cleanup.
 
 Scope is deliberately narrow.  Only *whole-chat* deaths are recorded — the
 ``forbidden`` and chat-level ``not_found`` (``chat not found``) error kinds.
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 # Error kinds (from gateway.platforms.base.classify_send_error) that mean the
 # *whole chat* is unreachable, not a transient or thread-level problem.
 _DEAD_ERROR_KINDS = frozenset({"forbidden", "not_found"})
+_DEAD_TARGET_RETRY_AFTER_SECONDS = 3600
 
 
 def _normalize(platform: str, chat_id: str) -> str:
@@ -99,7 +101,16 @@ class DeadTargetRegistry:
         if not chat_id:
             return False
         with self._lock:
-            return _normalize(platform, chat_id) in self._dead
+            entry = self._dead.get(_normalize(platform, chat_id))
+            if not entry:
+                return False
+            try:
+                marked_at = float(entry.get("marked_at", 0))
+            except (TypeError, ValueError):
+                marked_at = 0
+            if marked_at > 0 and time.time() - marked_at >= _DEAD_TARGET_RETRY_AFTER_SECONDS:
+                return False
+            return True
 
     def mark_dead(self, platform: str, chat_id: Optional[str],
                   reason: str = "") -> bool:

--- a/tests/gateway/test_dead_targets.py
+++ b/tests/gateway/test_dead_targets.py
@@ -9,11 +9,13 @@ Covers the full lifecycle through the real ``DeliveryRouter.deliver()`` path:
 and the standalone ``DeadTargetRegistry`` persistence/classification contract.
 """
 
+import time
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform
 from gateway.delivery import DeliveryRouter, DeliveryTarget
-from gateway.dead_targets import DeadTargetRegistry
+from gateway.dead_targets import DeadTargetRegistry, _DEAD_TARGET_RETRY_AFTER_SECONDS
 
 
 class ForbiddenThenOkAdapter:
@@ -87,6 +89,15 @@ class TestDeadTargetRegistry:
         path.write_text("{ this is not json")
         reg = DeadTargetRegistry()  # must not raise
         assert reg.all_dead() == {}
+
+    def test_stale_dead_flag_allows_reprobe(self, isolate):
+        reg = DeadTargetRegistry()
+        reg.mark_dead("telegram", "123", "forbidden")
+        reg._dead["telegram:123"]["marked_at"] = (
+            time.time() - _DEAD_TARGET_RETRY_AFTER_SECONDS - 1
+        )
+
+        assert reg.is_dead("telegram", "123") is False
 
 
 # --------------------------------------------------------------------------
@@ -167,6 +178,28 @@ async def test_shared_registry_is_used_when_injected(isolate):
     # Injected registry's pre-existing flag short-circuits before any send.
     assert res["telegram:500"]["skipped"] == "dead_target"
     assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stale_dead_target_is_reprobed_and_cleared_on_success(isolate):
+    shared = DeadTargetRegistry()
+    shared.mark_dead("telegram", "501", "pre-existing")
+    shared._dead["telegram:501"]["marked_at"] = (
+        time.time() - _DEAD_TARGET_RETRY_AFTER_SECONDS - 1
+    )
+    adapter = ForbiddenThenOkAdapter(fail_times=0)
+    router = DeliveryRouter(
+        GatewayConfig(),
+        adapters={Platform.TELEGRAM: adapter},
+        dead_targets=shared,
+    )
+    target = DeliveryTarget.parse("telegram:501")
+
+    res = await router.deliver("hi", [target])
+
+    assert res["telegram:501"]["success"] is True
+    assert adapter.calls == ["501"]
+    assert shared.is_dead("telegram", "501") is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`DeadTargetRegistry` records permanently unreachable delivery targets so cron/fanout sends do not hammer deleted groups, blocked bots, or missing chats. However, the registry also claimed to be self-healing: a successful send should clear the dead flag when the user re-adds the bot or restores the chat.

That self-healing path was unreachable. `DeliveryRouter.deliver()` checks `dead_targets.is_dead()` before calling the adapter, so a marked-dead target is always short-circuited and the successful-send clear path can never run.

## Why

A transiently valid dead classification can become stale: for example, a bot is removed from a chat, Hermes marks the target dead, then the user re-adds the bot. Without a retry window, all future scheduled or fanout deliveries to that chat continue returning `dead_target` until the user manually deletes the profile-local `gateway/dead_targets.json`.

That leaves delivery permanently wedged even after the platform target is usable again.

## Changes

- Add a retry window for dead-target entries.
- Keep recent dead targets short-circuited to avoid platform flood/log spam.
- Allow old dead-target entries to attempt one real send.
- Preserve the existing clear-on-success behavior: if the retry send succeeds, the dead flag is removed.
- If the retry send still fails with a dead-target error, `mark_dead()` refreshes the timestamp and the target is short-circuited again.

## Tests

```text
python -m pytest -p no:cacheprovider --basetemp=.pytest_tmp_dead_targets tests/gateway/test_dead_targets.py -q --timeout-method=thread
28 passed in 1.40s

python -m ruff check gateway/dead_targets.py tests/gateway/test_dead_targets.py