### PR TITLE
fix(auth): prevent provider auto-detection from disabling credential failover

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -417,7 +417,19 @@ def init_agent(
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
-    agent.provider = provider_name or ""
+    if provider_name is not None:
+        agent.provider = provider_name
+    elif (
+        agent._base_url_hostname == "chatgpt.com"
+        and "/backend-api/codex" in agent._base_url_lower
+    ):
+        agent.provider = "openai-codex"
+    elif agent._base_url_hostname == "api.x.ai":
+        agent.provider = "xai"
+    elif agent._base_url_hostname == "api.anthropic.com":
+        agent.provider = "anthropic"
+    else:
+        agent.provider = ""
     if credential_pool is not None:
         try:
             from agent.credential_pool import credential_pool_matches_provider
@@ -439,18 +451,8 @@ def init_agent(
         agent.api_mode = "codex_responses"
     elif agent.provider in {"xai", "xai-oauth"}:
         agent.api_mode = "codex_responses"
-    elif (provider_name is None) and (
-        agent._base_url_hostname == "chatgpt.com"
-        and "/backend-api/codex" in agent._base_url_lower
-    ):
-        agent.api_mode = "codex_responses"
-        agent.provider = "openai-codex"
-    elif (provider_name is None) and agent._base_url_hostname == "api.x.ai":
-        agent.api_mode = "codex_responses"
-        agent.provider = "xai"
-    elif agent.provider == "anthropic" or (provider_name is None and agent._base_url_hostname == "api.anthropic.com"):
+    elif agent.provider == "anthropic":
         agent.api_mode = "anthropic_messages"
-        agent.provider = "anthropic"
     elif agent._base_url_lower.rstrip("/").endswith("/anthropic"):
         # Third-party Anthropic-compatible endpoints (e.g. MiniMax, DashScope)
         # use a URL convention ending in /anthropic. Auto-detect these so the

--- a/tests/agent/test_credential_pool_provider_boundary.py
+++ b/tests/agent/test_credential_pool_provider_boundary.py
@@ -3,8 +3,11 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from agent.credential_pool import credential_pool_matches_provider
 from hermes_cli import runtime_provider as rp
+from run_agent import AIAgent
 
 
 def test_provider_match_requires_exact_non_custom_identity():
@@ -62,3 +65,80 @@ def test_runtime_ignores_pool_loaded_for_different_provider(monkeypatch):
     assert resolved["provider"] == "deepseek"
     assert resolved["api_key"] == "deepseek-key"
     assert resolved["base_url"] == "https://api.deepseek.com/v1"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "pool_provider", "expected_provider", "expected_api_mode"),
+    [
+        (
+            "https://chatgpt.com/backend-api/codex",
+            "openai-codex",
+            "openai-codex",
+            "codex_responses",
+        ),
+        ("https://api.x.ai/v1", "xai", "xai", "codex_responses"),
+        (
+            "https://api.anthropic.com",
+            "anthropic",
+            "anthropic",
+            "anthropic_messages",
+        ),
+    ],
+)
+def test_url_inferred_provider_keeps_matching_credential_pool(
+    base_url, pool_provider, expected_provider, expected_api_mode
+):
+    pool = SimpleNamespace(provider=pool_provider)
+
+    agent = AIAgent(
+        provider=None,
+        base_url=base_url,
+        api_key="test-key",
+        model="test-model",
+        credential_pool=pool,
+        skip_context_files=True,
+        skip_memory=True,
+        quiet_mode=True,
+    )
+
+    assert agent.provider == expected_provider
+    assert agent.api_mode == expected_api_mode
+    assert agent._credential_pool is pool
+
+
+def test_provider_inference_is_independent_of_explicit_api_mode():
+    pool = SimpleNamespace(provider="anthropic")
+
+    agent = AIAgent(
+        provider=None,
+        base_url="https://api.anthropic.com",
+        api_mode="chat_completions",
+        api_key="test-key",
+        model="test-model",
+        credential_pool=pool,
+        skip_context_files=True,
+        skip_memory=True,
+        quiet_mode=True,
+    )
+
+    assert agent.provider == "anthropic"
+    assert agent.api_mode == "chat_completions"
+    assert agent._credential_pool is pool
+
+
+def test_url_inference_still_rejects_mismatched_credential_pool():
+    pool = SimpleNamespace(provider="openai-codex")
+
+    agent = AIAgent(
+        provider=None,
+        base_url="https://api.anthropic.com",
+        api_key="test-key",
+        model="test-model",
+        credential_pool=pool,
+        skip_context_files=True,
+        skip_memory=True,
+        quiet_mode=True,
+    )
+
+    assert agent.provider == "anthropic"
+    assert agent._credential_pool is None


### PR DESCRIPTION
## What does this PR do?

Prevents provider auto-detection from silently disabling credential rotation and failover.

When an agent is constructed with `provider=None`, Hermes can infer OpenAI Codex, xAI, or Anthropic from its API endpoint. Credential-pool validation currently runs before that inference. The pool is therefore checked against an empty provider identity and discarded, even when it belongs to the provider Hermes identifies immediately afterward.

The initial request may still work with the supplied credential, but the agent no longer has its pool available for rotation or failover.

This PR resolves the provider identity before validating the pool. Mismatched pools continue to fail closed, and API-mode selection remains independent.

## Related Issue

Fixes #63425.

Follow-up to #63048.

### Regression history

#63048 added provider-boundary validation to prevent a credential pool from being used with the wrong provider or custom endpoint.

That validation is correct, but it was placed before the existing URL-based provider inference. With `provider=None`, the validation sees an empty provider identity and rejects a correctly scoped pool.

This change preserves the isolation added by #63048 while correcting the initialization order:

1. Resolve the explicit or URL-inferred provider.
2. Validate the credential pool against that provider.
3. Select the API mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Moved the existing Codex, xAI, and Anthropic endpoint inference ahead of credential-pool validation in `agent/agent_init.py`.
- Removed the now-redundant provider assignments from API-mode selection.
- Added public-constructor regressions covering:
  - matching pools for all three inferred providers
  - explicit `api_mode` preservation
  - rejection of a pool belonging to another provider

## How to Test

```bash
uv pip install -e '.[all,dev]'

pytest \
  tests/agent/test_credential_pool_provider_boundary.py \
  tests/agent/test_credential_pool_routing.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/run_agent/test_anthropic_third_party_oauth_guard.py \
  -q
```

Result:

```text
71 passed
```

The constructor regression fails on current `main`: Hermes infers the correct provider and API mode, but `agent._credential_pool` is `None`.

With this change, a matching pool remains attached to the agent. The negative control confirms that a pool belonging to another provider is still rejected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run all affected tests and they pass (71 passed)
- [x] I've added tests for my changes
- [x] I've tested on Linux 6.8 with Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A; no user-facing interface changed
- [x] `cli-config.yaml.example` — N/A; no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change uses existing platform-independent URL parsing
- [x] Tool descriptions and schemas — N/A; no tool behavior changed

## Screenshots / Logs

Not applicable. This change affects agent initialization and is covered by constructor-level regression tests.
