### PR TITLE
fix(gateway): keep process notification routing off-loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15432,7 +15432,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Routing must come from the queued watch event itself, not from whatever
         foreground message happened to be active when the queue was drained.
         """
-        source = self._build_process_event_source(evt)
+        source = await asyncio.to_thread(self._build_process_event_source, evt)
         if not source:
             logger.warning(
                 "Dropping watch notification with no routing metadata for process %s",
@@ -15623,15 +15623,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     })
                     if not synth_text:
                         break
-                    source = self._build_process_event_source({
-                        "session_id": session_id,
-                        "session_key": session_key,
-                        "platform": platform_name,
-                        "chat_id": chat_id,
-                        "thread_id": thread_id,
-                        "user_id": user_id,
-                        "user_name": user_name,
-                    })
+                    source = await asyncio.to_thread(
+                        self._build_process_event_source,
+                        {
+                            "session_id": session_id,
+                            "session_key": session_key,
+                            "platform": platform_name,
+                            "chat_id": chat_id,
+                            "thread_id": thread_id,
+                            "user_id": user_id,
+                            "user_name": user_name,
+                        },
+                    )
                     if not source:
                         logger.warning(
                             "Dropping completion notification with no routing metadata for process %s",

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,6 +8,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -386,6 +387,46 @@ async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeyp
     synth_event = adapter.handle_message.await_args.args[0]
     assert synth_event.message_id == "777"
     assert synth_event.source.thread_id == "24296"
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_loads_session_store_off_loop(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:dm:123:24296"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            thread_id="24296",
+            user_id="1",
+            user_name="Fabio",
+        )
+    )
+    loop_thread = threading.get_ident()
+    load_threads = []
+    real_ensure_loaded = runner.session_store._ensure_loaded
+
+    def spy_ensure_loaded():
+        load_threads.append(threading.get_ident())
+        return real_ensure_loaded()
+
+    monkeypatch.setattr(runner.session_store, "_ensure_loaded", spy_ensure_loaded)
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: Background process matched]",
+        {
+            "session_id": "proc_watch",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "message_id": "777",
+        },
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    assert load_threads
+    assert all(thread_id != loop_thread for thread_id in load_threads)
 
 
 def test_build_process_event_source_falls_back_to_session_key_chat_type(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Background process/watch notification routing now resolves its persisted `SessionStore` origin off the gateway event loop.

`_inject_watch_notification()` and the completion-notification branch in `_run_process_watcher()` are async gateway tasks. Both called `_build_process_event_source()` directly, and that helper may call `session_store._ensure_loaded()` before reading the stored origin for the process session key. That keeps synchronous SessionStore/disk work on the shared gateway loop and bypasses the async SessionStore boundary added for message-delivery safety.

## Why

Background process notifications are delivered back into the originating gateway session as synthetic message events. If resolving the process event source blocks on SessionStore I/O, the same event loop responsible for platform delivery, reconnects, and timers can stall.

This is the same boundary class as the gateway SessionStore async-boundary work: sync store/file/DB work should not run inline on loop-side gateway paths.

## Changes

- Offload `_build_process_event_source()` from `_inject_watch_notification()` via `asyncio.to_thread`.
- Offload the same source resolution in the process completion notification path.
- Add a regression test proving `_inject_watch_notification()` does not run `SessionStore._ensure_loaded()` on the event-loop thread while preserving the existing routing behavior.

## Tests

```text
python -m pytest tests/gateway/test_background_process_notifications.py -q --timeout-method=thread
32 passed

python -m pytest tests/gateway/test_async_session_store.py tests/gateway/test_background_process_notifications.py -q --timeout-method=thread
37 passed

python -m ruff check gateway/run.py tests/gateway/test_background_process_notifications.py