### PR TITLE
fix(cron): keep live one-shots when running-set check fails

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -209,7 +209,13 @@ def _job_running_in_this_process(job_id: str) -> bool:
         from cron.scheduler import get_running_job_ids
         return job_id in get_running_job_ids()
     except Exception:
-        return False
+        logger.warning(
+            "Cron running-set liveness check failed for job %r; keeping the "
+            "entry to avoid deleting a possibly live one-shot run",
+            job_id,
+            exc_info=True,
+        )
+        return True
 
 
 def _jobs_lock_file() -> Path:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1147,6 +1147,39 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("inflight") is None  # stale entry cleaned up
 
+    def test_stale_maxed_oneshot_kept_when_running_check_errors(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """If the running-set lookup fails, do not delete a possibly live run.
+
+        This is the fail-closed sibling of #62002/#62014: the liveness check is
+        the only signal distinguishing "expired but live" from "stale and dead".
+        Treating a lookup error as "not running" reopens the data-loss path by
+        deleting the job record underneath an in-flight one-shot.
+        """
+        import cron.scheduler as scheduler_mod
+        from cron.jobs import _hermes_now, _oneshot_run_claim_ttl_seconds
+
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        ttl = _oneshot_run_claim_ttl_seconds()
+        t0 = _hermes_now()
+        run_at = (t0 - timedelta(seconds=ttl + 300)).isoformat()
+        save_jobs([{
+            "id": "inflight-error", "name": "flight check", "prompt": "x",
+            "schedule": {"kind": "once", "run_at": run_at},
+            "next_run_at": run_at, "enabled": True, "state": "scheduled",
+            "repeat": {"times": 1, "completed": 1},
+            "run_claim": {"at": run_at, "by": "this-machine"},
+        }])
+
+        def fail_running_set():
+            raise RuntimeError("running set unavailable")
+
+        monkeypatch.setattr(scheduler_mod, "get_running_job_ids", fail_running_set)
+
+        assert get_due_jobs() == []
+        assert get_job("inflight-error") is not None
+
     def test_run_claim_heartbeat_keeps_long_run_claimed_past_ttl(
         self, tmp_cron_dir, monkeypatch
     ):


### PR DESCRIPTION
## Summary

This makes cron's one-shot stale-entry recovery fail closed when the in-process running-set liveness check raises.

## Why

PR #62014 fixed the P1 path where `get_due_jobs()` could delete a one-shot job record while that job was still running. The guard depends on `_job_running_in_this_process()` checking `cron.scheduler.get_running_job_ids()` before removing a maxed one-shot entry.

However, `_job_running_in_this_process()` currently catches any exception from that lookup and returns `False`. That treats “running set unavailable” as “definitely not running”, so the stale-entry cleanup can still delete the job record underneath a live run. Once that happens, the in-flight run cannot land its final `mark_job_run()` outcome/delivery state.

## Changes

- Make `_job_running_in_this_process()` fail closed on lookup errors.
- Log the liveness-check failure with traceback.
- Keep the one-shot entry instead of deleting it when liveness is unknown.
- Add a regression test for a maxed one-shot whose running-set lookup raises.

## Testing

```text
python -m pytest tests/cron/test_jobs.py -k "stale_maxed_oneshot_kept" -q --timeout-method=thread
2 passed, 129 deselected

python -m pytest tests/cron/test_jobs.py -k "run_claim or one_shot" -q --timeout-method=thread
12 passed, 119 deselected

python -m pytest tests/cron/test_jobs.py -q --timeout-method=thread
131 passed