### PR TITLE
refactor(service-manager): use S6_SERVICE_PREFIX instead of hardcoded 'gateway-'

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -572,7 +572,7 @@ class GatewayNotRegisteredError(S6Error):
             f"no such gateway {profile!r}: register it with "
             f"`hermes profile create {profile}` first, or pass "
             "an existing profile name via `-p <name>`",
-            service=f"gateway-{profile}",
+            service=f"{S6_SERVICE_PREFIX}{profile}",
         )
 
 


### PR DESCRIPTION
## Summary

`hermes_cli/service_manager.py` defines `S6_SERVICE_PREFIX = "gateway-"` and uses it consistently when building s6 service names (`f"{S6_SERVICE_PREFIX}{profile}"` at lines 618 and 621, plus prefix-stripping at 349, 832–833). One call site was missed and hardcodes the prefix instead.

`GatewayNotRegisteredError.__init__` builds its `service=` argument as `f"gateway-{profile}"` (line 575) — the same `gateway-<profile>` service name, but with the literal inlined.

## Fix

```diff
-            service=f"gateway-{profile}",
+            service=f"{S6_SERVICE_PREFIX}{profile}",
```

## Validation

- Behavior-neutral: both produce `gateway-<profile>`. The constant (`S6_SERVICE_PREFIX`, line 335) is defined well before this call site and is already the canonical way this file constructs service names.
- Provable by grep: after this change, the only remaining `gateway-` literal in the file is the constant definition itself; every service-name construction goes through `S6_SERVICE_PREFIX`.
- 1 file, 1 line, no import added.
- Checked open PRs: none touch this file.
