### PR TITLE
[Hermes][Gateway tests][1/n] Contain real Chrome and TTS side effects

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -733,7 +733,10 @@ def test_voice_toggle_tts_branch_also_carries_record_key(monkeypatch):
         ),
     )
     monkeypatch.setenv("HERMES_VOICE", "1")
-    monkeypatch.delenv("HERMES_VOICE_TTS", raising=False)
+    # Own the variable before dispatch mutates it. ``delenv(..., raising=False)``
+    # does not register teardown when the key starts absent, which leaked TTS=1
+    # into later tests and made the fake "partial answer complete" reply audible.
+    monkeypatch.setenv("HERMES_VOICE_TTS", "0")
 
     tts_resp = server.dispatch(
         {"id": "voice-tts", "method": "voice.toggle", "params": {"action": "tts"}}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7067,7 +7067,8 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch(
-            "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True
+            "hermes_cli.browser_connect.launch_chrome_debug",
+            return_value=ChromeDebugLaunch(launched=True),
         ):
             resp = server.handle_request(
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}


### PR DESCRIPTION
## What changed

This contains two real-machine side effects in `tests/test_tui_gateway_server.py`:

1. Patch the live `launch_chrome_debug` symbol with the current `ChromeDebugLaunch` return type, so the browser-connect retry test cannot launch a detached real Chrome process.
2. Seed `HERMES_VOICE_TTS=0` through pytest `monkeypatch` before the voice-toggle test mutates it, so teardown removes the runtime flag instead of leaking TTS into later tests.

## Root causes

- The browser test still mocked the retired `try_launch_chrome_debug` helper while production now calls `launch_chrome_debug`.
- `monkeypatch.delenv(..., raising=False)` registers no cleanup when the key starts absent. The tested handler then set `HERMES_VOICE_TTS=1`; later in the same file, the fake `partial answer complete` fixture generated an MP3 and launched `/usr/bin/afplay`.

## Verification

- Browser-connect selection: 16 passed; matching real-Chrome process set stayed empty before and after.
- TTS leak sequence: 2 passed; macOS unified audio log recorded 0 `afplay` events.

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k "browser_manage_connect or browser_debug_launch"
scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k "voice_toggle_tts_branch_also_carries_record_key or session_activate_returns_inflight_stream_before_completion"
```

## Scope

Test-only changes. No production runtime behavior or user configuration changes.