### PR TITLE
fix(desktop): hide text label on prose fences

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -37,6 +37,17 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('- **Scroll wheel** - zoom')
   })
 
+  it('does not expose the text language tag when demoting closed prose fences', () => {
+    const fence = '```'
+    const input = [fence + 'text', 'First paragraph.', 'Second paragraph.', 'Third paragraph.', fence].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output.split('\n')).not.toContain('text')
+    expect(output).toContain('First paragraph.')
+    expect(output).toContain('Third paragraph.')
+  })
+
   it('drops fences around a preview-only URL block', () => {
     const fence = '```'
     const input = ['Server is back.', '', fence, 'http://localhost:8812/', fence].join('\n')

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -158,7 +158,7 @@ function extend(out: string[], lines: string[]) {
 }
 
 function pushProseFence(out: string[], indent: string, info: string, lines: string[]) {
-  if (info) {
+  if (info && info.toLowerCase() !== 'text') {
     out.push(`${indent}${info}`.trimEnd())
   }
 


### PR DESCRIPTION
## Summary

- suppress the literal `text` language label when a closed fenced block is rendered as ordinary prose
- preserve the prose content and valid code-fence behavior
- add a focused regression test for the reported Desktop rendering defect

## Validation

- `npm exec --yes vitest -- --config <temporary no-import config with desktop @ alias> run --environment node apps/desktop/src/components/assistant-ui/markdown-text.test.ts apps/desktop/src/lib/markdown-code.test.ts`
- result: 2 test files passed; 19 tests passed
- `git diff --check` passed
- branch rebased cleanly onto current upstream `main` before commit

## Scope

Changed files:

- `apps/desktop/src/lib/markdown-preprocess.ts`
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`

Linear: none provided — this is an upstream Hermes Desktop renderer defect, not Mission Control product work.

Protected systems: none. No configuration, credentials, deployment, release, installation, or provider behavior is changed.

## Follow-up

A distinct dangling/streaming fence path can still expose a standalone `text` label through separate preprocessing logic. That case is intentionally excluded from this focused fix and should be evaluated separately.
