### PR TITLE
perf(cli): check local auth.json/config before slow provider registry sweep

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -855,16 +855,9 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
-    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
-    try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
-    except Exception:
-        pass
+    # Cheap local checks first: auth.json and config.yaml are on-disk lookups,
+    # while the PROVIDER_REGISTRY sweep below spawns subprocesses (gh) and can
+    # take 15-20s — long enough that desktop setup.status calls time out.
 
     # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
@@ -891,6 +884,17 @@ def _has_any_provider_configured() -> bool:
         cfg_api_key = (model_cfg.get("api_key") or "").strip()
         if cfg_provider or cfg_base_url or cfg_api_key:
             return True
+
+    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
+    try:
+        for provider_id, pconfig in PROVIDER_REGISTRY.items():
+            if pconfig.auth_type != "api_key":
+                continue
+            status = get_auth_status(provider_id)
+            if status.get("logged_in"):
+                return True
+    except Exception:
+        pass
 
     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
     # Only count these if Hermes has been explicitly configured — Claude Code


### PR DESCRIPTION
`_has_any_provider_configured()` probes every `api_key` provider in the registry via `get_auth_status()` — for Copilot that shells out to `gh auth token` (up to 5s) — *before* looking at `auth.json` and `config.yaml`, which are instant on-disk reads.

On a machine where the local files would already answer True (Portal OAuth or explicit provider in config), every `setup.status` request still paid for the full sweep — ~18s in our measurements. The desktop UI calls `setup.status` over the ws right after connecting; the stalled response hit the client timeout, the ws was torn down, and the UI showed the backend as dead even though it was healthy (issue #63454).

This reorders the checks cheapest-first: env vars → `.env` → `auth.json` → `config.yaml` → registry sweep → Claude Code credentials. Semantics are unchanged — the function still returns True/False for exactly the same configurations — only the short-circuit order differs. `setup.status` dropped from ~18s to ~0.5s here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
