### PR TITLE
fix(voice): add timeout to proc.wait() after kill in _play_system_audio

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1106,7 +1106,7 @@ def play_audio_file(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                proc.wait(timeout=10)
                 with _playback_lock:
                     _active_playback = None
             except Exception as e:


### PR DESCRIPTION
## Summary

Add a 10-second timeout to the proc.wait() call after proc.kill() in _play_system_audio, preventing a potential permanent hang.

## Problem

After killing a timed-out audio player process, the bare proc.wait() at tools/voice_mode.py:1109 has no timeout. If the killed process is stuck in D-state (e.g. NFS mount, zombie), the wait blocks forever, freezing the agent turn.

## Fix

Added timeout=10 to the post-kill proc.wait(). 10 seconds is ample for a SIGKILL-ed process to be reaped by the kernel.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: wait() now raises TimeoutExpired instead of hanging indefinitely if the process doesn't exit after kill