### PR TITLE
fix(azure): preserve reasoning item id for Azure AI Foundry Responses API

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -893,8 +893,9 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        _is_azure_for_input = base_url_host_matches(_host_for_input, "openai.azure.com")
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=_is_github_for_input,
+            replay_messages, is_github_responses=_is_github_for_input, is_azure_responses=_is_azure_for_input,
         )
 
         resp_kwargs: Dict[str, Any] = {

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -315,6 +315,7 @@ def _chat_messages_to_responses_input(
     *,
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
+    is_azure_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
@@ -429,12 +430,18 @@ def _chat_messages_to_responses_input(
                             # Responses API cannot look up items by ID and
                             # returns 404.  The encrypted_content blob is
                             # self-contained for reasoning chain continuity.
+                            # Azure AI Foundry Responses requires the id to
+                            # be retained; skip stripping when targeting
+                            # Azure.
                             # Also strip the internal "_issuer_kind" stamp;
                             # it is a Hermes-side metadata key and not part
                             # of the Responses API schema.
+                            skip_keys = {"_issuer_kind"}
+                            if not is_azure_responses:
+                                skip_keys.add("id")
                             replay_item = {
                                 k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
+                                if k not in skip_keys
                             }
                             items.append(replay_item)
                             if item_id:
@@ -604,6 +611,7 @@ def _preflight_codex_input_items(
     raw_items: Any,
     *,
     is_github_responses: bool = False,
+    is_azure_responses: bool = False,
 ) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -704,6 +712,10 @@ def _preflight_codex_input_items(
                 # store=False (our default) the API tries to resolve the
                 # id server-side and returns 404.  The id is still used
                 # above for local deduplication via seen_ids.
+                # Azure AI Foundry Responses requires the id to be
+                # retained; skip stripping when targeting Azure.
+                if is_azure_responses and isinstance(item_id, str) and item_id:
+                    reasoning_item["id"] = item_id
                 summary = item.get("summary")
                 if isinstance(summary, list):
                     reasoning_item["summary"] = summary
@@ -825,6 +837,7 @@ def _preflight_codex_api_kwargs(
     *,
     allow_stream: bool = False,
     is_github_responses: bool = False,
+    is_azure_responses: bool = False,
 ) -> Dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
@@ -849,6 +862,7 @@ def _preflight_codex_api_kwargs(
     normalized_input = _preflight_codex_input_items(
         api_kwargs.get("input"),
         is_github_responses=is_github_responses,
+        is_azure_responses=is_azure_responses,
     )
 
     tools = api_kwargs.get("tools")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -76,12 +76,19 @@ class ResponsesApiTransport(ProviderTransport):
     def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
         """Convert OpenAI chat messages to Responses API input items."""
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        from utils import base_url_host_matches
+
+        base_url = kwargs.get("base_url", "") or ""
+        is_azure_responses = base_url_host_matches(base_url, "openai.azure.com")
+
         issuer = self._resolve_issuer_kind(kwargs)
         self._last_issuer_kind = issuer
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=kwargs.get("is_xai_responses") is True,
             is_github_responses=kwargs.get("is_github_responses") is True,
+            is_azure_responses=is_azure_responses,
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -138,9 +145,13 @@ class ResponsesApiTransport(ProviderTransport):
         if not instructions:
             instructions = DEFAULT_AGENT_IDENTITY
 
+        from utils import base_url_host_matches
+
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        base_url = params.get("base_url", "") or ""
+        is_azure_responses = base_url_host_matches(base_url, "openai.azure.com")
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -247,6 +258,7 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
                 is_github_responses=is_github_responses,
+                is_azure_responses=is_azure_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
             ),
@@ -452,6 +464,7 @@ class ResponsesApiTransport(ProviderTransport):
         *,
         allow_stream: bool = False,
         is_github_responses: bool = False,
+        is_azure_responses: bool = False,
     ) -> dict:
         """Validate and sanitize Codex API kwargs before the call.
 
@@ -462,6 +475,7 @@ class ResponsesApiTransport(ProviderTransport):
             api_kwargs,
             allow_stream=allow_stream,
             is_github_responses=is_github_responses,
+            is_azure_responses=is_azure_responses,
         )
 
     def map_finish_reason(self, raw_reason: str) -> str:


### PR DESCRIPTION
## Description

Azure AI Foundry Responses API requires the `id` field in replayed encrypted reasoning items (`{type, id, encrypted_content, summary}`), but Hermes strips it for standard OpenAI Codex Responses where `store=False` makes server-side id resolution fail with 404.

This adds `is_azure_responses` plumbing through all relevant code paths:
- `_chat_messages_to_responses_input` — skip `id` stripping when targeting Azure
- `_preflight_codex_input_items` — re-add `id` before sending
- `_preflight_codex_api_kwargs` — pass through
- `ResponsesApiTransport` — detect Azure via `base_url_host_matches` and pass flag
- `_CodexCompletionsAdapter` in auxiliary client — same detection

Fixes #63257