### PR TITLE
fix(anthropic): sanitize tool schema property keys the API validator rejects

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1618,6 +1618,88 @@ def _sanitize_tool_id(tool_id: str) -> str:
     return sanitized or "tool_0"
 
 
+_ANTHROPIC_SCHEMA_PROPERTY_KEY_RE = None
+
+
+def _sanitize_anthropic_schema_property_key(key: str, seen: set[str]) -> str:
+    """Return a property key accepted by Anthropic's tool schema validator."""
+    import hashlib
+    import re
+
+    original = str(key or "")
+    sanitized = original.replace("[]", "")
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]+", "_", sanitized)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    if not sanitized:
+        sanitized = "property"
+    sanitized = sanitized[:64]
+    if sanitized not in seen:
+        seen.add(sanitized)
+        return sanitized
+
+    suffix = "_" + hashlib.sha1(original.encode("utf-8")).hexdigest()[:8]
+    base = sanitized[: 64 - len(suffix)] or "property"
+    candidate = base + suffix
+    counter = 2
+    while candidate in seen:
+        extra = f"_{counter}"
+        candidate = base[: 64 - len(suffix) - len(extra)] + suffix + extra
+        counter += 1
+    seen.add(candidate)
+    return candidate
+
+
+def _sanitize_anthropic_schema_property_keys(node: Any) -> Any:
+    """Recursively rewrite JSON Schema property keys to Anthropic-safe names."""
+    import re
+
+    global _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE
+    if _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE is None:
+        _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+
+    if isinstance(node, list):
+        return [_sanitize_anthropic_schema_property_keys(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    out = {
+        key: _sanitize_anthropic_schema_property_keys(value)
+        for key, value in node.items()
+    }
+    properties = out.get("properties")
+    if isinstance(properties, dict):
+        key_map: dict[str, str] = {}
+        seen: set[str] = set()
+        safe_properties: dict[str, Any] = {}
+        for prop_key, prop_schema in properties.items():
+            prop_key_str = str(prop_key)
+            if (
+                _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE.match(prop_key_str)
+                and prop_key_str not in seen
+            ):
+                safe_key = prop_key_str
+                seen.add(safe_key)
+            else:
+                safe_key = _sanitize_anthropic_schema_property_key(prop_key_str, seen)
+            key_map[prop_key_str] = safe_key
+            safe_properties[safe_key] = prop_schema
+        out["properties"] = safe_properties
+
+        required = out.get("required")
+        if isinstance(required, list):
+            rewritten_required = [
+                key_map.get(req, req)
+                for req in required
+                if isinstance(req, str) and key_map.get(req, req) in safe_properties
+            ]
+            if rewritten_required:
+                out["required"] = rewritten_required
+            else:
+                out.pop("required", None)
+
+    return out
+
+
 def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     """Normalize tool schemas before sending them to Anthropic.
 
@@ -1656,6 +1738,7 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
             normalized["type"] = "object"
     if normalized.get("type") == "object" and not isinstance(normalized.get("properties"), dict):
         normalized = {**normalized, "properties": {}}
+    normalized = _sanitize_anthropic_schema_property_keys(normalized)
     return normalized
 
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1618,86 +1618,17 @@ def _sanitize_tool_id(tool_id: str) -> str:
     return sanitized or "tool_0"
 
 
-_ANTHROPIC_SCHEMA_PROPERTY_KEY_RE = None
-
-
-def _sanitize_anthropic_schema_property_key(key: str, seen: set[str]) -> str:
-    """Return a property key accepted by Anthropic's tool schema validator."""
-    import hashlib
-    import re
-
-    original = str(key or "")
-    sanitized = original.replace("[]", "")
-    sanitized = re.sub(r"[^a-zA-Z0-9_.-]+", "_", sanitized)
-    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
-    if not sanitized:
-        sanitized = "property"
-    sanitized = sanitized[:64]
-    if sanitized not in seen:
-        seen.add(sanitized)
-        return sanitized
-
-    suffix = "_" + hashlib.sha1(original.encode("utf-8")).hexdigest()[:8]
-    base = sanitized[: 64 - len(suffix)] or "property"
-    candidate = base + suffix
-    counter = 2
-    while candidate in seen:
-        extra = f"_{counter}"
-        candidate = base[: 64 - len(suffix) - len(extra)] + suffix + extra
-        counter += 1
-    seen.add(candidate)
-    return candidate
-
-
 def _sanitize_anthropic_schema_property_keys(node: Any) -> Any:
-    """Recursively rewrite JSON Schema property keys to Anthropic-safe names."""
-    import re
+    """Recursively rewrite JSON Schema property keys to Anthropic-safe names.
 
-    global _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE
-    if _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE is None:
-        _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+    Thin wrapper over the shared, deterministic implementation in
+    ``tools.schema_sanitizer``. The rename is inverted at tool-dispatch time
+    (``restore_value_property_keys``) so handlers and MCP servers always
+    receive arguments under their original declared names.
+    """
+    from tools.schema_sanitizer import sanitize_schema_property_keys
 
-    if isinstance(node, list):
-        return [_sanitize_anthropic_schema_property_keys(item) for item in node]
-    if not isinstance(node, dict):
-        return node
-
-    out = {
-        key: _sanitize_anthropic_schema_property_keys(value)
-        for key, value in node.items()
-    }
-    properties = out.get("properties")
-    if isinstance(properties, dict):
-        key_map: dict[str, str] = {}
-        seen: set[str] = set()
-        safe_properties: dict[str, Any] = {}
-        for prop_key, prop_schema in properties.items():
-            prop_key_str = str(prop_key)
-            if (
-                _ANTHROPIC_SCHEMA_PROPERTY_KEY_RE.match(prop_key_str)
-                and prop_key_str not in seen
-            ):
-                safe_key = prop_key_str
-                seen.add(safe_key)
-            else:
-                safe_key = _sanitize_anthropic_schema_property_key(prop_key_str, seen)
-            key_map[prop_key_str] = safe_key
-            safe_properties[safe_key] = prop_schema
-        out["properties"] = safe_properties
-
-        required = out.get("required")
-        if isinstance(required, list):
-            rewritten_required = [
-                key_map.get(req, req)
-                for req in required
-                if isinstance(req, str) and key_map.get(req, req) in safe_properties
-            ]
-            if rewritten_required:
-                out["required"] = rewritten_required
-            else:
-                out.pop("required", None)
-
-    return out
+    return sanitize_schema_property_keys(node)
 
 
 def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:

--- a/tests/agent/test_anthropic_schema_property_keys.py
+++ b/tests/agent/test_anthropic_schema_property_keys.py
@@ -1,0 +1,156 @@
+"""Tests for _sanitize_anthropic_schema_property_keys.
+
+Anthropic's tool schema validator only accepts property keys matching
+``^[a-zA-Z0-9_.-]{1,64}$``. Tools (typically MCP servers) that ship keys
+like ``filters[]`` or ``user name`` fail request validation with an HTTP
+400, which disables native tool-use for the entire request — the model
+then emits its tool calls as plain text into the conversation instead of
+structured ``tool_use`` blocks.
+
+The sanitizer rewrites offending keys to validator-safe names inside
+``_normalize_tool_input_schema`` (and thus ``convert_tools_to_anthropic``),
+keeping ``required`` in sync and disambiguating collisions.
+"""
+
+from agent.anthropic_adapter import (
+    _sanitize_anthropic_schema_property_keys,
+    convert_tools_to_anthropic,
+)
+
+
+def _schema(properties, required=None):
+    schema = {"type": "object", "properties": properties}
+    if required is not None:
+        schema["required"] = required
+    return schema
+
+
+class TestSanitizeSchemaPropertyKeys:
+    def test_valid_keys_pass_through_unchanged(self):
+        schema = _schema(
+            {"query": {"type": "string"}, "max.results-2": {"type": "integer"}},
+            required=["query"],
+        )
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert out == schema
+
+    def test_array_bracket_suffix_is_stripped(self):
+        # Rails/PHP-style `filters[]` keys are the most common offender in
+        # MCP server schemas.
+        schema = _schema({"filters[]": {"type": "array"}}, required=["filters[]"])
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert set(out["properties"]) == {"filters"}
+        assert out["required"] == ["filters"]
+
+    def test_invalid_characters_become_underscores(self):
+        schema = _schema({"user name (full)": {"type": "string"}})
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert set(out["properties"]) == {"user_name_full"}
+
+    def test_empty_key_gets_placeholder_name(self):
+        schema = _schema({"": {"type": "string"}})
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert set(out["properties"]) == {"property"}
+
+    def test_key_longer_than_64_chars_is_truncated(self):
+        long_key = "k" * 80
+        schema = _schema({long_key: {"type": "string"}})
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        (key,) = out["properties"]
+        assert key == "k" * 64
+
+    def test_colliding_sanitized_keys_are_disambiguated(self):
+        # Both sanitize to "param"; the second gets a deterministic
+        # hash suffix instead of silently overwriting the first.
+        schema = _schema(
+            {"param[]": {"type": "array"}, "param()": {"type": "object"}},
+            required=["param[]", "param()"],
+        )
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        keys = list(out["properties"])
+        assert len(keys) == 2
+        assert "param" in keys
+        others = [k for k in keys if k != "param"]
+        assert others[0].startswith("param_")
+        assert set(out["required"]) == set(keys)
+        # Deterministic: same input, same output.
+        again = _sanitize_anthropic_schema_property_keys(schema)
+        assert list(again["properties"]) == keys
+
+    def test_required_entries_without_matching_property_are_dropped(self):
+        schema = _schema({"a": {"type": "string"}}, required=["a", "ghost"])
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert out["required"] == ["a"]
+
+    def test_required_removed_when_no_entries_survive(self):
+        schema = _schema({"a": {"type": "string"}}, required=["ghost"])
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        assert "required" not in out
+
+    def test_nested_properties_are_sanitized(self):
+        schema = _schema(
+            {
+                "outer": {
+                    "type": "object",
+                    "properties": {"inner[]": {"type": "string"}},
+                    "required": ["inner[]"],
+                },
+                "items_holder": {
+                    "type": "array",
+                    "items": _schema({"deep key": {"type": "string"}}),
+                },
+            }
+        )
+        out = _sanitize_anthropic_schema_property_keys(schema)
+        outer = out["properties"]["outer"]
+        assert set(outer["properties"]) == {"inner"}
+        assert outer["required"] == ["inner"]
+        items = out["properties"]["items_holder"]["items"]
+        assert set(items["properties"]) == {"deep_key"}
+
+    def test_non_dict_nodes_are_returned_unchanged(self):
+        assert _sanitize_anthropic_schema_property_keys("string") == "string"
+        assert _sanitize_anthropic_schema_property_keys(None) is None
+        assert _sanitize_anthropic_schema_property_keys([1, "a"]) == [1, "a"]
+
+
+class TestConvertToolsSanitizesPropertyKeys:
+    def test_invalid_keys_rewritten_end_to_end(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search with filters",
+                    "parameters": _schema(
+                        {
+                            "query": {"type": "string"},
+                            "filters[]": {"type": "array"},
+                        },
+                        required=["query", "filters[]"],
+                    ),
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        input_schema = result[0]["input_schema"]
+        assert set(input_schema["properties"]) == {"query", "filters"}
+        assert set(input_schema["required"]) == {"query", "filters"}
+
+    def test_valid_schema_unchanged_end_to_end(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "run",
+                    "description": "Run",
+                    "parameters": _schema(
+                        {"command": {"type": "string"}}, required=["command"]
+                    ),
+                },
+            }
+        ]
+        result = convert_tools_to_anthropic(tools)
+        input_schema = result[0]["input_schema"]
+        assert input_schema["properties"] == {"command": {"type": "string"}}
+        assert input_schema["required"] == ["command"]

--- a/tests/tools/test_mcp_property_key_restore.py
+++ b/tests/tools/test_mcp_property_key_restore.py
@@ -1,0 +1,190 @@
+"""Round-trip tests for strict-provider property-key sanitization (#63441).
+
+Anthropic's validator forces schema property keys like ``filters[]`` to be
+renamed before the model sees the tool (``filters``). The model then calls
+the tool using the sanitized names, but the MCP server's contract is the
+ORIGINAL inputSchema — so the dispatch path must map renamed argument keys
+back before ``session.call_tool()``. These tests cover that restore step,
+including the full ``_register_server_tools()`` → handler → ``call_tool``
+round trip.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask, _register_server_tools
+from tools.registry import ToolRegistry
+from tools.schema_sanitizer import (
+    restore_value_property_keys,
+    sanitize_schema_property_keys,
+)
+
+
+def _schema(properties, required=None):
+    schema = {"type": "object", "properties": properties}
+    if required is not None:
+        schema["required"] = required
+    return schema
+
+
+class TestRestoreValuePropertyKeys:
+    def test_renamed_key_restored(self):
+        schema = _schema({"filters[]": {"type": "array"}})
+        restored = restore_value_property_keys(schema, {"filters": ["a"]})
+        assert restored == {"filters[]": ["a"]}
+
+    def test_canonical_keys_pass_through(self):
+        schema = _schema({"filters[]": {"type": "array"}, "query": {"type": "string"}})
+        args = {"filters[]": ["a"], "query": "q"}
+        assert restore_value_property_keys(schema, args) == args
+
+    def test_valid_schema_is_identity(self):
+        schema = _schema({"query": {"type": "string"}})
+        args = {"query": "q", "unknown_extra": 1}
+        assert restore_value_property_keys(schema, args) == args
+
+    def test_collision_suffix_restored(self):
+        # `filters` and `filters[]` both exist: the second sanitizes to a
+        # deterministic hash-suffixed name, which must map back.
+        schema = _schema({"filters": {"type": "string"}, "filters[]": {"type": "array"}})
+        sanitized = sanitize_schema_property_keys(schema)
+        suffixed = [k for k in sanitized["properties"] if k != "filters"]
+        assert len(suffixed) == 1
+        restored = restore_value_property_keys(
+            schema, {"filters": "x", suffixed[0]: ["y"]}
+        )
+        assert restored == {"filters": "x", "filters[]": ["y"]}
+
+    def test_nested_object_and_array_items(self):
+        schema = _schema(
+            {
+                "outer[]": {
+                    "type": "array",
+                    "items": _schema({"inner key": {"type": "string"}}),
+                }
+            }
+        )
+        restored = restore_value_property_keys(
+            schema, {"outer": [{"inner_key": "v"}]}
+        )
+        assert restored == {"outer[]": [{"inner key": "v"}]}
+
+    def test_nullable_union_wrapper_branch(self):
+        # MCP/Pydantic optionals arrive as anyOf: [object, null]; the model
+        # saw the collapsed non-null branch, so restore must descend into it.
+        schema = _schema(
+            {
+                "opts[]": {
+                    "anyOf": [
+                        _schema({"page size": {"type": "integer"}}),
+                        {"type": "null"},
+                    ]
+                }
+            }
+        )
+        restored = restore_value_property_keys(
+            schema, {"opts": {"page_size": 10}}
+        )
+        assert restored == {"opts[]": {"page size": 10}}
+
+    def test_round_trip_matches_sanitized_schema(self):
+        # Whatever key the sanitized schema teaches the model, restore maps
+        # it back to the original for every property in one pass.
+        schema = _schema(
+            {
+                "query": {"type": "string"},
+                "filters[]": {"type": "array"},
+                "user name": {"type": "string"},
+            },
+            required=["query"],
+        )
+        sanitized = sanitize_schema_property_keys(schema)
+        model_args = {key: "v" for key in sanitized["properties"]}
+        restored = restore_value_property_keys(schema, model_args)
+        assert set(restored) == set(schema["properties"])
+
+    def test_non_dict_inputs_unchanged(self):
+        schema = _schema({"a[]": {"type": "array"}})
+        assert restore_value_property_keys(schema, "text") == "text"
+        assert restore_value_property_keys(None, {"a": 1}) == {"a": 1}
+        assert restore_value_property_keys(schema, None) is None
+
+
+class TestMcpDispatchRestoresKeys:
+    """End-to-end: _register_server_tools() → registry handler → call_tool."""
+
+    def _make_server(self, captured):
+        tool = SimpleNamespace(
+            name="search",
+            description="Search with filters",
+            inputSchema=_schema(
+                {
+                    "query": {"type": "string"},
+                    "filters[]": {"type": "array", "items": {"type": "string"}},
+                },
+                required=["query", "filters[]"],
+            ),
+        )
+        server = MCPServerTask("filtersrv")
+        server._tools = [tool]
+        server._rpc_lock = asyncio.Lock()
+
+        async def fake_call_tool(name, arguments=None):
+            captured["name"] = name
+            captured["arguments"] = arguments
+            return SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(text="ok")],
+                structuredContent=None,
+            )
+
+        server.session = SimpleNamespace(call_tool=fake_call_tool)
+        return server
+
+    def test_model_visible_schema_is_sanitized_and_dispatch_restores(self):
+        captured = {}
+        server = self._make_server(captured)
+        reg = ToolRegistry()
+
+        with patch("tools.registry.registry", reg), \
+             patch("tools.mcp_tool._get_connected_server_for_call", return_value=server), \
+             patch("tools.mcp_tool._run_on_mcp_loop",
+                   lambda coro_or_factory, timeout=30: asyncio.run(coro_or_factory())):
+            registered = _register_server_tools("filtersrv", server, {})
+            prefixed = "mcp__filtersrv__search"
+            assert prefixed in registered
+
+            # The Anthropic-visible schema renames filters[] -> filters.
+            from agent.anthropic_adapter import convert_tools_to_anthropic
+
+            entry = reg.get_entry(prefixed)
+            anthropic_tools = convert_tools_to_anthropic(
+                [{"type": "function", "function": entry.schema}]
+            )
+            visible = anthropic_tools[0]["input_schema"]["properties"]
+            assert "filters" in visible
+            assert "filters[]" not in visible
+
+            # The model answers with the sanitized key; the MCP server must
+            # still receive its declared `filters[]` argument.
+            entry.handler({"query": "q", "filters": ["a", "b"]})
+            assert captured["name"] == "search"
+            assert captured["arguments"] == {"query": "q", "filters[]": ["a", "b"]}
+
+    def test_canonical_arguments_untouched_by_dispatch(self):
+        captured = {}
+        server = self._make_server(captured)
+        reg = ToolRegistry()
+
+        with patch("tools.registry.registry", reg), \
+             patch("tools.mcp_tool._get_connected_server_for_call", return_value=server), \
+             patch("tools.mcp_tool._run_on_mcp_loop",
+                   lambda coro_or_factory, timeout=30: asyncio.run(coro_or_factory())):
+            _register_server_tools("filtersrv", server, {})
+            entry = reg.get_entry("mcp__filtersrv__search")
+
+            entry.handler({"query": "q", "filters[]": ["a"]})
+            assert captured["arguments"] == {"query": "q", "filters[]": ["a"]}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3931,6 +3931,24 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     "error": f"MCP server '{server_name}' is not connected"
                 }, ensure_ascii=False)
 
+        # Strict providers (Anthropic) rewrite schema property keys their
+        # validator rejects (e.g. ``filters[]`` → ``filters``) before the
+        # model ever sees the tool, so the model's arguments come back under
+        # the sanitized names. The server's contract is the ORIGINAL
+        # inputSchema — map renamed keys back before dispatch. The rename is
+        # deterministic given the original schema, so no per-request state
+        # is needed; arguments already using canonical names pass through
+        # untouched (#63441).
+        if args:
+            declared = next(
+                (t for t in (server._tools or []) if t.name == tool_name), None
+            )
+            input_schema = getattr(declared, "inputSchema", None)
+            if isinstance(input_schema, dict):
+                from tools.schema_sanitizer import restore_value_property_keys
+
+                args = restore_value_property_keys(input_schema, args)
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -499,3 +500,160 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             stripped,
         )
     return tools, stripped
+
+
+# ---------------------------------------------------------------------------
+# Strict property-key sanitization (Anthropic tool schema validator)
+# ---------------------------------------------------------------------------
+
+# Anthropic's tool schema validator only accepts property keys matching this
+# pattern; offending keys (e.g. Rails-style ``filters[]``) fail the whole
+# request with HTTP 400, which disables native tool-use for the turn.
+STRICT_PROPERTY_KEY_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+
+
+def sanitize_property_key(key: str, seen: set) -> str:
+    """Return a strict-validator-safe property key, unique within ``seen``.
+
+    Deterministic for a given ``(key, seen)`` state: renames never depend
+    on randomness, so the mapping can be recomputed later from the original
+    schema alone (see :func:`restore_value_property_keys`).
+    """
+    import hashlib
+
+    original = str(key or "")
+    sanitized = original.replace("[]", "")
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]+", "_", sanitized)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    if not sanitized:
+        sanitized = "property"
+    sanitized = sanitized[:64]
+    if sanitized not in seen:
+        seen.add(sanitized)
+        return sanitized
+
+    suffix = "_" + hashlib.sha1(original.encode("utf-8")).hexdigest()[:8]
+    base = sanitized[: 64 - len(suffix)] or "property"
+    candidate = base + suffix
+    counter = 2
+    while candidate in seen:
+        extra = f"_{counter}"
+        candidate = base[: 64 - len(suffix) - len(extra)] + suffix + extra
+        counter += 1
+    seen.add(candidate)
+    return candidate
+
+
+def _property_key_map(properties: dict) -> dict:
+    """Compute the original→sanitized key mapping for one ``properties`` dict.
+
+    Iterates in insertion order — the same order sanitization uses at
+    request-build time — so collision suffixes reproduce identically.
+    """
+    key_map: dict = {}
+    seen: set = set()
+    for prop_key in properties:
+        prop_key_str = str(prop_key)
+        if STRICT_PROPERTY_KEY_RE.match(prop_key_str) and prop_key_str not in seen:
+            seen.add(prop_key_str)
+            key_map[prop_key_str] = prop_key_str
+        else:
+            key_map[prop_key_str] = sanitize_property_key(prop_key_str, seen)
+    return key_map
+
+
+def sanitize_schema_property_keys(node: Any) -> Any:
+    """Recursively rewrite JSON Schema property keys to strict-safe names.
+
+    Keys already matching :data:`STRICT_PROPERTY_KEY_RE` pass through
+    untouched; ``required`` arrays are rewritten in step, and two keys that
+    sanitize to the same name are disambiguated with a deterministic hash
+    suffix so nothing is silently overwritten.
+    """
+    if isinstance(node, list):
+        return [sanitize_schema_property_keys(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    out = {
+        key: sanitize_schema_property_keys(value)
+        for key, value in node.items()
+    }
+    properties = out.get("properties")
+    if isinstance(properties, dict):
+        key_map = _property_key_map(properties)
+        out["properties"] = {
+            key_map[str(prop_key)]: prop_schema
+            for prop_key, prop_schema in properties.items()
+        }
+
+        required = out.get("required")
+        if isinstance(required, list):
+            rewritten_required = [
+                key_map.get(req, req)
+                for req in required
+                if isinstance(req, str) and key_map.get(req, req) in out["properties"]
+            ]
+            if rewritten_required:
+                out["required"] = rewritten_required
+            else:
+                out.pop("required", None)
+
+    return out
+
+
+def restore_value_property_keys(schema: Any, value: Any) -> Any:
+    """Rename sanitized property keys in ``value`` back to the schema's names.
+
+    Inverse of :func:`sanitize_schema_property_keys` applied to *data*
+    rather than schemas: given the ORIGINAL (unsanitized) schema, recompute
+    the deterministic rename map per object level and map any argument key
+    the model produced under a sanitized name back to the canonical name
+    the tool's real contract declares (e.g. ``filters`` → ``filters[]``).
+
+    Keys that were never renamed — including arguments already using the
+    canonical names — pass through untouched, so applying this to input
+    from providers that don't sanitize schemas is a no-op.
+    """
+    if not isinstance(schema, dict):
+        return value
+
+    if isinstance(value, list):
+        items = schema.get("items")
+        if isinstance(items, dict):
+            return [restore_value_property_keys(items, item) for item in value]
+        return value
+
+    if not isinstance(value, dict):
+        return value
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        # Nullable/union wrappers: descend into the first object-shaped
+        # branch (mirrors how nullable-union collapsing picked the non-null
+        # branch before the keys were sanitized).
+        for combinator in ("anyOf", "oneOf", "allOf"):
+            branches = schema.get(combinator)
+            if isinstance(branches, list):
+                for branch in branches:
+                    if isinstance(branch, dict) and isinstance(
+                        branch.get("properties"), dict
+                    ):
+                        return restore_value_property_keys(branch, value)
+        return value
+
+    reverse_map = {
+        sanitized: original
+        for original, sanitized in _property_key_map(properties).items()
+        if sanitized != original
+    }
+    restored: dict = {}
+    for arg_key, arg_value in value.items():
+        original_key = reverse_map.get(arg_key, arg_key)
+        sub_schema = properties.get(original_key)
+        restored[original_key] = (
+            restore_value_property_keys(sub_schema, arg_value)
+            if isinstance(sub_schema, dict)
+            else arg_value
+        )
+    return restored


### PR DESCRIPTION
## What does this PR do?

Fixes tool-call degradation when a tool schema contains property keys that Anthropic's validator rejects, and keeps the tool's real contract intact end to end.

Anthropic's tool schema validator only accepts property keys matching `^[a-zA-Z0-9_.-]{1,64}$`. Tools (in practice: MCP servers) that ship keys like `filters[]`, `user name`, or keys longer than 64 chars fail request validation with an HTTP 400. That doesn't just disable the one offending tool: the whole request's native tool-use breaks, and the model's tool calls end up as plain text leaked into the conversation instead of structured `tool_use` blocks.

The fix has two halves that round-trip:

1. **Outbound (schema)**: `sanitize_schema_property_keys()` rewrites offending keys to validator-safe names before the model sees the tool. Called from the Anthropic adapter's `_normalize_tool_input_schema()`, so it covers `convert_tools_to_anthropic()` and every Anthropic dispatch path. Keys already valid pass through untouched; `required` arrays are rewritten in step; colliding sanitizations get a deterministic sha1-based suffix.
2. **Inbound (arguments)**: the model answers using the sanitized names, but the MCP server's contract is its ORIGINAL `inputSchema`. `restore_value_property_keys()` recomputes the same deterministic rename map from the original schema alone and maps argument keys back to canonical names (`filters` → `filters[]`) in `_make_tool_handler()` before `session.call_tool()`. No per-request mapping state is carried; arguments already using canonical names (any non-sanitizing provider) pass through untouched.

Both halves live in `tools/schema_sanitizer.py` as shared, provider-neutral helpers; the Anthropic adapter delegates to them. The inbound restore was added after the hermes-sweeper review below correctly flagged that sanitizing only the outbound schema would deliver renamed argument keys to the MCP server.

## Provenance

The outbound half was accidentally included in #19777 (my ElevenLabs STT PR). I run my gateway from my working tree, hit this bug live with an MCP server whose schemas use `[]`-suffixed keys, and the local fix got auto-committed into the branch I happened to be on. teknium's sweeper review on #19777 correctly flagged it as unrelated to STT and missing focused adapter tests. This PR carries it with the tests it should have had; #19777 no longer touches the adapter.

## Relation to #40236 / #40298 / issue #40232

Those PRs propose generic property-key sanitization in `tools/schema_sanitizer.py` for all strict backends (including copilot). This PR now also hosts its helpers in `tools/schema_sanitizer.py`, wired only into the Anthropic path, and adds the piece the outbound-only approaches miss: restoring canonical argument names at tool dispatch so the server-side contract survives the rename. If maintainers prefer the generic wiring from #40236/#40298, the restore half here composes with it directly.

## Related Issue

No open issue. Flagged in the hermes-sweeper review of #19777; round-trip gap flagged in the hermes-sweeper review of this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py`: `STRICT_PROPERTY_KEY_RE`, `sanitize_property_key()`, `sanitize_schema_property_keys()`, `restore_value_property_keys()`, and the shared `_property_key_map()` that guarantees the outbound rename and inbound restore compute identical mappings.
- `agent/anthropic_adapter.py`: `_sanitize_anthropic_schema_property_keys()` is now a thin delegation into the shared implementation, called from `_normalize_tool_input_schema()`.
- `tools/mcp_tool.py`: `_make_tool_handler()` restores canonical argument keys from the tool's declared `inputSchema` before `session.call_tool()`.
- `tests/agent/test_anthropic_schema_property_keys.py`: 12 outbound tests (pass-through, `[]` stripping, invalid-char collapsing, empty keys, 64-char truncation, deterministic collision suffixes, `required` rewriting/dropping, nested recursion, non-dict nodes, end-to-end through `convert_tools_to_anthropic()`).
- `tests/tools/test_mcp_property_key_restore.py`: 10 round-trip tests: restore units (renames, collisions, nested objects/array items, nullable-union wrappers, canonical-args no-op) plus the end-to-end regression through `_register_server_tools()`: the Anthropic-visible schema shows `filters`, and the dispatched MCP call receives `filters[]`.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_anthropic_schema_property_keys.py tests/tools/test_mcp_property_key_restore.py tests/tools/test_schema_sanitizer.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py
```

Manual reproduction:
1. Connect an MCP server whose tool schemas contain a `filters[]`-style property key.
2. Without this fix: Anthropic requests 400 on schema validation and tool calls degrade to plain text in the chat.
3. With this fix: the model sees `filters`, native tool-use works, and the MCP server receives its declared `filters[]` argument.

Tested on: macOS 15 (the 14 credential-resolution failures in `tests/agent/test_anthropic_adapter.py` are pre-existing on main in any environment with live keychain credentials and are untouched by this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(anthropic): ...`, `fix(mcp): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls); relation to #40236/#40298 is addressed above
- [x] My PR contains **only** changes related to this fix
- [x] I've run the canonical runner on the touched test paths
- [x] I've added tests for my changes (22 tests)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] N/A. Internal adapter/dispatch hardening, no user-facing docs affected
- [x] N/A. No config keys
- [x] N/A. No architecture or workflow changes
- [x] Cross-platform: pure string/dict manipulation, no platform-specific paths
