### PR TITLE
fix(delegate): surface tool_trace on N-API-call subagent timeouts (#17308)

### DIFF
--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -282,3 +282,392 @@ class TestRunSingleChildTimeoutDump:
         if logs_dir.is_dir():
             dumps = list(logs_dir.glob("subagent-timeout-*.log"))
             assert dumps == []
+
+
+# ── #17308: N-API-call timeout structured diagnostics ─────────────────────
+
+class _StubChildWithMessages(_StubChild):
+    """_StubChild + a `_session_messages` view + configurable `current_tool`.
+
+    Mirrors the real AIAgent: ``_session_messages`` is the chat-completions
+    transcript that the assistant writes to as it works, and
+    ``get_activity_summary()['current_tool']`` reflects whatever tool the
+    main loop is currently dispatching.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_messages=None,
+        current_tool=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._session_messages = list(session_messages or [])
+        self._current_tool = current_tool
+
+    def get_activity_summary(self):
+        s = super().get_activity_summary()
+        s["current_tool"] = self._current_tool
+        return s
+
+
+class TestRunSingleChildTimeoutToolTrace:
+    """#17308: when a subagent times out *after* making API calls, the result
+    must surface ``tool_trace``, ``last_tool``, ``last_tool_status``, and
+    ``current_tool`` so the lead agent can tell 'tool finished, next LLM call
+    stuck' from 'tool itself hung'."""
+
+    def _invoke(self, child, monkeypatch):
+        from tools import delegate_tool
+        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.3)
+        parent = MagicMock()
+        parent._touch_activity = MagicMock()
+        parent._current_task_id = None
+        return delegate_tool._run_single_child(
+            task_index=0,
+            goal="test goal",
+            child=child,
+            parent_agent=parent,
+        )
+
+    def test_timeout_after_completed_tool_marks_status_ok(self, hermes_home, monkeypatch):
+        """Tool finished cleanly, then the next LLM request hung. The trace
+        must show ``status=ok`` on the last tool, and ``current_tool`` must
+        be None — the lead agent knows the suspect is the LLM call."""
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "web_search", "arguments": '{"q":"x"}'}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "results: ..."},
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=2,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert result["api_calls"] == 2
+        assert result["last_tool"] == "web_search"
+        assert result["last_tool_status"] == "ok"
+        assert result["current_tool"] is None
+        assert isinstance(result["tool_trace"], list) and len(result["tool_trace"]) == 1
+        entry = result["tool_trace"][0]
+        assert entry["tool"] == "web_search"
+        assert entry["status"] == "ok"
+        assert entry["result_bytes"] > 0
+        # Error message references the last tool for the lead agent's eyes.
+        assert "last_tool=web_search" in result["error"]
+        assert "status=ok" in result["error"]
+        # 0-API-call diagnostic dump must NOT fire on this branch.
+        assert result.get("diagnostic_path") is None
+
+    def test_timeout_inside_running_tool_marks_status_in_progress(
+        self, hermes_home, monkeypatch
+    ):
+        """Assistant invoked a tool but no tool-role response was written
+        before the timeout fired — the tool itself is hung. Status must be
+        ``in_progress`` so the lead agent suspects the tool, not the LLM."""
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "terminal", "arguments": '{"cmd":"sleep 9999"}'}},
+                ],
+            },
+            # No tool-role reply yet — the tool is still running.
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool="terminal",
+        )
+        result = self._invoke(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert result["last_tool"] == "terminal"
+        assert result["last_tool_status"] == "in_progress"
+        assert result["current_tool"] == "terminal"
+        assert result["tool_trace"][-1]["status"] == "in_progress"
+        assert "last_tool=terminal" in result["error"]
+        assert "status=in_progress" in result["error"]
+
+    def test_timeout_with_tool_error_preserves_error_status(self, hermes_home, monkeypatch):
+        """A tool returned an error, then the next LLM call hung. The trace
+        must keep ``status=error`` on that entry — don't lie and call it ok."""
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Error: rate limit"},
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        assert result["last_tool"] == "web_search"
+        assert result["last_tool_status"] == "error"
+        assert result["tool_trace"][-1]["status"] == "error"
+
+    def test_timeout_with_parallel_tool_calls_pairs_by_id(self, hermes_home, monkeypatch):
+        """Parallel tool_calls must be paired by tool_call_id, not order."""
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "web_search", "arguments": "{}"}},
+                    {"id": "b", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            # Replies arrive in reverse order — must still pair correctly.
+            {"role": "tool", "tool_call_id": "b", "content": "shell ok"},
+            {"role": "tool", "tool_call_id": "a", "content": "search ok"},
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        trace = result["tool_trace"]
+        assert [e["tool"] for e in trace] == ["web_search", "terminal"]
+        # web_search entry got the matching 'a' content; terminal got 'b'.
+        assert all(e["status"] == "ok" for e in trace)
+        # last_tool is the trailing assistant call — terminal in this case.
+        assert result["last_tool"] == "terminal"
+
+    def test_timeout_content_block_result_not_false_error(self, hermes_home, monkeypatch):
+        """Content-block list results must flatten before classification.
+
+        Mirror normal-path coverage in ``test_delegate.py``: a benign JSON body
+        wrapped as OpenAI content blocks should stay ``status=ok``.
+        """
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "image_generate",
+                            "arguments": '{"prompt": "x"}',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "text", "text": '{"success": true}'}],
+            },
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        assert result["status"] == "timeout"
+        assert result["last_tool"] == "image_generate"
+        assert result["last_tool_status"] == "ok"
+        assert result["tool_trace"][0]["status"] == "ok"
+        assert result["tool_trace"][0]["result_bytes"] > 0
+
+    def test_timeout_benign_output_containing_error_word_is_ok(
+        self, hermes_home, monkeypatch
+    ):
+        """Conservative classifier: the substring ``error`` alone is not enough.
+
+        Mirrors ``test_delegate.py`` normal-path intent — e.g. log lines like
+        ``no error detected`` must not paint the tool red.
+        """
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "scan complete: no error detected in module",
+            },
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        assert result["last_tool"] == "terminal"
+        assert result["last_tool_status"] == "ok"
+        assert result["tool_trace"][-1]["status"] == "ok"
+
+    def test_timeout_content_block_real_error_is_flagged(self, hermes_home, monkeypatch):
+        """Block-wrapped classic error markers still classify as error."""
+        msgs = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "text", "text": "Error: command not found"}],
+            },
+        ]
+        child = _StubChildWithMessages(
+            api_call_count=1,
+            hang_seconds=10.0,
+            session_messages=msgs,
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        assert result["last_tool"] == "terminal"
+        assert result["last_tool_status"] == "error"
+        assert result["tool_trace"][-1]["status"] == "error"
+
+    def test_zero_api_call_timeout_skips_tool_trace(self, hermes_home, monkeypatch):
+        """0-API-call timeouts are covered by diagnostic_path (#15105). The
+        new tool_trace fields must be empty/None on that branch — not stale."""
+        child = _StubChildWithMessages(
+            api_call_count=0,
+            hang_seconds=10.0,
+            session_messages=[{"role": "user", "content": "x"}],
+            current_tool=None,
+        )
+        result = self._invoke(child, monkeypatch)
+        assert result["status"] == "timeout"
+        assert result["api_calls"] == 0
+        assert result["diagnostic_path"] is not None
+        assert result["tool_trace"] == []
+        assert result["last_tool"] is None
+        assert result["last_tool_status"] is None
+        assert result["current_tool"] is None
+
+    def test_timeout_with_no_session_messages_attr_does_not_crash(
+        self, hermes_home, monkeypatch
+    ):
+        """Some agent shapes (mocks, exotic providers) won't expose
+        _session_messages. Reconstruction must degrade to an empty trace."""
+        child = _StubChild(api_call_count=2, hang_seconds=10.0)
+        # Note: plain _StubChild does NOT define _session_messages.
+        assert not hasattr(child, "_session_messages")
+        result = self._invoke(child, monkeypatch)
+        assert result["status"] == "timeout"
+        assert result["api_calls"] == 2
+        assert result["tool_trace"] == []
+        assert result["last_tool"] is None
+        assert result["last_tool_status"] is None
+        # Error message stays the legacy 'stuck on a slow API call' — no last_tool=
+        # suffix because we have nothing reliable to report.
+        assert "stuck on a slow API call" in result["error"]
+        assert "last_tool=" not in result["error"]
+
+
+# ── _build_tool_trace_from_messages helper ────────────────────────────
+
+class TestBuildToolTraceFromMessages:
+    """Pin the shared helper used by normal completion + N-API-call timeouts.
+
+    Error detection uses the conservative classifier, not substring matching.
+    """
+
+    def test_handles_non_list_input(self):
+        from tools.delegate_tool import _build_tool_trace_from_messages
+        assert _build_tool_trace_from_messages(None) == []
+        assert _build_tool_trace_from_messages("not a list") == []
+        assert _build_tool_trace_from_messages({"role": "user"}) == []
+
+    def test_skips_non_dict_entries(self):
+        from tools.delegate_tool import _build_tool_trace_from_messages
+        msgs = [
+            "junk",
+            None,
+            {"role": "assistant", "tool_calls": [
+                {"id": "x", "function": {"name": "t", "arguments": "{}"}}
+            ]},
+        ]
+        out = _build_tool_trace_from_messages(msgs)
+        assert len(out) == 1
+        assert out[0]["tool"] == "t"
+
+    def test_assistant_with_no_tool_calls_is_ignored(self):
+        from tools.delegate_tool import _build_tool_trace_from_messages
+        msgs = [{"role": "assistant", "content": "hello"}]
+        assert _build_tool_trace_from_messages(msgs) == []
+
+    def test_tool_response_without_call_id_falls_back_to_last_entry(self):
+        from tools.delegate_tool import _build_tool_trace_from_messages
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                {"id": None, "function": {"name": "web_search", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "content": "ok"},
+        ]
+        out = _build_tool_trace_from_messages(msgs)
+        assert out == [
+            {
+                "tool": "web_search",
+                "args_bytes": 2,
+                "result_bytes": 2,
+                "status": "ok",
+            }
+        ]
+
+    def test_content_blocks_and_benign_error_substring(self):
+        from tools.delegate_tool import _build_tool_trace_from_messages
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                {"id": "c1", "function": {"name": "image_generate", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "terminal", "arguments": "{}"}},
+            ]},
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "text", "text": '{"success": true}'}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c2",
+                "content": "no error detected",
+            },
+        ]
+        out = _build_tool_trace_from_messages(msgs)
+        assert out[0]["status"] == "ok"
+        assert out[1]["status"] == "ok"
+        assert out[0]["result_bytes"] > 0
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -334,6 +334,60 @@ def _looks_like_error_output(content: Any) -> bool:
     )
 
 
+
+def _build_tool_trace_from_messages(
+    messages: Any,
+) -> list[Dict[str, Any]]:
+    """Reconstruct an ordered tool_trace from a chat-completions message list.
+
+    Each assistant tool_call becomes an entry; matching tool-role responses
+    (paired by tool_call_id) decorate that entry with ``result_bytes`` and
+    ``status``. Entries that never received a response keep ``status`` unset —
+    callers can then mark the trailing one as ``"in_progress"``.
+
+    Uses the same content normalization + conservative error classifier as the
+    normal-completion path (``_stringify_tool_content`` /
+    ``_looks_like_error_output``). Extracted so the N-API-call timeout branch
+    can reuse it (closes #17308) without reintroducing substring heuristics.
+    """
+    tool_trace: list[Dict[str, Any]] = []
+    trace_by_id: Dict[str, Dict[str, Any]] = {}
+    if not isinstance(messages, list):
+        return tool_trace
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function", {}) if isinstance(tc.get("function"), dict) else {}
+                entry_t = {
+                    "tool": fn.get("name", "unknown"),
+                    "args_bytes": len(fn.get("arguments", "") or ""),
+                }
+                tool_trace.append(entry_t)
+                tc_id = tc.get("id")
+                if tc_id:
+                    trace_by_id[tc_id] = entry_t
+        elif msg.get("role") == "tool":
+            content = _stringify_tool_content(msg.get("content", ""))
+            is_error = _looks_like_error_output(content)
+            result_meta = {
+                "result_bytes": len(content),
+                "status": "error" if is_error else "ok",
+            }
+            # Match by tool_call_id for parallel calls
+            tc_id = msg.get("tool_call_id")
+            target = trace_by_id.get(tc_id) if tc_id else None
+            if target is not None:
+                target.update(result_meta)
+            elif tool_trace:
+                # Fallback for messages without tool_call_id
+                tool_trace[-1].update(result_meta)
+    return tool_trace
+
+
 def _normalize_role(r: Optional[str]) -> str:
     """Normalise a caller-provided role to 'leaf' or 'orchestrator'.
 
@@ -2017,6 +2071,54 @@ def _run_single_child(
                 except Exception:
                     pass
 
+            # For N-API-call timeouts, reconstruct what the child was doing
+            # so the lead agent can distinguish 'tool finished, next LLM request
+            # stuck' from 'tool itself hung'. Closes #17308 — the gap between
+            # #1175 (normal completion has tool_trace) and #15105 (0-API-call
+            # timeout has diagnostic_path) was that N-API-call timeouts
+            # surfaced a vague string and nothing else.
+            timeout_tool_trace: list[Dict[str, Any]] = []
+            timeout_last_tool: Optional[str] = None
+            timeout_last_tool_status: Optional[str] = None
+            timeout_current_tool: Optional[str] = None
+            if is_timeout and child_api_calls > 0:
+                try:
+                    _msgs = getattr(child, "_session_messages", None) or []
+                    timeout_tool_trace = _build_tool_trace_from_messages(_msgs)
+                except Exception as exc:
+                    logger.debug(
+                        "Subagent %d timeout: tool_trace reconstruction failed: %s",
+                        task_index,
+                        exc,
+                    )
+                    timeout_tool_trace = []
+                # current_tool from the activity summary captures a tool that
+                # was *started* but whose tool-role response never arrived —
+                # i.e. the tool itself is the prime suspect.
+                try:
+                    timeout_current_tool = (
+                        _summary.get("current_tool") if isinstance(_summary, dict) else None
+                    )
+                except Exception:
+                    timeout_current_tool = None
+                # last_tool / last_tool_status: read off the trace tail. If the
+                # final entry has no result yet, mark it in_progress — that's
+                # the 'tool itself hung' fingerprint.
+                if timeout_tool_trace:
+                    _tail = timeout_tool_trace[-1]
+                    timeout_last_tool = _tail.get("tool")
+                    if "status" in _tail:
+                        timeout_last_tool_status = _tail["status"]
+                    else:
+                        timeout_last_tool_status = "in_progress"
+                        _tail["status"] = "in_progress"
+                # Prefer the live current_tool when it disagrees with the
+                # trace tail (the trace can lag if the tool-role write is
+                # batched after the assistant call).
+                if timeout_current_tool and timeout_current_tool != timeout_last_tool:
+                    timeout_last_tool = timeout_current_tool
+                    timeout_last_tool_status = "in_progress"
+
             if is_timeout:
                 if child_api_calls == 0:
                     _err = (
@@ -2033,6 +2135,11 @@ def _run_single_child(
                         f"{child_api_calls} API call(s) completed — likely "
                         f"stuck on a slow API call or unresponsive network request."
                     )
+                    if timeout_last_tool:
+                        _suffix = f" last_tool={timeout_last_tool}"
+                        if timeout_last_tool_status:
+                            _suffix += f" (status={timeout_last_tool_status})"
+                        _err += _suffix
             else:
                 _err = str(_timeout_exc)
 
@@ -2046,6 +2153,13 @@ def _run_single_child(
                 "duration_seconds": duration,
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
+                # #17308: structured diagnostics for N-API-call timeouts.
+                # Empty/None on the 0-API-call branch (where diagnostic_path
+                # is the right artifact) and on non-timeout errors.
+                "tool_trace": timeout_tool_trace,
+                "last_tool": timeout_last_tool,
+                "last_tool_status": timeout_last_tool_status,
+                "current_tool": timeout_current_tool,
             }
         finally:
             # Shut down executor without waiting — if the child thread
@@ -2085,39 +2199,8 @@ def _run_single_child(
 
         # Build tool trace from conversation messages (already in memory).
         # Uses tool_call_id to correctly pair parallel tool calls with results.
-        tool_trace: list[Dict[str, Any]] = []
-        trace_by_id: Dict[str, Dict[str, Any]] = {}
         messages = result.get("messages") or []
-        if isinstance(messages, list):
-            for msg in messages:
-                if not isinstance(msg, dict):
-                    continue
-                if msg.get("role") == "assistant":
-                    for tc in msg.get("tool_calls") or []:
-                        fn = tc.get("function", {})
-                        entry_t = {
-                            "tool": fn.get("name", "unknown"),
-                            "args_bytes": len(fn.get("arguments", "")),
-                        }
-                        tool_trace.append(entry_t)
-                        tc_id = tc.get("id")
-                        if tc_id:
-                            trace_by_id[tc_id] = entry_t
-                elif msg.get("role") == "tool":
-                    content = _stringify_tool_content(msg.get("content", ""))
-                    is_error = _looks_like_error_output(content)
-                    result_meta = {
-                        "result_bytes": len(content),
-                        "status": "error" if is_error else "ok",
-                    }
-                    # Match by tool_call_id for parallel calls
-                    tc_id = msg.get("tool_call_id")
-                    target = trace_by_id.get(tc_id) if tc_id else None
-                    if target is not None:
-                        target.update(result_meta)
-                    elif tool_trace:
-                        # Fallback for messages without tool_call_id
-                        tool_trace[-1].update(result_meta)
+        tool_trace = _build_tool_trace_from_messages(messages)
 
         # Determine exit reason
         if interrupted:


### PR DESCRIPTION
## Summary

Salvage of #17329 by @Sanjays2402 onto current `main` (closes the N-API-call subagent timeout diagnostic gap from #17308).

When `delegate_task` child's subagent times out **after** `>0` API calls, return structured `tool_trace` / `last_tool` / `last_tool_status` / `current_tool` so the lead can tell:

1. **Tool finished, next LLM hung** → `status=ok`, `current_tool=None`
2. **Tool itself hung** → `status=in_progress`, `current_tool` set

## What changed vs #17329

- Rebased intent onto current main after conflicts.
- **Dropped** the reintroduced substring `"error" in content[:80]` heuristic in the shared helper (deliberately removed on main).
- Shared `_build_tool_trace_from_messages()` now uses `_stringify_tool_content()` + `_looks_like_error_output()` like the normal-completion path.
- Kept only the timeout-branch reconstruction + diagnostic field/message surfacing.
- Added timeout-path tests for content-block results and benign output containing the word `error` (mirrors `tests/tools/test_delegate.py`).

Cannot force-push @Sanjays2402's head branch from this account (maintainer-can-modify write returned 403), so this is a clean salvage PR. Recommend closing #17329 in favor of this once CI/reviews settle.

## Verification

```
uv run --python 3.11 --with pytest python -m pytest \
  tests/tools/test_delegate.py \
  tests/tools/test_delegate_subagent_timeout_diagnostic.py -q
# 177 passed
```

Known pre-existing main failures (if any) are unrelated; these suites are fully green locally.

Closes #17308 (via this salvage path).