### PR TITLE
fix(discord): anchor handoff threads in parent channel

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5496,6 +5496,17 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
 
+        def _track_created_thread(thread: Any) -> str:
+            thread_id = str(thread.id)
+            try:
+                self._threads.mark(thread_id)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Handoff thread %s created but participation tracking failed: %s",
+                    self.name, thread_id, exc,
+                )
+            return thread_id
+
         seed_error: Exception | None = None
 
         # Preferred path: create the thread from a visible parent message. A
@@ -5511,7 +5522,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
-                return str(thread.id)
+                return _track_created_thread(thread)
         except Exception as exc:
             seed_error = exc
             logger.debug(
@@ -5531,7 +5542,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason=reason,
             )
-            return str(thread.id)
+            return _track_created_thread(thread)
         except Exception as direct_error:
             logger.warning(
                 "[%s] Handoff thread: seed and direct create failed for "

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5457,11 +5457,12 @@ class DiscordAdapter(BasePlatformAdapter):
         parent_chat_id: str,
         name: str,
     ) -> Optional[str]:
-        """Create a Discord thread under a text channel for a handoff.
+        """Create a discoverable Discord thread under a text channel.
 
-        Falls back to a seed-message + ``message.create_thread`` path if
-        ``parent.create_thread`` is rejected (some channel types or
-        permission setups). Returns the new thread id as a string, or
+        Posts a visible parent-channel anchor and creates the thread from that
+        message so Discord clients expose the thread in the parent timeline.
+        Falls back to direct channel-level creation when sending or threading
+        the anchor is rejected. Returns the new thread id as a string, or
         ``None`` on failure or when the parent isn't a text channel
         (DMs, voice channels, threads themselves can't host threads).
         """
@@ -5495,38 +5496,47 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
 
-        # First try: create a thread directly on the channel.
+        seed_error: Exception | None = None
+
+        # Preferred path: create the thread from a visible parent message. A
+        # message-anchored public thread is discoverable in Discord's parent
+        # timeline; the actual handoff/cron brief is sent separately to the
+        # returned thread by the caller.
         try:
-            create = getattr(parent, "create_thread", None)
-            if create is not None:
-                thread = await create(
+            send = getattr(parent, "send", None)
+            if send is not None:
+                seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
+                thread = await seed_msg.create_thread(
                     name=thread_name,
                     auto_archive_duration=1440,
                     reason=reason,
                 )
                 return str(thread.id)
-        except Exception as direct_error:
+        except Exception as exc:
+            seed_error = exc
             logger.debug(
-                "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
-                self.name, direct_error,
+                "[%s] Handoff thread: seed-message create failed (%s); "
+                "trying direct channel fallback",
+                self.name, exc,
             )
 
-        # Fallback: post a seed message and create the thread from it.
+        # Fallback: direct channel-level creation preserves delivery when the
+        # bot can create threads but cannot send or thread the visible anchor.
         try:
-            send = getattr(parent, "send", None)
-            if send is None:
+            create = getattr(parent, "create_thread", None)
+            if create is None:
                 return None
-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
-            thread = await seed_msg.create_thread(
+            thread = await create(
                 name=thread_name,
                 auto_archive_duration=1440,
                 reason=reason,
             )
             return str(thread.id)
-        except Exception as fallback_error:
+        except Exception as direct_error:
             logger.warning(
-                "[%s] Handoff thread: both create paths failed for parent %s: %s",
-                self.name, parent_chat_id, fallback_error,
+                "[%s] Handoff thread: seed and direct create failed for "
+                "parent %s (seed error: %s; direct error: %s)",
+                self.name, parent_chat_id, seed_error, direct_error,
             )
             return None
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5508,6 +5508,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return thread_id
 
         seed_error: Exception | None = None
+        seed_msg: Any = None
 
         # Preferred path: create the thread from a visible parent message. A
         # message-anchored public thread is discoverable in Discord's parent
@@ -5542,7 +5543,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason=reason,
             )
-            return _track_created_thread(thread)
+            thread_id = _track_created_thread(thread)
+            if seed_msg is not None:
+                delete = getattr(seed_msg, "delete", None)
+                if delete is not None:
+                    try:
+                        await delete()
+                    except Exception as cleanup_error:
+                        logger.debug(
+                            "[%s] Handoff thread %s created via direct fallback, "
+                            "but stale seed cleanup failed: %s",
+                            self.name, thread_id, cleanup_error,
+                        )
+            return thread_id
         except Exception as direct_error:
             logger.warning(
                 "[%s] Handoff thread: seed and direct create failed for "

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -80,6 +80,70 @@ class TestMentionStrippedCommandDispatch:
         assert "/new" in response
 
 
+class TestHandoffThreadContinuation:
+    async def _create_handoff_thread(self, adapter):
+        thread = make_fake_thread(thread_id=90002, name="Daily brief")
+        seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+        parent = thread.parent
+        parent.send = AsyncMock(return_value=seed)
+        parent.create_thread = AsyncMock()
+        adapter._client = SimpleNamespace(
+            user=adapter._client.user,
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread(str(parent.id), "Daily brief")
+
+        assert thread_id == str(thread.id)
+        return thread
+
+    async def test_mentionless_followup_reaches_normal_handling(
+        self, discord_adapter, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+        monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        discord_adapter._fetch_channel_context = AsyncMock(return_value="")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+        thread = await self._create_handoff_thread(discord_adapter)
+        msg = make_discord_message(
+            content="How should we shape this newsletter?",
+            channel=thread,
+            mentions=[],
+        )
+
+        await dispatch(discord_adapter, msg)
+
+        discord_adapter.handle_message.assert_awaited_once()
+        await_args = discord_adapter.handle_message.await_args
+        assert await_args is not None
+        event = await_args.args[0]
+        assert event.text == "How should we shape this newsletter?"
+        assert event.source.thread_id == str(thread.id)
+
+    async def test_thread_require_mention_still_gates_mentionless_followup(
+        self, discord_adapter, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+        monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        discord_adapter.handle_message = AsyncMock()
+        thread = await self._create_handoff_thread(discord_adapter)
+        msg = make_discord_message(
+            content="How should we shape this newsletter?",
+            channel=thread,
+            mentions=[],
+        )
+
+        await dispatch(discord_adapter, msg)
+
+        discord_adapter.handle_message.assert_not_awaited()
+
+
 class TestAutoThreadingPreservesCommand:
     async def test_command_detected_after_auto_thread(self, discord_adapter, bot_user, monkeypatch):
         """@mention /help in channel with auto-thread → thread created AND command dispatched."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 import sys
@@ -449,7 +450,10 @@ async def test_typing_stop_cleans_up():
 
 class TestCreateHandoffThread:
     @pytest.mark.asyncio
-    async def test_creates_thread_from_visible_parent_seed(self):
+    async def test_creates_thread_from_visible_parent_seed(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
         events = []
         thread = SimpleNamespace(id=9001)
@@ -476,11 +480,16 @@ class TestCreateHandoffThread:
         thread_id = await adapter.create_handoff_thread("123", "Daily brief")
 
         assert thread_id == "9001"
+        assert "9001" in adapter._threads
+        assert json.loads((tmp_path / "discord_threads.json").read_text()) == ["9001"]
         assert events == ["send-seed", "create-from-seed"]
         parent.create_thread.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_cron_brief_is_distinct_child_in_created_thread(self):
+    async def test_cron_brief_is_distinct_child_in_created_thread(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
         thread = SimpleNamespace(
             id=9001,
@@ -533,7 +542,10 @@ class TestCreateHandoffThread:
         parent.create_thread.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_direct_channel_create_remains_fallback_when_seed_fails(self):
+    async def test_direct_channel_create_remains_fallback_when_seed_fails(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
         thread = SimpleNamespace(id=9001)
         seed = SimpleNamespace(
@@ -553,6 +565,67 @@ class TestCreateHandoffThread:
         thread_id = await adapter.create_handoff_thread("123", "Daily brief")
 
         assert thread_id == "9001"
+        assert "9001" in adapter._threads
+        assert json.loads((tmp_path / "discord_threads.json").read_text()) == ["9001"]
         parent.send.assert_awaited_once()
         seed.create_thread.assert_awaited_once()
         parent.create_thread.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_seed_create_does_not_duplicate_thread_when_tracking_fails(self):
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        adapter._threads.mark = MagicMock(side_effect=OSError("disk full"))
+        thread = SimpleNamespace(id=9001)
+        seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+        parent = SimpleNamespace(
+            send=AsyncMock(return_value=seed),
+            create_thread=AsyncMock(),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id == "9001"
+        parent.create_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_create_still_returns_thread_when_tracking_fails(self):
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        adapter._threads.mark = MagicMock(side_effect=OSError("disk full"))
+        thread = SimpleNamespace(id=9001)
+        parent = SimpleNamespace(
+            send=AsyncMock(side_effect=RuntimeError("seed denied")),
+            create_thread=AsyncMock(return_value=thread),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id == "9001"
+
+    @pytest.mark.asyncio
+    async def test_failed_thread_creation_remains_untracked(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        seed = SimpleNamespace(
+            create_thread=AsyncMock(side_effect=RuntimeError("seed denied"))
+        )
+        parent = SimpleNamespace(
+            send=AsyncMock(return_value=seed),
+            create_thread=AsyncMock(side_effect=RuntimeError("direct denied")),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id is None
+        assert not (tmp_path / "discord_threads.json").exists()

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -445,3 +445,114 @@ async def test_typing_stop_cleans_up():
 
     await adapter.stop_typing("12345")
     assert "12345" not in adapter._typing_tasks
+
+
+class TestCreateHandoffThread:
+    @pytest.mark.asyncio
+    async def test_creates_thread_from_visible_parent_seed(self):
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        events = []
+        thread = SimpleNamespace(id=9001)
+
+        async def create_from_seed(**_kwargs):
+            events.append("create-from-seed")
+            return thread
+
+        seed = SimpleNamespace(create_thread=AsyncMock(side_effect=create_from_seed))
+
+        async def send_seed(_content):
+            events.append("send-seed")
+            return seed
+
+        parent = SimpleNamespace(
+            send=AsyncMock(side_effect=send_seed),
+            create_thread=AsyncMock(),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id == "9001"
+        assert events == ["send-seed", "create-from-seed"]
+        parent.create_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cron_brief_is_distinct_child_in_created_thread(self):
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        thread = SimpleNamespace(
+            id=9001,
+            send=AsyncMock(return_value=SimpleNamespace(id=9002)),
+        )
+        seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+        parent = SimpleNamespace(
+            send=AsyncMock(return_value=seed),
+            create_thread=AsyncMock(),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda channel_id: parent if channel_id == 123 else thread,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+        result = await adapter.send(
+            "123",
+            "Here is today's cron brief.",
+            metadata={"thread_id": thread_id},
+        )
+
+        assert result.success is True
+        parent.send.assert_awaited_once()
+        anchor_text = parent.send.await_args.args[0]
+        thread.send.assert_awaited_once_with(
+            content="Here is today's cron brief.",
+            reference=None,
+        )
+        assert anchor_text != thread.send.await_args.kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_dm_parent_remains_unsupported(self, monkeypatch):
+        class FakeDMChannel:
+            send = AsyncMock()
+            create_thread = AsyncMock()
+
+        monkeypatch.setattr(_discord_mod, "DMChannel", FakeDMChannel)
+        parent = FakeDMChannel()
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id is None
+        parent.send.assert_not_awaited()
+        parent.create_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_channel_create_remains_fallback_when_seed_fails(self):
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        thread = SimpleNamespace(id=9001)
+        seed = SimpleNamespace(
+            create_thread=AsyncMock(
+                side_effect=RuntimeError("Missing Permissions")
+            )
+        )
+        parent = SimpleNamespace(
+            send=AsyncMock(return_value=seed),
+            create_thread=AsyncMock(return_value=thread),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id == "9001"
+        parent.send.assert_awaited_once()
+        seed.create_thread.assert_awaited_once()
+        parent.create_thread.assert_awaited_once()

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -549,9 +549,8 @@ class TestCreateHandoffThread:
         adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
         thread = SimpleNamespace(id=9001)
         seed = SimpleNamespace(
-            create_thread=AsyncMock(
-                side_effect=RuntimeError("Missing Permissions")
-            )
+            create_thread=AsyncMock(side_effect=RuntimeError("Missing Permissions")),
+            delete=AsyncMock(),
         )
         parent = SimpleNamespace(
             send=AsyncMock(return_value=seed),
@@ -570,6 +569,35 @@ class TestCreateHandoffThread:
         parent.send.assert_awaited_once()
         seed.create_thread.assert_awaited_once()
         parent.create_thread.assert_awaited_once()
+        seed.delete.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_direct_fallback_survives_seed_cleanup_failure(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+        thread = SimpleNamespace(id=9001)
+        seed = SimpleNamespace(
+            create_thread=AsyncMock(side_effect=RuntimeError("Missing Permissions")),
+            delete=AsyncMock(side_effect=RuntimeError("cleanup denied")),
+        )
+        parent = SimpleNamespace(
+            send=AsyncMock(return_value=seed),
+            create_thread=AsyncMock(return_value=thread),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+        assert thread_id == "9001"
+        assert "9001" in adapter._threads
+        assert json.loads((tmp_path / "discord_threads.json").read_text()) == ["9001"]
+        parent.create_thread.assert_awaited_once()
+        seed.delete.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_seed_create_does_not_duplicate_thread_when_tracking_fails(self):


### PR DESCRIPTION
## Summary
- create Discord handoff threads from a visible parent-channel seed message
- preserve direct channel-level thread creation as the fallback
- persist successful handoff thread IDs in the participation tracker so mentionless replies continue when `thread_require_mention=false`
- preserve mention gating when `thread_require_mention=true`, plus DM and failed-create behavior

## Root causes
1. `create_handoff_thread()` preferred `parent.create_thread()`, producing an anchorless public thread that Discord mobile did not expose reliably in the parent timeline.
2. Both successful handoff creation paths returned without calling `self._threads.mark(thread_id)`, so continuable cron threads were absent from `discord_threads.json` and mentionless replies were dropped before session routing.

## Verification
- TDD regression reproduced: 3 expected failures before the tracker fix (seed persistence, fallback persistence, mentionless continuation)
- `scripts/run_tests.sh tests/gateway/test_discord_send.py tests/e2e/test_discord_adapter.py -q` (34 passed)
- `scripts/run_tests.sh tests/cron/test_scheduler.py tests/gateway/test_discord_*.py tests/e2e/test_discord_adapter.py -q` (765 passed)
- `.venv/bin/ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_send.py tests/e2e/test_discord_adapter.py`
- `.venv/bin/python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_send.py tests/e2e/test_discord_adapter.py cron/scheduler.py`
- `git diff --check`
- independent Codex review: no blockers

## Deployment
No migration or config change. Restart the Hermes gateway after installing/checking out the merged version; this PR does not restart, update, merge, or deploy anything.