### PR TITLE
fix(agent): unwrap data/success envelope in auxiliary LLM responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7452,6 +7452,7 @@ def _validate_llm_response(
         raise RuntimeError(
             f"Auxiliary {task or 'call'}: LLM returned None response"
         )
+    response = _unwrap_data_envelope(response, task)
     from agent.aux_accounting import record_aux_usage
     record_aux_usage(response, task, provider=provider, base_url=base_url)
     # Allow SimpleNamespace responses from adapters (CodexAuxiliaryClient,
@@ -7499,6 +7500,55 @@ def _fail_relay_auxiliary_call() -> None:
             "Relay auxiliary failure finalization failed",
             exc_info=True,
         )
+
+
+def _unwrap_data_envelope(response: Any, task: str = None) -> Any:
+    """Unwrap gateway envelopes like {"data": {<chat completion>}, "success": true}.
+
+    Some OpenAI-compatible gateways (e.g. api.cline.bot) wrap non-streaming
+    JSON bodies in a data/success envelope.  The SDK leniently parses this
+    into a ChatCompletion with choices=None and keeps the envelope keys as
+    extra fields, so the real completion is reachable at ``response.data``.
+    Error envelopes ({"success": false, "data": {"error": ...}}) raise the
+    provider's actual error instead of a generic invalid-response error.
+    """
+    if _obj_get(response, "choices"):
+        return response
+    data = _obj_get(response, "data")
+    if not isinstance(data, dict):
+        return response
+    if _obj_get(response, "success") is False:
+        err = data.get("error") or data
+        msg = err.get("message") if isinstance(err, dict) else None
+        raise RuntimeError(
+            f"Auxiliary {task or 'call'}: provider returned error envelope: "
+            f"{msg or err}"
+        )
+    if not data.get("choices"):
+        return response
+    try:
+        return type(response).model_validate(data)
+    except (AttributeError, TypeError, ValueError):
+        # No model_validate (SimpleNamespace) or the inner payload fails
+        # strict validation (pydantic ValidationError is a ValueError).
+        pass
+    choices = []
+    for ch in data["choices"]:
+        msg = ch.get("message") if isinstance(ch, dict) else None
+        if isinstance(msg, dict):
+            choices.append(SimpleNamespace(
+                message=SimpleNamespace(**msg),
+                finish_reason=ch.get("finish_reason") or "stop",
+            ))
+    if not choices:
+        return response
+    return SimpleNamespace(
+        id=data.get("id", ""),
+        model=data.get("model", ""),
+        object=data.get("object", "chat.completion"),
+        choices=choices,
+        usage=data.get("usage"),
+    )
 
 
 def _recover_aux_response_message(response: Any) -> Optional[Any]:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -36,6 +36,7 @@ from agent.auxiliary_client import (
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
+    _unwrap_data_envelope,
 )
 
 
@@ -2770,6 +2771,106 @@ class TestStaleFallbackCandidateSkip:
                     task="compression",
                     messages=[{"role": "user", "content": "summarize"}],
                 )
+
+
+class TestDataEnvelopeUnwrap:
+    """Gateways like api.cline.bot wrap completions in {"data": ..., "success": ...}."""
+
+    def _envelope_data(self, content="unwrapped"):
+        return {
+            "id": "chatcmpl-env",
+            "object": "chat.completion",
+            "created": 1751000000,
+            "model": "cline-pass/kimi-k2.7-code",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+    def test_unwrap_envelope_via_model_validate(self):
+        """A leniently-parsed ChatCompletion with the envelope as extras is rebuilt."""
+        from openai.types.chat import ChatCompletion
+
+        wrapped = ChatCompletion.model_construct(
+            data=self._envelope_data(), success=True
+        )
+
+        result = _unwrap_data_envelope(wrapped, task="vision")
+
+        assert isinstance(result, ChatCompletion)
+        assert result.choices[0].message.content == "unwrapped"
+        assert result.model == "cline-pass/kimi-k2.7-code"
+        assert result.usage.total_tokens == 15
+
+    def test_call_llm_unwraps_data_envelope(self):
+        """End-to-end sync path; SimpleNamespace exercises the synthesis fallback."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=None, success=True, data=self._envelope_data()
+        )
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "cline-pass/kimi-k2.7-code")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("custom", "cline-pass/kimi-k2.7-code", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain") as mock_chain:
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "unwrapped"
+        mock_chain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_unwraps_data_envelope(self):
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=None, success=True, data=self._envelope_data()
+            )
+        )
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "cline-pass/kimi-k2.7-code")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("custom", "cline-pass/kimi-k2.7-code", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain") as mock_chain:
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "unwrapped"
+        mock_chain.assert_not_called()
+
+    def test_error_envelope_raises_provider_message(self):
+        wrapped = SimpleNamespace(
+            choices=None,
+            success=False,
+            data={"error": {"message": "upstream provider rejected the request",
+                            "code": "bad_model"}},
+        )
+
+        with pytest.raises(RuntimeError, match="upstream provider rejected the request"):
+            _unwrap_data_envelope(wrapped, task="vision")
+
+    def test_non_envelope_responses_unchanged(self):
+        normal = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))]
+        )
+        assert _unwrap_data_envelope(normal) is normal
+
+        # MagicMock's auto-attribute `data` is not a dict — must stay on the
+        # existing invalid-response path (guards the fallback tests below).
+        mock_resp = MagicMock(choices=[])
+        assert _unwrap_data_envelope(mock_resp) is mock_resp
+
+        no_choices = SimpleNamespace(choices=None, success=True, data={"no": "choices"})
+        assert _unwrap_data_envelope(no_choices) is no_choices
 
 
 class TestAuxiliaryFallbackLayering:


### PR DESCRIPTION
## What does this PR do?

Some OpenAI-compatible gateways (e.g. api.cline.bot) wrap non-streaming JSON bodies in `{"data": {<chat completion>}, "success": true}`. The OpenAI SDK leniently parses this into a `ChatCompletion` with `choices=None` and keeps the envelope keys as extra fields, so auxiliary calls (vision, compression, title generation, web extract) failed in `_validate_llm_response` with a generic "LLM returned invalid response (type=ChatCompletion)" error. Main chat was unaffected because it streams and SSE chunks pass through unwrapped.

This PR unwraps the envelope at the `_validate_llm_response` chokepoint, which every non-streaming auxiliary call passes through (sync `call_llm`, `async_call_llm`, and the retry helpers): the real completion is rebuilt via `model_validate` (with SimpleNamespace synthesis as fallback, matching the existing adapter pattern), and error envelopes (`{"success": false, "data": {"error": ...}}`) now surface the provider's actual error message instead of the generic one.

**Why this approach:** Detection is deliberately conservative — responses with top-level `choices` or without a dict-typed `data` field are returned untouched, so normal providers see zero behavior change. The fix is generic gateway-envelope normalization at a single central point, not a Cline special case (Cline-native integrations were previously closed as not-planned, cf. #60787 / #62538).

## Related Issue

Fixes #63408

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — new `_unwrap_data_envelope()` helper + one-line hook at the top of `_validate_llm_response()`. Rebuilds the wrapped completion via `type(response).model_validate(data)`, falls back to SimpleNamespace synthesis; raises the provider's real error message for `success: false` envelopes.
- `tests/agent/test_auxiliary_client.py` — new `TestDataEnvelopeUnwrap` class (5 tests): unwrap via `model_validate` with a real `ChatCompletion`, end-to-end sync (`call_llm`) and async (`async_call_llm`) unwrap, error-envelope message propagation, and non-envelope responses passing through unchanged (guards the existing recovery/fallback tests).

## How to Test

1. Configure a custom provider with `base_url: https://api.cline.bot`, set `auxiliary.vision.provider: custom` and `auxiliary.vision.model: cline-pass/kimi-k2.7-code`.
2. Call `vision_analyze` with any image. **Before:** fails with `LLM returned invalid response (type=ChatCompletion): 'ChatCompletion(id=None, choices=None, ...)'`. **After:** returns the actual analysis content.
3. Run the tests: `scripts/run_tests.sh tests/agent/test_auxiliary_client.py` — 305 pass, including the 5 new ones in `TestDataEnvelopeUnwrap`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(docstring on the new helper; no user-facing docs affected)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(no config changes)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(no architecture change)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure Python object handling, no OS-specific paths; `scripts/check-windows-footguns.py` clean)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(no tool schema changes)*

## Screenshots / Logs

Error before the fix (vision via custom provider against api.cline.bot):

```
LLM returned invalid response (type=ChatCompletion):
'ChatCompletion(id=None, choices=None, created=None, model=None...'
```

After the fix, the same call returns the model's actual vision analysis; error envelopes now surface the provider's real error message (e.g. `Auxiliary vision: provider returned error envelope: <message>`).
