### PR TITLE
perf(session-search): skip unused context enrichment

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -353,6 +353,14 @@ async def search_sessions(
                 source_filter=include_sources,
                 exclude_sources=exclude_list or None,
                 limit=fetch_limit,
+                fields=(
+                    "session_id",
+                    "role",
+                    "snippet",
+                    "source",
+                    "model",
+                    "session_started",
+                ),
             )
 
             for m in matches:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -14,7 +14,7 @@ import os
 import re
 import sqlite3
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Collection, Dict, List, Optional, Tuple
 
 from agent.skill_commands import describe_skill_invocation
 from hermes_state_common import (
@@ -34,6 +34,36 @@ logger = logging.getLogger("hermes_state")
 
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
+
+    _SEARCH_MESSAGE_RESULT_FIELDS = (
+        "id",
+        "session_id",
+        "role",
+        "snippet",
+        "timestamp",
+        "tool_name",
+        "source",
+        "model",
+        "session_started",
+        "context",
+    )
+
+    @classmethod
+    def _search_message_fields(
+        cls, fields: Optional[Collection[str]]
+    ) -> Optional[Tuple[str, ...]]:
+        """Validate and canonically order an optional result projection."""
+        if fields is None:
+            return None
+        if isinstance(fields, str):
+            raise TypeError("search fields must be a collection of field names, not a string")
+        requested = set(fields)
+        unknown = requested.difference(cls._SEARCH_MESSAGE_RESULT_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown search result field(s): {', '.join(sorted(unknown))}")
+        return tuple(
+            field for field in cls._SEARCH_MESSAGE_RESULT_FIELDS if field in requested
+        )
 
     def _try_incremental_merge_fts(self) -> None:
         """Run one bounded FTS5 merge pass without failing the completed write."""
@@ -1274,6 +1304,7 @@ class SessionSearchMixin:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        fields: Optional[Collection[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1295,6 +1326,7 @@ class SessionSearchMixin:
                 offset=offset,
                 sort=sort,
                 include_inactive=include_inactive,
+                fields=fields,
             )
             return rows
         finally:
@@ -1344,6 +1376,7 @@ class SessionSearchMixin:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        fields: Optional[Collection[str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1356,6 +1389,9 @@ class SessionSearchMixin:
 
         Returns matching messages with session metadata, content snippet,
         and surrounding context (1 message before and after the match).
+        ``fields`` selects a result projection; omitting it preserves the
+        complete legacy result. Context is only loaded when that projection
+        consumes it.
 
         ``sort`` controls temporal ordering:
           - ``None`` (default): FTS5 BM25 relevance only. Time-neutral.
@@ -1373,6 +1409,8 @@ class SessionSearchMixin:
         pre-compaction transcript stays discoverable after in-place compaction
         (#38763). Pass ``include_inactive=True`` to search every row regardless.
         """
+        result_fields = self._search_message_fields(fields)
+
         if not self._fts_enabled:
             return []
 
@@ -1458,6 +1496,7 @@ class SessionSearchMixin:
         # (indexed substring matching with ranking and snippets).  For shorter
         # CJK queries (1-2 chars), trigram can't match (it needs ≥9 UTF-8
         # bytes = 3 CJK chars), so we fall back to LIKE.
+        matches: List[Dict[str, Any]] = []
         is_cjk = self._contains_cjk(query)
         if is_cjk:
             raw_query = query.strip('"').strip()
@@ -1821,10 +1860,14 @@ class SessionSearchMixin:
                 if tri_matches:
                     matches = tri_matches
 
-        # Add surrounding context (1 message before + after each match).
-        # Each query takes its own fresh read transaction via _read_ctx, so
-        # we never hold a lock across N sequential queries.
-        for match in matches:
+        # Add surrounding context (1 message before + after each match) only
+        # when the selected result projection consumes it. Each query takes
+        # its own fresh read transaction via _read_ctx, so we never hold a
+        # lock across N sequential queries.
+        context_matches = (
+            matches if result_fields is None or "context" in result_fields else ()
+        )
+        for match in context_matches:
             try:
                 with self._read_ctx() as conn:
                     ctx_cursor = conn.execute(
@@ -1887,6 +1930,12 @@ class SessionSearchMixin:
         # Remove full content from result (snippet is enough, saves tokens)
         for match in matches:
             match.pop("content", None)
+
+        if result_fields is not None:
+            matches = [
+                {field: match[field] for field in result_fields if field in match}
+                for match in matches
+            ]
 
         return matches
 

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -14,6 +14,7 @@ class _FakeSessionDB:
 
     closed = False
     opened_read_only = None
+    requested_fields = None
 
     def __init__(self, *args, **kwargs):
         type(self).opened_read_only = kwargs.get("read_only")
@@ -57,8 +58,16 @@ class _FakeSessionDB:
             )
         ][:limit]
 
-    def search_messages(self, query, source_filter=None, exclude_sources=None, limit=20):
+    def search_messages(
+        self,
+        query,
+        source_filter=None,
+        exclude_sources=None,
+        limit=20,
+        fields=None,
+    ):
         assert query == "20260603*"
+        type(self).requested_fields = fields
         rows = [
             {
                 "session_id": "20260603_090200_exact",
@@ -98,10 +107,13 @@ class _FakeSessionDB:
 
 def test_desktop_session_search_merges_id_matches_before_content_matches(monkeypatch):
     _FakeSessionDB.opened_read_only = None
+    _FakeSessionDB.requested_fields = None
     monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
 
     response = asyncio.run(web_server.search_sessions(q="20260603", limit=2))
 
+    assert _FakeSessionDB.requested_fields is not None
+    assert "context" not in _FakeSessionDB.requested_fields
     # ID match surfaces first; the content hit on the SAME session is deduped
     # by lineage root (not double-listed); the unrelated content hit follows.
     assert response == {

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -655,8 +655,26 @@ class TestFTS5Search:
         assert isinstance(results[0]["context"], list)
         assert len(results[0]["context"]) > 0
 
+    def test_search_fields_project_results_without_changing_default(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Tell me about Kubernetes")
+        db.append_message("s1", role="assistant", content="Kubernetes is an orchestrator.")
 
+        projected = db.search_messages(
+            "Kubernetes", fields=("session_id", "role", "snippet")
+        )
+        default = db.search_messages("Kubernetes")
 
+        assert len(projected) == len(default) == 2
+        assert all(set(row) == {"session_id", "role", "snippet"} for row in projected)
+        assert [
+            (row["session_id"], row["role"], row["snippet"])
+            for row in projected
+        ] == [
+            (row["session_id"], row["role"], row["snippet"])
+            for row in default
+        ]
+        assert all("context" in row and row["context"] for row in default)
 
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -676,9 +676,45 @@ class TestFTS5Search:
         ]
         assert all("context" in row and row["context"] for row in default)
 
+    def test_search_projection_skips_context_enrichment_queries(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="before")
+        db.append_message("s1", role="assistant", content="projectionneedle")
+        db.append_message("s1", role="user", content="after")
 
+        statements = []
+        read_conn = db._get_read_conn() or db._conn
+        traced_connections = [db._conn]
+        if read_conn is not db._conn:
+            traced_connections.append(read_conn)
+        for conn in traced_connections:
+            conn.set_trace_callback(statements.append)
 
+        def context_query_count():
+            normalized = (" ".join(sql.upper().split()) for sql in statements)
+            return sum("WITH TARGET AS (" in sql for sql in normalized)
 
+        try:
+            projected = db.search_messages(
+                "projectionneedle", fields=("session_id", "snippet")
+            )
+            assert len(projected) == 1
+            assert context_query_count() == 0
+
+            full = db.search_messages(
+                "projectionneedle", fields=("session_id", "context")
+            )
+            assert len(full) == 1
+            assert full[0]["context"]
+            assert context_query_count() == 1
+
+            default = db.search_messages("projectionneedle")
+            assert len(default) == 1
+            assert default[0]["context"]
+            assert context_query_count() == 2
+        finally:
+            for conn in traced_connections:
+                conn.set_trace_callback(None)
 
     def test_sanitize_fts5_query_strips_dangerous_chars(self):
         """Unit test for _sanitize_fts5_query static method."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -113,6 +113,29 @@ class TestBrowseShape:
 # =========================================================================
 
 class TestDiscoveryShape:
+    def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
+        _seed_modpack_sessions(db)
+        original = db.search_messages
+        requested_fields = None
+
+        def search_spy(*args, **kwargs):
+            nonlocal requested_fields
+            requested_fields = kwargs.get("fields")
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(db, "search_messages", search_spy)
+
+        result = json.loads(session_search(query="modpack", limit=1, db=db))
+
+        assert result["success"] is True
+        assert requested_fields is not None
+        assert "context" not in requested_fields
+        assert len(result["results"]) == 1
+        hit = result["results"][0]
+        assert "bookend_start" in hit
+        assert hit["messages"]
+        assert "bookend_end" in hit
+
     def test_discovery_result_has_bookends_and_window(self, db):
         _seed_modpack_sessions(db)
         result = json.loads(session_search(query="modpack", limit=3, db=db))

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -55,6 +55,18 @@ _DEMOTED_SESSION_SOURCES = ("cron",)
 # the handful of distinct sessions a typical query returns.
 _DISCOVER_SCAN_LIMIT = 300
 
+# Raw FTS rows are only a discovery-plan input. The final response hydrates
+# its own anchored message window and bookends after lineage deduplication.
+_DISCOVER_SEARCH_FIELDS = (
+    "id",
+    "session_id",
+    "role",
+    "snippet",
+    "source",
+    "model",
+    "session_started",
+)
+
 # Prefixes that identify generated context-compaction handoff summaries.
 # These are inserted by agent/context_compressor.py as normal user/assistant
 # messages but contain machine-generated summary metadata — not user content.
@@ -693,6 +705,7 @@ def _discover(
             # of cron rows are still in hand for the demotion pass below.
             offset=0,
             sort=sort,
+            fields=_DISCOVER_SEARCH_FIELDS,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)


### PR DESCRIPTION
## What does this PR do?

Ports the session-search performance change onto base `fed48cf5b032304e0ef48338af9e324c8fd7423c` using the current fielded-retrieval ownership boundaries.

`SessionDB.search_messages()` now accepts an optional result projection. Calls that omit `fields` retain the complete legacy result, including per-hit surrounding `context`. Calls that request only raw discovery/dashboard fields skip context enrichment before projection. Discovery still hydrates its authoritative anchored window and bookends after lineage deduplication, so the public `session_search` result remains full.

The live dashboard endpoint is owned by `hermes_cli/web_routers/sessions.py`; `hermes_cli/web_server.py` only mounts and re-exports that handler, so no `web_server.py` edit is required.

The final exact SHA `b32fc73297ebcca2e3e062949ce2336522ff5b5a` received independent **Spec PASS** followed by **Standards PASS**. Immediately before publication, current `main` had no overlap with the six changed paths and `git merge-tree` remained conflict-free, so the reviewed fixed-base candidate was retained without another rebase.

## Related Issue

Existing PR #63389. No new issue linkage is asserted by this local repair.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Performance change with backward-compatible API behavior.

## Changes Made

- `hermes_state_search.py`
  - adds validated, canonically ordered `fields` projection support;
  - preserves the full/default response when `fields` is omitted;
  - runs per-hit context enrichment only when the selected result consumes `context`.
- `tools/session_search_tool.py`
  - requests only raw FTS fields used for ranking, lineage deduplication, and metadata fallback;
  - continues to build anchored messages and bookends through `get_anchored_view()`.
- `hermes_cli/web_routers/sessions.py`
  - requests only fields consumed by the dashboard session-search response.
- `tests/test_hermes_state.py`
  - covers compact projection, value parity, and unchanged rich default results;
  - traces real SQLite statements to prove a projection without `context` performs zero context-enrichment queries, while an explicit full projection and the default result perform exactly one per matching row.
- `tests/tools/test_session_search.py`
  - verifies discovery omits raw context while retaining bookends/messages.
- `tests/hermes_cli/test_web_server_session_search.py`
  - verifies the dashboard route requests a projection without context.

## Contract Verification

An isolated archive of exact base `fed48cf5b032304e0ef48338af9e324c8fd7423c` and the candidate were run in separate Python processes against byte-identical copies of one seeded SQLite DB (`sha256 dd91ee69b8985b7b8047e7b598ec93a0ddb42538cedd2ae5e2b24c29666fd028`).

Verified exact equality for:

- base default/full rows vs candidate default/full rows, including populated `context`;
- candidate projected rows vs the same fields selected from base rows;
- base vs candidate discovery payloads, including `bookend_start`, anchored `messages`, and `bookend_end` shape;
- base vs candidate dashboard search payloads.

Semantic artifact: `/tmp/hermes-pr-63389-benchmark/semantic-summary.json`.

Mutation proof: the focused trace test was run against a disposable mutation that restored unconditional context enrichment at `hermes_state_search.py:1604-1606`. It failed at the projected-call assertion with `assert 1 == 0`; after restoring production, the same test passed. `hermes_state_search.py` was restored byte-identically (`sha256 42ae10dd4e79b891360598ff7f65315922cab7e806a432afb500f1aa232d96ec`). The benchmark contract and artifacts are unchanged.

## Benchmark

Dataset and query:

- 80 deterministic sessions / 640 messages;
- query `projectorneedle`, result limit 300;
- exact base archive vs candidate projection;
- two rounds per implementation, ordered base → candidate → candidate → base;
- each round: 5 warmups + 25 measured iterations (50 measured iterations per side);
- result signature identical: `98bcc514813f4155b46f81f8ecb9f10be527198991c65db53fa7876c625ea8bb`.

| | median | p95 | context calls / iteration | context rows / iteration |
|---|---:|---:|---:|---:|
| Exact base | 4.024 ms | 4.222 ms | 300 | 825 |
| Candidate projection | 1.160 ms | 1.567 ms | 0 | 0 |

Observed local reduction: 71.2% median and 62.9% p95 (3.47× and 2.69× respectively). Wall time is machine-specific supporting evidence; eliminating 300 enrichment calls / 825 context rows per retrieval is the deterministic mechanism evidence. One candidate sample reached 4.164 ms, so the full measured distribution is retained in the artifact rather than hidden.

Benchmark harness and results:

- `/tmp/hermes-pr-63389_benchmark.py`
- `/tmp/hermes-pr-63389-benchmark/benchmark-summary.json`
- `/tmp/hermes-pr-63389-benchmark/{base-1,base-2,candidate-1,candidate-2}.json`

Representative commands:

```bash
git archive fed48cf5b032304e0ef48338af9e324c8fd7423c | tar -x -C /tmp/hermes-pr-63389-benchmark/base-fed48cf5b032304e0ef48338af9e324c8fd7423c
.venv/bin/python /tmp/hermes-pr-63389_benchmark.py seed \
  --source "$PWD" --db /tmp/hermes-pr-63389-benchmark/seed.db
.venv/bin/python /tmp/hermes-pr-63389_benchmark.py bench \
  --source /tmp/hermes-pr-63389-benchmark/base-fed48cf5b032304e0ef48338af9e324c8fd7423c \
  --db /tmp/hermes-pr-63389-benchmark/base-1.db --warmup 5 --iterations 25
.venv/bin/python /tmp/hermes-pr-63389_benchmark.py bench \
  --source "$PWD" --db /tmp/hermes-pr-63389-benchmark/candidate-1.db \
  --projection --warmup 5 --iterations 25
```

## How to Test

```bash
uv sync --frozen --extra all --extra dev

HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/test_hermes_state.py \
  tests/tools/test_session_search.py \
  tests/hermes_cli/test_web_server_session_search.py \
  tests/test_search_slow_query_log.py \
  -q
# 183 passed in 6.2s

HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/test_search_slow_query_log.py -q
# 5 passed in 0.3s

env -u PYTHONPATH -u VIRTUAL_ENV .venv/bin/ruff check \
  hermes_state_search.py \
  tools/session_search_tool.py \
  hermes_cli/web_routers/sessions.py \
  tests/test_hermes_state.py \
  tests/tools/test_session_search.py \
  tests/hermes_cli/test_web_server_session_search.py \
  tests/test_search_slow_query_log.py
# All checks passed!

git diff --check fed48cf5b032304e0ef48338af9e324c8fd7423c..HEAD
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [ ] Duplicate search — not repeated during this fixed-base, no-fetch local repair of existing PR #63389
- [x] My PR contains only changes related to this performance port
- [ ] Full `pytest tests/ -q` — not run; the focused 183-test session-search gate passed
- [x] I've added tests for the projection/default/discovery/dashboard contracts, including mutation-sensitive SQLite enrichment counts
- [x] I've tested on Linux 7.1.5-1-cachyos, Python 3.13.11, SQLite 3.50.4

### Documentation & Housekeeping

- [x] Documentation N/A — behavior is documented in the method docstring and this PR body
- [x] `cli-config.yaml.example` N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no workflow or architecture change
- [x] Cross-platform impact considered — Python/SQLite-only projection logic, no platform-specific path
- [x] Tool descriptions/schemas N/A — public `session_search` schema and full result shape are unchanged

## Screenshots / Logs

No UI change. Local SQLite 3.50.4 emitted the repository's WAL-reset warning and used `journal_mode=DELETE`; both exact-base and candidate runs used the same runtime and byte-identical seeded inputs. No push, PR edit, or GitHub mutation was performed.
