### PR TITLE
feat(mcp): add Arcade architecture analysis

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -97,7 +96,6 @@ class InstallSpec:
     type: str  # "git"
     url: str
     ref: str  # commit/tag/branch — pinned, never floats
-    requires: List[str] = field(default_factory=list)
     bootstrap: List[str] = field(default_factory=list)
 
 
@@ -124,7 +122,6 @@ class CatalogEntry:
     auth: AuthSpec
     tools: ToolsSpec = field(default_factory=ToolsSpec)
     install: Optional[InstallSpec] = None
-    platforms: List[str] = field(default_factory=list)
     post_install: str = ""
     manifest_path: Path = field(default_factory=Path)
 
@@ -185,19 +182,6 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         raise CatalogError(f"{path}: 'description' required")
 
     source = str(data.get("source") or "").strip()
-
-    platforms_raw = data.get("platforms") or []
-    if not isinstance(platforms_raw, list) or not all(
-        isinstance(platform_name, str) for platform_name in platforms_raw
-    ):
-        raise CatalogError(f"{path}: 'platforms' must be a list of strings")
-    platforms = [platform_name.lower() for platform_name in platforms_raw]
-    supported_platforms = {"linux", "macos", "windows"}
-    invalid_platforms = sorted(set(platforms) - supported_platforms)
-    if invalid_platforms:
-        raise CatalogError(
-            f"{path}: unsupported platform name(s): {', '.join(invalid_platforms)}"
-        )
 
     transport_raw = data.get("transport") or {}
     if not isinstance(transport_raw, dict):
@@ -274,19 +258,10 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         bootstrap = install_raw.get("bootstrap") or []
         if not isinstance(bootstrap, list):
             raise CatalogError(f"{path}: install.bootstrap must be a list")
-        requires = install_raw.get("requires") or []
-        if not isinstance(requires, list) or not all(
-            isinstance(executable, str) and executable.strip()
-            for executable in requires
-        ):
-            raise CatalogError(
-                f"{path}: install.requires must be a list of executable names"
-            )
         install = InstallSpec(
             type=i_type,
             url=url,
             ref=ref,
-            requires=[executable.strip() for executable in requires],
             bootstrap=[str(c) for c in bootstrap],
         )
 
@@ -298,7 +273,6 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         auth=auth,
         tools=tools_spec,
         install=install,
-        platforms=platforms,
         post_install=str(data.get("post_install") or ""),
         manifest_path=path,
     )
@@ -418,13 +392,6 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     bootstrap commands. Returns the install directory."""
     assert entry.install is not None and entry.install.type == "git"
     install = entry.install
-
-    for executable in install.requires:
-        if not shutil.which(executable):
-            raise CatalogError(
-                f"{entry.name} requires '{executable}' on PATH before installation"
-            )
-
     dest = _install_root() / entry.name
 
     git = shutil.which("git")
@@ -470,27 +437,6 @@ def _do_git_install(entry: CatalogEntry) -> Path:
         _run_bootstrap(dest, install.bootstrap)
 
     return dest
-
-
-def _current_platform() -> str:
-    """Return the manifest platform name for the running interpreter."""
-    if sys.platform == "darwin":
-        return "macos"
-    if sys.platform == "win32":
-        return "windows"
-    if sys.platform.startswith("linux"):
-        return "linux"
-    return sys.platform
-
-
-def _ensure_platform_supported(entry: CatalogEntry) -> None:
-    """Reject platform-gated entries before installation has side effects."""
-    current = _current_platform()
-    if entry.platforms and current not in entry.platforms:
-        supported = ", ".join(entry.platforms)
-        raise CatalogError(
-            f"{entry.name} supports only {supported}; current platform is {current}"
-        )
 
 
 def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
@@ -755,8 +701,6 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
            ``tools.default_enabled`` or all-on.
         6. Print post_install notes.
     """
-    _ensure_platform_supported(entry)
-
     print()
     print(color(f"  Installing MCP '{entry.name}'", Colors.CYAN + Colors.BOLD))
     if entry.description:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -96,6 +97,7 @@ class InstallSpec:
     type: str  # "git"
     url: str
     ref: str  # commit/tag/branch — pinned, never floats
+    requires: List[str] = field(default_factory=list)
     bootstrap: List[str] = field(default_factory=list)
 
 
@@ -122,6 +124,7 @@ class CatalogEntry:
     auth: AuthSpec
     tools: ToolsSpec = field(default_factory=ToolsSpec)
     install: Optional[InstallSpec] = None
+    platforms: List[str] = field(default_factory=list)
     post_install: str = ""
     manifest_path: Path = field(default_factory=Path)
 
@@ -182,6 +185,19 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         raise CatalogError(f"{path}: 'description' required")
 
     source = str(data.get("source") or "").strip()
+
+    platforms_raw = data.get("platforms") or []
+    if not isinstance(platforms_raw, list) or not all(
+        isinstance(platform_name, str) for platform_name in platforms_raw
+    ):
+        raise CatalogError(f"{path}: 'platforms' must be a list of strings")
+    platforms = [platform_name.lower() for platform_name in platforms_raw]
+    supported_platforms = {"linux", "macos", "windows"}
+    invalid_platforms = sorted(set(platforms) - supported_platforms)
+    if invalid_platforms:
+        raise CatalogError(
+            f"{path}: unsupported platform name(s): {', '.join(invalid_platforms)}"
+        )
 
     transport_raw = data.get("transport") or {}
     if not isinstance(transport_raw, dict):
@@ -258,10 +274,19 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         bootstrap = install_raw.get("bootstrap") or []
         if not isinstance(bootstrap, list):
             raise CatalogError(f"{path}: install.bootstrap must be a list")
+        requires = install_raw.get("requires") or []
+        if not isinstance(requires, list) or not all(
+            isinstance(executable, str) and executable.strip()
+            for executable in requires
+        ):
+            raise CatalogError(
+                f"{path}: install.requires must be a list of executable names"
+            )
         install = InstallSpec(
             type=i_type,
             url=url,
             ref=ref,
+            requires=[executable.strip() for executable in requires],
             bootstrap=[str(c) for c in bootstrap],
         )
 
@@ -273,6 +298,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         auth=auth,
         tools=tools_spec,
         install=install,
+        platforms=platforms,
         post_install=str(data.get("post_install") or ""),
         manifest_path=path,
     )
@@ -392,6 +418,13 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     bootstrap commands. Returns the install directory."""
     assert entry.install is not None and entry.install.type == "git"
     install = entry.install
+
+    for executable in install.requires:
+        if not shutil.which(executable):
+            raise CatalogError(
+                f"{entry.name} requires '{executable}' on PATH before installation"
+            )
+
     dest = _install_root() / entry.name
 
     git = shutil.which("git")
@@ -437,6 +470,27 @@ def _do_git_install(entry: CatalogEntry) -> Path:
         _run_bootstrap(dest, install.bootstrap)
 
     return dest
+
+
+def _current_platform() -> str:
+    """Return the manifest platform name for the running interpreter."""
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform
+
+
+def _ensure_platform_supported(entry: CatalogEntry) -> None:
+    """Reject platform-gated entries before installation has side effects."""
+    current = _current_platform()
+    if entry.platforms and current not in entry.platforms:
+        supported = ", ".join(entry.platforms)
+        raise CatalogError(
+            f"{entry.name} supports only {supported}; current platform is {current}"
+        )
 
 
 def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
@@ -701,6 +755,8 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
            ``tools.default_enabled`` or all-on.
         6. Print post_install notes.
     """
+    _ensure_platform_supported(entry)
+
     print()
     print(color(f"  Installing MCP '{entry.name}'", Colors.CYAN + Colors.BOLD))
     if entry.description:

--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -7,7 +7,7 @@ upstream advisories without auth or extra binaries:
 2. Python deps declared by user-installed plugins under ``~/.hermes/plugins``
    (``requirements.txt`` + ``pyproject.toml`` best-effort pin extraction).
 3. MCP servers wired in ``config.yaml`` whose ``command/args`` look like
-   ``npx -y <pkg>@<ver>`` or ``uvx <pkg>==<ver>``.
+   ``npx -y <pkg>@<ver>`` or ``uvx [--from] <pkg>==<ver>``.
 
 Vulnerabilities are looked up against OSV.dev (``api.osv.dev/v1/querybatch``
 + ``/v1/vulns/{id}``). Single-shot, on-demand, never daily — see the design
@@ -210,7 +210,10 @@ _NPX_PKG = re.compile(r"^(@[A-Za-z0-9._-]+/[A-Za-z0-9._-]+|[A-Za-z0-9._-]+)@([A-
 # uvx forms:
 #   uvx pkg==1.2.3
 #   uvx --with pkg==1.2.3 entrypoint
-_UVX_PKG = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([A-Za-z0-9._+!-]+)$")
+#   uvx --from 'pkg[extra]==1.2.3' entrypoint
+_UVX_PKG = re.compile(
+    r"^([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]+\])?==([A-Za-z0-9._+!-]+)$"
+)
 
 
 def _extract_mcp_component(server_name: str, command: str, args: list[str]) -> Optional[Component]:
@@ -240,9 +243,31 @@ def _extract_mcp_component(server_name: str, command: str, args: list[str]) -> O
             return None  # First non-flag token isn't a pinned ref
     # uvx (any prefix path)
     if cmd.endswith("uvx") or cmd == "uvx":
-        for token in args:
-            if token.startswith("-"):
-                continue
+        explicit_from = None
+        for index, token in enumerate(args):
+            if token == "--from" and index + 1 < len(args):
+                explicit_from = args[index + 1]
+                break
+            elif token.startswith("--from="):
+                explicit_from = token.removeprefix("--from=")
+                break
+
+        package_tokens = [explicit_from] if explicit_from is not None else []
+        if explicit_from is None:
+            skip_next = False
+            for token in args:
+                if skip_next:
+                    skip_next = False
+                    continue
+                if token in {"--python", "--with"}:
+                    skip_next = True
+                    continue
+                if token.startswith("-"):
+                    continue
+                package_tokens.append(token)
+                break
+
+        for token in package_tokens:
             m = _UVX_PKG.match(token)
             if m:
                 return Component(
@@ -251,7 +276,7 @@ def _extract_mcp_component(server_name: str, command: str, args: list[str]) -> O
                     ecosystem="PyPI",
                     source=f"mcp:{server_name}",
                 )
-            return None
+        return None
     return None
 
 

--- a/optional-mcps/arcade-agent/manifest.yaml
+++ b/optional-mcps/arcade-agent/manifest.yaml
@@ -1,0 +1,44 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: arcade-agent
+description: Analyze software architecture through a non-blocking end-to-end pipeline.
+source: https://github.com/lemduc/arcade-agent
+
+transport:
+  type: stdio
+  command: "${INSTALL_DIR}/.venv/bin/arcade-mcp"
+  version: 5a26cc6524d95537334ba5788cadfcaa6abfd45b
+
+install:
+  type: git
+  url: https://github.com/lemduc/arcade-agent.git
+  # Pin the commit that introduced the async analyze pipeline. Catalog installs
+  # never float with a branch, so reinstalling produces the same tool surface.
+  ref: 5a26cc6524d95537334ba5788cadfcaa6abfd45b
+  bootstrap:
+    - "python3 -m venv .venv"
+    - ".venv/bin/pip install '.[mcp]'"
+
+auth:
+  type: none
+
+# Keep Hermes's model-tool footprint narrow by default. `analyze` performs
+# ingest -> parse -> recover without blocking the MCP event loop, then runs
+# smell detection and metric computation concurrently. `get_full_result`
+# retrieves details from any session IDs returned by the pipeline.
+tools:
+  default_enabled:
+    - analyze
+    - get_full_result
+
+post_install: |
+  Arcade Agent runs locally and needs no credentials. The default tool set is
+  intentionally limited to the async end-to-end pipeline and result retrieval.
+
+  Start a new Hermes session, then ask it to analyze a local repository. Arcade
+  returns reusable graph, architecture, smell, and metric session IDs.
+
+  Enable Arcade's fine-grained parse, recover, query, or visualization tools with:
+    hermes mcp configure arcade-agent

--- a/optional-mcps/arcade-agent/manifest.yaml
+++ b/optional-mcps/arcade-agent/manifest.yaml
@@ -5,21 +5,27 @@ manifest_version: 1
 name: arcade-agent
 description: Parse codebases, recover architecture, detect smells, and compute quality metrics.
 source: https://github.com/lemduc/arcade-agent
+platforms: [linux, macos]
 
 transport:
   type: stdio
+  # Safe because the top-level platform gate rejects native Windows before
+  # installation; this pinned Arcade revision has no cross-platform launcher.
   command: "${INSTALL_DIR}/.venv/bin/arcade-mcp"
-  version: 3d7f6130b22050979d2d18084a63bc6a932b9789
+  version: d6956936fdb985116b101f51bfbd84d6fe221c07
 
 install:
   type: git
   url: https://github.com/lemduc/arcade-agent.git
-  # Pin the currently supported main commit. Catalog installs never float with
-  # a branch, so reinstalling produces the same tested tool surface.
-  ref: 3d7f6130b22050979d2d18084a63bc6a932b9789
+  # Pin a reviewed main commit from 2026-06-08, beyond the catalog's two-week
+  # supply-chain cooldown while retaining the advertised analysis tool surface.
+  ref: d6956936fdb985116b101f51bfbd84d6fe221c07
+  requires:
+    - python3.12
   bootstrap:
-    - "python3 -m venv .venv"
-    - ".venv/bin/pip install '.[mcp]'"
+    - "python3.12 -m venv .venv"
+    - ".venv/bin/python -m ensurepip --upgrade"
+    - ".venv/bin/python -m pip install '.[mcp]'"
 
 auth:
   type: none
@@ -40,6 +46,7 @@ post_install: |
   Arcade Agent runs locally and needs no credentials. The default tool set
   covers codebase summary, architecture recovery, smell detection, metrics,
   and result retrieval using the stable tools currently supported on main.
+  It requires Python 3.12 or newer exposed as python3.12 on Linux or macOS.
 
   Start a new Hermes session, then ask it to analyze a local repository. Pass
   the session ID returned by parse into recover, then reuse both session IDs

--- a/optional-mcps/arcade-agent/manifest.yaml
+++ b/optional-mcps/arcade-agent/manifest.yaml
@@ -5,34 +5,29 @@ manifest_version: 1
 name: arcade-agent
 description: Parse codebases, recover architecture, detect smells, and compute quality metrics.
 source: https://github.com/lemduc/arcade-agent
-platforms: [linux, macos]
 
 transport:
   type: stdio
-  # Safe because the top-level platform gate rejects native Windows before
-  # installation; this pinned Arcade revision has no cross-platform launcher.
-  command: "${INSTALL_DIR}/.venv/bin/arcade-mcp"
-  version: d6956936fdb985116b101f51bfbd84d6fe221c07
-
-install:
-  type: git
-  url: https://github.com/lemduc/arcade-agent.git
-  # Pin a reviewed main commit from 2026-06-08, beyond the catalog's two-week
-  # supply-chain cooldown while retaining the advertised analysis tool surface.
-  ref: d6956936fdb985116b101f51bfbd84d6fe221c07
-  requires:
-    - python3.12
-  bootstrap:
-    - "python3.12 -m venv .venv"
-    - ".venv/bin/python -m ensurepip --upgrade"
-    - ".venv/bin/python -m pip install '.[mcp]'"
+  # uvx manages the Python 3.12 runtime and isolates the exact PyPI release.
+  command: uvx
+  args:
+    - --python
+    - "3.12"
+    - --from
+    - "arcade-agent[mcp]==0.1.0"
+    - arcade-mcp
+  version: "0.1.0"
+  # Fail closed: even if a caller requests use_llm=true, Arcade must not
+  # invoke the external Claude CLI unless the user explicitly removes this.
+  env:
+    ARCADE_MOCK: "1"
 
 auth:
   type: none
 
 # Keep Hermes's model-tool footprint focused while exposing the complete
-# architecture workflow supported on Arcade Agent's main branch. Session IDs
-# from parse and recover feed the downstream tools without large payloads.
+# architecture workflow available in the pinned stable release. Session IDs
+# from parse and recover feed downstream tools without large payloads.
 tools:
   default_enabled:
     - summarize
@@ -43,10 +38,14 @@ tools:
     - get_full_result
 
 post_install: |
-  Arcade Agent runs locally and needs no credentials. The default tool set
-  covers codebase summary, architecture recovery, smell detection, metrics,
-  and result retrieval using the stable tools currently supported on main.
-  It requires Python 3.12 or newer exposed as python3.12 on Linux or macOS.
+  Arcade Agent runs locally and needs no credentials. uvx downloads the
+  pinned release on first use, manages Python 3.12, and reuses its own cache
+  afterwards. Parsing and summaries may write .arcade-cache in the analyzed
+  repository.
+
+  ARCADE_MOCK=1 prevents detect_smells(use_llm=true) from invoking the external
+  Claude CLI. Remove that environment override from mcp_servers.arcade-agent
+  only if you explicitly opt in to sending architecture context to Claude.
 
   Start a new Hermes session, then ask it to analyze a local repository. Pass
   the session ID returned by parse into recover, then reuse both session IDs

--- a/optional-mcps/arcade-agent/manifest.yaml
+++ b/optional-mcps/arcade-agent/manifest.yaml
@@ -3,20 +3,20 @@
 manifest_version: 1
 
 name: arcade-agent
-description: Analyze software architecture through a non-blocking end-to-end pipeline.
+description: Parse codebases, recover architecture, detect smells, and compute quality metrics.
 source: https://github.com/lemduc/arcade-agent
 
 transport:
   type: stdio
   command: "${INSTALL_DIR}/.venv/bin/arcade-mcp"
-  version: 5a26cc6524d95537334ba5788cadfcaa6abfd45b
+  version: 3d7f6130b22050979d2d18084a63bc6a932b9789
 
 install:
   type: git
   url: https://github.com/lemduc/arcade-agent.git
-  # Pin the commit that introduced the async analyze pipeline. Catalog installs
-  # never float with a branch, so reinstalling produces the same tool surface.
-  ref: 5a26cc6524d95537334ba5788cadfcaa6abfd45b
+  # Pin the currently supported main commit. Catalog installs never float with
+  # a branch, so reinstalling produces the same tested tool surface.
+  ref: 3d7f6130b22050979d2d18084a63bc6a932b9789
   bootstrap:
     - "python3 -m venv .venv"
     - ".venv/bin/pip install '.[mcp]'"
@@ -24,21 +24,26 @@ install:
 auth:
   type: none
 
-# Keep Hermes's model-tool footprint narrow by default. `analyze` performs
-# ingest -> parse -> recover without blocking the MCP event loop, then runs
-# smell detection and metric computation concurrently. `get_full_result`
-# retrieves details from any session IDs returned by the pipeline.
+# Keep Hermes's model-tool footprint focused while exposing the complete
+# architecture workflow supported on Arcade Agent's main branch. Session IDs
+# from parse and recover feed the downstream tools without large payloads.
 tools:
   default_enabled:
-    - analyze
+    - summarize
+    - parse
+    - recover
+    - detect_smells
+    - compute_metrics
     - get_full_result
 
 post_install: |
-  Arcade Agent runs locally and needs no credentials. The default tool set is
-  intentionally limited to the async end-to-end pipeline and result retrieval.
+  Arcade Agent runs locally and needs no credentials. The default tool set
+  covers codebase summary, architecture recovery, smell detection, metrics,
+  and result retrieval using the stable tools currently supported on main.
 
-  Start a new Hermes session, then ask it to analyze a local repository. Arcade
-  returns reusable graph, architecture, smell, and metric session IDs.
+  Start a new Hermes session, then ask it to analyze a local repository. Pass
+  the session ID returned by parse into recover, then reuse both session IDs
+  for smell detection and metric computation.
 
-  Enable Arcade's fine-grained parse, recover, query, or visualization tools with:
+  Enable Arcade's additional query, impact, or visualization tools with:
     hermes mcp configure arcade-agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/arcade-agent" = ["optional-mcps/arcade-agent/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -122,6 +122,27 @@ class TestManifestParsing:
         assert e.transport.args == ["-y", "demo-mcp"]
         assert e.auth.type == "none"
         assert e.install is None
+        assert e.platforms == []
+
+    def test_platforms_parsed(self, catalog_dir):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(platforms=["linux", "macos"]),
+        )
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog()[0].platforms == ["linux", "macos"]
+
+    def test_invalid_platform_rejected(self, catalog_dir):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(platforms=["plan9"]),
+        )
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog() == []
 
     def test_api_key_auth(self, catalog_dir):
         body = _basic_manifest(
@@ -150,6 +171,7 @@ class TestManifestParsing:
                 "type": "git",
                 "url": "https://example.com/demo.git",
                 "ref": "v1.0.0",
+                "requires": ["python3.12"],
                 "bootstrap": ["pip install -r requirements.txt"],
             },
             transport={
@@ -165,6 +187,7 @@ class TestManifestParsing:
         assert e.install is not None
         assert e.install.url == "https://example.com/demo.git"
         assert e.install.ref == "v1.0.0"
+        assert e.install.requires == ["python3.12"]
         assert e.install.bootstrap == ["pip install -r requirements.txt"]
 
     def test_invalid_manifest_skipped(self, catalog_dir):
@@ -231,6 +254,25 @@ class TestManifestParsing:
 
 
 class TestInstall:
+    def test_install_rejects_unsupported_platform_before_side_effects(
+        self, catalog_dir, monkeypatch
+    ):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(platforms=["linux", "macos"]),
+        )
+        from hermes_cli import mcp_catalog
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_catalog import CatalogError, install_entry
+
+        monkeypatch.setattr(mcp_catalog, "_current_platform", lambda: "windows")
+
+        with pytest.raises(CatalogError, match="supports only linux, macos"):
+            install_entry(_entry("demo"), enable=True)
+
+        assert "demo" not in load_config().get("mcp_servers", {})
+
     def test_install_simple_stdio_writes_config(self, catalog_dir):
         _write_manifest(catalog_dir, "demo", _basic_manifest())
         from hermes_cli.mcp_catalog import install_entry
@@ -672,6 +714,33 @@ class TestCustomMcpRows:
 
 
 class TestGitInstallShaRef:
+    def test_missing_prerequisite_fails_before_clone(
+        self, catalog_dir, monkeypatch
+    ):
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/x.git",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
+                "requires": ["python3.12"],
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _do_git_install
+
+        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda name: None)
+
+        with pytest.raises(CatalogError, match="requires 'python3.12' on PATH"):
+            _do_git_install(_entry("demo"))
+
     def test_sha_ref_skips_branch_attempt(self, catalog_dir, monkeypatch, tmp_path):
         """When install.ref is a SHA-shaped hex string, _do_git_install
         skips the `git clone --branch <ref>` attempt (which would always fail

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -122,27 +122,6 @@ class TestManifestParsing:
         assert e.transport.args == ["-y", "demo-mcp"]
         assert e.auth.type == "none"
         assert e.install is None
-        assert e.platforms == []
-
-    def test_platforms_parsed(self, catalog_dir):
-        _write_manifest(
-            catalog_dir,
-            "demo",
-            _basic_manifest(platforms=["linux", "macos"]),
-        )
-        from hermes_cli.mcp_catalog import list_catalog
-
-        assert list_catalog()[0].platforms == ["linux", "macos"]
-
-    def test_invalid_platform_rejected(self, catalog_dir):
-        _write_manifest(
-            catalog_dir,
-            "demo",
-            _basic_manifest(platforms=["plan9"]),
-        )
-        from hermes_cli.mcp_catalog import list_catalog
-
-        assert list_catalog() == []
 
     def test_api_key_auth(self, catalog_dir):
         body = _basic_manifest(
@@ -171,7 +150,6 @@ class TestManifestParsing:
                 "type": "git",
                 "url": "https://example.com/demo.git",
                 "ref": "v1.0.0",
-                "requires": ["python3.12"],
                 "bootstrap": ["pip install -r requirements.txt"],
             },
             transport={
@@ -187,7 +165,6 @@ class TestManifestParsing:
         assert e.install is not None
         assert e.install.url == "https://example.com/demo.git"
         assert e.install.ref == "v1.0.0"
-        assert e.install.requires == ["python3.12"]
         assert e.install.bootstrap == ["pip install -r requirements.txt"]
 
     def test_invalid_manifest_skipped(self, catalog_dir):
@@ -254,25 +231,6 @@ class TestManifestParsing:
 
 
 class TestInstall:
-    def test_install_rejects_unsupported_platform_before_side_effects(
-        self, catalog_dir, monkeypatch
-    ):
-        _write_manifest(
-            catalog_dir,
-            "demo",
-            _basic_manifest(platforms=["linux", "macos"]),
-        )
-        from hermes_cli import mcp_catalog
-        from hermes_cli.config import load_config
-        from hermes_cli.mcp_catalog import CatalogError, install_entry
-
-        monkeypatch.setattr(mcp_catalog, "_current_platform", lambda: "windows")
-
-        with pytest.raises(CatalogError, match="supports only linux, macos"):
-            install_entry(_entry("demo"), enable=True)
-
-        assert "demo" not in load_config().get("mcp_servers", {})
-
     def test_install_simple_stdio_writes_config(self, catalog_dir):
         _write_manifest(catalog_dir, "demo", _basic_manifest())
         from hermes_cli.mcp_catalog import install_entry
@@ -714,33 +672,6 @@ class TestCustomMcpRows:
 
 
 class TestGitInstallShaRef:
-    def test_missing_prerequisite_fails_before_clone(
-        self, catalog_dir, monkeypatch
-    ):
-        body = _basic_manifest(
-            install={
-                "type": "git",
-                "url": "https://example.com/x.git",
-                "ref": "abc1234567890abcdef1234567890abcdef12345",
-                "requires": ["python3.12"],
-                "bootstrap": [],
-            },
-            transport={
-                "type": "stdio",
-                "command": "${INSTALL_DIR}/run.sh",
-                "args": [],
-            },
-        )
-        _write_manifest(catalog_dir, "demo", body)
-
-        from hermes_cli import mcp_catalog
-        from hermes_cli.mcp_catalog import CatalogError, _do_git_install
-
-        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda name: None)
-
-        with pytest.raises(CatalogError, match="requires 'python3.12' on PATH"):
-            _do_git_install(_entry("demo"))
-
     def test_sha_ref_skips_branch_attempt(self, catalog_dir, monkeypatch, tmp_path):
         """When install.ref is a SHA-shaped hex string, _do_git_install
         skips the `git clone --branch <ref>` attempt (which would always fail
@@ -945,7 +876,17 @@ class TestShippedCatalog:
 
             t = entry.transport
             if t.type == "stdio" and (t.command or "") in launcher_commands:
-                pkg_args = [a for a in t.args if not a.startswith("-")]
+                pkg_args = []
+                if t.command in {"uvx", "pipx"}:
+                    for index, arg in enumerate(t.args):
+                        if arg == "--from" and index + 1 < len(t.args):
+                            pkg_args = [t.args[index + 1]]
+                            break
+                        if arg.startswith("--from="):
+                            pkg_args = [arg.removeprefix("--from=")]
+                            break
+                if not pkg_args:
+                    pkg_args = [a for a in t.args if not a.startswith("-")]
                 if not pkg_args:
                     problems.append(f"{entry.name}: launcher {t.command} has no package arg")
                     continue

--- a/tests/hermes_cli/test_security_audit.py
+++ b/tests/hermes_cli/test_security_audit.py
@@ -73,6 +73,42 @@ class TestMCPComponentExtraction:
         assert comp.name == "mcp-server-time"
         assert comp.version == "2.1.0"
 
+    def test_uvx_from_with_runtime_and_extras(self):
+        comp = sa._extract_mcp_component(
+            "arcade",
+            "uvx",
+            [
+                "--python",
+                "3.12",
+                "--from",
+                "arcade-agent[mcp]==0.1.0",
+                "arcade-mcp",
+            ],
+        )
+        assert comp == sa.Component(
+            name="arcade-agent",
+            version="0.1.0",
+            ecosystem="PyPI",
+            source="mcp:arcade",
+        )
+
+    def test_uvx_from_equals_with_extras(self):
+        comp = sa._extract_mcp_component(
+            "arcade",
+            "uvx",
+            ["--from=arcade-agent[mcp]==0.1.0", "arcade-mcp"],
+        )
+        assert comp is not None
+        assert (comp.name, comp.version) == ("arcade-agent", "0.1.0")
+
+    def test_uvx_unpinned_from_does_not_audit_pinned_entrypoint(self):
+        comp = sa._extract_mcp_component(
+            "arcade",
+            "uvx",
+            ["--from", "arcade-agent[mcp]", "arcade-mcp==9.9.9"],
+        )
+        assert comp is None
+
     def test_unpinned_returns_none(self):
         # Bare npx package name = "latest" at runtime; not an audit subject.
         assert sa._extract_mcp_component("x", "npx", ["-y", "some-pkg"]) is None

--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -71,11 +71,30 @@ class TestParsePackageFromArgs:
         assert name == "@scope/pkg"
         assert ver == "1.0"
 
-    def test_pypi_skips_flags(self):
-        name, ver = _parse_package_from_args(["--from", "mcp[cli]"], "PyPI")
-        # --from is a flag, mcp[cli] is the package
-        # Actually --from is a flag so it gets skipped, mcp[cli] is found
-        assert name == "mcp"
+    def test_pypi_from_with_runtime_and_extras(self):
+        name, ver = _parse_package_from_args(
+            [
+                "--python",
+                "3.12",
+                "--from",
+                "arcade-agent[mcp]==0.1.0",
+                "arcade-mcp",
+            ],
+            "PyPI",
+        )
+        assert (name, ver) == ("arcade-agent", "0.1.0")
+
+    def test_pypi_from_equals_with_extras(self):
+        name, ver = _parse_package_from_args(
+            ["--from=arcade-agent[mcp]==0.1.0", "arcade-mcp"], "PyPI"
+        )
+        assert (name, ver) == ("arcade-agent", "0.1.0")
+
+    def test_pypi_unpinned_from_does_not_parse_pinned_entrypoint(self):
+        name, ver = _parse_package_from_args(
+            ["--from", "arcade-agent[mcp]", "arcade-mcp==9.9.9"], "PyPI"
+        )
+        assert (name, ver) == ("arcade-agent", None)
 
     def test_empty_args(self):
         assert _parse_package_from_args([], "npm") == (None, None)

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -88,8 +88,21 @@ def _parse_package_from_args(
     # binary. Without this the first bare positional (often the command name)
     # is mistaken for the package.
     package_token = None
+    if ecosystem == "PyPI":
+        for index, arg in enumerate(args):
+            if not isinstance(arg, str):
+                continue
+            if arg == "--from" and index + 1 < len(args):
+                candidate = args[index + 1]
+                if isinstance(candidate, str):
+                    package_token = candidate
+                    break
+            if arg.startswith("--from="):
+                package_token = arg[len("--from="):]
+                break
+
     take_next = False
-    for arg in args:
+    for arg in args if package_token is None else ():
         if not isinstance(arg, str):
             continue
         if take_next:

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -62,8 +62,9 @@ hermes mcp install n8n    # install a catalog entry by name
 The picker shows each entry with its current status:
 
 ```
-n8n          available              Manage and inspect n8n workflows from Hermes
+arcade-agent available              Analyze software architecture asynchronously
 linear       enabled                Linear issue/project management (remote OAuth)
+n8n          available              Manage and inspect n8n workflows from Hermes
 github       installed (disabled)   GitHub repo + PR tools
 ```
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -135,6 +135,11 @@ bootstrap commands, and setup notes — with the `source:` rendered as a
 clickable link, so you can inspect exactly what an entry connects to or runs
 before clicking Install.
 
+Entries may declare `platforms` and `install.requires`. Hermes rejects an
+unsupported platform or missing prerequisite before cloning the upstream
+repository or changing `config.yaml`, with an error naming the supported
+platforms or required executable.
+
 ### Manifest version compatibility
 
 Manifests pin a `manifest_version`. The catalog is forward-compatible: if a

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -62,7 +62,7 @@ hermes mcp install n8n    # install a catalog entry by name
 The picker shows each entry with its current status:
 
 ```
-arcade-agent available              Analyze software architecture asynchronously
+arcade-agent available              Recover and evaluate software architecture
 linear       enabled                Linear issue/project management (remote OAuth)
 n8n          available              Manage and inspect n8n workflows from Hermes
 github       installed (disabled)   GitHub repo + PR tools

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -135,11 +135,6 @@ bootstrap commands, and setup notes — with the `source:` rendered as a
 clickable link, so you can inspect exactly what an entry connects to or runs
 before clicking Install.
 
-Entries may declare `platforms` and `install.requires`. Hermes rejects an
-unsupported platform or missing prerequisite before cloning the upstream
-repository or changing `config.yaml`, with an error naming the supported
-platforms or required executable.
-
 ### Manifest version compatibility
 
 Manifests pin a `manifest_version`. The catalog is forward-compatible: if a


### PR DESCRIPTION
## Summary

- add Arcade Agent to Hermes's optional MCP catalog without adding core model tools
- launch the exact PyPI release `arcade-agent[mcp]==0.1.0` through Hermes's existing `uvx` path
- expose a focused six-tool architecture workflow by default
- keep external semantic analysis fail-closed with `ARCADE_MOCK=1`
- teach the existing security audit, OSV guard, and catalog pin invariant to identify `uvx --from` packages with extras
- ship the manifest in wheels and document the catalog entry

## Why this shape

Architecture analysis is an optional third-party capability, so the MCP catalog is the appropriate footprint-ladder rung: zero model-tool cost until a user explicitly installs it.

```bash
hermes mcp install arcade-agent
```

`uvx` manages the isolated Python 3.12 runtime and executes the exact `arcade-agent[mcp]==0.1.0` release. That release was published on 2026-06-06, beyond the catalog's two-week supply-chain cooldown, and the PR does not depend on an unreleased Arcade pull request. No new catalog schema, platform gate, or git bootstrap path is introduced.

The default workflow enables:

1. `summarize`
2. `parse`
3. `recover`
4. `detect_smells`
5. `compute_metrics`
6. `get_full_result`

Additional Arcade tools remain opt-in through `hermes mcp configure arcade-agent`.

## Security and side effects

- `ARCADE_MOCK=1` prevents `detect_smells(use_llm=true)` from invoking the external Claude CLI by default
- users must explicitly remove that environment override to opt in to sending architecture context to Claude
- Arcade requires no credentials and runs as a local stdio MCP server after `uvx` obtains the pinned package
- parsing and summaries may write `.arcade-cache` inside the analyzed repository
- Hermes's security audit and pre-launch OSV malware check now resolve the actual `--from` package rather than mistaking `--python 3.12` or the entrypoint for the dependency

This catalog change still requires the repository's `mcp-catalog-reviewed` label before merge.

## Validation

- rebased onto current `upstream/main` (`9c3ffcaae`)
- `231 passed` across MCP catalog, security audit, OSV, packaging, change classification, and dashboard admin API tests via `scripts/run_tests.sh`
- Ruff and `git diff --check` pass
- real Hermes FastMCP probe through the manifest command reports 13 tools and all six defaults present
- wheel build contains `optional-mcps/arcade-agent/manifest.yaml`
