### PR TITLE
fix(desktop): rebuild node-pty for Electron when no prebuild covers the target

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,7 @@
     "profile:main:cpu": "wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
     "prebuild": "tsc -b . --clean",
-    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
+    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/ensure-node-pty-electron.mjs && node scripts/stage-native-deps.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",

--- a/apps/desktop/scripts/ensure-node-pty-electron.mjs
+++ b/apps/desktop/scripts/ensure-node-pty-electron.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// ensure-node-pty-electron.mjs — makes sure node-pty has a native binary
+// that Electron can actually load before stage-native-deps copies it.
+//
+// node-pty publishes no linux prebuild, and even when its install script
+// is allowed to run it compiles against the host Node ABI — which Electron
+// refuses to load. This script rebuilds node-pty against the workspace's
+// Electron version, but only when needed:
+//   - a published prebuild exists for the host platform/arch → skip
+//   - build/Release/pty.node exists and our stamp says it was already
+//     rebuilt for this Electron version → skip
+//   - otherwise → run @electron/rebuild -w node-pty and write the stamp
+//
+// The stamp lives inside build/Release so a fresh `npm ci` (which wipes
+// node_modules, and whose install script produces a Node-ABI binary with
+// no stamp) always triggers a rebuild.
+
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, join } from 'node:path'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { isMain } from './utils.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(here, '..')
+const require = createRequire(import.meta.url)
+
+const STAMP_NAME = '.hermes-electron-abi'
+
+function resolvePkgRoot(name) {
+  return dirname(require.resolve(`${name}/package.json`, { paths: [projectRoot] }))
+}
+
+export function ensureNodePtyForElectron() {
+  const ptyRoot = resolvePkgRoot('node-pty')
+  const target = `${process.platform}-${process.arch}`
+
+  // A published prebuild for the host target loads fine in Electron
+  // (they're built with the NAPI/Electron matrix upstream) — nothing to do.
+  if (existsSync(join(ptyRoot, 'prebuilds', target))) {
+    console.log(`[ensure-node-pty] prebuild exists for ${target}; no rebuild needed`)
+    return
+  }
+
+  const electronVersion = require(
+    require.resolve('electron/package.json', { paths: [projectRoot] })
+  ).version
+
+  const releaseDir = join(ptyRoot, 'build/Release')
+  const stampPath = join(releaseDir, STAMP_NAME)
+  if (existsSync(join(releaseDir, 'pty.node')) && existsSync(stampPath)) {
+    const stamped = readFileSync(stampPath, 'utf8').trim()
+    if (stamped === electronVersion) {
+      console.log(`[ensure-node-pty] pty.node already built for Electron ${electronVersion}`)
+      return
+    }
+  }
+
+  console.log(
+    `[ensure-node-pty] no ${target} prebuild and no Electron-ABI build; ` +
+      `rebuilding node-pty for Electron ${electronVersion}...`
+  )
+  // @electron/rebuild's exports expose only its entry point (lib/main.js);
+  // the CLI is a sibling file in the same directory.
+  const rebuildCli = join(
+    dirname(require.resolve('@electron/rebuild', { paths: [projectRoot] })),
+    'cli.js'
+  )
+  const result = spawnSync(
+    process.execPath,
+    [rebuildCli, '-v', electronVersion, '-w', 'node-pty', '-m', projectRoot],
+    { cwd: projectRoot, stdio: 'inherit' }
+  )
+  if (result.status !== 0) {
+    console.error('[ensure-node-pty] electron-rebuild failed; the packaged app would crash on launch')
+    process.exit(result.status ?? 1)
+  }
+  if (!existsSync(join(releaseDir, 'pty.node'))) {
+    console.error(`[ensure-node-pty] rebuild reported success but ${join(releaseDir, 'pty.node')} is missing`)
+    process.exit(1)
+  }
+  writeFileSync(stampPath, `${electronVersion}\n`)
+  console.log(`[ensure-node-pty] rebuilt pty.node for Electron ${electronVersion}`)
+}
+
+if (isMain(import.meta.url)) {
+  ensureNodePtyForElectron()
+}

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -117,12 +117,12 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
       }
     }
-  } else {
+  } else if (!existsSync(join(destRoot, 'build/Release/pty.node'))) {
     console.warn(
-      `[stage-native-deps] no prebuild found at prebuilds/${platform}-${arch} for node-pty. ` +
-        `If build/Release/* above is also empty, this target will fail at runtime. ` +
-        `Run "npx electron-rebuild -w node-pty" for this target, or check that ` +
-        `node-pty's published prebuilds cover ${platform}-${arch}.`
+      `[stage-native-deps] no prebuild found at prebuilds/${platform}-${arch} for node-pty ` +
+        `and build/Release is empty — this target will fail at runtime. ` +
+        `Run "node scripts/ensure-node-pty-electron.mjs" (or "npx electron-rebuild -w node-pty") ` +
+        `for this target, or check that node-pty's published prebuilds cover ${platform}-${arch}.`
     )
   }
 

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "allowScripts": {
+    "node-pty@1.1.0": true
   }
 }


### PR DESCRIPTION
## Problem

On Linux, the packaged desktop app crashes at launch:

```
Error: Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64
```

node-pty publishes prebuilds for darwin/win32 but **not linux**, and its compile-on-install script is blocked by the workspace `allowScripts` policy — so Linux packs ship node-pty with no native binary at all. `stage-native-deps.mjs` already warns about this, but the build still succeeds and the app crashes at runtime.

Even with the install script approved, `node-gyp rebuild` compiles against the host **Node** ABI, which Electron refuses to load ("compiled against a different Node.js version").

## Fix

- **New `apps/desktop/scripts/ensure-node-pty-electron.mjs`**, wired into the desktop `build` script ahead of `stage-native-deps.mjs`. It's a no-op when a published prebuild exists for the host platform/arch, or when `build/Release/pty.node` was already rebuilt for the current Electron version (tracked via a stamp file in `build/Release`, so a fresh `npm ci` always retriggers). Otherwise it runs `@electron/rebuild -w node-pty` against the workspace's Electron version and fails the build loudly if that doesn't produce `pty.node`.
- **Approve node-pty's install script** in the root `allowScripts`.
- **`stage-native-deps.mjs`**: only warn about a missing prebuild when `build/Release/pty.node` is also missing, so healthy Linux builds don't print a scary warning.

## Verification

- `ensure-node-pty-electron.mjs` rebuilds on first run, no-ops on the second (stamp match).
- Full `hermes desktop` pack on Fedora 44 (linux-x64, Electron 40.10.2): `pty.node` lands in `app.asar.unpacked`, and the packaged Electron loads node-pty and spawns a PTY successfully.
- Packaged app launches and runs; the previous main-process crash is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)