### PR TITLE
fix(state): add REINDEX strategy to repair stale B-tree indexes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -647,6 +647,29 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db FTS in-place rebuild pass failed: %s", exc)
 
+    # ── Strategy 0.5: rebuild stale B-tree indexes (#63386) ──
+    # PRAGMA integrity_check can report "wrong # of entries in index" when a
+    # B-tree index (e.g. idx_sessions_handoff_state) falls out of sync with its
+    # base table. REINDEX rewrites the index b-tree from the canonical table
+    # rows using the existing index definition, fixing the mismatch without
+    # touching data or FTS schema.
+    try:
+        conn = sqlite3.connect(str(db_path), isolation_level=None)
+        try:
+            conn.execute("REINDEX")
+            conn.commit()
+        finally:
+            conn.close()
+        if _db_opens_cleanly(db_path) is None:
+            report["repaired"] = True
+            report["strategy"] = "reindex_btree"
+            logger.warning(
+                "state.db B-tree indexes rebuilt via REINDEX: %s", db_path
+            )
+            return report
+    except sqlite3.DatabaseError as exc:
+        logger.warning("state.db REINDEX pass failed: %s", exc)
+
     # ── Strategy 1: de-duplicate sqlite_master (keeps FTS index) ──
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -333,6 +333,35 @@ def test_repair_noop_db_uses_already_healthy_shortcut(tmp_path):
     assert report["strategy"] == "already_healthy"
 
 
+def test_repair_rebuilds_stale_btree_indexes(tmp_path, monkeypatch):
+    """repair_state_db_schema uses REINDEX for 'wrong # of entries in index'.
+
+    When PRAGMA integrity_check reports a stale B-tree index (e.g.
+    idx_sessions_handoff_state), the FTS-rebuild and dedup strategies don't
+    help — REINDEX rewrites the index b-tree from the canonical table rows.
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    _reason = "wrong # of entries in index idx_sessions_handoff_state"
+    _call_count = {"n": 0}
+    _real_check = hermes_state._db_opens_cleanly
+
+    def _simulated_check(path):
+        _call_count["n"] += 1
+        # initial health check + post-Strategy-0 check report corruption;
+        # after REINDEX (Strategy 0.5) the DB is healthy.
+        if _call_count["n"] <= 2:
+            return _reason
+        return _real_check(path)
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _simulated_check)
+
+    report = repair_state_db_schema(db_path)
+    assert report["repaired"] is True
+    assert report["strategy"] == "reindex_btree"
+
+
 def test_select_cached_agent_history_prefers_longer_live_transcript():
     """Gateway guard keeps the live transcript when persisted history lags."""
     from gateway.run import _select_cached_agent_history


### PR DESCRIPTION
## What does this PR do?

Adds a REINDEX-based repair strategy to `repair_state_db_schema()` for B-tree index corruption (`PRAGMA integrity_check` reporting "wrong # of entries in index"). Previously, when a B-tree index (e.g. `idx_sessions_handoff_state`, `idx_sessions_gateway_peer`, `idx_sessions_session_key`) fell out of sync with its base table, the repair function only had FTS-focused strategies (FTS rebuild, sqlite_master dedup, drop-FTS+VACUUM) — none of which rebuild stale B-tree indexes. The new Strategy 0.5 runs `REINDEX` to rewrite the index b-tree from canonical table rows before escalating to more destructive strategies.

## Related Issue

Fixes #63386

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Added Strategy 0.5 in `repair_state_db_schema()` — runs `REINDEX` after the FTS-rebuild pass (Strategy 0) and before the sqlite_master dedup pass (Strategy 1). This rebuilds any stale B-tree indexes whose entry count diverged from the base table, which `integrity_check` surfaces as "wrong # of entries in index".
- `tests/test_state_db_malformed_repair.py`: Added `test_repair_rebuilds_stale_btree_indexes` — verifies the REINDEX strategy fires and reports `"reindex_btree"` when B-tree index corruption is detected.

## How to Test

1. Run the malformed-repair test suite: `python -m pytest tests/test_state_db_malformed_repair.py -v` — all 15 tests should pass, including the new `test_repair_rebuilds_stale_btree_indexes`.
2. The new test simulates a B-tree index corruption scenario (via `_db_opens_cleanly` returning "wrong # of entries in index"), then confirms `repair_state_db_schema` uses the `reindex_btree` strategy and reports `repaired=True`.
3. Existing tests (`test_fts_write_corruption_repaired_in_place`, `test_repair_preserves_sessions_and_messages`, etc.) still pass — the new strategy is inserted between existing strategies and does not change their behavior.

Observed result: 15 passed in 1.12s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
