### PR TITLE
fix(kanban): tolerate incomplete completed run history

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8349,7 +8349,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             "SELECT t.id, t.title, r.summary, r.ended_at "
             "FROM task_runs r JOIN tasks t ON r.task_id = t.id "
             "WHERE r.profile = ? AND r.task_id != ? "
-            "  AND r.outcome = 'completed' "
+            "  AND r.outcome = 'completed' AND r.ended_at IS NOT NULL "
             "ORDER BY r.ended_at DESC LIMIT 5",
             (task.assignee, task_id),
         ).fetchall()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -182,6 +182,32 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_ignores_completed_history_missing_end_time(worker_env):
+    """Legacy malformed runs must not break a worker's task context."""
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        historical = kb.create_task(
+            conn, title="legacy completed task", assignee="test-worker"
+        )
+        assert kb.claim_task(conn, historical)
+        assert kb.complete_task(conn, historical, summary="legacy completion")
+        conn.execute(
+            "UPDATE task_runs SET ended_at = NULL WHERE task_id = ?",
+            (historical,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+
+    shown = json.loads(kt._handle_show({}))
+    assert shown["task"]["id"] == worker_env
+    assert historical not in shown["worker_context"]
+
+
 def test_show_explicit_task_id(worker_env):
     """Peek at a different task than the one in env."""
     from hermes_cli import kanban_db as kb


### PR DESCRIPTION
## What does this PR do?

Prevents `kanban_show` from crashing when legacy or malformed `task_runs` history contains a row marked `completed` with `ended_at = NULL`.

The recent-worker-history renderer called `int(row["ended_at"])` unconditionally. Completed rows without an end time cannot be rendered chronologically, so this change excludes them from that bounded history query instead.

## Related Issue

No matching issue or PR found in an open/closed search for this specific `ended_at` / incomplete-completed-history failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/kanban_db.py`: require `r.ended_at IS NOT NULL` for recent completed role history before timestamp formatting.
- `tests/tools/test_kanban_tools.py`: add an end-to-end regression test via `kanban_show` with a deliberately malformed completed run.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_db.py`.
2. Confirm the two suites pass (322 tests).
3. The new regression test creates a completed historical task, nulls its `ended_at`, and verifies the current worker task still renders without including the malformed history item.

## Verification notes

- Targeted canonical test runner: **322 passed**.
- `py_compile` passed for `hermes_cli/kanban_db.py` and `tools/kanban_tools.py`.
- `git diff --check` passed.
- The full local suite was also attempted. It has unrelated host/baseline failures and a timeout (68 failures across unmodified files, plus 11 files that did not run). One representative failure, `tests/tools/test_search_hidden_dirs.py`, was reproduced unchanged on a clean `origin/main` worktree: the live-system guard blocks the test's `rg` subprocess as a potential process killer. Upstream CI remains the authoritative full-suite gate.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and issues.
- [x] This PR contains only the bounded Kanban crash fix and its regression test.
- [ ] I have a fully green local `pytest tests/ -q` run; see the baseline/host verification note above.
- [x] I added a regression test for the bug.
- [x] I tested on Linux (Ubuntu-hosted Hermes runtime).

### Documentation & Housekeeping

- [x] Relevant documentation/config/schema/tool descriptions are N/A; this only filters malformed historical rows before timestamp rendering.
- [x] Cross-platform impact considered: SQLite semantics and Python timestamp handling are platform-independent.
