### PR TITLE
fix(runtime): bound local DeepSeek V4 Flash stalls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1406,6 +1406,11 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
+    # Pending switch notices are turn-scoped. Clear before every early return
+    # too (no active fallback or cooldown), so a later primary success cannot
+    # emit a stale notice from an interrupted/abandoned prior turn.
+    agent._pending_fallback_notice = None
+
     if not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -252,6 +252,233 @@ def _codex_wait_notice_recovery(
     return f"; auto-reconnect at {int(min(deadlines))}s"
 
 
+_DFLASH_MODEL_FAMILY_RE = re.compile(
+    r"(?:^|[/_.:-])(?:dflash|deepseek[-_.]?v4[-_.]?flash)(?:$|[/_.:-])",
+    re.IGNORECASE,
+)
+# The production W2 runtime has a measured healthy cold-start TTFB of 116s.
+# Keep the default comfortably above that observation while still bounding an
+# opaque local queue wait such as the observed 494.5s no-first-chunk stall.
+_DFLASH_LOCAL_TIMEOUT_DEFAULT_S = 180.0
+
+
+def _is_dflash_like_model(model: Any) -> bool:
+    """Return whether *model* belongs to the local DeepSeek V4 Flash family.
+
+    ``dflash`` remains a supported shorthand, while production model IDs use
+    the explicit ``deepseek-v4-flash-*`` family (currently W2 and IQ3XXS).
+    Token boundaries avoid treating unrelated names such as ``dflashish`` as
+    this family.
+    """
+    return bool(_DFLASH_MODEL_FAMILY_RE.search(str(model or "").strip()))
+
+
+def _dflash_context_timeout_default(api_payload: Any) -> float:
+    """Return the implicit DFlash watchdog timeout for the request size."""
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return 300.0
+    if est_tokens > 50_000:
+        return 240.0
+    return _DFLASH_LOCAL_TIMEOUT_DEFAULT_S
+
+
+def _legacy_dflash_timeout_override(*names: str) -> float | None:
+    """Read a pre-config DFlash timeout override, if one is usable.
+
+    These names predate provider/model ``stale_timeout_seconds`` support and
+    remain only for compatibility with existing deployments. New behavioral
+    configuration belongs in config.yaml.
+    """
+    for name in names:
+        raw = os.getenv(name)
+        if raw is None:
+            continue
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _normalize_watchdog_timeout(timeout: float) -> float:
+    """Apply the shared convention that non-positive disables a watchdog."""
+    return float("inf") if timeout <= 0 else timeout
+
+
+def _dflash_local_stale_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return a bounded local-provider stale timeout for DFlash models.
+
+    Generic local endpoints retain their generous unbounded default because
+    large self-hosted models can legitimately prefill for a long time. The
+    DFlash family instead gets a finite default so an accepted request cannot
+    park forever without giving retry/fallback handling a chance to run.
+    """
+    if not _is_dflash_like_model(model):
+        return None
+
+    legacy_override = _legacy_dflash_timeout_override(
+        "HERMES_DFLASH_STALE_TIMEOUT",
+        "HERMES_DFLASH_STREAM_STALE_TIMEOUT",
+    )
+    timeout = (
+        legacy_override
+        if legacy_override is not None
+        else _DFLASH_LOCAL_TIMEOUT_DEFAULT_S
+    )
+    timeout = _normalize_watchdog_timeout(timeout)
+    if timeout == float("inf"):
+        return timeout
+
+    # Preserve the established legacy-override semantics while giving the
+    # implicit 180s default the same 240s/300s large-context protection as the
+    # first-chunk guard.
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 300.0)
+    if est_tokens > 50_000:
+        return max(timeout, 240.0)
+    if est_tokens > 25_000:
+        return max(timeout, 150.0)
+    if est_tokens > 10_000:
+        return max(timeout, 90.0)
+    return timeout
+
+
+def _dflash_local_first_chunk_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return the DFlash no-first-chunk cutoff for local streaming calls.
+
+    This low-level helper preserves the legacy DFlash-specific environment
+    overrides. Runtime calls should use
+    :func:`resolve_dflash_local_first_chunk_timeout`, which gives config.yaml
+    canonical precedence and otherwise shares the stream-stale policy.
+    """
+    if not _is_dflash_like_model(model):
+        return None
+
+    legacy_override = _legacy_dflash_timeout_override(
+        "HERMES_DFLASH_FIRST_CHUNK_TIMEOUT",
+        "HERMES_DFLASH_TTFB_TIMEOUT",
+    )
+    if legacy_override is not None:
+        return _normalize_watchdog_timeout(legacy_override)
+    return _dflash_context_timeout_default(api_payload)
+
+
+def resolve_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Resolve the no-chunk timeout for streaming chat completions."""
+    effective_model = api_kwargs.get("model") or agent.model
+    configured_timeout = get_provider_stale_timeout(
+        agent.provider,
+        effective_model,
+    )
+    if configured_timeout is not None:
+        stale_timeout_base = configured_timeout
+        uses_implicit_default = False
+    else:
+        env_timeout = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+        if env_timeout is not None:
+            stale_timeout_base = _env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+            uses_implicit_default = False
+        else:
+            stale_timeout_base = 180.0
+            uses_implicit_default = True
+
+    estimated_tokens = estimate_request_context_tokens(api_kwargs)
+    if (
+        uses_implicit_default
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        dflash_timeout = _dflash_local_stale_timeout(api_kwargs, effective_model)
+        if dflash_timeout is not None:
+            logger.debug(
+                "Local DFlash provider detected (%s) — stream stale timeout set to %.0fs",
+                agent.base_url,
+                dflash_timeout,
+            )
+            return dflash_timeout
+        # Generic local endpoints (Ollama, oMLX, llama-cpp) can prefill for
+        # minutes on large contexts, but a wedged local server must EVENTUALLY
+        # trip the detector rather than hang forever. config.yaml
+        # ``agent.local_stream_stale_timeout`` (default 900) sets the ceiling;
+        # ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` is the escape hatch.
+        local_default = 900.0
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+            if isinstance(agent_cfg, dict):
+                configured_local = agent_cfg.get("local_stream_stale_timeout")
+                if isinstance(configured_local, (int, float)):
+                    local_default = float(configured_local)
+        except Exception:
+            pass
+        local_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", local_default)
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout set to %.0fs",
+            agent.base_url,
+            local_timeout,
+        )
+        return local_timeout
+
+    if estimated_tokens > 100_000:
+        return max(stale_timeout_base, 300.0)
+    if estimated_tokens > 50_000:
+        return max(stale_timeout_base, 240.0)
+    return stale_timeout_base
+
+
+def resolve_dflash_local_first_chunk_timeout(
+    agent,
+    api_kwargs: dict,
+    resolved_stream_stale_timeout: float | None = None,
+) -> float | None:
+    """Resolve the local DFlash pre-first-chunk watchdog.
+
+    Provider/model ``stale_timeout_seconds`` is the canonical behavioral
+    configuration and controls both the pre-first-chunk and post-chunk stale
+    phases. Legacy first-chunk environment overrides remain compatible only
+    when config.yaml does not specify a value. Without either, the first-chunk
+    guard reuses the already-resolved stream timeout, including the 240s/300s
+    long-context floors.
+    """
+    effective_model = api_kwargs.get("model") or agent.model
+    if not (
+        agent.base_url
+        and is_local_endpoint(agent.base_url)
+        and _is_dflash_like_model(effective_model)
+    ):
+        return None
+
+    configured_timeout = get_provider_stale_timeout(
+        agent.provider,
+        effective_model,
+    )
+    if configured_timeout is not None:
+        if resolved_stream_stale_timeout is None:
+            resolved_stream_stale_timeout = resolve_stream_stale_timeout(
+                agent,
+                api_kwargs,
+            )
+        return resolved_stream_stale_timeout
+
+    legacy_override = _legacy_dflash_timeout_override(
+        "HERMES_DFLASH_FIRST_CHUNK_TIMEOUT",
+        "HERMES_DFLASH_TTFB_TIMEOUT",
+    )
+    if legacy_override is not None:
+        return _normalize_watchdog_timeout(legacy_override)
+
+    if resolved_stream_stale_timeout is None:
+        resolved_stream_stale_timeout = resolve_stream_stale_timeout(
+            agent,
+            api_kwargs,
+        )
+    return resolved_stream_stale_timeout
+
+
 # ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
 # A session wedged against an unresponsive provider hits the stale detector
 # on every call and loops forever (observed: 494 consecutive failures over
@@ -1990,19 +2217,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # answering, so "what model are you?" doesn't report the primary.
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
+        _reason_value = getattr(reason, "value", reason) if reason is not None else ""
+        _reason_label = str(_reason_value).replace("_", " ").strip()
+        _reason_suffix = f" (reason: {_reason_label})" if _reason_label else ""
         agent._buffer_status(
             f"🔄 Primary model failed — switching to fallback: "
-            f"{fb_model} via {fb_provider}"
+            f"{fb_model} via {fb_provider}{_reason_suffix}"
         )
-        # The buffered line above is dropped on successful recovery, but a
-        # provider/model switch is a durable state change operators must see
-        # even when the fallback succeeds.  Record a one-shot notice that the
-        # success path surfaces exactly once via _emit_pending_fallback_notice
-        # (see run_agent.py); it is discarded on terminal failure since the
-        # buffered line is flushed instead.  See fallback-observability fix.
+        # Retry chatter is dropped on successful recovery, but the provider /
+        # model switch is a durable state change operators must still see.
+        # The success path emits this one-shot notice before clearing buffered
+        # retry noise; terminal failure flushes the buffered switch line and
+        # discards this pending duplicate instead.
         agent._pending_fallback_notice = (
             f"🔄 Switched to fallback model: {old_model} via {old_provider} "
-            f"→ {fb_model} via {fb_provider}"
+            f"→ {fb_model} via {fb_provider}{_reason_suffix}"
         )
         logger.info(
             "Fallback activated: %s → %s (%s)",
@@ -3960,65 +4189,32 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 else "stream_error_cleanup"
             )
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts, so tolerate far longer silence than
-    # the cloud default — but a wedged local server must EVENTUALLY trip the
-    # detector rather than hang forever (an infinite timeout meant a crashed
-    # or deadlocked local endpoint stalled the session indefinitely).  900s
-    # tolerates slow prefill while still bounding a hung endpoint.  Applies
-    # unless the user explicitly set HERMES_STREAM_STALE_TIMEOUT; override the
-    # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT (documented in
-    # website/docs/reference/environment-variables.md).
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        # Read config.yaml ``agent.local_stream_stale_timeout`` (default 900),
-        # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
-        _local_default = 900.0
-        try:
-            from hermes_cli.config import load_config
+    _stream_stale_timeout = resolve_stream_stale_timeout(agent, api_kwargs)
+    # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
+    # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
+    # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
+    # model threshold during their thinking phase. The base timeout is
+    # resolved first; this floor can only increase it.
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    _local_dflash = bool(
+        agent.base_url
+        and is_local_endpoint(agent.base_url)
+        and _is_dflash_like_model(api_kwargs.get("model") or agent.model)
+    )
+    # Local DFlash has its own measured cold-start/context policy above. A
+    # generic reasoning floor would expand the 180s watchdog past the observed
+    # 494s hang and defeat the family-specific failover bound.
+    if _reasoning_floor is not None and not _local_dflash:
+        _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
-            _cfg = load_config()
-            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
-            if isinstance(_agent_cfg, dict):
-                _v = _agent_cfg.get("local_stream_stale_timeout")
-                if isinstance(_v, (int, float)):
-                    _local_default = float(_v)
-        except Exception:
-            pass
-        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
-        logger.debug(
-            "Local provider detected (%s) — stale stream timeout set to %.0fs",
-            agent.base_url, _stream_stale_timeout,
+    _dflash_first_chunk_timeout = None
+    if agent.base_url and is_local_endpoint(agent.base_url):
+        _dflash_first_chunk_timeout = resolve_dflash_local_first_chunk_timeout(
+            agent,
+            api_kwargs,
+            resolved_stream_stale_timeout=_stream_stale_timeout,
         )
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
-            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
@@ -4061,6 +4257,55 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # leave the live display alone.
                 agent._touch_activity(
                     f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+                )
+
+        # Local dflash has a distinct no-first-chunk failure mode: the HTTP
+        # request is accepted but the server never emits the first SSE chunk.
+        # Configured timeout policy applies to this phase too; once any chunk
+        # arrives, the normal stale detector below takes over.
+        _stream_diag = request_client_holder.get("diag")
+        _first_chunk_seen = bool(
+            _stream_diag and _stream_diag.get("first_chunk_at") is not None
+        )
+        if _dflash_first_chunk_timeout is not None and not _first_chunk_seen:
+            _first_elapsed = time.time() - last_chunk_time["t"]
+            if _first_elapsed > _dflash_first_chunk_timeout:
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                logger.warning(
+                    "Local dflash stream produced no first chunk for %.0fs "
+                    "(threshold %.0fs). model=%s context=~%s tokens. "
+                    "Killing connection.",
+                    _first_elapsed,
+                    _dflash_first_chunk_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ No first stream chunk from local dflash for "
+                    f"{int(_first_elapsed)}s "
+                    f"(context: ~{_est_ctx:,} tokens). Reconnecting..."
+                )
+                try:
+                    _close_request_client_once("dflash_first_chunk_kill")
+                except Exception:
+                    pass
+                try:
+                    agent._replace_primary_openai_client(
+                        reason="dflash_first_chunk_pool_cleanup"
+                    )
+                except Exception:
+                    pass
+                t.join(timeout=_env_float("HERMES_STREAM_ABORT_JOIN_TIMEOUT", 2.0))
+                if result["error"] is None and result["response"] is None:
+                    result["error"] = TimeoutError(
+                        f"Local dflash stream produced no first chunk after "
+                        f"{int(_first_elapsed)}s "
+                        f"(threshold: {int(_dflash_first_chunk_timeout)}s)"
+                    )
+                    break
+                last_chunk_time["t"] = time.time()
+                agent._touch_activity(
+                    f"local dflash first-chunk timeout after {int(_first_elapsed)}s"
                 )
 
         # Detect stale streams: connections kept alive by SSE pings

--- a/run_agent.py
+++ b/run_agent.py
@@ -1377,6 +1377,17 @@ class AIAgent:
         if env_timeout is not None:
             return float(env_timeout), False
 
+        # Local DeepSeek V4 Flash has a measured family-specific watchdog
+        # policy. Preserve the implicit-default signal so
+        # _compute_non_stream_stale_timeout can apply that bounded policy
+        # instead of the generic 600s reasoning-model floor.
+        base_url = getattr(self, "_base_url", None) or self.base_url or ""
+        if base_url and is_local_endpoint(base_url):
+            from agent.chat_completion_helpers import _is_dflash_like_model
+
+            if _is_dflash_like_model(self.model):
+                return 90.0, True
+
         # Reasoning-model floor: auto-mitigation for known reasoning models
         # (Nemotron 3 Ultra, OpenAI o1/o3, Anthropic Opus 4.x thinking,
         # DeepSeek R1, Qwen QwQ, xAI Grok reasoning, etc.) whose cloud
@@ -1403,6 +1414,19 @@ class AIAgent:
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
+            from agent.chat_completion_helpers import _dflash_local_stale_timeout
+
+            effective_model = (
+                api_payload.get("model")
+                if isinstance(api_payload, dict)
+                else self.model
+            ) or self.model
+            dflash_timeout = _dflash_local_stale_timeout(
+                api_payload,
+                effective_model,
+            )
+            if dflash_timeout is not None:
+                return dflash_timeout
             return float("inf")
 
         from agent.chat_completion_helpers import estimate_request_context_tokens
@@ -2923,6 +2947,10 @@ class AIAgent:
             if session_has_running_agent:
                 running_agent.interrupt(new_message.text)
         """
+        # A fallback notice belongs only to the turn that activated it. If
+        # that turn is cancelled, never let the next primary success announce
+        # a stale provider switch.
+        self._pending_fallback_notice = None
         # A hard stop and redirect share one lock so /stop cannot race with an
         # accepted correction and accidentally turn itself into a retry.
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
@@ -3009,6 +3037,11 @@ class AIAgent:
         intentionally cancels a model request to rebuild that same logical
         turn. Public hard-stop paths keep the default and clear everything.
         """
+        # ``clear_interrupt`` is the common turn-finalizer path, including
+        # cancellations noticed outside ``interrupt()`` itself. A redirect
+        # rebuilds the same logical turn, so its notice must survive.
+        if not preserve_redirect:
+            self._pending_fallback_notice = None
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is not None:
             with _redirect_lock:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -11,6 +11,14 @@ import pytest
 from unittest.mock import patch
 
 from agent.model_metadata import is_local_endpoint
+from agent.chat_completion_helpers import (
+    _dflash_local_first_chunk_timeout,
+    _dflash_local_stale_timeout,
+    _is_dflash_like_model,
+    interruptible_streaming_api_call,
+    resolve_dflash_local_first_chunk_timeout,
+    resolve_stream_stale_timeout,
+)
 
 
 class TestLocalStreamReadTimeout:
@@ -71,6 +79,353 @@ class TestLocalStreamReadTimeout:
             if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 120.0
+
+
+class TestLocalDflashStaleTimeout:
+    """dflash is local, but must not be allowed to wait forever with no chunks."""
+
+    @staticmethod
+    def _payload_for_estimated_tokens(tokens: int) -> dict[str, list[str]]:
+        return {"messages": ["x" * (tokens * 4)]}
+
+    def _make_agent(self, *, model="dflash", base_url="http://10.10.20.211:8080/v1"):
+        from run_agent import AIAgent
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=256_000):
+            return AIAgent(
+                api_key="sk-dummy",
+                base_url=base_url,
+                provider="taro",
+                model=model,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform="cli",
+            )
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "dflash",
+            "deepseek-v4-flash-w2",
+            "deepseek-v4-flash-iq3xxs",
+        ],
+    )
+    def test_default_local_dflash_stream_stale_timeout_is_bounded(
+        self,
+        monkeypatch,
+        tmp_path,
+        model,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model=model)
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": model, "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert timeout == 180.0
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "dflash",
+            "taro/dflash-w2",
+            "deepseek-v4-flash-w2",
+            "deepseek-v4-flash-iq3xxs",
+            "custom/deepseek_v4_flash:iq3xxs",
+        ],
+    )
+    def test_dflash_family_recognizes_aliases_and_production_ids(self, model):
+        assert _is_dflash_like_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            None,
+            "",
+            "qwen3.6-27b",
+            "deepseek-v4",
+            "deepseek-v3-flash-w2",
+            "notdeepseek-v4-flash-w2",
+            "dflashish",
+        ],
+    )
+    def test_dflash_family_rejects_unrelated_model_ids(self, model):
+        assert _is_dflash_like_model(model) is False
+
+    @pytest.mark.parametrize(
+        ("estimated_tokens", "expected_timeout"),
+        [
+            (50_000, 180.0),
+            (50_001, 240.0),
+            (100_000, 240.0),
+            (100_001, 300.0),
+            (120_000, 300.0),
+        ],
+    )
+    def test_default_dflash_first_chunk_timeout_scales_with_context(
+        self,
+        monkeypatch,
+        estimated_tokens,
+        expected_timeout,
+    ):
+        monkeypatch.delenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_TTFB_TIMEOUT", raising=False)
+
+        timeout = _dflash_local_first_chunk_timeout(
+            self._payload_for_estimated_tokens(estimated_tokens),
+            "dflash",
+        )
+
+        assert timeout == expected_timeout
+
+    @pytest.mark.parametrize(
+        "model",
+        ["deepseek-v4-flash-w2", "deepseek-v4-flash-iq3xxs"],
+    )
+    def test_production_dflash_first_chunk_default_allows_observed_cold_start(
+        self,
+        monkeypatch,
+        model,
+    ):
+        monkeypatch.delenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_TTFB_TIMEOUT", raising=False)
+
+        timeout = _dflash_local_first_chunk_timeout({"messages": []}, model)
+
+        assert timeout == 180.0
+        assert timeout > 116.0
+
+    def test_production_w2_no_first_chunk_wait_exits_at_family_deadline(
+        self,
+        monkeypatch,
+    ):
+        """Exercise the poll-loop guard without sleeping for the real deadline."""
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_TTFB_TIMEOUT", raising=False)
+
+        class Clock:
+            now = 0.0
+
+            @classmethod
+            def time(cls):
+                return cls.now
+
+        class NoResponseThread:
+            def __init__(self, *, target, daemon):
+                self.target = target
+                self.daemon = daemon
+
+            def start(self):
+                return None
+
+            def is_alive(self):
+                return True
+
+            def join(self, timeout=None):
+                if timeout == 0.3:
+                    Clock.now = 181.0
+
+        statuses = []
+        replacements = []
+
+        class Agent:
+            api_mode = "chat_completions"
+            base_url = "http://10.10.20.211:8080/v1"
+            provider = "taro"
+            model = "deepseek-v4-flash-w2"
+            _interrupt_requested = False
+            _consecutive_stale_streams = 0
+
+            @staticmethod
+            def _touch_activity(_message):
+                return None
+
+            @staticmethod
+            def _emit_wait_notice(_text):
+                return None
+
+            @staticmethod
+            def _buffer_status(message):
+                statuses.append(message)
+
+            @staticmethod
+            def _replace_primary_openai_client(*, reason):
+                replacements.append(reason)
+
+        monkeypatch.setattr(
+            "agent.chat_completion_helpers.threading.Thread",
+            NoResponseThread,
+        )
+        monkeypatch.setattr("agent.chat_completion_helpers.time.time", Clock.time)
+
+        with pytest.raises(
+            TimeoutError,
+            match=r"Local dflash stream produced no first chunk after 181s .*180s",
+        ):
+            interruptible_streaming_api_call(
+                Agent(),
+                {
+                    "model": "deepseek-v4-flash-w2",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+
+        assert len(statuses) == 1
+        assert "No first stream chunk from local dflash for 181s" in statuses[0]
+        assert statuses[0].endswith("Reconnecting...")
+        assert replacements == ["dflash_first_chunk_pool_cleanup"]
+
+    def test_dflash_first_chunk_timeout_has_independent_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", "45")
+
+        assert _dflash_local_first_chunk_timeout({"messages": []}, "dflash") == 45.0
+
+    def test_configured_model_stale_timeout_is_canonical_for_both_stream_phases(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            """providers:
+  taro:
+    stale_timeout_seconds: 320
+    models:
+      deepseek-v4-flash-w2:
+        stale_timeout_seconds: 360
+""",
+            encoding="utf-8",
+        )
+        # Config is canonical even when every legacy environment surface is
+        # present. The payload model must also win over the agent default.
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "12")
+        monkeypatch.setenv("HERMES_DFLASH_STALE_TIMEOUT", "45")
+        monkeypatch.setenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", "50")
+        monkeypatch.setenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", "55")
+        monkeypatch.setenv("HERMES_DFLASH_TTFB_TIMEOUT", "60")
+
+        agent = self._make_agent(model="deepseek-v4-flash-iq3xxs")
+        payload = {
+            "model": "deepseek-v4-flash-w2",
+            **self._payload_for_estimated_tokens(120_000),
+        }
+        stream_timeout = resolve_stream_stale_timeout(agent, payload)
+        first_chunk_timeout = resolve_dflash_local_first_chunk_timeout(
+            agent,
+            payload,
+            resolved_stream_stale_timeout=stream_timeout,
+        )
+
+        assert stream_timeout == 360.0
+        assert first_chunk_timeout == 360.0
+
+        provider_payload = {
+            "model": "deepseek-v4-flash-iq3xxs",
+            **self._payload_for_estimated_tokens(120_000),
+        }
+        provider_stream_timeout = resolve_stream_stale_timeout(
+            agent,
+            provider_payload,
+        )
+        provider_first_chunk_timeout = resolve_dflash_local_first_chunk_timeout(
+            agent,
+            provider_payload,
+            resolved_stream_stale_timeout=provider_stream_timeout,
+        )
+
+        assert provider_stream_timeout == 320.0
+        assert provider_first_chunk_timeout == 320.0
+
+    def test_generic_local_stream_stale_timeout_uses_the_local_ceiling(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="qwen3.6-27b")
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": "qwen3.6-27b", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        # Generic local endpoints keep the bounded 900s ceiling; only the
+        # DFlash family gets the tighter measured cold-start budget.
+        assert timeout == 900.0
+
+    def test_default_local_dflash_non_stream_stale_timeout_is_bounded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="deepseek-v4-flash-w2")
+
+        assert agent._compute_non_stream_stale_timeout({"messages": []}) == 180.0
+
+    def test_explicit_stream_stale_timeout_still_wins_for_dflash(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "12")
+        monkeypatch.setenv("HERMES_DFLASH_STALE_TIMEOUT", "75")
+
+        agent = self._make_agent(model="deepseek-v4-flash-w2")
+
+        assert resolve_stream_stale_timeout(
+            agent,
+            {"model": "deepseek-v4-flash-w2", "messages": []},
+        ) == 12.0
+
+    @pytest.mark.parametrize(
+        ("estimated_tokens", "expected_timeout"),
+        [
+            (10_000, 180.0),
+            (10_001, 180.0),
+            (25_000, 180.0),
+            (25_001, 180.0),
+            (50_000, 180.0),
+            (50_001, 240.0),
+            (100_000, 240.0),
+            (100_001, 300.0),
+        ],
+    )
+    def test_default_dflash_stale_timeout_threshold_boundaries(
+        self,
+        monkeypatch,
+        estimated_tokens,
+        expected_timeout,
+    ):
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        timeout = _dflash_local_stale_timeout(
+            self._payload_for_estimated_tokens(estimated_tokens),
+            "deepseek-v4-flash-iq3xxs",
+        )
+
+        assert timeout == expected_timeout
+
+    def test_non_positive_dflash_stale_timeout_disables_watchdog(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DFLASH_STALE_TIMEOUT", "0")
+
+        timeout = _dflash_local_stale_timeout(
+            self._payload_for_estimated_tokens(1),
+            "deepseek-v4-flash-w2",
+        )
+
+        assert timeout == float("inf")
 
 
 class TestIsLocalEndpoint:

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -13,6 +13,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 
+from agent.error_classifier import FailoverReason
 from run_agent import AIAgent
 
 
@@ -693,6 +694,109 @@ class TestRestoreInRunConversation:
         assert agent._fallback_index == 0
         assert agent.provider == "custom"
         assert agent.base_url == "https://my-llm.example.com/v1"
+
+    def test_successful_fallback_notice_emits_exactly_once_with_reason(self):
+        """Real fallback activation leaves one explainable success notice."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_status = emitted.append
+        primary_model = agent.model
+        primary_provider = agent.provider
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.server_error,
+            ) is True
+
+        expected = (
+            f"🔄 Switched to fallback model: {primary_model} via "
+            f"{primary_provider} → anthropic/claude-sonnet-4 via openrouter "
+            f"(reason: server error)"
+        )
+        assert agent._pending_fallback_notice == expected
+        assert "(reason: server error)" in agent._retry_status_buffer[-1][1]
+
+        # This is the production successful-response ordering.
+        agent._emit_pending_fallback_notice()
+        agent._clear_status_buffer()
+        agent._emit_pending_fallback_notice()
+
+        assert emitted == [expected]
+        assert agent._pending_fallback_notice is None
+
+    def test_activate_interrupt_restore_success_cannot_emit_stale_notice(self):
+        """Interrupted fallback state cannot leak into the next primary turn."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_status = emitted.append
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.timeout,
+            ) is True
+        assert agent._pending_fallback_notice is not None
+
+        agent.interrupt("cancel current turn")
+        assert agent._pending_fallback_notice is None
+        agent.clear_interrupt()
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent._pending_fallback_notice is None
+
+        # Simulate the next primary response succeeding.
+        agent._emit_pending_fallback_notice()
+        agent._clear_status_buffer()
+        assert emitted == []
+
+    def test_primary_restore_clears_unemitted_prior_turn_notice(self):
+        """Restore itself is a hard boundary for fallback-notice lifetime."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_status = emitted.append
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.timeout,
+            ) is True
+        assert agent._pending_fallback_notice is not None
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent._pending_fallback_notice is None
+
+        agent._emit_pending_fallback_notice()
+        assert emitted == []
 
 
 # =============================================================================

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -1,9 +1,9 @@
 """Tests for the retry/fallback status buffer helpers on AIAgent.
 
-These helpers defer noisy retry chatter (rate-limit retries, fallback
-switches, compression attempts) so users only see the trace when
-everything ultimately fails.  On successful recovery the buffer is
-silently dropped.
+These helpers defer noisy retry chatter (rate-limit retries and compression
+attempts) so users only see the trace when everything ultimately fails. On
+successful recovery the noisy buffer is dropped, while a durable provider /
+model fallback switch is surfaced exactly once.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What does this PR do?

Local providers intentionally keep generous timeout defaults because large models can prefill for minutes. That policy becomes an unbounded failure mode for local DeepSeek V4 Flash: an accepted request can sit behind a single-sequence server without producing its first SSE chunk, then retry or switch providers without a durable explanation.

This PR adds a narrowly scoped DeepSeek V4 Flash family policy. It recognizes production W2/IQ3XXS model ids, bounds first-chunk and post-chunk silence at 180/240/300 seconds by estimated context, and keeps unrelated local models unbounded. Provider/model `stale_timeout_seconds` remains canonical; older environment overrides remain compatibility-only.

It also preserves one successful-fallback notice with the classified reason and clears that one-shot state on interruption, terminal failure, and primary restoration. The status change does not mutate conversation context or prompt-cache state.

Observed reproduction: a local turn waited 494.5 seconds without a model response. A healthy cold W2 request measured 116 seconds to first response, so the 180-second default leaves measured cold-start headroom while bounding the opaque queue stall.

## Related Issue

No upstream issue yet; this was reproduced on a self-hosted vLLM DeepSeek V4 Flash deployment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: add token-bounded DFlash family detection, config-first timeout resolution, local no-first-chunk cancellation, and reason-bearing fallback notices.
- `run_agent.py`: apply the same bounded policy to non-stream local calls and clear pending switch notices at turn-cancellation boundaries.
- `agent/agent_runtime_helpers.py`: clear a pending notice before every primary-restore return path.
- Add behavioral coverage for W2/IQ3 ids, context floors, config precedence, unrelated-local preservation, poll-loop timeout, reason visibility, interruption, and exactly-once notice delivery.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_local_stream_timeout.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_retry_status_buffer.py -q --timeout=20` — 130 passed.
2. `scripts/run_tests.sh tests/agent/test_non_stream_stale_timeout.py tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_cascading_interrupt_6600.py -q --timeout=20` — 74 passed.
3. `.venv/bin/ruff check agent/agent_runtime_helpers.py agent/chat_completion_helpers.py run_agent.py tests/agent/test_local_stream_timeout.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_retry_status_buffer.py` — passed.

## Checklist

### Code

- [ ] I've read the Contributing Guide in full.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open PRs and found no duplicate of this local DFlash timeout/fallback fix.
- [x] This PR contains only the local timeout and fallback-explainability change plus its tests.
- [ ] I've run the complete `pytest tests/ -q` suite. Focused and adjacent suites above passed (204 tests total).
- [x] I've added tests for the changed behavior.
- [x] Tested on macOS 26 with Python 3.11 through the repository test wrapper.

### Documentation & Housekeeping

- [x] Documentation update N/A; behavior and config precedence are documented in source docstrings.
- [x] `cli-config.yaml.example` N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A; no workflow or architecture rule changed.
- [x] Cross-platform impact considered: the change is provider/runtime Python logic with no platform-specific branch.
- [x] Tool descriptions/schemas N/A.

## Screenshots / Logs

No visual surface changed. The focused poll-loop test advances a fake clock beyond the production-family deadline and proves a `TimeoutError` plus the visible reconnect reason, without sleeping for the real timeout.
