### PR TITLE
feat(lanyard): host-side brain RPC handlers (G3.2 MVP)

### DIFF
--- a/.github/workflows/release-lanyard-artifact.yml
+++ b/.github/workflows/release-lanyard-artifact.yml
@@ -1,0 +1,221 @@
+# Publish Hermes Lanyard runtime tarball to the product artifact S3 prefix.
+#
+# LanyardBrain-specific — does not replace docker.yml (GHCR images) or
+# upload_to_pypi.yml. Consumer: company-brain-deploy bootstrap → /opt/hermes-lanyard.
+#
+# Triggers: immutable release tags only (v*). Never treats branch names as versions.
+name: Release Lanyard artifact
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Immutable version label (e.g. v0.1.0). Must not be main/master/HEAD/latest."
+        required: true
+        type: string
+      skip_upload:
+        description: "Pack only; skip S3 upload (local/CI dry test)"
+        required: false
+        type: boolean
+        default: false
+      skip_frontend:
+        description: "Skip web/TUI npm builds (faster pack smoke)"
+        required: false
+        type: boolean
+        default: false
+
+# Default read-only; OIDC job escalates id-token.
+permissions:
+  contents: read
+
+concurrency:
+  group: lanyard-artifact-${{ github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pack-and-publish:
+    name: Pack runtime + publish to S3
+    # Fork-only path; never run on NousResearch/hermes-agent upstream.
+    if: github.repository == 'LanyardBrain/hermes-agent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC
+
+    env:
+      # Repository variables / secrets — never hardcode account IDs or bucket names.
+      # ARTIFACT_BUCKET: platform artifact bucket name (var)
+      # AWS_ROLE_ARN: OIDC role ARN matching ${name_prefix}-gha-hermes (var or secret)
+      # AWS_REGION: e.g. us-east-1 (var; default below is a fallback only for the action)
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+    steps:
+      - name: Resolve version
+        id: ver
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              VERSION="${INPUT_VERSION}"
+              ;;
+            release)
+              VERSION="${RELEASE_TAG}"
+              ;;
+            *)
+              # push tags / default
+              VERSION="${REF_NAME}"
+              ;;
+          esac
+          VERSION="${VERSION#refs/tags/}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve version from event ${EVENT_NAME}"
+            exit 1
+          fi
+          # Fail closed on mutable / branch-like labels
+          v_lc="$(echo "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          case "$v_lc" in
+            main|master|head|develop|development|trunk|latest|origin/*|refs/*)
+              echo "::error::Refusing mutable version label '${VERSION}'. Use an immutable tag (e.g. v0.1.0)."
+              exit 1
+              ;;
+          esac
+          if ! echo "$VERSION" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._+-]*$'; then
+            echo "::error::Version contains unsafe characters: '${VERSION}'"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # workflow_dispatch may pack a version that is only a label; checkout current ref.
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+
+      - name: Set up Node.js
+        if: github.event.inputs.skip_frontend != 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Pack Lanyard runtime
+        id: pack
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SKIP_FRONTEND: ${{ github.event.inputs.skip_frontend || 'false' }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/pack-lanyard-runtime.sh
+          EXTRA=()
+          if [ "$SKIP_FRONTEND" = "true" ]; then
+            EXTRA+=(--skip-frontend)
+          fi
+          # Capture machine-readable summary lines
+          set -o pipefail
+          scripts/pack-lanyard-runtime.sh --version "$VERSION" --output-dir dist/lanyard "${EXTRA[@]}" | tee /tmp/pack-summary.txt
+          # Export for later steps
+          while IFS= read -r line; do
+            case "$line" in
+              PACK_*=*)
+                echo "$line" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          done < /tmp/pack-summary.txt
+          test -f "dist/lanyard/hermes-${VERSION}.tar.gz"
+          test -f "dist/lanyard/hermes-${VERSION}.sha256"
+          echo "Recorded SHA-256:"
+          cat "dist/lanyard/hermes-${VERSION}.sha256"
+
+      - name: Upload GitHub Actions artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hermes-lanyard-${{ steps.ver.outputs.version }}
+          path: |
+            dist/lanyard/hermes-${{ steps.ver.outputs.version }}.tar.gz
+            dist/lanyard/hermes-${{ steps.ver.outputs.version }}.sha256
+            dist/lanyard/hermes-${{ steps.ver.outputs.version }}.sha256.hex
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Decide whether to upload to S3
+        id: should_upload
+        env:
+          SKIP_UPLOAD: ${{ github.event.inputs.skip_upload || 'false' }}
+          ROLE_ARN: ${{ vars.AWS_ROLE_ARN || secrets.AWS_ROLE_ARN || '' }}
+          BUCKET: ${{ vars.ARTIFACT_BUCKET || secrets.ARTIFACT_BUCKET || '' }}
+        run: |
+          set -euo pipefail
+          if [ "$SKIP_UPLOAD" = "true" ]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping S3 upload (skip_upload=true)"
+            exit 0
+          fi
+          if [ -z "$ROLE_ARN" ] || [ -z "$BUCKET" ]; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "upload=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::ARTIFACT_BUCKET / AWS_ROLE_ARN not configured — packed only (dispatch dry path)."
+              exit 0
+            fi
+            echo "::error::ARTIFACT_BUCKET and AWS_ROLE_ARN must be set (repo variables or secrets) to publish."
+            exit 1
+          fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
+          echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.should_upload.outputs.upload == 'true'
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN || secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          # Role name pattern from product-artifact-infra: ${name_prefix}-gha-hermes
+          # Trust: repo:LanyardBrain/hermes-agent:ref:refs/tags/*
+
+      - name: Upload to S3 hermes/ prefix
+        if: steps.should_upload.outputs.upload == 'true'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          BUCKET: ${{ steps.should_upload.outputs.bucket }}
+        run: |
+          set -euo pipefail
+          # Fail closed again at upload time
+          v_lc="$(echo "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          case "$v_lc" in
+            main|master|head|develop|development|trunk|latest)
+              echo "::error::Refusing to upload under mutable version '${VERSION}'"
+              exit 1
+              ;;
+          esac
+          TARBALL="dist/lanyard/hermes-${VERSION}.tar.gz"
+          SHA_FILE="dist/lanyard/hermes-${VERSION}.sha256"
+          PREFIX="s3://${BUCKET}/hermes/${VERSION}"
+          echo "Uploading to ${PREFIX}/"
+          aws s3 cp "$TARBALL" "${PREFIX}/hermes-${VERSION}.tar.gz"
+          aws s3 cp "$SHA_FILE" "${PREFIX}/hermes-${VERSION}.sha256"
+          echo "Published:"
+          echo "  ${PREFIX}/hermes-${VERSION}.tar.gz"
+          echo "  ${PREFIX}/hermes-${VERSION}.sha256"
+          echo "Pin fields for company-brain-deploy (operator fills after verify):"
+          echo "  hermes.version=${VERSION}"
+          echo "  hermes.url=s3://${BUCKET}/hermes/${VERSION}/hermes-${VERSION}.tar.gz"
+          echo "  hermes.sha256=$(cut -d' ' -f1 "$SHA_FILE")"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,87 @@
+# Weekly rebase of lanyard/portal-integration onto Nous upstream/main.
+# Schedule fires from this file on the fork default branch (main).
+# The job mutates the live gateway checkout only under hermes-agent/ —
+# never HERMES_HOME data (config, cron, skills, MCP, projects.db).
+name: Sync upstream (Lanyard portal)
+
+on:
+  schedule:
+    # Sunday 00:00 America/New_York during EST = 05:00 UTC.
+    # During EDT the same wall-clock is 04:00 UTC (~1h DST drift accepted).
+    - cron: "0 5 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: hermes-lanyard-upstream-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Rebase portal-integration onto upstream/main
+    runs-on: [self-hosted, linux, hermes-sync]
+    defaults:
+      run:
+        shell: bash
+        working-directory: /home/jrubin/.hermes/hermes-agent
+
+    steps:
+      - name: Refuse if working tree dirty
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::Working tree is dirty — refusing sync. Commit or stash local experiments, then re-run."
+            git status
+            exit 1
+          fi
+          echo "Working tree clean."
+
+      - name: Ensure remotes (origin=fork, upstream=Nous)
+        run: |
+          set -euo pipefail
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/NousResearch/hermes-agent.git
+          else
+            git remote add upstream https://github.com/NousResearch/hermes-agent.git
+          fi
+          if git remote get-url origin >/dev/null 2>&1; then
+            git remote set-url origin https://github.com/LanyardBrain/hermes-agent.git
+          else
+            git remote add origin https://github.com/LanyardBrain/hermes-agent.git
+          fi
+          git remote -v
+
+      - name: Fetch, checkout, rebase
+        run: |
+          set -euo pipefail
+          git fetch upstream main
+          git fetch origin
+          git checkout lanyard/portal-integration
+          # Track origin if needed
+          git branch -u origin/lanyard/portal-integration 2>/dev/null || true
+          echo "Before rebase: $(git rev-parse --short HEAD)"
+          git rebase upstream/main
+          echo "After rebase:  $(git rev-parse --short HEAD)"
+
+      - name: Portal smoke tests
+        run: |
+          set -euo pipefail
+          if [[ -x ./venv/bin/python ]]; then
+            PY=./venv/bin/python
+          else
+            PY=python3
+          fi
+          "$PY" -m pytest \
+            tests/gateway/test_session_env.py \
+            tests/gateway/relay/test_portal_metadata.py \
+            -q --tb=short
+
+      - name: Push force-with-lease
+        run: |
+          set -euo pipefail
+          git push --force-with-lease origin lanyard/portal-integration
+          echo "Pushed HEAD=$(git rev-parse HEAD)"
+          git log -1 --oneline
+          echo "Gateway not restarted (manual when convenient). HERMES_HOME data untouched."

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ apps/desktop/dist/
 apps/desktop/release/
 apps/desktop/*.tsbuildinfo
 
+# Local Lanyard runtime pack output (scripts/pack-lanyard-runtime.sh).
+# CI uploads the tarball to S3; never commit binary release artifacts.
+dist/lanyard/
+
 # Web UI assets — synced from @nous-research/ui at build time via
 # `npm run sync-assets` (see web/package.json).
 web/public/fonts/

--- a/docs/lanyard-brain-rpc.md
+++ b/docs/lanyard-brain-rpc.md
@@ -1,0 +1,92 @@
+# Lanyard Brain RPC (host handlers)
+
+Hermes host-side handlers for **Brain RPC** MVP methods. Portal invokes
+read-oriented operations on the customer brain host (vault, settings, projects)
+over the **existing egress-only relay WebSocket** — no public inbound host port.
+
+## Authority
+
+Cross-repo contract (normative schemas, auth, errors):
+
+- Deploy repo: [`company-brain-deploy/references/brain-rpc-contract.md`](https://github.com/LanyardBrain/company-brain-deploy/blob/main/references/brain-rpc-contract.md)
+- Related RBAC: `references/hermes-profile-rbac.md` (same deploy repo)
+- Transport substrate (chat relay, not method set): [`docs/relay-connector-contract.md`](./relay-connector-contract.md)
+
+This document is a **Hermes implementation note** only. Do not treat it as a
+substitute for the deploy contract. G3 overall readiness is owned by the deploy
+readiness matrix; G3.3 (Portal vertical slice) is separate.
+
+## Wire
+
+| Direction | Frame `type` |
+|-----------|----------------|
+| Portal/relay → Hermes | `brain_rpc_request` |
+| Hermes → Portal/relay | `brain_rpc_result` |
+
+Frames are newline-delimited JSON on the **authenticated** relay session the
+gateway already dials (`GATEWAY_RELAY_URL` + instance secret). The transport
+dispatches in `gateway/relay/ws_transport.py` when `type == brain_rpc_request`.
+
+## MVP methods
+
+| Method | Purpose |
+|--------|---------|
+| `brain.ping` | Liveness / echo |
+| `brain.health` | Structured readiness checks |
+| `vault.list` | Directory metadata (capped) |
+| `vault.stat` | Single-path metadata |
+| `vault.read` | Single-file content (size-capped) |
+| `settings.snapshot` | Redacted Hermes settings subset |
+| `projects.list` | Hermes `projects.db` rows (empty OK if missing) |
+
+## Auth (fail-closed)
+
+Host re-checks stamped claims (contract §3):
+
+1. **Auth present** — `tenant_id`, `instance_id`, `subject`, `expires_at`
+2. **Expiry** — expired → `unauthenticated`
+3. **Instance pin** — when `GATEWAY_RELAY_INSTANCE_ID` / `GATEWAY_RELAY_ID` is set, must match
+4. **Tenant pin** — when `BRAIN_TENANT_ID` / `GATEWAY_RELAY_TENANT_ID` is set, must match
+5. **Host profile** — capabilities from `$HERMES_HOME/profiles/<name>.json` (or builtin admin/contributor seeds)
+6. **Path ACL** — vault paths must fall under `subject.path_prefixes` (admin `vault_full` + empty prefixes = full vault)
+
+Channel secret verification (WS upgrade) remains the relay connector’s job.
+
+## Host configuration
+
+| Env | Meaning |
+|-----|---------|
+| `BRAIN_RPC_ENABLED` | Default `1`. Set `0`/`false` to refuse RPC with `unavailable` |
+| `VAULT_ROOT` | Vault filesystem root (preferred). Fallback: `COMPANY_BRAIN_VAULT_ROOT`, then `$HERMES_HOME/vault` |
+| `GATEWAY_RELAY_INSTANCE_ID` / `GATEWAY_RELAY_ID` | Local instance pin for L1 |
+| `BRAIN_TENANT_ID` / `GATEWAY_RELAY_TENANT_ID` | Optional local tenant pin |
+| `BRAIN_PROFILES_DIR` | Override for profile seed JSON directory |
+
+**Logging:** request id, method, tenant/instance/user, duration, error codes.
+Vault **file bodies are never logged**.
+
+## Code map
+
+```
+gateway/brain_rpc/
+  dispatcher.py     # envelope + concurrency bound
+  auth.py           # L1/L3/L4/L5
+  vault_ops.py      # list / stat / read
+  settings_snapshot.py
+  projects_handler.py
+  handlers.py       # method table
+gateway/relay/ws_transport.py   # frame hook → brain_rpc_result
+```
+
+## Tests
+
+```bash
+scripts/run_tests.sh tests/gateway/brain_rpc/ -q
+```
+
+## Non-goals (this track)
+
+- Portal BFF / browser API surface (G3.3)
+- Terraform/deploy modules
+- Vault write / settings mutate
+- Claiming G3 production-ready

--- a/docs/lanyard-release-artifact.md
+++ b/docs/lanyard-release-artifact.md
@@ -1,0 +1,127 @@
+# Hermes Lanyard release artifact
+
+LanyardBrain-specific path to publish a **runtime tarball** for company-brain
+hosts. This is separate from upstream Nous workflows (`docker.yml` → GHCR,
+`upload_to_pypi.yml` → PyPI).
+
+## Contract
+
+| Field | Value |
+|-------|--------|
+| S3 object shape | `s3://$ARTIFACT_BUCKET/hermes/<version>/hermes-<version>.tar.gz` |
+| Companion checksum | `…/hermes-<version>.sha256` (sha256sum format) |
+| Install path (bootstrap) | `/opt/hermes-lanyard` |
+| Layout | Single top-level dir `hermes-<version>/` flattened on extract; `bin/hermes` executable |
+| Versions | Immutable labels only (`v0.1.0`, CalVer tags, etc.) — **never** `main` / `master` / `HEAD` / `latest` |
+| OIDC role key | `hermes` → IAM role name `${name_prefix}-gha-hermes` |
+| Default trust | `repo:LanyardBrain/hermes-agent:ref:refs/tags/*` |
+
+Deploy-owned infra and pin validation live in **company-brain-deploy**
+(`modules/product-artifact-infra`, `artifacts/README.md`,
+`references/product-artifact-release-contract.md`). This repo only **builds and
+publishes** the object.
+
+## Local pack (no AWS)
+
+```bash
+# Full pack (needs uv, network for deps; npm optional unless you skip frontend)
+./scripts/pack-lanyard-runtime.sh --version v0.0.0-test
+
+# Faster smoke (skip web/TUI rebuild)
+./scripts/pack-lanyard-runtime.sh --version v0.0.0-test --skip-frontend
+
+# Outputs
+ls -la dist/lanyard/hermes-v0.0.0-test.tar.gz \
+       dist/lanyard/hermes-v0.0.0-test.sha256
+```
+
+Verify extract layout:
+
+```bash
+tmpdir=$(mktemp -d)
+tar -xzf dist/lanyard/hermes-v0.0.0-test.tar.gz -C "$tmpdir"
+# Bootstrap flattens a single top-level directory:
+# → expects $tmpdir/hermes-v0.0.0-test/bin/hermes (pre-flatten)
+test -x "$tmpdir/hermes-v0.0.0-test/bin/hermes"
+sha256sum -c dist/lanyard/hermes-v0.0.0-test.sha256
+```
+
+## GitHub Actions workflow
+
+File: [`.github/workflows/release-lanyard-artifact.yml`](../.github/workflows/release-lanyard-artifact.yml)
+
+| Trigger | Version source |
+|---------|----------------|
+| `push` tags `v*` | `github.ref_name` |
+| `release` published | release tag name |
+| `workflow_dispatch` | required `version` input (still rejects branch names) |
+
+Dispatch inputs:
+
+- `version` — immutable label
+- `skip_upload` — pack only (no S3)
+- `skip_frontend` — faster pack smoke
+
+### Required GitHub configuration
+
+Set on **LanyardBrain/hermes-agent** (repository **Variables** preferred for
+non-secrets; secrets also accepted by the workflow):
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `ARTIFACT_BUCKET` | variable | Platform artifact bucket name (no `s3://` prefix) |
+| `AWS_ROLE_ARN` | variable or secret | OIDC role ARN for publisher (`…-gha-hermes`) |
+| `AWS_REGION` | variable | AWS region (default `us-east-1` if unset) |
+
+Do **not** commit account IDs, role ARNs, or bucket names into this repository.
+
+OIDC role is created by company-brain-deploy `product-artifact-infra` when
+`enable_oidc_publishers = true` and an existing GitHub OIDC provider ARN is
+supplied. Until that apply is done, tag pushes will pack successfully but S3
+upload will fail closed if vars are missing.
+
+### Operator release process
+
+1. Land code on the branch you release from (e.g. `main` or
+   `lanyard/portal-integration`).
+2. Create an **immutable** git tag and push it (or publish a GitHub Release):
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+3. Workflow packs the runtime, writes SHA-256, assumes the Hermes OIDC role,
+   and uploads under `hermes/v0.1.0/`.
+4. Copy pin fields into company-brain-deploy compatibility / tenant pins
+   (**G7.H2** / deploy track — not this PR):
+
+   | Pin | Example shape |
+   |-----|----------------|
+   | `hermes.version` / `hermes_artifact_version` | `v0.1.0` |
+   | `hermes.url` / `hermes_artifact_url` | `s3://$ARTIFACT_BUCKET/hermes/v0.1.0/hermes-v0.1.0.tar.gz` |
+   | `hermes.sha256` / `hermes_artifact_sha256` | 64-char hex from the `.sha256` object |
+
+5. Bootstrap on the brain host downloads with the instance role, verifies
+   SHA-256, extracts into `/opt/hermes-lanyard`, and symlinks
+   `/usr/local/bin/hermes` when `bin/hermes` is present.
+
+Optional Ed25519 attestation (`HERMES_ARTIFACT_SIGNATURE_B64`) is a deploy-side
+concern; this workflow records SHA-256 only.
+
+## Tarball layout (after extract + flatten)
+
+```text
+/opt/hermes-lanyard/
+  bin/hermes              # relocatable wrapper
+  .venv/                  # uv relocatable virtualenv + hermes-agent
+  share/skills/           # bundled skills (HERMES_BUNDLED_SKILLS)
+  share/optional-skills/
+  VERSION
+  .install_method         # "lanyard-artifact"
+  .seed/build.env         # build metadata
+```
+
+## Explicit non-goals
+
+- Updating company-brain-deploy pin files (later track)
+- Replacing Docker/GHCR or PyPI publish paths
+- Embedding live AWS account IDs, bucket names, or employee-vault content

--- a/gateway/brain_rpc/__init__.py
+++ b/gateway/brain_rpc/__init__.py
@@ -1,0 +1,25 @@
+"""Host-side Brain RPC (G3.2) — MVP read methods on the customer Hermes host.
+
+Accepts ``brain_rpc_request`` frames on an authenticated relay WebSocket session
+and returns ``brain_rpc_result`` frames. Vault/settings/projects ops run locally
+on the host; there is no public inbound brain-RPC port.
+
+Contract (authority): company-brain-deploy ``references/brain-rpc-contract.md``.
+Local summary: ``docs/lanyard-brain-rpc.md``.
+"""
+
+from __future__ import annotations
+
+from gateway.brain_rpc.dispatcher import (
+    BRAIN_RPC_CONTRACT_VERSION,
+    BrainRpcDispatcher,
+    handle_brain_rpc_request,
+    is_brain_rpc_enabled,
+)
+
+__all__ = [
+    "BRAIN_RPC_CONTRACT_VERSION",
+    "BrainRpcDispatcher",
+    "handle_brain_rpc_request",
+    "is_brain_rpc_enabled",
+]

--- a/gateway/brain_rpc/auth.py
+++ b/gateway/brain_rpc/auth.py
@@ -1,0 +1,241 @@
+"""Auth verification for brain RPC (contract §3) — host layers L1/L3/L4/L5.
+
+L0 (channel secret) is enforced at the relay WebSocket upgrade. L2 (portal
+session) is BFF-side. Hermes re-checks stamped subject claims fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from gateway.brain_rpc.config import BrainRpcHostConfig
+from gateway.brain_rpc.errors import (
+    FORBIDDEN,
+    UNAUTHENTICATED,
+    BrainRpcError,
+)
+
+logger = logging.getLogger(__name__)
+
+# Built-in capability map when host profile seed files are missing.
+# Mirrors company-brain-deploy scripts/hermes-profiles/*.json — fail-closed
+# if the requested profile is unknown.
+_BUILTIN_PROFILE_CAPS: Dict[str, Set[str]] = {
+    "admin": {
+        "vault_full",
+        "vault_read",
+        "vault_write",
+        "chat",
+        "profile_manage",
+        "system_ops",
+        "shell_exec",
+        "gateway_config",
+        "beads_admin",
+    },
+    "contributor": {
+        "vault_read",
+        "vault_write",
+        "chat",
+    },
+}
+
+# Methods that do not require vault path ACL (still need auth).
+NO_PATH_ACL_METHODS = frozenset(
+    {
+        "brain.ping",
+        "brain.health",
+        "settings.snapshot",
+        "projects.list",
+    }
+)
+
+# Method → required capabilities (any-of). Empty set = authenticated only.
+METHOD_CAPABILITIES: Dict[str, Set[str]] = {
+    "brain.ping": set(),
+    "brain.health": set(),
+    "vault.list": {"vault_read", "vault_full"},
+    "vault.stat": {"vault_read", "vault_full"},
+    "vault.read": {"vault_read", "vault_full"},
+    "settings.snapshot": set(),  # both admin and contributor; payload redacted
+    "projects.list": {"vault_read", "vault_full"},
+}
+
+
+@dataclass
+class Subject:
+    portal_user_id: str
+    hermes_profile: str
+    roles: List[str] = field(default_factory=list)
+    path_prefixes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AuthContext:
+    tenant_id: str
+    instance_id: str
+    subject: Subject
+    session_id: Optional[str] = None
+    issued_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    capabilities: Set[str] = field(default_factory=set)
+
+
+def _parse_iso8601(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp; accept trailing Z."""
+    raw = (value or "").strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    dt = datetime.fromisoformat(raw)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def load_profile_capabilities(profiles_dir: Path, profile: str) -> Set[str]:
+    """Load capabilities for a host profile (seed JSON or builtin fallback)."""
+    name = (profile or "").strip()
+    if not name:
+        return set()
+    seed = profiles_dir / f"{name}.json"
+    if seed.is_file():
+        try:
+            data = json.loads(seed.read_text(encoding="utf-8"))
+            caps = data.get("capabilities") or []
+            if isinstance(caps, list):
+                return {str(c).strip() for c in caps if str(c).strip()}
+        except Exception as exc:  # noqa: BLE001 - corrupt seed → treat as unknown
+            logger.warning("brain_rpc: failed to load profile seed %s: %s", seed, exc)
+            return set()
+    return set(_BUILTIN_PROFILE_CAPS.get(name, set()))
+
+
+def verify_auth(
+    auth: Any,
+    *,
+    method: str,
+    host: BrainRpcHostConfig,
+    now: Optional[datetime] = None,
+) -> AuthContext:
+    """Validate the request ``auth`` object. Raises BrainRpcError on failure."""
+    if not isinstance(auth, dict) or not auth:
+        raise BrainRpcError(UNAUTHENTICATED, "missing auth")
+
+    tenant_id = str(auth.get("tenant_id") or "").strip()
+    instance_id = str(auth.get("instance_id") or "").strip()
+    if not tenant_id or not instance_id:
+        raise BrainRpcError(UNAUTHENTICATED, "missing tenant_id or instance_id")
+
+    # L1 — local pins when configured
+    if host.instance_id and instance_id != host.instance_id:
+        raise BrainRpcError(FORBIDDEN, "instance binding mismatch")
+    if host.tenant_id and tenant_id != host.tenant_id:
+        raise BrainRpcError(FORBIDDEN, "tenant binding mismatch")
+
+    expires_at = auth.get("expires_at")
+    if not expires_at:
+        raise BrainRpcError(UNAUTHENTICATED, "missing expires_at")
+    try:
+        exp = _parse_iso8601(str(expires_at))
+    except Exception as exc:
+        raise BrainRpcError(UNAUTHENTICATED, "invalid expires_at") from exc
+    current = now or datetime.now(timezone.utc)
+    if exp <= current:
+        raise BrainRpcError(UNAUTHENTICATED, "auth expired")
+
+    subject_raw = auth.get("subject")
+    if not isinstance(subject_raw, dict):
+        raise BrainRpcError(UNAUTHENTICATED, "missing subject")
+
+    portal_user_id = str(subject_raw.get("portal_user_id") or "").strip()
+    hermes_profile = str(subject_raw.get("hermes_profile") or "").strip()
+    if not portal_user_id or not hermes_profile:
+        raise BrainRpcError(UNAUTHENTICATED, "incomplete subject")
+
+    roles_raw = subject_raw.get("roles") or []
+    roles = [str(r) for r in roles_raw] if isinstance(roles_raw, list) else []
+
+    prefixes_raw = subject_raw.get("path_prefixes") or []
+    if not isinstance(prefixes_raw, list):
+        prefixes_raw = []
+    path_prefixes = [_normalize_prefix(p) for p in prefixes_raw if str(p).strip()]
+
+    # L4 — host profile matrix
+    capabilities = load_profile_capabilities(host.profiles_dir, hermes_profile)
+    if not capabilities and hermes_profile not in _BUILTIN_PROFILE_CAPS:
+        # Unknown profile with no seed file — fail closed.
+        raise BrainRpcError(FORBIDDEN, "unknown hermes_profile")
+
+    # Empty capability set from a known profile name that failed to load is
+    # still fail-closed for methods that require caps; brain.ping is allowed.
+
+    required = METHOD_CAPABILITIES.get(method)
+    if required is None:
+        # Unknown method handled later; auth still succeeds so dispatcher can
+        # return method_not_found (opacity vs auth).
+        pass
+    elif required:
+        if not (capabilities & required):
+            raise BrainRpcError(
+                FORBIDDEN,
+                "profile lacks capability",
+                details={"profile": hermes_profile, "method": method},
+            )
+
+    # Admin with empty path_prefixes from seed may use full vault via vault_full.
+    # Contributor must have path_prefixes for vault path methods (enforced at path check).
+    subject = Subject(
+        portal_user_id=portal_user_id,
+        hermes_profile=hermes_profile,
+        roles=roles,
+        path_prefixes=path_prefixes,
+    )
+    return AuthContext(
+        tenant_id=tenant_id,
+        instance_id=instance_id,
+        subject=subject,
+        session_id=str(auth.get("session_id") or "") or None,
+        issued_at=str(auth.get("issued_at") or "") or None,
+        expires_at=str(expires_at),
+        capabilities=capabilities,
+    )
+
+
+def _normalize_prefix(prefix: Any) -> str:
+    p = str(prefix).strip().replace("\\", "/")
+    if not p.startswith("/"):
+        p = "/" + p
+    # Collapse duplicate slashes; strip trailing slash except root
+    while "//" in p:
+        p = p.replace("//", "/")
+    if len(p) > 1 and p.endswith("/"):
+        p = p.rstrip("/")
+    return p
+
+
+def path_allowed(vault_path: str, auth: AuthContext) -> bool:
+    """L5 path ACL: vault-root-relative path must fall under path_prefixes.
+
+    ``vault_full`` capability with empty prefixes is treated as full vault
+    access (admin seed). Contributor with empty prefixes is denied.
+    """
+    if "vault_full" in auth.capabilities and not auth.subject.path_prefixes:
+        return True
+    if not auth.subject.path_prefixes:
+        return False
+    path = vault_path if vault_path.startswith("/") else f"/{vault_path}"
+    # Normalize
+    while "//" in path:
+        path = path.replace("//", "/")
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    for prefix in auth.subject.path_prefixes:
+        if prefix == "/":
+            return True
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False

--- a/gateway/brain_rpc/config.py
+++ b/gateway/brain_rpc/config.py
@@ -1,0 +1,112 @@
+"""Runtime config for host-side brain RPC.
+
+All behavioral knobs prefer env vars that company-brain-deploy / operator
+wiring already own. Missing optional binds fail closed only when the request
+claims a value we *can* check (see auth.py).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+# Default host cap for vault.read content (contract §4.5).
+DEFAULT_READ_MAX_BYTES = 1 * 1024 * 1024  # 1 MiB
+HARD_READ_MAX_BYTES = 4 * 1024 * 1024  # 4 MiB
+DEFAULT_LIST_LIMIT = 200
+HARD_LIST_LIMIT = 500
+MAX_IN_FLIGHT = 8
+MAX_TIMEOUT_MS = 30_000
+DEFAULT_TIMEOUT_MS = 10_000
+
+
+def is_brain_rpc_enabled() -> bool:
+    """Feature gate for Lanyard brain RPC.
+
+    Default ON so an authenticated relay session can serve MVP methods.
+    Set ``BRAIN_RPC_ENABLED=0`` (false/no/off) to refuse all requests with
+    ``unavailable`` without loading vault handlers — useful for hosts that
+    dial the relay for chat only.
+    """
+    raw = os.environ.get("BRAIN_RPC_ENABLED", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off", ""}
+
+
+def resolve_vault_root() -> Path:
+    """Vault root on the customer host.
+
+    Precedence:
+      1. ``VAULT_ROOT``
+      2. ``COMPANY_BRAIN_VAULT_ROOT``
+      3. ``$HERMES_HOME/vault`` (dev/test fallback; production sets VAULT_ROOT)
+    """
+    for key in ("VAULT_ROOT", "COMPANY_BRAIN_VAULT_ROOT"):
+        raw = os.environ.get(key, "").strip()
+        if raw:
+            return Path(raw).expanduser().resolve()
+    from hermes_constants import get_hermes_home
+
+    return (get_hermes_home() / "vault").resolve()
+
+
+def resolve_instance_id() -> Optional[str]:
+    """Local instance id this host is bound to (for L1 re-check)."""
+    for key in ("GATEWAY_RELAY_INSTANCE_ID", "GATEWAY_RELAY_ID", "BRAIN_INSTANCE_ID"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+    try:
+        from gateway.relay import relay_instance_id
+
+        return relay_instance_id()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_tenant_id() -> Optional[str]:
+    """Optional local tenant pin for L1 re-check.
+
+    Deploy may stamp ``BRAIN_TENANT_ID`` or ``GATEWAY_RELAY_TENANT_ID``. When
+    absent, host still requires ``auth.tenant_id`` present but cannot verify
+    the value against a local pin (relay L1 remains authoritative).
+    """
+    for key in ("BRAIN_TENANT_ID", "GATEWAY_RELAY_TENANT_ID"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+    return None
+
+
+def resolve_profiles_dir() -> Path:
+    """Directory holding host profile seed JSON files (admin.json, …)."""
+    raw = os.environ.get("BRAIN_PROFILES_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "profiles"
+
+
+@dataclass(frozen=True)
+class BrainRpcHostConfig:
+    vault_root: Path
+    instance_id: Optional[str]
+    tenant_id: Optional[str]
+    profiles_dir: Path
+    read_max_bytes: int = DEFAULT_READ_MAX_BYTES
+    hard_read_max_bytes: int = HARD_READ_MAX_BYTES
+    list_limit_default: int = DEFAULT_LIST_LIMIT
+    list_limit_max: int = HARD_LIST_LIMIT
+    max_in_flight: int = MAX_IN_FLIGHT
+
+    @classmethod
+    def from_env(cls) -> "BrainRpcHostConfig":
+        return cls(
+            vault_root=resolve_vault_root(),
+            instance_id=resolve_instance_id(),
+            tenant_id=resolve_tenant_id(),
+            profiles_dir=resolve_profiles_dir(),
+        )

--- a/gateway/brain_rpc/dispatcher.py
+++ b/gateway/brain_rpc/dispatcher.py
@@ -1,0 +1,262 @@
+"""Brain RPC dispatcher — parse request envelope, auth, dispatch, result.
+
+Entry point used by the relay WebSocket transport when it receives a
+``brain_rpc_request`` frame on an authenticated session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from gateway.brain_rpc.auth import verify_auth
+from gateway.brain_rpc.config import (
+    DEFAULT_TIMEOUT_MS,
+    MAX_IN_FLIGHT,
+    MAX_TIMEOUT_MS,
+    BrainRpcHostConfig,
+    is_brain_rpc_enabled,
+)
+from gateway.brain_rpc.errors import (
+    INTERNAL,
+    METHOD_NOT_FOUND,
+    RATE_LIMITED,
+    TIMEOUT,
+    UNAVAILABLE,
+    VERSION_UNSUPPORTED,
+    BrainRpcError,
+)
+from gateway.brain_rpc.handlers import BRAIN_RPC_CONTRACT_VERSION, HANDLERS
+
+logger = logging.getLogger(__name__)
+
+# Re-export for package consumers
+__all__ = [
+    "BRAIN_RPC_CONTRACT_VERSION",
+    "BrainRpcDispatcher",
+    "handle_brain_rpc_request",
+    "is_brain_rpc_enabled",
+]
+
+
+def _host_time() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _result_frame(
+    request_id: str,
+    *,
+    ok: bool,
+    result: Any = None,
+    error: Optional[Dict[str, Any]] = None,
+    meta: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "type": "brain_rpc_result",
+        "contract_version": BRAIN_RPC_CONTRACT_VERSION,
+        "request_id": request_id,
+        "ok": ok,
+        "result": result if ok else None,
+        "error": error if not ok else None,
+        "meta": meta or {},
+    }
+
+
+class BrainRpcDispatcher:
+    """Stateful dispatcher with in-flight concurrency bound (contract §7)."""
+
+    def __init__(
+        self,
+        host: Optional[BrainRpcHostConfig] = None,
+        *,
+        max_in_flight: int = MAX_IN_FLIGHT,
+    ) -> None:
+        self.host = host or BrainRpcHostConfig.from_env()
+        self._max_in_flight = max(1, max_in_flight)
+        # Event-loop-local counter (handle() is async; no threads share it).
+        self._in_flight = 0
+
+    async def handle(self, frame: Dict[str, Any]) -> Dict[str, Any]:
+        """Process one ``brain_rpc_request`` frame → ``brain_rpc_result`` frame."""
+        if not is_brain_rpc_enabled():
+            rid = str((frame or {}).get("request_id") or "")
+            return _result_frame(
+                rid,
+                ok=False,
+                error={
+                    "code": UNAVAILABLE,
+                    "message": "brain rpc disabled on host",
+                    "retryable": True,
+                    "details": {},
+                },
+                meta={"duration_ms": 0, "host_time": _host_time()},
+            )
+
+        # Bound concurrency: refuse rather than queue unbounded work.
+        if self._in_flight >= self._max_in_flight:
+            rid = str((frame or {}).get("request_id") or "")
+            return _result_frame(
+                rid,
+                ok=False,
+                error={
+                    "code": RATE_LIMITED,
+                    "message": "too many in-flight brain rpc calls",
+                    "retryable": True,
+                    "details": {},
+                },
+                meta={"duration_ms": 0, "host_time": _host_time()},
+            )
+
+        self._in_flight += 1
+        try:
+            return await self._handle_locked(frame)
+        finally:
+            self._in_flight -= 1
+
+    async def _handle_locked(self, frame: Dict[str, Any]) -> Dict[str, Any]:
+        started = time.monotonic()
+        request_id = str((frame or {}).get("request_id") or "")
+        profile_for_meta: Optional[str] = None
+
+        def _meta(extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            m: Dict[str, Any] = {
+                "duration_ms": duration_ms,
+                "host_time": _host_time(),
+            }
+            if profile_for_meta:
+                m["hermes_profile"] = profile_for_meta
+            if extra:
+                m.update(extra)
+            return m
+
+        try:
+            if not isinstance(frame, dict):
+                raise BrainRpcError(INTERNAL, "invalid frame")
+
+            if not request_id:
+                # Still return a result so the caller can see the failure.
+                request_id = ""
+
+            version = frame.get("contract_version", BRAIN_RPC_CONTRACT_VERSION)
+            try:
+                version_i = int(version)
+            except (TypeError, ValueError):
+                version_i = -1
+            if version_i != BRAIN_RPC_CONTRACT_VERSION:
+                raise BrainRpcError(
+                    VERSION_UNSUPPORTED,
+                    f"contract_version {version!r} unsupported; host supports {BRAIN_RPC_CONTRACT_VERSION}",
+                    details={"supported": BRAIN_RPC_CONTRACT_VERSION},
+                )
+
+            method = str(frame.get("method") or "").strip()
+            if not method:
+                raise BrainRpcError(METHOD_NOT_FOUND, "missing method")
+
+            timeout_ms = frame.get("timeout_ms", DEFAULT_TIMEOUT_MS)
+            try:
+                timeout_ms = int(timeout_ms)
+            except (TypeError, ValueError):
+                timeout_ms = DEFAULT_TIMEOUT_MS
+            if timeout_ms < 1:
+                timeout_ms = DEFAULT_TIMEOUT_MS
+            if timeout_ms > MAX_TIMEOUT_MS:
+                timeout_ms = MAX_TIMEOUT_MS
+
+            auth_ctx = verify_auth(frame.get("auth"), method=method, host=self.host)
+            profile_for_meta = auth_ctx.subject.hermes_profile
+
+            handler = HANDLERS.get(method)
+            if handler is None:
+                raise BrainRpcError(
+                    METHOD_NOT_FOUND,
+                    f"unknown method {method}",
+                    details={"method": method},
+                )
+
+            params = frame.get("params") or {}
+            if not isinstance(params, dict):
+                params = {}
+
+            # Run sync handlers off the event loop; respect timeout.
+            loop = asyncio.get_running_loop()
+
+            def _call() -> Dict[str, Any]:
+                return handler(params, auth_ctx, self.host)
+
+            try:
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(None, _call),
+                    timeout=timeout_ms / 1000.0,
+                )
+            except asyncio.TimeoutError as exc:
+                raise BrainRpcError(
+                    TIMEOUT,
+                    "host exceeded budget",
+                    retryable=True,
+                    details={"timeout_ms": timeout_ms},
+                ) from exc
+
+            logger.info(
+                "brain_rpc ok method=%s request_id=%s tenant=%s instance=%s user=%s duration_ms=%s",
+                method,
+                request_id,
+                auth_ctx.tenant_id,
+                auth_ctx.instance_id,
+                auth_ctx.subject.portal_user_id,
+                int((time.monotonic() - started) * 1000),
+            )
+            return _result_frame(request_id, ok=True, result=result, meta=_meta())
+
+        except BrainRpcError as err:
+            logger.info(
+                "brain_rpc error code=%s request_id=%s message=%s",
+                err.code,
+                request_id,
+                err.message,
+            )
+            return _result_frame(
+                request_id,
+                ok=False,
+                error=err.to_dict(),
+                meta=_meta(),
+            )
+        except Exception as exc:  # noqa: BLE001 - never leak stack to wire
+            logger.exception("brain_rpc internal error request_id=%s", request_id)
+            return _result_frame(
+                request_id,
+                ok=False,
+                error={
+                    "code": INTERNAL,
+                    "message": "internal host error",
+                    "retryable": True,
+                    "details": {},
+                },
+                meta=_meta(),
+            )
+
+
+# Process-wide default dispatcher (lazy).
+_default_dispatcher: Optional[BrainRpcDispatcher] = None
+
+
+def get_default_dispatcher() -> BrainRpcDispatcher:
+    global _default_dispatcher
+    if _default_dispatcher is None:
+        _default_dispatcher = BrainRpcDispatcher()
+    return _default_dispatcher
+
+
+async def handle_brain_rpc_request(frame: Dict[str, Any]) -> Dict[str, Any]:
+    """Module-level convenience used by the relay transport."""
+    return await get_default_dispatcher().handle(frame)
+
+
+def reset_default_dispatcher() -> None:
+    """Test helper: drop the process-wide dispatcher so host config reloads."""
+    global _default_dispatcher
+    _default_dispatcher = None

--- a/gateway/brain_rpc/errors.py
+++ b/gateway/brain_rpc/errors.py
@@ -1,0 +1,51 @@
+"""Brain RPC error model (contract §5)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+# Stable machine codes from contract §5.2
+UNAUTHENTICATED = "unauthenticated"
+FORBIDDEN = "forbidden"
+NOT_FOUND = "not_found"
+INVALID_ARGUMENT = "invalid_argument"
+PAYLOAD_TOO_LARGE = "payload_too_large"
+TIMEOUT = "timeout"
+UNAVAILABLE = "unavailable"
+CONFLICT = "conflict"
+METHOD_NOT_FOUND = "method_not_found"
+VERSION_UNSUPPORTED = "version_unsupported"
+RATE_LIMITED = "rate_limited"
+INTERNAL = "internal"
+
+# Which codes are retryable by default
+_RETRYABLE = frozenset({TIMEOUT, UNAVAILABLE, RATE_LIMITED, INTERNAL})
+
+
+@dataclass
+class BrainRpcError(Exception):
+    """Raised by handlers / auth to produce a structured brain_rpc_result error."""
+
+    code: str
+    message: str
+    retryable: Optional[bool] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.retryable is None:
+            self.retryable = self.code in _RETRYABLE
+        super().__init__(self.message)
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "retryable": bool(self.retryable),
+        }
+        if self.details:
+            out["details"] = self.details
+        else:
+            out["details"] = {}
+        return out

--- a/gateway/brain_rpc/handlers.py
+++ b/gateway/brain_rpc/handlers.py
@@ -1,0 +1,134 @@
+"""MVP method handlers (contract §4)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from gateway.brain_rpc.auth import AuthContext
+from gateway.brain_rpc.config import BrainRpcHostConfig
+from gateway.brain_rpc.errors import INVALID_ARGUMENT, BrainRpcError
+from gateway.brain_rpc.projects_handler import list_projects_snapshot
+from gateway.brain_rpc.settings_snapshot import build_settings_snapshot
+from gateway.brain_rpc.vault_ops import vault_list, vault_read, vault_stat
+
+logger = logging.getLogger(__name__)
+
+HandlerFn = Callable[[Dict[str, Any], AuthContext, BrainRpcHostConfig], Dict[str, Any]]
+
+BRAIN_RPC_CONTRACT_VERSION = 1
+
+
+def handle_brain_ping(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    echo = params.get("echo")
+    result: Dict[str, Any] = {
+        "pong": True,
+        "instance_id": auth.instance_id,
+        "contract_version": BRAIN_RPC_CONTRACT_VERSION,
+    }
+    if echo is not None:
+        s = str(echo)
+        if len(s) > 64:
+            raise BrainRpcError(
+                INVALID_ARGUMENT,
+                "echo exceeds 64 chars",
+                details={"limit": 64},
+            )
+        result["echo"] = s
+    return result
+
+
+def handle_brain_health(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    vault_ok = host.vault_root.is_dir() and os.access(host.vault_root, os.R_OK)
+    hermes_home_present = home.is_dir()
+    profiles_present = (
+        (host.profiles_dir / "admin.json").is_file()
+        or (host.profiles_dir / "contributor.json").is_file()
+        or host.profiles_dir.is_dir()
+        and any(host.profiles_dir.glob("*.json"))
+    )
+    projects_db = home / "projects.db"
+    projects_db_present = projects_db.is_file()
+
+    checks = {
+        "vault_root_readable": bool(vault_ok),
+        "hermes_home_present": bool(hermes_home_present),
+        "profiles_present": bool(profiles_present),
+        "projects_db_present": bool(projects_db_present),
+    }
+
+    if not vault_ok:
+        status = "unavailable"
+    elif not projects_db_present or not profiles_present:
+        status = "degraded"
+    else:
+        status = "ok"
+
+    versions = {
+        "brain_rpc": BRAIN_RPC_CONTRACT_VERSION,
+        "hermes_artifact": _best_effort_version("HERMES_ARTIFACT_VERSION", "/opt/company-brain/.seed/hermes_artifact"),
+        "client_core_seed": _best_effort_version(
+            "CLIENT_CORE_SEED_VERSION", "/opt/company-brain/.seed/client_core"
+        ),
+    }
+
+    return {
+        "status": status,
+        "checks": checks,
+        "versions": versions,
+        "profile": auth.subject.hermes_profile,
+    }
+
+
+def _best_effort_version(env_key: str, seed_path: str) -> Optional[str]:
+    env = os.environ.get(env_key, "").strip()
+    if env:
+        return env
+    p = Path(seed_path)
+    if p.is_file():
+        try:
+            text = p.read_text(encoding="utf-8").strip()
+            return text or None
+        except OSError:
+            return None
+    return None
+
+
+def handle_settings_snapshot(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    return build_settings_snapshot(params)
+
+
+def handle_projects_list(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    return list_projects_snapshot(params)
+
+
+HANDLERS: Dict[str, HandlerFn] = {
+    "brain.ping": handle_brain_ping,
+    "brain.health": handle_brain_health,
+    "vault.list": vault_list,
+    "vault.stat": vault_stat,
+    "vault.read": vault_read,
+    "settings.snapshot": handle_settings_snapshot,
+    "projects.list": handle_projects_list,
+}

--- a/gateway/brain_rpc/paths.py
+++ b/gateway/brain_rpc/paths.py
@@ -1,0 +1,73 @@
+"""Vault path normalization and resolution (contract §4.3–4.5)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Tuple
+
+from gateway.brain_rpc.errors import FORBIDDEN, INVALID_ARGUMENT, BrainRpcError
+
+
+def normalize_vault_path(raw: Any) -> str:
+    """Normalize a vault-root-relative POSIX path.
+
+    Rules:
+      - Must be a non-empty string starting with ``/``
+      - Reject ``..`` segments and null bytes
+      - Collapse ``.`` and duplicate slashes
+      - Result is absolute-looking (starts with /) but relative to vault root
+    """
+    if raw is None or not isinstance(raw, str) or not raw.strip():
+        raise BrainRpcError(INVALID_ARGUMENT, "path is required", details={"path": raw})
+    s = raw.strip().replace("\\", "/")
+    if "\x00" in s:
+        raise BrainRpcError(INVALID_ARGUMENT, "invalid path", details={"path": raw})
+    if not s.startswith("/"):
+        raise BrainRpcError(
+            INVALID_ARGUMENT,
+            "path must start with /",
+            details={"path": raw},
+        )
+    parts: list[str] = []
+    for seg in s.split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            raise BrainRpcError(
+                FORBIDDEN,
+                "path escape rejected",
+                details={"path": raw},
+            )
+        parts.append(seg)
+    return "/" + "/".join(parts) if parts else "/"
+
+
+def resolve_under_vault(vault_root: Path, vault_path: str) -> Tuple[Path, str]:
+    """Map a normalized vault path to a real filesystem path under vault_root.
+
+    Returns ``(fs_path, normalized_vault_path)``. Raises on breakout.
+    """
+    norm = normalize_vault_path(vault_path)
+    root = vault_root.resolve()
+    # Build relative path under root (strip leading /)
+    rel = norm.lstrip("/")
+    candidate = (root / rel).resolve() if rel else root
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise BrainRpcError(
+            FORBIDDEN,
+            "path escape rejected",
+            details={"path": norm},
+        ) from exc
+    # Extra defense: ensure string prefix match with sep boundary
+    root_s = str(root)
+    cand_s = str(candidate)
+    if cand_s != root_s and not cand_s.startswith(root_s + os.sep):
+        raise BrainRpcError(
+            FORBIDDEN,
+            "path escape rejected",
+            details={"path": norm},
+        )
+    return candidate, norm

--- a/gateway/brain_rpc/projects_handler.py
+++ b/gateway/brain_rpc/projects_handler.py
@@ -1,0 +1,61 @@
+"""projects.list handler (contract §4.7)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def list_projects_snapshot(
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    db_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Return Hermes projects for Portal pickers.
+
+    Missing ``projects.db`` → empty list with ``source: "none"`` (MVP simplicity).
+    """
+    params = params or {}
+    include_archived = bool(params.get("include_archived", False))
+
+    try:
+        from hermes_cli.projects_db import connect_closing, list_projects, projects_db_path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("brain_rpc projects: import failed: %s", exc)
+        return {"projects": [], "source": "none"}
+
+    path = db_path if db_path is not None else projects_db_path()
+    if not path.is_file():
+        return {"projects": [], "source": "none"}
+
+    try:
+        with connect_closing(db_path=path) as conn:
+            projects = list_projects(conn, include_archived=include_archived)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("brain_rpc projects: db read failed: %s", exc)
+        return {"projects": [], "source": "none"}
+
+    out: List[Dict[str, Any]] = []
+    for p in projects:
+        folders = []
+        for f in p.folders or []:
+            folders.append(
+                {
+                    "path": f.path,
+                    "label": f.label,
+                    "is_primary": bool(f.is_primary),
+                }
+            )
+        out.append(
+            {
+                "id": p.id,
+                "slug": p.slug,
+                "name": p.name,
+                "primary_path": p.primary_path,
+                "folders": folders,
+            }
+        )
+    return {"projects": out, "source": "hermes_projects_db"}

--- a/gateway/brain_rpc/settings_snapshot.py
+++ b/gateway/brain_rpc/settings_snapshot.py
@@ -1,0 +1,249 @@
+"""Redacted settings.snapshot (contract §4.6).
+
+Strips secret-shaped keys before anything leaves the host. BFF re-asserts
+redaction; host is the first line of defense.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from hermes_constants import display_hermes_home, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|token|password|passwd|secret|authorization|auth|credential|"
+    r"private[_-]?key|access[_-]?key|refresh[_-]?key|bearer|headers|env)$",
+    re.IGNORECASE,
+)
+
+_DEFAULT_INCLUDE = ("skills", "crons", "mcp_servers", "models", "integrations")
+
+
+def _is_secret_key(key: str) -> bool:
+    k = str(key)
+    if _SECRET_KEY_RE.search(k):
+        return True
+    lowered = k.lower()
+    for frag in (
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "private_key",
+        "passwd",
+        "password",
+        "authorization",
+    ):
+        if frag in lowered:
+            return True
+    return False
+
+
+def redact_value(value: Any, *, key: str = "") -> Any:
+    """Recursively strip secret-shaped keys from nested structures."""
+    if isinstance(value, dict):
+        out: Dict[str, Any] = {}
+        for k, v in value.items():
+            if _is_secret_key(str(k)):
+                continue
+            # Drop nested env/headers blocks entirely
+            if str(k).lower() in {"env", "headers", "secrets", "credentials"}:
+                continue
+            out[str(k)] = redact_value(v, key=str(k))
+        return out
+    if isinstance(value, list):
+        return [redact_value(v, key=key) for v in value]
+    return value
+
+
+def build_settings_snapshot(
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    hermes_home: Optional[Path] = None,
+) -> Dict[str, Any]:
+    params = params or {}
+    include_raw = params.get("include")
+    if isinstance(include_raw, list) and include_raw:
+        include: Set[str] = {str(x) for x in include_raw}
+    else:
+        include = set(_DEFAULT_INCLUDE)
+
+    home = hermes_home or get_hermes_home()
+    exported_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+    snapshot: Dict[str, Any] = {
+        "exported_at": exported_at,
+        "hermes_home": display_hermes_home(),
+        "source": "hermes",
+    }
+
+    if "skills" in include:
+        snapshot["skills"] = _collect_skills(home)
+    if "crons" in include:
+        snapshot["crons"] = _collect_crons(home)
+    if "mcp_servers" in include:
+        snapshot["mcp_servers"] = _collect_mcp_servers(home)
+    if "models" in include:
+        snapshot["models"] = _collect_models(home)
+    if "integrations" in include:
+        snapshot["integrations"] = _collect_integrations(home)
+
+    # Final redaction pass over the whole payload.
+    return redact_value(snapshot)
+
+
+def _load_yaml_config(home: Path) -> Dict[str, Any]:
+    cfg_path = home / "config.yaml"
+    if not cfg_path.is_file():
+        return {}
+    try:
+        import yaml
+
+        data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("brain_rpc settings: config load failed: %s", exc)
+        return {}
+
+
+def _collect_skills(home: Path) -> List[Dict[str, Any]]:
+    skills: List[Dict[str, Any]] = []
+    roots = [home / "skills"]
+    for root in roots:
+        if not root.is_dir():
+            continue
+        try:
+            for skill_md in root.rglob("SKILL.md"):
+                name = skill_md.parent.name
+                rel = str(skill_md.parent.relative_to(home)) if home in skill_md.parents else str(skill_md.parent)
+                skills.append(
+                    {
+                        "id": name,
+                        "name": name,
+                        "enabled": True,
+                        "path": rel,
+                        "source": "hermes",
+                    }
+                )
+        except OSError as exc:
+            logger.debug("brain_rpc settings: skills scan failed: %s", exc)
+    # Stable order
+    skills.sort(key=lambda s: s.get("id") or "")
+    return skills
+
+
+def _collect_crons(home: Path) -> List[Dict[str, Any]]:
+    jobs_path = home / "cron" / "jobs.json"
+    if not jobs_path.is_file():
+        return []
+    try:
+        import json
+
+        raw = json.loads(jobs_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("brain_rpc settings: cron load failed: %s", exc)
+        return []
+
+    jobs = raw if isinstance(raw, list) else (raw.get("jobs") if isinstance(raw, dict) else None)
+    if not isinstance(jobs, list):
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        jid = str(job.get("id") or job.get("job_id") or "")
+        name = str(job.get("name") or job.get("title") or jid or "job")
+        schedule = str(job.get("schedule") or job.get("cron") or "")
+        enabled = job.get("enabled")
+        if enabled is None:
+            enabled = not bool(job.get("paused") or job.get("disabled"))
+        out.append(
+            {
+                "id": jid or name,
+                "name": name,
+                "schedule": schedule,
+                "enabled": bool(enabled),
+            }
+        )
+    return out
+
+
+def _collect_mcp_servers(home: Path) -> List[Dict[str, Any]]:
+    cfg = _load_yaml_config(home)
+    servers = cfg.get("mcp_servers") or {}
+    if not isinstance(servers, dict):
+        return []
+    out: List[Dict[str, Any]] = []
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            entry = {}
+        # Never include command args that may embed secrets; transport only.
+        transport = str(entry.get("transport") or entry.get("type") or "stdio")
+        enabled = entry.get("enabled")
+        if enabled is None:
+            enabled = True
+        out.append(
+            {
+                "name": str(name),
+                "transport": transport,
+                "enabled": bool(enabled),
+            }
+        )
+    return out
+
+
+def _collect_models(home: Path) -> List[Dict[str, Any]]:
+    cfg = _load_yaml_config(home)
+    model = cfg.get("model")
+    out: List[Dict[str, Any]] = []
+    if isinstance(model, str) and model.strip():
+        out.append(
+            {
+                "provider": "default",
+                "model": model.strip(),
+                "is_active": True,
+                "connected": True,
+            }
+        )
+    elif isinstance(model, dict):
+        provider = str(model.get("provider") or model.get("backend") or "default")
+        model_name = str(model.get("model") or model.get("name") or model.get("default") or "")
+        if model_name:
+            out.append(
+                {
+                    "provider": provider,
+                    "model": model_name,
+                    "is_active": True,
+                    "connected": True,
+                }
+            )
+    return out
+
+
+def _collect_integrations(home: Path) -> List[Dict[str, Any]]:
+    # MVP: surface known CLI integration markers without credentials.
+    cfg = _load_yaml_config(home)
+    out: List[Dict[str, Any]] = []
+    # Gateway platforms present in config are integrations of type "messaging".
+    gw = cfg.get("gateway") or {}
+    if isinstance(gw, dict):
+        platforms = gw.get("platforms") or gw.get("enabled_platforms") or []
+        if isinstance(platforms, list):
+            for p in platforms:
+                out.append({"id": str(p), "name": str(p), "type": "messaging"})
+        elif isinstance(platforms, dict):
+            for p, meta in platforms.items():
+                enabled = True
+                if isinstance(meta, dict) and meta.get("enabled") is False:
+                    enabled = False
+                if enabled:
+                    out.append({"id": str(p), "name": str(p), "type": "messaging"})
+    return out

--- a/gateway/brain_rpc/vault_ops.py
+++ b/gateway/brain_rpc/vault_ops.py
@@ -1,0 +1,298 @@
+"""Vault list / stat / read handlers (contract §4.3–4.5).
+
+Never log file bodies. Metadata-only for list/stat; size-capped single-file read.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from gateway.brain_rpc.auth import AuthContext, path_allowed
+from gateway.brain_rpc.config import (
+    DEFAULT_LIST_LIMIT,
+    DEFAULT_READ_MAX_BYTES,
+    HARD_LIST_LIMIT,
+    HARD_READ_MAX_BYTES,
+    BrainRpcHostConfig,
+)
+from gateway.brain_rpc.errors import (
+    FORBIDDEN,
+    INVALID_ARGUMENT,
+    NOT_FOUND,
+    PAYLOAD_TOO_LARGE,
+    UNAVAILABLE,
+    BrainRpcError,
+)
+from gateway.brain_rpc.paths import normalize_vault_path, resolve_under_vault
+
+logger = logging.getLogger(__name__)
+
+
+def _mtime_iso(path: Path) -> Optional[str]:
+    try:
+        ts = path.stat().st_mtime
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    except OSError:
+        return None
+
+
+def _guess_mime(path: Path, kind: str) -> Optional[str]:
+    if kind != "file":
+        return None
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime
+
+
+def _entry_for(path: Path, vault_path: str) -> Dict[str, Any]:
+    if path.is_dir():
+        kind = "directory"
+        size = None
+    elif path.is_file():
+        kind = "file"
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = None
+    else:
+        # symlink to nowhere / special — treat as not a normal entry
+        kind = "file"
+        size = None
+    return {
+        "name": path.name if vault_path != "/" else path.name,
+        "path": vault_path if vault_path != "/" or path.name else "/",
+        "kind": kind,
+        "mime_type": _guess_mime(path, kind),
+        "size_bytes": size,
+        "mtime": _mtime_iso(path),
+    }
+
+
+def _require_path_acl(vault_path: str, auth: AuthContext) -> None:
+    if not path_allowed(vault_path, auth):
+        raise BrainRpcError(
+            FORBIDDEN,
+            "path not allowed for profile",
+            details={"path": vault_path},
+        )
+
+
+def _ensure_vault_root(host: BrainRpcHostConfig) -> Path:
+    root = host.vault_root
+    if not root.exists() or not root.is_dir():
+        raise BrainRpcError(
+            UNAVAILABLE,
+            "vault root not readable",
+            details={},
+        )
+    try:
+        # Probe readability without listing contents into logs.
+        next(root.iterdir(), None)
+    except OSError as exc:
+        raise BrainRpcError(UNAVAILABLE, "vault root not readable") from exc
+    return root
+
+
+def vault_list(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    root = _ensure_vault_root(host)
+    raw_path = params.get("path", "/")
+    norm = normalize_vault_path(raw_path if raw_path is not None else "/")
+    _require_path_acl(norm, auth)
+    fs_path, norm = resolve_under_vault(root, norm)
+
+    if not fs_path.exists():
+        raise BrainRpcError(NOT_FOUND, "path not found", details={"path": norm})
+    if not fs_path.is_dir():
+        raise BrainRpcError(
+            INVALID_ARGUMENT,
+            "path is not a directory",
+            details={"path": norm},
+        )
+
+    limit = params.get("limit", DEFAULT_LIST_LIMIT)
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise BrainRpcError(INVALID_ARGUMENT, "invalid limit") from exc
+    if limit < 1:
+        raise BrainRpcError(INVALID_ARGUMENT, "limit must be >= 1")
+    limit = min(limit, HARD_LIST_LIMIT)
+
+    cursor = params.get("cursor")
+    offset = 0
+    if cursor is not None and cursor != "":
+        try:
+            offset = int(cursor)
+            if offset < 0:
+                raise ValueError("negative")
+        except (TypeError, ValueError) as exc:
+            raise BrainRpcError(INVALID_ARGUMENT, "invalid cursor") from exc
+
+    try:
+        names = sorted(p.name for p in fs_path.iterdir())
+    except OSError as exc:
+        raise BrainRpcError(UNAVAILABLE, "cannot list directory") from exc
+
+    # Filter entries the subject cannot see (prefix ACL on children).
+    entries: List[Dict[str, Any]] = []
+    for name in names:
+        child_vault = f"{norm.rstrip('/')}/{name}" if norm != "/" else f"/{name}"
+        if not path_allowed(child_vault, auth):
+            continue
+        child_fs = fs_path / name
+        # For the root listing entry name, use the file name.
+        ent = _entry_for(child_fs, child_vault)
+        ent["name"] = name
+        entries.append(ent)
+
+    page = entries[offset : offset + limit]
+    next_offset = offset + len(page)
+    truncated = next_offset < len(entries)
+    next_cursor = str(next_offset) if truncated else None
+
+    return {
+        "path": norm,
+        "entries": page,
+        "next_cursor": next_cursor,
+        "truncated": truncated,
+    }
+
+
+def vault_stat(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    root = _ensure_vault_root(host)
+    norm = normalize_vault_path(params.get("path"))
+    _require_path_acl(norm, auth)
+    fs_path, norm = resolve_under_vault(root, norm)
+    if not fs_path.exists():
+        raise BrainRpcError(NOT_FOUND, "path not found", details={"path": norm})
+    ent = _entry_for(fs_path, norm)
+    # Name for root
+    if norm == "/":
+        ent["name"] = ""
+        ent["path"] = "/"
+        ent["kind"] = "directory"
+        ent["mime_type"] = None
+        ent["size_bytes"] = None
+    else:
+        ent["name"] = Path(norm).name
+    return ent
+
+
+def vault_read(
+    params: Dict[str, Any],
+    auth: AuthContext,
+    host: BrainRpcHostConfig,
+) -> Dict[str, Any]:
+    root = _ensure_vault_root(host)
+    norm = normalize_vault_path(params.get("path"))
+    _require_path_acl(norm, auth)
+    fs_path, norm = resolve_under_vault(root, norm)
+
+    if not fs_path.exists():
+        raise BrainRpcError(NOT_FOUND, "path not found", details={"path": norm})
+    if fs_path.is_dir():
+        raise BrainRpcError(
+            INVALID_ARGUMENT,
+            "path is a directory",
+            details={"path": norm},
+        )
+    if not fs_path.is_file():
+        raise BrainRpcError(NOT_FOUND, "path not found", details={"path": norm})
+
+    caller_max = params.get("max_bytes", DEFAULT_READ_MAX_BYTES)
+    try:
+        caller_max = int(caller_max)
+    except (TypeError, ValueError) as exc:
+        raise BrainRpcError(INVALID_ARGUMENT, "invalid max_bytes") from exc
+    if caller_max < 1:
+        raise BrainRpcError(INVALID_ARGUMENT, "max_bytes must be >= 1")
+
+    host_cap = min(host.read_max_bytes, host.hard_read_max_bytes, HARD_READ_MAX_BYTES)
+    max_bytes = min(caller_max, host_cap)
+
+    try:
+        size = fs_path.stat().st_size
+    except OSError as exc:
+        raise BrainRpcError(UNAVAILABLE, "cannot stat file") from exc
+
+    if size > max_bytes:
+        raise BrainRpcError(
+            PAYLOAD_TOO_LARGE,
+            "file exceeds max_bytes",
+            details={"path": norm, "size_bytes": size, "max_bytes": max_bytes},
+        )
+
+    try:
+        # Read size+1 to detect race growth past cap without logging content.
+        data = fs_path.read_bytes()
+    except OSError as exc:
+        raise BrainRpcError(UNAVAILABLE, "cannot read file") from exc
+
+    if len(data) > max_bytes:
+        raise BrainRpcError(
+            PAYLOAD_TOO_LARGE,
+            "file exceeds max_bytes",
+            details={"path": norm, "size_bytes": len(data), "max_bytes": max_bytes},
+        )
+
+    mime = _guess_mime(fs_path, "file") or "application/octet-stream"
+    encoding, content = _encode_content(data, mime)
+
+    # Intentionally do not log `content` / `data`.
+    logger.info(
+        "brain_rpc vault.read path=%s size=%d encoding=%s",
+        norm,
+        len(data),
+        encoding,
+    )
+
+    return {
+        "path": norm,
+        "kind": "file",
+        "mime_type": mime,
+        "encoding": encoding,
+        "content": content,
+        "size_bytes": len(data),
+    }
+
+
+def _encode_content(data: bytes, mime: str) -> tuple[str, str]:
+    text_like = (
+        mime.startswith("text/")
+        or mime in {"application/json", "application/xml", "application/javascript"}
+        or mime.endswith("+json")
+        or mime.endswith("+xml")
+        or mime == "application/x-yaml"
+        or mime == "application/yaml"
+    )
+    if text_like or _looks_like_text(data):
+        try:
+            return "utf-8", data.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+    return "base64", base64.b64encode(data).decode("ascii")
+
+
+def _looks_like_text(data: bytes) -> bool:
+    if not data:
+        return True
+    sample = data[: 8 * 1024]
+    if b"\x00" in sample:
+        return False
+    try:
+        sample.decode("utf-8")
+        return True
+    except UnicodeDecodeError:
+        return False

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -6,7 +6,9 @@ speaks the newline-delimited JSON frame protocol defined in the connector repo
 ``docs/relay-connector-contract.md``:
 
   gateway -> connector : hello, outbound, interrupt
-  connector -> gateway : descriptor, inbound, outbound_result, interrupt_inbound
+  connector -> gateway : descriptor, inbound, outbound_result, interrupt_inbound,
+                         brain_rpc_request
+  gateway -> connector : brain_rpc_result
 
 Frames:
   hello            {type, platform, botId}
@@ -16,6 +18,8 @@ Frames:
   outbound_result  {type, requestId, result}
   interrupt        {type, session_key, reason?}             (gateway egresses /stop)
   interrupt_inbound{type, session_key, chat_id}             (connector -> owning gateway)
+  brain_rpc_request{type, contract_version, request_id, …}  (Lanyard G3 host ops)
+  brain_rpc_result {type, contract_version, request_id, …}
 
 This is the concrete transport behind the ``RelayTransport`` Protocol; the
 ``RelayAdapter`` delegates all wire I/O to it. Outbound calls block on a
@@ -700,9 +704,51 @@ class WebSocketRelayTransport:
             if handler is not None:
                 fwd = _passthrough_from_wire(frame.get("forward", {}))
                 await handler(fwd, frame.get("bufferId"))
+        elif ftype == "brain_rpc_request":
+            # Lanyard G3.2: host-side brain RPC (vault/settings/projects). Rides
+            # the same authenticated outbound WS as chat inbound — no public
+            # host port. Feature-gated via BRAIN_RPC_ENABLED (default on).
+            await self._handle_brain_rpc_request(frame)
         else:
             # hello/outbound/interrupt are gateway->connector; ignore if echoed.
             pass
+
+    async def _handle_brain_rpc_request(self, frame: Dict[str, Any]) -> None:
+        """Dispatch a brain_rpc_request and emit brain_rpc_result on the wire.
+
+        Failures never drop the relay socket: every path yields a result frame
+        (or a best-effort internal error if the dispatcher itself crashes).
+        Vault file bodies are never logged here.
+        """
+        request_id = str(frame.get("request_id") or "")
+        try:
+            from gateway.brain_rpc import handle_brain_rpc_request
+
+            result = await handle_brain_rpc_request(frame)
+        except Exception:  # noqa: BLE001 - never kill the reader for RPC faults
+            logger.exception("relay: brain_rpc_request dispatch failed request_id=%s", request_id)
+            result = {
+                "type": "brain_rpc_result",
+                "contract_version": int(frame.get("contract_version") or 1),
+                "request_id": request_id,
+                "ok": False,
+                "result": None,
+                "error": {
+                    "code": "internal",
+                    "message": "internal host error",
+                    "retryable": True,
+                    "details": {},
+                },
+                "meta": {},
+            }
+        try:
+            await self._send(result)
+        except Exception:  # noqa: BLE001 - socket may be closing mid-RPC
+            logger.debug(
+                "relay: brain_rpc_result send failed request_id=%s",
+                request_id,
+                exc_info=True,
+            )
 
     def set_interrupt_inbound_handler(self, handler: Any) -> None:
         """Register the callback for connector->gateway interrupt_inbound frames."""

--- a/scripts/pack-lanyard-runtime.sh
+++ b/scripts/pack-lanyard-runtime.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# pack-lanyard-runtime.sh — Build a relocatable Hermes Lanyard runtime tarball.
+#
+# Consumer contract (company-brain-deploy bootstrap):
+#   - Object shape: s3://$BUCKET/hermes/<version>/<filename>.tar.gz
+#   - Archive may have a single top-level directory (flattened on extract)
+#   - After flatten into /opt/hermes-lanyard, expects bin/hermes executable
+#
+# Versions must be immutable labels (e.g. v0.1.0). Never main/master/HEAD/latest.
+#
+# Local dry-run (no AWS):
+#   ./scripts/pack-lanyard-runtime.sh --version v0.0.0-test
+#
+# Env / flags:
+#   --version VER          Required immutable version label
+#   --output-dir DIR       Where to write tarball + .sha256 (default: dist/lanyard)
+#   --skip-frontend        Skip web/TUI npm builds (faster local smoke)
+#   --python VER           Python for the venv (default: 3.12)
+#   HERMES_PACK_EXTRAS     Space-separated uv --extra names
+#                          (default: "all messaging")
+#
+# Offline for AWS only — still needs network for uv/npm unless caches are warm.
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+VERSION=""
+OUTPUT_DIR="${ROOT}/dist/lanyard"
+SKIP_FRONTEND=0
+PYTHON_VER="${HERMES_PACK_PYTHON:-3.12}"
+# shellcheck disable=SC2206
+EXTRAS=(${HERMES_PACK_EXTRAS:-all messaging})
+
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  echo "Usage: $0 --version <vX.Y.Z> [--output-dir DIR] [--skip-frontend] [--python VER]"
+}
+
+log() { echo "[pack-lanyard] $*" >&2; }
+die() { echo "[pack-lanyard] ERROR: $*" >&2; exit 1; }
+
+# Reject live git branches / mutable refs used as "versions".
+is_forbidden_version_ref() {
+  local v
+  v="$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$v" in
+    main|master|head|develop|development|trunk|latest|origin/*|refs/*|"")
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+    --skip-frontend) SKIP_FRONTEND=1; shift ;;
+    --python) PYTHON_VER="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$VERSION" ] || die "--version is required (e.g. v0.1.0)"
+if is_forbidden_version_ref "$VERSION"; then
+  die "Refusing mutable/forbidden version label: '${VERSION}'. Use an immutable tag-style label (e.g. v0.1.0)."
+fi
+# Soft shape check: prefer v-prefixed labels; allow pre-release suffixes.
+if ! echo "$VERSION" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._+-]*$'; then
+  die "Version contains unsafe characters: '${VERSION}'"
+fi
+
+command -v uv >/dev/null 2>&1 || die "uv is required on PATH (https://docs.astral.sh/uv/)"
+command -v tar >/dev/null 2>&1 || die "tar is required"
+command -v sha256sum >/dev/null 2>&1 || die "sha256sum is required"
+
+cd "$ROOT"
+
+STAGE_PARENT="$(mktemp -d "${TMPDIR:-/tmp}/hermes-lanyard-pack.XXXXXX")"
+cleanup() { rm -rf "$STAGE_PARENT"; }
+trap cleanup EXIT
+
+# Single top-level directory so bootstrap flatten_extract is a no-op or clean.
+TOP_NAME="hermes-${VERSION}"
+PREFIX="${STAGE_PARENT}/${TOP_NAME}"
+mkdir -p "$PREFIX/bin" "$PREFIX/share" "$PREFIX/.seed"
+
+log "Staging prefix: $PREFIX"
+log "Version: $VERSION"
+log "Extras: ${EXTRAS[*]}"
+
+# ---------- Frontend assets (package-data for hermes_cli) ----------
+if [ "$SKIP_FRONTEND" -eq 0 ]; then
+  if command -v npm >/dev/null 2>&1; then
+    log "Building web dashboard + TUI (set --skip-frontend to skip)"
+    if [ -f package-lock.json ]; then
+      npm ci --no-audit --no-fund
+    else
+      npm install --no-audit --no-fund
+    fi
+    (cd web && npm ci --no-audit --no-fund && npm run build)
+    (cd ui-tui && npm ci --no-audit --no-fund && npm run build)
+    mkdir -p hermes_cli/tui_dist
+    if [ -f ui-tui/dist/entry.js ]; then
+      cp -f ui-tui/dist/entry.js hermes_cli/tui_dist/entry.js
+    fi
+  else
+    log "WARN: npm not found — packing without rebuilt frontend assets"
+  fi
+else
+  log "Skipping frontend build (--skip-frontend)"
+fi
+
+# ---------- Relocatable venv + project install ----------
+log "Creating relocatable venv (python ${PYTHON_VER})"
+uv venv --relocatable --python "$PYTHON_VER" --clear "$PREFIX/.venv"
+
+EXTRA_ARGS=()
+for extra in "${EXTRAS[@]}"; do
+  EXTRA_ARGS+=(--extra "$extra")
+done
+
+log "Installing hermes-agent into prefix (uv sync --frozen --no-editable)"
+# Point the project environment at the stage venv so the install is self-contained.
+export UV_PROJECT_ENVIRONMENT="$PREFIX/.venv"
+uv sync --frozen --no-editable --no-dev "${EXTRA_ARGS[@]}"
+
+# ---------- Bundled skills / optional-skills (Homebrew-style share layout) ----------
+log "Copying skills into share/"
+if [ -d skills ]; then
+  cp -a skills "$PREFIX/share/skills"
+fi
+if [ -d optional-skills ]; then
+  cp -a optional-skills "$PREFIX/share/optional-skills"
+fi
+if [ -d optional-mcps ]; then
+  cp -a optional-mcps "$PREFIX/share/optional-mcps"
+fi
+if [ -d locales ]; then
+  cp -a locales "$PREFIX/share/locales"
+fi
+
+# ---------- bin/hermes relocatable wrapper ----------
+# Resolve ROOT from this script's location so the tree works after bootstrap
+# flatten into /opt/hermes-lanyard (or any install path).
+cat >"$PREFIX/bin/hermes" <<'WRAPPER'
+#!/bin/sh
+# Hermes Lanyard runtime entrypoint — relocatable.
+set -eu
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+VENV_PY="${ROOT}/.venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  echo "hermes: missing interpreter at $VENV_PY" >&2
+  exit 127
+fi
+# Bundled skill trees (same contract as Homebrew formula).
+if [ -d "${ROOT}/share/skills" ]; then
+  export HERMES_BUNDLED_SKILLS="${HERMES_BUNDLED_SKILLS:-${ROOT}/share/skills}"
+fi
+if [ -d "${ROOT}/share/optional-skills" ]; then
+  export HERMES_OPTIONAL_SKILLS="${HERMES_OPTIONAL_SKILLS:-${ROOT}/share/optional-skills}"
+fi
+export HERMES_MANAGED="${HERMES_MANAGED:-lanyard-artifact}"
+# Prefer the venv console script when present; fall back to module entry.
+if [ -x "${ROOT}/.venv/bin/hermes" ]; then
+  exec "${ROOT}/.venv/bin/hermes" "$@"
+fi
+exec "$VENV_PY" -m hermes_cli.main "$@"
+WRAPPER
+chmod 0755 "$PREFIX/bin/hermes"
+
+# Install-method stamp next to the code tree (not under HERMES_HOME).
+printf 'lanyard-artifact\n' >"$PREFIX/.install_method"
+printf '%s\n' "$VERSION" >"$PREFIX/VERSION"
+{
+  echo "version=${VERSION}"
+  echo "product=hermes-lanyard"
+  echo "built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "git_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+  fi
+} >"$PREFIX/.seed/build.env"
+
+# ---------- Archive + SHA-256 ----------
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(CDPATH= cd -- "$OUTPUT_DIR" && pwd)"
+TARBALL_NAME="hermes-${VERSION}.tar.gz"
+TARBALL_PATH="${OUTPUT_DIR}/${TARBALL_NAME}"
+SHA_PATH="${OUTPUT_DIR}/hermes-${VERSION}.sha256"
+
+log "Creating ${TARBALL_PATH}"
+# Deterministic-ish: sort names; do not store full uid/gid when supported.
+tar \
+  --sort=name \
+  --owner=0 --group=0 --numeric-owner \
+  -C "$STAGE_PARENT" \
+  -czf "$TARBALL_PATH" \
+  "$TOP_NAME" 2>/dev/null \
+  || tar -C "$STAGE_PARENT" -czf "$TARBALL_PATH" "$TOP_NAME"
+
+SHA="$(sha256sum "$TARBALL_PATH" | awk '{print $1}')"
+# sha256sum-compatible line (hash  filename) for easy verification
+printf '%s  %s\n' "$SHA" "$TARBALL_NAME" >"$SHA_PATH"
+
+# Also write a bare hash file some pin tools prefer
+printf '%s\n' "$SHA" >"${OUTPUT_DIR}/hermes-${VERSION}.sha256.hex"
+
+log "Tarball: $TARBALL_PATH"
+log "SHA-256: $SHA"
+log "SHA file: $SHA_PATH"
+
+# Layout smoke: extract and verify single top-level dir + bin/hermes (pre- and post-flatten).
+SMOKE="$(mktemp -d "${TMPDIR:-/tmp}/hermes-lanyard-smoke.XXXXXX")"
+tar -xzf "$TARBALL_PATH" -C "$SMOKE"
+mapfile -t _entries < <(find "$SMOKE" -mindepth 1 -maxdepth 1 ! -name '.*' | sort)
+if [ "${#_entries[@]}" -ne 1 ] || [ ! -d "${_entries[0]}" ]; then
+  rm -rf "$SMOKE"
+  die "Smoke check failed: expected exactly one top-level directory in tarball"
+fi
+TOP_EXTRACTED="${_entries[0]}"
+if [ ! -x "${TOP_EXTRACTED}/bin/hermes" ]; then
+  rm -rf "$SMOKE"
+  die "Smoke check failed: ${TOP_NAME}/bin/hermes missing or not executable"
+fi
+if [ ! -x "${TOP_EXTRACTED}/.venv/bin/python" ]; then
+  rm -rf "$SMOKE"
+  die "Smoke check failed: .venv/bin/python missing under top-level dir"
+fi
+# Simulate bootstrap flatten_extract (single top-level dir → install root)
+FLAT="$(mktemp -d "${TMPDIR:-/tmp}/hermes-lanyard-flat.XXXXXX")"
+# Prefer rsync if present; else tar-pipe to preserve hidden files
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a "${TOP_EXTRACTED}/" "$FLAT/"
+else
+  tar -C "$TOP_EXTRACTED" -cf - . | tar -C "$FLAT" -xf -
+fi
+if [ ! -x "$FLAT/bin/hermes" ] || [ ! -x "$FLAT/.venv/bin/python" ]; then
+  rm -rf "$SMOKE" "$FLAT"
+  die "Smoke check failed: layout incomplete after flatten simulation"
+fi
+log "Smoke layout OK (top-level ${TOP_NAME}/ + flattened bin/hermes + .venv)"
+rm -rf "$SMOKE" "$FLAT"
+
+# Machine-readable summary for CI
+cat <<EOF
+PACK_VERSION=${VERSION}
+PACK_TARBALL=${TARBALL_PATH}
+PACK_TARBALL_NAME=${TARBALL_NAME}
+PACK_SHA256=${SHA}
+PACK_SHA_FILE=${SHA_PATH}
+PACK_S3_KEY=hermes/${VERSION}/${TARBALL_NAME}
+EOF

--- a/tests/gateway/brain_rpc/__init__.py
+++ b/tests/gateway/brain_rpc/__init__.py
@@ -1,0 +1,1 @@
+# Brain RPC host-handler tests (G3.2).

--- a/tests/gateway/brain_rpc/conftest.py
+++ b/tests/gateway/brain_rpc/conftest.py
@@ -1,0 +1,135 @@
+"""Shared fixtures for brain RPC tests — tmp vault + profile seeds, no network."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from gateway.brain_rpc.config import BrainRpcHostConfig
+from gateway.brain_rpc.dispatcher import BrainRpcDispatcher, reset_default_dispatcher
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatcher():
+    reset_default_dispatcher()
+    yield
+    reset_default_dispatcher()
+
+
+@pytest.fixture
+def vault_root(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    legal = root / "Projects" / "Legal"
+    legal.mkdir(parents=True)
+    (legal / "memo.md").write_text("# Memo\nsecret body never logged\n", encoding="utf-8")
+    (legal / "exhibits").mkdir()
+    (legal / "exhibits" / "a.txt").write_text("exhibit-a", encoding="utf-8")
+    secrets = root / "Secrets"
+    secrets.mkdir()
+    (secrets / "keys.txt").write_text("do-not-read", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def profiles_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "profiles"
+    d.mkdir()
+    (d / "admin.json").write_text(
+        json.dumps(
+            {
+                "name": "admin",
+                "capabilities": [
+                    "vault_full",
+                    "vault_read",
+                    "vault_write",
+                    "chat",
+                    "profile_manage",
+                    "system_ops",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (d / "contributor.json").write_text(
+        json.dumps(
+            {
+                "name": "contributor",
+                "capabilities": ["vault_read", "vault_write", "chat"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return d
+
+
+@pytest.fixture
+def host_config(vault_root: Path, profiles_dir: Path) -> BrainRpcHostConfig:
+    return BrainRpcHostConfig(
+        vault_root=vault_root,
+        instance_id="inst_test",
+        tenant_id="ten_test",
+        profiles_dir=profiles_dir,
+    )
+
+
+@pytest.fixture
+def dispatcher(host_config: BrainRpcHostConfig) -> BrainRpcDispatcher:
+    return BrainRpcDispatcher(host=host_config)
+
+
+def _expires_at(*, minutes: int = 5) -> str:
+    return (
+        datetime.now(timezone.utc) + timedelta(minutes=minutes)
+    ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def make_auth(
+    *,
+    profile: str = "contributor",
+    path_prefixes: list | None = None,
+    tenant_id: str = "ten_test",
+    instance_id: str = "inst_test",
+    expired: bool = False,
+    roles: list | None = None,
+) -> dict:
+    if path_prefixes is None:
+        path_prefixes = ["/Projects/Legal"]
+    if roles is None:
+        roles = [profile]
+    return {
+        "tenant_id": tenant_id,
+        "instance_id": instance_id,
+        "subject": {
+            "portal_user_id": "usr_test",
+            "hermes_profile": profile,
+            "roles": roles,
+            "path_prefixes": path_prefixes,
+        },
+        "session_id": "sess_test",
+        "issued_at": _expires_at(minutes=-1),
+        "expires_at": _expires_at(minutes=-5 if expired else 5),
+    }
+
+
+def make_request(
+    method: str,
+    *,
+    params: dict | None = None,
+    auth: dict | None = None,
+    request_id: str = "req_1",
+    contract_version: int = 1,
+    timeout_ms: int = 10_000,
+) -> dict:
+    return {
+        "type": "brain_rpc_request",
+        "contract_version": contract_version,
+        "request_id": request_id,
+        "method": method,
+        "timeout_ms": timeout_ms,
+        "auth": auth if auth is not None else make_auth(),
+        "params": params if params is not None else {},
+        "idempotency_key": None,
+    }

--- a/tests/gateway/brain_rpc/test_auth.py
+++ b/tests/gateway/brain_rpc/test_auth.py
@@ -1,0 +1,119 @@
+"""Auth fail-closed + path ACL tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.brain_rpc.auth import path_allowed, verify_auth
+from gateway.brain_rpc.errors import FORBIDDEN, UNAUTHENTICATED, BrainRpcError
+from tests.gateway.brain_rpc.conftest import make_auth, make_request
+
+
+@pytest.mark.asyncio
+async def test_missing_auth(dispatcher):
+    req = make_request("brain.ping", auth=None)
+    req["auth"] = None
+    res = await dispatcher.handle(req)
+    assert res["ok"] is False
+    assert res["error"]["code"] == UNAUTHENTICATED
+
+
+@pytest.mark.asyncio
+async def test_expired_auth(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", auth=make_auth(expired=True))
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == UNAUTHENTICATED
+    assert "expired" in res["error"]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_instance_mismatch(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", auth=make_auth(instance_id="inst_other"))
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_tenant_mismatch(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", auth=make_auth(tenant_id="ten_other"))
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_unknown_profile_forbidden(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", auth=make_auth(profile="nosuchprofile"))
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_path_outside_prefixes_forbidden(dispatcher):
+    res = await dispatcher.handle(
+        make_request(
+            "vault.stat",
+            params={"path": "/Secrets/keys.txt"},
+            auth=make_auth(path_prefixes=["/Projects/Legal"]),
+        )
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_path_escape_dotdot(dispatcher):
+    res = await dispatcher.handle(
+        make_request(
+            "vault.stat",
+            params={"path": "/Projects/Legal/../../Secrets/keys.txt"},
+            auth=make_auth(path_prefixes=["/Projects/Legal"]),
+        )
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] in {FORBIDDEN, "invalid_argument"}
+
+
+def test_path_allowed_helpers(host_config):
+    auth = verify_auth(
+        make_auth(path_prefixes=["/Projects/Legal"]),
+        method="vault.list",
+        host=host_config,
+    )
+    assert path_allowed("/Projects/Legal", auth)
+    assert path_allowed("/Projects/Legal/memo.md", auth)
+    assert not path_allowed("/Secrets", auth)
+    assert not path_allowed("/Projects", auth)
+
+
+def test_admin_vault_full_empty_prefixes(host_config):
+    auth = verify_auth(
+        make_auth(profile="admin", path_prefixes=[]),
+        method="vault.list",
+        host=host_config,
+    )
+    assert path_allowed("/Secrets/keys.txt", auth)
+
+
+def test_contributor_empty_prefixes_deny(host_config):
+    auth = verify_auth(
+        make_auth(profile="contributor", path_prefixes=[]),
+        method="vault.list",
+        host=host_config,
+    )
+    assert not path_allowed("/Projects/Legal", auth)
+
+
+def test_missing_subject_raises(host_config):
+    bad = make_auth()
+    del bad["subject"]
+    with pytest.raises(BrainRpcError) as ei:
+        verify_auth(bad, method="brain.ping", host=host_config)
+    assert ei.value.code == UNAUTHENTICATED

--- a/tests/gateway/brain_rpc/test_handlers.py
+++ b/tests/gateway/brain_rpc/test_handlers.py
@@ -1,0 +1,229 @@
+"""MVP method handler tests against tmp vault fixtures (no network)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.projects_db import connect_closing, create_project
+from tests.gateway.brain_rpc.conftest import make_auth, make_request
+
+
+@pytest.mark.asyncio
+async def test_brain_ping(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", params={"echo": "hi"})
+    )
+    assert res["ok"] is True
+    assert res["type"] == "brain_rpc_result"
+    assert res["contract_version"] == 1
+    assert res["result"]["pong"] is True
+    assert res["result"]["echo"] == "hi"
+    assert res["result"]["instance_id"] == "inst_test"
+    assert res["meta"]["hermes_profile"] == "contributor"
+
+
+@pytest.mark.asyncio
+async def test_brain_ping_echo_too_long(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", params={"echo": "x" * 65})
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == "invalid_argument"
+
+
+@pytest.mark.asyncio
+async def test_brain_health(dispatcher, vault_root):
+    res = await dispatcher.handle(make_request("brain.health"))
+    assert res["ok"] is True
+    assert res["result"]["status"] in {"ok", "degraded", "unavailable"}
+    assert res["result"]["checks"]["vault_root_readable"] is True
+    assert res["result"]["profile"] == "contributor"
+    assert res["result"]["versions"]["brain_rpc"] == 1
+
+
+@pytest.mark.asyncio
+async def test_vault_list(dispatcher):
+    res = await dispatcher.handle(
+        make_request("vault.list", params={"path": "/Projects/Legal", "limit": 50})
+    )
+    assert res["ok"] is True
+    names = {e["name"] for e in res["result"]["entries"]}
+    assert "memo.md" in names
+    assert "exhibits" in names
+    for e in res["result"]["entries"]:
+        assert "content" not in e
+        assert e["kind"] in {"file", "directory"}
+
+
+@pytest.mark.asyncio
+async def test_vault_list_pagination(dispatcher):
+    res1 = await dispatcher.handle(
+        make_request("vault.list", params={"path": "/Projects/Legal", "limit": 1})
+    )
+    assert res1["ok"] is True
+    assert len(res1["result"]["entries"]) == 1
+    assert res1["result"]["truncated"] is True
+    cursor = res1["result"]["next_cursor"]
+    res2 = await dispatcher.handle(
+        make_request(
+            "vault.list",
+            params={"path": "/Projects/Legal", "limit": 1, "cursor": cursor},
+        )
+    )
+    assert res2["ok"] is True
+    assert len(res2["result"]["entries"]) == 1
+    assert res1["result"]["entries"][0]["name"] != res2["result"]["entries"][0]["name"]
+
+
+@pytest.mark.asyncio
+async def test_vault_stat(dispatcher):
+    res = await dispatcher.handle(
+        make_request("vault.stat", params={"path": "/Projects/Legal/memo.md"})
+    )
+    assert res["ok"] is True
+    assert res["result"]["kind"] == "file"
+    assert res["result"]["name"] == "memo.md"
+    assert res["result"]["size_bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_vault_stat_not_found(dispatcher):
+    res = await dispatcher.handle(
+        make_request("vault.stat", params={"path": "/Projects/Legal/missing.md"})
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_vault_read(dispatcher):
+    res = await dispatcher.handle(
+        make_request("vault.read", params={"path": "/Projects/Legal/memo.md"})
+    )
+    assert res["ok"] is True
+    assert res["result"]["encoding"] == "utf-8"
+    assert "Memo" in res["result"]["content"]
+    assert res["result"]["kind"] == "file"
+
+
+@pytest.mark.asyncio
+async def test_vault_read_payload_too_large(dispatcher, vault_root):
+    big = vault_root / "Projects" / "Legal" / "big.bin"
+    big.write_bytes(b"x" * 200)
+    res = await dispatcher.handle(
+        make_request(
+            "vault.read",
+            params={"path": "/Projects/Legal/big.bin", "max_bytes": 50},
+        )
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_vault_read_directory_invalid(dispatcher):
+    res = await dispatcher.handle(
+        make_request("vault.read", params={"path": "/Projects/Legal"})
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == "invalid_argument"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_read_secrets(dispatcher):
+    res = await dispatcher.handle(
+        make_request(
+            "vault.read",
+            params={"path": "/Secrets/keys.txt"},
+            auth=make_auth(profile="admin", path_prefixes=[]),
+        )
+    )
+    assert res["ok"] is True
+    assert res["result"]["content"] == "do-not-read"
+
+
+@pytest.mark.asyncio
+async def test_settings_snapshot_redacts_secrets(dispatcher, tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  model: test-model\n"
+        "mcp_servers:\n  demo:\n    transport: stdio\n"
+        "    env:\n      API_KEY: super-secret\n"
+        "    api_key: should-not-appear\n",
+        encoding="utf-8",
+    )
+    skills = home / "skills" / "demo-skill"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    res = await dispatcher.handle(make_request("settings.snapshot"))
+    assert res["ok"] is True
+    blob = json.dumps(res["result"])
+    assert "super-secret" not in blob
+    assert "should-not-appear" not in blob
+    assert "api_key" not in blob
+    assert res["result"]["source"] == "hermes"
+    assert any(s["id"] == "demo-skill" for s in res["result"]["skills"])
+    assert any(m["model"] == "test-model" for m in res["result"]["models"])
+    assert any(s["name"] == "demo" for s in res["result"]["mcp_servers"])
+
+
+@pytest.mark.asyncio
+async def test_projects_list_missing_db(dispatcher, tmp_path, monkeypatch):
+    home = tmp_path / "empty_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    res = await dispatcher.handle(make_request("projects.list"))
+    assert res["ok"] is True
+    assert res["result"]["projects"] == []
+    assert res["result"]["source"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_projects_list_with_db(dispatcher, tmp_path, monkeypatch):
+    home = tmp_path / "proj_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = home / "projects.db"
+    with connect_closing(db_path=db) as conn:
+        create_project(
+            conn,
+            name="Legal",
+            slug="legal",
+            folders=["/Projects/Legal"],
+            primary_path="/Projects/Legal",
+        )
+    res = await dispatcher.handle(make_request("projects.list"))
+    assert res["ok"] is True
+    assert res["result"]["source"] == "hermes_projects_db"
+    assert len(res["result"]["projects"]) == 1
+    assert res["result"]["projects"][0]["slug"] == "legal"
+
+
+@pytest.mark.asyncio
+async def test_method_not_found(dispatcher):
+    res = await dispatcher.handle(make_request("vault.write"))
+    assert res["ok"] is False
+    assert res["error"]["code"] == "method_not_found"
+
+
+@pytest.mark.asyncio
+async def test_version_unsupported(dispatcher):
+    res = await dispatcher.handle(
+        make_request("brain.ping", contract_version=99)
+    )
+    assert res["ok"] is False
+    assert res["error"]["code"] == "version_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_disabled_feature_gate(dispatcher, monkeypatch):
+    monkeypatch.setenv("BRAIN_RPC_ENABLED", "0")
+    res = await dispatcher.handle(make_request("brain.ping"))
+    assert res["ok"] is False
+    assert res["error"]["code"] == "unavailable"

--- a/tests/gateway/brain_rpc/test_ws_transport_brain_rpc.py
+++ b/tests/gateway/brain_rpc/test_ws_transport_brain_rpc.py
@@ -1,0 +1,108 @@
+"""Integration: brain_rpc_request over WebSocketRelayTransport (in-process WS)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from gateway.relay.ws_transport import WEBSOCKETS_AVAILABLE, WebSocketRelayTransport
+from tests.gateway.brain_rpc.conftest import make_request
+
+pytestmark = pytest.mark.skipif(not WEBSOCKETS_AVAILABLE, reason="websockets not installed")
+
+if WEBSOCKETS_AVAILABLE:
+    import websockets
+
+
+DESCRIPTOR = {
+    "contract_version": 1,
+    "platform": "lanyard_web",
+    "label": "Lanyard",
+    "max_message_length": 4000,
+    "supports_draft_streaming": False,
+    "supports_edit": False,
+    "supports_threads": False,
+    "markdown_dialect": "markdown",
+    "len_unit": "chars",
+}
+
+
+class _BrainRpcConnector:
+    """Connector stub that pushes one brain_rpc_request after hello."""
+
+    def __init__(self, request_frame: dict):
+        self.received: list[dict] = []
+        self._request = request_frame
+        self._server = None
+        self.url = ""
+        self.result: dict | None = None
+        self._result_event = asyncio.Event()
+
+    async def start(self):
+        self._server = await websockets.serve(self._handle, "127.0.0.1", 0)
+        sock = next(iter(self._server.sockets))
+        port = sock.getsockname()[1]
+        self.url = f"ws://127.0.0.1:{port}"
+
+    async def stop(self):
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(self, ws):
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                frame = json.loads(line)
+                self.received.append(frame)
+                ftype = frame.get("type")
+                if ftype == "hello":
+                    await ws.send(
+                        json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n"
+                    )
+                    await ws.send(json.dumps(self._request) + "\n")
+                elif ftype == "brain_rpc_result":
+                    self.result = frame
+                    self._result_event.set()
+
+
+@pytest.mark.asyncio
+async def test_ws_transport_brain_rpc_roundtrip(
+    vault_root: Path, profiles_dir: Path, monkeypatch
+):
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    monkeypatch.setenv("BRAIN_PROFILES_DIR", str(profiles_dir))
+    monkeypatch.setenv("GATEWAY_RELAY_INSTANCE_ID", "inst_test")
+    monkeypatch.setenv("BRAIN_TENANT_ID", "ten_test")
+    monkeypatch.setenv("BRAIN_RPC_ENABLED", "1")
+
+    # Reload host config for the process-wide dispatcher.
+    from gateway.brain_rpc.dispatcher import reset_default_dispatcher
+
+    reset_default_dispatcher()
+
+    req = make_request("brain.ping", params={"echo": "ws"}, request_id="ws_req_1")
+    srv = _BrainRpcConnector(req)
+    await srv.start()
+    try:
+        t = WebSocketRelayTransport(srv.url, "lanyard_web", "bot1")
+        await t.connect()
+        try:
+            await t.handshake()
+            await asyncio.wait_for(srv._result_event.wait(), timeout=5.0)
+        finally:
+            await t.disconnect()
+    finally:
+        await srv.stop()
+
+    assert srv.result is not None
+    assert srv.result["type"] == "brain_rpc_result"
+    assert srv.result["request_id"] == "ws_req_1"
+    assert srv.result["ok"] is True
+    assert srv.result["result"]["pong"] is True
+    assert srv.result["result"]["echo"] == "ws"


### PR DESCRIPTION
## Summary

Implements **Hermes host-side Brain RPC handlers (G3.2 MVP)** per the company-brain-deploy contract.

- Accept `brain_rpc_request` / emit `brain_rpc_result` on the authenticated relay WebSocket (no public inbound host port)
- MVP methods: `brain.ping`, `brain.health`, `vault.list`, `vault.stat`, `vault.read` (size-capped), `settings.snapshot` (redacted), `projects.list`
- Fail-closed auth: expired auth, tenant/instance binding, host profile capabilities, path_prefixes ACL, path escape rejection
- Feature gate: `BRAIN_RPC_ENABLED` (default on)
- Doc: `docs/lanyard-brain-rpc.md` → deploy contract

**Not in scope:** G3.3 Portal slice, Terraform/deploy modules, vault writes, claiming G3 production-ready.

Contract: https://github.com/LanyardBrain/company-brain-deploy/blob/main/references/brain-rpc-contract.md

## Acceptance checklist

- [x] MVP handlers for agreed methods
- [x] Auth verification (fail-closed)
- [x] Unit/integration tests (tmp vault fixtures; no network required)
- [x] Wire on relay session (`gateway/relay/ws_transport.py`)
- [x] Short host doc `docs/lanyard-brain-rpc.md`

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/brain_rpc/ -q` — 29 passed
- [ ] CI green on PR
- Manual (optional): with relay configured + `VAULT_ROOT` set, push a `brain_rpc_request` frame and confirm `brain_rpc_result`

Bead: cbd-hhj.6.2 (G3.2)