### PR TITLE
fix: make provider fallback policy explicit and visible

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1370,11 +1370,22 @@ def init_agent(
         agent._fallback_chain = [fallback_model]
     else:
         agent._fallback_chain = []
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import get_fallback_policy
+
+        agent._fallback_policy = get_fallback_policy(load_config_readonly())
+    except Exception:
+        # Config read failures must never widen provider routing.
+        agent._fallback_policy = "off"
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
+    agent._fallback_terminal_status_emitted = False
+    agent._pending_fallback_notice = None
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:
+        print(f"🛡️  Fallback policy: {agent._fallback_policy}")
         if len(agent._fallback_chain) == 1:
             fb = agent._fallback_chain[0]
             print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -335,6 +335,33 @@ def _codex_gpt55_autoraise_notice_seen(autoraise: Dict[str, Any]) -> bool:
         return False
 
 
+def _capture_fallback_entries(raw) -> List[Dict[str, Any]]:
+    """Normalize a caller-supplied chain without consulting live policy."""
+    candidates = (
+        raw
+        if isinstance(raw, list)
+        else [raw]
+        if isinstance(raw, dict)
+        else []
+    )
+    captured: List[Dict[str, Any]] = []
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        provider_name = str(entry.get("provider") or "").strip()
+        model_name = str(entry.get("model") or "").strip()
+        if not provider_name or not model_name:
+            continue
+        normalized = dict(entry)
+        normalized["provider"] = provider_name
+        normalized["model"] = model_name
+        base_url_hint = str(entry.get("base_url") or "").strip().rstrip("/")
+        if base_url_hint:
+            normalized["base_url"] = base_url_hint
+        captured.append(normalized)
+    return captured
+
+
 def _record_codex_gpt55_autoraise_notice(autoraise: Dict[str, Any]) -> None:
     """Persist that the autoraise notice was shown for this profile/config state.
 
@@ -511,6 +538,9 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     fallback_model: Dict[str, Any] = None,
+    fallback_chain_from_config: Optional[bool] = None,
+    initial_fallback_decision: str = None,
+    initial_fallback_entry: Dict[str, Any] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -570,6 +600,51 @@ def init_agent(
             remain skipped.
     """
     _install_safe_stdio()
+
+    # Resolve the fallback boundary before any provider client resolution.
+    # Several entry points pass an already-captured chain into AIAgent; without
+    # filtering here, the init-time auth fallback below could silently switch
+    # to a cloud route even when the live policy is ``off`` or ``local-only``.
+    _captured_fallback_chain = _capture_fallback_entries(fallback_model)
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import (
+            filter_fallback_chain_for_policy,
+            get_configured_fallback_chain,
+            get_fallback_policy,
+        )
+
+        _fallback_config = load_config_readonly()
+        _fallback_policy = get_fallback_policy(_fallback_config)
+        _eligible_fallback_chain = filter_fallback_chain_for_policy(
+            _captured_fallback_chain,
+            _fallback_config,
+        )
+        _config_fallback_chain = get_configured_fallback_chain(_fallback_config)
+        _fallback_chain_from_config = (
+            bool(fallback_chain_from_config)
+            if fallback_chain_from_config is not None
+            else (
+                isinstance(initial_fallback_entry, dict)
+                or (
+                    bool(_captured_fallback_chain)
+                    and _captured_fallback_chain == _config_fallback_chain
+                )
+            )
+        )
+    except Exception:
+        # A config read failure must never widen routing.
+        _fallback_config = {}
+        _fallback_policy = "off"
+        _eligible_fallback_chain = []
+        # Preserve the caller's ownership hint even while failing closed. A
+        # config-managed cached agent can then repopulate the chain on its first
+        # turn after a transient read failure, without requiring recreation.
+        _fallback_chain_from_config = (
+            bool(fallback_chain_from_config)
+            if fallback_chain_from_config is not None
+            else isinstance(initial_fallback_entry, dict)
+        )
 
     agent.model = model
     agent.max_iterations = max_iterations
@@ -757,6 +832,19 @@ def init_agent(
     agent.event_callback = event_callback
     agent.reaction_callback = reaction_callback
     agent.tool_gen_callback = tool_gen_callback
+    agent._fallback_policy = _fallback_policy
+    agent._pending_fallback_notice = (
+        str(initial_fallback_decision).strip()
+        if initial_fallback_decision
+        else None
+    )
+    agent._init_fallback_entry = (
+        dict(initial_fallback_entry)
+        if isinstance(initial_fallback_entry, dict)
+        else None
+    )
+    agent._active_fallback_entry = None
+    agent._fallback_restore_required = False
 
     
     # Tool execution state — allows _vprint during tool execution
@@ -1214,14 +1302,7 @@ def init_agent(
                     except Exception:
                         pass
                     # --- Init-time fallback (#17929) ---
-                    _fb_entries = []
-                    if isinstance(fallback_model, list):
-                        _fb_entries = [
-                            f for f in fallback_model
-                            if isinstance(f, dict) and f.get("provider") and f.get("model")
-                        ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-                        _fb_entries = [fallback_model]
+                    _fb_entries = _eligible_fallback_chain
                     _fb_resolved = False
                     for _fb in _fb_entries:
                         _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
@@ -1235,8 +1316,23 @@ def init_agent(
                             explicit_api_key=_fb_explicit_key,
                         )
                         if _fb_client is not None:
+                            _old_model = agent.model
+                            _old_provider = agent.provider
+                            _resolved_model = _fb_model or _fb["model"]
+                            _decision = (
+                                f"🔄 Fallback policy {_fallback_policy}: "
+                                f"{_old_model} via {_old_provider} could not initialize "
+                                f"(reason: credentials unavailable); switching to "
+                                f"{_resolved_model} via {_fb['provider']}."
+                            )
+                            # Gateways normally attach their renderer after
+                            # construction. Queue the decision for the turn
+                            # preflight in that case so it is still emitted
+                            # before the first request to the fallback target.
+                            agent._pending_fallback_notice = _decision
+                            agent._init_fallback_entry = dict(_fb)
                             agent.provider = _fb["provider"]
-                            agent.model = _fb_model or _fb["model"]
+                            agent.model = _resolved_model
                             agent._fallback_activated = True
                             client_kwargs = {
                                 "api_key": _fb_client.api_key,
@@ -1254,10 +1350,23 @@ def init_agent(
                             _fb_resolved = True
                             break
                     if not _fb_resolved:
+                        if _fallback_policy == "off":
+                            _fallback_detail = (
+                                " Fallback policy is off, so no backup provider was attempted."
+                            )
+                        elif _fallback_policy == "local-only":
+                            _fallback_detail = (
+                                " Fallback policy local-only found no usable local backup route."
+                            )
+                        else:
+                            _fallback_detail = (
+                                " No usable configured fallback provider remained."
+                            )
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
                             f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
+                            f"{_fallback_detail}"
                         )
                 if not getattr(agent, "_fallback_activated", False):
                     # No provider configured — reject with a clear message.
@@ -1361,27 +1470,19 @@ def init_agent(
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
-    if isinstance(fallback_model, list):
-        agent._fallback_chain = [
-            f for f in fallback_model
-            if isinstance(f, dict) and f.get("provider") and f.get("model")
-        ]
-    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-        agent._fallback_chain = [fallback_model]
-    else:
-        agent._fallback_chain = []
-    try:
-        from hermes_cli.config import load_config_readonly
-        from hermes_cli.fallback_config import get_fallback_policy
-
-        agent._fallback_policy = get_fallback_policy(load_config_readonly())
-    except Exception:
-        # Config read failures must never widen provider routing.
-        agent._fallback_policy = "off"
+    agent._fallback_chain = list(_eligible_fallback_chain)
+    # Keep the normalized unfiltered seed separately. Programmatic AIAgent
+    # callers can supply a chain without writing config.yaml; config-managed
+    # agents replace this seed when the file changes, including deletion.
+    agent._fallback_chain_seed = list(_captured_fallback_chain)
+    agent._fallback_chain_from_config = _fallback_chain_from_config
+    agent._fallback_excluded_providers = set()
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     agent._fallback_terminal_status_emitted = False
-    agent._pending_fallback_notice = None
+    # Keep an init-time decision queued for gateways whose status callback is
+    # attached only after construction.
+    agent._pending_fallback_notice = getattr(agent, "_pending_fallback_notice", None)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1406,6 +1406,10 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
+    # Pending switch notices are turn-scoped. Clear before every early return
+    # too (no active fallback or cooldown), so a later primary success cannot
+    # emit a stale notice from an interrupted/abandoned prior turn.
+    agent._pending_fallback_notice = None
     if not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1406,10 +1406,11 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
-    # Pending switch notices are turn-scoped. Clear before every early return
-    # too (no active fallback or cooldown), so a later primary success cannot
-    # emit a stale notice from an interrupted/abandoned prior turn.
+    # The turn preflight emits any queued init-time decision before calling
+    # this helper. Clear defensively here so direct callers cannot carry it
+    # across a later turn boundary.
     agent._pending_fallback_notice = None
+    agent._fallback_restore_required = False
     if not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was
@@ -1421,7 +1422,28 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
+    def _entry_key(entry):
+        return (
+            str((entry or {}).get("provider") or "").strip().lower(),
+            str((entry or {}).get("model") or "").strip().lower(),
+            str((entry or {}).get("base_url") or "").strip().rstrip("/").lower(),
+        )
+
+    active_entry = getattr(agent, "_active_fallback_entry", None)
+    active_still_eligible = active_entry is None or any(
+        _entry_key(candidate) == _entry_key(active_entry)
+        for candidate in (getattr(agent, "_fallback_chain", None) or [])
+    )
+    force_restore = (
+        getattr(agent, "_fallback_policy", "any") == "off"
+        or not active_still_eligible
+    )
+    agent._fallback_restore_required = force_restore
+
+    if (
+        not force_restore
+        and getattr(agent, "_rate_limited_until", 0) > time.monotonic()
+    ):
         return False  # primary still in rate-limit cooldown, stay on fallback
 
     rt = agent._primary_runtime
@@ -1593,6 +1615,8 @@ def restore_primary_runtime(agent) -> bool:
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0
+        agent._active_fallback_entry = None
+        agent._fallback_restore_required = False
 
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves
@@ -2457,6 +2481,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Reset fallback state ──
     agent._fallback_activated = False
     agent._fallback_index = 0
+    agent._active_fallback_entry = None
+    agent._init_fallback_entry = None
+    agent._pending_fallback_notice = None
 
     # When the user deliberately swaps primary providers (e.g. openrouter
     # → anthropic), drop any fallback entries that target the OLD primary
@@ -2469,6 +2496,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     new_norm = (new_provider or "").strip().lower()
     fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
     if old_norm and new_norm and old_norm != new_norm:
+        excluded_providers = set(
+            getattr(agent, "_fallback_excluded_providers", None) or set()
+        )
+        excluded_providers.update({old_norm, new_norm})
+        agent._fallback_excluded_providers = excluded_providers
         fallback_chain = [
             entry for entry in fallback_chain
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,7 +107,12 @@ class _OpenAIProxy:
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
-from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.model_metadata import (
+    MINIMUM_CONTEXT_LENGTH,
+    get_model_context_length,
+    is_local_endpoint,
+)
+from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -4374,6 +4379,20 @@ def _try_payment_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import get_fallback_policy
+
+        policy = get_fallback_policy(load_config_readonly())
+    except Exception:
+        policy = "off"
+    if policy == "off":
+        logger.warning(
+            "Auxiliary %s: fallback policy off; not switching after %s on %s",
+            task or "call", reason, failed_provider,
+        )
+        return None, None, ""
+
     # Normalise the failed provider label for matching.
     skip = failed_provider.lower().strip()
     # Also skip Step-1 main-provider path if it maps to the same backend.
@@ -4390,6 +4409,9 @@ def _try_payment_fallback(
 
     tried = []
     for label, try_fn in _get_provider_chain():
+        if policy == "local-only" and label != "local/custom":
+            tried.append(f"{label} (remote provider blocked by local-only policy)")
+            continue
         if label in skip_chain_labels:
             continue
         if _is_provider_unhealthy(label):
@@ -4398,6 +4420,11 @@ def _try_payment_fallback(
             continue
         client, model = try_fn()
         if client is not None:
+            if policy == "local-only" and not is_local_endpoint(
+                str(getattr(client, "base_url", "") or "")
+            ):
+                tried.append(f"{label} (remote blocked by local-only policy)")
+                continue
             logger.info(
                 "Auxiliary %s: %s on %s — falling back to %s (%s)",
                 task or "call", reason, failed_provider, label, model or "default",
@@ -4446,6 +4473,18 @@ def _try_main_agent_model_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import get_fallback_policy
+
+        policy_config = load_config_readonly()
+        policy = get_fallback_policy(policy_config)
+    except Exception:
+        policy_config = {}
+        policy = "off"
+    if policy == "off":
+        return None, None, ""
+
     main_provider = (_read_main_provider() or "").strip()
     main_model = (_read_main_model() or "").strip()
     if main_provider.lower() == "moa":
@@ -4489,6 +4528,26 @@ def _try_main_agent_model_fallback(
 
     if client is None:
         return None, None, ""
+    if policy == "local-only":
+        try:
+            from hermes_cli.fallback_config import fallback_entry_is_local
+
+            allowed_local = fallback_entry_is_local(
+                {
+                    "provider": main_provider,
+                    "model": resolved_model or main_model,
+                    "base_url": str(getattr(client, "base_url", "") or ""),
+                },
+                policy_config,
+            )
+        except Exception:
+            allowed_local = False
+        if not allowed_local:
+            logger.warning(
+                "Auxiliary %s: local-only policy blocked remote main-agent fallback %s",
+                task or "call", main_provider,
+            )
+            return None, None, ""
 
     label = f"main-agent({main_provider})"
     logger.info(
@@ -4617,6 +4676,21 @@ def _try_configured_fallback_chain(
     if not task:
         return None, None, ""
 
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import (
+            fallback_entry_is_local,
+            get_fallback_policy,
+        )
+
+        policy_config = load_config_readonly()
+        policy = get_fallback_policy(policy_config)
+    except Exception:
+        policy_config = {}
+        policy = "off"
+    if policy == "off":
+        return None, None, ""
+
     task_config = _get_auxiliary_task_config(task)
     chain = task_config.get("fallback_chain")
     if not chain or not isinstance(chain, list):
@@ -4663,6 +4737,11 @@ def _try_configured_fallback_chain(
         fb_model = fb_model_raw or None
 
         label = f"fallback_chain[{i}]({fb_provider})"
+        if policy == "local-only" and not fallback_entry_is_local(
+            entry, policy_config
+        ):
+            tried.append(f"{label} (remote/unknown blocked)")
+            continue
 
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
@@ -4670,6 +4749,11 @@ def _try_configured_fallback_chain(
             fb_client, resolved_model = None, None
 
         if fb_client is not None:
+            if policy == "local-only" and not is_local_endpoint(
+                str(getattr(fb_client, "base_url", "") or "")
+            ):
+                tried.append(f"{label} (resolved remote endpoint blocked)")
+                continue
             if min_ctx is not None and resolved_model:
                 fb_ctx = _candidate_context_window(
                     fb_provider,
@@ -4803,6 +4887,18 @@ def _try_main_fallback_chain(
             logger.debug("Auxiliary %s: main fallback %s failed to resolve: %s", task or "call", label, exc)
             fb_client, resolved_model = None, None
         if fb_client is not None:
+            try:
+                from hermes_cli.config import load_config_readonly
+                from hermes_cli.fallback_config import get_fallback_policy
+
+                policy = get_fallback_policy(load_config_readonly())
+            except Exception:
+                policy = "off"
+            if policy == "local-only" and not is_local_endpoint(
+                str(getattr(fb_client, "base_url", "") or "")
+            ):
+                tried.append(f"{label} (resolved remote endpoint blocked)")
+                continue
             if min_ctx is not None:
                 fb_ctx = _candidate_context_window(
                     fb_provider,
@@ -5011,14 +5107,36 @@ def _resolve_auto(
         return fb_client, fb_model
 
     # ── Step 3: aggregator / fallback chain ──────────────────────────────
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.fallback_config import get_fallback_policy
+
+        fallback_policy_config = load_config_readonly()
+        fallback_policy = get_fallback_policy(fallback_policy_config)
+    except Exception:
+        fallback_policy_config = {}
+        fallback_policy = "off"
+    if fallback_policy == "off":
+        logger.warning(
+            "Auxiliary auto-detect: main provider unavailable and fallback policy is off"
+        )
+        return None, None
     tried = []
     for label, try_fn in _get_provider_chain():
+        if fallback_policy == "local-only" and label != "local/custom":
+            tried.append(f"{label} (remote provider blocked by local-only policy)")
+            continue
         if _is_provider_unhealthy(label):
             _log_skip_unhealthy(label)
             tried.append(f"{label} (unhealthy)")
             continue
         client, model = try_fn()
         if client is not None:
+            if fallback_policy == "local-only" and not is_local_endpoint(
+                str(getattr(client, "base_url", "") or "")
+            ):
+                tried.append(f"{label} (remote blocked by local-only policy)")
+                continue
             if tried:
                 logger.info("Auxiliary auto-detect: using %s (%s) — skipped: %s",
                             label, model or "default", ", ".join(tried))

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1965,6 +1965,7 @@ def try_activate_fallback(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+        agent._active_fallback_entry = dict(fb)
 
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream
@@ -2120,20 +2121,6 @@ def try_activate_fallback(
         # answering, so "what model are you?" doesn't report the primary.
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
-        agent._buffer_status(
-            f"🔄 Primary model failed — switching to fallback: "
-            f"{fb_model} via {fb_provider}"
-        )
-        # The buffered line above is dropped on successful recovery, but a
-        # provider/model switch is a durable state change operators must see
-        # even when the fallback succeeds.  Record a one-shot notice that the
-        # success path surfaces exactly once via _emit_pending_fallback_notice
-        # (see run_agent.py); it is discarded on terminal failure since the
-        # buffered line is flushed instead.  See fallback-observability fix.
-        agent._pending_fallback_notice = (
-            f"🔄 Switched to fallback model: {old_model} via {old_provider} "
-            f"→ {fb_model} via {fb_provider}"
-        )
         logger.info(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1690,8 +1690,46 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+def _fallback_reason_text(reason: "FailoverReason | str | None") -> str:
+    if isinstance(reason, FailoverReason):
+        value = reason.value
+    else:
+        value = str(reason or "provider failure")
+    return value.strip().replace("_", " ") or "provider failure"
 
-def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
+
+def emit_fallback_policy_terminal_status(
+    agent,
+    reason: "FailoverReason | str | None" = None,
+) -> None:
+    """Fail loudly once when policy or exhaustion prevents another switch."""
+    if getattr(agent, "_fallback_terminal_status_emitted", False):
+        return
+    policy = getattr(agent, "_fallback_policy", "any")
+    current_model = str(getattr(agent, "model", "") or "unknown model")
+    current_provider = str(getattr(agent, "provider", "") or "unknown provider")
+    reason_text = _fallback_reason_text(reason)
+
+    if policy == "off":
+        detail = "fallback is disabled. No provider switch was attempted."
+    elif policy == "local-only":
+        detail = (
+            "no eligible local fallback remained. Remote and unknown-endpoint "
+            "fallbacks were not used."
+        )
+    else:
+        detail = "no usable configured fallback remained."
+    agent._emit_fallback_status(
+        f"❌ Fallback policy {policy}: {current_model} via {current_provider} "
+        f"failed (reason: {reason_text}); {detail}"
+    )
+    agent._fallback_terminal_status_emitted = True
+
+
+
+def try_activate_fallback(
+    agent, reason: "FailoverReason | str | None" = None,
+) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
     Called when the current model is failing after retries.  Swaps the
@@ -1712,6 +1750,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
         if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
             agent._rate_limited_until = time.monotonic() + 60
+    policy = getattr(agent, "_fallback_policy", "any")
+    if policy == "off":
+        agent._fallback_index = len(agent._fallback_chain)
+        emit_fallback_policy_terminal_status(agent, reason)
+        return False
     if agent._fallback_index >= len(agent._fallback_chain):
         # Chain exhausted.  If we actually walked a non-empty chain and the
         # failure was NOT a rate-limit/billing event (those already armed
@@ -1728,6 +1771,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 _existing_cooldown,
                 time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S,
             )
+        emit_fallback_policy_terminal_status(agent, reason)
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1
@@ -1743,6 +1787,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback(reason)  # skip invalid, try next
+
+    if policy == "local-only":
+        try:
+            from hermes_cli.config import load_config_readonly
+            from hermes_cli.fallback_config import fallback_entry_is_local
+
+            metadata_local = fallback_entry_is_local(fb, load_config_readonly())
+        except Exception:
+            metadata_local = False
+        if not metadata_local:
+            unavailable.add(fb_key)
+            logger.warning(
+                "Fallback policy local-only rejected %s/%s: endpoint metadata is remote or unknown",
+                fb_provider,
+                fb_model,
+            )
+            return agent._try_activate_fallback(reason)
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
@@ -1811,6 +1872,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_provider)
             unavailable.add(fb_key)
             return agent._try_activate_fallback(reason)  # try next in chain
+        if policy == "local-only" and not is_local_endpoint(str(fb_client.base_url)):
+            unavailable.add(fb_key)
+            logger.warning(
+                "Fallback policy local-only rejected resolved endpoint %s for %s/%s",
+                fb_client.base_url,
+                fb_provider,
+                fb_model,
+            )
+            try:
+                fb_client.close()
+            except Exception:
+                pass
+            return agent._try_activate_fallback(reason)
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 
@@ -1869,6 +1943,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model = agent.model
         old_provider = agent.provider
+
+        # This decision is intentionally immediate (not retry-buffered): the
+        # operator sees policy, reason, and destination before runtime state is
+        # changed and before the next provider request is sent.
+        agent._emit_fallback_status(
+            f"🔄 Fallback policy {policy}: {old_model} via {old_provider} failed "
+             f"(reason: {_fallback_reason_text(reason)}); switching to "
+             f"{fb_model} via {fb_provider}."
+         )
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -4310,6 +4393,7 @@ __all__ = [
     "build_api_kwargs",
     "build_assistant_message",
     "try_activate_fallback",
+    "emit_fallback_policy_terminal_status",
     "handle_max_iterations",
     "cleanup_task_resources",
     "interruptible_streaming_api_call",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2008,7 +2008,7 @@ def run_conversation(
                             f"⏳ {_nous_msg} Trying fallback..."
                         )
                         agent._buffer_status(f"⏳ {_nous_msg}")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(FailoverReason.rate_limit):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -2441,7 +2441,7 @@ def run_conversation(
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
                         agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback("invalid response"):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -2514,7 +2514,7 @@ def run_conversation(
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
                             agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback("invalid response"):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -2691,7 +2691,7 @@ def run_conversation(
                         agent._buffer_status(
                             "⚠️ Model declined to respond (safety refusal) — trying fallback..."
                         )
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(FailoverReason.content_policy_blocked):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -2860,7 +2860,9 @@ def run_conversation(
                             agent._emit_status(
                                 "Content filter terminated stream; switching to fallback..."
                             )
-                            if agent._try_activate_fallback():
+                            if agent._try_activate_fallback(
+                                FailoverReason.content_policy_blocked
+                            ):
                                 # Roll the partial content (if any was already
                                 # appended in a prior continuation pass) back to
                                 # the last clean turn so the fallback provider
@@ -4862,7 +4864,7 @@ def run_conversation(
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(reason=classified.reason):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -5085,7 +5087,7 @@ def run_conversation(
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(reason=classified.reason):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6509,7 +6511,7 @@ def run_conversation(
                             "⚠️ Model returning empty responses — "
                             "switching to fallback provider..."
                         )
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback("empty response"):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             agent._empty_content_retries = 0
@@ -6527,6 +6529,7 @@ def run_conversation(
                     # Exhausted retries and fallback chain (or no
                     # fallback configured).  Fall through to the
                     # "(empty)" terminal.
+                    agent._emit_fallback_policy_terminal_status("empty response")
                     # Surface the buffered retry/fallback trace so the
                     # user can see what was attempted before "(empty)".
                     agent._flush_status_buffer()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1750,7 +1750,6 @@ def run_conversation(
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
         total_chars = approx_tokens * 4
-
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens
         )
@@ -2852,12 +2851,7 @@ def run_conversation(
                             _cf_terminated
                             and agent._fallback_index < len(agent._fallback_chain)
                         ):
-                            agent._vprint(
-                                f"{agent.log_prefix}🛡️  Content filter terminated "
-                                f"stream — activating fallback provider...",
-                                force=True,
-                            )
-                            agent._emit_status(
+                            agent._buffer_status(
                                 "Content filter terminated stream; switching to fallback..."
                             )
                             if agent._try_activate_fallback(
@@ -6508,17 +6502,12 @@ def run_conversation(
                             agent.provider,
                         )
                         agent._buffer_status(
-                            "⚠️ Model returning empty responses — "
-                            "switching to fallback provider..."
+                            "⚠️ Model returned empty responses after retry exhaustion."
                         )
                         if agent._try_activate_fallback("empty response"):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             agent._empty_content_retries = 0
-                            agent._buffer_status(
-                                f"↻ Switched to fallback: {agent.model} "
-                                f"({agent.provider})"
-                            )
                             logger.info(
                                 "Fallback activated after empty responses: "
                                 "now using %s on %s",
@@ -6598,11 +6587,9 @@ def run_conversation(
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
-                # Successful content reached — surface the one-shot fallback
-                # switch notice (if a fallback activated this turn) before
-                # dropping the noisy retry buffer, so a provider/model switch
-                # stays visible even when the fallback succeeds.
-                agent._emit_pending_fallback_notice()
+                # Successful content reached. The fallback decision, if any,
+                # was already emitted before the fallback request; only noisy
+                # retry chatter remains buffered here.
                 agent._clear_status_buffer()
 
                 from agent.agent_runtime_helpers import (

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -381,8 +381,51 @@ def build_turn_context(
     # fallback boundary before any restore or provider selection this turn.
     agent._refresh_fallback_policy()
 
+    def _fallback_entry_key(entry):
+        return (
+            str((entry or {}).get("provider") or "").strip().lower(),
+            str((entry or {}).get("model") or "").strip().lower(),
+            str((entry or {}).get("base_url") or "").strip().rstrip("/").lower(),
+        )
+
+    # An auth fallback selected during construction becomes the live runtime
+    # before the first turn. Config edits must still revoke that permission:
+    # never send a request to a route that ``off``/``local-only`` or a chain
+    # deletion removed after construction.
+    init_fallback_entry = getattr(agent, "_init_fallback_entry", None)
+    if init_fallback_entry is not None and not any(
+        _fallback_entry_key(candidate) == _fallback_entry_key(init_fallback_entry)
+        for candidate in (getattr(agent, "_fallback_chain", None) or [])
+    ):
+        agent._pending_fallback_notice = None
+        policy = getattr(agent, "_fallback_policy", "off")
+        message = (
+            f"❌ Fallback policy {policy}: the init-time route "
+            f"{init_fallback_entry.get('model')} via "
+            f"{init_fallback_entry.get('provider')} is no longer eligible after "
+            "the fallback configuration changed; no model request was sent."
+        )
+        agent._emit_fallback_status(message)
+        agent._fallback_terminal_status_emitted = True
+        raise RuntimeError(message)
+
+    # Init/auth fallback may happen before a gateway attaches its status
+    # callback. Surface that queued, non-terminal decision exactly once now,
+    # before the first request to the selected provider.
+    agent._emit_pending_fallback_notice()
+
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()
+    if getattr(agent, "_fallback_restore_required", False):
+        policy = getattr(agent, "_fallback_policy", "off")
+        message = (
+            f"❌ Fallback policy {policy}: the active fallback route is no "
+            "longer eligible and the primary runtime could not be restored; "
+            "no model request was sent."
+        )
+        agent._emit_fallback_status(message)
+        agent._fallback_terminal_status_emitted = True
+        raise RuntimeError(message)
 
     # Tell auxiliary_client what the restored live main provider/model are for
     # this turn. Doing this before restoration leaked the previous turn's

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -377,11 +377,16 @@ def build_turn_context(
     # Bind the skill write-origin ContextVar for this thread.
     set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
 
+    # Cached gateway/desktop agents survive config edits. Refresh the exact
+    # fallback boundary before any restore or provider selection this turn.
+    agent._refresh_fallback_policy()
+
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()
 
-    # Tell auxiliary_client what the live main provider/model are for this turn
-    # after primary restoration has settled the runtime.
+    # Tell auxiliary_client what the restored live main provider/model are for
+    # this turn. Doing this before restoration leaked the previous turn's
+    # fallback route into auxiliary selection on cached agents.
     try:
         from agent.auxiliary_client import set_runtime_main
         set_runtime_main(

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -26,6 +26,7 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getSessionMessages, triggerCronJob } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { restoreFallbackNotices } from '@/lib/fallback-notices'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -319,7 +320,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
           const latest = await getSessionMessages(storedSessionId, storedProfile)
-          const messages = toChatMessages(latest.messages)
+          const messages = restoreFallbackNotices(storedSessionId, toChatMessages(latest.messages))
           updateSessionState(
             runtimeSessionId,
             state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
@@ -374,7 +375,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       }
 
       messagingTranscriptSignatureRef.current.set(signatureKey, sig)
-      const messages = toChatMessages(latest.messages)
+      const messages = restoreFallbackNotices(storedSessionId, toChatMessages(latest.messages))
 
       updateSessionState(
         runtimeSessionId,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/fallback-status.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/fallback-status.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { FALLBACK_NOTICE_STORAGE_KEY, restoreFallbackNotices } from '@/lib/fallback-notices'
+import { $currentFallbackPolicy, setCurrentFallbackPolicy } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const RUNTIME_ID = 'runtime-1'
+const STORED_ID = 'stored-1'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let states: Map<string, ClientSessionState>
+
+const message = (id: string, role: ChatMessage['role'], text: string): ChatMessage => ({
+  id,
+  role,
+  parts: [{ type: 'text', text }]
+})
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(RUNTIME_ID)
+  const sessionStateByRuntimeIdRef = useRef(states)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater, storedSessionId) => {
+      const current =
+        sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
+
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+describe('desktop fallback status', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    handleEvent = null
+    setCurrentFallbackPolicy('')
+
+    const initial = createClientSessionState(STORED_ID, [
+      message('user-1', 'user', 'keep going'),
+      { ...message('assistant-stream', 'assistant', ''), pending: true }
+    ])
+
+    initial.streamId = 'assistant-stream'
+    initial.busy = true
+    initial.awaitingResponse = true
+    states = new Map([[RUNTIME_ID, initial]])
+  })
+
+  afterEach(() => {
+    cleanup()
+    setCurrentFallbackPolicy('')
+    vi.restoreAllMocks()
+  })
+
+  it('persists a non-terminal decision and restores it before the fallback response', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { kind: 'fallback', text: 'Fallback policy local-only: local/a → local/b' },
+        session_id: RUNTIME_ID,
+        type: 'status.update'
+      })
+    )
+
+    const live = states.get(RUNTIME_ID)!
+    const notice = live.messages.find(item => item.role === 'system')
+
+    expect(notice && chatMessageText(notice)).toBe('Fallback policy local-only: local/a → local/b')
+    expect(live.busy).toBe(true)
+    expect(live.awaitingResponse).toBe(true)
+    expect(window.localStorage.getItem(FALLBACK_NOTICE_STORAGE_KEY)).toContain(STORED_ID)
+
+    const hydrated = restoreFallbackNotices(STORED_ID, [
+      message('stored-user', 'user', 'keep going'),
+      message('stored-answer', 'assistant', 'done on local/b')
+    ])
+
+    expect(hydrated.map(item => item.role)).toEqual(['user', 'system', 'assistant'])
+  })
+
+  it('keeps effective policy in the session state reflected by session.info', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { fallback_policy: 'local-only' },
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    )
+
+    expect(states.get(RUNTIME_ID)?.fallbackPolicy).toBe('local-only')
+    expect($currentFallbackPolicy.get()).toBe('local-only')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -11,6 +11,12 @@ import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
+import {
+  countTranscriptMessages,
+  createFallbackNotice,
+  deferFallbackNotice,
+  persistFallbackNotice
+} from '@/lib/fallback-notices'
 import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
@@ -46,6 +52,7 @@ import {
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentFallbackPolicy,
   setCurrentFastMode,
   setCurrentPersonality,
   setCurrentReasoningEffort,
@@ -367,6 +374,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           // (or a stale session model) and would silently revert the dropdown.
           // Active-session model/provider still flows through the session state
           // cache via updateSessionState → syncRuntimeMetadataToView below.
+
+          if (statePatch.fallbackPolicy) {
+            setCurrentFallbackPolicy(statePatch.fallbackPolicy)
+          }
 
           if (typeof payload?.cwd === 'string') {
             // The active session's agent can relocate itself (new repo/worktree
@@ -993,16 +1004,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (sessionId && fallbackText) {
           flushQueuedDeltas(sessionId)
-          updateSessionState(sessionId, state => {
-            const notice = {
-              id: `fallback-status-${Date.now()}`,
-              role: 'system' as const,
-              parts: [textPart(fallbackText)],
-              timestamp: Math.floor(Date.now() / 1000)
-            }
-            const streamIndex = state.streamId
-              ? state.messages.findIndex(message => message.id === state.streamId)
-              : -1
+          const notice = createFallbackNotice(fallbackText)
+
+          const nextState = updateSessionState(sessionId, state => {
+            const streamIndex = state.streamId ? state.messages.findIndex(message => message.id === state.streamId) : -1
             const messages = [...state.messages]
 
             // Keep the decision before the response produced by the selected
@@ -1016,6 +1021,24 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
             return { ...state, messages }
           })
+
+          if (nextState.storedSessionId) {
+            const noticeIndex = nextState.messages.findIndex(message => message.id === notice.id)
+
+            const beforeMessageCount = countTranscriptMessages(
+              noticeIndex >= 0 ? nextState.messages.slice(0, noticeIndex) : nextState.messages
+            )
+
+            persistFallbackNotice(nextState.storedSessionId, notice, beforeMessageCount)
+          } else {
+            const noticeIndex = nextState.messages.findIndex(message => message.id === notice.id)
+
+            const beforeMessageCount = countTranscriptMessages(
+              noticeIndex >= 0 ? nextState.messages.slice(0, noticeIndex) : nextState.messages
+            )
+
+            deferFallbackNotice(sessionId, notice, beforeMessageCount)
+          }
         } else if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -68,7 +68,13 @@ import type { RpcEvent } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 
-import { hasSessionInfoStatePatch, sessionInfoStatePatch, SUBAGENT_EVENT_TYPES, toTodoPayload } from './utils'
+import {
+  fallbackStatusText,
+  hasSessionInfoStatePatch,
+  sessionInfoStatePatch,
+  SUBAGENT_EVENT_TYPES,
+  toTodoPayload
+} from './utils'
 
 function firstBillingLine(text: string): string {
   return (text || '').split('\n')[0]?.trim() ?? ''
@@ -983,7 +989,34 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           revealDesktopPane(payload?.pane ?? '')
         }
       } else if (event.type === 'status.update') {
-        if (sessionId && payload?.kind === 'compacting') {
+        const fallbackText = fallbackStatusText(payload)
+
+        if (sessionId && fallbackText) {
+          flushQueuedDeltas(sessionId)
+          updateSessionState(sessionId, state => {
+            const notice = {
+              id: `fallback-status-${Date.now()}`,
+              role: 'system' as const,
+              parts: [textPart(fallbackText)],
+              timestamp: Math.floor(Date.now() / 1000)
+            }
+            const streamIndex = state.streamId
+              ? state.messages.findIndex(message => message.id === state.streamId)
+              : -1
+            const messages = [...state.messages]
+
+            // Keep the decision before the response produced by the selected
+            // fallback, even when an empty pending assistant bubble already
+            // exists for this turn.
+            if (streamIndex >= 0) {
+              messages.splice(streamIndex, 0, notice)
+            } else {
+              messages.push(notice)
+            }
+
+            return { ...state, messages }
+          })
+        } else if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)
         } else if (sessionId && payload?.kind === 'compacted') {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -25,9 +25,7 @@ describe('completionErrorText', () => {
 
 describe('fallbackStatusText', () => {
   it('returns only non-empty structured fallback status text', () => {
-    expect(fallbackStatusText(payload({ kind: 'fallback', text: '  switching locally  ' }))).toBe(
-      'switching locally'
-    )
+    expect(fallbackStatusText(payload({ kind: 'fallback', text: '  switching locally  ' }))).toBe('switching locally')
     expect(fallbackStatusText(payload({ kind: 'lifecycle', text: 'ignore' }))).toBeNull()
     expect(fallbackStatusText(payload({ kind: 'fallback', text: '   ' }))).toBeNull()
   })
@@ -44,10 +42,17 @@ describe('toTodoPayload', () => {
 
 describe('sessionInfoStatePatch / hasSessionInfoStatePatch', () => {
   it('extracts only present runtime fields', () => {
-    const patch = sessionInfoStatePatch(payload({ model: 'gpt', fast: true, branch: 'main' }))
-    expect(patch).toMatchObject({ model: 'gpt', fast: true, branch: 'main' })
+    const patch = sessionInfoStatePatch(
+      payload({ model: 'gpt', fast: true, branch: 'main', fallback_policy: 'local-only' })
+    )
+
+    expect(patch).toMatchObject({ model: 'gpt', fast: true, branch: 'main', fallbackPolicy: 'local-only' })
     expect(hasSessionInfoStatePatch(patch)).toBe(true)
     expect(hasSessionInfoStatePatch(sessionInfoStatePatch(payload({})))).toBe(false)
+  })
+
+  it('does not surface an unknown fallback policy as effective state', () => {
+    expect(sessionInfoStatePatch(payload({ fallback_policy: 'mystery' }))).toEqual({})
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -5,6 +5,7 @@ import type { GatewayEventPayload } from '@/lib/chat-messages'
 import {
   completionErrorText,
   delegateTaskPayloads,
+  fallbackStatusText,
   hasSessionInfoStatePatch,
   sessionInfoStatePatch,
   toTodoPayload
@@ -19,6 +20,16 @@ describe('completionErrorText', () => {
     expect(completionErrorText('Gateway error: nope')).toMatch(/^Gateway error/)
     expect(completionErrorText('here is your answer')).toBeNull()
     expect(completionErrorText('   ')).toBeNull()
+  })
+})
+
+describe('fallbackStatusText', () => {
+  it('returns only non-empty structured fallback status text', () => {
+    expect(fallbackStatusText(payload({ kind: 'fallback', text: '  switching locally  ' }))).toBe(
+      'switching locally'
+    )
+    expect(fallbackStatusText(payload({ kind: 'lifecycle', text: 'ignore' }))).toBeNull()
+    expect(fallbackStatusText(payload({ kind: 'fallback', text: '   ' }))).toBeNull()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -1,12 +1,21 @@
 import type { GatewayEventPayload } from '@/lib/chat-messages'
-import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { normalizeFallbackPolicyValue, normalizePersonalityValue } from '@/lib/chat-runtime'
 
 import type { ClientSessionState } from '../../../types'
 
 type SessionRuntimeStatePatch = Partial<
   Pick<
     ClientSessionState,
-    'branch' | 'cwd' | 'fast' | 'model' | 'personality' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+    | 'branch'
+    | 'cwd'
+    | 'fallbackPolicy'
+    | 'fast'
+    | 'model'
+    | 'personality'
+    | 'provider'
+    | 'reasoningEffort'
+    | 'serviceTier'
+    | 'yolo'
   >
 >
 
@@ -19,6 +28,14 @@ export function sessionInfoStatePatch(payload: GatewayEventPayload | undefined):
 
   if (typeof payload?.provider === 'string') {
     patch.provider = payload.provider || ''
+  }
+
+  if (typeof payload?.fallback_policy === 'string') {
+    const fallbackPolicy = normalizeFallbackPolicyValue(payload.fallback_policy)
+
+    if (fallbackPolicy) {
+      patch.fallbackPolicy = fallbackPolicy
+    }
   }
 
   if (typeof payload?.cwd === 'string') {
@@ -93,6 +110,7 @@ export function fallbackStatusText(payload: GatewayEventPayload | undefined): st
   }
 
   const text = payload.text.trim()
+
   return text || null
 }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -87,6 +87,15 @@ export function completionErrorText(finalText: string): string | null {
   return text && COMPLETION_ERROR_PATTERNS.some(re => re.test(text)) ? text : null
 }
 
+export function fallbackStatusText(payload: GatewayEventPayload | undefined): string | null {
+  if (payload?.kind !== 'fallback' || typeof payload.text !== 'string') {
+    return null
+  }
+
+  const text = payload.text.trim()
+  return text || null
+}
+
 export const SUBAGENT_EVENT_TYPES = new Set([
   'subagent.spawn_requested',
   'subagent.start',

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -8,6 +8,7 @@ import { stripAnsi } from '@/lib/ansi'
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
+import { countTranscriptMessages, pruneFallbackNoticesAfter } from '@/lib/fallback-notices'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { normalize } from '@/lib/text'
@@ -776,7 +777,8 @@ export function usePromptActions({
         return
       }
 
-      const plan = planReload($messages.get(), parentId)
+      const priorMessages = $messages.get()
+      const plan = planReload(priorMessages, parentId)
 
       if (!plan) {
         return
@@ -795,6 +797,15 @@ export function usePromptActions({
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
+
+        const reloadStoredSessionId = selectedStoredSessionIdRef.current
+
+        if (reloadStoredSessionId) {
+          pruneFallbackNoticesAfter(
+            reloadStoredSessionId,
+            countTranscriptMessages(priorMessages.slice(0, plan.userIndex))
+          )
+        }
       } catch (err) {
         updateSessionState(sessionId, state => ({
           ...state,
@@ -804,7 +815,7 @@ export function usePromptActions({
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [activeSessionIdRef, copy.regenerateFailed, requestGateway, updateSessionState]
+    [activeSessionIdRef, copy.regenerateFailed, requestGateway, selectedStoredSessionIdRef, updateSessionState]
   )
 
   // Cursor-style "restore checkpoint": rewind the conversation to a past user
@@ -850,6 +861,15 @@ export function usePromptActions({
 
       try {
         await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+
+        const restoreStoredSessionId = selectedStoredSessionIdRef.current
+
+        if (restoreStoredSessionId) {
+          pruneFallbackNoticesAfter(
+            restoreStoredSessionId,
+            countTranscriptMessages(messages.slice(0, plan.sourceIndex))
+          )
+        }
       } catch (err) {
         // The rewind never landed (e.g. the gateway stayed busy past the retry
         // deadline). Roll the optimistic truncation back to the full original
@@ -867,7 +887,7 @@ export function usePromptActions({
         throw err
       }
     },
-    [activeSessionIdRef, busyRef, submitRewindPrompt, updateSessionState]
+    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, submitRewindPrompt, updateSessionState]
   )
 
   const editMessage = useCallback(
@@ -901,6 +921,15 @@ export function usePromptActions({
 
       try {
         await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+
+        const editStoredSessionId = selectedStoredSessionIdRef.current
+
+        if (!plan.isFailedTurn && editStoredSessionId) {
+          pruneFallbackNoticesAfter(
+            editStoredSessionId,
+            countTranscriptMessages(messages.slice(0, plan.sourceIndex))
+          )
+        }
       } catch (err) {
         let surfaced = err
 
@@ -925,7 +954,7 @@ export function usePromptActions({
         notifyError(surfaced, copy.editFailed)
       }
     },
-    [activeSessionIdRef, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]
+    [activeSessionIdRef, busyRef, copy.editFailed, selectedStoredSessionIdRef, submitRewindPrompt, updateSessionState]
   )
 
   const handleThreadMessagesChange = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -933,6 +933,7 @@ describe('resumeSession failure recovery', () => {
             branch: '',
             busy: false,
             cwd: '',
+            fallbackPolicy: '',
             fast: false,
             interimBoundaryPending: false,
             interrupted: false,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -6,6 +6,7 @@ import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { restoreFallbackNotices } from '@/lib/fallback-notices'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
@@ -42,6 +43,7 @@ import {
   setCurrentBranch,
   setCurrentCwd,
   setCurrentCwdTransient,
+  setCurrentFallbackPolicy,
   setCurrentServiceTier,
   setCurrentUsage,
   setFreshDraftReady,
@@ -136,9 +138,14 @@ function applyStoredUsage(stored: { input_tokens?: number | null; output_tokens?
 function reconcileAuthoritativeMessages(
   authoritativeMessages: SessionResumeResponse['messages'],
   previousMessages: ChatMessage[],
-  liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
+  liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>,
+  storedSessionId?: string | null
 ): ChatMessage[] {
-  const authoritative = toChatMessages(authoritativeMessages)
+  // Fallback notices are desktop-local (never persisted server-side), so any
+  // authoritative transcript reload would drop them without this restore.
+  const authoritative = storedSessionId
+    ? restoreFallbackNotices(storedSessionId, toChatMessages(authoritativeMessages))
+    : toChatMessages(authoritativeMessages)
   const withLiveProjection = liveProjection ? appendLiveSessionProjection(authoritative, liveProjection) : authoritative
   const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
   const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
@@ -327,6 +334,7 @@ export function useSessionActions({
       // refreshCurrentModel). Only $currentServiceTier (a live-session mirror)
       // is cleared.
       setCurrentServiceTier('')
+      setCurrentFallbackPolicy('')
       setYoloActive(false)
       setNewChatWorkspaceTarget(hasWorkspaceTarget ? workspaceTarget : undefined)
 
@@ -734,7 +742,7 @@ export function useSessionActions({
 
               let activatedMessages =
                 activated.messages.length || activated.inflight || activated.queued
-                  ? reconcileAuthoritativeMessages(activated.messages, cachedViewState.messages, activated)
+                  ? reconcileAuthoritativeMessages(activated.messages, cachedViewState.messages, activated, storedSessionId)
                   : cachedViewState.messages
 
               const running = Boolean(activated.running ?? cachedViewState.busy)
@@ -759,7 +767,7 @@ export function useSessionActions({
                   persisted.session_id === activatedStoredSessionId
 
                 if (persisted && persistedMatchesActivatedSession) {
-                  activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
+                  activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages, undefined, activatedStoredSessionId || storedSessionId)
                 }
               }
 
@@ -901,7 +909,7 @@ export function useSessionActions({
             ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
             : $messages.get()
 
-          localSnapshot = reconcileAuthoritativeMessages(prefetchedResult.messages, previousMessages)
+          localSnapshot = reconcileAuthoritativeMessages(prefetchedResult.messages, previousMessages, undefined, prefetchedResult.session_id || storedSessionId)
           prefetchApplied = true
           prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
         }
@@ -928,7 +936,7 @@ export function useSessionActions({
                   ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
                   : currentMessages
 
-                const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
+                const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed, storedSessionId)
 
                 return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
               })()
@@ -1037,7 +1045,7 @@ export function useSessionActions({
           // only carrier of a crashed turn's progress on this path.
           const fallbackRecovery = recoverInFlightTurnJournal(
             storedSessionId,
-            reconcileAuthoritativeMessages(fallback.messages, previousMessages)
+            reconcileAuthoritativeMessages(fallback.messages, previousMessages, undefined, storedSessionId)
           )
 
           setMessages(fallbackRecovery.messages)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
+import { $currentFallbackPolicy, setCurrentFallbackPolicy } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
@@ -24,6 +25,17 @@ const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial
   ({ id, role, parts: [{ type: 'text', text }], ...extra }) as ChatMessage
 
 const session = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
+
+describe('applyRuntimeInfo fallback policy', () => {
+  it('hydrates the effective fallback policy on cold resume', () => {
+    setCurrentFallbackPolicy('')
+
+    expect(applyRuntimeInfo({ fallback_policy: 'local-only' })).toMatchObject({ fallbackPolicy: 'local-only' })
+    expect($currentFallbackPolicy.get()).toBe('local-only')
+
+    setCurrentFallbackPolicy('')
+  })
+})
 
 describe('applyRuntimeInfo approval mode', () => {
   beforeEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,6 +1,6 @@
 import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
-import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { normalizeFallbackPolicyValue, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages, textWithoutImageRefs } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
@@ -11,6 +11,7 @@ import {
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentFallbackPolicy,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -672,7 +673,16 @@ export async function resolveSessionProfile(storedSessionId: null | string): Pro
 type SessionRuntimeStatePatch = Partial<
   Pick<
     ClientSessionState,
-    'branch' | 'cwd' | 'fast' | 'model' | 'personality' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+    | 'branch'
+    | 'cwd'
+    | 'fallbackPolicy'
+    | 'fast'
+    | 'model'
+    | 'personality'
+    | 'provider'
+    | 'reasoningEffort'
+    | 'serviceTier'
+    | 'yolo'
   >
 >
 
@@ -701,6 +711,15 @@ export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionR
   if (typeof info.provider === 'string') {
     setCurrentProvider(info.provider)
     sessionState.provider = info.provider
+  }
+
+  if (typeof info.fallback_policy === 'string') {
+    const fallbackPolicy = normalizeFallbackPolicyValue(info.fallback_policy)
+
+    if (fallbackPolicy) {
+      setCurrentFallbackPolicy(fallbackPolicy)
+      sessionState.fallbackPolicy = fallbackPolicy
+    }
   }
 
   if (info.cwd) {
@@ -749,6 +768,7 @@ export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionR
 export function applyStoredSessionPreviewRuntimeInfo(stored: { model?: null | string } | undefined) {
   setCurrentModel(stored?.model || '')
   setCurrentProvider('')
+  setCurrentFallbackPolicy('')
   setCurrentReasoningEffort('')
   setCurrentServiceTier('')
   setCurrentFastMode(false)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -3,8 +3,10 @@ import { type MutableRefObject, useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { createFallbackNotice, deferFallbackNotice, restoreFallbackNotices } from '@/lib/fallback-notices'
 import {
   $activeSessionStoredIdRotation,
+  $currentFallbackPolicy,
   $currentFastMode,
   $currentModel,
   $currentProvider,
@@ -14,6 +16,7 @@ import {
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
+  setCurrentFallbackPolicy,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
@@ -112,12 +115,14 @@ describe('useSessionStateCache — per-session turn timer', () => {
 
       return null as unknown as number
     })
+    window.localStorage.clear()
     setTurnStartedAt(null)
     setCurrentModel('')
     setCurrentProvider('')
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setCurrentFallbackPolicy('')
   })
 
   afterEach(() => {
@@ -129,6 +134,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setCurrentFallbackPolicy('')
   })
 
   it("keeps a background session's running turn clock and never mirrors it to the view", () => {
@@ -147,6 +153,21 @@ describe('useSessionStateCache — per-session turn timer', () => {
     // ...but the global atom (statusbar timer) is untouched — a background turn
     // must not drive the foreground timer.
     expect($turnStartedAt.get()).toBeNull()
+  })
+
+  it('backfills a pre-bind fallback notice when the stored session id becomes known', () => {
+    let cache!: Cache
+    const notice = createFallbackNotice('init fallback', 1_700_000_000_000)
+    deferFallbackNotice('fg-runtime', notice, 1)
+
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    act(() => {
+      cache.ensureSessionState('fg-runtime', 'fg-stored')
+    })
+
+    const restored = restoreFallbackNotices('fg-stored', [userMessage('u', 'hello'), assistantText('a', 'answer')])
+    expect(restored.map(message => message.id)).toEqual(['u', notice.id, 'a'])
   })
 
   it("mirrors the focused session's turn clock into the global atom on view-sync", () => {
@@ -196,6 +217,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
         state => ({
           ...state,
           fast: true,
+          fallbackPolicy: 'local-only',
           model: 'anthropic/claude-opus-4.8',
           provider: 'anthropic',
           reasoningEffort: 'high',
@@ -209,6 +231,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentModel.get()).toBe('')
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
+    expect($currentFallbackPolicy.get()).toBe('')
 
     rerender(<Harness activeSessionId="bg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="bg-stored" />)
 
@@ -224,6 +247,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentReasoningEffort.get()).toBe('high')
     expect($currentServiceTier.get()).toBe('priority')
     expect($currentFastMode.get()).toBe(true)
+    expect($currentFallbackPolicy.get()).toBe('local-only')
   })
 
   it('clears stale model metadata when the newly focused session has no cached value', () => {
@@ -232,6 +256,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('high')
     setCurrentServiceTier('priority')
     setCurrentFastMode(true)
+    setCurrentFallbackPolicy('any')
 
     let cache!: Cache
 
@@ -257,6 +282,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
+    expect($currentFallbackPolicy.get()).toBe('')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -4,6 +4,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { flushPendingFallbackNotices } from '@/lib/fallback-notices'
 import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
@@ -11,6 +12,7 @@ import {
   $busy,
   $messages,
   setActiveSessionStoredIdRotation,
+  setCurrentFallbackPolicy,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -38,6 +40,7 @@ interface SessionStateCacheOptions {
 function syncRuntimeMetadataToView(state: ClientSessionState) {
   setCurrentModel(state.model ?? '')
   setCurrentProvider(state.provider ?? '')
+  setCurrentFallbackPolicy(state.fallbackPolicy ?? '')
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)
@@ -131,6 +134,7 @@ export function useSessionStateCache({
 
         if (storedSessionId) {
           runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+          flushPendingFallbackNotices(sessionId, storedSessionId)
         }
       }
 
@@ -142,6 +146,7 @@ export function useSessionStateCache({
 
     if (storedSessionId) {
       runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+      flushPendingFallbackNotices(sessionId, storedSessionId)
     }
 
     return created

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -24,6 +24,7 @@ import {
   $busy,
   $connection,
   $currentCwd,
+  $currentFallbackPolicy,
   $currentUsage,
   $selectedStoredSessionId,
   $sessions,
@@ -102,6 +103,7 @@ export function useStatusbarItems({
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
   const primaryUsage = useStore($currentUsage)
+  const currentFallbackPolicy = useStore($currentFallbackPolicy)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
@@ -500,6 +502,15 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
+        detail: currentFallbackPolicy || undefined,
+        hidden: !activeSessionId || !currentFallbackPolicy,
+        icon: <Codicon name="shield" size="0.75rem" />,
+        id: 'fallback-policy',
+        label: copy.fallback,
+        title: copy.effectiveFallbackPolicy(currentFallbackPolicy || copy.unknown),
+        variant: 'text'
+      },
+      {
         ...approvalModeItem,
         hidden: gatewayState !== 'open',
         toggleLabel: copy.toggleApprovalMode
@@ -528,6 +539,7 @@ export function useStatusbarItems({
       contextBar,
       contextUsage,
       copy,
+      currentFallbackPolicy,
       currentUsage,
       publishContextUsage,
       requestGateway,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -178,6 +178,8 @@ export interface ClientSessionState {
   cwd: string
   model: string
   provider: string
+  /** Effective runtime fallback policy reported by session.info. */
+  fallbackPolicy: '' | 'any' | 'local-only' | 'off'
   reasoningEffort: string
   serviceTier: string
   fast: boolean

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2477,6 +2477,9 @@ export const en: Translations = {
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },
       session: 'Session',
+      runtimeSessionElapsed: 'Runtime session elapsed',
+      fallback: 'Fallback',
+      effectiveFallbackPolicy: policy => `Effective fallback policy: ${policy}`,
       yoloOn: 'YOLO on — auto-approving dangerous commands. Shift+click toggles globally.',
       yoloOff: 'YOLO off. Shift+click toggles globally.',
       modelNone: 'none',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2327,6 +2327,9 @@ export const ja = defineLocale({
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },
       session: 'セッション',
+      runtimeSessionElapsed: 'ランタイムセッション経過時間',
+      fallback: 'フォールバック',
+      effectiveFallbackPolicy: policy => `有効なフォールバックポリシー: ${policy}`,
       yoloOn: 'YOLO オン — 危険なコマンドを自動承認中。Shift+クリックで全体に切り替え。',
       yoloOff: 'YOLO オフ。Shift+クリックで全体に切り替え。',
       modelNone: 'なし',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2082,6 +2082,9 @@ export interface Translations {
         tokenSummary: (used: string, max: string) => string
       }
       session: string
+      runtimeSessionElapsed: string
+      fallback: string
+      effectiveFallbackPolicy: (policy: string) => string
       yoloOn: string
       yoloOff: string
       modelNone: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2251,6 +2251,9 @@ export const zhHant = defineLocale({
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },
       session: '工作階段',
+      runtimeSessionElapsed: '執行時工作階段已用時間',
+      fallback: '備用',
+      effectiveFallbackPolicy: policy => `目前的備用策略：${policy}`,
       yoloOn: 'YOLO 已開啟 — 自動核准危險指令。Shift+點擊可全域切換。',
       yoloOff: 'YOLO 已關閉。Shift+點擊可全域切換。',
       modelNone: '無',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2658,6 +2658,9 @@ export const zh: Translations = {
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },
       session: '会话',
+      runtimeSessionElapsed: '运行时会话已用时间',
+      fallback: '备用',
+      effectiveFallbackPolicy: policy => `当前备用策略：${policy}`,
       yoloOn: 'YOLO 已开启 — 自动批准危险命令。Shift+点击可全局切换。',
       yoloOff: 'YOLO 已关闭。Shift+点击可全局切换。',
       modelNone: '无',

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -49,6 +49,7 @@ export type GatewayEventPayload = {
   todos?: unknown
   model?: string
   provider?: string
+  fallback_policy?: string
   reasoning_effort?: string
   service_tier?: string
   fast?: boolean

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -43,6 +43,7 @@ export function createClientSessionState(
     cwd: '',
     model: '',
     provider: '',
+    fallbackPolicy: '',
     reasoningEffort: '',
     serviceTier: '',
     fast: false,
@@ -59,6 +60,10 @@ export function createClientSessionState(
     turnStartedAt: null,
     usage: null
   }
+}
+
+export function normalizeFallbackPolicyValue(value: unknown): ClientSessionState['fallbackPolicy'] {
+  return value === 'off' || value === 'local-only' || value === 'any' ? value : ''
 }
 
 export function sessionTitle(session: SessionInfo): string {

--- a/apps/desktop/src/lib/fallback-notices.test.ts
+++ b/apps/desktop/src/lib/fallback-notices.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import {
+  createFallbackNotice,
+  deferFallbackNotice,
+  FALLBACK_NOTICE_STORAGE_KEY,
+  flushPendingFallbackNotices,
+  persistFallbackNotice,
+  pruneFallbackNoticesAfter,
+  restoreFallbackNotices
+} from './fallback-notices'
+
+const message = (id: string, role: ChatMessage['role'], text: string): ChatMessage => ({
+  id,
+  role,
+  parts: [{ type: 'text', text }]
+})
+
+describe('fallback notice persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('restores a decision at its transcript boundary without changing model history', () => {
+    const storedMessages = [
+      message('u1', 'user', 'first'),
+      message('a1', 'assistant', 'first answer'),
+      message('u2', 'user', 'second'),
+      message('a2', 'assistant', 'fallback answer')
+    ]
+
+    const notice = createFallbackNotice('Fallback policy local-only: switching to local/model', 1_700_000_000_000)
+
+    persistFallbackNotice('stored-1', notice, 3, 1_700_000_000_001)
+    const restored = restoreFallbackNotices('stored-1', storedMessages)
+
+    expect(restored.map(item => item.id)).toEqual(['u1', 'a1', 'u2', notice.id, 'a2'])
+    expect(restored[3]).toMatchObject({ role: 'system', timestamp: 1_700_000_000 })
+    expect(storedMessages.map(item => item.id)).toEqual(['u1', 'a1', 'u2', 'a2'])
+  })
+
+  it('is idempotent when a live notice is already present', () => {
+    const notice = createFallbackNotice('switching', 1_700_000_000_000)
+    persistFallbackNotice('stored-1', notice, 1)
+
+    const messages = [message('u1', 'user', 'hello'), notice, message('a1', 'assistant', 'answer')]
+    expect(restoreFallbackNotices('stored-1', messages)).toBe(messages)
+  })
+
+  it('uses collision-safe ids for rapid fallback chain switches', () => {
+    const first = createFallbackNotice('first switch', 1_700_000_000_000)
+    const second = createFallbackNotice('second switch', 1_700_000_000_000)
+
+    expect(first.id).not.toBe(second.id)
+  })
+
+  it('backfills a decision emitted before the stored session id is assigned', () => {
+    const notice = createFallbackNotice('init-time switch', 1_700_000_000_000)
+
+    deferFallbackNotice('runtime-before-bind', notice, 1)
+    expect(window.localStorage.getItem(FALLBACK_NOTICE_STORAGE_KEY)).toBeNull()
+
+    flushPendingFallbackNotices('runtime-before-bind', 'stored-after-bind')
+
+    const restored = restoreFallbackNotices('stored-after-bind', [
+      message('u1', 'user', 'hello'),
+      message('a1', 'assistant', 'answer')
+    ])
+
+    expect(restored.map(item => item.id)).toEqual(['u1', notice.id, 'a1'])
+  })
+
+  it('fails open on malformed renderer storage', () => {
+    window.localStorage.setItem(FALLBACK_NOTICE_STORAGE_KEY, '{bad json')
+    const messages = [message('u1', 'user', 'hello')]
+
+    expect(restoreFallbackNotices('stored-1', messages)).toBe(messages)
+  })
+
+  it('drops notices from an abandoned timeline after a rewind boundary', () => {
+    const retained = createFallbackNotice('retained switch', 1_700_000_000_000)
+    const abandoned = createFallbackNotice('abandoned switch', 1_700_000_000_001)
+    persistFallbackNotice('stored-1', retained, 2)
+    persistFallbackNotice('stored-1', abandoned, 3)
+
+    pruneFallbackNoticesAfter('stored-1', 2)
+
+    const restored = restoreFallbackNotices('stored-1', [
+      message('u1', 'user', 'first'),
+      message('a1', 'assistant', 'first answer'),
+      message('u2', 'user', 'rewritten prompt'),
+      message('a2', 'assistant', 'new answer')
+    ])
+
+    expect(restored.map(item => item.id)).toContain(retained.id)
+    expect(restored.map(item => item.id)).not.toContain(abandoned.id)
+  })
+})

--- a/apps/desktop/src/lib/fallback-notices.ts
+++ b/apps/desktop/src/lib/fallback-notices.ts
@@ -1,0 +1,274 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+import { textPart } from '@/lib/chat-messages'
+import { readKey, writeKey } from '@/lib/storage'
+
+export const FALLBACK_NOTICE_STORAGE_KEY = 'hermes.desktop.fallbackNotices.v1'
+
+const FALLBACK_NOTICE_ID_PREFIX = 'fallback-status-'
+const MAX_NOTICES_PER_SESSION = 40
+const MAX_SESSIONS = 100
+const MAX_NOTICE_TEXT_LENGTH = 1_000
+
+let fallbackNoticeSequence = 0
+
+interface PersistedFallbackNotice {
+  beforeMessageCount: number
+  id: string
+  text: string
+  timestamp: number
+}
+
+interface PersistedSessionFallbackNotices {
+  notices: PersistedFallbackNotice[]
+  updatedAt: number
+}
+
+type PersistedFallbackNoticeRegistry = Record<string, PersistedSessionFallbackNotices>
+
+interface PendingFallbackNotice {
+  beforeMessageCount: number
+  message: ChatMessage
+}
+
+const pendingFallbackNoticesByRuntimeId = new Map<string, PendingFallbackNotice[]>()
+
+function fallbackNoticeMessage(notice: PersistedFallbackNotice): ChatMessage {
+  return {
+    id: notice.id,
+    role: 'system',
+    parts: [textPart(notice.text)],
+    timestamp: notice.timestamp
+  }
+}
+
+function parseNotice(value: unknown): PersistedFallbackNotice | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  const row = value as Record<string, unknown>
+
+  if (
+    typeof row.id !== 'string' ||
+    !row.id.startsWith(FALLBACK_NOTICE_ID_PREFIX) ||
+    typeof row.text !== 'string' ||
+    !row.text.trim() ||
+    typeof row.timestamp !== 'number' ||
+    !Number.isFinite(row.timestamp) ||
+    typeof row.beforeMessageCount !== 'number' ||
+    !Number.isFinite(row.beforeMessageCount)
+  ) {
+    return null
+  }
+
+  return {
+    beforeMessageCount: Math.max(0, Math.floor(row.beforeMessageCount)),
+    id: row.id,
+    text: row.text.trim().slice(0, MAX_NOTICE_TEXT_LENGTH),
+    timestamp: row.timestamp
+  }
+}
+
+function readRegistry(): PersistedFallbackNoticeRegistry {
+  const raw = readKey(FALLBACK_NOTICE_STORAGE_KEY)
+
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    const entries = Object.entries(parsed as Record<string, unknown>).flatMap(([sessionId, value]) => {
+      if (!sessionId || !value || typeof value !== 'object' || Array.isArray(value)) {
+        return []
+      }
+
+      const row = value as Record<string, unknown>
+
+      const notices = Array.isArray(row.notices)
+        ? row.notices.map(parseNotice).filter((notice): notice is PersistedFallbackNotice => notice !== null)
+        : []
+
+      const updatedAt = typeof row.updatedAt === 'number' && Number.isFinite(row.updatedAt) ? row.updatedAt : 0
+
+      return notices.length ? [[sessionId, { notices, updatedAt }] as const] : []
+    })
+
+    return Object.fromEntries(entries)
+  } catch {
+    return {}
+  }
+}
+
+function writeRegistry(registry: PersistedFallbackNoticeRegistry) {
+  const bounded = Object.fromEntries(
+    Object.entries(registry)
+      .sort((left, right) => right[1].updatedAt - left[1].updatedAt)
+      .slice(0, MAX_SESSIONS)
+  )
+
+  writeKey(FALLBACK_NOTICE_STORAGE_KEY, Object.keys(bounded).length ? JSON.stringify(bounded) : null)
+}
+
+export function createFallbackNotice(text: string, nowMs = Date.now()): ChatMessage {
+  fallbackNoticeSequence += 1
+
+  return {
+    id: `${FALLBACK_NOTICE_ID_PREFIX}${nowMs}-${fallbackNoticeSequence}`,
+    role: 'system',
+    parts: [textPart(text.trim().slice(0, MAX_NOTICE_TEXT_LENGTH))],
+    timestamp: nowMs / 1_000
+  }
+}
+
+export function deferFallbackNotice(runtimeSessionId: string, message: ChatMessage, beforeMessageCount: number) {
+  const runtimeId = runtimeSessionId.trim()
+
+  if (!runtimeId || !isFallbackNoticeMessage(message)) {
+    return
+  }
+
+  const pending = pendingFallbackNoticesByRuntimeId.get(runtimeId) ?? []
+  pendingFallbackNoticesByRuntimeId.set(runtimeId, [
+    ...pending.filter(item => item.message.id !== message.id),
+    { beforeMessageCount, message }
+  ])
+}
+
+export function flushPendingFallbackNotices(runtimeSessionId: string, storedSessionId: string) {
+  const runtimeId = runtimeSessionId.trim()
+  const storedId = storedSessionId.trim()
+  const pending = pendingFallbackNoticesByRuntimeId.get(runtimeId)
+
+  if (!runtimeId || !storedId || !pending?.length) {
+    return
+  }
+
+  for (const item of pending) {
+    persistFallbackNotice(storedId, item.message, item.beforeMessageCount)
+  }
+
+  pendingFallbackNoticesByRuntimeId.delete(runtimeId)
+}
+
+export function isFallbackNoticeMessage(message: ChatMessage): boolean {
+  return message.role === 'system' && message.id.startsWith(FALLBACK_NOTICE_ID_PREFIX)
+}
+
+export function countTranscriptMessages(messages: readonly ChatMessage[]): number {
+  return messages.reduce(
+    (count, message) => count + (message.role === 'user' || message.role === 'assistant' ? 1 : 0),
+    0
+  )
+}
+
+export function persistFallbackNotice(
+  storedSessionId: string,
+  message: ChatMessage,
+  beforeMessageCount: number,
+  nowMs = Date.now()
+) {
+  const sessionId = storedSessionId.trim()
+
+  const text = message.parts
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('')
+    .trim()
+
+  if (!sessionId || !isFallbackNoticeMessage(message) || !text) {
+    return
+  }
+
+  const registry = readRegistry()
+  const previous = registry[sessionId]?.notices ?? []
+
+  const notice: PersistedFallbackNotice = {
+    beforeMessageCount: Math.max(0, Math.floor(beforeMessageCount)),
+    id: message.id,
+    text: text.slice(0, MAX_NOTICE_TEXT_LENGTH),
+    timestamp: message.timestamp ?? nowMs / 1_000
+  }
+
+  registry[sessionId] = {
+    notices: [...previous.filter(item => item.id !== notice.id), notice].slice(-MAX_NOTICES_PER_SESSION),
+    updatedAt: nowMs
+  }
+  writeRegistry(registry)
+}
+
+export function pruneFallbackNoticesAfter(storedSessionId: string, beforeMessageCount: number) {
+  const sessionId = storedSessionId.trim()
+
+  if (!sessionId) {
+    return
+  }
+
+  const registry = readRegistry()
+  const session = registry[sessionId]
+
+  if (!session) {
+    return
+  }
+
+  const boundary = Math.max(0, Math.floor(beforeMessageCount))
+  const notices = session.notices.filter(notice => notice.beforeMessageCount <= boundary)
+
+  if (notices.length) {
+    registry[sessionId] = { notices, updatedAt: Date.now() }
+  } else {
+    delete registry[sessionId]
+  }
+
+  writeRegistry(registry)
+}
+
+export function restoreFallbackNotices(storedSessionId: string, messages: ChatMessage[]): ChatMessage[] {
+  const notices = readRegistry()[storedSessionId.trim()]?.notices
+
+  if (!notices?.length) {
+    return messages
+  }
+
+  const existingIds = new Set(messages.map(message => message.id))
+  const missing = notices.filter(notice => !existingIds.has(notice.id))
+
+  if (!missing.length) {
+    return messages
+  }
+
+  const restored = [...messages]
+
+  for (const notice of missing.sort(
+    (left, right) => left.beforeMessageCount - right.beforeMessageCount || left.timestamp - right.timestamp
+  )) {
+    let insertionIndex = 0
+    let transcriptMessageCount = 0
+
+    while (insertionIndex < restored.length && transcriptMessageCount < notice.beforeMessageCount) {
+      const message = restored[insertionIndex]
+
+      if (message.role === 'user' || message.role === 'assistant') {
+        transcriptMessageCount += 1
+      }
+
+      insertionIndex += 1
+    }
+
+    // Preserve emission order when more than one fallback notice belongs at
+    // the same transcript boundary, while still keeping every notice before
+    // the assistant response produced by the selected fallback.
+    while (insertionIndex < restored.length && isFallbackNoticeMessage(restored[insertionIndex])) {
+      insertionIndex += 1
+    }
+
+    restored.splice(insertionIndex, 0, fallbackNoticeMessage(notice))
+  }
+
+  return restored
+}

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -387,6 +387,9 @@ export const $resumeFailedSessionId = atom<string | null>(null)
 export const $resumeExhaustedSessionId = atom<string | null>(null)
 export const $currentModel = atom(storedString(COMPOSER_MODEL_KEY) ?? '')
 export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
+// Effective per-session fallback policy reflected from session.info. The
+// durable source is backend config; this atom only mirrors the focused session.
+export const $currentFallbackPolicy = atom<'' | 'any' | 'local-only' | 'off'>('')
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
@@ -488,6 +491,9 @@ export const markComposerSelectionManual = (): void => {
   composerSelectionGeneration += 1
   setCurrentModelSource('manual')
 }
+
+export const setCurrentFallbackPolicy = (next: Updater<'' | 'any' | 'local-only' | 'off'>) =>
+  updateAtom($currentFallbackPolicy, next)
 
 export const setCurrentReasoningEffort = (next: Updater<string>) => {
   updateAtom($currentReasoningEffort, next)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -580,6 +580,7 @@ export interface SessionRuntimeInfo {
   cwd?: string
   desktop_contract?: number
   fast?: boolean
+  fallback_policy?: 'any' | 'local-only' | 'off'
   install_warning?: string
   model?: string
   personality?: string

--- a/cli.py
+++ b/cli.py
@@ -52,7 +52,7 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
 import yaml
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_configured_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
@@ -4437,7 +4437,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Fallback provider chain — tried in order when primary fails after retries.
         # Merge new ``fallback_providers`` entries with any legacy
         # ``fallback_model`` entries so old configs still participate.
-        self._fallback_model = get_fallback_chain(CLI_CONFIG)
+        self._fallback_model = get_configured_fallback_chain(CLI_CONFIG)
 
         # Signature of the currently-initialised agent's runtime.  Used to
         # rebuild the agent when provider / model / base_url changes across

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -46,7 +46,7 @@ from hermes_cli.config import (
     cron_model_drift_guard_enabled,
     load_config,
 )
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_configured_fallback_chain, get_fallback_chain
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
@@ -3436,7 +3436,7 @@ def run_job(
                     f"(or pin the original values to keep them). See #44585."
                 )
 
-        fallback_model = get_fallback_chain(_cfg) or None
+        fallback_model = get_configured_fallback_chain(_cfg) or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3292,6 +3292,9 @@ def run_job(
             or configured_provider_for_drift
             or None
         )
+        _initial_fallback_decision = None
+        _initial_fallback_entry = None
+        _runtime_model = model
         try:
             # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
             # already prefers persisted config over stale shell/env overrides when
@@ -3335,7 +3338,10 @@ def run_job(
                 if not fb_provider or not fb_model:
                     continue
                 try:
-                    from hermes_cli.fallback_config import resolve_entry_api_key
+                    from hermes_cli.fallback_config import (
+                        get_fallback_policy,
+                        resolve_entry_api_key,
+                    )
 
                     fb_kwargs = {
                         "requested": fb_provider,
@@ -3347,24 +3353,47 @@ def run_job(
                     if fb_api_key:
                         fb_kwargs["explicit_api_key"] = fb_api_key
                     runtime = resolve_runtime_provider(**fb_kwargs)
-                    model = fb_model
                     logger.info(
                         "Job '%s': fallback resolved to %s model %s",
                         job_id,
                         runtime.get("provider"),
                         fb_model,
                     )
+                    _policy = get_fallback_policy(_cfg)
+                    _initial_fallback_decision = (
+                        f"🔄 Fallback policy {_policy}: {model} via "
+                        f"{job.get('provider') or 'primary provider'} could not "
+                        f"initialize (reason: {auth_exc}); switching to "
+                        f"{fb_model} via {fb_provider}."
+                    )
+                    _initial_fallback_entry = dict(entry)
+                    _runtime_model = fb_model
                     break
                 except Exception as fb_exc:
                     logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
             if runtime is None:
-                raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+                from hermes_cli.fallback_config import get_fallback_policy
+
+                _policy = get_fallback_policy(_cfg)
+                if _policy == "off":
+                    _detail = "Fallback policy off: no backup provider was attempted."
+                elif _policy == "local-only":
+                    _detail = (
+                        "Fallback policy local-only: no usable local backup route remained."
+                    )
+                else:
+                    _detail = (
+                        "Fallback policy any: no usable configured backup route remained."
+                    )
+                raise RuntimeError(
+                    f"{format_runtime_provider_error(auth_exc)}\n{_detail}"
+                ) from auth_exc
         except Exception as exc:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
         reasoning_config = resolve_reasoning_config(
-            _cfg if isinstance(_cfg, dict) else {}, str(model)
+            _cfg if isinstance(_cfg, dict) else {}, str(_runtime_model)
         )
 
         # Provider/model-drift fail-closed guard (#44585).
@@ -3476,7 +3505,7 @@ def run_job(
             )
 
         agent = AIAgent(
-            model=model,
+            model=_runtime_model,
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
@@ -3488,6 +3517,9 @@ def run_job(
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
+            fallback_chain_from_config=True,
+            initial_fallback_decision=_initial_fallback_decision,
+            initial_fallback_entry=_initial_fallback_entry,
             credential_pool=credential_pool,
             providers_allowed=pr.get("only"),
             providers_ignored=pr.get("ignore"),

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2646,6 +2646,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "tool_complete_callback": tool_complete_callback,
             "session_db": self._ensure_session_db(),
             "fallback_model": fallback_model,
+            "fallback_chain_from_config": True,
             "reasoning_config": reasoning_config,
             "gateway_session_key": gateway_session_key,
         }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2354,10 +2354,31 @@ def _resolve_runtime_agent_kwargs() -> dict:
             logger.warning("Primary provider rate-limited (429): %s — trying fallback", auth_exc)
         else:
             logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
-        fb_config = _try_resolve_fallback_provider()
+        fb_config = _try_resolve_fallback_provider(primary_error=auth_exc)
         if fb_config is not None:
             return fb_config
-        raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+        try:
+            import yaml as _y
+            from hermes_cli.fallback_config import get_fallback_policy
+
+            cfg_path = _hermes_home / "config.yaml"
+            with open(cfg_path, encoding="utf-8") as _f:
+                policy = get_fallback_policy(_y.safe_load(_f) or {})
+        except Exception:
+            policy = "off"
+        if policy == "off":
+            fallback_detail = "Fallback policy off: no backup provider was attempted."
+        elif policy == "local-only":
+            fallback_detail = (
+                "Fallback policy local-only: no usable local backup route remained."
+            )
+        else:
+            fallback_detail = (
+                "Fallback policy any: no usable configured backup route remained."
+            )
+        raise RuntimeError(
+            f"{format_runtime_provider_error(auth_exc)}\n{fallback_detail}"
+        ) from auth_exc
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
@@ -2433,7 +2454,9 @@ def _credential_pool_for_provider(provider: Optional[str]):
         return None
 
 
-def _try_resolve_fallback_provider() -> dict | None:
+def _try_resolve_fallback_provider(
+    *, primary_error: Exception | None = None,
+) -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
@@ -2452,6 +2475,7 @@ def _try_resolve_fallback_provider() -> dict | None:
 
                 runtime = resolve_runtime_provider(
                     requested=entry.get("provider"),
+                    target_model=entry.get("model"),
                     explicit_base_url=entry.get("base_url"),
                     explicit_api_key=resolve_entry_api_key(entry),
                 )
@@ -2464,7 +2488,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     entry.get("provider") or runtime.get("provider"),
                     entry.get("model"),
                 )
-                return {
+                resolved = {
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),
                     "provider": runtime.get("provider"),
@@ -2475,6 +2499,29 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "credential_pool": runtime.get("credential_pool"),
                     "model": entry.get("model"),
                 }
+                if primary_error is not None:
+                    from hermes_cli.fallback_config import get_fallback_policy
+
+                    model_cfg = cfg.get("model")
+                    if isinstance(model_cfg, dict):
+                        primary_model = str(
+                            model_cfg.get("default") or model_cfg.get("model") or "configured model"
+                        )
+                        primary_provider = str(
+                            model_cfg.get("provider") or "primary provider"
+                        )
+                    else:
+                        primary_model = str(model_cfg or "configured model")
+                        primary_provider = "primary provider"
+                    policy = get_fallback_policy(cfg)
+                    resolved["initial_fallback_decision"] = (
+                        f"🔄 Fallback policy {policy}: {primary_model} via "
+                        f"{primary_provider} could not initialize (reason: "
+                        f"{primary_error}); switching to {entry.get('model')} "
+                        f"via {entry.get('provider')}."
+                    )
+                    resolved["initial_fallback_entry"] = dict(entry)
+                return resolved
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
                 continue
@@ -4618,6 +4665,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
+            "initial_fallback_decision": runtime_kwargs.get(
+                "initial_fallback_decision"
+            ),
+            "initial_fallback_entry": runtime_kwargs.get(
+                "initial_fallback_entry"
+            ),
         }
         route = {
             "model": model,
@@ -16356,6 +16409,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            fallback_decisions: List[str] = []
+
+            def _background_status_callback(event_type: str, message: str) -> None:
+                if event_type != "fallback":
+                    return
+                text = str(message or "").strip()
+                if text and text not in fallback_decisions:
+                    fallback_decisions.append(text)
+
+            async def _deliver_background_fallback_decisions() -> None:
+                if not fallback_decisions:
+                    return
+                try:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content="\n".join(fallback_decisions),
+                        metadata=_thread_metadata,
+                    )
+                except Exception as status_exc:
+                    logger.warning(
+                        "Background task %s fallback status delivery failed: %s",
+                        task_id,
+                        status_exc,
+                    )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -16405,6 +16482,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    fallback_chain_from_config=True,
+                    status_callback=_background_status_callback,
                 )
                 try:
                     return agent.run_conversation(
@@ -16414,7 +16493,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 finally:
                     self._cleanup_agent_resources(agent)
 
-            result = await self._run_in_executor_with_context(run_sync)
+            try:
+                result = await self._run_in_executor_with_context(run_sync)
+            except Exception:
+                await _deliver_background_fallback_decisions()
+                raise
+            await _deliver_background_fallback_decisions()
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -22378,6 +22462,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    fallback_chain_from_config=True,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,7 +68,7 @@ from agent.conversation_compression import (
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_configured_fallback_chain, get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -5878,7 +5878,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                fb = get_fallback_chain(cfg)
+                fb = get_configured_fallback_chain(cfg)
                 if fb:
                     return fb
         except Exception:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -14,6 +14,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 
 from __future__ import annotations
 
+import os
 import sys
 
 from rich.markup import escape as _escape
@@ -46,11 +47,50 @@ class CLIAgentSetupMixin:
         except Exception as exc:
             _primary_exc = exc
 
+        if runtime is not None and _primary_exc is None:
+            _active_init_fallback = getattr(
+                self, "_initial_fallback_entry", None
+            )
+            if isinstance(_active_init_fallback, dict):
+                _active_provider = str(
+                    _active_init_fallback.get("provider") or ""
+                ).strip().lower()
+                _active_model = str(
+                    _active_init_fallback.get("model") or ""
+                ).strip()
+                if (
+                    str(self.requested_provider or "").strip().lower()
+                    != _active_provider
+                    or str(self.model or "").strip() != _active_model
+                ):
+                    self._initial_fallback_entry = None
+                    self._initial_fallback_decision = None
+
         # Primary provider auth failed — try fallback providers before giving up.
+        _fallback_resolution_note = ""
         if runtime is None and _primary_exc is not None:
             from hermes_cli.auth import AuthError
             if isinstance(_primary_exc, AuthError):
-                _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
+                try:
+                    from hermes_cli.config import load_config_readonly
+                    from hermes_cli.fallback_config import (
+                        filter_fallback_chain_for_policy,
+                        get_configured_fallback_chain,
+                        get_fallback_policy,
+                    )
+
+                    _fb_config = load_config_readonly()
+                    _fb_policy = get_fallback_policy(_fb_config)
+                    self._fallback_model = get_configured_fallback_chain(_fb_config)
+                    _fb_chain = filter_fallback_chain_for_policy(
+                        self._fallback_model,
+                        _fb_config,
+                    )
+                except Exception:
+                    # Auth fallback is a routing decision. If its policy cannot
+                    # be read, fail closed instead of silently widening it.
+                    _fb_policy = "off"
+                    _fb_chain = []
                 for _fb in _fb_chain:
                     _fb_provider = (_fb.get("provider") or "").strip().lower()
                     _fb_model = (_fb.get("model") or "").strip()
@@ -59,7 +99,10 @@ class CLIAgentSetupMixin:
                     try:
                         from hermes_cli.fallback_config import resolve_entry_api_key
 
-                        _fb_kwargs = {"requested": _fb_provider}
+                        _fb_kwargs = {
+                            "requested": _fb_provider,
+                            "target_model": _fb_model,
+                        }
                         if _fb.get("base_url"):
                             _fb_kwargs["explicit_base_url"] = _fb["base_url"]
                         _fb_api_key = resolve_entry_api_key(_fb)
@@ -67,19 +110,39 @@ class CLIAgentSetupMixin:
                             _fb_kwargs["explicit_api_key"] = _fb_api_key
                         runtime = resolve_runtime_provider(**_fb_kwargs)
                         logger.warning(
-                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
-                            _primary_exc, _fb_provider, _fb_model,
+                            "Primary provider auth failed (%s). Fallback policy %s selected %s/%s",
+                            _primary_exc, _fb_policy, _fb_provider, _fb_model,
                         )
-                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                        _fallback_decision = (
+                            f"🔄 Fallback policy {_fb_policy}: primary provider could not initialize "
+                            f"(reason: {_primary_exc}); switching to {_fb_model} via {_fb_provider}."
+                        )
+                        _cprint(_fallback_decision)
+                        self._initial_fallback_entry = dict(_fb)
+                        self._initial_fallback_decision = _fallback_decision
                         self.requested_provider = _fb_provider
                         self.model = _fb_model
                         _primary_exc = None
                         break
                     except Exception:
                         continue
+                if runtime is None:
+                    if _fb_policy == "off":
+                        _fallback_resolution_note = (
+                            "\nFallback policy off: no backup provider was attempted."
+                        )
+                    elif _fb_policy == "local-only":
+                        _fallback_resolution_note = (
+                            "\nFallback policy local-only: no usable local backup route remained."
+                        )
+                    else:
+                        _fallback_resolution_note = (
+                            "\nFallback policy any: no usable configured backup route remained."
+                        )
 
         if runtime is None:
             message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."
+            message += _fallback_resolution_note
             ChatConsole().print(f"[bold red]{message}[/]")
             return False
 
@@ -393,6 +456,13 @@ class CLIAgentSetupMixin:
                 reasoning_callback=self._current_reasoning_callback(),
 
                 fallback_model=self._fallback_model,
+                fallback_chain_from_config=True,
+                # Classic CLI already printed the decision during credential
+                # resolution. Pass route identity (for live policy revocation)
+                # without queueing a duplicate status line on turn preflight.
+                initial_fallback_entry=getattr(
+                    self, "_initial_fallback_entry", None
+                ),
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1887,6 +1887,14 @@ class CLICommandsMixin:
         _cprint("  You can continue chatting — results will appear when done.\n")
 
         turn_route = self._resolve_turn_agent_config(prompt)
+        fallback_decisions = []
+
+        def _background_status(kind: str, text: str | None = None) -> None:
+            if kind != "fallback":
+                return
+            message = str(text or "").strip()
+            if message and message not in fallback_decisions:
+                fallback_decisions.append(message)
 
         def run_background():
             set_sudo_password_callback(self._sudo_password_callback)
@@ -1923,6 +1931,11 @@ class CLICommandsMixin:
                     provider_data_collection=self._provider_data_collection,
                     openrouter_min_coding_score=self._openrouter_min_coding_score,
                     fallback_model=self._fallback_model,
+                    fallback_chain_from_config=True,
+                    initial_fallback_entry=getattr(
+                        self, "_initial_fallback_entry", None
+                    ),
+                    status_callback=_background_status,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None
@@ -1956,6 +1969,8 @@ class CLICommandsMixin:
                 _cprint(f"  ✅ Background task #{task_num} complete")
                 _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                for decision in fallback_decisions:
+                    _cprint(f"  {decision}")
                 if response:
                     try:
                         from hermes_cli.skin_engine import get_active_skin
@@ -1993,6 +2008,8 @@ class CLICommandsMixin:
                     self._app.invalidate()
                     time.sleep(0.05)
                 print()
+                for decision in fallback_decisions:
+                    _cprint(f"  {decision}")
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
             finally:
                 try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1920,6 +1920,15 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                         "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
                     ))
 
+    # ── fallback_policy: exact failover boundary ─────────────────────────
+    fallback_policy = config.get("fallback_policy", "any")
+    if fallback_policy not in {"off", "local-only", "any"}:
+        issues.append(ConfigIssue(
+            "error",
+            "fallback_policy must be exactly one of: off, local-only, any",
+            "Set the top-level field, e.g. `fallback_policy: local-only`",
+        ))
+
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
     if fb is not None:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,6 +7,9 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    # Cross-provider fallback safety boundary. Compatibility default is
+    # ``any``; supported values are exactly: off | local-only | any.
+    "fallback_policy": "any",
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -11,6 +11,7 @@ Subcommands:
                            then append the selection to the chain
   hermes fallback remove   Pick an entry to delete from the chain
   hermes fallback clear    Remove all fallback entries
+  hermes fallback policy   Show or set off | local-only | any
 
 Storage: ``fallback_providers`` in ``~/.hermes/config.yaml`` (top-level, list of
 ``{provider, model, base_url?, api_mode?}`` dicts).  The legacy single-dict
@@ -21,7 +22,12 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import (
+    FALLBACK_POLICIES,
+    fallback_entry_is_local,
+    get_configured_fallback_chain,
+    get_fallback_policy,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +42,7 @@ def _read_chain(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     merged with ``fallback_providers`` entries kept first. The returned list is
     always a fresh copy — callers can mutate without touching the config dict.
     """
-    return get_fallback_chain(config)
+    return get_configured_fallback_chain(config)
 
 
 def _write_chain(config: Dict[str, Any], chain: List[Dict[str, Any]]) -> None:
@@ -110,7 +116,20 @@ def cmd_fallback_list(args) -> None:  # noqa: ARG001
 
     config = load_config()
     chain = _read_chain(config)
+    policy = get_fallback_policy(config)
 
+    print()
+    print(f"  Policy:    {policy}")
+    if policy == "off":
+        print("             Fallback is disabled; primary failures stop loudly.")
+    elif policy == "local-only":
+        eligible = sum(fallback_entry_is_local(entry, config) for entry in chain)
+        print(
+            "             Only endpoint-verified local routes are eligible "
+            f"({eligible}/{len(chain)} configured)."
+        )
+    else:
+        print("             Configured routes may be local or remote, in listed order.")
     print()
     if not chain:
         print("  No fallback providers configured.")
@@ -130,6 +149,24 @@ def cmd_fallback_list(args) -> None:  # noqa: ARG001
     print("  Tried in order when the primary fails (rate-limit, 5xx, connection errors).")
     print("  Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers")
     print()
+
+
+def cmd_fallback_policy(args) -> None:
+    """Show or safely persist the exact fallback policy."""
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    requested = getattr(args, "fallback_policy", None)
+    if requested is None:
+        print(get_fallback_policy(config))
+        return
+    if requested not in FALLBACK_POLICIES:
+        print("fallback policy must be exactly one of: off, local-only, any")
+        raise SystemExit(2)
+
+    config["fallback_policy"] = requested
+    save_config(config)
+    print(f"Fallback policy set to: {requested}")
 
 
 def _describe_primary(config: Dict[str, Any]) -> Optional[str]:
@@ -371,7 +408,9 @@ def cmd_fallback(args) -> None:
         cmd_fallback_remove(args)
     elif sub == "clear":
         cmd_fallback_clear(args)
+    elif sub == "policy":
+        cmd_fallback_policy(args)
     else:
         print(f"Unknown fallback subcommand: {sub}")
-        print("Use one of: list, add, remove, clear")
+        print("Use one of: list, add, remove, clear, policy")
         raise SystemExit(2)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -1,9 +1,30 @@
-"""Helpers for reading the effective fallback provider chain from config."""
+"""Helpers for reading and enforcing the fallback provider policy."""
 
 from __future__ import annotations
 
 import os
 from typing import Any
+
+
+FALLBACK_POLICIES = ("off", "local-only", "any")
+DEFAULT_FALLBACK_POLICY = "any"
+_BUILTIN_LOCAL_PROVIDER_IDS = frozenset({"custom", "local", "lmstudio"})
+
+
+def get_fallback_policy(config: dict[str, Any] | None) -> str:
+    """Return the configured fallback policy, failing closed on invalid input.
+
+    ``any`` is the compatibility default for configs written before the policy
+    existed. Invalid explicit values are treated as ``off`` at runtime; config
+    validation reports the mistake so a typo can never silently widen routing.
+    """
+    config = config or {}
+    if "fallback_policy" not in config:
+        return DEFAULT_FALLBACK_POLICY
+    value = config.get("fallback_policy")
+    if isinstance(value, str) and value in FALLBACK_POLICIES:
+        return value
+    return "off"
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -68,15 +89,102 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
-def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Return the effective fallback chain merged across old and new config keys.
+def _resolve_fallback_provider_definition(
+    entry: dict[str, Any],
+    config: dict[str, Any],
+):
+    provider = str(entry.get("provider") or "").strip()
+    if not provider:
+        return None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import resolve_provider_full
 
-    ``fallback_providers`` remains the primary source of truth and keeps its
-    order. Legacy ``fallback_model`` entries are appended afterwards unless
-    they target the same provider/model/base_url route as an earlier entry.
-    The returned list always contains fresh dict copies.
+        return resolve_provider_full(
+            provider,
+            user_providers=(
+                config.get("providers")
+                if isinstance(config.get("providers"), dict)
+                else None
+            ),
+            custom_providers=get_compatible_custom_providers(config),
+        )
+    except Exception:
+        return None
+
+
+def fallback_entry_endpoint(
+    entry: dict[str, Any],
+    config: dict[str, Any] | None = None,
+) -> str:
+    """Resolve an entry's endpoint from explicit or provider metadata.
+
+    This intentionally never infers locality from a model name. An explicit
+    ``base_url`` wins, followed by a provider-specific environment override,
+    then the canonical provider definition (including user providers).
     """
+    explicit = _normalized_base_url(entry.get("base_url"))
+    if explicit:
+        return explicit
 
+    config = config or {}
+    resolved = _resolve_fallback_provider_definition(entry, config)
+    if resolved is None:
+        return ""
+
+    env_name = str(getattr(resolved, "base_url_env_var", "") or "").strip()
+    if env_name:
+        env_url = _normalized_base_url(os.getenv(env_name))
+        if env_url:
+            return env_url
+    return _normalized_base_url(getattr(resolved, "base_url", ""))
+
+
+def fallback_entry_is_local(
+    entry: dict[str, Any],
+    config: dict[str, Any] | None = None,
+) -> bool:
+    """Return whether provider metadata proves that an entry is local."""
+    config = config or {}
+    endpoint = fallback_entry_endpoint(entry, config)
+    if not endpoint:
+        return False
+    try:
+        from agent.model_metadata import is_local_endpoint
+
+        if not is_local_endpoint(endpoint):
+            return False
+
+        # A built-in cloud provider remains a remote route even if a stale or
+        # hostile environment variable points its client at localhost. Users
+        # who deliberately redefine that provider under ``providers:`` get a
+        # ``user-config`` definition and are judged by that endpoint instead.
+        resolved = _resolve_fallback_provider_definition(entry, config)
+        if (
+            resolved is not None
+            and getattr(resolved, "source", "") != "user-config"
+            and str(getattr(resolved, "id", "") or "").strip().lower()
+            not in _BUILTIN_LOCAL_PROVIDER_IDS
+        ):
+            return False
+        canonical_endpoint = _normalized_base_url(
+            getattr(resolved, "base_url", "") if resolved is not None else ""
+        )
+        if (
+            canonical_endpoint
+            and getattr(resolved, "source", "") != "user-config"
+            and not is_local_endpoint(canonical_endpoint)
+        ):
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def get_configured_fallback_chain(
+    config: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Return the ordered configured chain before policy filtering."""
     config = config or {}
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
@@ -88,5 +196,17 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
                 continue
             seen.add(identity)
             chain.append(entry)
+    return chain
 
+
+def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return the chain eligible under ``off | local-only | any``."""
+    config = config or {}
+    policy = get_fallback_policy(config)
+    if policy == "off":
+        return []
+
+    chain = get_configured_fallback_chain(config)
+    if policy == "local-only":
+        return [entry for entry in chain if fallback_entry_is_local(entry, config)]
     return chain

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -210,3 +210,27 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     if policy == "local-only":
         return [entry for entry in chain if fallback_entry_is_local(entry, config)]
     return chain
+
+
+def filter_fallback_chain_for_policy(
+    entries: Any,
+    config: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Filter a caller-supplied chain through the effective routing policy.
+
+    Some runtime entry points resolve the primary provider before constructing
+    an :class:`AIAgent` and therefore cannot use :func:`get_fallback_chain`
+    directly: the ordered entries have already been captured by the caller.
+    This helper applies the same ``off | local-only | any`` boundary to that
+    captured chain so init/auth fallback can never bypass the configured
+    policy.  Returned entries are normalized fresh copies.
+    """
+    config = config or {}
+    policy = get_fallback_policy(config)
+    if policy == "off":
+        return []
+
+    chain = _iter_fallback_entries(entries)
+    if policy == "local-only":
+        return [entry for entry in chain if fallback_entry_is_local(entry, config)]
+    return chain

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -16149,6 +16149,16 @@ def main():
         "clear",
         help="Remove all fallback entries",
     )
+    fallback_policy_parser = fallback_subparsers.add_parser(
+        "policy",
+        help="Show or set the fallback boundary: off | local-only | any",
+    )
+    fallback_policy_parser.add_argument(
+        "fallback_policy",
+        nargs="?",
+        choices=("off", "local-only", "any"),
+        help="Omit to show the current policy",
+    )
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -29,7 +29,11 @@ from pathlib import Path
 from typing import Optional
 
 from gateway.session_context import declare_stateless_channel
-from hermes_cli.fallback_config import get_configured_fallback_chain
+from hermes_cli.fallback_config import (
+    filter_fallback_chain_for_policy,
+    get_configured_fallback_chain,
+    get_fallback_policy,
+)
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -323,7 +327,11 @@ def _run_agent(
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
     from hermes_cli.models import detect_provider_for_model
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.auth import AuthError
+    from hermes_cli.runtime_provider import (
+        format_runtime_provider_error,
+        resolve_runtime_provider,
+    )
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
 
@@ -382,11 +390,79 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
-        requested=effective_provider,
-        target_model=effective_model or None,
-        explicit_base_url=explicit_base_url_from_alias,
-    )
+    # Capture the ordered chain before resolving the primary.  A credential
+    # failure happens before AIAgent exists, so relying on its init-time
+    # fallback would make ``hermes -z`` silently bypass the configured policy.
+    # Keep the unfiltered chain for AIAgent's later per-turn refresh, but apply
+    # the live policy before attempting any startup substitute here.
+    _fb = get_configured_fallback_chain(cfg)
+    _eligible_fb = filter_fallback_chain_for_policy(_fb, cfg)
+    _fallback_policy = get_fallback_policy(cfg)
+    _initial_fallback_decision = None
+    _initial_fallback_entry = None
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=effective_provider,
+            target_model=effective_model or None,
+            explicit_base_url=explicit_base_url_from_alias,
+        )
+    except AuthError as primary_exc:
+        runtime = None
+        primary_model = str(effective_model or "configured model")
+        primary_provider = str(
+            effective_provider
+            or (
+                model_cfg.get("provider")
+                if isinstance(model_cfg, dict)
+                else None
+            )
+            or "primary provider"
+        )
+        for entry in _eligible_fb:
+            try:
+                explicit_api_key = str(entry.get("api_key") or "").strip() or None
+                if not explicit_api_key:
+                    key_env = str(
+                        entry.get("key_env") or entry.get("api_key_env") or ""
+                    ).strip()
+                    if key_env:
+                        explicit_api_key = os.getenv(key_env, "").strip() or None
+
+                runtime = resolve_runtime_provider(
+                    requested=entry.get("provider"),
+                    target_model=entry.get("model"),
+                    explicit_base_url=entry.get("base_url"),
+                    explicit_api_key=explicit_api_key,
+                )
+            except Exception:
+                continue
+
+            effective_model = str(entry.get("model") or effective_model)
+            _initial_fallback_entry = dict(entry)
+            _initial_fallback_decision = (
+                f"🔄 Fallback policy {_fallback_policy}: {primary_model} via "
+                f"{primary_provider} could not initialize (reason: {primary_exc}); "
+                f"switching to {effective_model} via {entry.get('provider')}."
+            )
+            break
+
+        if runtime is None:
+            if _fallback_policy == "off":
+                fallback_note = (
+                    "Fallback policy off: no backup provider was attempted."
+                )
+            elif _fallback_policy == "local-only":
+                fallback_note = (
+                    "Fallback policy local-only: no usable local backup route remained."
+                )
+            else:
+                fallback_note = (
+                    "Fallback policy any: no usable configured backup route remained."
+                )
+            raise RuntimeError(
+                f"{format_runtime_provider_error(primary_exc)}\n{fallback_note}"
+            ) from primary_exc
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -402,10 +478,6 @@ def _run_agent(
     # os._exit and skips finalizers, so an un-closed connection here would leak.
     agent = None
     try:
-        # Read the configured fallback chain from profile config; the agent
-        # applies the fallback policy (off | local-only | any) itself.
-        _fb = get_configured_fallback_chain(cfg)
-
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
@@ -419,6 +491,9 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            fallback_chain_from_config=True,
+            initial_fallback_decision=_initial_fallback_decision,
+            initial_fallback_entry=_initial_fallback_entry,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 from gateway.session_context import declare_stateless_channel
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import get_configured_fallback_chain
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -402,10 +402,9 @@ def _run_agent(
     # os._exit and skips finalizers, so an un-closed connection here would leak.
     agent = None
     try:
-        # Read the effective fallback chain from profile config so oneshot
-        # workers honour the same merge semantics as interactive CLI and
-        # gateway sessions.
-        _fb = get_fallback_chain(cfg)
+        # Read the configured fallback chain from profile config; the agent
+        # applies the fallback policy (off | local-only | any) itself.
+        _fb = get_configured_fallback_chain(cfg)
 
         agent = AIAgent(
             api_key=runtime.get("api_key"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -493,6 +493,9 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        fallback_chain_from_config: Optional[bool] = None,
+        initial_fallback_decision: str = None,
+        initial_fallback_entry: Dict[str, Any] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
@@ -571,6 +574,9 @@ class AIAgent:
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
             fallback_model=fallback_model,
+            fallback_chain_from_config=fallback_chain_from_config,
+            initial_fallback_decision=initial_fallback_decision,
+            initial_fallback_entry=initial_fallback_entry,
             credential_pool=credential_pool,
             checkpoints_enabled=checkpoints_enabled,
             checkpoint_max_snapshots=checkpoint_max_snapshots,
@@ -1117,16 +1123,14 @@ class AIAgent:
             pass
 
     def _emit_pending_fallback_notice(self) -> None:
-        """Surface the one-shot fallback-switch notice on successful recovery.
+        """Surface an init-time fallback decision exactly once before use.
 
-        A provider/model switch is a durable state change operators must see,
-        unlike transient retry chatter that ``_clear_status_buffer`` drops.
-        ``try_activate_fallback`` records the switch in
-        ``self._pending_fallback_notice``; this emits it exactly once via
-        ``_emit_status`` and then clears it, so a successful fallback still
-        produces one visible notice.  On terminal failure the buffered switch
-        line is flushed instead (and this notice discarded) — see
-        ``_flush_status_buffer`` — so the user always sees the switch once.
+        Gateway render callbacks are commonly attached after ``AIAgent``
+        construction, so init/auth fallback cannot emit to them immediately.
+        The constructor queues that decision here and the turn preflight emits
+        it before the first request to the selected fallback. Runtime fallback
+        decisions are emitted immediately by ``try_activate_fallback`` and do
+        not use this slot.
         """
         try:
             notice = getattr(self, "_pending_fallback_notice", None)
@@ -1134,7 +1138,7 @@ class AIAgent:
                 # Clear before emitting so a (swallowed) callback error can't
                 # leave the notice set for a stale re-emit on a later turn.
                 self._pending_fallback_notice = None
-                self._emit_status(notice)
+                self._emit_fallback_status(notice)
         except Exception:
             # Never break the conversation loop on a notice hiccup.
             pass
@@ -1146,9 +1150,9 @@ class AIAgent:
         was tried before the turn gave up.
         """
         try:
-            # The buffered trace already carries the fallback switch line, so
-            # drop any one-shot fallback notice to avoid a stale duplicate
-            # leaking into a later successful turn.
+            # A queued init-time decision should already have been emitted by
+            # the turn preflight. Clear defensively at terminal exhaustion so
+            # it can never leak into a later turn.
             self._pending_fallback_notice = None
             buf = getattr(self, "_retry_status_buffer", None)
             if not buf:
@@ -2938,6 +2942,10 @@ class AIAgent:
             if session_has_running_agent:
                 running_agent.interrupt(new_message.text)
         """
+        # A fallback notice belongs only to the turn that activated it. If
+        # that turn is cancelled, never let the next primary success announce
+        # a stale provider switch.
+        self._pending_fallback_notice = None
         # A hard stop and redirect share one lock so /stop cannot race with an
         # accepted correction and accidentally turn itself into a retry.
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
@@ -3024,6 +3032,11 @@ class AIAgent:
         intentionally cancels a model request to rebuild that same logical
         turn. Public hard-stop paths keep the default and clear everything.
         """
+        # ``clear_interrupt`` is the common turn-finalizer path, including
+        # cancellations noticed outside ``interrupt()`` itself. A redirect
+        # rebuilds the same logical turn, so its notice must survive.
+        if not preserve_redirect:
+            self._pending_fallback_notice = None
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is not None:
             with _redirect_lock:
@@ -5913,17 +5926,63 @@ class AIAgent:
         emit_fallback_policy_terminal_status(self, reason)
 
     def _refresh_fallback_policy(self) -> str:
-        """Refresh the policy for cached agents at the start of every turn."""
+        """Refresh the effective policy and ordered chain once per turn."""
         try:
             from hermes_cli.config import load_config_readonly
-            from hermes_cli.fallback_config import get_fallback_policy
+            from hermes_cli.fallback_config import (
+                filter_fallback_chain_for_policy,
+                get_configured_fallback_chain,
+                get_fallback_policy,
+            )
 
-            policy = get_fallback_policy(load_config_readonly())
+            config = load_config_readonly()
+            policy = get_fallback_policy(config)
+            configured_chain = get_configured_fallback_chain(config)
+            if getattr(self, "_fallback_chain_from_config", False):
+                seed = configured_chain
+                chain = filter_fallback_chain_for_policy(seed, config)
+                chain_from_config = True
+            else:
+                seed = list(
+                    getattr(self, "_fallback_chain_seed", None)
+                    or getattr(self, "_fallback_chain", None)
+                    or []
+                )
+                chain = filter_fallback_chain_for_policy(seed, config)
+                chain_from_config = False
         except Exception:
             policy = "off"
+            seed = list(
+                getattr(self, "_fallback_chain_seed", None)
+                or getattr(self, "_fallback_chain", None)
+                or []
+            )
+            chain = []
+            chain_from_config = getattr(self, "_fallback_chain_from_config", False)
+        excluded_providers = {
+            str(provider).strip().lower()
+            for provider in (
+                getattr(self, "_fallback_excluded_providers", None) or set()
+            )
+            if str(provider).strip()
+        }
+        if excluded_providers:
+            chain = [
+                entry
+                for entry in chain
+                if str(entry.get("provider") or "").strip().lower()
+                not in excluded_providers
+            ]
         self._fallback_policy = policy
+        self._fallback_chain_seed = [dict(entry) for entry in seed]
+        self._fallback_chain_from_config = chain_from_config
+        self._fallback_chain = [dict(entry) for entry in chain]
+        self._fallback_model = (
+            self._fallback_chain[0] if self._fallback_chain else None
+        )
+        self._fallback_index = 0
+        self._unavailable_fallback_keys = set()
         self._fallback_terminal_status_emitted = False
-        self._pending_fallback_notice = None
         return policy
 
     def _has_pending_fallback(self) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -945,6 +945,21 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
 
+    def _emit_fallback_status(self, message: str) -> None:
+        """Emit an immediate, structured fallback decision/status message."""
+        try:
+            self._vprint(f"{self.log_prefix}{message}", force=True)
+        except Exception:
+            pass
+        if self.status_callback:
+            try:
+                self.status_callback("fallback", message)
+            except Exception:
+                logger.debug(
+                    "status_callback error in _emit_fallback_status",
+                    exc_info=True,
+                )
+
     def _emit_warning(self, message: str) -> None:
         """Emit a user-visible warning through the same status plumbing.
 
@@ -5882,10 +5897,34 @@ class AIAgent:
         from agent.chat_completion_helpers import interruptible_streaming_api_call
         return interruptible_streaming_api_call(self, api_kwargs, on_first_delta=on_first_delta)
 
-    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+    def _try_activate_fallback(
+        self, reason: "FailoverReason | str | None" = None,
+    ) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
         return try_activate_fallback(self, reason)
+
+    def _emit_fallback_policy_terminal_status(
+        self, reason: "FailoverReason | str | None" = None,
+    ) -> None:
+        """Forwarder for the policy-aware terminal fallback status."""
+        from agent.chat_completion_helpers import emit_fallback_policy_terminal_status
+
+        emit_fallback_policy_terminal_status(self, reason)
+
+    def _refresh_fallback_policy(self) -> str:
+        """Refresh the policy for cached agents at the start of every turn."""
+        try:
+            from hermes_cli.config import load_config_readonly
+            from hermes_cli.fallback_config import get_fallback_policy
+
+            policy = get_fallback_policy(load_config_readonly())
+        except Exception:
+            policy = "off"
+        self._fallback_policy = policy
+        self._fallback_terminal_status_emitted = False
+        self._pending_fallback_notice = None
+        return policy
 
     def _has_pending_fallback(self) -> bool:
         """Whether a fallback provider is actually available to switch to.
@@ -5895,6 +5934,8 @@ class AIAgent:
         fallback chain configured).  Mirrors the early-return guard in
         ``try_activate_fallback`` (#35314, #17446).
         """
+        if getattr(self, "_fallback_policy", "any") == "off":
+            return False
         chain = getattr(self, "_fallback_chain", None) or []
         index = getattr(self, "_fallback_index", 0)
         return index < len(chain)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2526,6 +2526,37 @@ class TestTryPaymentFallback:
         assert model is None
         assert label == ""
 
+    def test_policy_off_never_walks_builtin_remote_chain(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "off"},
+        ), patch("agent.auxiliary_client._get_provider_chain") as chain:
+            client, model, label = _try_payment_fallback("custom", task="vision")
+
+        chain.assert_not_called()
+        assert (client, model, label) == (None, None, "")
+
+    def test_local_only_skips_remote_and_returns_local_endpoint(self):
+        remote = MagicMock(base_url="https://api.anthropic.com")
+        local = MagicMock(base_url="http://10.55.0.3:8000/v1")
+        remote_resolver = MagicMock(return_value=(remote, "claude"))
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "local-only"},
+        ), patch(
+            "agent.auxiliary_client._get_provider_chain",
+            return_value=[
+                ("anthropic", remote_resolver),
+                ("local/custom", lambda: (local, "qwen")),
+            ],
+        ), patch("agent.auxiliary_client._read_main_provider", return_value="custom"):
+            client, model, label = _try_payment_fallback("failed", task="compression")
+
+        assert client is local
+        assert model == "qwen"
+        assert label == "local/custom"
+        remote_resolver.assert_not_called()
+
 
 class TestCallLlmPaymentFallback:
     """call_llm() retries with a different provider on 402 / payment / rate-limit errors."""

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -94,6 +94,8 @@ class _FakeAgent:
         # Records _cached_system_prompt at the moment _ensure_db_session()
         # is called (regression guard for #45499 turn-setup ordering).
         self._ensure_db_prompt_at_call = "<unset>"
+        self._fallback_policy_refreshes = 0
+        self._fallback_events = []
 
     def _warn_context_overflow_blocked(self, reason, preflight_tokens, threshold_tokens):
         # Mirror the real AIAgent helper so tests can assert the warning fired.
@@ -115,7 +117,12 @@ class _FakeAgent:
         self._ensure_db_prompt_at_call = self._cached_system_prompt
 
     def _restore_primary_runtime(self):
-        pass
+        self._fallback_events.append("restore")
+
+    def _refresh_fallback_policy(self):
+        self._fallback_policy_refreshes += 1
+        self._fallback_events.append("refresh")
+        return "any"
 
     def _cleanup_dead_connections(self):
         return False
@@ -252,6 +259,16 @@ def test_applies_agent_side_effects():
     # task/turn ids assigned on the agent.
     assert agent._current_task_id
     assert agent._current_turn_id
+
+
+def test_cached_agent_refreshes_policy_before_restore_on_every_turn():
+    agent = _FakeAgent()
+
+    _build(agent)
+    _build(agent)
+
+    assert agent._fallback_policy_refreshes == 2
+    assert agent._fallback_events == ["refresh", "restore", "refresh", "restore"]
 
 
 def test_task_id_passthrough():

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -124,6 +124,9 @@ class _FakeAgent:
         self._fallback_events.append("refresh")
         return "any"
 
+    def _emit_pending_fallback_notice(self):
+        self._fallback_events.append("pending")
+
     def _cleanup_dead_connections(self):
         return False
 
@@ -268,7 +271,10 @@ def test_cached_agent_refreshes_policy_before_restore_on_every_turn():
     _build(agent)
 
     assert agent._fallback_policy_refreshes == 2
-    assert agent._fallback_events == ["refresh", "restore", "refresh", "restore"]
+    assert agent._fallback_events == [
+        "refresh", "pending", "restore",
+        "refresh", "pending", "restore",
+    ]
 
 
 def test_task_id_passthrough():

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -59,6 +59,10 @@ def _make_background_cli_stub():
     cli._provider_data_collection = None
     cli._openrouter_min_coding_score = None
     cli._fallback_model = None
+    cli._initial_fallback_entry = {
+        "provider": "backup",
+        "model": "backup-model",
+    }
     cli._agent_running = False
     cli._spinner_text = ""
     cli.bell_on_complete = False
@@ -362,6 +366,7 @@ class TestCliApprovalUi:
 
         class FakeAgent:
             def __init__(self, **kwargs):
+                seen["agent_kwargs"] = kwargs
                 self._print_fn = None
                 self.thinking_callback = None
 
@@ -396,6 +401,10 @@ class TestCliApprovalUi:
         assert seen["approval"].__func__ is HermesCLI._approval_callback
         assert seen["sudo"].__self__ is cli
         assert seen["sudo"].__func__ is HermesCLI._sudo_password_callback
+        assert seen["agent_kwargs"]["initial_fallback_entry"] == {
+            "provider": "backup",
+            "model": "backup-model",
+        }
         assert not cli._background_tasks
 
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,109 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_cli_init_auth_fallback_obeys_local_only_policy(monkeypatch):
+    cli = _import_cli()
+    config = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [
+            {"provider": "openrouter", "model": "remote-backup"},
+        ],
+    }
+    calls = []
+    messages = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        raise AuthError("primary credentials unavailable", code="missing_credentials")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly", lambda: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error", str
+    )
+    monkeypatch.setattr(
+        cli,
+        "ChatConsole",
+        lambda: SimpleNamespace(print=messages.append),
+    )
+
+    shell = cli.HermesCLI(model="primary-model", compact=True, max_turns=1)
+    shell.requested_provider = "primary-provider"
+
+    assert shell._ensure_runtime_credentials() is False
+    assert [call["requested"] for call in calls] == ["primary-provider"]
+    assert any("Fallback policy local-only" in message for message in messages)
+
+
+def test_cli_init_auth_fallback_uses_live_chain_and_explicit_route(monkeypatch):
+    cli = _import_cli()
+    local = {
+        "provider": "custom",
+        "model": "local-backup",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "api_key": "local-test-key",
+    }
+    config = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [local],
+    }
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        if kwargs["requested"] == "primary-provider":
+            raise AuthError(
+                "primary credentials unavailable", code="missing_credentials"
+            )
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": local["base_url"],
+            "api_key": local["api_key"],
+            "source": "fallback-config",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly", lambda: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error", str
+    )
+
+    shell = cli.HermesCLI(model="primary-model", compact=True, max_turns=1)
+    shell.requested_provider = "primary-provider"
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.requested_provider == "custom"
+    assert shell.model == "local-backup"
+    assert shell._initial_fallback_entry == local
+    assert "Fallback policy local-only" in shell._initial_fallback_decision
+    assert calls[1] == {
+        "requested": "custom",
+        "target_model": "local-backup",
+        "explicit_base_url": local["base_url"],
+        "explicit_api_key": local["api_key"],
+    }
+
+    captured = {}
+
+    class _DummyAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+    assert shell._init_agent() is True
+    assert captured["initial_fallback_entry"] == local
+    assert "initial_fallback_decision" not in captured
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2495,6 +2495,65 @@ class TestRunJobConfigEnvVarExpansion:
         models = [e.get("model") for e in fb if isinstance(e, dict)]
         assert models == ["gpt-4o-mini", "claude-sonnet-4-6"]
 
+    def test_init_auth_fallback_decision_is_passed_to_cron_agent(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.auth import AuthError
+
+        local = {
+            "provider": "custom",
+            "model": "local-backup",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "key_env": "CRON_LOCAL_FALLBACK_KEY",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "model: primary-model\n"
+            "fallback_policy: local-only\n"
+            "fallback_providers:\n"
+            "  - provider: custom\n"
+            "    model: local-backup\n"
+            "    base_url: http://127.0.0.1:8000/v1\n"
+            "    key_env: CRON_LOCAL_FALLBACK_KEY\n"
+        )
+        monkeypatch.setenv("CRON_LOCAL_FALLBACK_KEY", "local-secret")
+        job = {"id": "auth-fallback", "name": "auth fallback", "prompt": "hi"}
+        fake_db = MagicMock()
+        fallback_runtime = {
+            **self._RUNTIME,
+            "provider": "custom",
+            "base_url": local["base_url"],
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=[AuthError("primary token expired"), fallback_runtime],
+             ) as mock_resolve, \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["model"] == "local-backup"
+        assert kwargs["initial_fallback_entry"] == local
+        assert "policy local-only" in kwargs["initial_fallback_decision"]
+        assert "primary token expired" in kwargs["initial_fallback_decision"]
+        assert mock_resolve.call_args_list[1].kwargs == {
+            "requested": "custom",
+            "target_model": "local-backup",
+            "explicit_base_url": local["base_url"],
+            "explicit_api_key": "local-secret",
+        }
+
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):
         """When the env var is not set, the literal ${VAR} is kept verbatim (not crashed)."""
         (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_UNSET_VAR}\n")

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -23,9 +23,11 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
 
         call_count = {"n": 0}
+        calls = []
 
         def _mock_resolve(**kwargs):
             call_count["n"] += 1
+            calls.append(kwargs)
             # First call = primary path (gateway reads model.provider from
             # config.yaml internally; we simulate the auth failure here).
             # Second call = fallback path with explicit_api_key + explicit_base_url
@@ -51,8 +53,17 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
 
         assert result["provider"] == "openrouter"
         assert result["api_key"] == "fallback-key"
+        assert result["initial_fallback_entry"] == {
+            "provider": "openrouter",
+            "model": "meta-llama/llama-4-maverick",
+        }
+        assert "Codex token refresh failed" in result["initial_fallback_decision"]
+        assert "switching to meta-llama/llama-4-maverick via openrouter" in result[
+            "initial_fallback_decision"
+        ]
         # Should have been called at least twice (primary + fallback)
         assert call_count["n"] >= 2
+        assert calls[1]["target_model"] == "meta-llama/llama-4-maverick"
 
     def test_auth_error_no_fallback_raises(self, tmp_path, monkeypatch):
         """When primary fails and no fallback configured, RuntimeError is raised."""
@@ -68,8 +79,11 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
             side_effect=AuthError("token expired"),
         ):
             from gateway.run import _resolve_runtime_agent_kwargs
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError) as exc_info:
                 _resolve_runtime_agent_kwargs()
+
+        assert "Fallback policy any" in str(exc_info.value)
+        assert "no usable configured backup route remained" in str(exc_info.value)
 
     def test_legacy_fallback_is_appended_after_fallback_providers(self, tmp_path, monkeypatch):
         """When both keys exist, the legacy entry still participates in resolution."""

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -282,6 +282,48 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_fallback_decision_is_delivered_before_background_result(self):
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "fallback answer"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "fallback answer"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+
+            def run_conversation(**_kwargs):
+                MockAgent.call_args.kwargs["status_callback"](
+                    "fallback",
+                    "Fallback policy local-only: switching to local-model via custom.",
+                )
+                return {"final_response": "fallback answer", "messages": []}
+
+            mock_agent_instance.run_conversation.side_effect = run_conversation
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        assert mock_adapter.send.await_count == 2
+        first = mock_adapter.send.await_args_list[0].kwargs["content"]
+        second = mock_adapter.send.await_args_list[1].kwargs["content"]
+        assert "Fallback policy local-only" in first
+        assert "fallback answer" in second
+
+    @pytest.mark.asyncio
     async def test_media_files_routed_by_type(self, monkeypatch):
         """Result media is routed to the type-specific sender, not send_document.
 
@@ -352,13 +394,21 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert _os.path.realpath(
+                mock_adapter.send_voice.call_args.kwargs["audio_path"]
+            ) == _os.path.realpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _os.path.realpath(
+                mock_adapter.send_video.call_args.kwargs["video_path"]
+            ) == _os.path.realpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _os.path.realpath(
+                mock_adapter.send_image_file.call_args.kwargs["image_path"]
+            ) == _os.path.realpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _os.path.realpath(
+                mock_adapter.send_document.call_args.kwargs["file_path"]
+            ) == _os.path.realpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)
@@ -435,12 +485,22 @@ class TestRunBackgroundTask:
             mock_agent_instance = MagicMock()
             mock_agent_instance.shutdown_memory_provider = MagicMock()
             mock_agent_instance.close = MagicMock()
-            mock_agent_instance.run_conversation.side_effect = RuntimeError("boom")
+
+            def fail_after_fallback(**_kwargs):
+                MockAgent.call_args.kwargs["status_callback"](
+                    "fallback",
+                    "Fallback policy any: switching to backup-model via backup.",
+                )
+                raise RuntimeError("boom")
+
+            mock_agent_instance.run_conversation.side_effect = fail_after_fallback
             MockAgent.return_value = mock_agent_instance
 
             await runner._run_background_task("say hello", source, "bg_test")
 
-        mock_adapter.send.assert_called_once()
+        assert mock_adapter.send.await_count == 2
+        assert "Fallback policy any" in mock_adapter.send.await_args_list[0].kwargs["content"]
+        assert "failed: boom" in mock_adapter.send.await_args_list[1].kwargs["content"]
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -186,11 +186,14 @@ fallback_providers:
     )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *, requested=None, target_model=None, explicit_base_url=None, explicit_api_key=None
+    ):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
             raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
         assert requested == "openrouter"
+        assert target_model == "minimax/minimax-m2.7"
         return {
             "api_key": "sk-openrouter",
             "base_url": "https://openrouter.ai/api/v1",
@@ -235,8 +238,11 @@ fallback_providers:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("MY_FALLBACK_KEY", "env-secret")
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *, requested=None, target_model=None, explicit_base_url=None, explicit_api_key=None
+    ):
         assert requested == "custom"
+        assert target_model == "fallback-model"
         assert explicit_base_url == "https://fallback.example/v1"
         assert explicit_api_key == "env-secret"
         return {
@@ -260,4 +266,3 @@ fallback_providers:
     assert runtime_kwargs["api_key"] == "env-secret"
     assert runtime_kwargs["base_url"] == "https://fallback.example/v1"
     assert runtime_kwargs["model"] == "fallback-model"
-

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -175,6 +175,17 @@ class TestFallbackModelValidation:
         })
         assert any("fallback_model[0]" in i.message and "should be a dict" in i.message for i in issues)
 
+    def test_fallback_policy_accepts_exact_supported_values(self):
+        for policy in ("off", "local-only", "any"):
+            assert validate_config_structure({"fallback_policy": policy}) == []
+
+    def test_fallback_policy_rejects_typos_and_case_variants(self):
+        for policy in ("local", "ANY", True, None):
+            issues = validate_config_structure({"fallback_policy": policy})
+            assert any(
+                issue.severity == "error" and "fallback_policy" in issue.message
+                for issue in issues
+            )
 
 class TestMissingModelSection:
     """Warn when custom_providers exists but model section is missing."""

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -480,6 +480,55 @@ class TestDispatcher:
             cmd_fallback(types.SimpleNamespace(fallback_command="nope"))
 
 
+class TestPolicyCommand:
+    def test_show_defaults_to_any_for_legacy_config(self, isolated_home, capsys):
+        _write_config(isolated_home, {})
+        from hermes_cli.fallback_cmd import cmd_fallback_policy
+
+        cmd_fallback_policy(types.SimpleNamespace(fallback_policy=None))
+
+        assert capsys.readouterr().out.strip() == "any"
+
+    def test_set_exact_policy(self, isolated_home, capsys):
+        _write_config(isolated_home, {"fallback_policy": "any"})
+        from hermes_cli.fallback_cmd import cmd_fallback_policy
+
+        cmd_fallback_policy(types.SimpleNamespace(fallback_policy="local-only"))
+
+        assert _read_config(isolated_home)["fallback_policy"] == "local-only"
+        assert "local-only" in capsys.readouterr().out
+
+    def test_invalid_direct_call_fails_without_writing(self, isolated_home):
+        _write_config(isolated_home, {"fallback_policy": "off"})
+        from hermes_cli.fallback_cmd import cmd_fallback_policy
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_fallback_policy(types.SimpleNamespace(fallback_policy="remote"))
+
+        assert exc.value.code == 2
+        assert _read_config(isolated_home)["fallback_policy"] == "off"
+
+    def test_list_shows_policy_and_local_eligibility(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "fallback_policy": "local-only",
+            "fallback_providers": [
+                {
+                    "provider": "custom",
+                    "model": "local",
+                    "base_url": "http://127.0.0.1:8000/v1",
+                },
+                {"provider": "openrouter", "model": "remote"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_list
+
+        cmd_fallback_list(types.SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "Policy:    local-only" in out
+        assert "(1/2 configured)" in out
+
+
 # ---------------------------------------------------------------------------
 # argparse wiring — verify the subparser is registered
 # ---------------------------------------------------------------------------
@@ -503,8 +552,9 @@ class TestArgparseWiring:
         # --help exits 0
         assert result.returncode == 0, f"stderr: {result.stderr}"
         out = result.stdout + result.stderr
-        # All four subcommands should appear in help
+        # All subcommands should appear in help
         assert "list" in out
         assert "add" in out
         assert "remove" in out
         assert "clear" in out
+        assert "policy" in out

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from hermes_cli.fallback_config import (
+    filter_fallback_chain_for_policy,
     get_configured_fallback_chain,
     get_fallback_chain,
     get_fallback_policy,
@@ -147,3 +148,27 @@ def test_invalid_explicit_policy_fails_closed():
 
     assert get_fallback_policy(cfg) == "off"
     assert get_fallback_chain(cfg) == []
+
+
+def test_supplied_init_chain_is_filtered_by_policy():
+    entries = [
+        {"provider": "openrouter", "model": "remote"},
+        {
+            "provider": "custom",
+            "model": "local",
+            "base_url": "http://127.0.0.1:8000/v1",
+        },
+    ]
+
+    assert filter_fallback_chain_for_policy(
+        entries,
+        {"fallback_policy": "off"},
+    ) == []
+    assert filter_fallback_chain_for_policy(
+        entries,
+        {"fallback_policy": "local-only"},
+    ) == [entries[1]]
+    assert filter_fallback_chain_for_policy(
+        entries,
+        {"fallback_policy": "any"},
+    ) == entries

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,6 +1,13 @@
-"""Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
+"""Tests for hermes_cli/fallback_config.py."""
 
-from hermes_cli.fallback_config import resolve_entry_api_key
+from __future__ import annotations
+
+from hermes_cli.fallback_config import (
+    get_configured_fallback_chain,
+    get_fallback_chain,
+    get_fallback_policy,
+    resolve_entry_api_key,
+)
 
 
 class TestResolveEntryApiKey:
@@ -38,3 +45,105 @@ class TestResolveEntryApiKey:
         monkeypatch.setenv("FB_KEY", "env-key")
         entry = {"api_key": "   ", "key_env": "FB_KEY"}
         assert resolve_entry_api_key(entry) == "env-key"
+
+
+def test_missing_policy_preserves_legacy_any_behavior():
+    cfg = {
+        "fallback_providers": [
+            {"provider": "openrouter", "model": "remote"},
+            {
+                "provider": "custom",
+                "model": "local",
+                "base_url": "http://127.0.0.1:8000/v1",
+            },
+        ]
+    }
+
+    assert get_fallback_policy(cfg) == "any"
+    assert get_fallback_chain(cfg) == cfg["fallback_providers"]
+
+
+def test_off_keeps_configured_order_but_has_no_eligible_routes():
+    cfg = {
+        "fallback_policy": "off",
+        "fallback_providers": [
+            {"provider": "openrouter", "model": "first"},
+            {"provider": "anthropic", "model": "second"},
+        ],
+    }
+
+    assert get_configured_fallback_chain(cfg) == cfg["fallback_providers"]
+    assert get_fallback_chain(cfg) == []
+
+
+def test_local_only_uses_endpoint_metadata_not_model_names(monkeypatch):
+    monkeypatch.setenv("LM_BASE_URL", "http://10.55.0.3:1234/v1")
+    cfg = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [
+            {"provider": "opencode-zen", "model": "local-looking-name"},
+            {"provider": "lmstudio", "model": "cloud-looking-name"},
+            {"provider": "mystery", "model": "definitely-local"},
+        ],
+    }
+
+    assert get_fallback_chain(cfg) == [
+        {"provider": "lmstudio", "model": "cloud-looking-name"}
+    ]
+
+
+def test_local_only_does_not_reclassify_builtin_cloud_provider_via_env(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENCODE_ZEN_BASE_URL", "http://127.0.0.1:9999/v1")
+    cfg = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [
+            {"provider": "opencode-zen", "model": "remote-model"},
+        ],
+    }
+
+    assert get_fallback_chain(cfg) == []
+
+
+def test_local_only_rejects_builtin_anthropic_even_with_explicit_local_url():
+    cfg = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [
+            {
+                "provider": "anthropic",
+                "model": "claude",
+                "base_url": "http://localhost:9000/v1",
+            }
+        ],
+    }
+
+    assert get_fallback_chain(cfg) == []
+
+
+def test_local_only_allows_explicit_user_provider_redefinition():
+    cfg = {
+        "fallback_policy": "local-only",
+        "providers": {
+            "anthropic": {
+                "base_url": "http://10.55.0.3:9000/v1",
+            }
+        },
+        "fallback_providers": [
+            {"provider": "anthropic", "model": "local-compatible"}
+        ],
+    }
+
+    assert get_fallback_chain(cfg) == [
+        {"provider": "anthropic", "model": "local-compatible"}
+    ]
+
+
+def test_invalid_explicit_policy_fails_closed():
+    cfg = {
+        "fallback_policy": "ANY",
+        "fallback_providers": [{"provider": "openrouter", "model": "remote"}],
+    }
+
+    assert get_fallback_policy(cfg) == "off"
+    assert get_fallback_chain(cfg) == []

--- a/tests/hermes_cli/test_oneshot_fallback.py
+++ b/tests/hermes_cli/test_oneshot_fallback.py
@@ -1,0 +1,152 @@
+"""Policy-aware startup fallback coverage for ``hermes -z``."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from hermes_cli.auth import AuthError
+import hermes_cli.oneshot as oneshot
+
+
+def _module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _install_oneshot_stubs(monkeypatch, *, config, resolve_runtime):
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt, **_kwargs):
+            captured["prompt"] = prompt
+            return {"final_response": "ok", "failed": False, "partial": False}
+
+    monkeypatch.setitem(sys.modules, "run_agent", _module("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        _module("hermes_cli.config", load_config=lambda: config),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        _module(
+            "hermes_cli.models",
+            detect_provider_for_model=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        _module(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=resolve_runtime,
+            format_runtime_provider_error=lambda exc: f"formatted: {exc}",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: set(),
+        ),
+    )
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    return captured
+
+
+def test_oneshot_auth_failure_uses_policy_eligible_fallback(monkeypatch):
+    calls = []
+
+    def resolve_runtime_provider(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise AuthError("primary token expired")
+        return {
+            "api_key": kwargs.get("explicit_api_key"),
+            "base_url": kwargs.get("explicit_base_url"),
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+    fallback = {
+        "provider": "custom",
+        "model": "local-draft",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "key_env": "ONESHOT_BACKUP_KEY",
+    }
+    monkeypatch.setenv("ONESHOT_BACKUP_KEY", "local-secret")
+    captured = _install_oneshot_stubs(
+        monkeypatch,
+        config={
+            "model": {"default": "primary-model", "provider": "primary"},
+            "fallback_policy": "any",
+            "fallback_providers": [fallback],
+        },
+        resolve_runtime=resolve_runtime_provider,
+    )
+
+    text, result = oneshot._run_agent("keep going")
+
+    assert text == "ok"
+    assert result["failed"] is False
+    assert calls[1] == {
+        "requested": "custom",
+        "target_model": "local-draft",
+        "explicit_base_url": "http://127.0.0.1:8000/v1",
+        "explicit_api_key": "local-secret",
+    }
+    assert captured["model"] == "local-draft"
+    assert captured["fallback_model"] == [fallback]
+    assert captured["fallback_chain_from_config"] is True
+    assert captured["initial_fallback_entry"] == fallback
+    assert "Fallback policy any" in captured["initial_fallback_decision"]
+    assert "primary token expired" in captured["initial_fallback_decision"]
+    assert "local-draft via custom" in captured["initial_fallback_decision"]
+    assert captured["prompt"] == "keep going"
+
+
+def test_oneshot_policy_off_fails_before_attempting_configured_fallback(monkeypatch):
+    calls = []
+
+    def resolve_runtime_provider(**kwargs):
+        calls.append(kwargs)
+        raise AuthError("primary token expired")
+
+    _install_oneshot_stubs(
+        monkeypatch,
+        config={
+            "model": {"default": "primary-model", "provider": "primary"},
+            "fallback_policy": "off",
+            "fallback_providers": [
+                {
+                    "provider": "custom",
+                    "model": "must-not-run",
+                    "base_url": "http://127.0.0.1:8000/v1",
+                }
+            ],
+        },
+        resolve_runtime=resolve_runtime_provider,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        oneshot._run_agent("keep going")
+
+    assert len(calls) == 1
+    assert "formatted: primary token expired" in str(exc_info.value)
+    assert "Fallback policy off: no backup provider was attempted." in str(
+        exc_info.value
+    )

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1599,6 +1599,11 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(sys.modules, "hermes_state", mod("hermes_state", SessionDB=FakeSessionDB))
     monkeypatch.setitem(
         sys.modules,
+        "hermes_cli.auth",
+        mod("hermes_cli.auth", AuthError=RuntimeError),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "hermes_cli.config",
         mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
     )
@@ -1612,6 +1617,7 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         "hermes_cli.runtime_provider",
         mod(
             "hermes_cli.runtime_provider",
+            format_runtime_provider_error=lambda exc: str(exc),
             resolve_runtime_provider=lambda **_kwargs: {
                 "api_key": "k",
                 "base_url": "u",

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -67,3 +67,143 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_policy_off_never_resolves_configured_fallback():
+    """Init/auth fallback must obey ``off`` before resolving any backup."""
+    calls = []
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        calls.append((provider, model))
+        return None, None
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"fallback_policy": "off"},
+    ), patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        side_effect=fake_resolve,
+    ), patch(
+        "run_agent.get_tool_definitions", return_value=_make_tool_defs()
+    ), patch(
+        "run_agent.check_toolset_requirements", return_value={}
+    ), patch("run_agent.OpenAI", return_value=MagicMock()):
+        with pytest.raises(
+            RuntimeError,
+            match="Fallback policy is off, so no backup provider was attempted",
+        ):
+            AIAgent(
+                provider="alibaba-coding-plan",
+                model="qwen3.6-plus",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=[
+                    {"provider": "openrouter", "model": "remote-backup"}
+                ],
+            )
+
+    assert calls == [("alibaba-coding-plan", "qwen3.6-plus")]
+
+
+def test_init_local_only_skips_remote_and_queues_local_decision():
+    """Init fallback filters the captured chain and explains the local switch."""
+    local = {
+        "provider": "custom",
+        "model": "local-backup",
+        "base_url": "http://127.0.0.1:8000/v1",
+    }
+    config = {
+        "fallback_policy": "local-only",
+        "fallback_providers": [
+            {"provider": "openrouter", "model": "remote-backup"},
+            local,
+        ],
+    }
+    calls = []
+    local_client = _mock_client(base_url=local["base_url"])
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        calls.append((provider, model))
+        if provider == "custom":
+            return local_client, model
+        return None, None
+
+    with patch(
+        "hermes_cli.config.load_config_readonly", return_value=config
+    ), patch(
+        "agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve
+    ), patch(
+        "run_agent.get_tool_definitions", return_value=_make_tool_defs()
+    ), patch(
+        "run_agent.check_toolset_requirements", return_value={}
+    ), patch("run_agent.OpenAI", return_value=MagicMock()):
+        agent = AIAgent(
+            provider="alibaba-coding-plan",
+            model="qwen3.6-plus",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=config["fallback_providers"],
+        )
+
+    assert calls == [
+        ("alibaba-coding-plan", "qwen3.6-plus"),
+        ("custom", "local-backup"),
+    ]
+    assert agent.provider == "custom"
+    assert agent.model == "local-backup"
+    assert agent._fallback_policy == "local-only"
+    assert agent._fallback_chain == [local]
+    assert "policy local-only" in agent._pending_fallback_notice
+    assert "credentials unavailable" in agent._pending_fallback_notice
+
+
+def test_init_fallback_is_revoked_before_first_request_when_policy_changes():
+    """A cached init route cannot survive a live switch to ``off``."""
+    fallback = {"provider": "openrouter", "model": "remote-backup"}
+    config = {
+        "fallback_policy": "any",
+        "fallback_providers": [fallback],
+    }
+    fallback_client = _mock_client()
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        if provider == "openrouter":
+            return fallback_client, model
+        return None, None
+
+    with patch(
+        "hermes_cli.config.load_config_readonly", return_value=config
+    ), patch(
+        "agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve
+    ), patch(
+        "run_agent.get_tool_definitions", return_value=_make_tool_defs()
+    ), patch(
+        "run_agent.check_toolset_requirements", return_value={}
+    ), patch("run_agent.OpenAI", return_value=MagicMock()):
+        agent = AIAgent(
+            provider="alibaba-coding-plan",
+            model="qwen3.6-plus",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[fallback],
+        )
+
+    statuses = []
+    agent.status_callback = lambda kind, text: statuses.append((kind, text))
+    fallback_client.chat.completions.create.reset_mock()
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"fallback_policy": "off", "fallback_providers": []},
+    ):
+        with pytest.raises(RuntimeError, match="no model request was sent"):
+            agent.run_conversation("must not reach the fallback")
+
+    fallback_client.chat.completions.create.assert_not_called()
+    assert agent._pending_fallback_notice is None
+    assert len(statuses) == 1
+    assert statuses[0][0] == "fallback"
+    assert "policy off" in statuses[0][1]

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -121,6 +121,16 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent._restore_primary_runtime() is False
 
+    def test_restore_clears_pending_notice_without_changing_policy(self):
+        agent = _make_agent()
+        agent._fallback_policy = "local-only"
+        agent._pending_fallback_notice = "stale switch"
+
+        assert agent._restore_primary_runtime() is False
+
+        assert agent._pending_fallback_notice is None
+        assert agent._fallback_policy == "local-only"
+
     def test_restores_model_and_provider(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -12,7 +12,9 @@ Verifies that:
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
 
+from agent.error_classifier import FailoverReason
 from run_agent import AIAgent
 
 
@@ -704,6 +706,114 @@ class TestRestoreInRunConversation:
         assert agent.provider == "custom"
         assert agent.base_url == "https://my-llm.example.com/v1"
 
+    def test_runtime_fallback_decision_emits_immediately_once_with_reason(self):
+        """Runtime fallback reports its non-terminal decision before use."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_fallback_status = emitted.append
+        primary_model = agent.model
+        primary_provider = agent.provider
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.server_error,
+            ) is True
+
+        expected = (
+            f"🔄 Fallback policy any: {primary_model} via {primary_provider} failed "
+            f"(reason: server error); switching to "
+            f"anthropic/claude-sonnet-4 via openrouter."
+        )
+        assert emitted == [expected]
+        assert agent._pending_fallback_notice is None
+        assert not any(
+            "switching to fallback" in text.lower()
+            for _kind, text in getattr(agent, "_retry_status_buffer", [])
+        )
+
+        # A successful response only drops retry chatter; it cannot emit a
+        # second fallback decision.
+        agent._clear_status_buffer()
+        agent._emit_pending_fallback_notice()
+
+        assert emitted == [expected]
+        assert agent._pending_fallback_notice is None
+
+    def test_activate_interrupt_restore_success_cannot_emit_stale_notice(self):
+        """Interrupted fallback state cannot leak into the next primary turn."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_fallback_status = emitted.append
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.timeout,
+            ) is True
+        assert len(emitted) == 1
+        assert agent._pending_fallback_notice is None
+
+        agent.interrupt("cancel current turn")
+        assert agent._pending_fallback_notice is None
+        agent.clear_interrupt()
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent._pending_fallback_notice is None
+
+        # Simulate the next primary response succeeding.
+        agent._emit_pending_fallback_notice()
+        agent._clear_status_buffer()
+        assert len(emitted) == 1
+
+    def test_primary_restore_clears_unemitted_prior_turn_notice(self):
+        """Restore itself is a hard boundary for fallback-notice lifetime."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+            provider="custom",
+        )
+        emitted = []
+        agent._emit_fallback_status = emitted.append
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.timeout,
+            ) is True
+        assert len(emitted) == 1
+        assert agent._pending_fallback_notice is None
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent._pending_fallback_notice is None
+
+        agent._emit_pending_fallback_notice()
+        assert len(emitted) == 1
 
 # =============================================================================
 # Rate-limit cooldown gate
@@ -749,6 +859,38 @@ class TestRateLimitCooldown:
 
         assert result is True
         assert agent._fallback_activated is False
+
+    @pytest.mark.parametrize(
+        ("policy", "refreshed_chain"),
+        [("off", []), ("any", [])],
+    )
+    def test_policy_or_chain_removal_overrides_cooldown(
+        self, policy, refreshed_chain
+    ):
+        """A cached fallback cannot outlive the refreshed routing boundary."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        )
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        agent._rate_limited_until = time.monotonic() + 60
+        agent._fallback_policy = policy
+        agent._fallback_chain = refreshed_chain
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent._fallback_activated is False
+        assert agent._active_fallback_entry is None
+        assert agent._fallback_restore_required is False
 
     def test_cooldown_set_on_rate_limit_reason(self):
         """_try_activate_fallback with rate_limit reason sets _rate_limited_until."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,6 +7,7 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+from agent.error_classifier import FailoverReason
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -295,6 +296,120 @@ class TestFallbackChainAdvancement:
 
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
+
+
+class TestExplicitFallbackPolicy:
+    def test_cached_agent_refreshes_policy_without_recreation(self):
+        agent = _make_agent(
+            fallback_model=[{"provider": "openrouter", "model": "remote"}]
+        )
+        original_chain = list(agent._fallback_chain)
+        agent._fallback_terminal_status_emitted = True
+        agent._pending_fallback_notice = "stale"
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "local-only"},
+        ):
+            assert agent._refresh_fallback_policy() == "local-only"
+
+        assert agent._fallback_policy == "local-only"
+        assert agent._fallback_chain == original_chain
+        assert agent._fallback_terminal_status_emitted is False
+        assert agent._pending_fallback_notice is None
+
+    def test_off_never_resolves_or_switches_and_fails_loudly(self):
+        agent = _make_agent(
+            fallback_model=[{"provider": "openrouter", "model": "remote"}]
+        )
+        primary_provider = agent.provider
+        agent._fallback_policy = "off"
+        statuses = []
+        agent.status_callback = lambda kind, text: statuses.append((kind, text))
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            assert agent._try_activate_fallback(FailoverReason.server_error) is False
+
+        resolve.assert_not_called()
+        assert agent.provider == primary_provider
+        assert statuses and statuses[-1][0] == "fallback"
+        assert "policy off" in statuses[-1][1]
+        assert "No provider switch was attempted" in statuses[-1][1]
+
+    def test_local_only_rejects_remote_metadata_before_resolution(self):
+        agent = _make_agent(
+            fallback_model=[{"provider": "anthropic", "model": "claude"}]
+        )
+        agent._fallback_policy = "local-only"
+        statuses = []
+        agent.status_callback = lambda kind, text: statuses.append((kind, text))
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            assert agent._try_activate_fallback(FailoverReason.timeout) is False
+
+        resolve.assert_not_called()
+        assert "no eligible local fallback remained" in statuses[-1][1]
+        assert "Remote and unknown-endpoint fallbacks were not used" in statuses[-1][1]
+
+    def test_local_only_switch_status_precedes_runtime_mutation(self):
+        local = {
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+        }
+        agent = _make_agent(fallback_model=[local])
+        agent._fallback_policy = "local-only"
+        primary_identity = (agent.model, agent.provider)
+        observed = []
+
+        def status(kind, text):
+            observed.append((kind, text, agent.model, agent.provider))
+
+        agent.status_callback = status
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(local["base_url"]), "local-model"),
+        ):
+            assert agent._try_activate_fallback(FailoverReason.server_error) is True
+
+        decision = next(item for item in observed if item[0] == "fallback")
+        assert decision[2:4] == primary_identity
+        assert "reason: server error" in decision[1]
+        assert "switching to local-model via custom" in decision[1]
+        assert agent.model == "local-model"
+        assert agent.provider == "custom"
+
+    def test_local_only_rechecks_resolved_endpoint_before_switch(self):
+        local = {
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+        }
+        agent = _make_agent(fallback_model=[local])
+        agent._fallback_policy = "local-only"
+        remote_client = _mock_client("https://remote.example/v1")
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(remote_client, "local-model"),
+        ):
+            assert agent._try_activate_fallback() is False
+
+        remote_client.close.assert_called_once()
+        assert agent.model != "local-model"
+
+    def test_terminal_policy_status_is_emitted_once(self):
+        agent = _make_agent(fallback_model=[])
+        agent._fallback_policy = "any"
+        statuses = []
+        agent.status_callback = lambda kind, text: statuses.append((kind, text))
+
+        assert agent._try_activate_fallback(FailoverReason.timeout) is False
+        assert agent._try_activate_fallback(FailoverReason.timeout) is False
+
+        fallback_statuses = [item for item in statuses if item[0] == "fallback"]
+        assert len(fallback_statuses) == 1
+        assert "policy any" in fallback_statuses[0][1]
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -11,7 +11,11 @@ from agent.error_classifier import FailoverReason
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(
+    fallback_model=None,
+    fallback_chain_from_config=None,
+    initial_fallback_entry=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -25,6 +29,8 @@ def _make_agent(fallback_model=None):
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            fallback_chain_from_config=fallback_chain_from_config,
+            initial_fallback_entry=initial_fallback_entry,
         )
         agent.client = MagicMock()
         return agent
@@ -299,24 +305,180 @@ class TestFallbackChainAdvancement:
 
 
 class TestExplicitFallbackPolicy:
-    def test_cached_agent_refreshes_policy_without_recreation(self):
+    def test_cached_agent_refreshes_policy_and_chain_without_recreation(self):
         agent = _make_agent(
-            fallback_model=[{"provider": "openrouter", "model": "remote"}]
+            fallback_model=[{"provider": "openrouter", "model": "remote"}],
+            fallback_chain_from_config=True,
         )
-        original_chain = list(agent._fallback_chain)
         agent._fallback_terminal_status_emitted = True
-        agent._pending_fallback_notice = "stale"
+        agent._pending_fallback_notice = "queued init decision"
+
+        refreshed = [
+            {
+                "provider": "custom",
+                "model": "local-b",
+                "base_url": "http://127.0.0.1:9000/v1",
+            },
+            {
+                "provider": "custom",
+                "model": "local-a",
+                "base_url": "http://127.0.0.1:8000/v1",
+            },
+        ]
 
         with patch(
             "hermes_cli.config.load_config_readonly",
-            return_value={"fallback_policy": "local-only"},
+            return_value={
+                "fallback_policy": "local-only",
+                "fallback_providers": refreshed,
+            },
         ):
             assert agent._refresh_fallback_policy() == "local-only"
 
         assert agent._fallback_policy == "local-only"
-        assert agent._fallback_chain == original_chain
+        assert agent._fallback_chain == refreshed
+        assert agent._fallback_model == refreshed[0]
+        assert agent._fallback_index == 0
         assert agent._fallback_terminal_status_emitted is False
-        assert agent._pending_fallback_notice is None
+        assert agent._pending_fallback_notice == "queued init decision"
+
+    def test_cached_agent_refresh_removes_deleted_routes(self):
+        initial = [{"provider": "openrouter", "model": "deleted"}]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={
+                "fallback_policy": "any",
+                "fallback_providers": initial,
+            },
+        ):
+            agent = _make_agent(fallback_model=initial)
+
+        assert agent._fallback_chain_from_config is True
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "any", "fallback_providers": []},
+        ):
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain == []
+        assert agent._fallback_model is None
+
+    def test_programmatic_chain_survives_empty_default_config(self):
+        supplied = [{"provider": "openrouter", "model": "library-backup"}]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "any", "fallback_providers": []},
+        ):
+            agent = _make_agent(fallback_model=supplied)
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain_from_config is False
+        assert agent._fallback_chain == supplied
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "off", "fallback_providers": []},
+        ):
+            agent._refresh_fallback_policy()
+        assert agent._fallback_chain == []
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"fallback_policy": "any", "fallback_providers": []},
+        ):
+            agent._refresh_fallback_policy()
+        assert agent._fallback_chain == supplied
+
+    def test_programmatic_chain_is_not_replaced_by_unrelated_config_chain(self):
+        supplied = [{"provider": "openrouter", "model": "library-backup"}]
+        configured = [{"provider": "openrouter", "model": "profile-backup"}]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={
+                "fallback_policy": "any",
+                "fallback_providers": configured,
+            },
+        ):
+            agent = _make_agent(
+                fallback_model=supplied,
+                fallback_chain_from_config=False,
+            )
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain_from_config is False
+        assert agent._fallback_chain == supplied
+
+    def test_config_managed_chain_recovers_after_init_config_read_failure(self):
+        supplied = [{"provider": "openrouter", "model": "initial-backup"}]
+        recovered = [{"provider": "openrouter", "model": "recovered-backup"}]
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=OSError("config temporarily unreadable"),
+        ):
+            agent = _make_agent(
+                fallback_model=supplied,
+                fallback_chain_from_config=True,
+            )
+
+        assert agent._fallback_policy == "off"
+        assert agent._fallback_chain == []
+        assert agent._fallback_chain_from_config is True
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={
+                "fallback_policy": "any",
+                "fallback_providers": recovered,
+            },
+        ):
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain == recovered
+
+    def test_initial_entry_without_captured_chain_infers_config_ownership(self):
+        selected = {"provider": "openrouter", "model": "profile-backup"}
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={
+                "fallback_policy": "any",
+                "fallback_providers": [selected],
+            },
+        ):
+            agent = _make_agent(
+                fallback_model=None,
+                initial_fallback_entry=selected,
+            )
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain_from_config is True
+        assert agent._fallback_chain == [selected]
+
+    def test_initial_entry_recovers_config_ownership_after_read_failure(self):
+        selected = {"provider": "openrouter", "model": "profile-backup"}
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=OSError("config temporarily unreadable"),
+        ):
+            agent = _make_agent(
+                fallback_model=None,
+                initial_fallback_entry=selected,
+            )
+
+        assert agent._fallback_chain_from_config is True
+        assert agent._fallback_chain == []
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={
+                "fallback_policy": "any",
+                "fallback_providers": [selected],
+            },
+        ):
+            agent._refresh_fallback_policy()
+
+        assert agent._fallback_chain == [selected]
 
     def test_off_never_resolves_or_switches_and_fails_loudly(self):
         agent = _make_agent(

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -1,9 +1,9 @@
 """Tests for the retry/fallback status buffer helpers on AIAgent.
 
-These helpers defer noisy retry chatter (rate-limit retries, fallback
-switches, compression attempts) so users only see the trace when
-everything ultimately fails.  On successful recovery the buffer is
-silently dropped.
+These helpers defer noisy retry chatter (rate-limit retries and compression
+attempts) so users only see the trace when everything ultimately fails.
+Runtime fallback decisions bypass this buffer and are emitted immediately;
+init-time decisions may be queued until a gateway renderer is attached.
 """
 
 from __future__ import annotations
@@ -135,39 +135,34 @@ def test_mixed_kinds_replay_through_correct_channels():
     assert warns == ["warn-1"]
 
 
-def test_pending_fallback_notice_emitted_once_on_success():
-    """On successful recovery the one-shot fallback notice is surfaced even
-    though the noisy retry buffer is dropped."""
+def test_pending_init_fallback_notice_emitted_once_before_request():
+    """A queued init decision uses the structured fallback channel once."""
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._emit_fallback_status = lambda msg: emitted.append(msg)
 
-    # Simulate try_activate_fallback: buffer the noisy switch line AND record
-    # the durable one-shot notice.
-    agent._buffer_status("🔄 Primary model failed — switching to fallback: m2 via p2")
-    agent._pending_fallback_notice = "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
+    agent._pending_fallback_notice = (
+        "🔄 Fallback policy any: m1 via p1 could not initialize; switching to m2 via p2."
+    )
 
     # Success path order: emit pending notice, then drop the buffer.
     agent._emit_pending_fallback_notice()
-    agent._clear_status_buffer()
 
-    # The durable notice was shown exactly once; the buffered retry noise was
-    # silently dropped.
-    assert emitted == ["🔄 Switched to fallback model: m1 via p1 → m2 via p2"]
-    assert agent._retry_status_buffer == []
-    # Notice is cleared so it cannot re-emit on a later turn.
+    assert emitted == [
+        "🔄 Fallback policy any: m1 via p1 could not initialize; switching to m2 via p2."
+    ]
     assert agent._pending_fallback_notice is None
 
     # A second success path with no new fallback emits nothing.
     agent._emit_pending_fallback_notice()
-    assert emitted == ["🔄 Switched to fallback model: m1 via p1 → m2 via p2"]
+    assert len(emitted) == 1
 
 
 def test_pending_fallback_notice_noop_when_unset():
     """No fallback this turn → no notice emitted on the success path."""
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._emit_fallback_status = lambda msg: emitted.append(msg)
 
     # No _pending_fallback_notice attribute set at all.
     agent._emit_pending_fallback_notice()
@@ -205,8 +200,10 @@ def test_pending_fallback_notice_survives_emit_callback_error():
         seen.append(msg)
         raise RuntimeError("simulated callback failure")
 
-    agent._emit_status = boom
-    agent._pending_fallback_notice = "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
+    agent._emit_fallback_status = boom
+    agent._pending_fallback_notice = (
+        "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
+    )
 
     # Should not raise.
     agent._emit_pending_fallback_notice()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4580,7 +4580,9 @@ class TestRunConversation:
 
         assert result["final_response"] == "Recovered on fallback"
         assert result["completed"] is True
-        mock_try_activate_fallback.assert_called_once_with()
+        mock_try_activate_fallback.assert_called_once_with(
+            FailoverReason.content_policy_blocked
+        )
         assert mock_run_codex_stream.call_count == 2
         assert hook_events[0]["error_type"] == "ContentPolicyBlocked"
         assert hook_events[0]["retryable"] is False
@@ -5014,7 +5016,7 @@ class TestRunConversation:
 
         fallback_called = {"called": False}
 
-        def _mock_fallback():
+        def _mock_fallback(*_args, **_kwargs):
             fallback_called["called"] = True
             # Simulate what _try_activate_fallback does: just advance the
             # index and set the flag (the client is already mocked).
@@ -5042,6 +5044,8 @@ class TestRunConversation:
         agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
         agent._fallback_index = 0
         agent._fallback_activated = False
+        emitted_statuses = []
+        agent.status_callback = lambda kind, text: emitted_statuses.append((kind, text))
 
         empty_resp = _mock_response(content=None, finish_reason="stop")
         # 4 empty from primary (1 + 3 retries), fallback activated,
@@ -5051,11 +5055,15 @@ class TestRunConversation:
             empty_resp, empty_resp, empty_resp, empty_resp,  # fallback exhausted
         ]
 
-        def _mock_fallback():
+        def _mock_fallback(*_args, **_kwargs):
             if agent._fallback_index >= len(agent._fallback_chain):
                 return False
             agent._fallback_index += 1
             agent._fallback_activated = True
+            agent._emit_fallback_status(
+                "Fallback policy any: primary failed; switching to "
+                "anthropic/claude-sonnet-4 via openrouter."
+            )
             agent.model = "anthropic/claude-sonnet-4"
             agent.provider = "openrouter"
             return True
@@ -5071,6 +5079,20 @@ class TestRunConversation:
         # #34452: explanation replaces the bare "(empty)" sentinel.
         assert result["final_response"] != "(empty)"
         assert "No reply:" in result["final_response"]
+        switch_decisions = [
+            text
+            for kind, text in emitted_statuses
+            if kind == "fallback" and "switching to" in text
+        ]
+        assert switch_decisions == [
+            "Fallback policy any: primary failed; switching to "
+            "anthropic/claude-sonnet-4 via openrouter."
+        ]
+        assert not any(
+            "switched to fallback" in text.lower()
+            for kind, text in emitted_statuses
+            if kind != "fallback"
+        )
 
     def test_empty_response_emits_status_for_gateway(self, agent):
         """_emit_status is called during empty retries so gateway users see feedback."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1195,9 +1195,11 @@ class TestInit:
 
 class TestInterrupt:
     def test_interrupt_sets_flag(self, agent):
+        agent._pending_fallback_notice = "about to switch"
         with patch("run_agent._set_interrupt"):
             agent.interrupt()
             assert agent._interrupt_requested is True
+            assert agent._pending_fallback_notice is None
 
     def test_interrupt_with_message(self, agent):
         with patch("run_agent._set_interrupt"):
@@ -1207,9 +1209,11 @@ class TestInterrupt:
     def test_clear_interrupt(self, agent):
         with patch("run_agent._set_interrupt"):
             agent.interrupt("msg")
+            agent._pending_fallback_notice = "stale"
             agent.clear_interrupt()
             assert agent._interrupt_requested is False
             assert agent._interrupt_message is None
+            assert agent._pending_fallback_notice is None
 
     def test_is_interrupted_property(self, agent):
         assert agent.is_interrupted is False

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -32,7 +32,13 @@ def _make_agent(chain):
     agent._fallback_activated = False
     agent._fallback_index = 0
     agent._fallback_chain = list(chain)
+    agent._fallback_chain_seed = list(chain)
+    agent._fallback_chain_from_config = True
+    agent._fallback_excluded_providers = set()
     agent._fallback_model = chain[0] if chain else None
+    agent._active_fallback_entry = None
+    agent._init_fallback_entry = None
+    agent._pending_fallback_notice = None
 
     return agent
 
@@ -102,3 +108,31 @@ def test_switch_within_same_provider_preserves_chain():
         )
 
     assert agent._fallback_chain == chain
+
+
+def test_switch_pruning_survives_live_config_refresh():
+    chain = [
+        {"provider": "openrouter", "model": "x-ai/grok-4"},
+        {"provider": "anthropic", "model": "claude-sonnet-4-5"},
+        {"provider": "nous", "model": "hermes-4"},
+    ]
+    agent = _make_agent(chain)
+
+    _switch_to_anthropic(agent)
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={
+            "fallback_policy": "any",
+            "fallback_providers": chain,
+        },
+    ):
+        agent._refresh_fallback_policy()
+
+    assert agent._fallback_chain == [
+        {"provider": "nous", "model": "hermes-4"}
+    ]
+    assert agent._fallback_model == {
+        "provider": "nous",
+        "model": "hermes-4",
+    }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3343,6 +3343,33 @@ def test_load_fallback_model_merges_chain_providers_first(monkeypatch):
     ]
 
 
+def test_effective_fallback_model_applies_local_only_policy(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "fallback_policy": "local-only",
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "remote"},
+                {
+                    "provider": "custom",
+                    "model": "local",
+                    "base_url": "http://127.0.0.1:8000/v1",
+                },
+            ],
+        },
+    )
+
+    assert server._load_fallback_model()[0]["provider"] == "openrouter"
+    assert server._load_effective_fallback_model() == [
+        {
+            "provider": "custom",
+            "model": "local",
+            "base_url": "http://127.0.0.1:8000/v1",
+        }
+    ]
+
+
 def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     captured = {}
     fallback_chain = [
@@ -8348,6 +8375,19 @@ def test_session_info_includes_mcp_servers(monkeypatch):
 
     assert info["provider"] == "openai-codex"
     assert info["mcp_servers"] == fake_status
+
+
+def test_session_info_includes_active_fallback_policy():
+    info = server._session_info(
+        types.SimpleNamespace(
+            tools=[],
+            model="local-model",
+            provider="custom",
+            _fallback_policy="local-only",
+        )
+    )
+
+    assert info["fallback_policy"] == "local-only"
 
 
 def test_session_info_includes_session_title(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3423,6 +3423,7 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
         model="gpt-5.5",
         provider="openai-codex",
         _fallback_chain=chain,
+        _active_fallback_entry=chain[0],
     )
     monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
     monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
@@ -3431,6 +3432,7 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     kwargs = server._background_agent_kwargs(agent, "task-id")
 
     assert kwargs["fallback_model"] == chain
+    assert kwargs["initial_fallback_entry"] == chain[0]
 
 
 def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
@@ -14314,8 +14316,10 @@ class TestResolveRuntimeWithFallback:
         from hermes_cli.auth import AuthError
 
         fallback_runtime = {"provider": "deepseek", "api_key": "fb-tok"}
+        calls = []
 
         def fake_resolve(**kwargs):
+            calls.append(kwargs)
             if kwargs.get("requested") == "openai-codex":
                 raise AuthError("No Codex credentials stored")
             return fallback_runtime
@@ -14327,14 +14331,39 @@ class TestResolveRuntimeWithFallback:
         monkeypatch.setattr(
             server,
             "_load_fallback_model",
-            lambda: [{"provider": "deepseek", "model": "deepseek-v4-pro"}],
+            lambda: [
+                {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "base_url": "https://fallback.example/v1",
+                    "key_env": "TUI_FALLBACK_KEY",
+                }
+            ],
         )
+        monkeypatch.setenv("TUI_FALLBACK_KEY", "env-fallback-key")
         resolution = server._resolve_runtime_with_fallback(
             {"requested": "openai-codex"},
         )
-        assert resolution.runtime == fallback_runtime
         assert resolution.selected_model == "deepseek-v4-pro"
         assert resolution.used_fallback is True
+        runtime = resolution.runtime
+        assert runtime["provider"] == "deepseek"
+        assert runtime["api_key"] == "fb-tok"
+        assert runtime["initial_fallback_entry"] == {
+            "provider": "deepseek",
+            "model": "deepseek-v4-pro",
+            "base_url": "https://fallback.example/v1",
+            "key_env": "TUI_FALLBACK_KEY",
+        }
+        assert calls[1] == {
+            "requested": "deepseek",
+            "target_model": "deepseek-v4-pro",
+            "explicit_base_url": "https://fallback.example/v1",
+            "explicit_api_key": "env-fallback-key",
+        }
+        assert "No Codex credentials stored" in runtime[
+            "initial_fallback_decision"
+        ]
 
     def test_auth_error_skips_provider_only_fallback(self, monkeypatch):
         """Auth fallback requires one complete provider/model pair."""
@@ -14367,7 +14396,7 @@ class TestResolveRuntimeWithFallback:
         )
 
         assert requested == ["openai-codex", "openrouter"]
-        assert resolution.runtime == fallback_runtime
+        assert resolution.runtime["provider"] == "openrouter"
         assert resolution.selected_model == "z-ai/glm-5.2"
         assert resolution.used_fallback is True
 
@@ -14425,10 +14454,12 @@ class TestResolveRuntimeWithFallback:
         )
         import pytest
 
-        with pytest.raises(AuthError, match="No credentials for openai-codex"):
+        with pytest.raises(AuthError, match="No credentials for openai-codex") as exc_info:
             server._resolve_runtime_with_fallback(
                 {"requested": "openai-codex"},
             )
+        assert "Fallback policy" in str(exc_info.value)
+        assert "no usable configured backup route remained" in str(exc_info.value)
 
     def test_auth_error_skips_non_dict_entries(self, monkeypatch):
         """Fallback chain entries that are not dicts are skipped."""
@@ -14456,9 +14487,14 @@ class TestResolveRuntimeWithFallback:
         resolution = server._resolve_runtime_with_fallback(
             {"requested": "openai-codex"},
         )
-        assert resolution.runtime == fallback_runtime
         assert resolution.selected_model == "claude-sonnet-4-6"
         assert resolution.used_fallback is True
+        assert resolution.runtime["provider"] == "anthropic"
+        assert resolution.runtime["api_key"] == "ant-tok"
+        assert resolution.runtime["initial_fallback_entry"] == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+        }
 
     def test_make_agent_uses_fallback_on_auth_error(self, monkeypatch):
         """Integration: _make_agent falls back to configured fallback
@@ -14485,7 +14521,7 @@ class TestResolveRuntimeWithFallback:
 
         monkeypatch.delenv("HERMES_MODEL", raising=False)
         monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
-        monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+        monkeypatch.setenv("HERMES_TUI_PROVIDER", "openai-codex")
         monkeypatch.setattr(
             server,
             "_load_cfg",
@@ -14516,9 +14552,83 @@ class TestResolveRuntimeWithFallback:
         )
 
         assert agent.model == "deepseek-v4-pro"
+        assert captured["model"] == "deepseek-v4-pro"
         assert captured["provider"] == "deepseek"
         assert captured["base_url"] == "https://fallback.invalid/v1"
         assert captured["api_key"] == "fb-tok"
+        assert captured["initial_fallback_entry"] == {
+            "provider": "deepseek",
+            "model": "deepseek-v4-pro",
+        }
+        assert "switching to deepseek-v4-pro via deepseek" in captured[
+            "initial_fallback_decision"
+        ]
+
+    def test_session_override_auth_fallback_does_not_reapply_primary_secrets(
+        self, monkeypatch
+    ):
+        import types
+
+        from hermes_cli.auth import AuthError
+
+        captured = {}
+
+        def fake_resolve(**kwargs):
+            if kwargs.get("requested") == "custom":
+                raise AuthError("primary override credentials expired")
+            return {
+                "provider": "deepseek",
+                "api_key": "fallback-key",
+                "base_url": "https://fallback.example/v1",
+                "api_mode": "chat_completions",
+            }
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return types.SimpleNamespace(model=kwargs.get("model"))
+
+        monkeypatch.setattr(
+            server,
+            "_load_cfg",
+            lambda: {
+                "fallback_policy": "any",
+                "fallback_providers": [
+                    {"provider": "deepseek", "model": "deepseek-v4-pro"}
+                ],
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            lambda **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve,
+        )
+        monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+        monkeypatch.setattr(server, "_get_db", lambda: None)
+
+        agent = server._make_agent(
+            "sid",
+            "session-key",
+            model_override={
+                "model": "primary-model",
+                "provider": "custom",
+                "base_url": "https://primary.example/v1",
+                "api_key": "primary-secret",
+                "api_mode": "codex_responses",
+            },
+        )
+
+        assert agent.model == "deepseek-v4-pro"
+        assert captured["base_url"] == "https://fallback.example/v1"
+        assert captured["api_key"] == "fallback-key"
+        assert captured["api_mode"] == "chat_completions"
+        assert captured["initial_fallback_entry"] == {
+            "provider": "deepseek",
+            "model": "deepseek-v4-pro",
+        }
 
 
 def test_get_usage_does_not_substitute_cumulative_total_for_context_used():

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3272,6 +3272,8 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
+        parent._fallback_chain_from_config = True
+        parent._active_fallback_entry = fallback_entry
 
         with patch("run_agent.AIAgent") as MockAgent:
             MockAgent.return_value = MagicMock()
@@ -3288,6 +3290,8 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertEqual(kwargs["fallback_model"], [fallback_entry])
+        self.assertIs(kwargs["fallback_chain_from_config"], True)
+        self.assertEqual(kwargs["initial_fallback_entry"], fallback_entry)
 
     def test_child_gets_no_fallback_when_parent_chain_empty(self):
         """When parent._fallback_chain is empty, fallback_model is None."""
@@ -3309,6 +3313,29 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+    def test_explicit_child_route_does_not_inherit_parent_fallback_identity(self):
+        parent = _make_mock_parent(depth=0)
+        fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini"}
+        parent._fallback_chain = [fallback_entry]
+        parent._fallback_chain_from_config = True
+        parent._active_fallback_entry = fallback_entry
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test explicit child route",
+                context=None,
+                toolsets=None,
+                model="different-model",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertIsNone(kwargs["initial_fallback_entry"])
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1460,6 +1460,25 @@ def _build_child_agent(
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
     parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    parent_fallback_entry = (
+        getattr(parent_agent, "_active_fallback_entry", None)
+        or getattr(parent_agent, "_init_fallback_entry", None)
+    )
+    parent_route = (
+        str(getattr(parent_agent, "provider", None) or "").strip().lower(),
+        str(getattr(parent_agent, "model", None) or "").strip().lower(),
+        str(getattr(parent_agent, "base_url", None) or "")
+        .strip()
+        .rstrip("/")
+        .lower(),
+    )
+    child_route = (
+        str(effective_provider or "").strip().lower(),
+        str(effective_model or "").strip().lower(),
+        str(effective_base_url or "").strip().rstrip("/").lower(),
+    )
+    if child_route != parent_route:
+        parent_fallback_entry = None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1515,6 +1534,10 @@ def _build_child_agent(
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
             fallback_model=parent_fallback,
+            fallback_chain_from_config=getattr(
+                parent_agent, "_fallback_chain_from_config", False
+            ),
+            initial_fallback_entry=parent_fallback_entry,
             enabled_toolsets=child_toolsets,
             disabled_toolsets=child_disabled_toolsets,
             quiet_mode=True,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5525,6 +5525,10 @@ def _agent_fallback_model(agent):
 
 def _background_agent_kwargs(agent, task_id: str) -> dict:
     cfg = _load_cfg()
+    active_fallback_entry = (
+        getattr(agent, "_active_fallback_entry", None)
+        or getattr(agent, "_init_fallback_entry", None)
+    )
 
     return {
         "base_url": getattr(agent, "base_url", None) or None,
@@ -5558,6 +5562,10 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
+        "fallback_chain_from_config": getattr(
+            agent, "_fallback_chain_from_config", False
+        ),
+        "initial_fallback_entry": active_fallback_entry,
     }
 
 
@@ -5849,7 +5857,7 @@ def _resolve_runtime_with_fallback(
                 fb_api_key = resolve_entry_api_key(entry)
                 if fb_api_key:
                     fb_kwargs["explicit_api_key"] = fb_api_key
-                runtime = resolve_runtime_provider(**fb_kwargs)
+                runtime = dict(resolve_runtime_provider(**fb_kwargs))
                 import logging
 
                 logging.getLogger(__name__).warning(
@@ -5858,10 +5866,44 @@ def _resolve_runtime_with_fallback(
                     fb_provider,
                     fb_model,
                 )
+                from hermes_cli.fallback_config import get_fallback_policy
+
+                policy = get_fallback_policy(_load_cfg())
+                primary_model = str(
+                    kwargs.get("target_model") or "configured model"
+                )
+                primary_provider = str(
+                    kwargs.get("requested") or "primary provider"
+                )
+                runtime["initial_fallback_decision"] = (
+                    f"🔄 Fallback policy {policy}: {primary_model} via "
+                    f"{primary_provider} could not initialize (reason: "
+                    f"{primary_exc}); switching to {fb_model} via "
+                    f"{fb_provider}."
+                )
+                runtime["initial_fallback_entry"] = dict(entry)
                 return _RuntimeFallbackResolution(runtime, fb_model, True)
             except Exception:
                 continue
-        raise
+        from hermes_cli.fallback_config import get_fallback_policy
+
+        policy = get_fallback_policy(_load_cfg())
+        if policy == "off":
+            detail = "Fallback policy off: no backup provider was attempted."
+        elif policy == "local-only":
+            detail = (
+                "Fallback policy local-only: no usable local backup route remained."
+            )
+        else:
+            detail = (
+                "Fallback policy any: no usable configured backup route remained."
+            )
+        raise AuthError(
+            f"{primary_exc}\n{detail}",
+            provider=getattr(primary_exc, "provider", ""),
+            code=getattr(primary_exc, "code", None),
+            relogin_required=getattr(primary_exc, "relogin_required", False),
+        ) from primary_exc
 
 
 def _make_agent(
@@ -6047,6 +6089,9 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        fallback_chain_from_config=True,
+        initial_fallback_decision=runtime.get("initial_fallback_decision"),
+        initial_fallback_entry=runtime.get("initial_fallback_entry"),
         **_agent_cbs(sid),
     )
 
@@ -13392,7 +13437,12 @@ def _(rid, params: dict) -> dict:
             from run_agent import AIAgent
 
             result = AIAgent(
-                **_background_agent_kwargs(session["agent"], task_id)
+                **_background_agent_kwargs(session["agent"], task_id),
+                status_callback=lambda kind, text=None: _status_update(
+                    parent,
+                    str(kind),
+                    None if text is None else str(text),
+                ),
             ).run_conversation(
                 user_message=text,
                 task_id=task_id,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4627,6 +4627,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     info: dict = {
         "model": mirror.get("model", getattr(agent, "model", "")),
         "provider": mirror.get("provider", getattr(agent, "provider", "")),
+        "fallback_policy": getattr(agent, "_fallback_policy", "any"),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
@@ -5482,15 +5483,35 @@ def _parse_tui_skills_env() -> list[str]:
 def _load_fallback_model():
     """Return the configured fallback chain for TUI-created agents.
 
-    Delegates to the shared ``get_fallback_chain`` helper so the TUI path
+    Delegates to the shared configured-chain helper so the TUI path
     stays in parity with ``HermesCLI.__init__`` and ``gateway/run.py``:
     ``fallback_providers`` is the primary source of truth and keeps its
     order, with legacy ``fallback_model`` entries merged in afterwards
     (deduped on provider/model/base_url).
     """
-    from hermes_cli.fallback_config import get_fallback_chain
+    from hermes_cli.fallback_config import get_configured_fallback_chain
 
-    return get_fallback_chain(_load_cfg())
+    return get_configured_fallback_chain(_load_cfg())
+
+
+def _load_effective_fallback_model():
+    """Return only routes eligible under the active fallback policy."""
+    from hermes_cli.fallback_config import (
+        fallback_entry_is_local,
+        get_fallback_policy,
+    )
+
+    cfg = _load_cfg()
+    policy = get_fallback_policy(cfg)
+    if policy == "off":
+        return []
+    chain = _load_fallback_model() or []
+    if policy == "local-only":
+        return [
+            entry for entry in chain
+            if isinstance(entry, dict) and fallback_entry_is_local(entry, cfg)
+        ]
+    return chain
 
 
 def _agent_fallback_model(agent):
@@ -5808,7 +5829,7 @@ def _resolve_runtime_with_fallback(
             False,
         )
     except AuthError as primary_exc:
-        fb_chain = _load_fallback_model() or []
+        fb_chain = _load_effective_fallback_model() or []
         for entry in fb_chain:
             if not isinstance(entry, dict):
                 continue

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -889,9 +889,10 @@ For task-specific direct endpoints, Hermes uses the task's configured API key or
 
 ## Fallback Providers (config.yaml only)
 
-The primary model fallback chain is configured exclusively through `config.yaml` — there are no environment variables for it. Add a top-level `fallback_providers` list with `provider` and `model` keys to enable automatic failover when your main model encounters errors. Auxiliary tasks whose provider is `auto` also consult this chain before Hermes' built-in auxiliary discovery chain.
+The primary model fallback chain is configured exclusively through `config.yaml` — there are no environment variables for it. Set the exact top-level `fallback_policy` (`off`, `local-only`, or `any`) and add a `fallback_providers` list with `provider` and `model` keys. Auxiliary tasks whose provider is `auto` obey the same policy before Hermes' built-in auxiliary discovery chain.
 
 ```yaml
+fallback_policy: any  # compatibility default; off | local-only | any
 fallback_providers:
   - provider: openrouter
     model: anthropic/claude-sonnet-4

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -135,7 +135,7 @@ Prompt caches are keyed to the model (and on most providers, the account) servin
 :::
 
 :::info Per-Turn, Not Per-Session
-Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a single turn, fallback activates at most once — if the fallback also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops within a turn while giving the primary model a fresh chance every turn.
+Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a turn, Hermes walks the eligible ordered chain and attempts each route at most once. Every actual switch is reported once as non-terminal status; only policy rejection or exhaustion is terminal. This bounds failover loops while still letting a later configured backup recover the turn.
 :::
 
 ### Examples

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -27,17 +27,30 @@ The easiest path is the interactive manager:
 hermes fallback
 ```
 
-`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `remove` (alias `rm`), and `clear` to manage the chain. Changes persist under the top-level `fallback_providers:` list in `config.yaml`.
+`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `remove` (alias `rm`), and `clear` to manage the chain. `hermes fallback policy` shows the active safety boundary; set it with `hermes fallback policy off`, `local-only`, or `any`. Changes persist under top-level keys in `config.yaml`.
 
 If you'd rather edit the YAML directly, add a top-level `fallback_providers` list to `~/.hermes/config.yaml`:
 
 ```yaml
+fallback_policy: any
 fallback_providers:
   - provider: openrouter
     model: anthropic/claude-sonnet-4
 ```
 
 Each entry requires both `provider` and `model`. Entries missing either field are ignored.
+
+### Fallback Policy
+
+| Value | Behavior |
+|-------|----------|
+| `off` | Never switches providers. The turn fails loudly with the policy and failure reason. |
+| `local-only` | Tries only routes whose endpoint metadata proves they are local. Remote and unknown endpoints are rejected. |
+| `any` | Preserves the historical behavior: configured local or remote routes are tried in order. |
+
+`any` is the compatibility default when an older config has no `fallback_policy` key. Values are exact and case-sensitive; an invalid explicit value fails closed as `off` and is reported by config validation.
+
+`local-only` checks the explicit `base_url`, provider configuration, and provider-specific base-URL environment override. It recognizes loopback, private/LAN, container-local, link-local, and Tailscale endpoints. Built-in cloud providers such as OpenCode, Anthropic, OpenRouter, and Nous remain remote even if a base-URL environment variable points them at localhost; deliberately redefine a local-compatible route under `providers:` or use `provider: custom`. Hermes does **not** guess from model names: an entry such as `model: my-local-model` with a remote or unknown endpoint is not eligible. It rechecks the resolved client's actual endpoint before switching as a second guard.
 
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
@@ -109,12 +122,13 @@ The fallback activates automatically when the primary model fails with:
 
 When triggered, Hermes:
 
-1. Resolves credentials for the fallback provider
-2. Builds a new API client
-3. Swaps the model, provider, and client in-place
-4. Resets the retry counter and continues the conversation
+1. Applies `fallback_policy` and finds the next eligible route
+2. Resolves credentials and builds the fallback client
+3. Shows the policy, classified failure reason, and destination in CLI/desktop status **before** switching
+4. Swaps the model, provider, and client in-place
+5. Resets the retry counter and continues the conversation
 
-The switch is seamless — your conversation history, tool calls, and context are preserved. The agent continues from exactly where it left off, just using a different model.
+Your conversation history, tool calls, and context are preserved. If policy blocks fallback or no eligible route remains, Hermes shows a terminal fallback status instead of silently ending or selecting an unrelated provider.
 
 :::warning Fallback resets the prompt cache
 Prompt caches are keyed to the model (and on most providers, the account) serving the request. When fallback fires, the new provider:model has no cached prefix for your conversation, so the next request re-reads the entire history at full input-token price instead of the ~75–90% discounted cached rate. The same applies when the turn ends and the primary is restored — that first request back on the primary is a full re-read too (unless the primary's cache TTL hasn't expired). This is unavoidable — it's the cost of staying alive through an outage — but it's why a long session that bounces between providers can cost noticeably more than one that stays put.
@@ -206,7 +220,7 @@ Main provider + main model → auxiliary.<task>.fallback_chain →
 fallback_providers / fallback_model → built-in auxiliary discovery chain
 ```
 
-The task-specific chain is most precise and wins when present. The top-level `fallback_providers` chain is the same policy the main agent uses, so free-only or same-provider fallback rules apply to auxiliary tasks on `auto` as well.
+The task-specific chain is most precise and wins when present. `fallback_policy` is the global cross-provider boundary for auxiliary fallback too: `off` stops after the selected main route fails, `local-only` filters task-specific, top-level, and built-in candidates by resolved endpoint, and `any` preserves the full chain.
 
 **Built-in text discovery chain (compression, web extract, title generation, etc.):**
 
@@ -222,7 +236,7 @@ Main provider (if vision-capable) → OpenRouter → Nous Portal →
 Codex OAuth → Anthropic → Custom endpoint → give up
 ```
 
-Those built-in chains are a convenience fallback for users who have not declared a task-specific or main fallback policy.
+Those built-in chains are a convenience fallback under `fallback_policy: any`. Under `local-only`, remote rungs such as OpenRouter, Nous, OpenCode, and Anthropic are skipped; under `off`, the built-in fallback chain is not walked.
 
 ### Configuring Auxiliary Providers
 


### PR DESCRIPTION
## What changed

- Adds an explicit `fallback_policy` with `off`, `local-only`, and `any` modes.
- Enforces the policy before startup/auth fallback and during live turns across CLI, one-shot, gateway, cron, delegated/background agents, and the core runtime.
- Refreshes config-owned fallback chains between turns so deletion, reordering, and policy changes take effect without recreating an agent.
- Emits a structured fallback decision before switching routes, keeps rejection/exhaustion terminal, and removes duplicate successful-recovery switch chatter.
- Persists fallback notices in the Desktop transcript sidecar so reload/resume preserves the operator-visible routing explanation without injecting it into model context.
- Documents the policy and exposes `hermes fallback policy` management.

## Why

Fallback routing was assembled and cached independently by several entry points. That let init-time auth recovery bypass the live policy, made stale routes survive config changes, and could switch a turn to another provider without a durable user-facing explanation.

This change makes routing eligibility a shared policy boundary and treats the fallback decision as observable runtime state rather than incidental console text.

## Upstream-port notes

- Exact safety ancestry is included ahead of the two fallback commits: browser containment `398ed14ef` followed by TTS-state containment `8f58ce2b553dbf1a7b0f500849fa540e11f492b0`.
- The two fallback commits preserve the original authorship and subjects while resolving against current upstream `main`.
- Fork-only dynamic free-promotion machinery was deliberately excluded.
- Upstream's newer per-message gateway fallback refresh path and workspace-state behavior were preserved.
- The new Desktop statusbar copy is routed through i18n in all four locales (`en`, `ja`, `zh`, `zh-hant`).

## Safety and compatibility

- `off` fails loudly without attempting a backup route.
- `local-only` admits only routes whose endpoint/provider metadata proves they are local; unknown endpoints fail closed.
- `any` preserves the historical configured-chain behavior for existing configs.
- Manual `/model` selections remain excluded from automatic fallback for the active session.

## Validation

- Focused runtime/provider/CLI/gateway/delegation set: **300 passed**.
- Fallback config, command, validation, and retry-status files: **78 passed**.
- Primary-runtime restoration file: **42 passed**.
- Interrupt stale-notice selection: **2 passed**.
- Narrow cron selection (init-auth fallback propagation + existing cron title contract): **2 passed**.
- Desktop workspace Vitest on seven affected files: **92 passed**.
- Desktop renderer + Electron TypeScript typecheck: passed.
- ESLint on every changed Desktop TypeScript/TSX file: passed.
- `git diff --check`: passed.

`tests/test_tui_gateway_server.py` was intentionally not executed. No live application was launched, installed, restarted, or modified.

A broader `tests/run_agent/test_run_agent.py` attempt hit an unrelated macOS/Python subprocess segfault in coding-context git probing after reporting two stale-notice assertions. Those two assertions were fixed and rerun narrowly (**2 passed**); the prohibited TUI suite was never collected.

## Known review follow-ups (non-blocking P2)

- Same provider/model/base-URL eligibility identity does not yet include `api_key`/`key_env`/`api_mode`, so an active fallback client can retain same-route credential changes until the primary cooldown ends.
- API-server agents do not currently pass a `status_callback`, so fallback status is server-visible but not yet streamed to that API client surface.
- Partial-stream content-filter handling can use misleading terminal wording and retry a deterministic filter when policy leaves no eligible route.
- Desktop notice persistence is keyed by stored session ID rather than profile + session ID; the pre-bind pending map is not explicitly bounded, and multi-window localStorage writes are not serialized.

This is intentionally a draft for focused review of those boundaries and the cross-runtime port.
