### PR TITLE
fix(desktop): reuse slash-created runtime session after /goal

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -289,6 +289,60 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     expect(renderedText).not.toContain('/goal: no output')
   })
 
+  it('reuses the slash-created runtime session for the immediate /goal kickoff send', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = 'rt-goal-kickoff'
+
+      return 'rt-goal-kickoff'
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return {
+          type: 'send',
+          notice: '⊙ Goal set. Starting now.',
+          message: 'write the implementation plan'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const ok = await handle!.submitText('/goal write the implementation plan')
+
+    expect(ok).toBe(true)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'prompt.submit'])
+    expect(calls[0]?.params).toEqual({
+      command: 'goal write the implementation plan',
+      session_id: 'rt-goal-kickoff'
+    })
+    expect(calls[1]?.params).toEqual({
+      session_id: 'rt-goal-kickoff',
+      text: 'write the implementation plan'
+    })
+  })
+
   it('dispatches a slash command with a multiline arg instead of "empty slash command" (#41323, #55510)', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     const states: Record<string, unknown>[] = []
@@ -1390,6 +1444,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
+
     let releaseResume: () => void = () => {}
 
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -226,7 +226,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       setAwaitingResponse(true)
       clearNotifications()
 
-      let sessionId: null | string = activeSessionId
+      // Slash flows can create/bind a runtime session and then immediately
+      // submit a send-directive in the same tick (e.g. `/goal <text>`). The
+      // prop can still be stale for that render, so prefer the live ref to
+      // avoid minting a second session for the follow-up prompt.
+      let sessionId: null | string = activeSessionId || activeSessionIdRef.current
 
       if (sessionId) {
         seedOptimistic(sessionId)


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop-only slash-submit race behind `#63352`.

`/goal <text>` first ensures a runtime session through the slash pipeline, then immediately submits the kickoff prompt. In that same tick, `useSubmitPrompt` was still reading the stale `activeSessionId` prop instead of the freshly updated `activeSessionIdRef.current`, so the desktop could mint a second runtime session for the follow-up send. That split the slash-created local session row from the backend-persisted session path and could leave later desktop submits looking local-only after `/goal`.

This change makes the submit path prefer the live runtime-session ref, and adds a regression test that proves the immediate `/goal` kickoff send reuses the same runtime session instead of creating another one.

## Related Issue

Fixes #63352

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Prefer `activeSessionIdRef.current` in `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` when deciding which runtime session to submit through.
- Add a desktop regression test in `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` that reproduces the slash-created-session race and asserts `/goal` only creates one runtime session.

## How to Test

1. From `apps/desktop`, run `../../node_modules/.bin/vitest run --environment jsdom src/app/session/hooks/use-prompt-actions/index.test.tsx`.
2. Confirm the new `/goal` regression passes and the suite stays green.
3. Optionally reproduce manually by issuing `/goal <text>` in Desktop and verifying the kickoff send and later follow-up submits stay on the same backend session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `../../node_modules/.bin/vitest run --environment jsdom src/app/session/hooks/use-prompt-actions/index.test.tsx` → `43 passed`
- `../../node_modules/.bin/eslint src/app/session/hooks/use-prompt-actions/submit.ts src/app/session/hooks/use-prompt-actions/index.test.tsx` → passed
- `./node_modules/.bin/tsc -p apps/desktop/tsconfig.json --noEmit` → passed
- `git diff --check` → passed
