### PR TITLE
fix(whatsapp): authorize first-contact LID senders via senderPn

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -63,6 +63,15 @@ export function expandWhatsAppIdentifiers(identifier, sessionDir) {
   return resolved;
 }
 
+export function matchesAllowedSender(senderId, senderPn, allowedUsers, sessionDir) {
+  // WhatsApp Multi-Device can expose a first-contact sender as an opaque LID
+  // before it persists LID mapping files. Baileys supplies the same sender's
+  // authenticated phone JID separately in msg.key.senderPn, so consult it
+  // as an additional alias without changing the allowlist itself.
+  return matchesAllowedUser(senderId, allowedUsers, sessionDir)
+    || matchesAllowedUser(senderPn, allowedUsers, sessionDir);
+}
+
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
   // Empty allowlist = NO ONE allowed (secure default, #8389).  Operators
   // who want an open bot must set ``WHATSAPP_ALLOWED_USERS=*`` explicitly.

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  matchesAllowedSender,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
@@ -41,6 +42,27 @@ test('matchesAllowedUser accepts mapped lid sender when allowlist only contains 
     const allowedUsers = parseAllowedUsers('+19175395595');
     assert.equal(matchesAllowedUser('267383306489914@lid', allowedUsers, sessionDir), true);
     assert.equal(matchesAllowedUser('188012763865257@lid', allowedUsers, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
+test('matchesAllowedSender accepts Baileys senderPn when a first-contact LID has no mapping yet', () => {
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const allowedUsers = parseAllowedUsers('+19175395595');
+    // On a first message from a WhatsApp Multi-Device contact, Baileys can
+    // emit a LID as senderId before it has written LID mapping files, while
+    // senderPn carries WhatsApp's authenticated phone JID.
+    assert.equal(
+      matchesAllowedSender('267383306489914@lid', '19175395595@s.whatsapp.net', allowedUsers, sessionDir),
+      true,
+    );
+    assert.equal(
+      matchesAllowedSender('267383306489914@lid', '18881234567@s.whatsapp.net', allowedUsers, sessionDir),
+      false,
+    );
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }

--- a/scripts/whatsapp-bridge/bridge.inbound.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.inbound.test.mjs
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const BRIDGE_DIR = path.dirname(new URL(import.meta.url).pathname);
+const FIRST_CONTACT_LID = '267383306489914@lid';
+const ALLOWLISTED_PHONE = '19175395595@s.whatsapp.net';
+const UNALLOWLISTED_PHONE = '18881234567@s.whatsapp.net';
+
+function writeBridgeHarness(tempDir) {
+  for (const file of ['allowlist.js', 'bridge_helpers.js', 'outbound_ids.js', 'owner_message_gate.js']) {
+    copyFileSync(path.join(BRIDGE_DIR, file), path.join(tempDir, file));
+  }
+
+  const bridgeSource = readFileSync(path.join(BRIDGE_DIR, 'bridge.js'), 'utf8')
+    .replace("from '@whiskeysockets/baileys'", "from './test-baileys.mjs'")
+    .replace("from 'express'", "from './test-express.mjs'")
+    .replace("from '@hapi/boom'", "from './test-boom.mjs'")
+    .replace("from 'pino'", "from './test-pino.mjs'")
+    .replace("from 'qrcode-terminal'", "from './test-qrcode.mjs'");
+  writeFileSync(path.join(tempDir, 'bridge.mjs'), bridgeSource);
+
+  writeFileSync(path.join(tempDir, 'test-baileys.mjs'), `
+    export const DisconnectReason = { loggedOut: 401 };
+    export const makeWASocket = () => {
+      const handlers = new Map();
+      const socket = {
+        ev: { on: (name, handler) => handlers.set(name, handler) },
+        user: { id: '15559998888@s.whatsapp.net' },
+        updateMediaMessage: async () => {},
+      };
+      globalThis.__whatsappTestSocket = socket;
+      globalThis.__whatsappTestHandlers = handlers;
+      return socket;
+    };
+    export const useMultiFileAuthState = async () => ({ state: {}, saveCreds: async () => {} });
+    export const fetchLatestBaileysVersion = async () => ({ version: [2, 3000, 0] });
+    export const downloadMediaMessage = async () => Buffer.from('');
+    export const getAggregateVotesInPollMessage = () => [];
+    export const decryptPollVote = () => ({});
+    export const getKeyAuthor = key => key?.participant || key?.remoteJid || '';
+    export const jidNormalizedUser = value => value;
+  `);
+  writeFileSync(path.join(tempDir, 'test-express.mjs'), `
+    const routes = new Map();
+    globalThis.__whatsappTestRoutes = routes;
+    const app = {
+      use: () => {},
+      get: (route, handler) => routes.set('GET ' + route, handler),
+      post: (route, handler) => routes.set('POST ' + route, handler),
+      listen: (_port, _host, callback) => callback(),
+    };
+    function express() { return app; }
+    express.json = () => (_req, _res, next) => next();
+    export default express;
+  `);
+  writeFileSync(path.join(tempDir, 'test-boom.mjs'), `
+    export class Boom { constructor() { this.output = { statusCode: 500 }; } }
+  `);
+  writeFileSync(path.join(tempDir, 'test-pino.mjs'), 'export default function pino() { return {}; }\n');
+  writeFileSync(path.join(tempDir, 'test-qrcode.mjs'), 'export default { generate() {} };\n');
+}
+
+async function waitForInboundHandler() {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const handler = globalThis.__whatsappTestHandlers?.get('messages.upsert');
+    if (handler) return handler;
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  throw new Error('bridge did not register messages.upsert handler');
+}
+
+test('bridge accepts first-contact LID via allowlisted senderPn and emits phone identity', async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-bridge-inbound-'));
+  const originalEnv = {
+    WHATSAPP_ALLOWED_USERS: process.env.WHATSAPP_ALLOWED_USERS,
+    WHATSAPP_DM_POLICY: process.env.WHATSAPP_DM_POLICY,
+    WHATSAPP_MODE: process.env.WHATSAPP_MODE,
+  };
+  const originalArgv = process.argv;
+
+  try {
+    writeBridgeHarness(tempDir);
+    process.env.WHATSAPP_ALLOWED_USERS = '+19175395595';
+    process.env.WHATSAPP_DM_POLICY = 'allowlist';
+    process.env.WHATSAPP_MODE = 'bot';
+    process.argv = [...process.argv, '--session', tempDir];
+
+    await import(`${pathToFileURL(path.join(tempDir, 'bridge.mjs')).href}?test=${Date.now()}`);
+    const inboundHandler = await waitForInboundHandler();
+
+    await inboundHandler({
+      type: 'notify',
+      messages: [
+        {
+          key: {
+            id: 'allowed-first-contact',
+            remoteJid: FIRST_CONTACT_LID,
+            senderPn: ALLOWLISTED_PHONE,
+            fromMe: false,
+          },
+          pushName: 'Allowed sender',
+          messageTimestamp: 123,
+          message: { conversation: 'accepted' },
+        },
+        {
+          key: {
+            id: 'blocked-first-contact',
+            remoteJid: '188012763865257@lid',
+            senderPn: UNALLOWLISTED_PHONE,
+            fromMe: false,
+          },
+          pushName: 'Blocked sender',
+          messageTimestamp: 124,
+          message: { conversation: 'rejected' },
+        },
+      ],
+    });
+
+    let emitted;
+    globalThis.__whatsappTestRoutes.get('GET /messages')(
+      {},
+      { json: value => { emitted = value; } },
+    );
+
+    assert.equal(emitted.length, 1);
+    assert.equal(emitted[0].messageId, 'allowed-first-contact');
+    assert.equal(emitted[0].body, 'accepted');
+    assert.equal(emitted[0].senderId, ALLOWLISTED_PHONE);
+    assert.equal(emitted[0].senderName, 'Allowed sender');
+  } finally {
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    process.argv = originalArgv;
+    delete globalThis.__whatsappTestSocket;
+    delete globalThis.__whatsappTestHandlers;
+    delete globalThis.__whatsappTestRoutes;
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedSender, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -532,8 +532,10 @@ async function startSocket() {
 
       const chatId = msg.key.remoteJid;
       const senderId = msg.key.participant || chatId;
+      const senderPn = msg.key.senderPn || '';
+      const resolvedSenderId = senderPn || senderId;
       const isGroup = chatId.endsWith('@g.us');
-      const senderNumber = senderId.replace(/@.*/, '');
+      const senderNumber = resolvedSenderId.replace(/@.*/, '');
       emitDebugEvent({
         stage: 'upsert',
         type,
@@ -634,7 +636,7 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedSender(senderId, senderPn, ALLOWED_USERS, SESSION_DIR)) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',
@@ -710,7 +712,7 @@ async function startSocket() {
       const event = await extractBridgeEvent({
         msg,
         chatId,
-        senderId,
+        senderId: resolvedSenderId,
         senderNumber,
         botIds,
         isGroup,


### PR DESCRIPTION
## Summary

Fixes #63415.

WhatsApp Multi-Device may deliver a first-contact sender as an opaque `@lid` before the bridge has persisted LID mapping files. In that state, an explicitly allowlisted phone number is rejected because the bridge checks only `senderId`, even though Baileys provides the authenticated phone JID in `msg.key.senderPn`.

This change:

- adds `matchesAllowedSender()` to evaluate both the existing sender ID and `senderPn` against the unchanged allowlist;
- prefers `senderPn` for the event identity passed downstream when it is present;
- adds a regression test for an unmapped LID with an allowlisted versus unallowlisted phone JID.

Unknown phone identities remain rejected; this does not widen the allowlist.

## Validation

```text
node --test scripts/whatsapp-bridge/allowlist.test.mjs
# 6 passed, including the new first-contact LID/senderPn case

node --check scripts/whatsapp-bridge/bridge.js
git diff --check
```

## Scope

This concerns inbound authorization before an LID mapping exists. It is complementary to, rather than a duplicate of, the outbound LID-target resolution work.