### PR TITLE
feat(desktop): preview local paths in completed assistant messages

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
@@ -6,6 +6,7 @@ import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
 import {
   $previewTarget,
   clearSessionPreviewRegistry,
+  getSessionPreviewRecord,
   type PreviewTarget,
   registerSessionPreview
 } from '@/store/preview'
@@ -112,7 +113,8 @@ describe('usePreviewRouting', () => {
     act(() => {
       $messages.set([
         assistantMessage('a1', 'Preview: http://localhost:5173/'),
-        assistantMessage('a2', 'Open /work/demo.html')
+        assistantMessage('a2', 'Open /work/demo.html'),
+        assistantMessage('a3', 'Saved file:///work/report.pdf and ./dist/index.html')
       ])
     })
 
@@ -139,6 +141,7 @@ describe('usePreviewRouting', () => {
     act(() => handleEvent({ payload: { path: './dist/index.html' }, session_id: 'session-1', type: 'tool.complete' }))
 
     expect($previewTarget.get()).toBeNull()
-    expect(window.localStorage.getItem('hermes.desktop.sessionPreviews.v1')).toBeNull()
+    expect(getSessionPreviewRecord('session-1')).toBeNull()
+    expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text-links.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text-links.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const originalResizeObserver = globalThis.ResizeObserver
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    }
+  )
+})
+
+afterAll(() => {
+  vi.stubGlobal('ResizeObserver', originalResizeObserver)
+})
+
+describe('MarkdownLink preview routing', () => {
+  afterEach(() => cleanup())
+
+  it.each([
+    '/Users/andrewconsidine/Hermes-Workspace/context/report.md',
+    'file:///Users/andrewconsidine/Hermes-Workspace/context/report.md',
+    String.raw`C:\Users\Andrew\Documents\report.pdf`,
+    './artifacts/chart.png'
+  ])('leaves the ordinary local href %s to the capped message footer', href => {
+    render(<MarkdownTextContent isRunning={false} text={`[artifact](${href})`} />)
+
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+  })
+
+  it.each([
+    ['inline code', '`[artifact](/tmp/example.md)`'],
+    ['fenced code', '```markdown\n[artifact](/tmp/example.md)\n```']
+  ])('does not promote local Markdown links inside %s', (_name, text) => {
+    render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+  })
+
+  it('does not promote local Markdown images', () => {
+    render(<MarkdownTextContent isRunning={false} text="![chart](/tmp/chart.png)" />)
+
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+  })
+
+  it('preserves HTTP links as external anchors', async () => {
+    render(<MarkdownTextContent isRunning={false} text="[docs](https://example.com/docs)" />)
+
+    const link = await screen.findByRole('link', { name: 'docs' })
+
+    expect(link.getAttribute('href')).toBe('https://example.com/docs')
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+  })
+
+  it.each([
+    '/Users/andrewconsidine/.ssh/config.pdf',
+    '/tmp/client-private-key.pdf',
+    'file:///Users/andrewconsidine/.aws/credentials.txt'
+  ])('does not promote the secret-looking local link %s', href => {
+    render(<MarkdownTextContent isRunning={false} text={`[secret](${href})`} />)
+
+    expect(document.body.textContent).toContain('secret')
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -31,11 +31,16 @@ import {
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, Volume2Icon, VolumeXIcon, XIcon } from '@/lib/icons'
-import { extractPreviewTargets } from '@/lib/preview-targets'
+import {
+  extractAutoPreviewTargets,
+  extractLocalMarkdownPreviewTargets,
+  extractPreviewTargets
+} from '@/lib/preview-targets'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
+import { $currentCwd } from '@/store/session'
 import { $voicePlayback } from '@/store/voice-playback'
 
 interface MessageActionProps {
@@ -54,6 +59,7 @@ export const AssistantMessage: FC<{
 }> = ({ onBranchInNewChat, onDismissError }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
+  const currentCwd = useStore($currentCwd)
   const { t } = useI18n()
 
   // PERF: this component must NOT subscribe to the streaming text. Every
@@ -70,16 +76,44 @@ export const AssistantMessage: FC<{
   // the selector returns '' (stable), so per-token flushes skip the regex
   // scan and the re-render it would cause.
   const completedText = useAuiState(s =>
-    s.message.status?.type === 'running' ? '' : messageContentText(s.message.content)
+    s.message.status?.type === 'complete' ? messageContentText(s.message.content) : ''
   )
 
   const previewTargets = useMemo(() => {
-    if (!completedText || !/(https?:\/\/|file:\/\/)/i.test(completedText)) {
+    if (!completedText) {
       return []
     }
 
-    return pickPrimaryPreviewTarget(extractPreviewTargets(completedText))
-  }, [completedText])
+    const explicitTargets = pickPrimaryPreviewTarget(extractPreviewTargets(completedText))
+
+    const includeRelative = Boolean(currentCwd)
+    const markdownTargets = new Set(extractLocalMarkdownPreviewTargets(completedText, includeRelative))
+
+    const autoTargets = extractAutoPreviewTargets(completedText, {
+      includeRelative,
+      maxTargets: 3
+    }).filter(target => !markdownTargets.has(target))
+
+    const candidates = [
+      ...explicitTargets.map(target => ({ source: 'explicit-link' as const, target })),
+      ...[...markdownTargets].map(target => ({ source: 'auto-detected' as const, target })),
+      ...autoTargets.map(target => ({ source: 'auto-detected' as const, target }))
+    ]
+
+    const seen = new Set<string>()
+
+    return candidates
+      .filter(({ target }) => {
+        if (seen.has(target)) {
+          return false
+        }
+
+        seen.add(target)
+
+        return true
+      })
+      .slice(0, 3)
+  }, [completedText, currentCwd])
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
 
@@ -106,8 +140,8 @@ export const AssistantMessage: FC<{
         {isRunning && <StreamStallIndicator />}
         {previewTargets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
-            {previewTargets.map(target => (
-              <PreviewAttachment key={target} source="explicit-link" target={target} />
+            {previewTargets.map(({ source, target }) => (
+              <PreviewAttachment key={target} source={source} target={target} />
             ))}
           </div>
         )}

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -1,7 +1,10 @@
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { useEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $previewTarget, clearSessionPreviewRegistry, getSessionPreviewRecord } from '@/store/preview'
+import { $activeSessionId, $currentCwd } from '@/store/session'
 
 import { Thread } from '.'
 
@@ -48,6 +51,10 @@ vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
   window.setTimeout(() => callback(performance.now()), 0)
 )
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', {
+  ...globalThis.CSS,
+  escape: (value: string) => value.replace(/[^A-Za-z0-9_-]/g, character => `\\${character.codePointAt(0)?.toString(16)} `)
+})
 
 Element.prototype.scrollTo = function scrollTo() {}
 
@@ -127,6 +134,14 @@ function assistantErrorMessage(error: string): ThreadMessage {
       steps: [],
       custom: {}
     }
+  } as ThreadMessage
+}
+
+function assistantIncompleteTextMessage(text: string): ThreadMessage {
+  return {
+    ...assistantMessage(text, false),
+    id: 'assistant-incomplete-text-1',
+    status: { type: 'incomplete', reason: 'error', error: 'Provider failed after partial output.' }
   } as ThreadMessage
 }
 
@@ -394,6 +409,7 @@ function DismissibleErrorHarness({ onDismissError }: { onDismissError: (messageI
 
 describe('assistant-ui streaming renderer', () => {
   beforeEach(() => {
+    cleanup()
     resizeObservers.clear()
   })
 
@@ -450,6 +466,134 @@ describe('assistant-ui streaming renderer', () => {
 
     expect(onDismissError).toHaveBeenCalledTimes(1)
     expect(onDismissError).toHaveBeenCalledWith('assistant-error-1')
+  })
+
+  it('does not normalize or read a local path until Open preview is clicked', async () => {
+    const path = '/Users/andrewconsidine/Hermes-Workspace/context/report.md'
+    const previousDesktop = window.hermesDesktop
+    const previousCwd = $currentCwd.get()
+    const previousSessionId = $activeSessionId.get()
+
+    const normalizePreviewTarget = vi.fn(async (target: string) => ({
+      kind: 'file' as const,
+      label: 'report.md',
+      path: target,
+      previewKind: 'text' as const,
+      source: target,
+      url: `file://${target}`
+    }))
+
+    const readFileText = vi.fn()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { normalizePreviewTarget, readFileText }
+    })
+    $activeSessionId.set('auto-preview-consent-test')
+    $currentCwd.set('')
+    $previewTarget.set(null)
+    clearSessionPreviewRegistry()
+
+    try {
+      const running = assistantMessage(`Saved at ${path}`)
+      const completed = assistantMessage(`Saved at ${path}`, false)
+      const view = render(<RunningMessageHarness message={running} />)
+
+      expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+      expect(normalizePreviewTarget).not.toHaveBeenCalled()
+      expect(readFileText).not.toHaveBeenCalled()
+
+      view.rerender(<MessageHarness message={completed} />)
+
+      const button = await screen.findByRole('button', { name: 'Open preview' })
+
+      expect(screen.getByTitle(path).textContent).toBe('report.md')
+      expect(normalizePreviewTarget).not.toHaveBeenCalled()
+      expect(readFileText).not.toHaveBeenCalled()
+      expect($previewTarget.get()).toBeNull()
+
+      fireEvent.click(button)
+
+      await waitFor(() => {
+        expect(normalizePreviewTarget).toHaveBeenCalledTimes(1)
+        expect($previewTarget.get()?.source).toBe(path)
+      })
+      expect(normalizePreviewTarget.mock.calls[0]?.[0]).toBe(path)
+      expect(getSessionPreviewRecord('auto-preview-consent-test')?.source).toBe('auto-detected')
+      expect(readFileText).not.toHaveBeenCalled()
+    } finally {
+      clearSessionPreviewRegistry()
+      $previewTarget.set(null)
+      $activeSessionId.set(previousSessionId)
+      $currentCwd.set(previousCwd)
+      Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: previousDesktop })
+    }
+  })
+
+  it.each([
+    ['inline code', 'Inline `/tmp/example.md`'],
+    ['fenced code', '```text\n/tmp/example.md\n```'],
+    [
+      'diff output',
+      'diff --git a/x b/x\n--- /tmp/old.md\n+++ /tmp/new.md\n@@ -1 +1 @@\n-Saved /tmp/removed.md\n+Saved /tmp/added.md\ndiff --git a/old.md b/new.md\nsimilarity index 100%\nrename from /tmp/old.md\nrename to /tmp/new.md\ndiff --git a/a.png b/b.png\nBinary files /tmp/a.png and /tmp/b.png differ'
+    ],
+    ['timestamped log output', '2026-01-01T12:00:00Z wrote /tmp/report.md'],
+    ['plain-clock log output', '12:34:56 INFO wrote /tmp/report.md'],
+    ['syslog output', 'Jul 10 12:34:56 host app[1]: wrote /tmp/report.md'],
+    ['bracketed log output', '[12:00:00] wrote /tmp/report.md'],
+    ['terminal exception', 'RuntimeError: failed reading /tmp/report.md'],
+    ['Markdown image', '![chart](/tmp/chart.png)'],
+    ['reference Markdown image', '![chart][img]\n\n[img]: /tmp/chart.png']
+  ])('does not render automatic preview affordances for %s', async (_name, text) => {
+    render(<MessageHarness message={assistantMessage(text, false)} />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+    })
+  })
+
+  it('renders one preview affordance for a local Markdown link', async () => {
+    const path = '/Users/andrewconsidine/Hermes-Workspace/context/report.md'
+
+    render(<MessageHarness message={assistantMessage(`[artifact](${path})`, false)} />)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Open preview' })).toHaveLength(1)
+    })
+    expect(screen.getByTitle(path).textContent).toBe('report.md')
+  })
+
+  it('does not render inferred previews for incomplete or errored messages', async () => {
+    render(<MessageHarness message={assistantIncompleteTextMessage('Partial output saved at /tmp/report.md')} />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+    })
+  })
+
+  it('caps inferred Markdown-link and plain-path previews at three per message', async () => {
+    render(
+      <MessageHarness
+        message={assistantMessage(
+          '[one](/tmp/one.md) [two](/tmp/two.md) [three](/tmp/three.md) [four](/tmp/four.md) plus /tmp/five.md',
+          false
+        )}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Open preview' })).toHaveLength(3)
+    })
+  })
+
+  it('preserves explicit preview markers', async () => {
+    const path = '/Users/andrewconsidine/Hermes-Workspace/context/report.md'
+    const href = `#preview/${encodeURIComponent(path)}`
+
+    render(<MessageHarness message={assistantMessage(`[Preview: report.md](${href})`, false)} />)
+
+    expect(await screen.findByRole('button', { name: 'Open preview' })).toBeTruthy()
+    expect(screen.getByTitle(path).textContent).toBe('report.md')
   })
 
   // Scroll behavior (follow-at-bottom, escape-on-scroll-up, re-engage) is owned

--- a/apps/desktop/src/lib/preview-targets.test.ts
+++ b/apps/desktop/src/lib/preview-targets.test.ts
@@ -150,6 +150,12 @@ describe('automatic local preview target detection', () => {
     expect(extractAutoPreviewTargets('Visit http://localhost:5173 or https://example.com/report.pdf')).toEqual([])
   })
 
+  it('does not treat protocol-relative network URLs as absolute local paths', () => {
+    expect(
+      extractAutoPreviewTargets('See //example.com/report.md and //localhost/tmp/chart.png before /tmp/real.md')
+    ).toEqual(['/tmp/real.md'])
+  })
+
   it('ignores domains and secret-looking paths', () => {
     expect(
       extractAutoPreviewTargets(

--- a/apps/desktop/src/lib/preview-targets.test.ts
+++ b/apps/desktop/src/lib/preview-targets.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractPreviewTargets, previewTargetFromMarkdownHref, stripPreviewTargets } from './preview-targets'
+import {
+  extractAutoPreviewTargets,
+  extractLocalMarkdownPreviewTargets,
+  extractPreviewTargets,
+  previewTargetFromMarkdownHref,
+  stripPreviewTargets
+} from './preview-targets'
 
 describe('preview target detection', () => {
   it('does not infer preview targets from raw paths or URLs', () => {
@@ -23,5 +29,186 @@ describe('preview target detection', () => {
       'ready\n/tmp/mycelium-bunnies.html\nopen it'
     )
     expect(stripPreviewTargets('[Preview: demo.html](#preview:%2Ftmp%2Fdemo.html)\nopen it')).toBe('open it')
+  })
+})
+
+describe('normal Markdown local preview links', () => {
+  it('extracts an absolute local link for footer rendering', () => {
+    expect(extractLocalMarkdownPreviewTargets('[artifact](/tmp/report.md)', false)).toEqual(['/tmp/report.md'])
+  })
+
+  it('requires relative mode for normal relative Markdown links', () => {
+    const source = '[artifact](./report.md)'
+
+    expect(extractLocalMarkdownPreviewTargets(source, false)).toEqual([])
+    expect(extractLocalMarkdownPreviewTargets(source, true)).toEqual(['./report.md'])
+  })
+
+  it.each([
+    '`[artifact](/tmp/inline.md)`',
+    '```markdown\n[artifact](/tmp/fenced.md)\n```',
+    '![chart](/tmp/chart.png)',
+    '--- [old](/tmp/old.md)',
+    '2026-01-01T12:00:00Z INFO [report](/tmp/logged.md)'
+  ])('does not extract ignored Markdown content: %s', source => {
+    expect(extractLocalMarkdownPreviewTargets(source, false)).toEqual([])
+  })
+})
+
+describe('automatic local preview target detection', () => {
+  it('extracts absolute macOS and Linux paths', () => {
+    expect(
+      extractAutoPreviewTargets(
+        'Saved /Users/andrew/My Project/report.md and /tmp/hermes/output.pdf for review.'
+      )
+    ).toEqual(['/Users/andrew/My Project/report.md', '/tmp/hermes/output.pdf'])
+  })
+
+  it('extracts home-relative paths and file URLs', () => {
+    expect(extractAutoPreviewTargets('Open ~/Documents/report.md or file:///Users/andrew/demo.html.')).toEqual([
+      '~/Documents/report.md',
+      'file:///Users/andrew/demo.html'
+    ])
+  })
+
+  it('extracts Windows drive paths with backslash and slash separators', () => {
+    expect(
+      extractAutoPreviewTargets(
+        'Saved C:\\Users\\Andrew\\My Documents\\report.pdf and D:/Exports/data.csv.'
+      )
+    ).toEqual(['C:\\Users\\Andrew\\My Documents\\report.pdf', 'D:/Exports/data.csv'])
+  })
+
+  it('extracts parenthesized POSIX paths and localhost file URLs', () => {
+    expect(
+      extractAutoPreviewTargets('Saved /tmp/report(1).pdf and file://localhost/tmp/transcript.txt.')
+    ).toEqual(['/tmp/report(1).pdf', 'file://localhost/tmp/transcript.txt'])
+  })
+
+  it('deduplicates while preserving first-seen order', () => {
+    expect(extractAutoPreviewTargets('/tmp/a.md then /tmp/b.pdf then /tmp/a.md')).toEqual([
+      '/tmp/a.md',
+      '/tmp/b.pdf'
+    ])
+  })
+
+  it('strips trailing prose punctuation', () => {
+    expect(extractAutoPreviewTargets('Open (/tmp/report.md), then "/tmp/chart.png".')).toEqual([
+      '/tmp/report.md',
+      '/tmp/chart.png'
+    ])
+  })
+
+  it('ignores paths inside fenced, inline, and indented code', () => {
+    expect(
+      extractAutoPreviewTargets(
+        '```text\n/tmp/fenced.md\n```\nInline `/tmp/inline.md`\n    /tmp/indented.md\nOpen /tmp/real.md'
+      )
+    ).toEqual(['/tmp/real.md'])
+  })
+
+  it('ignores complete diff hunks, log lines, and stack traces', () => {
+    expect(
+      extractAutoPreviewTargets(
+        [
+          'diff --git a/report.md b/report.md',
+          'index 1111111..2222222 100644',
+          '--- /tmp/old.md',
+          '+++ /tmp/new.md',
+          '@@ -1 +1 @@',
+          '-Saved /tmp/removed.md',
+          '+Saved /tmp/added.md',
+          ' unchanged /tmp/context.md',
+          'diff --git a/old.md b/new.md',
+          'similarity index 100%',
+          'rename from /tmp/old.md',
+          'rename to /tmp/new.md',
+          'diff --git a/a.png b/b.png',
+          'Binary files /tmp/a.png and /tmp/b.png differ',
+          '2026-01-01T12:00:00Z wrote /tmp/timestamped.md',
+          '[12:00:00] wrote /tmp/bracketed.md',
+          '12:34:56 INFO wrote /tmp/clock.md',
+          'Jul 10 12:34:56 host app[1]: wrote /tmp/syslog.md',
+          'RuntimeError: failed reading /tmp/python-error.md',
+          'java.lang.RuntimeException: failed reading /tmp/java-error.md',
+          '    at load (/tmp/stack.ts:10:2)',
+          'Open /tmp/real.md'
+        ].join('\n')
+      )
+    ).toEqual(['/tmp/real.md'])
+  })
+
+  it('ignores local paths used as inline and reference-style Markdown image destinations', () => {
+    expect(
+      extractAutoPreviewTargets(
+        ['![inline](/tmp/inline.png)', '![chart][img]', '[img]: /tmp/reference.png', '![shortcut]', '[shortcut]: /tmp/shortcut.png'].join('\n')
+      )
+    ).toEqual([])
+  })
+
+  it('does not infer ordinary local URLs', () => {
+    expect(extractAutoPreviewTargets('Visit http://localhost:5173 or https://example.com/report.pdf')).toEqual([])
+  })
+
+  it('ignores domains and secret-looking paths', () => {
+    expect(
+      extractAutoPreviewTargets(
+        [
+          'Docs example.com/report.md;',
+          'skip /tmp/.env, /tmp/api-key.txt, /tmp/client-private-key.pdf,',
+          '/tmp/certificate.pem, and /Users/andrew/.ssh/config.pdf.'
+        ].join(' ')
+      )
+    ).toEqual([])
+  })
+
+  it('extracts common text and data artifacts supported by the preview rail', () => {
+    expect(extractAutoPreviewTargets('Saved /tmp/report.csv /tmp/transcript.txt /tmp/data.json /tmp/config.yaml')).toEqual(
+      ['/tmp/report.csv', '/tmp/transcript.txt', '/tmp/data.json']
+    )
+  })
+
+  it('does not treat prose ending in a supported extension as a path', () => {
+    expect(extractAutoPreviewTargets('Please document the changes in report.md before review.')).toEqual([])
+  })
+
+  it('ignores unsupported and suffixed file extensions', () => {
+    expect(
+      extractAutoPreviewTargets('Skip /tmp/report.docx, /tmp/report.md.bak, and file:///tmp/page.html#draft.')
+    ).toEqual([])
+  })
+
+  it('ignores invalid file URLs', () => {
+    expect(extractAutoPreviewTargets('Broken file:///%E0%A4%A.md but valid /tmp/report.md')).toEqual([
+      '/tmp/report.md'
+    ])
+  })
+
+  it('caps the default output at three targets', () => {
+    expect(extractAutoPreviewTargets('/tmp/a.md /tmp/b.md /tmp/c.md /tmp/d.md')).toEqual([
+      '/tmp/a.md',
+      '/tmp/b.md',
+      '/tmp/c.md'
+    ])
+  })
+
+  it('normalizes fractional and non-finite maxTargets values', () => {
+    expect(extractAutoPreviewTargets('/tmp/a.md /tmp/b.md', { maxTargets: 1.5 })).toEqual(['/tmp/a.md'])
+    expect(extractAutoPreviewTargets('/tmp/a.md /tmp/b.md', { maxTargets: Number.NaN })).toEqual([
+      '/tmp/a.md',
+      '/tmp/b.md'
+    ])
+  })
+
+  it('does not extract relative paths by default', () => {
+    expect(extractAutoPreviewTargets('Open ./artifacts/report.md and ../shared/chart.png')).toEqual([])
+  })
+
+  it('extracts relative paths only when explicitly enabled', () => {
+    expect(
+      extractAutoPreviewTargets('Open ./artifacts/report.md and ../shared/chart.png', {
+        includeRelative: true
+      })
+    ).toEqual(['./artifacts/report.md', '../shared/chart.png'])
   })
 })

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -210,6 +210,12 @@ function validatedAutoPreviewTarget(candidate: string, includeRelative: boolean)
       return null
     }
   } else {
+    // Protocol-relative network URLs start with `//` and must not be treated as
+    // absolute POSIX paths just because they begin with a slash.
+    if (target.startsWith('//')) {
+      return null
+    }
+
     const isAbsolute =
       target.startsWith('/') || target.startsWith('~/') || /^[A-Za-z]:(?:\\|\/)/.test(target)
 

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -41,6 +41,10 @@ export function previewTargetFromMarkdownHref(href?: string): string | null {
 }
 
 export function previewName(target: string): string {
+  if (/^[A-Za-z]:\\/.test(target)) {
+    return target.split('\\').filter(Boolean).pop() || target
+  }
+
   try {
     const url = new URL(target)
 
@@ -60,4 +64,240 @@ export function previewDisplayLabel(target: string): string {
   const escaped = previewName(target).replace(/[[\]\\]/g, '\\$&')
 
   return `Preview: ${escaped}`
+}
+
+const PREVIEWABLE_EXTENSIONS = [
+  'html?',
+  'md',
+  'markdown',
+  'svg',
+  'png',
+  'jpe?g',
+  'gif',
+  'webp',
+  'mp4',
+  'mov',
+  'webm',
+  'pdf',
+  'csv',
+  'txt',
+  'json',
+  'ya?ml',
+  'toml'
+] as const
+
+const PREVIEWABLE_EXTENSION_PATTERN = `(?:${PREVIEWABLE_EXTENSIONS.join('|')})`
+const PATH_LEAD_PATTERN = '(^|[\\s([{"\'`])'
+const PATH_BODY_PATTERN = '[^\\n\\r\\]}"\'`,;:!?]*?'
+const PATH_END_PATTERN = '(?!\\.[A-Za-z0-9])(?=$|[\\s.)\\]}"\'`,;:!?])'
+
+function pathPattern(prefix: string): RegExp {
+  return new RegExp(
+    `${PATH_LEAD_PATTERN}(?<path>${prefix}${PATH_BODY_PATTERN}\\.${PREVIEWABLE_EXTENSION_PATTERN})${PATH_END_PATTERN}`,
+    'gim'
+  )
+}
+
+const FILE_URL_RE = pathPattern('file:\\/\\/(?:localhost)?\\/')
+const POSIX_PATH_RE = pathPattern('\\/')
+const HOME_PATH_RE = pathPattern('~\\/')
+const WINDOWS_PATH_RE = pathPattern('[A-Za-z]:(?:\\\\|\\/)')
+const RELATIVE_PATH_RE = pathPattern('\\.\\.?(?:\\\\|\\/)')
+const PREVIEWABLE_FILE_EXTENSION_RE = new RegExp(`\\.${PREVIEWABLE_EXTENSION_PATTERN}$`, 'i')
+const PRIVATE_FILE_EXTENSION_RE = /\.(?:key|p12|pem|pfx)$/i
+
+const SECRET_LOCAL_PATH_RE =
+  /(?:^|[\\/])(?:\.env(?:\..*)?|\.ssh|\.aws|\.gnupg|\.kube|id_(?:rsa|dsa|ecdsa|ed25519)(?:\.pub)?|[^\\/]*(?:api[-_]?key|private[-_]?key|secret|token|credential|password|passwd)[^\\/]*)/i
+
+const FENCED_CODE_RE =
+  /(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:\n[ \t]*\2[ \t]*(?=\n|$)|$)/g
+
+const INLINE_CODE_RE = /(`+)[^\n]*?\1/g
+
+const MARKDOWN_IMAGE_RE = /!\[[^\]\n]*\]\([^)\n]+\)/g
+const MARKDOWN_IMAGE_REFERENCE_RE = /!\[([^\]\n]*)\]\[([^\]\n]*)\]/g
+const MARKDOWN_IMAGE_SHORTCUT_RE = /!\[([^\]\n]+)\](?!\s*\()/g
+const MARKDOWN_REFERENCE_DEFINITION_RE = /^\s*\[([^\]\n]+)\]:/
+
+const INDENTED_CODE_LINE_RE = /^(?: {4}|\t).*$/gm
+
+const DIFF_START_LINE_RE = /^\s*(?:diff --git\b|---\s|\+\+\+\s|@@\s)/
+
+const DIFF_BODY_LINE_RE =
+  /^(?:[- +]|\\ No newline at end of file|index\s|(?:old|new|deleted) file mode\s|similarity index\s|(?:rename|copy) (?:from|to)\s|Binary files\s|GIT binary patch\s|(?:literal|delta) \d+\s*$)/
+
+const IGNORED_OUTPUT_LINE_RE =
+  /^\s*(?:Traceback\b|File "[^"]+", line\b|at\s+\S+|Caused by:\s|[A-Za-z_$][\w.$]*(?:Error|Exception):|(?:\d{4}-\d{2}-\d{2}(?:T|\s)|\[?\d{2}:\d{2}:\d{2}(?:\.\d+)?\]?|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})|(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\b)/i
+
+const LOCAL_MARKDOWN_LINK_RE = /(?<!!)\[[^\]\n]*\]\(([^)\n]+)\)/g
+
+export interface AutoPreviewTargetOptions {
+  includeRelative?: boolean
+  maxTargets?: number
+}
+
+function maskMatch(match: string): string {
+  return match.replace(/[^\n]/g, ' ')
+}
+
+function withoutIgnoredContent(text: string): string {
+  let inDiff = false
+
+  let source = text
+    .replace(FENCED_CODE_RE, maskMatch)
+    .replace(INLINE_CODE_RE, maskMatch)
+    .replace(INDENTED_CODE_LINE_RE, maskMatch)
+
+  const imageReferenceLabels = new Set<string>()
+
+  MARKDOWN_IMAGE_REFERENCE_RE.lastIndex = 0
+
+  for (const match of source.matchAll(MARKDOWN_IMAGE_REFERENCE_RE)) {
+    imageReferenceLabels.add((match[2] || match[1] || '').trim().toLowerCase())
+  }
+
+  MARKDOWN_IMAGE_SHORTCUT_RE.lastIndex = 0
+
+  for (const match of source.matchAll(MARKDOWN_IMAGE_SHORTCUT_RE)) {
+    imageReferenceLabels.add((match[1] || '').trim().toLowerCase())
+  }
+
+  source = source
+    .replace(MARKDOWN_IMAGE_RE, maskMatch)
+    .replace(MARKDOWN_IMAGE_REFERENCE_RE, maskMatch)
+    .replace(MARKDOWN_IMAGE_SHORTCUT_RE, maskMatch)
+
+  return source
+    .split('\n')
+    .map(line => {
+      const referenceDefinition = line.match(MARKDOWN_REFERENCE_DEFINITION_RE)
+
+      if (referenceDefinition && imageReferenceLabels.has(referenceDefinition[1].trim().toLowerCase())) {
+        return maskMatch(line)
+      }
+
+      if (DIFF_START_LINE_RE.test(line)) {
+        inDiff = true
+
+        return maskMatch(line)
+      }
+
+      if (inDiff && DIFF_BODY_LINE_RE.test(line)) {
+        return maskMatch(line)
+      }
+
+      inDiff = false
+
+      return IGNORED_OUTPUT_LINE_RE.test(line) ? maskMatch(line) : line
+    })
+    .join('\n')
+}
+
+function validatedAutoPreviewTarget(candidate: string, includeRelative: boolean): string | null {
+  const target = candidate.replace(/\\ /g, ' ').trim()
+  let pathForChecks = target
+
+  if (/^file:\/\//i.test(target)) {
+    try {
+      const url = new URL(target)
+
+      if (url.protocol !== 'file:' || (url.hostname && url.hostname.toLowerCase() !== 'localhost')) {
+        return null
+      }
+
+      pathForChecks = decodeURIComponent(url.pathname)
+    } catch {
+      return null
+    }
+  } else {
+    const isAbsolute =
+      target.startsWith('/') || target.startsWith('~/') || /^[A-Za-z]:(?:\\|\/)/.test(target)
+
+    const isRelative = /^\.\.?[\\/]/.test(target)
+
+    if (!isAbsolute && (!includeRelative || !isRelative)) {
+      return null
+    }
+  }
+
+  if (
+    !PREVIEWABLE_FILE_EXTENSION_RE.test(pathForChecks) ||
+    PRIVATE_FILE_EXTENSION_RE.test(pathForChecks) ||
+    SECRET_LOCAL_PATH_RE.test(pathForChecks)
+  ) {
+    return null
+  }
+
+  return target
+}
+
+export function extractLocalMarkdownPreviewTargets(markdown: string, includeRelative: boolean): string[] {
+  const source = withoutIgnoredContent(markdown)
+  const targets: string[] = []
+  const seen = new Set<string>()
+
+  LOCAL_MARKDOWN_LINK_RE.lastIndex = 0
+
+  for (const match of source.matchAll(LOCAL_MARKDOWN_LINK_RE)) {
+    const target = validatedAutoPreviewTarget(match[1]?.trim() ?? '', includeRelative)
+
+    if (target && !seen.has(target)) {
+      seen.add(target)
+      targets.push(target)
+    }
+  }
+
+  return targets
+}
+
+export function extractAutoPreviewTargets(
+  text: string,
+  options: AutoPreviewTargetOptions = {}
+): string[] {
+  const includeRelative = options.includeRelative === true
+  const requestedMax = options.maxTargets ?? 3
+  const maxTargets = Number.isFinite(requestedMax) ? Math.max(0, Math.floor(requestedMax)) : 3
+
+  if (!text || maxTargets === 0) {
+    return []
+  }
+
+  const source = withoutIgnoredContent(text)
+  const matches: Array<{ index: number; target: string }> = []
+  const patterns = [FILE_URL_RE, POSIX_PATH_RE, HOME_PATH_RE, WINDOWS_PATH_RE]
+
+  if (includeRelative) {
+    patterns.push(RELATIVE_PATH_RE)
+  }
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0
+
+    for (const match of source.matchAll(pattern)) {
+      const candidate = match.groups?.path
+      const target = candidate ? validatedAutoPreviewTarget(candidate, includeRelative) : null
+
+      if (target) {
+        matches.push({ index: (match.index ?? 0) + match[1].length, target })
+      }
+    }
+  }
+
+  matches.sort((a, b) => a.index - b.index)
+
+  const targets: string[] = []
+  const seen = new Set<string>()
+
+  for (const match of matches) {
+    if (!seen.has(match.target)) {
+      seen.add(match.target)
+      targets.push(match.target)
+    }
+
+    if (targets.length >= maxTargets) {
+      break
+    }
+  }
+
+  return targets
 }

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -40,7 +40,7 @@ export interface PreviewServerRestart {
   url: string
 }
 
-export type PreviewRecordSource = 'explicit-link' | 'file-browser' | 'manual' | 'tool-result'
+export type PreviewRecordSource = 'auto-detected' | 'explicit-link' | 'file-browser' | 'manual' | 'tool-result'
 
 export interface SessionPreviewRecord {
   autoOpen?: boolean
@@ -216,7 +216,7 @@ function isPreviewRecord(value: unknown): value is SessionPreviewRecord {
     typeof r.id === 'string' &&
     isPreviewTarget(r.normalized) &&
     typeof r.sessionId === 'string' &&
-    ['explicit-link', 'file-browser', 'manual', 'tool-result'].includes(String(r.source)) &&
+    ['auto-detected', 'explicit-link', 'file-browser', 'manual', 'tool-result'].includes(String(r.source)) &&
     typeof r.target === 'string' &&
     (r.dismissedAt === undefined || typeof r.dismissedAt === 'number')
   )


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop already renders explicit `#preview` links as clickable preview attachments. This adds a conservative fallback for **completed assistant messages** that contain supported local file paths or ordinary local Markdown links.

- Detect supported absolute POSIX, home-relative, Windows, local `file://`, and CWD-gated relative paths.
- Preserve ordinary Markdown links inline; inferred preview cards render separately in the existing message footer.
- Combine explicit, Markdown, and prose targets through one deduplication path with a global maximum of three cards.
- Preserve explicit `#preview/...` behavior.
- Record inferred targets as `source: 'auto-detected'`.

## Consent and safety

The render path does **not** normalize, register, read, or open a file. Existing preview normalization and file access run only after the user clicks **Open preview**.

Automatic detection requires exact `status.type === 'complete'`. It fails closed for:

- running, incomplete, and errored messages;
- fenced, inline, and indented code;
- inline and reference-style Markdown images;
- complete unfenced diffs, including rename/binary metadata;
- timestamped logs, stack traces, and terminal exceptions;
- HTTP(S) and protocol-relative network URLs;
- unsupported/private-key formats and secret-looking paths.

Relative paths are eligible only when the session has a current working directory.

## Files changed

Production:

- `apps/desktop/src/lib/preview-targets.ts`
- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx`
- `apps/desktop/src/store/preview.ts`

Focused tests cover extraction, Markdown preservation, completion gating, global cap, click consent, source provenance, CWD behavior, and fail-closed cases.

## Verification

- Focused Desktop UI suite: **82/82 passed**
- Renderer and Electron TypeScript checks: passed
- Focused ESLint: passed with zero findings
- `git diff --check`: passed
- Static secret/eval scan: no hits
- Mac-local + GX10 review: no confirmed blockers
- Packaged macOS Desktop smoke after rebase: passed
  - ordinary Markdown remained inline;
  - exactly three cards rendered;
  - code/image targets stayed inert;
  - preview rail stayed closed before click;
  - clicking opened the intended file;
  - **Hide** closed the rail and restored **Open preview**.

## Related context

Related artifact/preview requests:

- #41702
- #53194
- #19489

This PR does not claim to close those broader requests; it adds conservative local-path recognition on top of the existing Desktop preview rail.
