### PR TITLE
fix(matrix): drain crypto handlers before DB shutdown

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import asyncio
 import array
+import importlib
 import inspect
 import logging
 import mimetypes
@@ -62,6 +63,8 @@ import shutil
 import subprocess
 import sys
 import time
+from contextvars import ContextVar
+from functools import wraps
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
 
@@ -138,6 +141,39 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
+
+
+_MATRIX_CRYPTO_TASK_OWNER: ContextVar[Any | None] = ContextVar(
+    "matrix_crypto_task_owner",
+    default=None,
+)
+_BACKGROUND_TRACKER_ATTR = "_hermes_matrix_background_tracker"
+
+
+def _install_mautrix_background_task_tracker() -> bool:
+    """Track nested mautrix crypto tasks without claiming other clients' work."""
+    try:
+        background_task = importlib.import_module("mautrix.util.background_task")
+    except ImportError:
+        # Structural test doubles and older SDKs may omit this optional module.
+        return False
+
+    create = getattr(background_task, "create")
+    if getattr(create, _BACKGROUND_TRACKER_ATTR, False):
+        return True
+
+    @wraps(create)
+    def tracked_create(coro, *args, **kwargs):
+        owner = _MATRIX_CRYPTO_TASK_OWNER.get()
+        task = create(coro, *args, **kwargs)
+        if owner is not None:
+            owner._track_matrix_handler_task(task)
+        return task
+
+    setattr(tracked_create, _BACKGROUND_TRACKER_ATTR, True)
+    setattr(background_task, "create", tracked_create)
+    return True
+
 
 logger = logging.getLogger(__name__)
 
@@ -1030,6 +1066,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._client: Any = None  # mautrix.client.Client
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
+        self._matrix_handler_tasks: Set[asyncio.Task] = set()
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
         self._closing = False
         self._startup_ts: float = 0.0
@@ -1654,6 +1691,7 @@ class MatrixAdapter(BasePlatformAdapter):
                                     )
 
                     client.crypto = olm
+                    self._instrument_crypto_handlers(client, olm)
                     logger.info(
                         "Matrix: E2EE enabled (store: %s%s)",
                         str(_CRYPTO_DB_PATH),
@@ -1757,6 +1795,95 @@ class MatrixAdapter(BasePlatformAdapter):
         self._mark_connected()
         return True
 
+    def _track_matrix_handler_task(self, task: asyncio.Task) -> None:
+        """Keep adapter-owned handler work visible to disconnect()."""
+        if task.done():
+            return
+        self._matrix_handler_tasks.add(task)
+        task.add_done_callback(self._matrix_handler_tasks.discard)
+
+    def _instrument_crypto_handlers(self, client: Any, olm: Any) -> None:
+        """Track mautrix crypto handlers and background work they spawn."""
+        if not _install_mautrix_background_task_tracker():
+            logger.debug(
+                "Matrix: mautrix background task helper unavailable; "
+                "only top-level crypto handlers will be tracked"
+            )
+
+        crypto_owners = [olm]
+        dispatchers = getattr(client, "dispatchers", {})
+        if isinstance(dispatchers, dict):
+            crypto_owners.extend(
+                dispatcher
+                for dispatcher in dispatchers.values()
+                if type(dispatcher).__name__ == "DecryptionDispatcher"
+            )
+
+        event_handlers = getattr(client, "event_handlers", {})
+        if not isinstance(event_handlers, dict):
+            logger.warning(
+                "Matrix: mautrix event handler registry unavailable; "
+                "crypto teardown task tracking is disabled"
+            )
+            return
+
+        registrations = []
+        for event_type, handlers in event_handlers.items():
+            if not isinstance(handlers, dict):
+                continue
+            for handler, props in list(handlers.items()):
+                handler_owner = getattr(handler, "__self__", None)
+                if any(handler_owner is owner for owner in crypto_owners):
+                    registrations.append((event_type, handler, props))
+
+        for event_type, handler, props in registrations:
+            tracked_handler = self._tracked_crypto_handler(handler)
+            client.remove_event_handler(event_type, handler)
+            client.add_event_handler(
+                event_type,
+                tracked_handler,
+                # Mautrix defaults most crypto handlers to fire-and-forget.
+                # Returning them from handle_sync makes the sync loop own the
+                # top-level task; the wrapper tracks nested crypto work.
+                wait_sync=True,
+                sync_stream=getattr(props, "sync_stream", None),
+            )
+
+        logger.debug(
+            "Matrix: tracking %d mautrix crypto event handler(s)",
+            len(registrations),
+        )
+
+    def _tracked_crypto_handler(self, handler):
+        @wraps(handler)
+        async def tracked(*args, **kwargs):
+            task = asyncio.current_task()
+            if task is not None:
+                self._track_matrix_handler_task(task)
+            token = _MATRIX_CRYPTO_TASK_OWNER.set(self)
+            try:
+                return await handler(*args, **kwargs)
+            finally:
+                _MATRIX_CRYPTO_TASK_OWNER.reset(token)
+
+        return tracked
+
+    async def _drain_matrix_handler_tasks(self) -> None:
+        """Cancel and await handlers before their crypto-store dependency closes."""
+        current = asyncio.current_task()
+        while True:
+            pending = [
+                task
+                for task in self._matrix_handler_tasks
+                if task is not current and not task.done()
+            ]
+            if not pending:
+                break
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._matrix_handler_tasks.clear()
+
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
@@ -1783,6 +1910,8 @@ class MatrixAdapter(BasePlatformAdapter):
         if redaction_tasks:
             await asyncio.gather(*redaction_tasks, return_exceptions=True)
         self._reaction_redaction_tasks.clear()
+
+        await self._drain_matrix_handler_tasks()
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
@@ -2722,12 +2851,21 @@ class MatrixAdapter(BasePlatformAdapter):
         if inspect.isawaitable(tasks):
             tasks = await tasks
         if tasks:
+            tasks = list(tasks)
+            for task in tasks:
+                if isinstance(task, asyncio.Task):
+                    self._track_matrix_handler_task(task)
             # return_exceptions=True so one failing event handler doesn't abort
             # the whole gather and silently drop the SIBLING events in the same
             # sync response (a bare gather re-raises the first exception, leaving
             # the rest of the batch unprocessed). Mirrors the invite/redaction
             # gathers above. Surface each failure instead of swallowing it.
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+            try:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+            finally:
+                for task in tasks:
+                    if isinstance(task, asyncio.Task):
+                        self._matrix_handler_tasks.discard(task)
             for result in results:
                 if isinstance(result, Exception):
                     logger.warning(

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1647,6 +1647,115 @@ class TestMatrixEncryptedEventHandler:
 
 class TestMatrixDisconnect:
     @pytest.mark.asyncio
+    async def test_disconnect_drains_nested_crypto_tasks_before_stopping_db(self):
+        """Mautrix crypto work must not outlive the SQLite crypto pool."""
+        adapter = _make_adapter()
+        adapter._sync_task = None
+
+        background_task = types.ModuleType("mautrix.util.background_task")
+        setattr(
+            background_task,
+            "create",
+            lambda coro, *args, **kwargs: asyncio.create_task(coro),
+        )
+        mautrix_util = types.ModuleType("mautrix.util")
+        setattr(mautrix_util, "background_task", background_task)
+
+        class CryptoHandler:
+            def __init__(self):
+                self.nested_started = asyncio.Event()
+                self.nested_finished = asyncio.Event()
+
+            async def handle(self, _event):
+                getattr(background_task, "create")(self._nested_store_read())
+
+            async def _nested_store_read(self):
+                self.nested_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    self.nested_finished.set()
+
+        crypto = CryptoHandler()
+
+        class DecryptionDispatcher(CryptoHandler):
+            pass
+
+        decrypt = DecryptionDispatcher()
+
+        async def ordinary_handler(_event):
+            return None
+
+        props = types.SimpleNamespace(wait_sync=False, sync_stream=None)
+
+        class FakeClient:
+            def __init__(self):
+                self.event_handlers = {
+                    "encrypted": {decrypt.handle: props},
+                    "device": {crypto.handle: props},
+                    "message": {ordinary_handler: props},
+                }
+                self.dispatchers = {DecryptionDispatcher: decrypt}
+                self.api = types.SimpleNamespace(
+                    session=types.SimpleNamespace(close=AsyncMock())
+                )
+
+            def remove_event_handler(self, event_type, handler):
+                self.event_handlers[event_type].pop(handler)
+
+            def add_event_handler(
+                self, event_type, handler, *, wait_sync=False, sync_stream=None
+            ):
+                self.event_handlers[event_type][handler] = types.SimpleNamespace(
+                    wait_sync=wait_sync,
+                    sync_stream=sync_stream,
+                )
+
+            def handle_sync(self, _data):
+                handler = next(iter(self.event_handlers["encrypted"]))
+                return [asyncio.create_task(handler(object()))]
+
+        client = FakeClient()
+        adapter._client = client
+
+        crypto_db = types.SimpleNamespace()
+
+        async def stop_crypto_db():
+            assert decrypt.nested_finished.is_set()
+
+        crypto_db.stop = AsyncMock(side_effect=stop_crypto_db)
+        adapter._crypto_db = crypto_db
+
+        with patch.dict(
+            sys.modules,
+            {
+                "mautrix.util": mautrix_util,
+                "mautrix.util.background_task": background_task,
+            },
+        ):
+            adapter._instrument_crypto_handlers(client, crypto)
+
+            wrapped_crypto = next(iter(client.event_handlers["encrypted"]))
+            assert wrapped_crypto is not decrypt.handle
+            assert client.event_handlers["encrypted"][wrapped_crypto].wait_sync is True
+            wrapped_device = next(iter(client.event_handlers["device"]))
+            assert wrapped_device is not crypto.handle
+            assert client.event_handlers["device"][wrapped_device].wait_sync is True
+            assert next(iter(client.event_handlers["message"])) is ordinary_handler
+
+            await adapter._dispatch_sync(
+                {"rooms": {"join": {}}, "next_batch": "s1"}
+            )
+            await asyncio.wait_for(decrypt.nested_started.wait(), timeout=1)
+            assert adapter._matrix_handler_tasks
+
+            await adapter.disconnect()
+
+        assert decrypt.nested_finished.is_set()
+        crypto_db.stop.assert_awaited_once()
+        assert adapter._matrix_handler_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_disconnect_closes_api_session(self):
         """disconnect() should close client.api.session."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- re-register mautrix Olm and decryption handlers as sync-owned tasks while preserving their stream filters
- track nested mautrix crypto background work with an adapter-scoped context
- cancel and await all tracked crypto work before stopping the Matrix SQLite crypto database

This prevents standalone/cron E2EE teardown from closing the crypto pool while decrypt or device handlers still use it. Ordinary Matrix application handlers keep their existing dispatch behavior.

Closes #63395.

## Root cause and coverage

Pinned mautrix 0.21.0 dispatches most crypto handlers through a fire-and-forget background task helper. Hermes awaited only the small `wait_sync` subset, so cancelling `_sync_task` did not own every crypto task before `_crypto_db.stop()`.

The regression models both the decryption dispatcher and Olm-owned handlers, including nested background work. It proves cancellation completes before database stop and that non-crypto handlers are not rewritten. The sibling audit covers initial sync, continuous sync, reconnect cleanup, and the ephemeral adapter path used by cron delivery.

## Validation

- 102 Matrix and async-session-store tests passed after rebasing onto current main
- Ruff, `git diff --check`, public commit identity, metadata scan, gitleaks, and the Hermes publish gate passed
- no live Matrix account, homeserver, credentials, or Hermes state was used
