### PR TITLE
Harden auto-approve edit gate: treat shell-rc and config-execution files as sensitive

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -42,7 +42,32 @@ _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
 _PERMISSION_REQUEST_IDS = count(1)
 
 
-SENSITIVE_AUTO_APPROVE_NAMES = {".env", ".env.local", ".env.production", "id_rsa", "id_ed25519"}
+SENSITIVE_AUTO_APPROVE_NAMES = {
+    ".env",
+    ".env.local",
+    ".env.production",
+    "id_rsa",
+    "id_ed25519",
+    # Shell startup / login files: writing these runs arbitrary code at the
+    # next shell or login.
+    ".bashrc",
+    ".bash_profile",
+    ".bash_login",
+    ".profile",
+    ".zshrc",
+    ".zshenv",
+    ".zprofile",
+    ".zlogin",
+    # Tool config files that can execute commands or redirect trust.
+    ".gitconfig",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    ".envrc",
+}
+# Path components that indicate credentials, VCS internals, or persistence
+# locations. Any edit whose path contains one of these must always prompt.
+SENSITIVE_AUTO_APPROVE_DIR_PARTS = {".git", ".ssh", "autostart", "systemd"}
 AUTO_APPROVE_ASK = "ask"
 AUTO_APPROVE_WORKSPACE = "workspace_session"
 AUTO_APPROVE_SESSION = "session"
@@ -190,11 +215,22 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
 
 
 def _is_sensitive_auto_approve_path(path: str) -> bool:
-    parts = Path(path).expanduser().parts
-    lowered = {part.lower() for part in parts}
-    if ".git" in lowered or ".ssh" in lowered:
+    expanded = Path(path).expanduser()
+    lowered = {part.lower() for part in expanded.parts}
+    if lowered & SENSITIVE_AUTO_APPROVE_DIR_PARTS:
         return True
-    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+    if expanded.name.lower() in SENSITIVE_AUTO_APPROVE_NAMES:
+        return True
+    # Any dotfile directly in the user's home directory is treated as sensitive.
+    # This catches shell and tool rc/config files (arbitrary code execution or
+    # trust redirection) that are not individually enumerated above.
+    try:
+        resolved = expanded.resolve(strict=False)
+        if resolved.name.startswith(".") and resolved.parent == Path.home().resolve(strict=False):
+            return True
+    except (OSError, RuntimeError):
+        pass
+    return False
 
 
 def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:

--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -24,13 +24,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class EditProposal:
-    """A proposed single-file edit that can be shown to an ACP client."""
+    """A proposed file edit that can be shown to an ACP client."""
 
     tool_name: str
     path: str
     old_text: str | None
     new_text: str
     arguments: dict[str, Any]
+    # The individual target file paths this proposal touches. For single-file
+    # proposals this is ``(path,)``; for multi-file V4A patches ``path`` is a
+    # human-readable ", "-joined display string, while ``target_paths`` preserves
+    # each real path so security decisions can evaluate them independently.
+    target_paths: tuple[str, ...] = ()
 
 
 EditApprovalRequester = Callable[[EditProposal], bool]
@@ -117,6 +122,7 @@ def _proposal_for_write_file(arguments: dict[str, Any]) -> EditProposal:
         old_text=_read_text_if_exists(path),
         new_text=str(content),
         arguments=dict(arguments),
+        target_paths=(path,),
     )
 
 
@@ -150,6 +156,7 @@ def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
         old_text=old_text,
         new_text=new_text,
         arguments=dict(arguments),
+        target_paths=(path,),
     )
 
 
@@ -197,6 +204,9 @@ def _proposal_for_patch_v4a(arguments: dict[str, Any]) -> EditProposal:
         # and denied patches cannot mutate.
         new_text=patch_body,
         arguments=dict(arguments),
+        # Preserve every real target path (not just the joined display string) so
+        # a mixed patch touching a sensitive or out-of-workspace file is caught.
+        target_paths=tuple(paths),
     )
 
 
@@ -233,36 +243,65 @@ def _is_sensitive_auto_approve_path(path: str) -> bool:
     return False
 
 
+def _proposal_target_paths(proposal: EditProposal) -> tuple[str, ...]:
+    """Every real file path a proposal touches, for path-based security checks.
+
+    Falls back to the display ``path`` for any proposal constructed without an
+    explicit ``target_paths`` so the check is never silently skipped.
+    """
+    return proposal.target_paths or (proposal.path,)
+
+
+def _path_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:
     """Return whether an ACP edit proposal may bypass the prompt for this session.
 
     This is intentionally session-scoped and conservative: sensitive paths still
-    ask even under autonomous policies.
+    ask even under autonomous policies. Every individual target path is evaluated
+    independently, so a multi-file V4A patch is auto-approved only when *all* of
+    its targets qualify -- a single sensitive or out-of-workspace file forces the
+    prompt.
     """
 
     policy = str(policy or AUTO_APPROVE_ASK).strip()
-    if policy == AUTO_APPROVE_ASK or _is_sensitive_auto_approve_path(proposal.path):
+    if policy == AUTO_APPROVE_ASK:
         return False
-    path = Path(proposal.path).expanduser().resolve(strict=False)
+
+    targets = _proposal_target_paths(proposal)
+    # Any sensitive target (shell rc, credentials, .git/.ssh, home dotfile, ...)
+    # forces the prompt, even inside a mixed multi-file patch.
+    if any(_is_sensitive_auto_approve_path(target) for target in targets):
+        return False
+
     if policy == AUTO_APPROVE_SESSION:
         return True
+
     if policy == AUTO_APPROVE_WORKSPACE:
         # `/tmp` is the POSIX path but tempfile.gettempdir() is the real one on
         # every platform: `/private/tmp` on macOS (because `/tmp` is a symlink
         # and Path.resolve() follows it) and the per-user Temp dir on Windows.
         tmp_root = Path(tempfile.gettempdir()).resolve(strict=False)
-        try:
-            path.relative_to(tmp_root)
-            return True
-        except ValueError:
-            pass
-        if cwd:
-            root = Path(cwd).expanduser().resolve(strict=False)
-            try:
-                path.relative_to(root)
-                return True
-            except ValueError:
-                return False
+        workspace_root = (
+            Path(cwd).expanduser().resolve(strict=False) if cwd else None
+        )
+        # Auto-approve only if EVERY target is inside the temp dir or workspace;
+        # one out-of-scope target in a multi-file patch forces the prompt.
+        for target in targets:
+            resolved = Path(target).expanduser().resolve(strict=False)
+            if _path_within(resolved, tmp_root):
+                continue
+            if workspace_root is not None and _path_within(resolved, workspace_root):
+                continue
+            return False
+        return True
+
     return False
 
 

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
+    build_edit_proposal,
     clear_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
@@ -267,3 +268,110 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def _v4a_multifile_patch(*paths: str) -> str:
+    body = ["*** Begin Patch"]
+    for p in paths:
+        body.append(f"*** Update File: {p}")
+        body.append("@@")
+        body.append("+x")
+    body.append("*** End Patch")
+    return "\n".join(body) + "\n"
+
+
+def test_shell_and_config_rc_files_are_sensitive(tmp_path):
+    # New protected names added by this PR: writing any of these runs code or
+    # redirects trust at the next shell/login/tool invocation.
+    for name in (
+        ".bashrc",
+        ".bash_profile",
+        ".profile",
+        ".zshrc",
+        ".zshenv",
+        ".gitconfig",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        ".envrc",
+    ):
+        target = tmp_path / name
+        assert not should_auto_approve_edit(
+            EditProposal("write_file", str(target), None, "x", {}),
+            "session",
+            str(tmp_path),
+        ), f"{name} should be treated as sensitive"
+
+
+def test_persistence_and_credential_dir_paths_are_sensitive(tmp_path):
+    for rel in (
+        ".config/autostart/evil.desktop",
+        ".config/systemd/user/evil.service",
+        ".ssh/authorized_keys",
+        ".git/config",
+    ):
+        target = tmp_path / rel
+        assert not should_auto_approve_edit(
+            EditProposal("write_file", str(target), None, "x", {}),
+            "session",
+            str(tmp_path),
+        ), f"{rel} should be treated as sensitive"
+
+
+def test_v4a_proposal_preserves_individual_target_paths(tmp_path):
+    a = tmp_path / "a.py"
+    b = tmp_path / "pkg" / "b.py"
+    proposal = build_edit_proposal(
+        "patch", {"mode": "patch", "patch": _v4a_multifile_patch(str(a), str(b))}
+    )
+    assert proposal is not None
+    # Individual real paths are preserved for security checks...
+    assert proposal.target_paths == (str(a), str(b))
+    # ...while the display path stays the joined, human-readable string.
+    assert proposal.path == f"{a}, {b}"
+
+
+def test_multifile_v4a_patch_with_sensitive_target_not_last_is_not_auto_approved(tmp_path):
+    # Regression for the joined-display-string bug: the sensitive file is NOT the
+    # trailing path, so parsing ", ".join(paths) as one Path previously saw only
+    # "app.py" and auto-approved -- editing .bashrc with no prompt.
+    sensitive = tmp_path / ".bashrc"
+    normal = tmp_path / "app.py"
+    proposal = build_edit_proposal(
+        "patch",
+        {"mode": "patch", "patch": _v4a_multifile_patch(str(sensitive), str(normal))},
+    )
+    assert proposal is not None
+    assert proposal.target_paths == (str(sensitive), str(normal))
+    # Even the most permissive non-ask policies must now force the prompt.
+    assert not should_auto_approve_edit(proposal, "session", str(tmp_path))
+    assert not should_auto_approve_edit(proposal, "workspace_session", str(tmp_path))
+
+
+def test_multifile_v4a_patch_with_out_of_workspace_target_is_not_auto_approved(tmp_path):
+    # The same joined-string flaw defeated the workspace-containment check: a
+    # patch touching a file outside the workspace could still auto-approve.
+    inside = tmp_path / "a.py"
+    outside = Path(tmp_path.anchor) / "hermes_escape_dir_xyz" / "b.py"
+    proposal = build_edit_proposal(
+        "patch",
+        {"mode": "patch", "patch": _v4a_multifile_patch(str(inside), str(outside))},
+    )
+    assert proposal is not None
+    # workspace policy: one out-of-scope target forces the prompt.
+    assert not should_auto_approve_edit(proposal, "workspace_session", str(tmp_path))
+    # session policy trusts any non-sensitive path, so it still auto-approves.
+    assert should_auto_approve_edit(proposal, "session", str(tmp_path))
+
+
+def test_multifile_v4a_patch_all_safe_workspace_paths_auto_approves(tmp_path):
+    # Ensure the stricter per-target logic does not over-block legitimate
+    # multi-file patches entirely inside the workspace.
+    a = tmp_path / "a.py"
+    b = tmp_path / "pkg" / "b.py"
+    proposal = build_edit_proposal(
+        "patch", {"mode": "patch", "patch": _v4a_multifile_patch(str(a), str(b))}
+    )
+    assert proposal is not None
+    assert should_auto_approve_edit(proposal, "workspace_session", str(tmp_path))
+    assert should_auto_approve_edit(proposal, "session", str(tmp_path))


### PR DESCRIPTION
### What

Expands the auto-approve edit gate's sensitive-path check (`acp_adapter/edit_approval.py`) so it also treats shell startup files, tool config files, and user persistence locations as sensitive, so they keep prompting even under autonomous policies.

### Why

`should_auto_approve_edit` intentionally keeps sensitive paths prompting even under autonomous policies (its docstring: "sensitive paths still ask even under autonomous policies"). But `_is_sensitive_auto_approve_path` only covered `.env*`, `id_rsa`/`id_ed25519`, and `.git`/`.ssh` path components. It missed the files that most directly lead to code execution or persistence:

- shell startup / login files: `.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, ... (run at the next shell/login)
- tool config that executes or redirects trust: `.gitconfig` (alias/pager gadgets), `.npmrc`, `.pypirc`, `.netrc`, `.envrc`
- persistence: `.config/autostart/*.desktop`, `.config/systemd/user/*.service`

Under the `session` auto-approve policy these were written with no prompt, which is an easy path to running attacker-influenced content at the next shell/git/login.

### Change

- Adds the shell/tool rc/config names to the sensitive-name set.
- Treats any dotfile located directly in the user's home directory as sensitive (catches rc files not individually enumerated).
- Adds `autostart`/`systemd` to the sensitive path components.

Ordinary in-project edits still auto-approve; only home-directory config and persistence files now prompt. Offered as a hardening improvement per SECURITY.md §3.2 ("the approval gate can always catch more patterns").

Verified the change blocks the files above under every non-ask policy while leaving normal in-project file edits auto-approving.