### PR TITLE
fix(mcp): preserve canonical media and image attachment extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1468,7 +1468,7 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"']?MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
-    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
+    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+(?!MEDIA:)\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
     r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
     re.IGNORECASE,
 )

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -270,13 +270,31 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 # Unknown non-text content type
                 attachments.append({"type": ptype, "data": part})
 
-    # MEDIA: tags in text content
+    # MEDIA: tags and markdown image URLs in text content. Reuse the gateway's
+    # canonical extractors so spaced paths, quoted paths, and cleanup rules do
+    # not diverge between native delivery and the MCP attachment view.
     text = _extract_message_content(msg)
     if text:
-        media_pattern = re.compile(r'MEDIA:\s*(\S+)')
-        for match in media_pattern.finditer(text):
-            path = match.group(1)
-            attachments.append({"type": "media", "path": path})
+        from gateway.platforms.base import BasePlatformAdapter
+
+        seen_media = {
+            item.get("path") for item in attachments if item.get("type") == "media"
+        }
+        media, _ = BasePlatformAdapter.extract_media(text)
+        for path, _is_voice in media:
+            if path not in seen_media:
+                attachments.append({"type": "media", "path": path})
+                seen_media.add(path)
+
+        image_scan = BasePlatformAdapter._mask_protected_spans(text)
+        images, _ = BasePlatformAdapter.extract_images(image_scan)
+        seen_images = {
+            item.get("url") for item in attachments if item.get("type") == "image"
+        }
+        for url, _alt_text in images:
+            if url not in seen_images:
+                attachments.append({"type": "image", "url": url})
+                seen_images.add(url)
 
     return attachments
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -338,6 +338,21 @@ class TestExtractMedia:
         media, _ = BasePlatformAdapter.extract_media(content)
         assert len(media) == 2
 
+    def test_multiple_media_tags_on_one_line(self):
+        content = "MEDIA: /a.png and MEDIA: /b.mp3"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/a.png", False), ("/b.mp3", False)]
+        assert cleaned == "and"
+
+    def test_multiple_no_space_media_tags_on_one_line(self):
+        for content in (
+            "MEDIA: /a.png and MEDIA:/b.mp3",
+            "MEDIA:/a.png and MEDIA:/b.mp3",
+            "MEDIA:/a.png MEDIA:/b.mp3",
+        ):
+            media, _cleaned = BasePlatformAdapter.extract_media(content)
+            assert media == [("/a.png", False), ("/b.mp3", False)]
+
     def test_voice_directive_removed_from_content(self):
         content = "[[audio_as_voice]]\nSome text\nMEDIA:/voice.ogg"
         _, cleaned = BasePlatformAdapter.extract_media(content)

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -347,6 +347,65 @@ class TestAttachmentExtraction:
         msg = {"content": "MEDIA: /a.png and MEDIA: /b.mp3"}
         assert len(_extract_attachments(msg)) == 2
 
+    def test_multiple_no_space_media_tags(self):
+        from mcp_serve import _extract_attachments
+
+        msg = {"content": "MEDIA:/a.png MEDIA:/b.mp3"}
+        assert _extract_attachments(msg) == [
+            {"type": "media", "path": "/a.png"},
+            {"type": "media", "path": "/b.mp3"},
+        ]
+
+    def test_media_tag_with_spaces_uses_canonical_path_extractor(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": "MEDIA: /tmp/my chart.png"}
+        assert _extract_attachments(msg) == [
+            {"type": "media", "path": "/tmp/my chart.png"}
+        ]
+
+    def test_extensionless_media_uses_canonical_path_extractor(self, tmp_path):
+        from mcp_serve import _extract_attachments
+
+        artifact = tmp_path / "Dockerfile"
+        artifact.write_text("FROM scratch")
+        msg = {"content": f"MEDIA: {artifact}"}
+        assert _extract_attachments(msg) == [
+            {"type": "media", "path": str(artifact.resolve())}
+        ]
+
+    def test_media_example_in_code_block_is_not_reported(self):
+        from mcp_serve import _extract_attachments
+
+        msg = {"content": "```text\nMEDIA: /tmp/example.png\n```"}
+        assert _extract_attachments(msg) == []
+
+    def test_markdown_image_url_in_text_is_reported(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": "![chart](https://example.com/chart.png)"}
+        assert _extract_attachments(msg) == [
+            {"type": "image", "url": "https://example.com/chart.png"}
+        ]
+
+    def test_markdown_image_examples_in_protected_spans_are_not_reported(self):
+        from mcp_serve import _extract_attachments
+
+        for content in (
+            "```md\n![chart](https://example.com/chart.png)\n```",
+            "`![chart](https://example.com/chart.png)`",
+            "> ![chart](https://example.com/chart.png)",
+        ):
+            assert _extract_attachments({"content": content}) == []
+
+    def test_result_markers_remain_text_only(self):
+        from mcp_serve import _extract_attachments
+        msg = {
+            "content": (
+                "RESULT=PASS\nEXIT_CODE=0\nARTIFACT=/tmp/chart.png\n"
+                "SUMMARY=fixture passed"
+            )
+        }
+        assert _extract_attachments(msg) == []
+
     def test_no_attachments(self):
         from mcp_serve import _extract_attachments
         assert _extract_attachments({"content": "plain text"}) == []


### PR DESCRIPTION
## Summary
- reuse the gateway canonical MEDIA and markdown-image extractors in `attachments_fetch`
- preserve paths with spaces and extensionless artifacts while ignoring protected examples
- split multiple same-line MEDIA tags correctly in the shared parser

## Independent review
Codex GPT-5.5 reviewed the diff. Three P2 edge cases were found and fixed (extensionless paths, no-space same-line tags, protected markdown-image examples). Final review found no remaining actionable issues.

## Verification
- `pytest -q tests/test_mcp_serve.py tests/gateway/test_platform_base.py` → 270 passed, 2 skipped
- `ruff check` on all changed files → clean
- `git diff --check` → clean