### PR TITLE
fix(codex): scope app-server notifications to active turn

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -92,6 +92,67 @@ class TurnResult:
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 
 
+def _notification_belongs_to_turn(
+    note: dict,
+    *,
+    thread_id: Optional[str],
+    turn_id: Optional[str],
+) -> bool:
+    """Return whether a multiplexed notification belongs to this turn.
+
+    Codex app-server can carry parent and hosted subagent threads over one
+    JSON-RPC connection.  An explicitly foreign child or
+    stale-turn event must not mutate the active parent's transcript or mark
+    its turn complete.  Unscoped notifications remain accepted for protocol
+    compatibility.
+    """
+    if not isinstance(note, dict):
+        return False
+    params = note.get("params") or {}
+    if not isinstance(params, dict):
+        return True
+
+    nested_turn = params.get("turn") or {}
+    nested_item = params.get("item") or {}
+
+    observed_thread_id = params.get("threadId") or params.get("thread_id")
+    if observed_thread_id is None and isinstance(nested_turn, dict):
+        observed_thread_id = (
+            nested_turn.get("threadId")
+            or nested_turn.get("thread_id")
+        )
+    if observed_thread_id is None and isinstance(nested_item, dict):
+        observed_thread_id = (
+            nested_item.get("threadId")
+            or nested_item.get("thread_id")
+        )
+
+    if (
+        thread_id is not None
+        and observed_thread_id is not None
+        and str(observed_thread_id) != str(thread_id)
+    ):
+        return False
+
+    observed_turn_id = params.get("turnId") or params.get("turn_id")
+    if observed_turn_id is None and isinstance(nested_turn, dict):
+        observed_turn_id = nested_turn.get("id") or nested_turn.get("turnId")
+    if observed_turn_id is None and isinstance(nested_item, dict):
+        observed_turn_id = (
+            nested_item.get("turnId")
+            or nested_item.get("turn_id")
+        )
+
+    if (
+        turn_id is not None
+        and observed_turn_id is not None
+        and str(observed_turn_id) != str(turn_id)
+    ):
+        return False
+
+    return True
+
+
 def _coerce_turn_input_text(user_input: Any) -> str:
     """Collapse Hermes/OpenAI rich content into app-server text input.
 
@@ -505,6 +566,17 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
+                    if not _notification_belongs_to_turn(
+                        pending,
+                        thread_id=self._thread_id,
+                        turn_id=result.turn_id,
+                    ):
+                        logger.debug(
+                            "ignoring foreign codex notification while draining "
+                            "server request: method=%s",
+                            pending.get("method"),
+                        )
+                        continue
                     _apply_token_usage_notification(result, pending)
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)
@@ -536,6 +608,16 @@ class CodexAppServerSession:
                 continue
 
             method = note.get("method", "")
+            if not _notification_belongs_to_turn(
+                note,
+                thread_id=self._thread_id,
+                turn_id=result.turn_id,
+            ):
+                logger.debug(
+                    "ignoring foreign codex notification: method=%s", method
+                )
+                continue
+
             if self._on_event is not None:
                 try:
                     self._on_event(note)
@@ -723,6 +805,16 @@ class CodexAppServerSession:
                 continue
 
             method = note.get("method", "")
+            if not _notification_belongs_to_turn(
+                note,
+                thread_id=self._thread_id,
+                turn_id=result.turn_id,
+            ):
+                logger.debug(
+                    "ignoring foreign codex notification: method=%s", method
+                )
+                continue
+
             if self._on_event is not None:
                 try:
                     self._on_event(note)

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -92,25 +92,15 @@ class TurnResult:
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 
 
-def _notification_belongs_to_turn(
+def _notification_scope_ids(
     note: dict,
-    *,
-    thread_id: Optional[str],
-    turn_id: Optional[str],
-) -> bool:
-    """Return whether a multiplexed notification belongs to this turn.
-
-    Codex app-server can carry parent and hosted subagent threads over one
-    JSON-RPC connection.  An explicitly foreign child or
-    stale-turn event must not mutate the active parent's transcript or mark
-    its turn complete.  Unscoped notifications remain accepted for protocol
-    compatibility.
-    """
+) -> tuple[Optional[str], Optional[str]]:
+    """Extract the thread/turn identity carried by a notification."""
     if not isinstance(note, dict):
-        return False
+        return None, None
     params = note.get("params") or {}
     if not isinstance(params, dict):
-        return True
+        return None, None
 
     nested_turn = params.get("turn") or {}
     nested_item = params.get("item") or {}
@@ -127,13 +117,6 @@ def _notification_belongs_to_turn(
             or nested_item.get("thread_id")
         )
 
-    if (
-        thread_id is not None
-        and observed_thread_id is not None
-        and str(observed_thread_id) != str(thread_id)
-    ):
-        return False
-
     observed_turn_id = params.get("turnId") or params.get("turn_id")
     if observed_turn_id is None and isinstance(nested_turn, dict):
         observed_turn_id = nested_turn.get("id") or nested_turn.get("turnId")
@@ -142,6 +125,35 @@ def _notification_belongs_to_turn(
             nested_item.get("turnId")
             or nested_item.get("turn_id")
         )
+
+    return observed_thread_id, observed_turn_id
+
+
+def _notification_belongs_to_turn(
+    note: dict,
+    *,
+    thread_id: Optional[str],
+    turn_id: Optional[str],
+) -> bool:
+    """Return whether a multiplexed notification belongs to this turn.
+
+    Codex app-server can carry parent and hosted subagent threads over one
+    JSON-RPC connection.  An explicitly foreign child or
+    stale-turn event must not mutate the active parent's transcript or mark
+    its turn complete.  Unscoped notifications remain accepted for protocol
+    compatibility.
+    """
+    if not isinstance(note, dict):
+        return False
+
+    observed_thread_id, observed_turn_id = _notification_scope_ids(note)
+
+    if (
+        thread_id is not None
+        and observed_thread_id is not None
+        and str(observed_thread_id) != str(thread_id)
+    ):
+        return False
 
     if (
         turn_id is not None
@@ -805,6 +817,38 @@ class CodexAppServerSession:
                 continue
 
             method = note.get("method", "")
+            observed_thread_id, observed_turn_id = _notification_scope_ids(note)
+            if result.turn_id is None:
+                if method == "turn/started":
+                    if (
+                        observed_thread_id is not None
+                        and str(observed_thread_id) != str(self._thread_id)
+                    ):
+                        logger.debug(
+                            "ignoring foreign compact turn/started: thread=%s",
+                            observed_thread_id,
+                        )
+                        continue
+                    if observed_turn_id is None:
+                        logger.debug(
+                            "ignoring compact turn/started without a turn id"
+                        )
+                        continue
+                    result.turn_id = str(observed_turn_id)
+                elif observed_turn_id is not None or method in {
+                    "item/completed",
+                    "turn/completed",
+                }:
+                    # thread/compact/start does not return a turn id. Until the
+                    # new turn/started arrives, any terminal/projectable event
+                    # is stale or cannot be safely attributed to this compaction.
+                    logger.debug(
+                        "ignoring codex notification before compact turn start: "
+                        "method=%s",
+                        method,
+                    )
+                    continue
+
             if not _notification_belongs_to_turn(
                 note,
                 thread_id=self._thread_id,

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -95,6 +95,17 @@ class FakeClient:
 
     # Test helpers
     def queue_notification(self, method: str, **params):
+        # Keep legacy fixture shorthand aligned with the IDs returned by the
+        # fake thread/start and turn/start responses.
+        if params.get("threadId") in {"t", "th"}:
+            params["threadId"] = "thread-fake-001"
+        if params.get("turnId") == "tu1":
+            params["turnId"] = "turn-fake-001"
+        turn = params.get("turn")
+        if isinstance(turn, dict) and turn.get("id") == "tu1":
+            turn = dict(turn)
+            turn["id"] = "turn-fake-001"
+            params["turn"] = turn
         self._notifications.append({"method": method, "params": params})
 
     def queue_server_request(self, method: str, request_id: Any = "srv-1", **params):
@@ -195,6 +206,173 @@ class TestRunTurn:
                    for m in r.projected_messages)
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
+
+    def test_subagent_completion_does_not_end_parent_turn(self):
+        """A child completion must not become the parent's response."""
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-child-001",
+            turnId="turn-child-001",
+            item={
+                "type": "agentMessage",
+                "id": "child-message-1",
+                "text": "child summary",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-child-001",
+            turn={
+                "id": "turn-child-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            item={
+                "type": "agentMessage",
+                "id": "parent-message-1",
+                "text": "parent synthesis",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "turn-fake-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).run_turn("delegate this", turn_timeout=2.0)
+
+        assert result.final_text == "parent synthesis"
+        assert result.interrupted is False
+        assert result.error is None
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "parent synthesis"}
+        ]
+
+    def test_stale_completion_on_parent_thread_is_ignored(self):
+        """A late completion from the previous parent turn is not terminal."""
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="turn-previous",
+            item={
+                "type": "agentMessage",
+                "id": "stale-message",
+                "text": "stale previous answer",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "turn-previous",
+                "status": "completed",
+                "error": None,
+            },
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            item={
+                "type": "agentMessage",
+                "id": "current-message",
+                "text": "current parent answer",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "turn-fake-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).run_turn("new prompt", turn_timeout=2.0)
+
+        assert result.final_text == "current parent answer"
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "current parent answer"}
+        ]
+
+    def test_foreign_completion_in_server_request_drain_is_ignored(self):
+        """Approval draining must not project a child result into the parent."""
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="pwd",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-child-001",
+            turnId="turn-child-001",
+            item={
+                "type": "agentMessage",
+                "id": "child-message",
+                "text": "child drain summary",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-child-001",
+            turn={
+                "id": "turn-child-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        original_respond = client.respond
+
+        def respond_and_release_parent(request_id, response):
+            original_respond(request_id, response)
+            client.queue_notification(
+                "item/completed",
+                threadId="thread-fake-001",
+                turnId="turn-fake-001",
+                item={
+                    "type": "agentMessage",
+                    "id": "parent-message",
+                    "text": "parent after approval",
+                },
+            )
+            client.queue_notification(
+                "turn/completed",
+                threadId="thread-fake-001",
+                turn={
+                    "id": "turn-fake-001",
+                    "status": "completed",
+                    "error": None,
+                },
+            )
+
+        client.respond = respond_and_release_parent
+        session = make_session(
+            client,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+        )
+
+        result = session.run_turn("delegate then continue", turn_timeout=2.0)
+
+        assert client.responses == [("approval-1", {"decision": "accept"})]
+        assert result.final_text == "parent after approval"
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "parent after approval"}
+        ]
 
     def test_token_usage_notification_is_captured(self):
         client = FakeClient()
@@ -527,6 +705,61 @@ class TestCompactThread:
         assert r.final_text == "compacted"
         assert r.token_usage_last["totalTokens"] == 12
         assert r.model_context_window == 200000
+
+    def test_compact_thread_ignores_foreign_child_completion(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-child-001",
+            turnId="child-compact-turn",
+            item={
+                "type": "agentMessage",
+                "id": "child-compact-message",
+                "text": "child compact summary",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-child-001",
+            turn={
+                "id": "child-compact-turn",
+                "status": "completed",
+                "error": None,
+            },
+        )
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1"},
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="compact-turn-1",
+            item={
+                "type": "agentMessage",
+                "id": "parent-compact-message",
+                "text": "parent compacted",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-1",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.error is None
+        assert result.turn_id == "compact-turn-1"
+        assert result.final_text == "parent compacted"
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "parent compacted"}
+        ]
 
     def test_compact_thread_interrupted_returns_non_success(self):
         client = FakeClient()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -709,6 +709,11 @@ class TestCompactThread:
     def test_compact_thread_ignores_foreign_child_completion(self):
         client = FakeClient()
         client.queue_notification(
+            "turn/started",
+            threadId="thread-child-001",
+            turn={"id": "child-compact-turn"},
+        )
+        client.queue_notification(
             "item/completed",
             threadId="thread-child-001",
             turnId="child-compact-turn",
@@ -759,6 +764,61 @@ class TestCompactThread:
         assert result.final_text == "parent compacted"
         assert result.projected_messages == [
             {"role": "assistant", "content": "parent compacted"}
+        ]
+
+    def test_compact_thread_ignores_stale_same_thread_completion_before_start(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="previous-compact-turn",
+            item={
+                "type": "agentMessage",
+                "id": "stale-compact-message",
+                "text": "stale compact result",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "previous-compact-turn",
+                "status": "completed",
+                "error": None,
+            },
+        )
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1"},
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="compact-turn-1",
+            item={
+                "type": "agentMessage",
+                "id": "current-compact-message",
+                "text": "current compact result",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-1",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.error is None
+        assert result.turn_id == "compact-turn-1"
+        assert result.final_text == "current compact result"
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "current compact result"}
         ]
 
     def test_compact_thread_interrupted_returns_non_success(self):


### PR DESCRIPTION
## Problem

Codex app-server can multiplex notifications for the active parent thread, hosted subagent threads, and late events from prior turns over the same JSON-RPC connection.

`CodexAppServerSession.run_turn()` previously projected every `item/completed` notification into the active result and treated every `turn/completed` notification as terminal. A child completion could therefore replace the parent's `final_text` and end the parent turn before it synthesized a response.

A deterministic reproduction queues:

1. a child `agentMessage` and child `turn/completed`
2. the active parent's `agentMessage` and `turn/completed`

Before this change, the result is the child summary instead of the parent synthesis.

## Root cause

The app-server session adapter did not scope dequeued notifications to the thread and turn returned by `thread/start` and `turn/start`. The generic conversation loop, delegation tool, and TUI delivery layers are not required to reproduce the failure.

## Fix

- Extract notification thread/turn identity in one helper.
- Reject explicitly foreign thread or turn IDs before callbacks, accounting, projection, or terminal handling.
- Apply the guard in the normal turn loop, approval/server-request drain, and compaction loop.
- Preserve unscoped notifications in normal turns for protocol compatibility.
- In `compact_thread()`, do not accept turn-scoped or terminal/projectable events until a same-thread `turn/started` establishes the active compaction turn ID.
- Reject a foreign child `turn/started` before it can establish that ID.

## Review follow-up

The automated review correctly identified that `thread/compact/start` does not return a turn ID. A same-thread stale `turn/completed` queued before the new `turn/started` could therefore pass the original guard while `result.turn_id` was still `None`.

The follow-up commit adds the exact ordering regression and gates compaction events until the new turn identity is known. The branch was also rebased onto current `main` (`3f2a389c7e`).

## Regression coverage

The tests verify that:

- a subagent completion does not end the parent turn
- a late completion from a previous parent turn is ignored
- approval-request draining cannot project a child result into the parent
- compaction ignores a foreign child's `turn/started` and completion
- compaction ignores same-thread stale item/turn completions queued before the new `turn/started`

The primary parent-continuation regression fails before the source fix (`child summary` != `parent synthesis`). The new compaction regression fails on the first PR revision by returning `previous-compact-turn` instead of `compact-turn-1`.

## Verification

On the rebased branch:

- Targeted regressions: **5 passed**
- Full app-server session suite: **69 passed**
- App-server session/projector/MCP/integration/compaction group: **143 passed**
- Delegation, async delegation, tool-loop, interrupt, TUI protocol, and child-mirroring group: **346 passed**
- Read/search-loop regression file: **25 passed standalone**
- `ruff check` on changed Python files: passed
- `git diff --check`: passed
- Patch scan for credentials, personal paths, and deployment-specific content: no findings

## Compatibility

- Ordinary app-server tool continuation is unchanged.
- Synchronous and asynchronous Hermes delegation tests remain green.
- Non-Codex providers are unaffected.
- Existing interrupt, timeout, approval, compaction, TUI, and gateway behavior remains covered by the passing suites above.
