### PR TITLE
fix(update): support package-installed gateway updates

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -213,6 +213,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
     "claude-fable-5": 1000000,
     "claude-fable": 1000000,
+    "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4532,12 +4532,6 @@ class GatewaySlashCommandsMixin:
         if is_managed():
             return f"✗ {format_managed_message('update Hermes Agent')}"
 
-        project_root = Path(__file__).parent.parent.resolve()
-        git_dir = project_root / '.git'
-
-        if not git_dir.exists():
-            return t("gateway.update.not_git_repo")
-
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:
             return t("gateway.update.hermes_cmd_not_found")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -531,6 +531,24 @@ def is_uv_tool_install() -> bool:
     return False
 
 
+def is_user_site_install(project_root: Optional[Path] = None) -> bool:
+    """Return True when the running Hermes package lives in Python's user site.
+
+    A user-site install (typically ``pip install --user``) must be upgraded with
+    the running interpreter and ``--user``. ``uv pip install --system`` targets
+    a different environment and can either fail on permissions or upgrade an
+    unrelated interpreter when ``VIRTUAL_ENV`` is inherited from the caller.
+    """
+    try:
+        import site
+
+        root = (project_root or get_project_root()).resolve()
+        user_site = Path(site.getusersitepackages()).resolve()
+        return root == user_site or user_site in root.parents
+    except (AttributeError, OSError, TypeError):
+        return False
+
+
 def recommended_update_command_for_method(method: str) -> str:
     """Return the update command or guidance for a given install method."""
     if method == "nixos":
@@ -542,6 +560,8 @@ def recommended_update_command_for_method(method: str) -> str:
     if method == "pip":
         if is_uv_tool_install():
             return "uv tool upgrade hermes-agent"
+        if is_user_site_install():
+            return f"{sys.executable} -m pip install --user --upgrade hermes-agent"
         import shutil
         if shutil.which("uv"):
             return "uv pip install --upgrade hermes-agent"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9375,17 +9375,20 @@ def cmd_update(args):
 def _cmd_update_pip(args):
     """Update Hermes via pip (for PyPI installs)."""
     from hermes_cli import __version__
-    from hermes_cli.config import is_uv_tool_install
+    from hermes_cli.config import is_user_site_install, is_uv_tool_install
 
     print(f"→ Current version: {__version__}")
     print("→ Checking PyPI for updates...")
 
     from hermes_cli.managed_uv import ensure_uv, update_managed_uv
 
-    # Keep managed uv current before using it.
-    update_managed_uv()
-
-    uv = ensure_uv()
+    user_site_install = is_user_site_install(PROJECT_ROOT)
+    uv = None
+    if not user_site_install:
+        # User-site installs use the running interpreter's pip directly. Do
+        # not bootstrap/update uv when it will not be used.
+        update_managed_uv()
+        uv = ensure_uv()
     in_venv = sys.prefix != sys.base_prefix
     # pipx-managed installs live under .../pipx/venvs/<name>/...
     pipx_managed = "pipx" in sys.prefix.split(os.sep)
@@ -9398,7 +9401,17 @@ def _cmd_update_pip(args):
     # set it for them.
     export_virtualenv = False
 
-    if is_uv_tool_install():
+    if user_site_install:
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--user",
+            "--upgrade",
+            "hermes-agent",
+        ]
+    elif is_uv_tool_install():
         if not uv:
             print("✗ Detected a uv-tool install but managed uv install failed.")
             print("  Install uv manually: https://docs.astral.sh/uv/getting-started/installation/")
@@ -9422,10 +9435,17 @@ def _cmd_update_pip(args):
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 
     print(f"→ Running: {' '.join(cmd)}")
-    run_kwargs = {}
-    if export_virtualenv:
-        run_kwargs["env"] = {**os.environ, "VIRTUAL_ENV": sys.prefix}
-    result = subprocess.run(cmd, **run_kwargs)
+    run_env = None
+    if user_site_install:
+        # A service may inherit VIRTUAL_ENV from an unrelated launcher. pip
+        # should target sys.executable's user site, never that foreign env.
+        run_env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    elif export_virtualenv:
+        run_env = {**os.environ, "VIRTUAL_ENV": sys.prefix}
+    if run_env is None:
+        result = subprocess.run(cmd)
+    else:
+        result = subprocess.run(cmd, env=run_env)
     if result.returncode != 0:
         print("✗ Update failed")
         sys.exit(1)
@@ -9519,14 +9539,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
     git_dir = PROJECT_ROOT / ".git"
 
     if not git_dir.exists():
+        from hermes_cli.config import detect_install_method
+
+        method = detect_install_method(PROJECT_ROOT)
+        if method == "pip":
+            # Package installs must always be upgraded by their package
+            # manager. On Windows, the ZIP fallback is only for source/git
+            # layouts whose checkout metadata is unavailable or unusable.
+            _cmd_update_pip(args)
+            return
         if sys.platform == "win32":
             use_zip_update = True
         else:
-            from hermes_cli.config import detect_install_method
-            method = detect_install_method(PROJECT_ROOT)
-            if method == "pip":
-                _cmd_update_pip(args)
-                return
             print("✗ Not a git repository. Please reinstall:")
             print(
                 "  curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -174,6 +174,15 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_claude_sonnet_5_uses_1m_context(self):
+        """Sonnet 5 must not fall through to the generic Claude 200K cap."""
+        assert DEFAULT_CONTEXT_LENGTHS["claude-sonnet-5"] == 1_000_000
+        with patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            assert get_model_context_length("claude-sonnet-5") == 1_000_000
+            assert get_model_context_length("anthropic/claude-sonnet-5") == 1_000_000
+
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model
         # IDs to the correct fallback entries without 128k probe-down.

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -63,47 +63,29 @@ class TestHandleUpdateCommand:
         mock_popen.assert_not_called()  # must return before reaching Popen
 
     @pytest.mark.asyncio
-    async def test_no_git_directory(self, tmp_path):
-        """Returns an error when .git does not exist."""
+    async def test_no_git_directory_delegates_to_cli_for_package_installs(self, tmp_path):
+        """A packaged install without .git still starts ``hermes update``.
+
+        The CLI owns install-method detection and knows how to update pip/uv,
+        Homebrew, Docker, and git layouts. The gateway must not reject valid
+        packaged installs before the CLI can choose the correct path.
+        """
         runner = _make_runner()
         event = _make_event()
-        # Point _hermes_home to tmp_path and project_root to a dir without .git
-        fake_root = tmp_path / "project"
-        fake_root.mkdir()
-        with patch("gateway.run._hermes_home", tmp_path), \
-             patch("gateway.run.Path") as MockPath:
-            # Path(__file__).parent.parent.resolve() -> fake_root
-            MockPath.return_value = MagicMock()
-            MockPath.__truediv__ = Path.__truediv__
-            # Easier: just patch the __file__ resolution in the method
-            pass
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
 
-        # Simpler approach — mock at method level using a wrapper
-        runner = _make_runner()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]), \
+             patch("shutil.which", return_value="/usr/bin/setsid"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
 
-        with patch("gateway.run._hermes_home", tmp_path):
-            # The handler does Path(__file__).parent.parent.resolve()
-            # We need to make project_root / '.git' not exist.
-            # Since Path(__file__) resolves to the real gateway/run.py,
-            # project_root will be the real hermes-agent dir (which HAS .git).
-            # Patch Path to control this.
-            original_path = Path
-
-            class FakePath(type(Path())):
-                pass
-
-            # Actually, simplest: just patch the specific file attr.
-            # The _handle_update_command handler lives in gateway/slash_commands.py
-            # (extracted from run.py in the god-file decomposition); it resolves
-            # project_root via Path(__file__).parent.parent, so fake that file.
-            fake_file = str(fake_root / "gateway" / "slash_commands.py")
-            (fake_root / "gateway").mkdir(parents=True)
-            (fake_root / "gateway" / "slash_commands.py").touch()
-
-            with patch("gateway.slash_commands.__file__", fake_file):
-                result = await runner._handle_update_command(event)
-
-        assert "Not a git repository" in result
+        assert "Starting Hermes update" in result
+        mock_popen.assert_called_once()
+        spawned = mock_popen.call_args[0][0]
+        assert spawned[:2] == ["/usr/bin/setsid", "bash"]
+        assert "hermes update --gateway" in spawned[-1]
 
     @pytest.mark.asyncio
     async def test_no_hermes_binary(self, tmp_path):

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -192,11 +192,14 @@ class TestCmdUpdatePipUsesUvTool:
         assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "upgrade", "hermes-agent"]
 
     @patch("subprocess.run")
-    def test_runs_uv_pip_install_when_not_uv_tool(self, mock_run):
-        """Existing behavior preserved when uv is present but Hermes isn't a tool install."""
+    def test_runs_uv_pip_install_when_not_uv_tool(self, mock_run, monkeypatch):
+        """Existing venv behavior is preserved for non-tool uv installs."""
+        from hermes_cli import main as hm
         from hermes_cli.main import _cmd_update_pip
 
         mock_run.return_value = subprocess.CompletedProcess(["uv"], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/venv")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
         with patch("shutil.which", return_value="/usr/local/bin/uv"), \
              patch("hermes_cli.config.is_uv_tool_install", return_value=False):
             _cmd_update_pip(SimpleNamespace())
@@ -340,3 +343,59 @@ class TestCmdUpdatePipInstallLayouts:
         assert "--system" not in cmd
         assert cmd == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
         assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"] == "/home/u/.hermes/hermes-agent/venv"
+
+    @patch("subprocess.run")
+    def test_user_site_install_uses_running_python_and_clears_foreign_virtualenv(
+        self, mock_run, monkeypatch
+    ):
+        """``pip --user`` upgrades its own interpreter, not inherited VIRTUAL_ENV."""
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "executable", "/usr/local/bin/python3.12")
+        monkeypatch.setenv("VIRTUAL_ENV", "/opt/unrelated")
+
+        with patch("hermes_cli.config.is_user_site_install", return_value=True), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False), \
+             patch("hermes_cli.managed_uv.update_managed_uv") as mock_update_uv, \
+             patch("hermes_cli.managed_uv.ensure_uv") as mock_ensure_uv:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/local/bin/python3.12",
+            "-m",
+            "pip",
+            "install",
+            "--user",
+            "--upgrade",
+            "hermes-agent",
+        ]
+        assert "VIRTUAL_ENV" not in mock_run.call_args.kwargs["env"]
+        mock_update_uv.assert_not_called()
+        mock_ensure_uv.assert_not_called()
+
+
+class TestCmdUpdateImplPackageRouting:
+    def test_windows_no_git_pip_install_uses_pip_not_zip(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+
+        args = SimpleNamespace(
+            yes=True,
+            backup=False,
+            force=True,
+            force_venv=True,
+            branch=None,
+        )
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm.sys, "platform", "win32")
+
+        with patch.object(hm, "_is_windows", return_value=False), \
+             patch.object(hm, "_run_pre_update_backup"), \
+             patch.object(hm, "_pause_windows_gateways_for_update", return_value=None), \
+             patch.object(hm, "_cmd_update_pip") as update_pip, \
+             patch.object(hm, "_update_via_zip") as update_zip, \
+             patch("hermes_cli.config.detect_install_method", return_value="pip"):
+            hm._cmd_update_impl(args, gateway_mode=True)
+
+        update_pip.assert_called_once_with(args)
+        update_zip.assert_not_called()


### PR DESCRIPTION
## Summary
- allow gateway `/update` for packaged installs without `.git`
- route user-site installs through the active interpreter with `pip --user` and clear unrelated `VIRTUAL_ENV`
- preserve uv-tool, pipx, venv, system, and Windows package-manager update paths
- register Claude Sonnet 5 as a 1,000,000-token model

## Independent review
Codex GPT-5.5 reviewed the complete diff. It found one Windows no-git package-routing edge case; the implementation and a regression test were added. Final review found no actionable regressions.

## Verification
- `pytest -q tests/gateway/test_update_command.py tests/hermes_cli/test_uv_tool_update.py tests/agent/test_model_metadata.py` → 179 passed
- `ruff check` on all changed files → clean
- live Linux installed-package smoke previously confirmed `/update` delegates without the git-repository error
- live auxiliary model metadata confirmed `claude-sonnet-5` context = 1,000,000