### PR TITLE
fix(cron): expose per-job model and provider pins

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -48,6 +48,29 @@ def _cron_api(**kwargs):
     return json.loads(cronjob_tool(**kwargs))
 
 
+def _cron_inference_args(args, existing_job=None):
+    """Return CLI provider/model values with model-tool resolution parity.
+
+    The model-callable cron surface pins the active config provider when a
+    model is supplied without ``provider``. Keep the standalone CLI on the
+    same config-backed path so a model-only pin cannot silently follow later
+    interactive provider switches. Explicit empty strings still mean clear.
+    """
+    provider = getattr(args, "provider", None)
+    model = getattr(args, "model", None)
+    existing_provider = str((existing_job or {}).get("provider") or "").strip()
+    if (
+        provider is None
+        and isinstance(model, str)
+        and model.strip()
+        and not existing_provider
+    ):
+        from tools.cronjob_tools import _resolve_model_override
+
+        return _resolve_model_override({"model": model})
+    return provider, model
+
+
 def _active_cron_provider_name() -> str:
     """Name of the resolved cron scheduler provider ('builtin', 'chronos', …).
 
@@ -94,6 +117,16 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Start it with: hermes gateway install", Colors.DIM))
     print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
     print(color("     Check status:  hermes cron status", Colors.DIM))
+
+
+def _print_inference_routing(job, indent: str = "    ") -> None:
+    """Show whether an agent-backed job is pinned or inherits global config."""
+    if job.get("no_agent"):
+        return
+    provider = str(job.get("provider") or "").strip() or "inherited"
+    model = str(job.get("model") or "").strip() or "inherited"
+    print(f"{indent}Provider:  {provider}")
+    print(f"{indent}Model:     {model}")
 
 
 def cron_list(show_all: bool = False):
@@ -160,6 +193,8 @@ def cron_list(show_all: bool = False):
             print(f"    Script:    {script}")
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
+        else:
+            _print_inference_routing(job)
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
@@ -298,6 +333,7 @@ def cron_create(args):
     # raises GatewayLifecycleBlocked, the `cronjob` tool wrapper catches it and
     # returns it as result["error"], and the `if not result.get("success")`
     # branch below prints it in red and exits 1 — same UX as before.
+    provider, model = _cron_inference_args(args)
     result = _cron_api(
         action="create",
         schedule=args.schedule,
@@ -305,6 +341,8 @@ def cron_create(args):
         name=getattr(args, "name", None),
         deliver=getattr(args, "deliver", None),
         repeat=getattr(args, "repeat", None),
+        provider=provider,
+        model=model,
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         script=getattr(args, "script", None),
@@ -324,6 +362,8 @@ def cron_create(args):
         print(f"  Script: {job_data['script']}")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    else:
+        _print_inference_routing(job_data, indent="  ")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
     print(f"  Next run: {result['next_run_at']}")
@@ -361,6 +401,7 @@ def cron_edit(args):
             if skill not in final_skills:
                 final_skills.append(skill)
 
+    provider, model = _cron_inference_args(args, existing_job=job)
     result = _cron_api(
         action="update",
         job_id=args.job_id,
@@ -369,6 +410,8 @@ def cron_edit(args):
         name=getattr(args, "name", None),
         deliver=getattr(args, "deliver", None),
         repeat=getattr(args, "repeat", None),
+        provider=provider,
+        model=model,
         skills=final_skills,
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
@@ -390,6 +433,8 @@ def cron_edit(args):
         print(f"  Script: {updated['script']}")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    else:
+        _print_inference_routing(updated, indent="  ")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
     return 0

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -40,6 +40,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     )
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument(
+        "--provider",
+        help="Per-job provider override. Use with --model to isolate this job from the interactive/global lane.",
+    )
+    cron_create.add_argument(
+        "--model",
+        help="Per-job model override. Use with --provider to isolate this job from the interactive/global lane.",
+    )
+    cron_create.add_argument(
         "--skill",
         dest="skills",
         action="append",
@@ -81,6 +89,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument("--name", help="New job name")
     cron_edit.add_argument("--deliver", help="New delivery target")
     cron_edit.add_argument("--repeat", type=int, help="New repeat count")
+    cron_edit.add_argument(
+        "--provider",
+        help="New per-job provider override. Pass empty string to clear and inherit the global provider.",
+    )
+    cron_edit.add_argument(
+        "--model",
+        help="New per-job model override. Pass empty string to clear and inherit the global model.",
+    )
     cron_edit.add_argument(
         "--skill",
         dest="skills",

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -121,6 +121,132 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
 
+    def test_create_edit_list_model_provider_pin_lifecycle(
+        self, tmp_cron_dir, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        rc = cron_cli.cron_create(
+            SimpleNamespace(
+                schedule="every 1h",
+                prompt="Run background maintenance",
+                name="Background maintenance",
+                deliver=None,
+                repeat=None,
+                provider=" local ",
+                model=" cheap/model ",
+                skill=None,
+                skills=None,
+                script=None,
+                workdir=None,
+                no_agent=False,
+            )
+        )
+        assert rc == 0
+        job = list_jobs()[0]
+        assert job["provider"] == "local"
+        assert job["model"] == "cheap/model"
+
+        cron_cli.cron_list(show_all=True)
+        listed = capsys.readouterr().out
+        assert "Provider:  local" in listed
+        assert "Model:     cheap/model" in listed
+
+        # Omitted flags preserve both pins while another field changes.
+        rc = cron_cli.cron_edit(
+            SimpleNamespace(job_id=job["id"], name="Renamed maintenance")
+        )
+        assert rc == 0
+        preserved = get_job(job["id"])
+        assert preserved["provider"] == "local"
+        assert preserved["model"] == "cheap/model"
+
+        # A model-only edit preserves the existing provider pin, even when the
+        # global config names another provider.
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n  default: global/model\n",
+            encoding="utf-8",
+        )
+        rc = cron_cli.cron_edit(
+            SimpleNamespace(job_id=job["id"], model="replacement/model")
+        )
+        assert rc == 0
+        model_changed = get_job(job["id"])
+        assert model_changed["provider"] == "local"
+        assert model_changed["model"] == "replacement/model"
+
+        # Empty strings follow the existing script/workdir clearing UX and
+        # clear only the axis named by the caller.
+        rc = cron_cli.cron_edit(
+            SimpleNamespace(job_id=job["id"], model="")
+        )
+        assert rc == 0
+        model_cleared = get_job(job["id"])
+        assert model_cleared["provider"] == "local"
+        assert model_cleared["model"] is None
+
+        rc = cron_cli.cron_edit(
+            SimpleNamespace(job_id=job["id"], provider="")
+        )
+        assert rc == 0
+        provider_cleared = get_job(job["id"])
+        assert provider_cleared["provider"] is None
+        assert provider_cleared["model"] is None
+
+    def test_list_labels_legacy_missing_model_provider_as_inherited(
+        self, tmp_cron_dir, capsys, monkeypatch
+    ):
+        from cron.jobs import load_jobs, save_jobs
+
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+        job = create_job(
+            prompt="Legacy job",
+            schedule="every 1h",
+            provider="local",
+            model="cheap/model",
+        )
+        jobs = load_jobs()
+        jobs[0].pop("provider", None)
+        jobs[0].pop("model", None)
+        save_jobs(jobs)
+
+        cron_cli.cron_list(show_all=True)
+
+        out = capsys.readouterr().out
+        assert job["id"] in out
+        assert "Provider:  inherited" in out
+        assert "Model:     inherited" in out
+
+    def test_model_only_cli_pin_uses_configured_provider(
+        self, tmp_cron_dir, capsys, monkeypatch
+    ):
+        from hermes_constants import get_hermes_home
+
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n  default: global/model\n",
+            encoding="utf-8",
+        )
+
+        rc = cron_cli.cron_create(
+            SimpleNamespace(
+                schedule="every 1h",
+                prompt="Pinned model job",
+                model="background/model",
+            )
+        )
+
+        assert rc == 0
+        job = list_jobs()[0]
+        assert job["model"] == "background/model"
+        assert job["provider"] == "openrouter"
+
     def test_list_does_not_crash_when_repeat_is_null(self, tmp_cron_dir, capsys):
         """A one-shot job can be persisted with ``"repeat": null``. `cron
         list` must render it as ∞ rather than crashing on .get(...)\\.get."""

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -49,6 +49,7 @@ def test_cron_create_options():
     ns = parser.parse_args([
         "cron", "create", "0 9 * * *", "daily task prompt",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
+        "--provider", "openrouter", "--model", "cheap/model",
         "--skill", "a", "--skill", "b", "--no-agent",
         "--workdir", "/tmp/x",
     ])
@@ -57,6 +58,8 @@ def test_cron_create_options():
     assert ns.name == "daily"
     assert ns.deliver == "origin"
     assert ns.repeat == 3
+    assert ns.provider == "openrouter"
+    assert ns.model == "cheap/model"
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
@@ -68,6 +71,25 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j", "--no-agent"]).no_agent is True
     assert parser.parse_args(["cron", "edit", "j", "--agent"]).no_agent is False
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
+
+
+def test_cron_edit_model_provider_set_preserve_and_clear_shapes():
+    parser = _build()
+    pinned = parser.parse_args([
+        "cron", "edit", "j", "--provider", "local", "--model", "cheap/model",
+    ])
+    assert pinned.provider == "local"
+    assert pinned.model == "cheap/model"
+
+    preserved = parser.parse_args(["cron", "edit", "j"])
+    assert preserved.provider is None
+    assert preserved.model is None
+
+    cleared = parser.parse_args([
+        "cron", "edit", "j", "--provider", "", "--model", "",
+    ])
+    assert cleared.provider == ""
+    assert cleared.model == ""
 
 
 def test_cron_dispatch_func_is_injected_handler():

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -22,7 +22,7 @@ Cron jobs can:
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
 
 :::tip
-At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To make a job deliberately track your global default, pin it to the new values after changing them. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
+At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`hermes cron edit <job_id> --provider … --model …` or `cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To make a job deliberately track your global default, pin it to the new values after changing them. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
 :::
 
 :::warning
@@ -49,6 +49,9 @@ hermes cron create "every 1h" "Use both skills and combine the result" \
   --skill blogwatcher \
   --skill maps \
   --name "Skill combo"
+hermes cron create "every 1h" "Run background maintenance" \
+  --provider "<provider>" \
+  --model "<model>"
 ```
 
 ### Through natural conversation
@@ -152,6 +155,8 @@ hermes cron edit <job_id> --skill blogwatcher --skill maps
 hermes cron edit <job_id> --add-skill maps
 hermes cron edit <job_id> --remove-skill blogwatcher
 hermes cron edit <job_id> --clear-skills
+hermes cron edit <job_id> --provider "<provider>" --model "<model>"
+hermes cron edit <job_id> --provider "" --model ""
 ```
 
 Notes:
@@ -160,6 +165,14 @@ Notes:
 - `--add-skill` appends to the existing list without replacing it
 - `--remove-skill` removes specific attached skills
 - `--clear-skills` removes all attached skills
+- omitted `--provider` / `--model` flags preserve the existing per-job pins
+- on create, or when the job has no provider pin, a non-empty `--model`
+  without `--provider` pins the current `model.provider` from `config.yaml`,
+  matching the agent's `cronjob` tool; a model-only edit preserves an existing
+  provider pin, and both flags make the pair fully explicit
+- `--provider ""` / `--model ""` clear those pins and return that axis to the
+  inherited global configuration; `hermes cron list` labels unpinned axes as
+  `inherited`
 
 ## Lifecycle actions
 
@@ -732,7 +745,10 @@ The referenced jobs' most recent completed outputs are injected above the prompt
 
 Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
 
-Jobs may store `model` and `provider` as `null`. When those fields are omitted, Hermes resolves them at execution time from the global configuration. They only appear in the job record when a per-job override is set.
+Jobs may store `model` and `provider` as `null`, and older records may omit the
+keys entirely. Both shapes mean that axis is inherited from global
+configuration at execution time; `hermes cron list` labels it `inherited`.
+Non-null values are per-job pins.
 
 The storage uses atomic file writes so interrupted writes do not leave a partially written job file behind.
 


### PR DESCRIPTION
## What does this PR do?

Cron job records and the model-callable `cronjob` tool already support per-job `provider` and `model` pins, but `hermes cron create/edit` exposed neither field. CLI-created or legacy jobs could therefore remain unpinned and follow the global interactive lane, which is especially disruptive when an unattended job and an interactive turn share a single-sequence local server.

This PR exposes the existing guarded storage/API behavior through the standalone CLI. Omitted flags preserve current pins; empty strings clear one axis explicitly; a model-only pin snapshots the configured provider when no provider pin exists. List/create/edit receipts show either the exact pin or `inherited`.

## Related Issue

No upstream issue yet; reproduced with a scheduled job inheriting the same local model as an interactive desktop turn.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `--provider` / `--model` to cron create and edit parsers.
- Route CLI values through the existing guarded `cronjob` API and reuse its config-backed model/provider resolver.
- Preserve omitted values and support explicit per-axis clearing.
- Render pinned values or `inherited` in CLI receipts.
- Document and test set/preserve/model-only/clear/legacy-null behavior.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_parser_builder.py tests/cron/test_jobs.py tests/cron/test_cron_provider_pin.py tests/cron/test_cronjob_schema.py tests/tools/test_cronjob_tools.py -q --timeout=20` — 250 passed on current upstream main.
2. `.venv/bin/ruff check hermes_cli/cron.py hermes_cli/subcommands/cron.py tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_parser_builder.py` — passed.
3. `python -m hermes_cli.main cron edit --help` — shows both flags and empty-string clear semantics.

## Checklist

### Code

- [ ] I've read the Contributing Guide in full.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open PRs and found no duplicate CLI pin exposure change.
- [x] This PR contains only cron CLI pin/display/docs/tests.
- [ ] I've run the complete `pytest tests/ -q` suite. The six directly related files above passed (250 tests).
- [x] I've added tests for the changed behavior.
- [x] Tested on macOS 26 with Python 3.11 through the repository test wrapper.

### Documentation & Housekeeping

- [x] Updated the cron user guide.
- [x] `cli-config.yaml.example` N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A; no architecture/workflow rule changed.
- [x] Cross-platform impact considered: argparse and cron storage behavior are platform-neutral.
- [x] Tool descriptions/schemas N/A; the existing model-callable tool already supported these fields.

## Screenshots / Logs

No graphical surface changed. The CLI help and temporary-store tests are the relevant user-visible evidence.
