### PR TITLE
feat: add configurable commit attribution trailers to git commits

### DIFF
--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -28,6 +28,60 @@ _COMMIT_CONTEXT_DIFF_MAX_CHARS = 120_000
 _COMMIT_CONTEXT_UNTRACKED_MAX = 80
 _TRUNK_BRANCHES = ("main", "master")
 
+_DEFAULT_TRAILER_NAME = "Hermes Agent"
+_DEFAULT_TRAILER_EMAIL = "hermes@nousresearch.com"
+
+
+def _build_commit_trailer() -> str:
+    """Build an attribution trailer string based on config.
+
+    Reads from config.yaml under the ``git`` key:
+
+    * ``git.commit_trailer`` (bool) — set to ``false`` to disable entirely.
+      Default: ``true``.
+    * ``git.commit_trailer_type`` (str) — ``"co-authored-by"`` (default) or
+      ``"generated-by"``.  ``Co-authored-by:`` follows the Git trailer
+      convention used by pairing tools.  ``Generated-by:`` is a bespoke
+      marker that doesn't imply human co-authorship.
+    * ``git.commit_trailer_name`` (str) — the name portion of the trailer.
+      Default: ``"Hermes Agent"``.
+    * ``git.commit_trailer_email`` (str) — the email portion of the trailer
+      (only used for ``Co-authored-by``).  Default: ``"hermes@nousresearch.com"``.
+
+    Returns an empty string when trailers are disabled, and a string of the
+    form ``"\\nTrailer-Name: value\\n"`` otherwise.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return ""
+
+    git_cfg = cfg.get("git", {})
+    if isinstance(git_cfg, dict) and git_cfg.get("commit_trailer") is False:
+        return ""
+
+    trailer_type = (
+        git_cfg.get("commit_trailer_type", "co-authored-by") if isinstance(git_cfg, dict) else "co-authored-by"
+    )
+    trailer_name = (
+        git_cfg.get("commit_trailer_name", _DEFAULT_TRAILER_NAME) if isinstance(git_cfg, dict) else _DEFAULT_TRAILER_NAME
+    )
+
+    trailer_type = trailer_type.strip().lower()
+    if trailer_type == "generated-by":
+        trailer_line = f"Generated-by: {trailer_name}"
+    else:
+        trailer_email = (
+            git_cfg.get("commit_trailer_email", _DEFAULT_TRAILER_EMAIL)
+            if isinstance(git_cfg, dict)
+            else _DEFAULT_TRAILER_EMAIL
+        )
+        trailer_line = f"Co-authored-by: {trailer_name} <{trailer_email}>"
+
+    return f"\n{trailer_line}\n"
+
 
 def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int, str, str]:
     """Run ``git`` in ``cwd``. Returns (returncode, stdout, stderr); never raises
@@ -366,7 +420,8 @@ def review_commit(cwd: str, message: str, push: bool) -> dict:
     _, raw, _ = _git(cwd, ["status", "--porcelain=v2", "-z"])
     if not any(_entry_staged(tag, xy) for tag, xy, _ in _walk_entries(raw)):
         _git_ok(cwd, ["add", "-A"])
-    _git_ok(cwd, ["commit", "-m", message])
+    trailer = _build_commit_trailer()
+    _git_ok(cwd, ["commit", "-m", f"{message}{trailer}"])
     if push:
         _review_push(cwd)
     return {"ok": True}

--- a/tests/hermes_cli/test_web_git.py
+++ b/tests/hermes_cli/test_web_git.py
@@ -1,0 +1,229 @@
+"""Tests for hermes_cli/web_git.py — commit attribution trailers."""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+# ── _build_commit_trailer ──────────────────────────────────────────────
+
+
+class TestBuildCommitTrailer:
+    """Unit tests for the _build_commit_trailer helper."""
+
+    def test_default_trailer(self, monkeypatch):
+        """Default config produces Co-authored-by: Hermes Agent <hermes@nousresearch.com>."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        # Simulate a config with git section missing (falls through to defaults)
+        def mock_load_config():
+            return {"git": {}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == "\nCo-authored-by: Hermes Agent <hermes@nousresearch.com>\n"
+
+    def test_default_trailer_missing_git_section(self, monkeypatch):
+        """When the git section is entirely absent, defaults are used."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            return {}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == "\nCo-authored-by: Hermes Agent <hermes@nousresearch.com>\n"
+
+    def test_trailer_disabled(self, monkeypatch):
+        """commit_trailer: False returns empty string."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            return {"git": {"commit_trailer": False}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == ""
+
+    def test_generated_by_trailer(self, monkeypatch):
+        """commit_trailer_type: 'generated-by' produces Generated-by: Hermes Agent."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            return {"git": {"commit_trailer_type": "generated-by"}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == "\nGenerated-by: Hermes Agent\n"
+
+    def test_custom_name_and_email(self, monkeypatch):
+        """Custom name/email are reflected in the trailer."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            return {
+                "git": {
+                    "commit_trailer_name": "MyBot",
+                    "commit_trailer_email": "bot@example.com",
+                }
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == "\nCo-authored-by: MyBot <bot@example.com>\n"
+
+    def test_custom_name_generated_by(self, monkeypatch):
+        """Custom name with generated-by type."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            return {
+                "git": {
+                    "commit_trailer_type": "generated-by",
+                    "commit_trailer_name": "CodingAgent",
+                }
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == "\nGenerated-by: CodingAgent\n"
+
+    def test_load_config_exception_is_safe(self, monkeypatch):
+        """When load_config raises, _build_commit_trailer returns empty string."""
+        from hermes_cli.web_git import _build_commit_trailer
+
+        def mock_load_config():
+            raise RuntimeError("config broken")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        result = _build_commit_trailer()
+        assert result == ""
+
+
+# ── review_commit ──────────────────────────────────────────────────────
+
+
+class TestReviewCommitTrailer:
+    """Integration-style: verify the trailer is actually passed to git commit."""
+
+    def test_trailer_appended_to_message(self, monkeypatch):
+        """review_commit passes message + trailer to git."""
+        from hermes_cli.web_git import review_commit
+
+        # Mock config to return a known trailer
+        def mock_load_config():
+            return {"git": {"commit_trailer_type": "generated-by"}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        # Track the actual git commit command
+        actual_commit_args = []
+
+        def fake_git(cwd, args):
+            actual_commit_args.append(args)
+            return (0, "", "")
+
+        def fake_git_ok(cwd, args):
+            actual_commit_args.append(args)
+            return None
+
+        monkeypatch.setattr("hermes_cli.web_git._git", fake_git)
+        monkeypatch.setattr("hermes_cli.web_git._git_ok", fake_git_ok)
+        monkeypatch.setattr("hermes_cli.web_git._git_out", lambda *a: "## main...origin/main\n")
+        monkeypatch.setattr("hermes_cli.web_git._entry_staged", lambda *a: True)
+
+        review_commit(".", "feat: add widget", push=False)
+
+        # Find the commit command
+        commit_cmd = None
+        for args in actual_commit_args:
+            if args and args[0] == "commit":
+                commit_cmd = args
+                break
+
+        assert commit_cmd is not None, "git commit was never called"
+        assert commit_cmd == [
+            "commit", "-m",
+            "feat: add widget\nGenerated-by: Hermes Agent\n",
+        ], f"Unexpected commit args: {commit_cmd}"
+
+    def test_trailer_disabled_no_trailer_in_message(self, monkeypatch):
+        """When commit_trailer is false, the message is passed as-is."""
+        from hermes_cli.web_git import review_commit
+
+        def mock_load_config():
+            return {"git": {"commit_trailer": False}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        actual_commit_args = []
+
+        def fake_git_ok(cwd, args):
+            actual_commit_args.append(args)
+            return None
+
+        monkeypatch.setattr("hermes_cli.web_git._git", lambda *a: (0, "", ""))
+        monkeypatch.setattr("hermes_cli.web_git._git_ok", fake_git_ok)
+        monkeypatch.setattr("hermes_cli.web_git._git_out", lambda *a: "## main...origin/main\n")
+        monkeypatch.setattr("hermes_cli.web_git._entry_staged", lambda *a: True)
+
+        review_commit(".", "feat: plain commit", push=False)
+
+        commit_cmd = None
+        for args in actual_commit_args:
+            if args and args[0] == "commit":
+                commit_cmd = args
+                break
+
+        assert commit_cmd is not None, "git commit was never called"
+        assert commit_cmd == ["commit", "-m", "feat: plain commit"], (
+            f"Unexpected commit args: {commit_cmd}"
+        )
+
+    def test_auto_stage_then_commit_with_trailer(self, monkeypatch):
+        """When nothing is staged, review_commit stages everything first."""
+        from hermes_cli.web_git import review_commit
+
+        def mock_load_config():
+            return {"git": {"commit_trailer_type": "generated-by"}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", mock_load_config)
+
+        actual_commands = []
+
+        def fake_has_staged(tag, xy):
+            # Simulate that nothing is staged
+            return False
+
+        def fake_git(cwd, args):
+            if args[0] == "status":
+                return (0, "1 . N... 0\tREADME.md\0", "")
+            return (0, "", "")
+
+        def fake_git_ok(cwd, args):
+            actual_commands.append(args)
+            return None
+
+        monkeypatch.setattr("hermes_cli.web_git._git", fake_git)
+        monkeypatch.setattr("hermes_cli.web_git._git_ok", fake_git_ok)
+        monkeypatch.setattr("hermes_cli.web_git._entry_staged", fake_has_staged)
+
+        review_commit(".", "fix: resolve timeout", push=False)
+
+        # Should have: add -A then commit with trailer
+        assert len(actual_commands) >= 2, f"Expected at least 2 commands, got: {actual_commands}"
+
+        add_cmd = actual_commands[0]
+        assert add_cmd == ["add", "-A"], f"Expected add -A, got: {add_cmd}"
+
+        commit_cmd = actual_commands[1]
+        assert commit_cmd == [
+            "commit", "-m",
+            "fix: resolve timeout\nGenerated-by: Hermes Agent\n",
+        ], f"Unexpected commit: {commit_cmd}"


### PR DESCRIPTION
## Summary

Commit attribution trailers are a configurable mechanism for marking Hermes-authored commits in git history.  This PR adds a `_build_commit_trailer()` helper and modifies `review_commit()` in `hermes_cli/web_git.py` to append the trailer to every commit message.

## Root Cause

Hermes commits via `review_commit()` in `hermes_cli/web_git.py` using a plain `git commit -m <message>` with no authorship information.  The resulting history shows agent-written code as authored solely by the human who owns the repository.  There is no marker that an agent produced the change, which makes it impossible to later distinguish human-written from agent-written commits — for code review, for `git blame`, and for anyone who needs to reason about the provenance of a change.

## Change

1. **New helper:** `_build_commit_trailer()` reads from `config.yaml` under the `git` key and returns either:
   - `\nCo-authored-by: Name <email>\n` (default)
   - `\nGenerated-by: Name\n` (when `commit_trailer_type` is `"generated-by"`)
   - An empty string (when `commit_trailer` is `false`)
2. **Modified `review_commit()`:** Appends the trailer to the commit message before passing it to `git commit`.
3. **Configuration** (all optional, all under `git:` in `config.yaml`):
   - `commit_trailer` (bool, default `true`) — master switch
   - `commit_trailer_type` (`"co-authored-by"` or `"generated-by"`, default `"co-authored-by"`)
   - `commit_trailer_name` (str, default `"Hermes Agent"`)
   - `commit_trailer_email` (str, default `"hermes@nousresearch.com"`)
4. **Tests:** 10 unit tests covering all code paths — default config, disabled trailer, `generated-by` type, custom name/email, exception safety, and integration-style tests that verify `review_commit` passes the proper message to git.

## Verification

```
$ uv run pytest tests/hermes_cli/test_web_git.py -v
============================== 10 passed in 0.82s ==============================
```

All existing tests in the test suite continue to pass.

Closes #63374
