### PR TITLE
fix(backup): keep same-second snapshots distinct

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -807,9 +807,20 @@ def create_quick_snapshot(
     root = _quick_snapshot_root(home)
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    snap_id = f"{ts}-{label}" if label else ts
-    snap_dir = root / snap_id
-    snap_dir.mkdir(parents=True, exist_ok=True)
+    base_id = f"{ts}-{label}" if label else ts
+    snap_id = base_id
+    counter = 1
+    while True:
+        snap_dir = root / snap_id
+        try:
+            # Snapshot IDs have second-level precision. Reserve the directory
+            # atomically so repeated or concurrent calls cannot overwrite an
+            # earlier snapshot created during the same second.
+            snap_dir.mkdir(parents=True, exist_ok=False)
+            break
+        except FileExistsError:
+            snap_id = f"{base_id}-{counter}"
+            counter += 1
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1411,6 +1411,38 @@ class TestQuickSnapshot:
         snap_id = create_quick_snapshot(label="before-upgrade", hermes_home=hermes_home)
         assert "before-upgrade" in snap_id
 
+    def test_same_second_snapshots_are_unique(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        with patch.object(backup_mod, "datetime") as mock_datetime:
+            mock_datetime.now.return_value.strftime.return_value = "20260712-120000"
+
+            config = hermes_home / "config.yaml"
+            config.write_text("version: one\n", encoding="utf-8")
+            first = backup_mod.create_quick_snapshot(
+                label="manual", hermes_home=hermes_home
+            )
+
+            config.write_text("version: two\n", encoding="utf-8")
+            second = backup_mod.create_quick_snapshot(
+                label="manual", hermes_home=hermes_home
+            )
+
+        assert first is not None
+        assert second is not None
+        assert second.startswith(f"{first}-")
+        snapshot_root = hermes_home / "state-snapshots"
+        assert (snapshot_root / first / "config.yaml").read_text(
+            encoding="utf-8"
+        ) == "version: one\n"
+        assert (snapshot_root / second / "config.yaml").read_text(
+            encoding="utf-8"
+        ) == "version: two\n"
+        assert backup_mod.restore_quick_snapshot(first, hermes_home=hermes_home)
+        assert config.read_text(encoding="utf-8") == "version: one\n"
+        assert backup_mod.restore_quick_snapshot(second, hermes_home=hermes_home)
+        assert config.read_text(encoding="utf-8") == "version: two\n"
+
     def test_state_db_safely_copied(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(hermes_home=hermes_home)


### PR DESCRIPTION
## What does this PR do?

Quick snapshot IDs currently have one-second precision. When two snapshots use the same label during one second, `create_quick_snapshot()` selects the same directory and opens it with `exist_ok=True`. The second call then returns the same ID and overwrites files from the first snapshot, silently removing the older recovery point.

This change reserves each snapshot directory with `exist_ok=False` and retries with a numeric suffix on collision. Normal snapshot IDs remain unchanged, while repeated or concurrent same-second calls receive distinct directories.

## Related Issue

No issue filed; this was found while testing quick-snapshot retention behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Allocate a unique quick-snapshot directory when the timestamp and label already exist.
- Use atomic directory creation so separate callers cannot select the same snapshot ID.
- Add a regression test proving both same-second file versions remain independently restorable.

## How to Test

1. Freeze the snapshot timestamp and create two `manual` snapshots with different `config.yaml` contents.
2. Confirm the calls return `20260712-120000-manual` and `20260712-120000-manual-1`.
3. Confirm both snapshot directories retain their respective file contents.
4. Run `scripts/run_tests.sh -j 1 tests/hermes_cli/test_backup.py -q` (146 passed).
5. Run `.venv/bin/ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux, Python 3.13

The complete backup test module passes. I left the repository-wide checkbox unchecked rather than claim a clean run of machine-specific integration tests.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `Path.mkdir`, matching the existing cross-platform implementation
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before: both calls returned the same ID, one directory remained, and the first file version was lost.

After: each call returns a distinct ID and both file versions remain intact.
