### PR TITLE
fix(dashboard): handle PTY replay disconnect

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15556,8 +15556,6 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    await session.attach(ws)
-
     # --- writer loop: WebSocket → PTY master ----------------------------
     # No reader task here: the session's drain task (spawned once per PTY,
     # inside the registry) forwards PTY output to whichever socket is
@@ -15565,6 +15563,7 @@ async def pty_ws(ws: WebSocket) -> None:
     # closes the attached socket with 4410, which unparks ``ws.receive()``
     # below — same half-open-socket protection the legacy pump has (#54028).
     try:
+        await session.attach(ws)
         while True:
             try:
                 msg = await ws.receive()

--- a/tests/test_pty_keepalive_ws.py
+++ b/tests/test_pty_keepalive_ws.py
@@ -51,3 +51,45 @@ async def test_attach_token_reuses_same_session(monkeypatch):
         assert len(spawned) == 1                # reattached, did not respawn
     finally:
         web_server.PTY_REGISTRY._sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_snapshot_detaches_session(monkeypatch):
+    from starlette.websockets import WebSocketDisconnect
+
+    class FakeWS:
+        client = None
+        query_params = {"attach": "TOK"}
+
+        async def accept(self):
+            pass
+
+    class FakeSession:
+        async def attach(self, ws):
+            raise WebSocketDisconnect()
+
+    class FakeRegistry:
+        detached = None
+
+        async def attach_or_spawn(self, key, *, spawn):
+            return FakeSession(), False
+
+        def detach(self, key, ws):
+            self.detached = (key, ws)
+
+    registry = FakeRegistry()
+    ws = FakeWS()
+    monkeypatch.setattr(web_server, "PTY_REGISTRY", registry)
+    monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test"))
+    monkeypatch.setattr(web_server, "_ws_host_origin_reason", lambda ws: None)
+    monkeypatch.setattr(web_server, "_ws_client_reason", lambda ws: None)
+    monkeypatch.setattr(web_server, "_channel_or_close_code", lambda ws: None)
+
+    async def fake_argv(**kw):
+        return (["x"], "/tmp", {})
+
+    monkeypatch.setattr(web_server, "_resolve_chat_argv_async", fake_argv)
+
+    await web_server.pty_ws(ws)  # type: ignore[arg-type]
+
+    assert registry.detached == ("TOK", ws)


### PR DESCRIPTION
## What does this PR do?

Handles a client disconnect during keep-alive PTY snapshot replay at the WebSocket route boundary that already owns disconnect handling and registry cleanup.

`session.attach(ws)` currently runs immediately before `pty_ws` enters its existing `try / except WebSocketDisconnect / finally detach` block. Moving that call inside the block prevents the expected disconnect from escaping as an ASGI error and guarantees the registry detaches the socket.

This keeps `PtySession.attach()` transport-agnostic and avoids a broad exception catch or duplicate state rollback.

## Related Issue

Fixes #63394

Related to #63193, which addresses the same race with additional session-layer rollback. This is an intentionally narrower alternative using the route's existing cleanup boundary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: include initial PTY snapshot replay in the existing WebSocket disconnect/cleanup boundary.
- `tests/test_pty_keepalive_ws.py`: add a deterministic regression proving disconnect during attach returns cleanly and calls `PTY_REGISTRY.detach()`.

## How to Test

1. Run the focused regression:
   ```bash
   venv/bin/python -m pytest tests/test_pty_keepalive_ws.py::test_disconnect_during_snapshot_detaches_session -q
   ```
2. Run the relevant PTY/dashboard suites:
   ```bash
   scripts/run_tests.sh tests/test_pty_session.py tests/test_pty_keepalive_ws.py tests/test_web_server.py
   ```
3. Run the full suite:
   ```bash
   scripts/run_tests.sh
   ```

Expected: the regression and existing suites pass; a `WebSocketDisconnect` raised by `session.attach()` does not escape, and registry detach is called for the attach token.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and documented the overlap with #63193
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.0-3-pve (Proxmox LXC)

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A; no public API or user workflow change
- [x] `cli-config.yaml.example` updated — N/A; no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md` updated — N/A; no architecture or workflow changes
- [x] Cross-platform impact considered — route-level async exception handling is platform-independent
- [x] Tool descriptions/schemas updated — N/A; no tool behavior changes

## Validation

| Check | Result |
|---|---|
| Regression test before fix | Failed with uncaught `WebSocketDisconnect` |
| Regression test after fix | Passed |
| Relevant PTY/dashboard suites | 16 passed |
| Independent code review | Passed; no security, logic, or race-condition findings |
| Full suite | Completed with 6 unrelated failures: 5 reproduce on clean `origin/main`; the Mistral lazy-install failure passed on focused rerun |
| `git diff --check` | Passed |
