### PR TITLE
fix(cli): serialize concurrent web-UI builds with an exclusive flock

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4869,6 +4869,51 @@ def _run_npm_install_deterministic(
 
 
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
+    """Build the web UI frontend if npm is available, serializing across processes.
+
+    Concurrent dashboard boots (e.g. the desktop app's retry loop after a
+    readiness timeout) used to each spawn their own ``npm install`` +
+    ``vite build`` over the same tree; the parallel builds starved each
+    other, none finished, the dist sentinel never advanced, and every new
+    boot re-triggered the build. One process builds under an exclusive
+    flock; the rest serve the existing dist (stale is acceptable) or, when
+    no dist exists yet, block until the builder finishes.
+    """
+    if not (web_dir / "package.json").exists():
+        return True
+    if not _web_ui_build_needed(web_dir):
+        return True
+    try:
+        import fcntl
+    except ImportError:
+        # Windows: no flock — fall through to the unserialized build.
+        return _do_build_web_ui(web_dir, fatal=fatal)
+    project_root = web_dir.parent.parent if web_dir.parent.name == "apps" else web_dir.parent
+    dist_index = project_root / "hermes_cli" / "web_dist" / "index.html"
+    try:
+        lock_file = open(project_root / ".web_ui_build.lock", "a")
+    except OSError:
+        return _do_build_web_ui(web_dir, fatal=fatal)
+    try:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            if dist_index.exists():
+                # Another process is already building — serve the current
+                # dist instead of piling a second build onto the same tree.
+                return True
+            # No dist at all (first-ever build): wait for the builder.
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        # Re-check under the lock: the previous holder may have finished
+        # the build while this process was waiting or racing for it.
+        if not _web_ui_build_needed(web_dir):
+            return True
+        return _do_build_web_ui(web_dir, fatal=fatal)
+    finally:
+        lock_file.close()
+
+
+def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
     Args:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4878,10 +4878,12 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     boot re-triggered the build. One process builds under an exclusive
     flock; the rest serve the existing dist (stale is acceptable) or, when
     no dist exists yet, block until the builder finishes.
+
+    Staleness is checked once, inside :func:`_do_build_web_ui`, after the
+    lock is held — so a process that queued behind the builder skips the
+    rebuild, and the (os.walk-based) check runs at most once per boot.
     """
     if not (web_dir / "package.json").exists():
-        return True
-    if not _web_ui_build_needed(web_dir):
         return True
     try:
         import fcntl
@@ -4904,10 +4906,6 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
                 return True
             # No dist at all (first-ever build): wait for the builder.
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        # Re-check under the lock: the previous holder may have finished
-        # the build while this process was waiting or racing for it.
-        if not _web_ui_build_needed(web_dir):
-            return True
         return _do_build_web_ui(web_dir, fatal=fatal)
     finally:
         lock_file.close()


### PR DESCRIPTION
Concurrent dashboard boots (e.g. the desktop app's retry loop after a readiness timeout) each spawn their own `npm install --workspace web` + `vite build` over the same tree. The parallel builds starve each other, none finishes, the dist sentinel (`hermes_cli/web_dist/.vite/manifest.json`) never advances, and every subsequent boot re-triggers the build — a self-sustaining cascade of orphaned backends and CPU contention (details in issue #63454).

This change serializes the build with an exclusive `flock` on `<project_root>/.web_ui_build.lock`:

- One process acquires the lock and builds.
- Losers of the race serve the existing dist if one exists — a stale UI beats a hung boot, mirroring the existing stale-dist fallback for failed builds.
- If no dist exists at all (first-ever build), losers block until the builder finishes, then re-check staleness.
- On Windows (`fcntl` unavailable) behavior is unchanged.

The staleness check is re-run under the lock so queued processes don't rebuild redundantly after the winner finishes.

Tested on macOS 12 (Intel): armed the rebuild trigger (touched `package-lock.json`) and started 5 `hermes dashboard` instances concurrently. Exactly one `npm ci` + `vite build` ran; the other four came up serving the previous dist as soon as their module imports finished (HTTP 200 in ~0.2s once bound, no `EADDRINUSE`); the winner finished its build, advanced the sentinel, and subsequent boots skipped the build entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
