### PR TITLE
fix(gateway): prevent standing-goal loop after failed agent turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10286,14 +10286,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
+                _is_failed = False
                 if isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
+                    _is_failed = bool(
+                        _agent_result.get("failed")
+                        or _agent_result.get("error")
+                        or _agent_result.get("interrupted")
+                    )
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
-                # Skip for empty responses (interrupted / errored) — the
-                # judge would almost always say "continue" and we'd loop
+                # Skip for empty, failed, interrupted, or errored responses —
+                # the judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                if _final_text.strip() and not _is_failed:
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:


### PR DESCRIPTION
Fixes #63180

## Problem

When a gateway session has an active standing goal (`/goal`), a
model/provider failure that normalizes into a non-empty error string
triggers the goal judge, which often says "continue", enqueuing another
synthetic continuation. This creates a self-sustaining loop that appends
duplicate `[Continuing toward your standing goal]` blocks until the
session grows enormous or the model rejects it.

## Root Cause

The gate at the goal-continuation call site only checked whether
`final_response` was empty (`if _final_text.strip():`), but provider
failures are normalized into non-empty error text (e.g. `⚠️ Proxy error:
...`), so the check passed and the judge ran on every error.

The repo already had a helper
`_should_clear_resume_pending_after_turn` with the correct failure-detection
pattern (checking `failed`, `error`, `interrupted` flags on the result
dict), but the goal-continuation path wasn't using it.

## Fix

Extend the gate to also inspect `failed`, `error`, and `interrupted` flags
on the agent result dict before calling the goal judge. When any flag is set,
skip the continuation — let the user drive the next turn.