### PR TITLE
fix(agent): normalize empty content to None for assistant messages with tool_calls

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1265,6 +1265,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             tool_calls.append(tc_dict)
         msg["tool_calls"] = tool_calls
 
+    # Normalize empty-string content to None when tool_calls are present.
+    # The OpenAI API spec requires assistant messages with tool_calls to use
+    # content: null (or omit content), not an empty string. Most providers
+    # are lenient, but strict validators like DeepSeek reject content:"" with
+    # HTTP 400 ("An assistant message with 'tool_calls' must be followed by
+    # tool messages..."). (#63200)
+    if msg.get("tool_calls") and msg.get("content") == "":
+        msg["content"] = None
+
     return msg
 
 

--- a/tests/agent/test_assistant_msg_empty_content.py
+++ b/tests/agent/test_assistant_msg_empty_content.py
@@ -1,0 +1,101 @@
+"""Regression test for #63200.
+
+``build_assistant_message`` must normalize empty-string ``content`` to ``None``
+when ``tool_calls`` are present. The OpenAI API spec requires assistant messages
+with tool_calls to use ``content: null`` (or omit it), not an empty string.
+Strict validators like DeepSeek reject ``content: ""`` with HTTP 400.
+"""
+
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import build_assistant_message
+
+
+class _FakeToolCall:
+    def __init__(self, tc_id, name, arguments):
+        self.id = tc_id
+        self.type = "function"
+        self.function = MagicMock()
+        self.function.name = name
+        self.function.arguments = arguments
+        self.extra_content = None
+
+    def __getattr__(self, _name):
+        return None
+
+
+class _FakeAssistantMsg:
+    def __init__(self, content, tool_calls):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.function_call = None
+        self.reasoning_content = None
+        self.model_extra = None
+        self.reasoning_details = None
+
+    def __getattr__(self, _name):
+        return None
+
+
+class _FakeAgent:
+    stream_delta_callback = None
+    _stream_callback = None
+    reasoning_callback = None
+    verbose_logging = False
+
+    def _extract_reasoning(self, _msg):
+        return None
+
+    def _strip_think_blocks(self, text):
+        return text
+
+    def _needs_thinking_reasoning_pad(self):
+        return False
+
+    def _split_responses_tool_id(self, _raw):
+        return (None, None)
+
+    def _derive_responses_function_call_id(self, _call_id, _resp_id):
+        return None
+
+    def _deterministic_call_id(self, _name, _args, idx):
+        return f"det_{idx}"
+
+
+def test_empty_content_normalized_to_none_with_tool_calls():
+    """Assistant message with tool_calls and empty content should have content=None."""
+    tc = _FakeToolCall("call_1", "terminal", "{}")
+    msg = build_assistant_message(
+        _FakeAgent(), _FakeAssistantMsg("", [tc]), "tool_calls"
+    )
+    assert msg["tool_calls"] is not None
+    assert msg["content"] is None
+
+
+def test_nonempty_content_preserved_with_tool_calls():
+    """Assistant message with tool_calls and real content should keep it."""
+    tc = _FakeToolCall("call_1", "terminal", "{}")
+    msg = build_assistant_message(
+        _FakeAgent(), _FakeAssistantMsg("Running command...", [tc]), "tool_calls"
+    )
+    assert msg["tool_calls"] is not None
+    assert msg["content"] == "Running command..."
+
+
+def test_empty_content_without_tool_calls_stays_empty():
+    """Assistant message with no tool_calls should keep empty string content."""
+    msg = build_assistant_message(
+        _FakeAgent(), _FakeAssistantMsg("", None), "stop"
+    )
+    assert msg.get("tool_calls") is None
+    assert msg["content"] == ""
+
+
+def test_none_content_with_tool_calls_stays_none():
+    """Assistant message with tool_calls and None content should stay None."""
+    tc = _FakeToolCall("call_1", "terminal", "{}")
+    msg = build_assistant_message(
+        _FakeAgent(), _FakeAssistantMsg(None, [tc]), "tool_calls"
+    )
+    assert msg["tool_calls"] is not None
+    assert msg["content"] is None


### PR DESCRIPTION
## What does this PR do?

Normalizes empty-string `content` to `None` on assistant messages that carry `tool_calls`. The OpenAI API spec requires assistant messages with `tool_calls` to use `content: null` (or omit the field), not an empty string. Most providers are lenient, but strict validators like DeepSeek reject `content: ""` with HTTP 400, breaking every subsequent turn in the session once a single tool-call turn is stored.

## Related Issue

Fixes #63200

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — In `build_assistant_message()`, after assembling `tool_calls`, set `content = None` when it would otherwise be `""`. This is a 3-line addition at the return boundary, touching no other logic.
- `tests/agent/test_assistant_msg_empty_content.py` — 4 regression tests covering: empty content + tool_calls → None, non-empty content + tool_calls → preserved, empty content without tool_calls → stays `""`, None content + tool_calls → stays None.

## How to Test

1. `python -m pytest tests/agent/test_assistant_msg_empty_content.py -x -q` — should pass (4 tests).
2. `python -m pytest tests/agent/test_tool_call_arg_no_redaction.py -x -q` — existing test suite should still pass (confirms no regression).
3. Manual verification: configure a DeepSeek model, trigger a tool call, and confirm the next turn does not produce HTTP 400.

Observed result: All 4 new tests pass; existing `test_tool_call_arg_no_redaction.py` tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
