### PR TITLE
fix(moa): add tool_call_batch_cadence for periodic advisor refresh (#63393)

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -723,6 +723,10 @@ class MoAChatCompletions:
         # caller to stitch in the live session_id + resolved aggregator output
         # and flush to the trace file (only when moa.save_traces is on).
         self._pending_trace: Any = None
+        # Tool-call batch cadence counter. Incremented on every create() call.
+        # When tool_call_batch_cadence > 0, the reference fan-out runs only
+        # every N tool iterations, reducing cost/latency for rapid tool chains.
+        self._tool_call_batch_count = 0
 
     def consume_reference_usage(self) -> tuple[Any, Any]:
         """Pop pending reference-fan-out usage + cost, resetting both to empty.
@@ -837,6 +841,16 @@ class MoAChatCompletions:
         # configured aggregator act alone — it is the preset's acting model, so
         # a disabled MoA preset is simply "use the aggregator directly."
         if not preset.get("enabled", True):
+            reference_models = []
+
+        # Tool-call batch cadence. When > 0, thin the reference fan-out to run
+        # only every N tool-call iterations. On off-cadence iterations we skip
+        # references entirely — the aggregator runs alone with its own context,
+        # avoiding the cost/latency of re-running advisors on every tool step.
+        # Default 0 = run every iteration (current behavior unchanged).
+        tool_call_batch_cadence = preset.get("tool_call_batch_cadence", 0)
+        self._tool_call_batch_count += 1
+        if tool_call_batch_cadence > 0 and (self._tool_call_batch_count - 1) % tool_call_batch_cadence != 0:
             reference_models = []
 
         from agent.usage_pricing import CanonicalUsage

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -101,6 +101,7 @@ def _default_preset() -> dict[str, Any]:
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "per_iteration",
+        "tool_call_batch_cadence": 0,
         "enabled": True,
     }
 
@@ -145,6 +146,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # aggregator gets their upfront plan-level advice, then acts alone
         # for the rest of the tool loop.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        "tool_call_batch_cadence": _coerce_int(raw.get("tool_call_batch_cadence"), 0),
     }
 
 
@@ -192,6 +194,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "per_iteration"),
+        "tool_call_batch_cadence": active.get("tool_call_batch_cadence", 0),
         "enabled": active["enabled"],
     }
 


### PR DESCRIPTION
## Summary

Adds `tool_call_batch_cadence` — a new per-preset setting that controls how many tool-call iterations pass between reference advisor refreshes. Default 0 = run every iteration (current behavior, fully backward compatible).

## Changes

### `hermes_cli/moa_config.py`
- `_default_preset()`: add `"tool_call_batch_cadence": 0`
- `_normalize_preset()`: coerce via existing `_coerce_int(raw.get("tool_call_batch_cadence"), 0)`
- `normalize_moa_config()`: flatten into active view

### `agent/moa_loop.py`
- `MoAChatCompletions.__init__`: add `_tool_call_batch_count` counter
- `create()`: increment counter on each call; when cadence > 0 and the counter doesn't align, skip the reference fan-out entirely — the aggregator runs alone with its own context

## How it works

```yaml
presets:
  default:
    tool_call_batch_cadence: 3   # run advisors every 3rd tool iteration
```

With `cadence: 3`:
- Iterations 1, 4, 7, ... → advisors refreshed, aggregator gets fresh guidance
- Iterations 2, 3, 5, 6, ... → no advisor re-run, aggregator acts alone

Values:
- `0` (default): every iteration — no behavioral change
- `1`: every iteration (same as 0)
- `N > 1`: run every Nth iteration

## Testing

All 76 existing MoA tests pass:
```
22 passed (test_moa_config.py)
39 passed (test_moa_loop_mode.py, test_moa_switch_api_mode.py, test_moa_aggregator_*)
15 passed (test_moa_streaming.py, test_moa_reference_emit.py, test_moa_trace_streamed_capture.py)
```

Closes #63393
