### PR TITLE
fix(gateway): preserve multiplex profile in model picker

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1441,6 +1441,12 @@ class GatewaySlashCommandsMixin:
         from hermes_cli.providers import get_label
 
         raw_args = event.get_command_args().strip()
+        source = event.source
+        _command_profile_home = None
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            _command_profile_home = getattr(
+                self, "_resolve_profile_home_for_source"
+            )(source)
 
         # Parse --provider, --global, --session, and --refresh flags
         (
@@ -1467,7 +1473,7 @@ class GatewaySlashCommandsMixin:
         current_api_key = ""
         user_provs = None
         custom_provs = None
-        config_path = _hermes_home / "config.yaml"
+        config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
             cfg = _load_gateway_config()
             if cfg:
@@ -1485,9 +1491,8 @@ class GatewaySlashCommandsMixin:
         except Exception:
             pass
 
-        # Check for session override
-        source = event.source
-        # Normalize the source the same way a normal message turn does
+        # Check for session override. Normalize the source the same way a normal
+        # message turn does
         # (Telegram DM topic recovery) before deriving the override key, so
         # the override is stored under the key the next message turn reads
         # (#30479).
@@ -1503,7 +1508,7 @@ class GatewaySlashCommandsMixin:
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
             # Try interactive picker if the platform supports it
-            adapter = self.adapters.get(source.platform)
+            adapter = getattr(self, "_adapter_for_source")(source)
             has_picker = (
                 adapter is not None
                 and getattr(type(adapter), "send_model_picker", None) is not None
@@ -1536,8 +1541,9 @@ class GatewaySlashCommandsMixin:
                     _cur_provider = current_provider
                     _cur_base_url = current_base_url
                     _cur_api_key = current_api_key
+                    _picker_profile_home = _command_profile_home
 
-                    async def _on_model_selected(
+                    async def _on_model_selected_scoped(
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
@@ -1735,6 +1741,20 @@ class GatewaySlashCommandsMixin:
                         else:
                             lines.append(t("gateway.model.session_only_hint"))
                         return "\n".join(lines)
+
+                    async def _on_model_selected(
+                        _chat_id: str, model_id: str, provider_slug: str
+                    ) -> str:
+                        if _picker_profile_home is None:
+                            return await _on_model_selected_scoped(
+                                _chat_id, model_id, provider_slug
+                            )
+                        from gateway.run import _profile_runtime_scope
+
+                        with _profile_runtime_scope(_picker_profile_home):
+                            return await _on_model_selected_scoped(
+                                _chat_id, model_id, provider_slug
+                            )
 
                     metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     result = await adapter.send_model_picker(

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -80,6 +80,22 @@ def _fake_switch_result():
     )
 
 
+def _stub_picker_dependencies(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        lambda **kw: [{"slug": "openrouter", "name": "OpenRouter", "models": ["gpt-5.5"]}],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _fake_switch_result(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_display_context_length",
+        lambda *a, **k: 272000,
+    )
+
+
 def _setup_isolated_home(tmp_path, monkeypatch, model_yaml_value):
     """Write a config.yaml with the given ``model:`` value and stub heavy bits."""
     import gateway.run as gateway_run
@@ -93,35 +109,41 @@ def _setup_isolated_home(tmp_path, monkeypatch, model_yaml_value):
     )
 
     monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
-    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
-    # The picker-setup path calls list_picker_providers, which otherwise hits
-    # the network (OpenRouter model catalog). Stub it to a minimal list — these
-    # tests capture and fire the on_model_selected callback and don't assert on
-    # picker contents. The handler imports it as a local alias at call time, so
-    # patching the source-module attribute takes effect.
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.list_picker_providers",
-        lambda **kw: [{"slug": "openrouter", "name": "OpenRouter", "models": ["gpt-5.5"]}],
-    )
-    # switch_model is imported as a local alias inside the handler
-    # (`from hermes_cli.model_switch import switch_model as _switch_model`),
-    # so patching the source-module attribute takes effect at call time.
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.switch_model",
-        lambda **kw: _fake_switch_result(),
-    )
-    # The confirmation builder resolves context length for display, which
-    # otherwise makes real outbound HTTP calls (Ollama /api/show + the
-    # OpenRouter models catalog). Stub it — these tests don't assert on the
-    # displayed context, and the closure imports it lazily from this module.
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.resolve_display_context_length",
-        lambda *a, **k: 272000,
-    )
+    _stub_picker_dependencies(monkeypatch)
     # save_config writes to ``get_hermes_home() / config.yaml`` — point it here.
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
     monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
     return cfg_path
+
+
+def _make_named_runner(monkeypatch, default_adapter, named_adapter, named_home):
+    runner = _make_runner(default_adapter)
+    monkeypatch.setattr(
+        runner, "config", types.SimpleNamespace(multiplex_profiles=True), raising=False
+    )
+    monkeypatch.setattr(
+        runner,
+        "_profile_adapters",
+        {"named": {Platform.TELEGRAM: named_adapter}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        runner, "_resolve_profile_home_for_source", lambda source: named_home
+    )
+    return runner
+
+
+def _named_event(args):
+    return MessageEvent(
+        text=f"/model {args}".rstrip(),
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="named-chat",
+            chat_type="dm",
+            profile="named",
+        ),
+    )
 
 
 async def _drive_picker(runner, event):
@@ -201,3 +223,103 @@ async def test_picker_tap_session_flag_does_not_persist(tmp_path, monkeypatch):
     written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert written["model"]["default"] == "old-model"
     assert written["model"]["provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_multiplex_picker_keeps_profile_adapter_and_callback_scope(
+    tmp_path, monkeypatch
+):
+    """A named profile must present and execute its picker under one identity."""
+    from agent.secret_scope import get_secret, set_multiplex_active
+
+    default_adapter = _FakePickerAdapter()
+    named_adapter = _FakePickerAdapter()
+    named_home = tmp_path / "profiles" / "named"
+    named_home.mkdir(parents=True)
+    (named_home / ".env").write_text("PROFILE_MODEL_KEY=named-secret\n", encoding="utf-8")
+    runner = _make_named_runner(monkeypatch, default_adapter, named_adapter, named_home)
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "old-model", "provider": "openai-codex"},
+    )
+    resolved = []
+
+    def _profile_switch(**kwargs):
+        resolved.append(get_secret("PROFILE_MODEL_KEY"))
+        return _fake_switch_result()
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _profile_switch)
+    event = _named_event("--session")
+
+    set_multiplex_active(True)
+    try:
+        sent = await runner._handle_model_command(event)
+
+        assert sent is None
+        assert default_adapter.captured_callback is None
+        assert named_adapter.captured_callback is not None
+        assert resolved == []
+
+        confirmation = await named_adapter.captured_callback(
+            "named-chat", "gpt-5.5", "openrouter"
+        )
+    finally:
+        set_multiplex_active(False)
+
+    assert "gpt-5.5" in confirmation
+    assert resolved == ["named-secret"]
+
+
+@pytest.mark.asyncio
+async def test_multiplex_picker_global_persists_only_named_profile(
+    tmp_path, monkeypatch
+):
+    """A named picker must not seed its global write from the default profile."""
+    import gateway.run as gateway_run
+    from agent.secret_scope import set_multiplex_active
+
+    default_home = tmp_path / "default"
+    named_home = tmp_path / "profiles" / "named"
+    default_home.mkdir(parents=True)
+    named_home.mkdir(parents=True)
+    default_cfg = {
+        "marker": "default",
+        "model": {"default": "default-old", "provider": "openai-codex"},
+    }
+    named_cfg = {
+        "marker": "named",
+        "model": {"default": "named-old", "provider": "openai-codex"},
+    }
+    (default_home / "config.yaml").write_text(
+        yaml.safe_dump(default_cfg, sort_keys=False), encoding="utf-8"
+    )
+    (named_home / "config.yaml").write_text(
+        yaml.safe_dump(named_cfg, sort_keys=False), encoding="utf-8"
+    )
+
+    default_adapter = _FakePickerAdapter()
+    named_adapter = _FakePickerAdapter()
+    runner = _make_named_runner(monkeypatch, default_adapter, named_adapter, named_home)
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    _stub_picker_dependencies(monkeypatch)
+    event = _named_event("--global")
+
+    set_multiplex_active(True)
+    try:
+        with gateway_run._profile_runtime_scope(named_home):
+            sent = await runner._handle_model_command(event)
+        assert sent is None
+        assert named_adapter.captured_callback is not None
+        confirmation = await named_adapter.captured_callback(
+            "named-chat", "gpt-5.5", "openrouter"
+        )
+    finally:
+        set_multiplex_active(False)
+
+    assert "gpt-5.5" in confirmation
+    assert yaml.safe_load((default_home / "config.yaml").read_text()) == default_cfg
+    written = yaml.safe_load((named_home / "config.yaml").read_text())
+    assert written["marker"] == "named"
+    assert written["model"]["default"] == "gpt-5.5"
+    assert written["model"]["provider"] == "openrouter"


### PR DESCRIPTION
## What does this PR do?

Preserves one exact multiplex profile identity across the gateway `/model` picker: adapter selection, deferred callback credential resolution, and global config read/write.

On current `main`, the picker reads `self.adapters` directly, so a named-profile event can present through the default profile's adapter. The stored `on_model_selected` callback also runs after the routed profile scope has exited, and `--global` can seed a named-profile write from the default profile's config.

This resolves the adapter with `_adapter_for_source(source)`, captures the routed profile home once, and re-enters that scope when the deferred callback runs. The same captured home selects the config file used for persistence.

## Related Issue

Follow-up to #58587. Complements #61488 and #48187; it does not duplicate their session-default or context-length policy changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: route the picker through the profile-aware adapter registry.
- `gateway/slash_commands.py`: capture the routed profile home for deferred callback execution and profile-local config persistence.
- `tests/gateway/test_model_picker_persist.py`: exercise the production handler, profile secret scope, routed adapter registry, and profile-local config write.

## How to Test

1. Use a temporary `HERMES_HOME` with `plugins.enabled: []` so a user plugin cannot mask core behavior.
2. On unpatched current `main`, run the two new multiplex picker tests: both fail because the default adapter captures the picker.
3. On this branch, run:

   ```bash
   python -m pytest -q \
     tests/gateway/test_model_picker_persist.py \
     tests/gateway/test_multiplex_adapter_registry.py \
     tests/gateway/test_model_command_custom_providers.py \
     tests/gateway/test_model_command_flat_string_config.py
   ```

   Result: `23 passed`.

4. Additional validation:

   ```bash
   ruff check gateway/slash_commands.py tests/gateway/test_model_picker_persist.py
   git diff --check origin/main...HEAD
   python scripts/check-windows-footguns.py --all
   ```

   All clean.

## Not in Scope

- Messaging-platform `/model` session-default policy; #61488 covers that.
- Route-scoped context-length resolution; #48187 and the #62152 PR cluster cover that.
- Per-model/provider reasoning policy.
- First-completion backend readiness or rollback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows footgun scan is clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
Unpatched current main + new regressions: 2 failed
Patched focused suite:                     23 passed
Ruff:                                      clean
Windows footguns:                          clean
```
