### PR TITLE
fix(file): keep native Windows paths for rg searches

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -15,6 +15,7 @@ from tools.file_operations import (
     SearchResult,
     SearchMatch,
     LintResult,
+    ExecuteResult,
     ShellFileOperations,
     MAX_LINE_LENGTH,
     normalize_read_pagination,
@@ -477,6 +478,14 @@ class TestShellFileOpsHelpers:
         # Non-drive paths are untouched.
         assert file_ops._escape_shell_arg("/tmp/foo") == "'/tmp/foo'"
 
+    def test_escape_native_shell_arg_keeps_windows_drive_paths(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        assert file_ops._escape_shell_arg("C:/Users/alice/repo") == "'/c/Users/alice/repo'"
+        assert file_ops._escape_native_shell_arg("C:/Users/alice/repo") == "'C:/Users/alice/repo'"
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 
@@ -504,6 +513,59 @@ class TestShellFileOpsHelpers:
         assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
         assert commands[2] == "sed -n '1,500p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+
+    def test_rg_file_search_keeps_native_windows_path(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def fake_exec(command, **kwargs):
+            commands.append(command)
+            if len(commands) == 1:
+                return ExecuteResult(stdout="", exit_code=0)
+            return ExecuteResult(stdout="C:/Users/alice/repo/src/app.py\n", exit_code=0)
+
+        file_ops._exec = fake_exec
+        result = file_ops._search_files_rg("app.py", "C:/Users/alice/repo", limit=10, offset=0)
+
+        assert result.files == ["C:/Users/alice/repo/src/app.py"]
+        assert commands[0] == (
+            "rg --files --sortr=modified -g '*app.py' "
+            "'C:/Users/alice/repo' 2>/dev/null | head -n 10"
+        )
+        assert commands[1] == (
+            "rg --files -g '*app.py' "
+            "'C:/Users/alice/repo' 2>/dev/null | head -n 10"
+        )
+
+    def test_rg_content_search_keeps_native_windows_path(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def fake_exec(command, **kwargs):
+            commands.append(command)
+            return ExecuteResult(stdout="C:/Users/alice/repo/src/app.py:7:needle\n", exit_code=0)
+
+        file_ops._exec = fake_exec
+        result = file_ops._search_with_rg(
+            "needle",
+            "C:/Users/alice/repo",
+            file_glob=None,
+            limit=10,
+            offset=0,
+            output_mode="content",
+            context=0,
+        )
+
+        assert result.total_count == 1
+        assert result.matches[0].path == "C:/Users/alice/repo/src/app.py"
+        assert commands == [
+            "set -o pipefail; rg --line-number --no-heading --with-filename "
+            "'needle' 'C:/Users/alice/repo' | head -n 10"
+        ]
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -973,6 +973,15 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_shell_arg(self, arg: str) -> str:
+        """Escape a shell argument without MSYS drive-path rewriting.
+
+        Native Windows binaries invoked from Git Bash, such as ``rg.exe`` when
+        ``MSYS_NO_PATHCONV=1`` is set, expect drive-qualified paths like
+        ``C:/Users/...`` rather than MSYS paths like ``/c/Users/...``.
+        """
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2212,7 +2221,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_shell_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2223,7 +2232,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_shell_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2279,7 +2288,7 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_shell_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,


### PR DESCRIPTION
## What does this PR do?

Fixes `search_files` returning zero results for explicit Windows drive paths when ripgrep is the backend.

`_escape_shell_arg()` intentionally rewrites `C:/...` to `/c/...` for Git Bash shell utilities, but native Windows `rg.exe` receives paths under `MSYS_NO_PATHCONV=1` and expects the drive-qualified path. This PR keeps the existing MSYS rewrite for normal shell file operations and the grep/find fallbacks, while passing the `rg` path argument through shell quoting without drive-path rewriting.

## Related Issue

Fixes #63177

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py`: added native shell quoting for paths that are passed to `rg`.
- `tools/file_operations.py`: updated `_search_files_rg()` and `_search_with_rg()` to preserve native Windows paths for ripgrep.
- `tests/tools/test_file_operations.py`: added regression coverage for the native path helper and all three ripgrep path call sites.

## How to Test

1. On Windows Git Bash with native `rg.exe`, call `search_files(pattern="needle", path="C:/Users/<user>/Documents/Obsidian Vault")`.
2. Confirm the generated ripgrep command receives `C:/Users/...` rather than `/c/Users/...`.
3. Confirm matches are returned instead of `total_count: 0`.

Focused validation run here:

```text
uv run pytest tests/tools/test_file_operations.py -q
95 passed in 0.80s

uv run ruff check tools/file_operations.py tests/tools/test_file_operations.py
All checks passed!
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local focused tests; Windows path behavior is covered by unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
set -o pipefail; rg --line-number --no-heading --with-filename 'needle' 'C:/Users/alice/repo' | head -n 10
```

The regression test asserts that the path remains `C:/Users/alice/repo` for ripgrep instead of being rewritten to `/c/Users/alice/repo`.