### PR TITLE
fix(agent): enrich error_msg with API body for output-cap pattern matching

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2978,6 +2978,21 @@ def run_conversation(
                 
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
+                # str(error) on OpenAI SDK 2.x returns only the message string
+                # (typically "Error code: 400"), not the API response body.
+                # Enrich with the body message so output-cap and context-overflow
+                # pattern matching (parse_available_output_tokens_from_error,
+                # is_output_cap_error) can find the real error detail.
+                _err_body = getattr(api_error, "body", None)
+                if isinstance(_err_body, dict):
+                    _err_obj = _err_body.get("error", {})
+                    _body_msg = (
+                        str(_err_obj.get("message") or "")
+                        if isinstance(_err_obj, dict)
+                        else str(_err_body.get("message") or "")
+                    ).lower()
+                    if _body_msg and _body_msg not in error_msg:
+                        error_msg = f"{error_msg} {_body_msg}"
                 _error_summary = agent._summarize_api_error(api_error)
                 logger.warning(
                     "API call failed (attempt %s/%s) error_type=%s %s summary=%s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10286,14 +10286,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
+                _is_failed = False
                 if isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
+                    _is_failed = bool(
+                        _agent_result.get("failed")
+                        or _agent_result.get("error")
+                        or _agent_result.get("interrupted")
+                    )
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
-                # Skip for empty responses (interrupted / errored) — the
-                # judge would almost always say "continue" and we'd loop
+                # Skip for empty, failed, interrupted, or errored responses —
+                # the judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                if _final_text.strip() and not _is_failed:
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:


### PR DESCRIPTION
Fixes #63161

## Problem

When Qwen3-35B (or any vLLM/OpenAI-compatible model) returns a context
overflow error where `requested max_tokens + input_tokens > context_window`,
Hermes should detect this as an output-cap error, reduce `max_tokens`, and
retry. Instead, it loops through compression attempts until exhaustion.

## Root Cause

The `error_msg` used for pattern matching in the conversation loop
(`str(api_error).lower()` at line 2980) returns only the exception's
message text. In OpenAI SDK 2.x, `APIStatusError.__str__()` returns just
the `message` string (typically "Error code: 400"), **not** the API
response body. The actual context-length details live in
`api_error.body["error"]["message"]`, which `str()` never sees.

When `parse_available_output_tokens_from_error(error_msg)` runs on
`"error code: 400"`, it can't find any of the vLLM/Qwen output-cap
patterns ("maximum context length", "requested", "output tokens",
"prompt contains"), returns `None`, and the code falls through to
context compression — which can't help because the input already fits.

Meanwhile, `classify_api_error()` (in `error_classifier.py`) already
merges `str(error)` with the body message correctly, so the error IS
classified as `context_overflow`, but the follow-up
`parse_available_output_tokens_from_error` uses the bare `str()` text.

## Fix

Enrich `error_msg` with the API response body's error message when
`str(error)` alone doesn't contain it, matching the approach already
used in `classify_api_error`.

## Testing

```
Error: "HTTP 400: This model's maximum context length is 262144 tokens…"
Before: error_msg = "error code: 400" → parse returns None
After:  error_msg = "error code: 400 this model's maximum context length…"
        → parse returns 65535 → max_tokens reduced → retry succeeds
```