### PR TITLE
fix(docs): remove phantom /skill and /q alias from hermes-agent SKILL.md

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -312,7 +312,6 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
@@ -359,7 +358,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit)       Exit CLI
 ```
 
 ---
@@ -917,7 +916,7 @@ and logs — avoids shell-escaping backslashes in bash.
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement
-3. Load explicitly: `/skill name` or `hermes -s name`
+3. Load explicitly: `hermes -s <name>` (the `-s`/`--skills` CLI flag preloads skills for the session)
 
 ### Gateway issues
 Check logs first:

--- a/tests/skills/test_hermes_agent_skill_docs.py
+++ b/tests/skills/test_hermes_agent_skill_docs.py
@@ -1,0 +1,132 @@
+"""Regression tests for docs in skills/autonomous-ai-agents/hermes-agent/SKILL.md.
+
+The bundled hermes-agent skill is the source every Hermes session reads for
+slash-command reference. If the doc lists a command that does not exist in
+``hermes_cli/commands.py``, agents propagate the phantom into the system
+prompt and users hit dead ends. These tests guard the docs against two
+specific drift cases reported in issue #50605:
+
+1. ``/skill <name>`` — listed as a slash command, but no
+   ``CommandDef("skill", ...)`` exists in the registry.
+2. ``/q`` — listed as an alias for ``/quit`` in the Exit section, but
+   the registry declares ``q`` as the alias for ``/queue`` and only
+   ``exit`` as an alias for ``/quit``.
+
+Fixes #50605
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.commands import COMMAND_REGISTRY
+
+
+# Repo-relative path to the bundled hermes-agent skill docs.
+HERMES_AGENT_SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "autonomous-ai-agents"
+    / "hermes-agent"
+    / "SKILL.md"
+)
+
+
+def _read_skill_md() -> str:
+    assert HERMES_AGENT_SKILL_MD.is_file(), (
+        f"hermes-agent SKILL.md missing at {HERMES_AGENT_SKILL_MD}"
+    )
+    return HERMES_AGENT_SKILL_MD.read_text(encoding="utf-8")
+
+
+def _registered_names() -> set[str]:
+    return {cmd.name for cmd in COMMAND_REGISTRY}
+
+
+def _registered_aliases() -> set[str]:
+    aliases: set[str] = set()
+    for cmd in COMMAND_REGISTRY:
+        aliases.update(cmd.aliases)
+    return aliases
+
+
+@pytest.fixture(scope="module")
+def skill_md_text() -> str:
+    return _read_skill_md()
+
+
+class TestSlashCommandsMatchRegistry:
+    """Every slash command named in the SKILL.md doc must exist in the registry."""
+
+    def test_no_phantom_skill_slash_command(self, skill_md_text: str) -> None:
+        """``/skill <name>`` is not a registered command — only ``/skills`` is.
+
+        The doc previously listed ``/skill <name>`` as "Load a skill into
+        session", which misleads agents and users into typing a dead command.
+        """
+        registered = _registered_names()
+        # ``/skills`` (the catalog browser) is the real skills-related slash
+        # command and is allowed to appear; the singular ``/skill`` is not.
+        assert "skill" not in registered, (
+            "Test setup invariant violated: a CommandDef('skill', ...) appeared "
+            "in the registry — update this test to reflect the new command."
+        )
+
+        # The phantom appears in two known places: the slash-command table and
+        # the "Skills not showing" troubleshooting section. Match the command
+        # line (with its argument placeholder) and the standalone invocation.
+        assert "/skill <name>" not in skill_md_text, (
+            "Phantom slash command ``/skill <name>`` is documented in the "
+            "hermes-agent SKILL.md but no CommandDef('skill', ...) exists in "
+            "the registry. Issue #50605."
+        )
+        assert "`/skill name`" not in skill_md_text, (
+            "Phantom slash command ``/skill name`` is documented in the "
+            "hermes-agent SKILL.md troubleshooting section but no such command "
+            "exists in the registry. Issue #50605."
+        )
+
+    def test_q_alias_for_quit_is_documented_correctly(self, skill_md_text: str) -> None:
+        """``/quit`` is only aliased as ``/exit``; ``/q`` is the alias for ``/queue``.
+
+        The previous Exit section claimed ``/quit (/exit, /q)``, but the
+        registry binds ``q`` to ``queue`` (which queues a prompt for the next
+        turn) — typing ``/q`` to exit actually queues, silently. This test
+        catches the regression at the doc level.
+        """
+        registered = _registered_names()
+        assert "quit" in registered, "Registry invariant violated: /quit missing"
+
+        # Find which command the alias ``q`` actually maps to.
+        q_owner: str | None = None
+        for cmd in COMMAND_REGISTRY:
+            if "q" in cmd.aliases:
+                q_owner = cmd.name
+                break
+        assert q_owner is not None, "Registry invariant violated: no command has alias 'q'"
+        assert q_owner != "quit", (
+            f"Test setup invariant violated: alias 'q' now belongs to /{q_owner}; "
+            "update this test to reflect the new binding."
+        )
+
+        # The Exit section must not advertise ``/q`` as an alias for /quit.
+        # We look for the exact Exit-line pattern from the issue.
+        assert "/quit (/exit, /q)" not in skill_md_text, (
+            "The Exit section of hermes-agent SKILL.md incorrectly documents "
+            "``/q`` as an alias for ``/quit``. In the registry, ``/q`` is the "
+            "alias for ``/queue``. Issue #50605."
+        )
+        # And no standalone ``/q`` should be advertised in the Exit block.
+        # Match a trailing-alias pattern only inside the Exit section to keep
+        # the assertion scoped; the bullet line is ``/quit (/exit, /q)``.
+        exit_section_marker = "### Exit"
+        idx = skill_md_text.find(exit_section_marker)
+        assert idx != -1, "Exit section header missing from SKILL.md"
+        # Take a window after the Exit header up to the next blank-line section.
+        exit_block = skill_md_text[idx : idx + 400]
+        assert "(/exit, /q)" not in exit_block, (
+            "The Exit section still lists ``/q`` as an alias for ``/quit``. "
+            "In the registry, ``/q`` is the alias for ``/queue``. Issue #50605."
+        )


### PR DESCRIPTION
## Summary

The bundled `hermes-agent` SKILL.md documented two slash commands that do not exist in the registry (`hermes_cli/commands.py`), and the SKILL.md is loaded into every Hermes session's system prompt as the slash-command reference, so the phantoms propagated into every agent.

1. **`/skill <name>`** — listed as "Load a skill into session" in both the slash-command table and the "Skills not showing" troubleshooting section. There is no `CommandDef("skill", ...)`. The only skills-related slash command is `/skills` (plural, the catalog browser). The real way to preload a skill for a session is the `-s` / `--skills` CLI flag, which was already mentioned alongside the phantom.

2. **`/q`** — listed as an alias for `/quit` in the Exit section. In the registry, `q` is the alias for `/queue` (queues a prompt for the next turn), so typing `/q` to exit silently queues a prompt instead of exiting. `/quit` is only aliased as `/exit`.

## Changes

- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`: removed the phantom `/skill <name>` line from the slash-command table, corrected the `/quit` alias line from `(/exit, /q)` to `(/exit)`, and replaced the troubleshooting entry "`/skill name` or `hermes -s name`" with "`hermes -s <name>` (the `-s`/`--skills` CLI flag preloads skills for the session)".
- `tests/skills/test_hermes_agent_skill_docs.py`: regression test that asserts the SKILL.md does not contain the phantoms and that the registry alias ownership of `q` is consistent with the registry of record. Will catch any future drift.

The website Docusaurus pages under `website/docs/.../autonomous-ai-agents-hermes-agent.md` (English + zh-Hans) carry the same phantom strings but are auto-generated from the source SKILL.md by `website/scripts/generate-skill-docs.py`, so the next docs build will pick up the source fix automatically — they are intentionally not edited by hand in this PR.

## Testing

- New regression test (red→green):
  ```bash
  python3 -m pytest tests/skills/test_hermes_agent_skill_docs.py -v
  # tests/skills/test_hermes_agent_skill_docs.py::TestSlashCommandsMatchRegistry::test_no_phantom_skill_slash_command PASSED
  # tests/skills/test_hermes_agent_skill_docs.py::TestSlashCommandsMatchRegistry::test_q_alias_for_quit_is_documented_correctly PASSED
  # 2 passed
  ```
- Wider skill/commands suite (no regressions):
  ```bash
  python3 -m pytest tests/skills/ tests/hermes_cli/test_commands.py tests/tools/test_skills_tool.py -q
  # 558 passed
  ```
- Diff: 3 lines changed in SKILL.md, 131 lines added in test file.

Fixes #50605