### PR TITLE
fix: Make MoA strictly opt-in in model pickers (#63353)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -602,7 +602,16 @@ def _moa_provider_row(current_provider: str = "") -> dict | None:
     Shared by the CLI inventory (:func:`build_models_payload`) and the gateway
     picker path (:func:`hermes_cli.model_switch.list_picker_providers`) so the
     row shape stays in one place. Returns ``None`` when no MoA presets exist.
+
+    MoA is strictly opt-in: the row is only surfaced when the user's raw
+    config.yaml explicitly enables at least one MoA preset. The synthesized
+    ``default`` preset from ``normalize_moa_config({})`` (which every user gets
+    via DEFAULT_CONFIG defaults) must not be treated as a user choice — see
+    issue #63353.
     """
+    if not _raw_config_has_enabled_moa_preset():
+        return None
+
     try:
         from hermes_cli.config import load_config
         from hermes_cli.moa_config import normalize_moa_config

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -186,7 +186,18 @@ def test_build_models_payload_returns_expected_shape():
          "source": "built-in"},
     ]
     ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
-    with _list_auth_returning(rows):
+    raw_config = {
+        "moa": {
+            "presets": {
+                "default": {"enabled": True},
+            },
+        },
+    }
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value=raw_config),
+        patch("hermes_cli.config.load_config", return_value=raw_config),
+    ):
         payload = build_models_payload(ctx)
     assert set(payload.keys()) == {"providers", "model", "provider"}
     assert payload["model"] == "m1"
@@ -339,7 +350,8 @@ def test_pricing_can_force_fresh_nous_tier():
 def test_include_unconfigured_appends_canonical_skeletons():
     """include_unconfigured=True adds CANONICAL_PROVIDERS rows that
     list_authenticated_providers didn't emit. Skeleton rows have empty
-    models and source='canonical'."""
+    models and source='canonical'. MoA is a virtual routing mode, not a
+    canonical provider, so it is excluded — see issue #63353."""
     rows = [
         {"slug": "openrouter", "name": "OpenRouter", "models": ["m1"],
          "total_models": 1, "is_current": True, "is_user_defined": False,
@@ -349,11 +361,13 @@ def test_include_unconfigured_appends_canonical_skeletons():
     with _list_auth_returning(rows):
         payload = build_models_payload(ctx, include_unconfigured=True)
     # All canonical providers other than openrouter should appear as
-    # skeleton rows.
+    # skeleton rows. MoA is virtual/opt-in and excluded from unconfigured.
     from hermes_cli.models import CANONICAL_PROVIDERS
 
     seen_slugs = {r["slug"] for r in payload["providers"]}
     for entry in CANONICAL_PROVIDERS:
+        if entry.slug == "moa":
+            continue  # virtual; only shown when explicitly configured
         assert entry.slug in seen_slugs, f"missing {entry.slug}"
     # Skeletons have empty models and source='canonical'.
     skeletons = [r for r in payload["providers"]
@@ -601,7 +615,8 @@ def test_canonical_order_with_unconfigured_preserves_full_universe():
     """Combined picker call: include_unconfigured + picker_hints +
     canonical_order is the production TUI shape. Verify the result
     has CANONICAL_PROVIDERS in declaration order, hints applied,
-    custom rows trailing.
+    custom rows trailing. MoA is excluded from unconfigured skeletons
+    (virtual, opt-in only — issue #63353).
     """
     from hermes_cli.models import CANONICAL_PROVIDERS
 
@@ -621,8 +636,12 @@ def test_canonical_order_with_unconfigured_preserves_full_universe():
     slugs = [r["slug"] for r in payload["providers"]]
     # First row: first canonical provider in declaration order.
     assert slugs[0] == CANONICAL_PROVIDERS[0].slug
-    # Custom row trails canonical universe.
-    assert slugs.index("custom:Ollama") >= len(CANONICAL_PROVIDERS)
+    # Custom row trails all visible canonical rows. MoA is virtual/opt-in
+    # so it is excluded from the unconfigured skeleton set.
+    visible_canonical_count = sum(
+        1 for e in CANONICAL_PROVIDERS if e.slug != "moa"
+    )
+    assert slugs.index("custom:Ollama") >= visible_canonical_count
 
 
 # ─── Integration: end-to-end through real load_picker_context ──────────


### PR DESCRIPTION
## Summary

Make MoA strictly opt-in in model pickers by adding a `_raw_config_has_enabled_moa_preset()` guard to `_moa_provider_row()`.

## Problem (issue #63353)

The virtual MoA provider row always appeared in model pickers, even for users who never configured MoA. This was because `normalize_moa_config({})` synthesizes a built-in `default` preset with GPT-5.5/DeepSeek references and Opus aggregator — completely different from the model the user actually selected.

Concrete observation from the issue:
- User configured `openai-codex:gpt-5.6-sol`
- No `moa:` block in `config.yaml`
- Runtime transiently switched to `provider=moa` during model selection

## What this PR changes

1. **`hermes_cli/inventory.py`** — Added `_raw_config_has_enabled_moa_preset()` guard at the top of `_moa_provider_row()`. The function already existed and was used in `_filter_explicit_provider_rows()` but was missing from `_moa_provider_row()`, which is the entry point for non-explicit picker paths (TUI full picker, dashboard picker, etc.).

2. **`tests/hermes_cli/test_inventory.py`** — Updated three tests:
   - `test_build_models_payload_returns_expected_shape`: now patches `read_raw_config` + `load_config` to include MoA config so the test still validates MoA row shape
   - `test_include_unconfigured_appends_canonical_skeletons`: skips `moa` in canonical-provider iteration since it's virtual/opt-in
   - `test_canonical_order_with_unconfigured_preserves_full_universe`: accounts for MoA being excluded from visible canonical count

## Behavior after this PR

- With no raw `moa:` configuration, model pickers contain **no MoA row**
- Once a user explicitly saves at least one enabled MoA preset in `config.yaml`, the MoA row appears
- The existing guard in `_filter_explicit_provider_rows()` continues to work for explicit-only pickers (desktop chat pickers)
- The synthesized `default` preset from `normalize_moa_config({})` is no longer treated as a user choice

Fixes #63353