### PR TITLE
fix(tui): stop recovery hanging after gateway restart

### DIFF
--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -227,6 +227,42 @@ describe('GatewayClient websocket attach mode', () => {
     gw.kill()
   })
 
+  it('re-arms event delivery when the gateway transport restarts', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const seen: string[] = []
+
+    gw.on('event', ev => seen.push(ev.type))
+    gw.start()
+
+    const firstSocket = FakeWebSocket.instances[0]!
+
+    firstSocket.open()
+    gw.drain()
+    await Promise.resolve()
+    firstSocket.message(
+      JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
+    )
+
+    expect(seen).toEqual(['gateway.ready'])
+
+    gw.start()
+    const replacementSocket = FakeWebSocket.instances[1]!
+
+    replacementSocket.open()
+    replacementSocket.message(
+      JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
+    )
+    replacementSocket.message(
+      JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type: 'session.info', payload: {} } })
+    )
+
+    await vi.waitFor(() => expect(seen).toHaveLength(3))
+    expect(seen).toEqual(['gateway.ready', 'gateway.ready', 'session.info'])
+
+    gw.kill()
+  })
+
   it('mirrors event frames to sidecar websocket when configured', async () => {
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
     process.env.HERMES_TUI_SIDECAR_URL = 'ws://gateway.test/api/pub?token=abc&channel=demo'

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -146,6 +146,7 @@ export class GatewayClient extends EventEmitter {
   private ready = false
   private readyTimer: ReturnType<typeof setTimeout> | null = null
   private subscribed = false
+  private drainArmed = false
   private drainGeneration = 0
   private stdoutRl: ReturnType<typeof createInterface> | null = null
   private stderrRl: ReturnType<typeof createInterface> | null = null
@@ -229,6 +230,10 @@ export class GatewayClient extends EventEmitter {
     this.stdoutRl = null
     this.stderrRl = null
     this.clearReadyTimer()
+
+    if (this.drainArmed) {
+      this.scheduleDrain()
+    }
   }
 
   private startReadyTimer(python: string, cwd: string) {
@@ -615,7 +620,7 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
-  drain() {
+  private scheduleDrain() {
     // Defer the buffered-event replay to the next microtask, and DO NOT flip
     // `subscribed` until that microtask runs.
     //
@@ -659,6 +664,14 @@ export class GatewayClient extends EventEmitter {
         this.emit('exit', code)
       }
     })
+  }
+
+  drain() {
+    // Remember that the consumer has mounted. Transport resets temporarily
+    // clear `subscribed`, but replacement transports must re-arm this same
+    // deferred FIFO drain without requiring the mount effect to run again.
+    this.drainArmed = true
+    this.scheduleDrain()
   }
 
   getLogTail(limit = 20): string {


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI recovery hang after the Python gateway crashes or disconnects.

The TUI already attempts to recover automatically:

1. It detects that the gateway exited.
2. It starts a replacement gateway.
3. The replacement sends `gateway.ready`.
4. The TUI should receive that event and resume the user's session.

Step 4 is currently broken. Restarting the gateway resets `GatewayClient` to an unsubscribed state. The replacement gateway's events are buffered, but the React subscription effect only runs when the TUI first mounts—it does not run again after a gateway restart.

As a result, the replacement process starts successfully, but its `gateway.ready` event is never delivered. The TUI remains stuck on:

```text
gateway exited · recovering session…
```

The user must restart the entire TUI to recover.

This PR makes `GatewayClient` remember that the TUI consumer already subscribed. After replacing a gateway transport, it automatically re-arms the existing deferred event drain. The replacement gateway's `gateway.ready` event can then reach the recovery handler and resume the persisted session.

The initial startup behavior from #36658 remains unchanged: events received before React mounts are still buffered and delivered on a later microtask.

## Related Issue

Fixes #63434.

Related history:

- #35893 added automatic session recovery after an unexpected gateway exit.
- #36658 deferred initial buffered-event delivery to avoid React state updates during the first commit.
- #60727 adds heartbeat-driven reconnect behavior, but its reconnects still pass through the same subscription reset and do not address this recovery hang.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Separated the lifetime of the mounted TUI consumer from the lifetime of an individual gateway transport.
- Re-armed deferred event delivery whenever `GatewayClient` resets for a replacement transport.
- Preserved the generation guard that prevents stale drain microtasks from delivering old events.
- Added a regression that replaces a live gateway transport and verifies that:
  - the original `gateway.ready` is delivered
  - the replacement `gateway.ready` is delivered
  - the following `session.info` arrives once and in FIFO order

## How to Test

From `ui-tui`:

```bash
npm run build --prefix packages/hermes-ink

npm test -- --run \
  src/__tests__/gatewayClient.test.ts \
  src/__tests__/gatewayRecovery.test.ts \
  src/__tests__/createGatewayEventHandler.test.ts

npm run typecheck
npx eslint src/gatewayClient.ts src/__tests__/gatewayClient.test.ts
npx prettier --check src/gatewayClient.ts src/__tests__/gatewayClient.test.ts
```

Results:

```text
3 test files passed
96 tests passed
TypeScript typecheck passed
ESLint passed
Prettier passed
```

The new regression fails on current `main`:

```text
expected [ 'gateway.ready' ] to have a length of 3 but got 1
```

Only the original gateway event is delivered. The replacement gateway's events remain buffered.

With this change, the observed order is:

```text
gateway.ready
gateway.ready
session.info
```

This proves that event delivery survives the transport replacement and preserves FIFO ordering.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run all affected tests and checks; they pass
- [x] I've added tests for my changes
- [x] I've tested on Linux 6.8 with Node.js

### Documentation & Housekeeping

- [x] Documentation — N/A; no user-facing interface changed
- [x] `cli-config.yaml.example` — N/A; no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change uses platform-independent event and microtask behavior
- [x] Tool descriptions and schemas — N/A; no tool behavior changed

## Screenshots / Logs

Not applicable. This transport-lifecycle failure is covered by a deterministic fake-WebSocket regression.
