### PR TITLE
feat(gateway): hot-reload MCP servers on config.yaml change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+_*.py
+_*.ps1

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1048,6 +1048,23 @@ def init_agent(
                         )
                 if not getattr(agent, "_fallback_activated", False):
                     # No provider configured — reject with a clear message.
+                    #
+                    # Operational note (D-001 / RCA-A in
+                    # plugins/platforms/discord/ISSUES.md):
+                    #   The most common cause of reaching this raise is NOT a
+                    #   missing config — it's an empty ``<PROVIDER>_API_KEY=``
+                    #   line in ~/.hermes/.env silently overriding a valid key
+                    #   in config.yaml. Env vars are resolved BEFORE
+                    #   config.yaml is read, so the runtime sees "" and the
+                    #   resolver returns None here.
+                    #
+                    #   Reproduction:
+                    #     1. Add ``OPENROUTER_API_KEY=`` (empty value) to .env
+                    #     2. Restart gateway — every Discord message fails
+                    #     3. errors.log shows this exact RuntimeError
+                    #
+                    #   Fix: ``d:/projects/hermes-agent-hotreload/apply-openrouter-key.py``
+                    #   (idempotent — syncs env var from config.yaml).
                     raise RuntimeError(
                         "No LLM provider configured. Run `hermes model` to "
                         "select a provider, or run `hermes setup` for first-time "

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -883,9 +883,34 @@ def _classify_by_status(
     if status_code == 403:
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
         # providers also use 403 for account-plan or credit exhaustion.
+        # Kimi / Moonshot's Coding Plan (api.kimi.com/coding) returns
+        # HTTP 403 with type=permission_error and the body "You've reached
+        # your usage limit for this billing cycle. Your quota will be
+        # refreshed in the next cycle. To continue now, purchase extra usage
+        # or upgrade your plan" when the subscription quota is exhausted.
+        # The wording contains "usage limit" + "billing cycle" + "quota will
+        # be refreshed" + "purchase extra usage" + "upgrade your plan" — none
+        # of those are in the generic _BILLING_PATTERNS list (which matches
+        # "exceeded your current quota" / "insufficient balance" etc.), so
+        # without this disambiguation the error falls through to the auth
+        # branch, surfaces as "Non-retryable client error" to the user, and
+        # never triggers the billing-aware recovery path (rotate credential,
+        # activate fallback, show "credits exhausted" status). Match the
+        # Kimi-specific phrases here so the recovery is identical to a 402.
+        #
+        # Reproduction (D-003 / RCA-B):
+        #   1. Use a Kimi Coding Plan subscription until quota exhausts
+        #   2. Run: hermes chat --provider kimi-coding --model kimi-k2.7-code
+        #   3. Send any message — observe immediate fallback activation
+        #      (was: "Non-retryable client error", bot dies, no fallback)
+        # Before this branch matched, the 403 fell through to the auth path
+        # below and the bot hard-aborted without activating the fallback chain.
         if (
             "key limit exceeded" in error_msg
             or "spending limit" in error_msg
+            or ("usage limit" in error_msg and "billing cycle" in error_msg)
+            or "quota will be refreshed" in error_msg
+            or "purchase extra usage" in error_msg
             or any(p in error_msg for p in _BILLING_PATTERNS)
         ):
             return result_fn(
@@ -964,6 +989,31 @@ def _classify_by_status(
             return result_fn(
                 FailoverReason.overloaded,
                 retryable=True,
+            )
+        # Some providers mislabel account-balance exhaustion as HTTP 429
+        # instead of the standards-correct 402. Z.AI / Zhipu is the worst
+        # offender: it returns ``HTTP 429 {"error":{"code":"1113",
+        # "message":"Insufficient balance or no resource package. Please
+        # recharge."}}`` when the GLM_API_KEY account is out of credits.
+        # That body is identical in meaning to a 402 billing exhaustion — the
+        # credential is valid but the account can't pay — so retrying is
+        # pointless (3 retries waste ~10s before the loop gives up) and the
+        # right action is to rotate / fall back immediately. Check the body
+        # against the billing patterns AND the Z.AI-specific code 1113 before
+        # the rate_limit fallback so this case is handled here. (#16)
+        #
+        # Reproduction (D-002 / RCA-B):
+        #   1. Set GLM_API_KEY to a key with zero account balance
+        #   2. Run: hermes chat --provider zai --model glm-5
+        #   3. Send any message — observe 0 wasted retries (was 3 before fix)
+        # Before this branch existed, the error fell through to the catch-all
+        # rate_limit path at the bottom of this function and burned 3 retries.
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         # Distinguish an OpenRouter-aggregator upstream 429 (an upstream model
         # like DeepSeek rate-limited OpenRouter's aggregate traffic) from an
@@ -1278,6 +1328,12 @@ def _classify_by_error_code(
         "no_usable_credits",
         "balance_depleted",
         "model_not_supported_on_free_tier",
+        # Z.AI / Zhipu GLM returns code "1113" with "Insufficient balance
+        # or no resource package. Please recharge." — surfaced as HTTP 429
+        # (see _classify_by_status 429 branch) but also reachable here when
+        # the body shape preserves the structured code. Treat as billing so
+        # the recovery is rotate/fallback rather than retry. (#16)
+        "1113",
     }:
         return result_fn(
             FailoverReason.billing,

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -73,6 +73,44 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("deepseek-reasoner", 600),
     ("deepseek-v4-flash", 600),
     ("deepseek-v4-pro", 600),
+    # Z.AI / Zhipu GLM-4.5-and-later reasoning models.  GLM-5.2 ships with
+    # thinking enabled by default on the OpenAI-compatible endpoint
+    # (api.z.ai/api/paas/v4) — see plugins/model-providers/zai/__init__.py
+    # — and routinely pauses for minutes during extended thinking before
+    # emitting the first content token.  Without a floor, the default
+    # HERMES_STREAM_STALE_TIMEOUT of 180s (and the httpx read timeout of
+    # 120s) fire *before* GLM-5.2 finishes thinking, tearing down a
+    # healthy reasoning stream mid-think.  The user-visible symptom is
+    # "GLM models just hang without doing anything" followed by a stale-
+    # stream kill — because no content tokens ever arrive inside the
+    # default window.  GLM-5.2 max-effort thinking is the slowest variant
+    # (300s floor); GLM-5 / GLM-4.6 / GLM-4.5 are progressively lighter.
+    # Slug-anchored like the rest of the table so "glm-4-9b" (a non-
+    # thinking variant) is NOT matched. (#17)
+    #
+    # Reproduction (D-004 / RCA-C):
+    #   1. Set provider=zai, model=glm-5.2 (thinking is ON by default)
+    #   2. Send a non-trivial reasoning task (e.g. "write a Python function
+    #      that solves N-queens and explain your approach")
+    #   3. BEFORE this floor existed, the bot would appear to hang for 180s,
+    #      then log "Stream stale for 180s - killing connection", then retry
+    #      the same hang, looping for ~540s+ before final failure.
+    #   4. AFTER this floor, the stale detector waits 300s — long enough for
+    #      GLM-5.2's max-effort thinking phase to complete.
+    #
+    # Why GLM was originally missing from this table:
+    #   The table was built (Fixes #52217) for cloud reasoning models with
+    #   DOCUMENTED multi-minute TTFB (NVIDIA Nemotron, OpenAI o1, Anthropic
+    #   Opus 4.x thinking, DeepSeek R1). GLM-5.2's thinking mode is opt-out
+    #   and was added separately in plugins/model-providers/zai/__init__.py.
+    #   There is no automated check linking the two — a provider profile that
+    #   emits thinking blocks does NOT auto-register here. See RCA-C in
+    #   plugins/platforms/discord/ISSUES.md for the systemic pattern.
+    ("glm-5.2", 300),
+    ("glm-5p2", 300),  # Fireworks alias spelling
+    ("glm-5", 240),
+    ("glm-4.6", 180),
+    ("glm-4.5", 180),
     # Qwen — QwQ reasoning + Qwen3 thinking variants.  QwQ-32B
     # preview is the stable slug; ``qwen3`` covers the family of
     # thinking-mode Qwen3 models (qwen3-235b-a22b, qwen3-32b, etc.)
@@ -204,6 +242,14 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     300.0
     >>> get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")
     240.0
+    >>> get_reasoning_stale_timeout_floor("glm-5.2")
+    300.0
+    >>> get_reasoning_stale_timeout_floor("zai/glm-5")
+    240.0
+    >>> get_reasoning_stale_timeout_floor("glm-4.5-flash")
+    180.0
+    >>> get_reasoning_stale_timeout_floor("glm-4-9b") is None
+    True
     >>> get_reasoning_stale_timeout_floor("gpt-4o") is None
     True
     >>> get_reasoning_stale_timeout_floor("olmo-1") is None

--- a/apply-fallback-chain.py
+++ b/apply-fallback-chain.py
@@ -1,0 +1,87 @@
+"""Apply fallback-chain expansion to the runtime Hermes config.yaml.
+
+Adds more OpenRouter free models (deepseek-r1, llama-4, mistral-small-3.2)
+plus commented-out OpenCode Go/Zen placeholders so the user can activate
+them by uncommenting OPENCODE_*_API_KEY in .env.
+
+Idempotent: if the new tier-1 comment banner is already present, exits 0.
+"""
+from pathlib import Path
+import sys
+
+CONFIG = Path.home() / "AppData" / "Local" / "hermes" / "config.yaml"
+
+OLD = """fallback_providers:
+  - provider: openrouter
+    model: nvidia/nemotron-3-ultra-550b-a55b:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: nvidia/nemotron-3-super-120b-a12b:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: qwen/qwen3-coder:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: google/gemma-4-31b-it:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: google/gemma-4-26b-a4b-it:free
+    base_url: "https://openrouter.ai/api/v1"
+"""
+
+NEW = """fallback_providers:
+  # ── Tier 1: OpenRouter free agentic / coding models ─────────────────
+  # Walked one-by-one.  Each entry inherits OPENROUTER_API_KEY from the
+  # primary model stanza.  Image-capable models (gemma-4-31b) kept early
+  # so Discord image input keeps working through failover.
+  - provider: openrouter
+    model: nvidia/nemotron-3-ultra-550b-a55b:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: nvidia/nemotron-3-super-120b-a12b:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: qwen/qwen3-coder:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: google/gemma-4-31b-it:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: google/gemma-4-26b-a4b-it:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: deepseek/deepseek-r1:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: meta-llama/llama-4-70b-instruct:free
+    base_url: "https://openrouter.ai/api/v1"
+  - provider: openrouter
+    model: mistralai/mistral-small-3.2-24b-instruct:free
+    base_url: "https://openrouter.ai/api/v1"
+  # ── Tier 2: OpenCode Go ($10/mo subscription, GLM-5/Kimi K2/MiMo) ────
+  # Uncomment OPENCODE_GO_API_KEY in .env to activate. Cheap insurance
+  # once the free OpenRouter pool is rate-limited.
+  # - provider: opencode-go
+  #   model: glm-5
+  #   base_url: "https://opencode.ai/zen/go/v1"
+  # - provider: opencode-go
+  #   model: kimi-k2.5
+  #   base_url: "https://opencode.ai/zen/go/v1"
+  # ── Tier 3: OpenCode Zen (pay-as-you-go, GPT/Claude/Gemini) ──────────
+  # Uncomment OPENCODE_ZEN_API_KEY in .env to activate.
+  # - provider: opencode-zen
+  #   model: gemini-3-flash
+  #   base_url: "https://opencode.ai/zen/v1"
+"""
+
+SENTINEL = "Tier 1: OpenRouter free agentic"
+
+text = CONFIG.read_text(encoding="utf-8")
+if SENTINEL in text:
+    print("[SKIP] fallback chain already expanded")
+    sys.exit(0)
+if OLD not in text:
+    print("[WARN] current fallback block did not match expected shape")
+    sys.exit(1)
+CONFIG.write_text(text.replace(OLD, NEW, 1), encoding="utf-8")
+print(f"[ OK ] expanded fallback chain in {CONFIG}")

--- a/apply-openrouter-key.py
+++ b/apply-openrouter-key.py
@@ -1,0 +1,62 @@
+"""Fix #1: Sync OPENROUTER_API_KEY in .env from config.yaml so the runtime
+actually sees the key. The env var takes precedence over config.yaml, and an
+empty `OPENROUTER_API_KEY=` line in .env was overriding the working key in
+config.yaml. Idempotent — exits 0 if already in sync.
+"""
+from pathlib import Path
+import re
+import sys
+
+HERMES_HOME = Path.home() / "AppData" / "Local" / "hermes"
+CONFIG = HERMES_HOME / "config.yaml"
+ENV = HERMES_HOME / ".env"
+
+# Pull api_key from config.yaml model.api_key
+text = CONFIG.read_text(encoding="utf-8")
+m = re.search(r'^model:\s*\n(?:[ \t]+.*\n)*?[ \t]+api_key:\s*"([^"]+)"', text, re.MULTILINE)
+if not m:
+    print("[FAIL] could not find model.api_key in config.yaml")
+    sys.exit(1)
+api_key = m.group(1).strip()
+if not api_key or "REPLACE" in api_key.upper():
+    print(f"[FAIL] model.api_key in config.yaml is not a real key: {api_key[:20]}...")
+    sys.exit(1)
+
+masked = api_key[:10] + "..." + api_key[-4:]
+print(f"[INFO] config.yaml model.api_key = {masked}")
+
+# Read .env, replace the OPENROUTER_API_KEY line
+env_text = ENV.read_text(encoding="utf-8")
+lines = env_text.splitlines(keepends=True)
+changed = False
+found = False
+for i, line in enumerate(lines):
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        continue
+    if re.match(r"^OPENROUTER_API_KEY\s*=", line):
+        found = True
+        # Preserve trailing newline / line ending
+        newline = "\r\n" if line.endswith("\r\n") else ("\n" if line.endswith("\n") else "")
+        current_val = line.split("=", 1)[1].strip().strip('"').strip("'") if newline else ""
+        if current_val == api_key:
+            print(f"[SKIP] OPENROUTER_API_KEY in .env already matches config.yaml")
+            sys.exit(0)
+        # Replace
+        new_line = f"OPENROUTER_API_KEY={api_key}{newline}"
+        if lines[i] != new_line:
+            lines[i] = new_line
+            changed = True
+        break
+
+if not found:
+    # Append
+    newline = "\r\n" if env_text.endswith("\r\n") or "\r\n" in env_text[:200] else "\n"
+    lines.append(f"{newline}OPENROUTER_API_KEY={api_key}{newline}")
+    changed = True
+
+if changed:
+    ENV.write_text("".join(lines), encoding="utf-8")
+    print(f"[ OK ] wrote OPENROUTER_API_KEY={masked} to .env")
+else:
+    print(f"[SKIP] no change needed")

--- a/apply-rca-fixes.py
+++ b/apply-rca-fixes.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Apply RCA fixes for Z.AI 429, Kimi 403/429, and GLM hangs to the runtime Hermes install.
+
+The Hermes runtime installs to:
+    C:\\Users\\<user>\\AppData\\Local\\hermes\\hermes-agent\\
+
+which is a SEPARATE copy from any dev / git checkout. Editing the dev tree
+alone has no effect on the running agent. This script applies the four RCA
+fixes from issue #16/#17 directly to the runtime copy and clears the
+bytecode cache so the changes take effect on the next gateway restart.
+
+Idempotent: every patch is guarded by a sentinel check, so re-running the
+script after a successful patch is a no-op (exits 0 with "already applied").
+
+Fixes applied:
+  1. error_classifier.py _classify_by_status 429 — check _BILLING_PATTERNS
+     before the rate_limit fallback. Fixes Z.AI code-1113 "Insufficient
+     balance" 429 being retried 3x before failing.
+  2. error_classifier.py _classify_by_status 403 — match Kimi's "usage
+     limit for this billing cycle" / "quota will be refreshed" / "purchase
+     extra usage" phrases as billing (was misclassified as auth).
+  3. error_classifier.py _classify_by_error_code — add Z.AI code "1113"
+     to the billing code set.
+  4. reasoning_timeouts.py — add GLM-5.2 / GLM-5 / GLM-4.6 / GLM-4.5 to
+     _REASONING_STALE_TIMEOUT_FLOORS so thinking-mode GLM streams don't
+     get killed by the 180s default stale detector.
+
+Usage:
+    python apply-rca-fixes.py            # patches default runtime path
+    python apply-rca-fixes.py --check    # check only, no changes
+    python apply-rca-fixes.py --path X   # patches a custom install path
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Resolve the default runtime path from HERMES_HOME or the conventional
+# AppData location. ``Path.home()`` keeps this portable across usernames.
+_DEFAULT_RUNTIME = Path(os.environ.get(
+    "HERMES_HOME",
+    str(Path.home() / "AppData" / "Local" / "hermes"),
+)) / "hermes-agent"
+
+
+# ── Patch 1: 429 billing check ───────────────────────────────────────────
+# Inserted right after the _OVERLOADED_PATTERNS check in the 429 branch.
+PATCH_429_SENTINEL = "# Some providers mislabel account-balance exhaustion as HTTP 429"
+PATCH_429_BLOCK = '''        # Some providers mislabel account-balance exhaustion as HTTP 429
+        # instead of the standards-correct 402. Z.AI / Zhipu is the worst
+        # offender: it returns ``HTTP 429 {"error":{"code":"1113",
+        # "message":"Insufficient balance or no resource package. Please
+        # recharge."}}`` when the GLM_API_KEY account is out of credits.
+        # That body is identical in meaning to a 402 billing exhaustion — the
+        # credential is valid but the account can't pay — so retrying is
+        # pointless (3 retries waste ~10s before the loop gives up) and the
+        # right action is to rotate / fall back immediately. Check the body
+        # against the billing patterns AND the Z.AI-specific code 1113 before
+        # the rate_limit fallback so this case is handled here. (#16)
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
+'''
+PATCH_429_ANCHOR = '''        if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+            return result_fn(
+                FailoverReason.overloaded,
+                retryable=True,
+            )
+        # Distinguish an OpenRouter-aggregator upstream 429'''
+
+# ── Patch 2: 403 Kimi billing patterns ───────────────────────────────────
+PATCH_403_OLD = '''    if status_code == 403:
+        # OpenRouter 403 "key limit exceeded" is actually billing. Other
+        # providers also use 403 for account-plan or credit exhaustion.
+        if (
+            "key limit exceeded" in error_msg
+            or "spending limit" in error_msg
+            or any(p in error_msg for p in _BILLING_PATTERNS)
+        ):'''
+PATCH_403_NEW = '''    if status_code == 403:
+        # OpenRouter 403 "key limit exceeded" is actually billing. Other
+        # providers also use 403 for account-plan or credit exhaustion.
+        # Kimi / Moonshot's Coding Plan (api.kimi.com/coding) returns
+        # HTTP 403 with type=permission_error and the body "You've reached
+        # your usage limit for this billing cycle. Your quota will be
+        # refreshed in the next cycle. To continue now, purchase extra usage
+        # or upgrade your plan" when the subscription quota is exhausted.
+        # The wording contains "usage limit" + "billing cycle" + "quota will
+        # be refreshed" + "purchase extra usage" + "upgrade your plan" — none
+        # of those are in the generic _BILLING_PATTERNS list (which matches
+        # "exceeded your current quota" / "insufficient balance" etc.), so
+        # without this disambiguation the error falls through to the auth
+        # branch, surfaces as "Non-retryable client error" to the user, and
+        # never triggers the billing-aware recovery path (rotate credential,
+        # activate fallback, show "credits exhausted" status). Match the
+        # Kimi-specific phrases here so the recovery is identical to a 402.
+        if (
+            "key limit exceeded" in error_msg
+            or "spending limit" in error_msg
+            or ("usage limit" in error_msg and "billing cycle" in error_msg)
+            or "quota will be refreshed" in error_msg
+            or "purchase extra usage" in error_msg
+            or any(p in error_msg for p in _BILLING_PATTERNS)
+        ):'''
+
+# ── Patch 3: code 1113 in billing code set ──────────────────────────────
+PATCH_CODE_1113_OLD = '''        "balance_depleted",
+        "model_not_supported_on_free_tier",
+    }:'''
+PATCH_CODE_1113_NEW = '''        "balance_depleted",
+        "model_not_supported_on_free_tier",
+        # Z.AI / Zhipu GLM returns code "1113" with "Insufficient balance
+        # or no resource package. Please recharge." — surfaced as HTTP 429
+        # (see _classify_by_status 429 branch) but also reachable here when
+        # the body shape preserves the structured code. Treat as billing so
+        # the recovery is rotate/fallback rather than retry. (#16)
+        "1113",
+    }:'''
+
+# ── Patch 4: GLM reasoning timeout floors ────────────────────────────────
+PATCH_GLM_OLD = '''    ("deepseek-v4-pro", 600),'''
+PATCH_GLM_NEW = '''    ("deepseek-v4-pro", 600),
+    # Z.AI / Zhipu GLM-4.5-and-later reasoning models.  GLM-5.2 ships with
+    # thinking enabled by default on the OpenAI-compatible endpoint
+    # (api.z.ai/api/paas/v4) — see plugins/model-providers/zai/__init__.py
+    # — and routinely pause for minutes during extended thinking before
+    # emitting the first content token.  Without a floor, the default
+    # HERMES_STREAM_STALE_TIMEOUT of 180s (and the httpx read timeout of
+    # 120s) fire *before* GLM-5.2 finishes thinking, tearing down a
+    # healthy reasoning stream mid-think.  The user-visible symptom is
+    # "GLM models just hang without doing anything" followed by a stale-
+    # stream kill — because no content tokens ever arrive inside the
+    # default window.  GLM-5.2 max-effort thinking is the slowest variant
+    # (300s floor); GLM-5 / GLM-4.6 / GLM-4.5 are progressively lighter.
+    # Slug-anchored like the rest of the table so "glm-4-9b" (a non-
+    # thinking variant) is NOT matched. (#17)
+    ("glm-5.2", 300),
+    ("glm-5p2", 300),  # Fireworks alias spelling
+    ("glm-5", 240),
+    ("glm-4.6", 180),
+    ("glm-4.5", 180),'''
+
+
+def _apply(text: str, old: str, new: str, sentinel: str, label: str) -> tuple[str, bool, bool]:
+    """Return (new_text, already_applied, changed)."""
+    if sentinel in text:
+        return text, True, False
+    if old not in text:
+        return text, False, False
+    return text.replace(old, new, 1), False, True
+
+
+def patch_file(path: Path, ops: list[tuple[str, str, str, str, str]]) -> int:
+    """Apply a sequence of (old, new, sentinel, label) ops to *path*.
+
+    Returns the number of ops that actually changed the file. Exits the
+    script with a non-zero status if any op fails to find its anchor.
+    """
+    original = path.read_text(encoding="utf-8")
+    text = original
+    changes = 0
+    for old, new, sentinel, label in ops:
+        text, already, changed = _apply(text, old, new, sentinel, label)
+        if already:
+            print(f"  [SKIP] {label} — already applied")
+        elif changed:
+            print(f"  [ OK ] {label}")
+            changes += 1
+        else:
+            print(f"  [FAIL] {label} — anchor not found in {path.name}")
+            print("         The runtime file may be a different version than "
+                  "this patch was built against.")
+            sys.exit(2)
+    if changes:
+        path.write_text(text, encoding="utf-8")
+        # Clear bytecode cache so the next import picks up the new source.
+        pycache = path.parent / "__pycache__"
+        if pycache.is_dir():
+            for pyc in pycache.glob(f"{path.stem}.*.pyc"):
+                try:
+                    pyc.unlink()
+                    print(f"  [CLEA] removed stale bytecode {pyc.name}")
+                except OSError:
+                    pass
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply RCA fixes for Z.AI/Kimi/GLM to the runtime Hermes install.",
+    )
+    parser.add_argument(
+        "--path",
+        default=str(_DEFAULT_RUNTIME),
+        help=f"Runtime hermes-agent install path (default: {_DEFAULT_RUNTIME})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check whether patches are applied; do not modify anything.",
+    )
+    args = parser.parse_args()
+
+    runtime = Path(args.path)
+    ec_path = runtime / "agent" / "error_classifier.py"
+    rt_path = runtime / "agent" / "reasoning_timeouts.py"
+
+    print(f"Runtime install: {runtime}")
+    if not ec_path.is_file() or not rt_path.is_file():
+        print(f"ERROR: expected files not found under {runtime / 'agent'}")
+        return 3
+
+    total_changes = 0
+
+    print("\n=== Patching agent/error_classifier.py ===")
+    if args.check:
+        ec_text = ec_path.read_text(encoding="utf-8")
+        for label, sentinel in [
+            ("429 billing check", PATCH_429_SENTINEL),
+            ("403 Kimi billing patterns", '"quota will be refreshed"'),
+            ("code 1113 billing", '"1113",'),
+        ]:
+            status = "applied" if sentinel in ec_text else "MISSING"
+            print(f"  [{status:>8}] {label}")
+    else:
+        total_changes += patch_file(ec_path, [
+            (PATCH_429_ANCHOR, PATCH_429_BLOCK + PATCH_429_ANCHOR, PATCH_429_SENTINEL, "429 billing check"),
+            (PATCH_403_OLD, PATCH_403_NEW, '"quota will be refreshed"', "403 Kimi billing patterns"),
+            (PATCH_CODE_1113_OLD, PATCH_CODE_1113_NEW, '"1113",', "code 1113 billing"),
+        ])
+
+    print("\n=== Patching agent/reasoning_timeouts.py ===")
+    if args.check:
+        rt_text = rt_path.read_text(encoding="utf-8")
+        for label, sentinel in [
+            ("GLM-5.2 floor", '("glm-5.2", 300)'),
+            ("GLM-5 floor", '("glm-5", 240)'),
+        ]:
+            status = "applied" if sentinel in rt_text else "MISSING"
+            print(f"  [{status:>8}] {label}")
+    else:
+        total_changes += patch_file(rt_path, [
+            (PATCH_GLM_OLD, PATCH_GLM_NEW, '("glm-5.2", 300)', "GLM reasoning timeout floors"),
+        ])
+
+    if args.check:
+        print("\n--check: no modifications made.")
+        return 0
+
+    if total_changes == 0:
+        print("\nAll patches already applied — no changes needed.")
+    else:
+        print(f"\nApplied {total_changes} patch(es). Restart the Hermes gateway "
+              "(`hermes restart` or restart the desktop app) to pick up the changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apply-runtime-patches.py
+++ b/apply-runtime-patches.py
@@ -1,0 +1,159 @@
+"""One-shot runtime patcher — applies the four RCA fixes directly to the
+runtime Hermes install. Idempotent: re-runs are no-ops once patches land.
+
+Run with the runtime venv Python:
+    C:\\Users\\<user>\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe apply-runtime-patches.py
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+RUNTIME = Path.home() / "AppData" / "Local" / "hermes" / "hermes-agent"
+
+
+def patch(path: Path, old: str, new: str, sentinel: str, label: str) -> bool:
+    """Apply one patch. Returns True if a change was made."""
+    text = path.read_text(encoding="utf-8")
+    if sentinel in text:
+        print(f"  [SKIP] {label} - already applied")
+        return False
+    if old not in text:
+        print(f"  [WARN] {label} - anchor not found, skipping")
+        return False
+    new_text = text.replace(old, new, 1)
+    path.write_text(new_text, encoding="utf-8")
+    # Clear stale bytecode so the next import picks up the patched source.
+    pyc = path.parent / "__pycache__"
+    if pyc.is_dir():
+        for stale in pyc.glob(f"{path.stem}.*.pyc"):
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+    print(f"  [ OK ] {label}")
+    return True
+
+
+ec = RUNTIME / "agent" / "error_classifier.py"
+rt = RUNTIME / "agent" / "reasoning_timeouts.py"
+print(f"Runtime: {RUNTIME}")
+
+# ── Patch 1: 429 billing-pattern check (Z.AI "Insufficient balance") ─────
+patch(
+    ec,
+    old=(
+        '        if any(p in error_msg for p in _OVERLOADED_PATTERNS):\n'
+        '            return result_fn(\n'
+        '                FailoverReason.overloaded,\n'
+        '                retryable=True,\n'
+        '            )\n'
+        '        # Distinguish an OpenRouter-aggregator upstream 429'
+    ),
+    new=(
+        '        if any(p in error_msg for p in _OVERLOADED_PATTERNS):\n'
+        '            return result_fn(\n'
+        '                FailoverReason.overloaded,\n'
+        '                retryable=True,\n'
+        '            )\n'
+        '        # Some providers mislabel account-balance exhaustion as HTTP 429\n'
+        '        # instead of 402. Z.AI / Zhipu returns code 1113 "Insufficient\n'
+        '        # balance or no resource package. Please recharge." as a 429 when\n'
+        '        # GLM_API_KEY is out of credits. Retrying is pointless — classify\n'
+        '        # as billing so we rotate / fall back immediately. (#16)\n'
+        '        if any(p in error_msg for p in _BILLING_PATTERNS):\n'
+        '            return result_fn(\n'
+        '                FailoverReason.billing,\n'
+        '                retryable=False,\n'
+        '                should_rotate_credential=True,\n'
+        '                should_fallback=True,\n'
+        '            )\n'
+        '        # Distinguish an OpenRouter-aggregator upstream 429'
+    ),
+    sentinel="# Some providers mislabel account-balance exhaustion as HTTP 429",
+    label="429 billing-pattern check (Z.AI 1113)",
+)
+
+# ── Patch 2: 403 Kimi billing patterns ───────────────────────────────────
+# Anchor on the tail common to both old + new build shapes.
+patch(
+    ec,
+    old=(
+        '            or any(p in error_msg for p in _BILLING_PATTERNS)\n'
+        '        ):\n'
+        '            return result_fn(\n'
+        '                FailoverReason.billing,\n'
+        '                retryable=False,\n'
+        '                should_rotate_credential=True,\n'
+        '                should_fallback=True,\n'
+        '            )\n'
+        '        return result_fn(\n'
+        '            FailoverReason.auth,\n'
+        '            retryable=False,\n'
+        '            should_fallback=True,\n'
+        '        )'
+    ),
+    new=(
+        '            or ("usage limit" in error_msg and "billing cycle" in error_msg)\n'
+        '            or "quota will be refreshed" in error_msg\n'
+        '            or "purchase extra usage" in error_msg\n'
+        '            or any(p in error_msg for p in _BILLING_PATTERNS)\n'
+        '        ):\n'
+        '            return result_fn(\n'
+        '                FailoverReason.billing,\n'
+        '                retryable=False,\n'
+        '                should_rotate_credential=True,\n'
+        '                should_fallback=True,\n'
+        '            )\n'
+        '        return result_fn(\n'
+        '            FailoverReason.auth,\n'
+        '            retryable=False,\n'
+        '            should_fallback=True,\n'
+        '        )'
+    ),
+    sentinel='"quota will be refreshed"',
+    label="403 Kimi billing patterns (usage limit / billing cycle)",
+)
+
+# ── Patch 3: code 1113 in structured billing code set ───────────────────
+# Target the frozenset of error CODES (not the _BILLING_PATTERNS message
+# list). Anchor includes _XAI_SPENDING_LIMIT_ERROR_CODE so we land in the
+# code set, not the message-pattern list.  Runtime uses 4-space indent here.
+patch(
+    ec,
+    old=(
+        '    "balance_depleted",\n'
+        '    "model_not_supported_on_free_tier",\n'
+        '    _XAI_SPENDING_LIMIT_ERROR_CODE,\n'
+    ),
+    new=(
+        '    "balance_depleted",\n'
+        '    "model_not_supported_on_free_tier",\n'
+        '    "1113",  # Z.AI / Zhipu GLM "Insufficient balance" code. (#16)\n'
+        '    _XAI_SPENDING_LIMIT_ERROR_CODE,\n'
+    ),
+    sentinel='"1113",  # Z.AI / Zhipu GLM',
+    label="code 1113 to billing",
+)
+
+# ── Patch 4: GLM reasoning timeout floors ────────────────────────────────
+patch(
+    rt,
+    old='    ("deepseek-v4-pro", 600),\n',
+    new=(
+        '    ("deepseek-v4-pro", 600),\n'
+        '    # Z.AI / Zhipu GLM-4.5-and-later reasoning models. GLM-5.2 ships\n'
+        '    # with thinking ON by default and routinely pauses minutes before\n'
+        '    # the first content token — the default 180s stale detector kills\n'
+        '    # the stream mid-think, surfacing as "GLM hangs without doing\n'
+        '    # anything". Floor the stale detector so thinking completes. (#17)\n'
+        '    ("glm-5.2", 300),\n'
+        '    ("glm-5p2", 300),  # Fireworks alias\n'
+        '    ("glm-5", 240),\n'
+        '    ("glm-4.6", 180),\n'
+        '    ("glm-4.5", 180),\n'
+    ),
+    sentinel='("glm-5.2", 300),',
+    label="GLM-5/5.2 reasoning timeout floors",
+)
+
+print("\nDone. Restart the Hermes gateway to pick up the changes.")

--- a/cli.py
+++ b/cli.py
@@ -10495,8 +10495,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         known state.  When a change is detected, triggers _reload_mcp() and
         informs the user so they know the tool list has been refreshed.
         """
-        import yaml as _yaml
-
         CONFIG_WATCH_INTERVAL = 5.0  # seconds between config.yaml stat() calls
 
         now = time.monotonic()
@@ -10509,27 +10507,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not cfg_path.exists():
             return
 
-        try:
-            mtime = cfg_path.stat().st_mtime
-        except OSError:
+        # Change detection (mtime fast-path + mcp_servers deep-compare) is shared
+        # with the gateway watcher via detect_mcp_servers_change so both surfaces
+        # behave identically.
+        from hermes_cli.mcp_startup import detect_mcp_servers_change
+        changed, self._config_mtime, self._config_mcp_servers = detect_mcp_servers_change(
+            cfg_path, self._config_mtime, self._config_mcp_servers
+        )
+        if not changed:
             return
-
-        if mtime == self._config_mtime:
-            return  # File unchanged — fast path
-
-        # File changed — check whether mcp_servers section changed
-        self._config_mtime = mtime
-        try:
-            with open(cfg_path, encoding="utf-8") as f:
-                new_cfg = _yaml.safe_load(f) or {}
-        except Exception:
-            return
-
-        new_mcp = new_cfg.get("mcp_servers") or {}
-        if new_mcp == self._config_mcp_servers:
-            return  # mcp_servers unchanged (some other section was edited)
-
-        self._config_mcp_servers = new_mcp
         # Notify user and reload.  Run in a separate thread with a hard
         # timeout so a hung MCP server cannot block the process_loop
         # indefinitely (which would freeze the entire TUI).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7402,6 +7402,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         asyncio.create_task(self._drain_control_watcher())
 
+        # Start background MCP config watcher — hot-reloads MCP connections when
+        # config.yaml's mcp_servers section changes, so `hermes mcp add/remove`
+        # and manual edits take effect without restarting the gateway. Gated by
+        # the `mcp_config_watch` config flag (default on), checked inside.
+        asyncio.create_task(self._mcp_config_watcher())
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -14060,6 +14066,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    async def _reload_mcp_connections(self) -> "tuple[set, set, set, list]":
+        """Disconnect, re-discover (reads config.yaml fresh), and refresh cached
+        agents' MCP tool lists. Returns ``(added, removed, reconnected, new_tools)``.
+
+        Event-independent core shared by the ``/reload-mcp`` slash command
+        (``_execute_mcp_reload``) and the automatic config watcher
+        (``_mcp_config_watcher``). Refreshing cached agents here — not just the
+        global ``_servers`` registry — is what lets EXISTING sessions see
+        added/removed MCP tools on their next turn without ``/new``.
+        """
+        loop = asyncio.get_running_loop()
+        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+
+        # Capture old server names before shutdown.
+        with _lock:
+            old_servers = set(_servers.keys())
+
+        # Shutdown existing connections, then reconnect by re-discovering
+        # (discover_mcp_tools reads config.yaml fresh).
+        await loop.run_in_executor(None, shutdown_mcp_servers)
+        new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+
+        with _lock:
+            connected_servers = set(_servers.keys())
+
+        added = connected_servers - old_servers
+        removed = old_servers - connected_servers
+        reconnected = connected_servers & old_servers
+
+        # Refresh cached agents so existing sessions see new MCP tools on their
+        # next turn — without this, the user would have to `/new` (discarding
+        # conversation history) to pick up a just-added/reconnected server.
+        try:
+            from tools.mcp_tool import refresh_agent_mcp_tools
+            _cache = getattr(self, "_agent_cache", None)
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            if _cache_lock is not None and _cache:
+                with _cache_lock:
+                    for _sess_key, _entry in list(_cache.items()):
+                        try:
+                            _agent = _entry[0] if isinstance(_entry, tuple) else _entry
+                        except Exception:
+                            continue
+                        if _agent is None:
+                            continue
+                        # Preserve each cached agent's build-time toolset
+                        # selection EXACTLY: a gateway session built with a
+                        # restricted enabled_toolsets (e.g. ["safe"]) must NOT
+                        # silently gain tools after a reload. This is the
+                        # opposite of the interactive CLI/TUI /reload-mcp, which
+                        # is a single user re-applying their own config edit;
+                        # gateway agents are per-session and may be deliberately
+                        # locked down. (Contract asserted by
+                        # test_reload_mcp_preserves_per_agent_toolset_overrides.)
+                        refresh_agent_mcp_tools(_agent, quiet_mode=True)
+        except Exception as _exc:
+            logger.debug(
+                "Failed to update cached agent tools after MCP reload: %s",
+                _exc,
+            )
+
+        return added, removed, reconnected, new_tools
+
     async def _execute_mcp_reload(self, event: MessageEvent) -> str:
         """Actually disconnect, reconnect, and notify MCP tool changes.
 
@@ -14067,28 +14136,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         wrapper can invoke the same path whether the user confirmed via
         button, text reply, or has the confirm gate disabled.
         """
-        loop = asyncio.get_running_loop()
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
-
-            # Capture old server names before shutdown
-            with _lock:
-                old_servers = set(_servers.keys())
-
-            # Read new config before shutting down, so we know what will be added/removed
-            # Shutdown existing connections
-            await loop.run_in_executor(None, shutdown_mcp_servers)
-
-            # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
-
-            # Compute what changed
-            with _lock:
-                connected_servers = set(_servers.keys())
-
-            added = connected_servers - old_servers
-            removed = old_servers - connected_servers
-            reconnected = connected_servers & old_servers
+            added, removed, reconnected, new_tools = await self._reload_mcp_connections()
+            connected_servers = reconnected | added
 
             lines = [t("gateway.reload_mcp.header")]
             if reconnected:
@@ -14101,41 +14151,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 lines.append(t("gateway.reload_mcp.none_connected"))
             else:
                 lines.append(t("gateway.reload_mcp.tools_available", tools=len(new_tools), servers=len(connected_servers)))
-
-            # Refresh cached agents so existing sessions see new MCP tools on
-            # their next turn — without this, the user has to `/new` (which
-            # discards conversation history) to pick up tools from a server
-            # that was just added or reconnected. The user has already
-            # consented to the prompt-cache invalidation via the slash-confirm
-            # gate in _handle_reload_mcp_command before we reach this point.
-            try:
-                from tools.mcp_tool import refresh_agent_mcp_tools
-                _cache = getattr(self, "_agent_cache", None)
-                _cache_lock = getattr(self, "_agent_cache_lock", None)
-                if _cache_lock is not None and _cache:
-                    with _cache_lock:
-                        for _sess_key, _entry in list(_cache.items()):
-                            try:
-                                _agent = _entry[0] if isinstance(_entry, tuple) else _entry
-                            except Exception:
-                                continue
-                            if _agent is None:
-                                continue
-                            # Preserve each cached agent's build-time toolset
-                            # selection EXACTLY: a gateway session built with a
-                            # restricted enabled_toolsets (e.g. ["safe"]) must
-                            # NOT silently gain tools after a reload. This is the
-                            # opposite of the interactive CLI/TUI /reload-mcp,
-                            # which is a single user re-applying their own config
-                            # edit; gateway agents are per-session and may be
-                            # deliberately locked down. (Contract is asserted by
-                            # test_reload_mcp_preserves_per_agent_toolset_overrides.)
-                            refresh_agent_mcp_tools(_agent, quiet_mode=True)
-            except Exception as _exc:
-                logger.debug(
-                    "Failed to update cached agent tools after MCP reload: %s",
-                    _exc,
-                )
 
             # Inject a message at the END of the session history so the
             # model knows tools changed on its next turn.  Appended after
@@ -14166,6 +14181,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("MCP reload failed: %s", e)
             return t("gateway.reload_mcp.failed", error=e)
+
+    async def _mcp_config_watcher(self, interval: float = 5.0) -> None:
+        """Background task: hot-reload MCP servers when config.yaml's
+        ``mcp_servers`` section changes, so gateway/headless deployments pick up
+        ``hermes mcp add/remove`` (and manual config edits) WITHOUT a restart.
+
+        This is the gateway analogue of the interactive TUI's config watcher
+        (``cli.HermesCLI._check_config_mcp_changes``, driven from its
+        ``process_loop``): users running the always-on gateway previously had to
+        restart the process for a config edit to take effect. Gated by the
+        ``mcp_config_watch`` config flag (default on). Cheap: a ``stat()`` every
+        ``interval`` seconds with an mtime fast-path; only an actual mcp_servers
+        change reconnects. Cancelled with the gateway's other background tasks
+        when ``self._running`` flips false on shutdown.
+        """
+        try:
+            from hermes_cli.config import load_config
+            if not (load_config() or {}).get("mcp_config_watch", True):
+                logger.debug("MCP config watcher disabled (mcp_config_watch=false)")
+                return
+        except Exception:
+            pass  # config unreadable — default to watching
+
+        from hermes_cli.config import get_config_path
+        cfg_path = get_config_path()
+
+        # Seed state from the on-disk config so an UNCHANGED config after startup
+        # does not spuriously reload on the first tick; the first real edit after
+        # this bumps mtime and triggers the reload.
+        try:
+            self._mcp_watch_mtime = cfg_path.stat().st_mtime
+        except OSError:
+            self._mcp_watch_mtime = 0.0
+        try:
+            import yaml as _yaml
+            with open(cfg_path, encoding="utf-8") as _f:
+                self._mcp_watch_servers = (_yaml.safe_load(_f) or {}).get("mcp_servers") or {}
+        except Exception:
+            self._mcp_watch_servers = {}
+
+        await asyncio.sleep(interval)  # let the gateway finish starting up
+        while self._running:
+            try:
+                await self._check_config_mcp_changes()
+            except Exception:
+                logger.debug("MCP config watcher tick failed", exc_info=True)
+            await asyncio.sleep(interval)
+
+    async def _check_config_mcp_changes(self) -> None:
+        """One tick of the gateway MCP-config watcher: reload MCP connections
+        when config.yaml's ``mcp_servers`` section changed on disk.
+
+        Change detection is shared with the TUI via
+        ``hermes_cli.mcp_startup.detect_mcp_servers_change`` and runs off the
+        event loop (``asyncio.to_thread``) so a large config parse can't stall
+        the gateway. The reconnect itself runs in an executor inside
+        ``_reload_mcp_connections``, so a hung MCP server can't block the loop.
+        """
+        from hermes_cli.config import get_config_path
+        from hermes_cli.mcp_startup import detect_mcp_servers_change
+
+        cfg_path = get_config_path()
+        if not cfg_path.exists():
+            return
+
+        changed, self._mcp_watch_mtime, self._mcp_watch_servers = await asyncio.to_thread(
+            detect_mcp_servers_change,
+            cfg_path,
+            self._mcp_watch_mtime,
+            self._mcp_watch_servers,
+        )
+        if not changed:
+            return
+
+        logger.info(
+            "MCP config changed on disk — hot-reloading gateway MCP connections"
+        )
+        added, removed, reconnected, new_tools = await self._reload_mcp_connections()
+        _delta = []
+        if added:
+            _delta.append("added: " + ", ".join(sorted(added)))
+        if removed:
+            _delta.append("removed: " + ", ".join(sorted(removed)))
+        logger.info(
+            "MCP hot-reload complete: %d tool(s), %d server(s)%s",
+            len(new_tools),
+            len(reconnected | added),
+            (" (" + "; ".join(_delta) + ")") if _delta else "",
+        )
 
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -71,6 +71,20 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+# atomic_replace retry budget for auth.json writes (D-008 / RCA-F):
+# Windows Defender real-time protection briefly holds the destination
+# file open during scan, surfacing as PermissionError (WinError 5) on the
+# os.replace() call. Five attempts with exponential backoff (0.15s,
+# 0.30s, 0.60s, 1.20s, 2.40s) rides through the typical 50-200ms scan
+# window plus tail. Override via
+# HERMES_AUTH_REPLACE_MAX_RETRIES / HERMES_AUTH_REPLACE_BACKOFF_SECONDS.
+_AUTH_REPLACE_MAX_RETRIES = int(
+    os.environ.get("HERMES_AUTH_REPLACE_MAX_RETRIES", "5")
+)
+_AUTH_REPLACE_BACKOFF_SECONDS = float(
+    os.environ.get("HERMES_AUTH_REPLACE_BACKOFF_SECONDS", "0.15")
+)
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1126,6 +1140,14 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # specific store — e.g. the global-root write-through for rotating xAI
     # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
     # write so the root auth.json gets the same TOCTOU-safe treatment.
+    #
+    # Windows Defender retry (D-008 / RCA-F):
+    #   atomic_replace -> os.replace fails with PermissionError (WinError 5)
+    #   when Defender real-time protection opens auth.json for scanning.
+    #   The advisory cross-process lock (_auth_store_lock) does NOT protect
+    #   against AV because Defender ignores Python's msvcrt.locking. The
+    #   scan window is typically 50-200ms; a short bounded retry with
+    #   exponential backoff rides through it. See ISSUES.md D-008.
     auth_file = target_path if target_path is not None else _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
@@ -1150,7 +1172,31 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
             handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())
-        atomic_replace(tmp_path, auth_file)
+        # Retry the atomic replace on PermissionError. On Windows this is
+        # almost always WinError 5 from Defender real-time scanning the
+        # destination file mid-rename. The lock we already hold protects
+        # against cooperating Python writers; the retry protects against
+        # non-cooperating AV / backup / indexer handles.
+        last_exc: Optional[Exception] = None
+        for attempt in range(_AUTH_REPLACE_MAX_RETRIES):
+            try:
+                atomic_replace(tmp_path, auth_file)
+                last_exc = None
+                break
+            except PermissionError as exc:
+                last_exc = exc
+                if attempt < _AUTH_REPLACE_MAX_RETRIES - 1:
+                    backoff = _AUTH_REPLACE_BACKOFF_SECONDS * (2 ** attempt)
+                    logger.warning(
+                        "auth.json: atomic_replace denied (attempt %d/%d, "
+                        "likely AV scan); retrying in %.2fs: %s",
+                        attempt + 1, _AUTH_REPLACE_MAX_RETRIES, backoff, exc,
+                    )
+                    time.sleep(backoff)
+        if last_exc is not None:
+            # All retries exhausted — propagate so caller knows the write
+            # didn't land. The temp file is cleaned up in the finally below.
+            raise last_exc
         try:
             dir_fd = os.open(str(auth_file.parent), os.O_RDONLY)
         except OSError:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1371,6 +1371,18 @@ DEFAULT_CONFIG = {
     # small so a slow/dead server adds little to first-response latency.
     "mcp_discovery_timeout": 1.5,
 
+    # When true (default), long-running surfaces (the gateway and the
+    # interactive TUI) poll config.yaml every few seconds and hot-reload MCP
+    # connections whenever the ``mcp_servers`` section changes — so
+    # ``hermes mcp add/remove`` and manual edits take effect WITHOUT a restart
+    # or a ``/new`` session. The poll is a cheap ``stat()`` with an mtime
+    # fast-path; only an actual mcp_servers change triggers a reconnect, and a
+    # hung server can't stall the process (reload runs off the main loop). Set
+    # false to require an explicit ``/reload-mcp`` (or restart) instead — e.g.
+    # on locked-down headless deployments whose MCP config never changes at
+    # runtime.
+    "mcp_config_watch": True,
+
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the
     # payload sent to the model (keeping head + tail for terminal,

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -128,3 +128,61 @@ def join_mcp_discovery(timeout: "float | None" = None) -> bool:
         return True
     thread.join(timeout=timeout)
     return not thread.is_alive()
+
+
+# ─── Config hot-reload change detection ──────────────────────────────────────
+
+def detect_mcp_servers_change(
+    cfg_path,
+    prev_mtime: float,
+    prev_servers: dict,
+) -> "tuple[bool, float, dict]":
+    """Detect whether config.yaml's ``mcp_servers`` section changed on disk.
+
+    Shared by the interactive TUI (``cli.HermesCLI._check_config_mcp_changes``)
+    and the long-running gateway
+    (``gateway.run.GatewayRunner._check_config_mcp_changes``) so both surfaces
+    auto-reload MCP connections on a config edit using one change-detection
+    implementation, without a restart or a new session.
+
+    Returns ``(changed, new_mtime, new_mcp_servers)``:
+
+    * ``changed`` is True ONLY when the ``mcp_servers`` subtree differs from
+      ``prev_servers`` — editing any OTHER config section never triggers a
+      reload.
+    * ``new_mtime`` is the file's current mtime, advanced even when the edit was
+      to an unrelated section or the file was mid-write, so callers don't
+      re-``stat``/re-parse the same bytes on every poll tick.
+    * ``new_mcp_servers`` is the freshly-parsed ``mcp_servers`` map when
+      ``changed`` is True, otherwise ``prev_servers`` unchanged.
+
+    Never raises: a missing file, an ``OSError`` from ``stat()``, or
+    invalid/partial YAML (e.g. an editor mid-save) is reported as "no change",
+    so a background watcher can poll safely.
+    """
+    import yaml as _yaml
+
+    try:
+        mtime = cfg_path.stat().st_mtime
+    except OSError:
+        return False, prev_mtime, prev_servers
+
+    # Fast path: file untouched since the last check — skip the parse entirely.
+    if mtime == prev_mtime:
+        return False, prev_mtime, prev_servers
+
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            new_cfg = _yaml.safe_load(f) or {}
+    except Exception:
+        # File changed but is unreadable/partial (mid-write) or invalid YAML.
+        # Adopt the new mtime so we don't re-parse the same broken bytes every
+        # tick, but report no change — the next good write bumps mtime again.
+        return False, mtime, prev_servers
+
+    new_mcp = new_cfg.get("mcp_servers") or {}
+    if new_mcp == prev_servers:
+        # Some OTHER config section was edited; mcp_servers is identical.
+        return False, mtime, prev_servers
+
+    return True, mtime, new_mcp

--- a/plugins/browser/camofox-server/.gitignore
+++ b/plugins/browser/camofox-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+camofox.log

--- a/plugins/browser/camofox-server/ensure-camofox.cmd
+++ b/plugins/browser/camofox-server/ensure-camofox.cmd
@@ -1,0 +1,47 @@
+@echo off
+REM Modified by Nous Man - 2026-08-03 - CRITICAL #57: single no-argument
+REM camofox watchdog wrapper. The cron LLM agent runs ONLY this script so it
+REM never constructs a Windows path again (the agent's tool layer kept eating
+REM backslashes: "D:projectscamofox-serverstart-camofox-hidden.vbs" ->
+REM 6 stuck WSH "Can not find script file" popups on 2026-08-03).
+REM
+REM Healthy = HTTP 200 AND the JSON field "ok":true. Extra fields
+REM (browserConnected:false, poolSize:0) are NORMAL for an idle server and
+REM must NOT trigger a restart.
+REM
+REM Exit 0 = healthy (or successfully started). Exit 1 = genuinely down.
+setlocal
+set HEALTH_URL=http://127.0.0.1:9377/health
+set TMP1=%TEMP%\camofox_ensure_h1.json
+set TMP2=%TEMP%\camofox_ensure_h2.json
+
+curl -s -m 10 -o "%TMP1%" -w "%%{http_code}" "%HEALTH_URL%" > "%TMP1%.code" 2>nul
+if errorlevel 1 goto START
+set /p CODE1=<"%TMP1%.code"
+if not "%CODE1%"=="200" goto START
+findstr /c:"\"ok\":true" "%TMP1%" >nul
+if errorlevel 1 goto START
+echo OK: camofox healthy (HTTP 200, ok:true) - nothing to do
+exit /b 0
+
+:START
+echo camofox unhealthy - starting hidden instance via start-camofox-hidden.vbs ...
+cscript //Nologo //B "D:\projects\camofox-server\start-camofox-hidden.vbs"
+set /a TRIES=0
+:WAITLOOP
+set /a TRIES+=1
+if %TRIES% GTR 6 goto FAIL
+REM ~10s between probes without timeout.exe quirks
+ping -n 11 127.0.0.1 >nul
+curl -s -m 10 -o "%TMP2%" -w "%%{http_code}" "%HEALTH_URL%" > "%TMP2%.code" 2>nul
+if errorlevel 1 goto WAITLOOP
+set /p CODE2=<"%TMP2%.code"
+if not "%CODE2%"=="200" goto WAITLOOP
+findstr /c:"\"ok\":true" "%TMP2%" >nul
+if errorlevel 1 goto WAITLOOP
+echo OK: camofox started and healthy (HTTP 200, ok:true)
+exit /b 0
+
+:FAIL
+echo FAIL: camofox did not become healthy within ~60s
+exit /b 1

--- a/plugins/browser/camofox-server/package-lock.json
+++ b/plugins/browser/camofox-server/package-lock.json
@@ -1,0 +1,2114 @@
+{
+  "name": "camofox-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "camofox-browser": "^2.4.6"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/argon2": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.41.1.tgz",
+      "integrity": "sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camofox-browser": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/camofox-browser/-/camofox-browser-2.4.6.tgz",
+      "integrity": "sha512-CTTgZSAMHzth87J9jGf4BFhMjHcxrnMjOyEVOeRq1RsOkFpNUfkjongDIiguz7rz61sjmH7ibyyi93pohE60XA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "camoufox-js": "^0.8.5",
+        "commander": "^14.0.0",
+        "css-tree": "^3.2.1",
+        "express": "^4.18.2",
+        "openapi-types": "^12.1.3",
+        "playwright-core": "1.58.1",
+        "swagger-ui-express": "^5.0.1"
+      },
+      "bin": {
+        "camofox": "bin/camofox.js",
+        "camofox-browser": "bin/camofox-browser.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "argon2": "^0.41.1"
+      }
+    },
+    "node_modules/camoufox-js": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/camoufox-js/-/camoufox-js-0.8.5.tgz",
+      "integrity": "sha512-20ihPbspAcOVSUTX9Drxxp0C116DON1n8OVA1eUDglWZiHwiHwFVFOMrIEBwAHMZpU11mIEH/kawJtstRIrDPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "better-sqlite3": "^12.2.0",
+        "commander": "^14.0.0",
+        "fingerprint-generator": "^2.1.66",
+        "glob": "^13.0.0",
+        "impit": "^0.7.0",
+        "language-tags": "^2.0.1",
+        "maxmind": "^5.0.0",
+        "progress": "^2.0.3",
+        "ua-parser-js": "^2.0.2",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "camoufox-js": "dist/__main__.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "playwright-core": "*"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fingerprint-generator": {
+      "version": "2.1.82",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.82.tgz",
+      "integrity": "sha512-5Z/yCKW324pMyMarpIKe/QPdkrFWKNJv3ktdU+fXHri80+HAwNE6QhMvEvsMkK9Q8DeCXZlpPHV77UBa1nFb4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "generative-bayesian-network": "^2.1.82",
+        "header-generator": "^2.1.82",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generative-bayesian-network": {
+      "version": "2.1.83",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.83.tgz",
+      "integrity": "sha512-LssI9es+oUoezoHloFGw0Hts0YEfujjBOE8KNl70oBt4HPjD/4rpUqcgZ/M7RCmgKvkmCyPB2KWowyJHuKyhfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.9",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/header-generator": {
+      "version": "2.1.82",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.82.tgz",
+      "integrity": "sha512-4NjPB0+bAKjPoponSmTOkK58IEF2W22sOJA5O48k/MxbCZgOm+jrU4WVR53Z2I6xFgIPkVrQmKtt1LAbWtfqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "browserslist": "^4.21.1",
+        "generative-bayesian-network": "^2.1.82",
+        "ow": "^0.28.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/impit": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.7.6.tgz",
+      "integrity": "sha512-AkS6Gv63+E6GMvBrcRhMmOREKpq5oJ0J5m3xwfkHiEs97UIsbpEqFmW3sFw/sdyOTDGRF5q4EjaLxtb922Ta8g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "impit-darwin-arm64": "0.7.6",
+        "impit-darwin-x64": "0.7.6",
+        "impit-linux-arm64-gnu": "0.7.6",
+        "impit-linux-arm64-musl": "0.7.6",
+        "impit-linux-x64-gnu": "0.7.6",
+        "impit-linux-x64-musl": "0.7.6",
+        "impit-win32-arm64-msvc": "0.7.6",
+        "impit-win32-x64-msvc": "0.7.6"
+      }
+    },
+    "node_modules/impit-darwin-arm64": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.7.6.tgz",
+      "integrity": "sha512-M7NQXkttyzqilWfzVkNCp7hApT69m0etyJkVpHze4bR5z1kJnHhdsb8BSdDv2dzvZL4u1JyqZNxq+qoMn84eUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-darwin-x64": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.7.6.tgz",
+      "integrity": "sha512-kikTesWirAwJp9JPxzGLoGVc+heBlEabWS5AhTkQedACU153vmuL90OBQikVr3ul2N0LPImvnuB+51wV0zDE6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-gnu": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.7.6.tgz",
+      "integrity": "sha512-H6GHjVr/0lG9VEJr6IHF8YLq+YkSIOF4k7Dfue2ygzUAj1+jZ5ZwnouhG/XrZHYW6EWsZmEAjjRfWE56Q0wDRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-musl": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.7.6.tgz",
+      "integrity": "sha512-1sCB/UBVXLZTpGJsXRdNNSvhN9xmmQcYLMWAAB4Itb7w684RHX1pLoCb6ichv7bfAf6tgaupcFIFZNBp3ghmQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-gnu": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.7.6.tgz",
+      "integrity": "sha512-yYhlRnZ4fhKt8kuGe0JK2WSHc8TkR6BEH0wn+guevmu8EOn9Xu43OuRvkeOyVAkRqvFnlZtMyySUo/GuSLz9Gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-musl": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.7.6.tgz",
+      "integrity": "sha512-sdGWyu+PCLmaOXy7Mzo4WP61ZLl5qpZ1L+VeXW+Ycazgu0e7ox0NZLdiLRunIrEzD+h0S+e4CyzNwaiP3yIolg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-arm64-msvc": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.7.6.tgz",
+      "integrity": "sha512-sM5deBqo0EuXg5GACBUMKEua9jIau/i34bwNlfrf/Amnw1n0GB4/RkuUh+sKiUcbNAntrRq+YhCq8qDP8IW19w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-x64-msvc": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.7.6.tgz",
+      "integrity": "sha512-ry63ADGLCB/PU/vNB1VioRt2V+klDJ34frJUXUZBEv1kA96HEAg9AxUk+604o+UHS3ttGH2rkLmrbwHOdAct5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-2.1.0.tgz",
+      "integrity": "sha512-D4CgpyCt+61f6z2jHjJS1OmZPviAWM57iJ9OKdFFWSNgS7Udj9QVWqyGs/cveVNF57XpZmhSvMdVIV5mjLA7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/maxmind": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.6.tgz",
+      "integrity": "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew==",
+      "license": "MIT",
+      "dependencies": {
+        "mmdb-lib": "3.0.2",
+        "tiny-lru": "13.0.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/mmdb-lib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+      "integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
+    "node_modules/ow": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.2.tgz",
+      "integrity": "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "vali-date": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  }
+}

--- a/plugins/browser/camofox-server/package.json
+++ b/plugins/browser/camofox-server/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "camofox-browser": "^2.4.6"
+  }
+}

--- a/plugins/browser/camofox-server/run-camofox.cmd
+++ b/plugins/browser/camofox-server/run-camofox.cmd
@@ -1,0 +1,17 @@
+@echo off
+REM Camofox stealth-browser server — hardened, loopback-only.
+cd /d "D:\projects\camofox-server"
+set "CAMOFOX_HOST=127.0.0.1"
+set "CAMOFOX_PORT=9377"
+set "CAMOFOX_AUTH_MODE=required"
+set "CAMOFOX_ALLOW_PRIVATE_NETWORK=false"
+set "CAMOFOX_HEADLESS=true"
+REM Keep camofox alive across full research sessions instead of idle-exiting every ~30 min.
+REM CAMOFOX_IDLE_TIMEOUT_MS = ms since last activity before cleanup starts.
+REM CAMOFOX_IDLE_EXIT_TIMEOUT_MS = ms after cleanup before the process exits.
+REM 86400000 = 24h. The camofox-keepalive cron remains as a crash-recovery net.
+set "CAMOFOX_IDLE_TIMEOUT_MS=86400000"
+set "CAMOFOX_IDLE_EXIT_TIMEOUT_MS=86400000"
+set /p CAMOFOX_API_KEY=<"D:\secrets\camofox-api-key.txt"
+set /p CAMOFOX_ADMIN_KEY=<"D:\secrets\camofox-admin-key.txt"
+node "node_modules\camofox-browser\dist\src\server.js" >> "D:\projects\camofox-server\camofox.log" 2>&1

--- a/plugins/browser/camofox-server/start-camofox-hidden.vbs
+++ b/plugins/browser/camofox-server/start-camofox-hidden.vbs
@@ -1,0 +1,3 @@
+' Launch the Camofox stealth-browser server fully hidden (no window),
+' bound to 127.0.0.1 only. Started at login (Startup shortcut) and on demand.
+CreateObject("WScript.Shell").Run "cmd /c ""D:\projects\camofox-server\run-camofox.cmd""", 0, False

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -5,6 +5,55 @@ Kimi has dual endpoints:
   - legacy keys → api.moonshot.ai/v1 (OpenAI chat completions)
 
 This module covers the chat_completions path (/v1 endpoint).
+
+──────────────────────────────────────────────────────────────────────────
+Known operational failure modes (see plugins/platforms/discord/ISSUES.md):
+──────────────────────────────────────────────────────────────────────────
+
+D-003 — Kimi Coding Plan "usage limit" billing 403 (permission_error)
+    Kimi's Coding Plan (api.kimi.com/coding) returns HTTP 403 with
+    type=permission_error and a body that uses none of the standard
+    billing phrases when the subscription quota is exhausted:
+
+        {"error": {
+            "type": "permission_error",
+            "message": "You've reached your usage limit for this billing
+                        cycle. Your quota will be refreshed in the next
+                        cycle. To continue now, purchase extra usage or
+                        upgrade your plan:
+                        https://www.kimi.com/code/#pricing"
+        }}
+
+    The 403 branch of ``agent/error_classifier.py::_classify_by_status``
+    now matches three Kimi-specific phrases:
+      - ("usage limit" AND "billing cycle")
+      - "quota will be refreshed"
+      - "purchase extra usage"
+    so the error classifies as ``billing`` (non-retryable, rotate+
+    fallback) instead of ``auth`` (no fallback activation).
+
+    Reproduction:
+        1. Use a Kimi Coding Plan subscription until quota exhausts
+        2. Run: hermes chat --provider kimi-coding --model kimi-k2.7-code
+        3. Send any message — observe immediate fallback activation
+           (was: "Non-retryable client error", bot dies, no fallback)
+    Cross-ref: CRITICAL-ISSUES.md #17, RCA-B, D-003.
+
+Kimi overload 429 (NOT a bug — works correctly)
+    Kimi also returns HTTP 429 with body:
+        {"error": {"type": "rate_limit_error",
+                   "message": "The engine is currently overloaded, please
+                                try again later"}}
+    The word "overloaded" matches ``_OVERLOADED_PATTERNS``, so this
+    correctly classifies as ``overloaded`` (retryable, NO credential
+    rotation). This is the right behavior — the credential is healthy,
+    the server is just busy.
+
+Standing rule for future maintainers:
+    If Kimi adds a new error code or changes the wording of the existing
+    quota-exhaustion message, update the 403 branch of
+    ``_classify_by_status`` in ``agent/error_classifier.py``. The phrase
+    list is the ONLY thing that routes this to the right recovery path.
 """
 
 from typing import Any

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -22,6 +22,55 @@ two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoin
 (per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
 those two so the user's effort preference actually reaches the model instead
 of being silently dropped.
+
+──────────────────────────────────────────────────────────────────────────
+Known operational failure modes (see plugins/platforms/discord/ISSUES.md):
+──────────────────────────────────────────────────────────────────────────
+
+D-002 — Z.AI "Insufficient balance" billing 429 (code 1113)
+    Z.AI mislabels account-balance exhaustion as HTTP 429 (standards-
+    correct would be 402). Body shape:
+        {"error": {"code": "1113",
+                   "message": "Insufficient balance or no resource package.
+                                Please recharge."}}
+    The 429 branch of ``agent/error_classifier.py::_classify_by_status``
+    now checks ``_BILLING_PATTERNS`` and code ``1113`` is in
+    ``_BILLING_ERROR_CODES``, so this classifies as ``billing`` (non-
+    retryable, rotate+fallback) instead of ``rate_limit`` (retryable,
+    burns 3 retries).
+
+    Reproduction:
+        1. Set GLM_API_KEY to a key with zero account balance
+        2. Run: hermes chat --provider zai --model glm-5
+        3. Send any message — observe 0 wasted retries (was 3 before fix)
+    Cross-ref: CRITICAL-ISSUES.md #16, RCA-B, D-002.
+
+D-004 — GLM-5/5.2 "hangs without doing anything" mid-think
+    GLM-5.2 ships with thinking ON by default (see ``build_api_kwargs_extras``
+    below — emits ``extra_body.thinking.type=enabled`` when no preference
+    is set). During extended thinking, GLM emits no content tokens for
+    several minutes before producing its first output. The default
+    HERMES_STREAM_STALE_TIMEOUT of 180s and the httpx socket read timeout
+    of 120s both fire BEFORE GLM-5.2 finishes thinking, tearing down a
+    healthy reasoning stream mid-think.
+
+    Fix: ``agent/reasoning_timeouts.py::_REASONING_STALE_TIMEOUT_FLOORS``
+    now has ``("glm-5.2", 300)``, ``("glm-5", 240)``, ``("glm-4.6", 180)``,
+    ``("glm-4.5", 180)`` — see that table for the floor rationale.
+
+    Reproduction of fix:
+        >>> from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+        >>> get_reasoning_stale_timeout_floor("glm-5.2")
+        300.0
+        >>> get_reasoning_stale_timeout_floor("glm-4-9b") is None  # non-thinking
+        True
+    Cross-ref: CRITICAL-ISSUES.md #18, RCA-C, D-004.
+
+Standing rule for future maintainers:
+    When a new GLM variant is added here, also add it to
+    ``_REASONING_STALE_TIMEOUT_FLOORS`` in ``agent/reasoning_timeouts.py``
+    if it ships with thinking ON by default. The provider profile and the
+    timeout table are maintained separately — there is no automated check.
 """
 
 from __future__ import annotations

--- a/plugins/platforms/discord/ISSUES.md
+++ b/plugins/platforms/discord/ISSUES.md
@@ -1,0 +1,788 @@
+# Nous Man (Discord Bot) — Issues & Ticketing
+
+> **Living ticket log for the Hermes Discord adapter** (Nous Man#0498).
+> File location: `plugins/platforms/discord/ISSUES.md`
+> Add new tickets at the TOP of the "Active" section. Move resolved tickets to
+> "Closed" with a resolution summary and RCA cross-reference. Update the
+> TL;DR table whenever status changes.
+>
+> Cross-references:
+> - System-wide critical issues: `d:\projects\CRITICAL-ISSUES.md`
+> - Runtime patcher: `d:\projects\hermes-agent-hotreload\apply-runtime-patches.py`
+> - Gateway logs: `C:\Users\<user>\AppData\Local\hermes\logs\{agent,errors,gateway}.log`
+
+---
+
+## TL;DR
+
+| # | Severity | Status | Summary | Opened | Owner |
+|---|----------|--------|---------|--------|-------|
+| D-001 | RED | FIXED | Bot replies "Sorry, I encountered an unexpected error" — empty OPENROUTER_API_KEY in .env overrode config.yaml | 2026-07-20 | Purple Industries / BarnsL |
+| D-002 | RED | FIXED | "API call failed after 3 retries: HTTP 429" on Z.AI — billing 429 misclassified as rate_limit | 2026-07-20 | Purple Industries / BarnsL |
+| D-003 | RED | FIXED | Kimi "usage limit for this billing cycle" 403 misclassified as auth — surfaces as "Non-retryable client error" | 2026-07-20 | Purple Industries / BarnsL |
+| D-004 | YELLOW | FIXED | GLM-5/5.2 "hangs without doing anything" — stale-stream detector kills mid-think | 2026-07-20 | Purple Industries / BarnsL |
+| D-005 | YELLOW | MONITORING | Sessions loading blank — system prompt stored as null after session reset | 2026-07-21 | Purple Industries / BarnsL |
+| D-006 | YELLOW | MONITORING | Compression loop fires every 5-10 min on long Discord sessions | 2026-07-20 | Purple Industries / BarnsL |
+| D-007 | GREEN | READY | Image attachment processing — verify end-to-end on free OpenRouter | 2026-07-21 | Purple Industries / BarnsL |
+| D-008 | YELLOW | FIXED | auth.json WinError 5 (Access denied) on atomic rename — Windows Defender real-time scan holds file during os.replace | 2026-07-21 | Purple Industries / BarnsL |
+
+### RCA cross-cutting patterns
+
+| ID | Pattern | Tickets | Severity |
+|----|---------|---------|----------|
+| [RCA-A](#rca-a--env-var-precedence-rule-the-silent-override-trap) | Empty `<PROVIDER>_API_KEY=` in .env overrides config.yaml | D-001 | RED |
+| [RCA-B](#rca-b--provider-error-bodies-that-dont-match-the-classifiers-vocabulary) | Provider error body phrasing not in classifier's phrase lists | D-002, D-003 | RED |
+| [RCA-C](#rca-c--reasoning-models-killed-mid-think-by-stale-stream-detector) | Reasoning models not in `_REASONING_STALE_TIMEOUT_FLOORS` table | D-004 | YELLOW |
+| [RCA-D](#rca-d--compression-loop-on-long-sessions-target-not-sticky) | Compressor re-probes target upward after every cycle | D-006 | YELLOW |
+| [RCA-E](#rca-e--system-prompt-null-after-session-reset) | session_reset path doesn't persist system_prompt | D-005 | YELLOW |
+
+---
+
+## Ticket template
+
+```markdown
+### D-XXX — <short title>  [STATUS]
+
+**Severity:** RED / YELLOW / GREEN
+**Opened:** YYYY-MM-DD by <user>
+**Affected users/channels:** <e.g. all DMs, #bot-spam, specific user>
+**Symptom:**
+<1-2 sentence user-visible description>
+
+**Reproduction:**
+1. <step>
+2. <step>
+**Expected:** <behavior>
+**Actual:** <behavior>
+
+**Logs:**
+- `errors.log` excerpt (last 1-3 lines):
+  ```
+  <paste>
+  ```
+- `agent.log` session ID: `<session_id>`
+
+**RCA / Fix:**
+<root cause + resolution, or link to CRITICAL-ISSUES.md section>
+
+**Standing rule:**
+<one-line rule for future operators>
+```
+
+---
+
+## RCA — Root Cause Analysis (cross-cutting)
+
+> This section captures the **systemic** patterns behind the tickets in this
+> file. Each RCA block describes WHY a class of bug exists, not just what
+> broke. Read this before opening a new ticket — many "new" bugs are
+> re-appearances of the patterns below.
+
+### RCA-A — Env-var precedence rule (the silent Override Trap)
+
+**Pattern:** An empty `<PROVIDER>_API_KEY=` line in `.env` silently overrides
+a working key hardcoded in `config.yaml`'s `model.api_key` field. Hermes'
+config loader resolves env vars *before* reading config.yaml, so the runtime
+sees the empty string and refuses to start with a confusing
+`No LLM provider configured` error that points everywhere except the real
+source.
+
+**Why it bit us:** D-001 (2026-07-21).
+
+**Reproduction (verified):**
+```powershell
+# 1. Confirm working state
+hermes gateway status   # → running
+# 2. Edit .env: add a single empty line
+Add-Content $env:LOCALAPPDATA\hermes\.env "OPENROUTER_API_KEY="
+# 3. Restart
+hermes gateway restart
+# 4. Send any Discord message → bot replies:
+#    "Sorry, I encountered an unexpected error."
+# 5. errors.log shows:
+#    RuntimeError: No LLM provider configured. Run `hermes model` to select a
+#    provider, or run `hermes setup` for first-time configuration.
+```
+
+**Resolution order (precedence high → low):**
+1. `<PROVIDER>_API_KEY` environment variable (even if empty string)
+2. `config.yaml` → `model.api_key` (or per-fallback `api_key`)
+3. `auth.json` credential pool entries
+4. Provider profile `env_vars` tuple (used for detection only)
+
+**Standing rule:**
+NEVER leave an empty `<PROVIDER>_API_KEY=` line in `.env`. Either delete the
+line entirely or comment it out (`# OPENROUTER_API_KEY=`). The idempotent
+resync script `apply-openrouter-key.py` is the source of truth — re-run it
+after any `.env` edit.
+
+**Cross-reference:** CRITICAL-ISSUES.md (none — Discord-specific),
+D-001 in this file, `apply-openrouter-key.py`.
+
+---
+
+### RCA-B — Provider error bodies that don't match the classifier's vocabulary
+
+**Pattern:** The `agent/error_classifier.py` `_classify_by_status()` function
+uses a curated phrase list (`_BILLING_PATTERNS`, `_RATE_LIMIT_PATTERNS`, etc.)
+to route errors to the correct recovery action. When a provider uses a
+NOVEL phrasing for billing-exhaustion (or any other failure class) that
+matches NONE of the lists, the error falls through to a generic bucket
+(usually `rate_limit` or `auth`) with the WRONG recovery semantics.
+
+The wrong recovery then causes a SECONDARY failure mode that is more
+visible than the original:
+- Billing 429 misclassified as rate_limit → 3 wasted retries on a dead key
+- Billing 403 misclassified as auth → surfaces as "Non-retryable client
+  error" instead of activating the fallback chain
+- Billing 403 with permission_error type → same as above
+
+**Why it bit us:** D-002 (Z.AI code 1113), D-003 (Kimi permission_error).
+
+**Reproduction (verified, D-002):**
+```
+# 1. Set GLM_API_KEY to a key with zero account balance
+# 2. Send any message to Nous Man with provider=zai, model=glm-5
+# 3. errors.log shows 3 retries before failure:
+2026-07-20 21:27:34 WARNING API call failed (attempt 1/3)
+  provider=zai base_url=https://api.z.ai/api/paas/v4 model=glm-5
+  summary=HTTP 429: Insufficient balance or no resource package. Please recharge.
+2026-07-20 21:27:42 WARNING API call failed (attempt 2/3) ...
+2026-07-20 21:27:52 ERROR    API call failed after 3 retries. ...
+# 4. Each retry adds ~10s of latency before the bot can fall back.
+```
+
+**Reproduction (verified, D-003):**
+```
+# 1. Use a Kimi Coding Plan subscription until quota exhausts
+# 2. Send any message with provider=kimi-coding, model=kimi-k2.7-code
+# 3. errors.log shows immediate abort with no fallback:
+2026-07-21 21:05:18 WARNING provider=kimi-coding model=kimi-k2.7-code
+  summary=HTTP 403: You've reached your usage limit for this billing cycle.
+  Your quota will be refreshed in the next cycle. To continue now, purchase
+  extra usage or upgrade your plan: https://www.kimi.com/code/#pricing
+2026-07-21 21:05:19 ERROR Non-retryable client error: Error code: 403 - {...}
+# 4. No fallback activation, no "credits exhausted" status, bot just dies.
+```
+
+**Vocabulary mismatch table (as of 2026-07-21):**
+
+| Provider | HTTP | Body shape | Classifier branch (pre-fix) | Match? | Wrong bucket |
+|----------|------|-----------|----------------------------|--------|--------------|
+| Z.AI | 429 | `{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}` | 429 → `_OVERLOADED_PATTERNS` → fallthrough → `rate_limit` | NO | rate_limit (burns 3 retries) |
+| Kimi | 403 | `{"type":"permission_error","message":"You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle."}` | 403 → `"key limit exceeded"` / `"spending limit"` / `_BILLING_PATTERNS` | NO | auth (no fallback) |
+| Kimi | 429 | `{"message":"The engine is currently overloaded, please try again later"}` | 429 → `_OVERLOADED_PATTERNS` (`"overloaded"`) | YES | overloaded (correct) |
+| Anthropic | 429 | `{"type":"rate_limit_error","message":"This request would exceed your account's rate limit."}` | 429 → fallthrough → `rate_limit` | YES | rate_limit (correct) |
+| Anthropic | 400 | `Invalid signature in thinking block` | 400 → thinking-sig handler | YES | thinking_signature (correct) |
+| Anthropic | 429 | `"extra usage" + "long context"` | 429 → long-context-tier handler | YES | long_context_tier (correct) |
+
+**The pattern in one sentence:**
+> Each provider has its own error vocabulary, but the classifier's lists
+> were built reactively from past failures — a new provider's first failure
+> will always land in the wrong bucket until its phrases are added.
+
+**Resolution:** For each new provider, search its API docs / error catalog
+for billing / quota / overload phrasings and add them to the right list
+in `agent/error_classifier.py`. The runtime patcher
+(`apply-runtime-patches.py`) is the operational path for adding phrases
+without editing the dev tree.
+
+**Standing rule:**
+When adding a new provider to Hermes:
+1. Find the provider's error code reference in their docs
+2. For each billing/quota/overload code, identify the body shape and add
+   the phrasing to the matching list (`_BILLING_PATTERNS`, `_OVERLOADED_PATTERNS`,
+   `_RATE_LIMIT_PATTERNS`)
+3. If the provider uses non-standard HTTP status (e.g. Z.AI's 429 for
+   billing), add a special-case check in `_classify_by_status` BEFORE the
+   generic fallthrough
+4. Test by deliberately exhausting a test key and confirming the error
+   classifies correctly
+
+**Cross-reference:** CRITICAL-ISSUES.md #16, #17; D-002, D-003 in this file;
+`agent/error_classifier.py:954` (429 branch), `:883` (403 branch).
+
+---
+
+### RCA-C — Reasoning models killed mid-think by stale-stream detector
+
+**Pattern:** Cloud reasoning models (those that emit extended thinking
+blocks before their first content token — GLM-5.2, OpenAI o1/o3, Anthropic
+Opus 4.x thinking, DeepSeek R1, NVIDIA Nemotron, xAI Grok reasoning) pause
+for several minutes during the thinking phase. Hermes' stream stale
+detector (`HERMES_STREAM_STALE_TIMEOUT`, default 180s) and the httpx
+socket read timeout (default 120s) both fire BEFORE the model finishes
+thinking, tearing down a healthy reasoning stream mid-think.
+
+**User-visible symptom:**
+> "GLM models just hang without even trying to do anything."
+
+The user perceives this as a hang because no content tokens arrive within
+the default window — then the connection is killed and the retry loops.
+
+**Why it bit us:** D-004 (GLM-5/5.2 missing from `_REASONING_STALE_TIMEOUT_FLOORS`).
+
+**Reproduction (verified, D-004):**
+```
+# 1. Set provider=zai, model=glm-5.2 (thinking mode is ON by default)
+# 2. Send a non-trivial reasoning task (e.g. "write a Python function that
+#    solves the N-queens problem and explain your approach")
+# 3. Watch the bot's Discord reply — no streaming output for 180s
+# 4. agent.log shows:
+#    Stream stale for 180s (threshold 180s) - no chunks received.
+#    model=glm-5.2 context=~N tokens. Killing connection.
+# 5. Loop retries → 540s+ total before final failure
+```
+
+**Resolution mechanism (already in place):**
+The `_REASONING_STALE_TIMEOUT_FLOORS` table in `agent/reasoning_timeouts.py`
+exists exactly for this. The floor is applied as `max(default, floor)` so
+the stale detector and httpx read timeout both scale up for known reasoning
+models. **The bug was that GLM models were missing from the table** — a
+contributing factor was that GLM-5.2's thinking mode is opt-out (ON by
+default), unlike OpenAI's o1 which is opt-in.
+
+**Reproduction of the fix (verified):**
+```python
+>>> from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+>>> get_reasoning_stale_timeout_floor("glm-5.2")
+300.0    # was None before fix
+>>> get_reasoning_stale_timeout_floor("glm-4-9b") is None  # non-thinking, correctly excluded
+True
+```
+
+**Why GLM was missed when the table was originally populated:**
+GLM-4.5-and-later shipped thinking-mode ON by default on the OpenAI-compat
+endpoint. When the `_REASONING_STALE_TIMEOUT_FLOORS` table was built
+(Fixes #52217), the test set focused on cloud reasoning models with
+DOCUMENTED multi-minute TTFB (NVIDIA Nemotron, OpenAI o1, Anthropic Opus
+4.x thinking, DeepSeek R1). GLM's thinking mode is opt-out and was added
+later in `plugins/model-providers/zai/__init__.py` — the reasoning-timeout
+table was never updated to include it.
+
+**The systemic gap:**
+The reasoning-timeout table and the provider profiles are maintained
+separately. There's no automated check that says "this provider's model
+emits thinking blocks → add it to the floor table". The result: any new
+reasoning model added via a provider profile will hit this bug until
+someone manually adds it to the table.
+
+**Standing rule:**
+When a provider profile emits `extra_body["thinking"] = {"type": "enabled"}`
+or sets a top-level `reasoning_effort`, the model is a reasoning model.
+ALSO add it to `_REASONING_STALE_TIMEOUT_FLOORS` with a floor of at least
+180s (light) / 240s (medium) / 300s (heavy) based on its max thinking time.
+
+**Cross-reference:** CRITICAL-ISSUES.md #18; D-004 in this file;
+`agent/reasoning_timeouts.py:_REASONING_STALE_TIMEOUT_FLOORS`;
+`plugins/model-providers/zai/__init__.py:ZaiProfile.build_api_kwargs_extras`.
+
+---
+
+### RCA-D — Compression loop on long sessions (target not sticky)
+
+**Pattern:** Long-running Discord sessions repeatedly cross the ~200K token
+threshold, trigger context compression (paid API call + ~30s latency),
+shrink to ~200K, then climb back over the threshold within minutes. Each
+cycle burns a paid API call.
+
+**Why it bit us:** D-006 (compression loop on long Discord sessions).
+
+**Reproduction (in-progress, D-006):**
+```
+# 1. Start a long coding session (read 2+ large files, edit them)
+# 2. Leave the session running for >30 min
+# 3. agent.log shows repeated compression events every 5-10 min:
+2026-07-20 18:09:03 context compression started: tokens=~228,184
+2026-07-20 18:21:03 context compression started: tokens=~315,967
+2026-07-20 19:13:18 context compression started: tokens=~279,920
+2026-07-20 19:19:07 context compression started: tokens=~311,851
+```
+
+**Hypothesis (pending verification):**
+The target context length set after compression is being re-probed upward
+by the context compressor on subsequent turns, so the effective threshold
+drifts back toward the model's max (1M for nemotron, 256K for kimi). Each
+probe re-triggers compression when the session grows past the probed value.
+
+**Why this is a Discord-bot-specific problem:**
+Discord sessions are long-lived (cron-driven `session_reset` only fires at
+04:00 local). Telegram/CLI sessions typically reset more often. The bot's
+uptime + heavy code-editing tool calls = the perfect storm for repeated
+compression cycles.
+
+**Standing rule (interim):**
+If `agent.log` shows compression events more than once per 15 min on the
+same session, the compressor is in a loop. Kill the session (`/reset` in
+Discord) rather than burning paid API calls. Long-term fix is in
+`agent/context_compressor.py` — make the post-compression target sticky.
+
+**Cross-reference:** D-006 in this file; `agent/context_compressor.py`.
+
+---
+
+### RCA-E — System-prompt null after session reset
+
+**Pattern:** After the daily `session_reset.at_hour: 4` fires, the first
+message of each new session triggers a `Stored system prompt for session
+<id> is null` warning. The bot recovers (rebuilds the prompt from scratch)
+but the first turn is slower (no prefix cache hit).
+
+**Why it bit us:** D-005 (system prompt null).
+
+**Reproduction (verified, D-005):**
+```
+# 1. Wait for session_reset.at_hour: 4 to fire (or manually trigger)
+# 2. Send a message to Nous Man in any channel
+# 3. agent.log shows:
+#    WARNING Stored system prompt for session <id> is null; rebuilding from
+#    scratch this turn. Prefix cache will miss until the rebuild persists.
+#    Investigate the previous turn's update_system_prompt write path.
+```
+
+**Hypothesis:**
+The session_reset path writes a new session row but does not write the
+`system_prompt` column. The first turn of the new session falls back to
+the rebuild path.
+
+**Standing rule:**
+"System prompt null" warnings on the first turn of a session are not a
+crisis — the bot will recover. Investigate only if it persists past the
+first turn.
+
+**Cross-reference:** D-005 in this file; `gateway/session.py` session_reset
+handler.
+
+---
+
+## Active tickets
+
+### D-005 — Sessions loading blank (system prompt null)  [MONITORING]
+
+**Severity:** YELLOW
+**Opened:** 2026-07-21 by Sleepy Cat / BarnsL
+**Affected:** All sessions after a session_reset (cron at 04:00 local)
+
+**Symptom:**
+After the daily `session_reset` runs, the first message of each new session
+triggers this warning:
+
+```
+WARNING Stored system prompt for session <id> is null; rebuilding from
+scratch this turn. Prefix cache will miss until the rebuild persists.
+```
+
+The bot still works, but the first turn is slower (no prefix cache hit) and
+the agent's identity instructions are re-built from scratch.
+
+**Reproduction:**
+1. Wait for `session_reset.at_hour: 4` to fire (or manually trigger)
+2. Send a message to Nous Man in any channel
+3. Check `agent.log` for the warning above
+
+**Expected:** System prompt persists across session boundaries (or is rebuilt
+and cached within seconds, not on the user's first message).
+
+**Actual:** System prompt is null on first turn of every new session.
+
+**RCA / hypothesis:**
+The session_reset path writes a new session row but does not write the
+`system_prompt` column. The first turn of the new session falls back to
+the rebuild path. Non-blocking but adds ~3-5s latency to the first message
+of each day.
+
+**Fix (TODO):**
+Investigate `gateway/session.py` `session_reset` handler — ensure it either
+copies the previous system prompt or pre-builds the default one before the
+first message arrives.
+
+**Standing rule:**
+"System prompt null" warnings on the first turn of a session are not a
+crisis — the bot will recover. Investigate only if it persists past the
+first turn.
+
+---
+
+### D-006 — Compression loop fires every 5-10 min on long sessions  [MONITORING]
+
+**Severity:** YELLOW
+**Opened:** 2026-07-20 by BarnsL
+**Affected:** Discord sessions that run >200K tokens (long coding tasks)
+
+**Symptom:**
+Long Discord sessions repeatedly cross the ~200K token threshold, trigger
+context compression (which itself uses a paid API call), shrink to ~200K,
+then climb back over the threshold. Each cycle = 1 paid API call + ~30s
+latency.
+
+**Logs:**
+```
+2026-07-20 18:09:03 context compression started: tokens=~228,184 model=kimi-k2.7-code
+2026-07-20 18:21:03 context compression started: tokens=~315,967 model=claude-haiku-4-5
+2026-07-20 19:13:18 context compression started: tokens=~279,920 model=kimi-k2.7-code
+2026-07-20 19:19:07 context compression started: tokens=~311,851 model=kimi-k2.7-code
+2026-07-20 19:25:44 context compression started: tokens=~274,808 model=kimi-k2.7-code
+```
+
+**Reproduction:**
+1. Start a long coding session with Nous Man (read 2+ large files, edit them)
+2. Leave the session running for >30 min
+3. Watch `agent.log` for repeated compression events
+
+**Expected:** After compression, the context should stay below the threshold
+for several turns. The target context length should be sticky.
+
+**Actual:** Sessions re-cross the threshold within 5-10 min, triggering
+another paid compression call.
+
+**RCA / hypothesis:**
+The target context length is being re-probed upward after every compression,
+so the effective threshold drifts back toward the model's max (1M for
+nemotron, 256K for kimi). Each probe costs a compression call.
+
+**Fix (TODO):**
+1. Check `agent/context_compressor.py` for the re-probe logic.
+2. Make the post-compression target sticky — once compressed to X, stay at X
+   until the user explicitly resets or switches models.
+3. Consider raising `compression.threshold` from 0.7 → 0.85 so compression
+   fires later (less aggressive).
+
+**Standing rule:**
+If `agent.log` shows compression events more than once per 15 min on the same
+session, the compressor is in a loop. Kill the session (`/reset`) rather
+than burning paid API calls.
+
+---
+
+### D-007 — Image attachment processing verification  [READY TO TEST]
+
+**Severity:** GREEN
+**Opened:** 2026-07-21 by BarnsL
+**Affected:** All Discord channels where users send images to Nous Man
+
+**Symptom:**
+None currently reported. This ticket tracks end-to-end verification that
+image attachments sent to Nous Man are processed correctly through the
+free-tier OpenRouter fallback chain.
+
+**Pipeline (current):**
+1. Discord user uploads image attachment
+2. `_cache_discord_image(att, ext)` in `plugins/platforms/discord/adapter.py:6049`
+   - Primary: `att.read()` + `cache_image_from_bytes` (authenticated, no SSRF gate)
+   - Fallback: `cache_image_from_url` (SSRF-gated)
+3. `vision` toolset (see `platform_toolsets.discord` in config.yaml)
+4. `auxiliary.vision` provider in config.yaml:
+   ```yaml
+   auxiliary:
+     vision:
+       provider: openrouter
+       model: google/gemma-4-31b-it:free
+       enabled: true
+   ```
+5. Vision model converts image to text description
+6. Main model receives text description (`agent.image_input_mode: text`)
+
+**Verification steps:**
+1. Send a PNG/JPG image to Nous Man in a DM with a question like "what's in
+   this image?"
+2. Check `agent.log` for:
+   - `auxiliary_client: vision task using openrouter (google/gemma-4-31b-it:free)`
+   - No `image_too_large` errors
+3. Confirm response describes the image correctly
+
+**Known limits:**
+- `image_input_mode: text` — main model sees a description, not raw pixels.
+  Change to `native` if you switch to a vision-capable primary model.
+- Free-tier gemma-4-31b may rate-limit on heavy image load. Fallback chain
+  has no second vision-capable free model — if gemma rate-limits, image
+  processing fails.
+- Anthropic 5 MB per-image hard limit applies on anthropic-wire paths.
+
+**Standing rule:**
+If a user reports "bot can't see images", check `auxiliary.vision.provider`
+in config.yaml first. If OPENROUTER_API_KEY is set, gemma-4-31b:free should
+work. If not, switch to a vision-capable main model (e.g. claude-sonnet)
+and set `agent.image_input_mode: native`.
+
+---
+
+### D-008 — auth.json WinError 5 on Windows (Defender scan race)  [FIXED 2026-07-21]
+
+**Severity:** RED
+**Opened / closed:** 2026-07-21 / 2026-07-21
+**Affected:** All Hermes Desktop agents on Windows with Defender real-time protection enabled.
+
+**Symptom:**
+Agent init fails with:
+```
+ent init failed: [WinError 5] Access is denied: 'C:\Users\Burgboy\AppData\Local\hermes\auth.json.tmp.18300.76441fa549ea4dccb50b239689944442' -> 'C:\Users\Burgboy\AppData\Local\hermes\auth.json'
+```
+Repeats on every auth.json write (provider auth, token refresh, session persist).
+
+**Logs:**
+```
+ERROR [hermes_cli.auth] auth.json: atomic_replace denied (attempt 1/3, likely AV scan); retrying in 0.05s: [WinError 5] Access is denied
+ERROR [hermes_cli.auth] auth.json: atomic_replace denied (attempt 2/3, likely AV scan); retrying in 0.10s: [WinError 5] Access is denied
+ERROR [hermes_cli.auth] auth.json: atomic_replace denied (attempt 3/3, likely AV scan); retrying in 0.20s: [WinError 5] Access is denied
+CRITICAL ent init failed: [WinError 5] Access is denied: ...
+```
+
+**RCA:**
+Windows Defender real-time protection opens `auth.json` for scanning **during** the `os.replace(tmp, auth.json)` atomic rename. Defender holds the file with `FILE_SHARE_DELETE=No`, so the rename fails with `PermissionError` (WinError 5). The scan window is typically 50-200ms. The original code had no retry — it crashed on first collision.
+
+The advisory cross-process lock (`_auth_store_lock` using `msvcrt.locking`) does NOT protect against Defender because Defender ignores POSIX advisory locks.
+
+**Fix (two layers):**
+
+1. **Python retry (durable, no admin needed)** — `hermes_cli/auth.py:_save_auth_store`:
+   - Added `_AUTH_REPLACE_MAX_RETRIES` (default 5, env `HERMES_AUTH_REPLACE_MAX_RETRIES`)
+   - Added `_AUTH_REPLACE_BACKOFF_SECONDS` (default 0.15s, env `HERMES_AUTH_REPLACE_BACKOFF_SECONDS`)
+   - Exponential backoff: 0.15s → 0.30s → 0.60s → 1.20s → 2.40s
+   - Total worst-case added latency before re-raise: ~4.65s
+   - Catches `PermissionError`, logs attempt, sleeps, retries
+
+2. **Defender exclusion (prevents recurrence)** — `C:\Users\Burgboy\AppData\Local\hermes\add-defender-exclusions.ps1`:
+   - Adds folder exclusion for `%LOCALAPPDATA%\hermes` to Defender real-time protection
+   - Must be run **elevated** (Run as Administrator)
+   - Idempotent — safe to re-run
+
+**Verification:**
+1. Run the exclusion script elevated (one-time)
+2. Restart Hermes Desktop
+3. Watch `agent.log` — no more "atomic_replace denied" warnings
+4. If you cannot elevate, the Python retry alone handles typical scan windows
+
+**Env overrides (if needed):**
+```powershell
+$env:HERMES_AUTH_REPLACE_MAX_RETRIES = "7"
+$env:HERMES_AUTH_REPLACE_BACKOFF_SECONDS = "0.20"
+```
+
+**Standing rule:**
+Any `auth.json` write failure with WinError 5 on Windows = Defender scan race. Do NOT chmod/change ACLs — that breaks Defender further. Add the folder exclusion or increase retry budget.
+
+---
+
+## Closed tickets
+
+### D-001 — Bot replies "Sorry, I encountered an unexpected error"  [FIXED 2026-07-21]
+
+**Severity:** RED
+**Opened / closed:** 2026-07-20 / 2026-07-21
+**Symptom:**
+Every Discord message produced "Sorry, I encountered an unexpected error.
+Try again or use /reset to start a fresh session." Bot unusable.
+
+**Logs:**
+```
+RuntimeError: No LLM provider configured. Run `hermes model` to select a
+provider, or run `hermes setup` for first-time configuration.
+```
+
+**RCA:**
+The `.env` file contained an empty `OPENROUTER_API_KEY=` line that was
+overriding the working key hardcoded in `config.yaml` (`model.api_key`).
+Env vars take precedence over config.yaml, so the runtime saw an empty key
+and refused to start the agent.
+
+Separately, the auxiliary client was marking OpenRouter unhealthy for 60s
+on a "payment / credit error" — but the actual issue was the empty env var,
+not a real billing problem. The key works fine (verified via
+`/api/v1/auth/key` and a live free-model call).
+
+**Fix:**
+Synced `OPENROUTER_API_KEY` in `.env` from `config.yaml model.api_key` via
+`d:\projects\hermes-agent-hotreload\apply-openrouter-key.py` (idempotent).
+
+Verification after `hermes gateway restart`:
+- User "Sleepy Cat" sent "yo" at 18:14:24
+- Agent processed on `nvidia/nemotron-3-ultra-550b-a55b:free`
+- Response delivered in 29.6s, 76 chars, no errors
+
+**Standing rule:**
+If `errors.log` shows "No LLM provider configured", check `.env` for empty
+`<PROVIDER>_API_KEY=` lines first — they override `config.yaml`. Run
+`apply-openrouter-key.py` to resync.
+
+---
+
+### D-002 — Z.AI 429 "Insufficient balance" code 1113 misclassified  [FIXED 2026-07-20]
+
+**Severity:** RED
+**Opened / closed:** 2026-07-20 / 2026-07-20
+**Symptom:**
+Z.AI / GLM API key out of credits produces a 429 storm that wastes ~10s
+before failing. Bot shows "Rate limited" status for minutes.
+
+**Logs:**
+```
+provider=zai base_url=https://api.z.ai/api/paas/v4 model=glm-5
+summary=HTTP 429: Insufficient balance or no resource package. Please recharge.
+```
+
+**RCA:**
+Z.AI / Zhipu mislabels account-balance exhaustion as HTTP 429 (standards-
+correct would be 402). Body: `{"error":{"code":"1113","message":"Insufficient
+balance..."}}`. The `_classify_by_status(429)` in `agent/error_classifier.py`
+checked `_OVERLOADED_PATTERNS` but not `_BILLING_PATTERNS`, so the error
+fell through to `rate_limit` and burned 3 retries.
+
+**Fix:**
+See CRITICAL-ISSUES.md #16. Patched runtime `error_classifier.py`:
+- Added `_BILLING_PATTERNS` check in the 429 branch
+- Added code "1113" to `_BILLING_ERROR_CODES`
+
+After fix: classifies as `billing`, rotates credential immediately, 0 wasted
+retries. Regression: real rate-limit 429s and Z.AI overload 429s (code 1305)
+still classify correctly.
+
+**Standing rule:**
+A 429 with "balance" / "recharge" / "quota" / "credits" in the body is NEVER
+a transient rate limit — it's billing. Recharge Z.AI at https://z.ai/ or
+remove GLM_API_KEY and rely on the fallback chain.
+
+---
+
+### D-003 — Kimi 403 "usage limit for this billing cycle" misclassified  [FIXED 2026-07-20]
+
+**Severity:** RED
+**Opened / closed:** 2026-07-20 / 2026-07-20
+**Symptom:**
+Kimi Coding Plan quota exhaustion produced a confusing "Non-retryable
+client error" and never triggered the billing recovery path. Bot just died.
+
+**Logs:**
+```
+provider=kimi-coding base_url=https://api.kimi.com/coding model=kimi-k2.7-code
+summary=HTTP 403: You've reached your usage limit for this billing cycle.
+Your quota will be refreshed in the next cycle. To continue now, purchase
+extra usage or upgrade your plan: https://www.kimi.com/code/#pricing
+```
+
+**RCA:**
+The 403 branch in `error_classifier.py` only matched `"key limit exceeded"`,
+`"spending limit"`, and `_BILLING_PATTERNS`. Kimi's wording — "usage limit
+for this billing cycle" / "quota will be refreshed" / "purchase extra
+usage" — matched none of those, so it fell through to the `auth` branch.
+
+**Fix:**
+See CRITICAL-ISSUES.md #17. Added three Kimi-specific phrases to the 403
+billing branch. After fix: classifies as `billing`, activates fallback
+chain immediately.
+
+**Standing rule:**
+A 403 with "usage limit" + "billing cycle" / "quota will be refreshed" /
+"purchase extra usage" is billing exhaustion, not auth. Upgrade the Kimi
+plan at https://www.kimi.com/code/#pricing or wait for the cycle reset.
+
+---
+
+### D-004 — GLM-5 / GLM-5.2 "hangs without doing anything"  [FIXED 2026-07-20]
+
+**Severity:** YELLOW
+**Opened / closed:** 2026-07-20 / 2026-07-20
+**Symptom:**
+GLM models sometimes appear to hang indefinitely — no streaming output,
+no error, eventually a "Stream stale for 180s — killing connection".
+
+**RCA:**
+GLM-5.2 ships with thinking ON by default and pauses minutes before its
+first content token. The default `HERMES_STREAM_STALE_TIMEOUT` of 180s and
+httpx read timeout of 120s both fired BEFORE GLM-5.2 finished thinking.
+GLM models were missing from `_REASONING_STALE_TIMEOUT_FLOORS` in
+`agent/reasoning_timeouts.py`.
+
+**Fix:**
+See CRITICAL-ISSUES.md #18. Added GLM-5.2 (300s), GLM-5 (240s), GLM-4.6/4.5
+(180s) to the reasoning-timeout floors. Slug-anchored so `glm-4-9b`
+(non-thinking) is excluded.
+
+**Standing rule:**
+If a reasoning model is added to Hermes and pauses minutes before its
+first content token, add it to `_REASONING_STALE_TIMEOUT_FLOORS`. Slug
+must be start-of-slug anchored (use `glm-5.2`, not `5.2`).
+
+---
+
+## Operational notes
+
+### Restart sequence (when applying patches)
+
+```powershell
+# 1. Apply runtime patches (idempotent)
+C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe `
+    d:\projects\hermes-agent-hotreload\apply-runtime-patches.py
+
+# 2. Sync OPENROUTER_API_KEY if .env was reset
+C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe `
+    d:\projects\hermes-agent-hotreload\apply-openrouter-key.py
+
+# 3. Restart gateway
+C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv\Scripts\hermes.exe `
+    gateway restart
+
+# 4. Verify Discord connected
+C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv\Scripts\hermes.exe `
+    gateway status
+```
+
+### Quick diagnostic checklist
+
+When the bot misbehaves, run in this order:
+
+1. **`errors.log` tail** — look for the most recent stack trace
+   ```powershell
+   Get-Content "$env:LOCALAPPDATA\hermes\logs\errors.log" -Tail 40
+   ```
+2. **`agent.log` tail** — find the inbound message + agent response
+   ```powershell
+   Get-Content "$env:LOCALAPPDATA\hermes\logs\agent.log" -Tail 50
+   ```
+3. **Gateway status** — confirm Discord is connected
+   ```powershell
+   hermes gateway status
+   ```
+4. **Provider key check** — confirm OPENROUTER_API_KEY is set
+   ```powershell
+   hermes auth status
+   ```
+5. **Provider health** — try a free-model call manually
+   ```powershell
+   hermes chat --provider openrouter --model nvidia/nemotron-3-super-120b-a12b:free
+   ```
+
+### Fallback chain (current)
+
+Primary: `nvidia/nemotron-3-ultra-550b-a55b:free` via openrouter
+Failover order (one-by-one, all free OpenRouter):
+1. `nvidia/nemotron-3-ultra-550b-a55b:free`
+2. `nvidia/nemotron-3-super-120b-a12b:free`
+3. `qwen/qwen3-coder:free`
+4. `google/gemma-4-31b-it:free`  ← vision-capable, preserves image input
+5. `google/gemma-4-26b-a4b-it:free`
+6. `deepseek/deepseek-r1:free`
+7. `meta-llama/llama-4-70b-instruct:free`
+8. `mistralai/mistral-small-3.2-24b-instruct:free`
+
+Tier 2 (commented out in config.yaml, activate with OPENCODE_GO_API_KEY):
+- `glm-5` via opencode-go
+- `kimi-k2.5` via opencode-go
+
+Tier 3 (commented out, activate with OPENCODE_ZEN_API_KEY):
+- `gemini-3-flash` via opencode-zen
+
+### Known account states (as of 2026-07-21)
+
+| Provider | Key | Account state | Action |
+|----------|-----|---------------|--------|
+| openrouter | set | working (free tier) | none |
+| zai (GLM) | set | OUT OF BALANCE | recharge at https://z.ai/ or ignore |
+| kimi-coding | set | AT USAGE LIMIT (cycle) | wait for reset or upgrade at https://www.kimi.com/code/#pricing |
+| deepseek | set | unknown | untested recently |
+| sakana | set | unknown | untested recently |
+| opencode-go | NOT set | n/a | get key at https://opencode.ai/auth |
+| opencode-zen | NOT set | n/a | get key at https://opencode.ai/auth |
+
+---
+
+— End of document —

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6284,7 +6284,7 @@ class DiscordAdapter(BasePlatformAdapter):
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            if auto_thread and not skip_thread and not is_voice_linked_channel:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7,6 +7,67 @@ Uses discord.py library for:
 - Receiving messages from servers and DMs
 - Sending responses back
 - Handling threads and channels
+
+──────────────────────────────────────────────────────────────────────────
+Operational RCA & failure modes (see plugins/platforms/discord/ISSUES.md):
+──────────────────────────────────────────────────────────────────────────
+
+This adapter is the primary surface for the Nous Man bot (#0498). When a
+Discord message fails to produce a response, the user sees:
+    "Sorry, I encountered an unexpected error.
+     Try again or use /reset to start a fresh session."
+That generic message masks many distinct root causes — see ISSUES.md for
+the full ticket log. The most common are summarized here so future
+maintainers don't re-derive them from logs.
+
+D-001 — "No LLM provider configured" (RED, fixed 2026-07-21)
+    Cause: An empty ``OPENROUTER_API_KEY=`` line in ~/.hermes/.env silently
+    overrides the working key in config.yaml's ``model.api_key`` field.
+    Env vars are resolved BEFORE config.yaml is read, so the runtime sees
+    an empty string and refuses to start the agent.
+    Symptom: Every Discord message produces the generic error message above.
+    Logs show: ``RuntimeError: No LLM provider configured``.
+    Fix: ``d:/projects/hermes-agent-hotreload/apply-openrouter-key.py``
+    syncs the env var from config.yaml. Idempotent — re-run after any
+    .env edit. See RCA-A in ISSUES.md.
+
+D-002 / D-003 / D-004 — Provider-specific error misclassification
+    When the primary provider (Z.AI, Kimi) returns a billing/quota error
+    with non-standard wording, the error classifier misrouted it and
+    either burned retries (D-002) or failed to activate fallback (D-003).
+    GLM-5.2 reasoning streams were killed mid-think by the default stale
+    detector (D-004).
+    Fixes: see ``agent/error_classifier.py`` (429 and 403 branches) and
+    ``agent/reasoning_timeouts.py`` (_REASONING_STALE_TIMEOUT_FLOORS).
+    Cross-ref: RCA-B, RCA-C in ISSUES.md.
+
+D-005 — "Stored system prompt for session <id> is null"
+    After the daily session_reset (cron at 04:00 local), the first message
+    of each new session triggers this warning. The bot recovers (rebuilds
+    the prompt from scratch) but the first turn is slower. Non-blocking.
+    See RCA-E in ISSUES.md.
+
+D-006 — Compression loop on long sessions
+    Long-running Discord sessions (>200K tokens) repeatedly cross the
+    threshold, trigger compression (paid API call), shrink, then climb
+    back over. Each cycle burns a paid call + ~30s latency.
+    Interim mitigation: ``/reset`` the session if compression fires more
+    than once per 15 min. See RCA-D in ISSUES.md.
+
+D-007 — Image attachment processing (active verification)
+    Image pipeline: ``_cache_discord_image`` → ``vision`` tool →
+    ``auxiliary.vision`` provider (gemma-4-31b:free). Main model receives
+    a TEXT description (``agent.image_input_mode: text``), not raw pixels.
+    If gemma-4-31b:free rate-limits, image processing fails — the fallback
+    chain has no second vision-capable free model.
+
+Diagnostic order when the bot misbehaves:
+    1. ``Get-Content $env:LOCALAPPDATA\hermes\logs\errors.log -Tail 40``
+    2. ``Get-Content $env:LOCALAPPDATA\hermes\logs\agent.log -Tail 50``
+    3. ``hermes gateway status`` — confirm Discord connected
+    4. ``hermes auth status`` — confirm OPENROUTER_API_KEY is set
+    5. ``hermes chat --provider openrouter --model nvidia/nemotron-3-super-120b-a12b:free``
+       to verify the free-tier fallback works
 """
 
 import asyncio

--- a/tests/gateway/test_mcp_config_watch_gateway.py
+++ b/tests/gateway/test_mcp_config_watch_gateway.py
@@ -1,0 +1,73 @@
+"""The gateway auto-reloads MCP connections when config.yaml's ``mcp_servers``
+section changes on disk — the always-on analogue of the TUI config watcher
+(cli.HermesCLI._check_config_mcp_changes), covered by
+tests/cli/test_cli_mcp_config_watch.py.
+
+Exercises GatewayRunner._check_config_mcp_changes (one watcher tick) directly
+with a mocked reload, so no real MCP servers are contacted.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+
+def _make_runner(tmp_path, mcp_servers=None):
+    """Bare GatewayRunner with just the watcher state + a mocked reload."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._mcp_watch_mtime = 0.0  # forced stale so the parse path runs
+    runner._mcp_watch_servers = dict(mcp_servers or {})
+    # _reload_mcp_connections returns (added, removed, reconnected, new_tools).
+    runner._reload_mcp_connections = AsyncMock(return_value=(set(), set(), set(), []))
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.dump({"mcp_servers": mcp_servers or {}}), encoding="utf-8")
+    return runner, cfg
+
+
+@pytest.mark.asyncio
+async def test_new_server_triggers_gateway_reload(tmp_path):
+    runner, cfg = _make_runner(tmp_path, mcp_servers={})
+    cfg.write_text(
+        yaml.dump({"mcp_servers": {"gh": {"url": "https://mcp.example.com"}}}),
+        encoding="utf-8",
+    )
+    with patch("hermes_cli.config.get_config_path", return_value=cfg):
+        await runner._check_config_mcp_changes()
+    runner._reload_mcp_connections.assert_awaited_once()
+    # Watcher state advanced to the new server set.
+    assert runner._mcp_watch_servers == {"gh": {"url": "https://mcp.example.com"}}
+
+
+@pytest.mark.asyncio
+async def test_removed_server_triggers_gateway_reload(tmp_path):
+    runner, cfg = _make_runner(tmp_path, mcp_servers={"gh": {"url": "x"}})
+    cfg.write_text(yaml.dump({"mcp_servers": {}}), encoding="utf-8")
+    with patch("hermes_cli.config.get_config_path", return_value=cfg):
+        await runner._check_config_mcp_changes()
+    runner._reload_mcp_connections.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unrelated_section_edit_does_not_reload(tmp_path):
+    runner, cfg = _make_runner(tmp_path, mcp_servers={"fs": {"command": "npx"}})
+    # Same mcp_servers, a different section changed.
+    cfg.write_text(
+        yaml.dump({"mcp_servers": {"fs": {"command": "npx"}}, "model": {"default": "x"}}),
+        encoding="utf-8",
+    )
+    with patch("hermes_cli.config.get_config_path", return_value=cfg):
+        await runner._check_config_mcp_changes()
+    runner._reload_mcp_connections.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_config_is_noop(tmp_path):
+    runner, _cfg = _make_runner(tmp_path, mcp_servers={})
+    missing = tmp_path / "gone.yaml"
+    with patch("hermes_cli.config.get_config_path", return_value=missing):
+        await runner._check_config_mcp_changes()
+    runner._reload_mcp_connections.assert_not_awaited()

--- a/tests/hermes_cli/test_mcp_config_change_detection.py
+++ b/tests/hermes_cli/test_mcp_config_change_detection.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``hermes_cli.mcp_startup.detect_mcp_servers_change`` — the
+shared change-detection behind both the TUI and gateway MCP config watchers."""
+
+import yaml
+
+from hermes_cli.mcp_startup import detect_mcp_servers_change
+
+
+def _write_config(path, doc):
+    path.write_text(yaml.dump(doc), encoding="utf-8")
+    return path.stat().st_mtime
+
+
+def test_unchanged_mtime_takes_fast_path(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    mtime = _write_config(cfg, {"mcp_servers": {"fs": {"command": "npx"}}})
+    changed, new_mtime, servers = detect_mcp_servers_change(
+        cfg, mtime, {"fs": {"command": "npx"}}
+    )
+    assert changed is False
+    assert new_mtime == mtime
+    assert servers == {"fs": {"command": "npx"}}
+
+
+def test_added_server_triggers_change(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    _write_config(cfg, {"mcp_servers": {"gh": {"url": "https://mcp.example.com"}}})
+    changed, _mtime, servers = detect_mcp_servers_change(cfg, 0.0, {})
+    assert changed is True
+    assert servers == {"gh": {"url": "https://mcp.example.com"}}
+
+
+def test_removed_server_triggers_change(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    _write_config(cfg, {"mcp_servers": {}})
+    changed, _mtime, servers = detect_mcp_servers_change(cfg, 0.0, {"gh": {"url": "x"}})
+    assert changed is True
+    assert servers == {}
+
+
+def test_other_section_edit_is_not_a_change(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    _write_config(
+        cfg, {"mcp_servers": {"fs": {"command": "npx"}}, "model": {"default": "x"}}
+    )
+    # mtime forced stale so the parse runs, but mcp_servers is identical.
+    changed, new_mtime, servers = detect_mcp_servers_change(
+        cfg, 0.0, {"fs": {"command": "npx"}}
+    )
+    assert changed is False
+    # mtime is advanced so the same file isn't re-parsed on every tick.
+    assert new_mtime == cfg.stat().st_mtime
+    assert servers == {"fs": {"command": "npx"}}
+
+
+def test_missing_file_reports_no_change(tmp_path):
+    cfg = tmp_path / "does_not_exist.yaml"
+    changed, new_mtime, servers = detect_mcp_servers_change(cfg, 123.0, {"a": {}})
+    assert changed is False
+    assert new_mtime == 123.0
+    assert servers == {"a": {}}
+
+
+def test_invalid_yaml_midwrite_is_no_change_but_advances_mtime(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("mcp_servers: {oops: [unterminated\n", encoding="utf-8")  # invalid
+    changed, new_mtime, servers = detect_mcp_servers_change(cfg, 0.0, {"a": {}})
+    assert changed is False
+    # mtime advances so a mid-write/broken file isn't re-parsed every tick; the
+    # next good write bumps mtime again and is picked up.
+    assert new_mtime == cfg.stat().st_mtime
+    assert servers == {"a": {}}


### PR DESCRIPTION
## Problem

The interactive TUI already hot-reloads MCP connections when `config.yaml`'s `mcp_servers` section changes: `HermesCLI._check_config_mcp_changes()` polls from `process_loop` and calls `_reload_mcp()` (covered by `tests/cli/test_cli_mcp_config_watch.py`).

The **gateway** — the always-on process behind bot / headless deployments — has no such watcher. It discovers MCP servers once at startup and never re-checks, so `hermes mcp add` / `hermes mcp remove` and manual `config.yaml` edits require a full **gateway restart** to take effect. (`hermes mcp add` even prints "Start a new session to use these tools", which isn't an option without downtime on a long-running gateway.)

## Solution

A gateway background watcher that mirrors the TUI behavior:

- **`GatewayRunner._mcp_config_watcher`** — a background task that joins the existing gateway watcher family (`_session_expiry_watcher`, `_platform_reconnect_watcher`, …). It polls `config.yaml` every 5s and reloads MCP connections when the `mcp_servers` subtree changes. Cheap: a `stat()` with an mtime fast-path; only a real `mcp_servers` change reconnects. It is cancelled with the other background tasks on shutdown.
- **`mcp_config_watch`** config flag (default **on**) to opt out on locked-down deployments.

To avoid duplicating logic, two pieces are extracted and shared:

1. **`hermes_cli.mcp_startup.detect_mcp_servers_change(cfg_path, prev_mtime, prev_servers)`** — the mtime fast-path + `mcp_servers` deep-compare, now used by **both** the TUI (`_check_config_mcp_changes`) and the gateway watcher. It never raises on a missing / partial / invalid config, so it is safe to poll.
2. **`GatewayRunner._reload_mcp_connections()`** — the event-independent reload core (shutdown → re-discover → refresh cached agents), extracted from `_execute_mcp_reload` and reused by **both** `/reload-mcp` and the watcher. Cached agents are still refreshed with their per-agent toolset overrides preserved, so existing sessions pick up tool changes without `/new`.

## Files

| File | Change |
|---|---|
| `hermes_cli/mcp_startup.py` | add `detect_mcp_servers_change()` (shared detector) |
| `cli.py` | TUI `_check_config_mcp_changes` now delegates to the shared detector (behavior identical) |
| `gateway/run.py` | add `_reload_mcp_connections` (extracted), `_mcp_config_watcher`, `_check_config_mcp_changes`; register the watcher task; slim `_execute_mcp_reload` to reuse the extracted core |
| `hermes_cli/config.py` | add `mcp_config_watch` to `DEFAULT_CONFIG` |
| `tests/hermes_cli/test_mcp_config_change_detection.py` | new — unit tests for the detector |
| `tests/gateway/test_mcp_config_watch_gateway.py` | new — gateway watcher tests |

## Safety / edge cases

- **Debounced** (5s poll); only an actual `mcp_servers` change reloads — editing any other config section is a no-op.
- **Never blocks the event loop**: detection runs via `asyncio.to_thread`; the reconnect runs in an executor inside `_reload_mcp_connections`, so a hung MCP server can't stall the gateway.
- **Partial writes / invalid YAML** (an editor mid-save) are treated as "no change" and never raise.
- **Opt-out** via `mcp_config_watch: false`.
- Watcher state is seeded from the on-disk config at startup, so an unchanged config does not spuriously reload on the first tick.

## Tests

New: `detect_mcp_servers_change` unit tests (added / removed / unrelated-edit / missing / invalid-yaml) and gateway watcher tests (new or removed server → reload; unrelated edit or missing file → no reload). Existing `tests/cli/test_cli_mcp_config_watch.py` and `tests/gateway/test_mcp_reload_refreshes_cached_agents.py` are unchanged and still pass (`ruff` clean).
