### PR TITLE
fix: protect household approval gates

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2764,12 +2764,20 @@ class GatewaySlashCommandsMixin:
         new setting takes effect on the next message.
         """
         from gateway.run import _hermes_home
-        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli.write_approval_commands import (
+            approval_toggle_allowed,
+            handle_pending_subcommand,
+        )
         from tools import write_approval as wa
         from tools.memory_tool import load_on_disk_store
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
+        if args and args[0].lower() in {"approval", "mode"} and not approval_toggle_allowed(
+            get_active_profile_name() or ""
+        ):
+            return "Approval gate changes are operator-managed for this profile."
         session_key = self._session_key_for_source(event.source)
         config_path = _hermes_home / "config.yaml"
 
@@ -2814,11 +2822,19 @@ class GatewaySlashCommandsMixin:
         ``hermes skills diff <name>`` that diffs a bundled skill vs stock.)
         """
         from gateway.run import _hermes_home
-        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli.write_approval_commands import (
+            approval_toggle_allowed,
+            handle_pending_subcommand,
+        )
         from tools import write_approval as wa
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
+        if args and args[0].lower() in {"approval", "mode"} and not approval_toggle_allowed(
+            get_active_profile_name() or ""
+        ):
+            return "Approval gate changes are operator-managed for this profile."
         session_key = self._session_key_for_source(event.source)
         config_path = _hermes_home / "config.yaml"
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2766,6 +2766,7 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _hermes_home
         from hermes_cli.profiles import get_active_profile_name
         from hermes_cli.write_approval_commands import (
+            approval_profile_name,
             approval_toggle_allowed,
             handle_pending_subcommand,
         )
@@ -2775,7 +2776,10 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
         if args and args[0].lower() in {"approval", "mode"} and not approval_toggle_allowed(
-            get_active_profile_name() or ""
+            approval_profile_name(
+                getattr(getattr(event, "source", None), "profile", None),
+                get_active_profile_name(),
+            )
         ):
             return "Approval gate changes are operator-managed for this profile."
         session_key = self._session_key_for_source(event.source)
@@ -2824,6 +2828,7 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _hermes_home
         from hermes_cli.profiles import get_active_profile_name
         from hermes_cli.write_approval_commands import (
+            approval_profile_name,
             approval_toggle_allowed,
             handle_pending_subcommand,
         )
@@ -2832,7 +2837,10 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
         if args and args[0].lower() in {"approval", "mode"} and not approval_toggle_allowed(
-            get_active_profile_name() or ""
+            approval_profile_name(
+                getattr(getattr(event, "source", None), "profile", None),
+                get_active_profile_name(),
+            )
         ):
             return "Approval gate changes are operator-managed for this profile."
         session_key = self._session_key_for_source(event.source)

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -21,6 +21,14 @@ from typing import List, Optional
 from tools import write_approval as wa
 
 
+HOUSEHOLD_PROFILES = frozenset({"family", "home", "partner", "kid-1", "kid-2"})
+
+
+def approval_toggle_allowed(profile_name: str) -> bool:
+    """Return whether a profile may change its durable-write approval gates."""
+    return (profile_name or "").strip().lower() not in HOUSEHOLD_PROFILES
+
+
 def _fmt_state(subsystem: str) -> str:
     on = wa.write_approval_enabled(subsystem)
     return f"{subsystem}.write_approval = {'on' if on else 'off'}"

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -29,6 +29,17 @@ def approval_toggle_allowed(profile_name: str) -> bool:
     return (profile_name or "").strip().lower() not in HOUSEHOLD_PROFILES
 
 
+def approval_profile_name(source_profile: str | None, active_profile: str | None) -> str:
+    """Resolve the profile whose approval command is being handled.
+
+    Multiplexed gateways stamp the routed profile on the inbound source. That
+    profile must win over the process-active profile, otherwise a household
+    route can inherit the admin/default gateway's toggle permission. Unstamped
+    legacy events retain the active-profile fallback.
+    """
+    return (source_profile or active_profile or "").strip()
+
+
 def _fmt_state(subsystem: str) -> str:
     on = wa.write_approval_enabled(subsystem)
     return f"{subsystem}.write_approval = {'on' if on else 'off'}"

--- a/tests/gateway/test_household_approval_toggle_guard.py
+++ b/tests/gateway/test_household_approval_toggle_guard.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler_name", ["_handle_memory_command", "_handle_skills_command"])
+async def test_household_gateway_cannot_disable_write_approval(handler_name):
+    handler = GatewaySlashCommandsMixin.__new__(GatewaySlashCommandsMixin)
+    event = SimpleNamespace(
+        get_command_args=lambda: "approval off",
+        source=SimpleNamespace(chat_id="test"),
+    )
+
+    with patch(
+        "hermes_cli.profiles.get_active_profile_name",
+        return_value="family",
+    ):
+        result = await getattr(handler, handler_name)(event)
+
+    assert result == "Approval gate changes are operator-managed for this profile."

--- a/tests/gateway/test_household_approval_toggle_guard.py
+++ b/tests/gateway/test_household_approval_toggle_guard.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from gateway.slash_commands import GatewaySlashCommandsMixin
+from hermes_cli.write_approval_commands import approval_profile_name, approval_toggle_allowed
 
 
 @pytest.mark.asyncio
@@ -12,13 +13,30 @@ async def test_household_gateway_cannot_disable_write_approval(handler_name):
     handler = GatewaySlashCommandsMixin.__new__(GatewaySlashCommandsMixin)
     event = SimpleNamespace(
         get_command_args=lambda: "approval off",
-        source=SimpleNamespace(chat_id="test"),
+        source=SimpleNamespace(chat_id="test", profile="family"),
     )
 
     with patch(
         "hermes_cli.profiles.get_active_profile_name",
-        return_value="family",
+        return_value="dev",
     ):
         result = await getattr(handler, handler_name)(event)
 
     assert result == "Approval gate changes are operator-managed for this profile."
+
+
+@pytest.mark.parametrize(
+    ("source_profile", "active_profile", "expected"),
+    [
+        ("family", "dev", "family"),
+        ("dev", "family", "dev"),
+        (None, "family", "family"),
+        (None, None, ""),
+    ],
+)
+def test_routed_profile_wins_over_active_profile(
+    source_profile, active_profile, expected
+):
+    resolved = approval_profile_name(source_profile, active_profile)
+    assert resolved == expected
+    assert approval_toggle_allowed(resolved) is (expected != "family")

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -36,6 +36,15 @@ def _set_approval(subsystem, enabled):
 # Config resolution
 # ---------------------------------------------------------------------------
 
+def test_household_profiles_cannot_toggle_approval_gate():
+    from hermes_cli.write_approval_commands import approval_toggle_allowed
+
+    for profile in ("family", "home", "partner", "kid-1", "kid-2"):
+        assert approval_toggle_allowed(profile) is False
+    assert approval_toggle_allowed("dev") is True
+    assert approval_toggle_allowed("rescue") is True
+
+
 def test_default_gate_is_off(hermes_home):
     from tools import write_approval as wa
     # Default: gate off → writes flow freely.


### PR DESCRIPTION
Closing this upstream PR: the household deployment is maintained and reviewed in the `DIZ-admin/hermes-agent` fork. The routed-profile fix is now tracked in fork-local PR https://github.com/DIZ-admin/hermes-agent/pull/21.