### PR TITLE
fix(oidc): add User-Agent headers to PyJWKClient for Cloudflare/WAF compat (#63273)

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -420,6 +420,10 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
                 self._jwks_url,
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "User-Agent": "Hermes-Agent/1.0",
+                    "Accept": "application/json",
+                },
             )
         return self._jwks_client
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,7 +601,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
-                headers={"User-Agent": "Hermes-Agent/1.0"},
+                headers={
+                    "User-Agent": "Hermes-Agent/1.0",
+                    "Accept": "application/json",
+                },
             )
         return self._jwks_client
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,6 +601,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={"User-Agent": "Hermes-Agent/1.0"},
             )
         return self._jwks_client
 


### PR DESCRIPTION
## Description

Self-hosted OIDC fails when the JWKS endpoint is behind Cloudflare or similar WAF because PyJWKClient sends requests without a User-Agent header, triggering Cloudflare's bot detection (HTTP 403/1010).

The browser completes the OIDC flow, but Hermes then fails while retrieving the public signing key and reports 'Auth provider self-hosted unreachable'.

## Fix

Pass User-Agent: Hermes-Agent/1.0 and Accept: application/json headers to PyJWKClient in both OIDC auth providers (self-hosted and Nous).

Fixes #63273