### PR TITLE
fix(cron): prevent long-running scheduled scripts from running twice

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1976,6 +1976,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
+_RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 
 
 def _get_script_timeout() -> int:
@@ -2133,6 +2134,71 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
         return False, f"Script execution failed: {exc}"
+
+
+def _run_job_script_with_claim_heartbeat(
+    job: dict, script_path: str
+) -> tuple[bool, str]:
+    """Run a cron script while keeping its owned one-shot claim fresh.
+
+    Script execution is synchronous and may legitimately outlive the stale
+    claim TTL.  Without a concurrent heartbeat, another scheduler process can
+    mistake the live run for a dead owner and dispatch the same one-shot again.
+    Recurring jobs and unclaimed/manual runs have no durable one-shot claim and
+    therefore use the ordinary script path without starting a thread.
+
+    The claim owner is captured from the dispatched job and never re-read from
+    storage.  ``heartbeat_run_claim`` compares that stable owner before every
+    refresh, so a stale runner cannot extend a replacement owner's claim.
+    """
+    schedule = job.get("schedule")
+    claim = job.get("run_claim")
+    owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    if not (
+        isinstance(schedule, dict)
+        and schedule.get("kind") == "once"
+        and owner
+    ):
+        return _run_job_script(script_path)
+
+    job_id = str(job.get("id") or "")
+    stop = threading.Event()
+    heartbeat_context = contextvars.copy_context()
+
+    def _heartbeat_loop() -> None:
+        while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
+            try:
+                heartbeat_run_claim(job_id, expected_owner=owner)
+            except Exception:
+                logger.debug(
+                    "Job '%s': script run_claim heartbeat failed",
+                    job_id,
+                    exc_info=True,
+                )
+
+    heartbeat_thread = threading.Thread(
+        target=heartbeat_context.run,
+        args=(_heartbeat_loop,),
+        name="cron-script-claim-heartbeat",
+        daemon=True,
+    )
+    try:
+        heartbeat_thread.start()
+    except Exception:
+        logger.debug(
+            "Job '%s': could not start script run_claim heartbeat",
+            job_id,
+            exc_info=True,
+        )
+        return _run_job_script(script_path)
+
+    try:
+        return _run_job_script(script_path)
+    finally:
+        stop.set()
+        # Event.wait() wakes immediately.  Keep completion bounded if the
+        # heartbeat is already waiting on another process's jobs-file lock.
+        heartbeat_thread.join(timeout=1.0)
 
 
 def _parse_wake_gate(script_output: str) -> bool:
@@ -2542,7 +2608,7 @@ def run_job(
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
         finally:
             if _prior_cwd is not None:
                 try:
@@ -2631,7 +2697,7 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -3113,7 +3179,6 @@ def run_job(
         _run_claim_owner = (
             str(_run_claim.get("by") or "") if isinstance(_run_claim, dict) else ""
         )
-        _CLAIM_HEARTBEAT_SECONDS = 60.0
         _last_claim_heartbeat = time.monotonic()
 
         def _heartbeat_run_claim_if_due():
@@ -3121,7 +3186,7 @@ def run_job(
             if not _is_oneshot or not _run_claim_owner:
                 return
             _mono = time.monotonic()
-            if _mono - _last_claim_heartbeat < _CLAIM_HEARTBEAT_SECONDS:
+            if _mono - _last_claim_heartbeat < _RUN_CLAIM_HEARTBEAT_SECONDS:
                 return
             _last_claim_heartbeat = _mono
             try:

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -1,0 +1,165 @@
+"""Regression coverage for one-shot claims during blocking cron scripts."""
+
+from datetime import datetime, timedelta, timezone
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("no_agent", "script_output"),
+    [
+        (True, "watchdog complete"),
+        (False, '{"wakeAgent": false}'),
+    ],
+    ids=("script-only-job", "pre-agent-script"),
+)
+def test_long_running_script_refreshes_owned_claim_in_profile_store(
+    tmp_path, monkeypatch, no_agent, script_output
+):
+    """Both blocking script paths keep their one-shot claim alive.
+
+    The real store update runs on the heartbeat thread.  A second store holds
+    the same job ID, proving the thread inherited the active profile's
+    ContextVar instead of falling back to another profile's default paths.
+    """
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    default_cron = tmp_path / "default" / "cron"
+    default_cron.mkdir(parents=True)
+    profile_home.mkdir()
+
+    monkeypatch.setattr(jobs, "CRON_DIR", default_cron)
+    monkeypatch.setattr(jobs, "JOBS_FILE", default_cron / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", default_cron / "output")
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+
+    original_timestamp = "2026-07-12T12:00:00+00:00"
+    original_time = datetime.fromisoformat(original_timestamp)
+    claim_ttl = jobs._oneshot_run_claim_ttl_seconds()
+    current_time = [original_time + timedelta(seconds=claim_ttl - 60)]
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: current_time[0])
+
+    def _job() -> dict:
+        return {
+            "id": "long-script",
+            "name": "long script",
+            "prompt": "inspect the script output",
+            "script": "watchdog.py",
+            "no_agent": no_agent,
+            "schedule": {
+                "kind": "once",
+                "run_at": original_timestamp,
+            },
+            "next_run_at": original_timestamp,
+            "enabled": True,
+            "run_claim": {
+                "at": original_timestamp,
+                "by": "dispatch-owner",
+            },
+        }
+
+    # Safe fallback store: if ContextVars are not propagated to the heartbeat
+    # thread, this record would be modified instead of the profile record.
+    jobs.save_jobs([_job()])
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([_job()])
+        claimed_job = jobs.get_job("long-script")
+
+    heartbeat_seen = threading.Event()
+    real_heartbeat = jobs.heartbeat_run_claim
+    second_scheduler_scan = {}
+
+    def _observed_heartbeat(job_id: str, *, expected_owner: str) -> bool:
+        updated = real_heartbeat(job_id, expected_owner=expected_owner)
+        # A different scheduler scans after the ORIGINAL claim's TTL while the
+        # script is still blocked. The refreshed claim must keep the job out of
+        # the due set and preserve its durable record.
+        current_time[0] = original_time + timedelta(seconds=claim_ttl + 10)
+        second_scheduler_scan["due"] = jobs.get_due_jobs()
+        second_scheduler_scan["record_present"] = jobs.get_job(job_id) is not None
+        heartbeat_seen.set()
+        return updated
+
+    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+        assert heartbeat_seen.wait(timeout=2), (
+            "claim was not refreshed while script blocked"
+        )
+        return True, script_output
+
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_job_script", _blocking_script)
+
+    with (
+        jobs.use_cron_store(profile_home),
+        patch("hermes_state.SessionDB", return_value=MagicMock()),
+    ):
+        success, _doc, _response, error = scheduler.run_job(claimed_job)
+        profile_claim = jobs.get_job("long-script")["run_claim"]
+
+    assert success is True
+    assert error is None
+    assert profile_claim["at"] != original_timestamp
+    assert profile_claim["by"] == "dispatch-owner"
+    assert second_scheduler_scan == {"due": [], "record_present": True}
+    assert jobs.get_job("long-script")["run_claim"] == {
+        "at": original_timestamp,
+        "by": "dispatch-owner",
+    }
+
+
+def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
+    """A stale script runner cannot refresh a replacement owner's claim."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    original_timestamp = "2026-07-12T12:00:00+00:00"
+    replacement_timestamp = "2026-07-12T12:00:30+00:00"
+    job = {
+        "id": "reclaimed-script",
+        "script": "watchdog.py",
+        "schedule": {"kind": "once", "run_at": original_timestamp},
+        "run_claim": {"at": original_timestamp, "by": "original-owner"},
+    }
+
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([
+            {
+                **job,
+                "run_claim": {
+                    "at": replacement_timestamp,
+                    "by": "replacement-owner",
+                },
+            }
+        ])
+
+    heartbeat_seen = threading.Event()
+    real_heartbeat = jobs.heartbeat_run_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_owner: str) -> bool:
+        updated = real_heartbeat(job_id, expected_owner=expected_owner)
+        heartbeat_seen.set()
+        return updated
+
+    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+        assert heartbeat_seen.wait(timeout=2)
+        return True, "done"
+
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_job_script", _blocking_script)
+
+    with jobs.use_cron_store(profile_home):
+        assert scheduler._run_job_script_with_claim_heartbeat(job, "watchdog.py") == (
+            True,
+            "done",
+        )
+        assert jobs.get_job("reclaimed-script")["run_claim"] == {
+            "at": replacement_timestamp,
+            "by": "replacement-owner",
+        }


### PR DESCRIPTION
## What does this PR do?

Prevents long-running one-shot scheduled scripts from being started a second time while their original execution is still active.

One-shot jobs use a time-limited run claim to prevent duplicate execution. Existing code refreshes that claim while the agent is running, but not while either blocking script path is running:

- script-only jobs using `no_agent`
- scripts that run before agent or wake-gate evaluation

Scripts can run longer than the claim lifetime. Once the claim appears stale, another scheduler scan can claim and start the same job again.

This PR keeps the existing owner-bound claim alive while either script path is running. The heartbeat:

- only runs for claimed one-shot jobs
- uses the claim owner captured before the script starts
- preserves the active profile's cron-store context in the background thread
- stops when script execution finishes
- does not refresh a claim that has been replaced by another owner

Recurring, unclaimed, and quick jobs are unchanged. Script timeout, output, delivery, and wake-gate behavior are also unchanged.

## Related Issue

Follow-up to #62002, #62014, and #62155.

No new issue was opened because this is a missed sibling path of the existing run-claim heartbeat fix. Searches of open and merged PRs found no submitted fix covering the blocking script paths.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🎨 Style / UI
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Chore

## Changes Made

- Added a claim-heartbeat wrapper around blocking scheduled-script execution.
- Applied it to both script-only and pre-agent script paths.
- Reused the scheduler's existing 60-second claim-heartbeat cadence.
- Propagated the active profile context into the heartbeat thread.
- Added regression coverage proving:
  - a second scheduler scan cannot redispatch a script after the original claim lifetime
  - profile-specific cron stores remain isolated
  - a replacement claim owner is not refreshed

## How to Test

```bash
uv pip install -e '.[all,dev]'
pytest tests/cron/test_script_claim_heartbeat.py tests/cron/test_scheduler.py tests/cron/test_jobs.py -q
```

Result:

```text
348 passed, 2 warnings in 65.40s
```

The warnings are existing unawaited-coroutine warnings outside this change.

Also validated:

- Full cron suite: 682 passed
- Autoreview: no actionable findings
- Ruff and `git diff --check`: clean

Tested on Linux with Python 3.12.3.

## Checklist

### Code

- [x] I've read the contributing guide
- [x] My commits follow Conventional Commits
- [x] I've searched open and merged PRs for an existing fix
- [x] This PR contains one focused logical change
- [x] I've installed the declared development and test dependencies
- [x] I've run the tests covering the affected scheduler and claim lifecycle; all 348 pass
- [x] I've added regression tests for the changed behavior
- [x] I've tested the affected scheduler behavior on Linux
- [x] I've considered cross-platform behavior; the change uses only standard-library threading and context propagation

### Documentation & Housekeeping

- [x] Documentation changes are not needed because no user-facing interface or configuration changed
- [x] No new environment variables or configuration keys were added
- [x] No tool schemas or core tool surface changed
- [x] No `AGENTS.md` update is needed

## Screenshots / Logs

Not applicable. This change affects background cron coordination and is covered by the regression tests above.

## Reviewer Guidance

Suggested review order:

1. The script heartbeat helper in `cron/scheduler.py`
2. Its two script-execution call sites
3. `tests/cron/test_script_claim_heartbeat.py`
