### PR TITLE
fix(browser): block private supervisor snapshot state

### DIFF
--- a/tests/tools/test_browser_snapshot_ssrf.py
+++ b/tests/tools/test_browser_snapshot_ssrf.py
@@ -8,6 +8,8 @@ This is the fix for the SSRF bypass described in issue #44731.
 """
 
 import json
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -218,6 +220,121 @@ class TestBrowserSnapshotPrivateNetworkGuard:
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
         assert result["success"] is True
+
+    def test_blocks_private_supervisor_child_frame_state(self, monkeypatch):
+        """Supervisor frame/dialog state must not expose private child frames."""
+        private_url = "http://169.254.169.254/latest/meta-data/"
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(
+            browser_tool,
+            "_is_safe_url",
+            lambda url: not str(url).startswith("http://169.254.169.254"),
+        )
+        monkeypatch.setattr(
+            browser_tool,
+            "_is_always_blocked_url",
+            lambda url: str(url).startswith("http://169.254.169.254"),
+        )
+
+        def mock_run_browser_command(task_id, command, args=None, **kwargs):
+            if command == "snapshot":
+                return _make_snapshot_result(snapshot="PUBLIC TOP PAGE")
+            if command == "eval":
+                return _make_eval_result("https://example.com/public")
+            return {"success": False, "error": "unknown command"}
+
+        class FakeSupervisor:
+            def snapshot(self):
+                return SimpleNamespace(
+                    active=True,
+                    to_dict=lambda: {
+                        "pending_dialogs": [
+                            {
+                                "id": "d-1",
+                                "type": "alert",
+                                "message": "IMDS-SECRET-FROM-PRIVATE-IFRAME",
+                                "default_prompt": "",
+                                "opened_at": 1.0,
+                                "frame_id": "private-frame",
+                            }
+                        ],
+                        "frame_tree": {
+                            "top": {
+                                "frame_id": "top",
+                                "url": "https://example.com/public",
+                                "origin": "https://example.com",
+                                "is_oopif": False,
+                            },
+                            "children": [
+                                {
+                                    "frame_id": "private-frame",
+                                    "url": private_url,
+                                    "origin": "http://169.254.169.254",
+                                    "is_oopif": True,
+                                    "session_id": "child-session",
+                                }
+                            ],
+                        },
+                    },
+                )
+
+        fake_module = SimpleNamespace(SUPERVISOR_REGISTRY={"test": FakeSupervisor()})
+        monkeypatch.setitem(sys.modules, "tools.browser_supervisor", fake_module)
+        monkeypatch.setattr(
+            browser_tool, "_run_browser_command", mock_run_browser_command
+        )
+
+        result = json.loads(browser_browser_snapshot(task_id="test"))
+
+        assert result["success"] is False
+        assert "browser supervisor state" in result["error"]
+        assert private_url in result["error"]
+        assert "IMDS-SECRET-FROM-PRIVATE-IFRAME" not in json.dumps(result)
+
+    def test_allows_public_supervisor_frame_state(self, monkeypatch):
+        """Public supervisor frame/dialog state still merges into snapshots."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+        monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
+
+        def mock_run_browser_command(task_id, command, args=None, **kwargs):
+            if command == "snapshot":
+                return _make_snapshot_result(snapshot="PUBLIC TOP PAGE")
+            if command == "eval":
+                return _make_eval_result("https://example.com/public")
+            return {"success": False, "error": "unknown command"}
+
+        class FakeSupervisor:
+            def snapshot(self):
+                return SimpleNamespace(
+                    active=True,
+                    to_dict=lambda: {
+                        "pending_dialogs": [],
+                        "frame_tree": {
+                            "top": {
+                                "frame_id": "top",
+                                "url": "https://example.com/public",
+                                "origin": "https://example.com",
+                                "is_oopif": False,
+                            }
+                        },
+                    },
+                )
+
+        fake_module = SimpleNamespace(SUPERVISOR_REGISTRY={"test": FakeSupervisor()})
+        monkeypatch.setitem(sys.modules, "tools.browser_supervisor", fake_module)
+        monkeypatch.setattr(
+            browser_tool, "_run_browser_command", mock_run_browser_command
+        )
+
+        result = json.loads(browser_browser_snapshot(task_id="test"))
+
+        assert result["success"] is True
+        assert result["frame_tree"]["top"]["url"] == "https://example.com/public"
 
     def test_blocks_loopback_url(self, monkeypatch):
         """Loopback URLs (localhost) must be blocked."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3004,7 +3004,20 @@ def browser_snapshot(
             if _supervisor is not None:
                 _sv_snap = _supervisor.snapshot()
                 if _sv_snap.active:
-                    response.update(_redact_browser_output(_sv_snap.to_dict()))
+                    _sv_payload = _sv_snap.to_dict()
+                    if _eval_ssrf_guard_active(effective_task_id):
+                        _blocked_url = _supervisor_snapshot_private_url(_sv_payload)
+                        if _blocked_url:
+                            return json.dumps({
+                                "success": False,
+                                "error": (
+                                    "Blocked: browser supervisor state references a "
+                                    "private or internal frame URL "
+                                    f"({_blocked_url}). Refusing to expose frame "
+                                    "tree or dialog state from that page."
+                                ),
+                            }, ensure_ascii=False)
+                    response.update(_redact_browser_output(_sv_payload))
         except Exception as _sv_exc:
             logger.debug("supervisor snapshot merge failed: %s", _sv_exc)
 
@@ -3015,6 +3028,39 @@ def browser_snapshot(
             "error": result.get("error", "Failed to get snapshot")
         }
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+
+
+def _supervisor_snapshot_private_url(value: Any) -> Optional[str]:
+    """Return the first private/internal URL embedded in supervisor state."""
+
+    def _blocked_url(text: str) -> Optional[str]:
+        try:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(text)
+            if parsed.scheme.lower() not in {"http", "https"}:
+                return None
+            if _is_always_blocked_url(text) or not _is_safe_url(text):
+                return text
+        except Exception:
+            return text
+        return None
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"url", "origin"} and isinstance(item, str):
+                blocked = _blocked_url(item)
+                if blocked:
+                    return blocked
+            nested = _supervisor_snapshot_private_url(item)
+            if nested:
+                return nested
+    elif isinstance(value, list):
+        for item in value:
+            nested = _supervisor_snapshot_private_url(item)
+            if nested:
+                return nested
+    return None
 
 
 def browser_click(ref: str, task_id: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary

This blocks `browser_snapshot()` from returning CDP supervisor frame/dialog state when the supervisor snapshot references a private or internal child-frame URL.

## Why

`browser_snapshot()` already re-checks the top-level page URL before returning page content. However, it then merges CDP supervisor state (`pending_dialogs`, `recent_dialogs`, and `frame_tree`) without applying the same private-network boundary to child frames.

That means a public top-level page could contain or navigate a child frame to a private/internal URL, and the supervisor payload could still expose:

- the private child-frame URL/origin/session metadata through `frame_tree`
- dialog text/default prompt captured from that private frame through `pending_dialogs` or `recent_dialogs`

This crosses the same browser private-network boundary as the existing snapshot/eval/browser-console guards: the browser backend may reach network locations the terminal/user context should not expose to the model.

## Changes

- Scan serialized supervisor snapshot state for private/internal `url` or `origin` values before merging it into `browser_snapshot()`.
- If the normal browser SSRF guard is active and supervisor state references a private/internal frame URL, return a blocked response instead of exposing frame tree or dialog state.
- Preserve existing behavior for local backends, local sidecar sessions, and `browser.allow_private_urls`.
- Add regression coverage for:
  - public top page + private child frame blocks supervisor state
  - public supervisor frame state still merges normally

## Testing

```text
python -m pytest tests/tools/test_browser_snapshot_ssrf.py -k "supervisor_child_frame_state or public_supervisor" -q --timeout-method=thread
2 passed, 17 deselected

python -m pytest tests/tools/test_browser_snapshot_ssrf.py -q --timeout-method=thread
19 passed

python -m pytest tests/tools/test_browser_snapshot_ssrf.py tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_console_ssrf.py tests/tools/test_browser_private_page_action_guard.py -q --timeout-method=thread
50 passed

python -m pytest tests/tools/test_browser_cdp_tool.py -q --timeout-method=thread
25 passed

python -m pytest tests/tools/test_browser_supervisor.py -q --timeout-method=thread
22 skipped