### PR TITLE
fix(local): remove redundant temp-file read in _update_cwd

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1144,31 +1144,16 @@ class LocalEnvironment(BaseEnvironment):
                 pass
 
     def _update_cwd(self, result: dict):
-        """Read CWD from temp file (local-only, no round-trip needed).
+        """Extract CWD from command output via the stdout marker.
 
-        Skip the assignment when the path no longer exists as a directory —
-        ``pwd -P`` on a deleted cwd can leave a stale value in the marker
-        file, and propagating it would re-wedge the next ``Popen``.  The
-        ``_run_bash`` recovery path will resolve a safe fallback if needed.
+        The base class's ``_extract_cwd_from_output`` already parses the
+        ``__HERMES_CWD_<session>__`` marker that the shell bootstrap emits
+        after every command — no need for a redundant temp-file read.
 
-        On Windows, the value written by Git Bash's ``pwd -P`` is in
-        MSYS form (``/c/Users/x``). Translate it to native Windows form
-        before validating with ``os.path.isdir`` and before storing on
-        ``self.cwd``; otherwise the isdir check rejects every valid
-        result and ``_run_bash`` later prints a misleading "cwd is
-        missing" warning on every command.
+        The local override of ``_extract_cwd_from_output`` handles Windows
+        MSYS path normalization and stale-directory validation, so deferring
+        to it covers both platforms correctly.
         """
-        try:
-            with open(self._cwd_file, encoding="utf-8") as f:
-                cwd_path = f.read().strip()
-            if _IS_WINDOWS:
-                cwd_path = _msys_to_windows_path(cwd_path)
-            if cwd_path and os.path.isdir(cwd_path):
-                self.cwd = cwd_path
-        except (OSError, FileNotFoundError):
-            pass
-
-        # Still strip the marker from output so it's not visible
         self._extract_cwd_from_output(result)
 
     def _extract_cwd_from_output(self, result: dict):


### PR DESCRIPTION
## Description

`LocalEnvironment._update_cwd()` read the CWD from a temp file on every `terminal()` call, then immediately called `_extract_cwd_from_output()` which already parses the same CWD from the stdout marker — a redundant file I/O for every command (~12,000 I/O operations per hour with active use).

The local override of `_extract_cwd_from_output` already handles Windows MSYS path normalization and stale-directory validation, so deferring to it covers all the same cases correctly.

Fixes #63225