### PR TITLE
fix(dashboard): per-profile platform status reads the profile's gateway_state.json

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2607,7 +2607,7 @@ async def get_status(profile: Optional[str] = None):
 
         # Prefer the detailed health endpoint response (has full state) when the
         # local runtime status file is absent or stale (cross-container).
-        local_runtime = read_runtime_status()
+        local_runtime = read_runtime_status(get_hermes_home() / "gateway_state.json")
         runtime = local_runtime
         if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
             runtime = remote_health_body
@@ -7853,7 +7853,7 @@ async def get_messaging_platforms(profile: Optional[str] = None):
     # all resolve against the requested profile's HERMES_HOME.
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
-        runtime = read_runtime_status()
+        runtime = read_runtime_status(get_hermes_home() / "gateway_state.json")
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
@@ -7920,7 +7920,7 @@ async def test_messaging_platform(platform_id: str, profile: Optional[str] = Non
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
         payload = _messaging_platform_payload(
-            entry, env_on_disk, read_runtime_status(), scoped=scoped_dir is not None
+            entry, env_on_disk, read_runtime_status(get_hermes_home() / "gateway_state.json"), scoped=scoped_dir is not None
         )
     if not payload["enabled"]:
         message = f"{entry['name']} is disabled. Enable it, then restart the gateway."


### PR DESCRIPTION
## Problem

The dashboard **Connected Platforms** panel (`GET /api/status?profile=…`) and the Desktop's messaging endpoints (`GET /api/messaging/platforms`, `POST /api/messaging/platforms/{id}/test`) compute per-profile platform status as:

```
gateway_platforms = runtime_platforms  ∩  configured_platforms
```

The **configured** seam is override-aware — it honors the `HERMES_HOME` override set by `_config_profile_scope` / `_profile_scope`, so it correctly returns the profile's platforms (read from the profile `.env`).

The **runtime** seam, however, was called as bare `read_runtime_status()` (no path). That resolves the state file via `_get_runtime_status_path()` → `_get_process_hermes_home()`, which **deliberately ignores the profile override** and uses `os.environ['HERMES_HOME']` / the platform default — i.e. it **always reads the root machine gateway's `gateway_state.json`**, regardless of the requested profile.

### Symptom
When platforms run on dedicated **per-profile** gateways (env-driven, e.g. `TELEGRAM_BOT_TOKEN` / `DISCORD_BOT_TOKEN` in each profile's `.env`) and the machine/default gateway serves only `api_server`, the intersection becomes:

```
{telegram, discord} ∩ {api_server}  =  ∅
```

so the panel shows **only `api_server`** for a profile whose Telegram/Discord bots are actually connected and responding. The Desktop's `/api/messaging/platforms` reports the same platforms as *configured but disabled*.

## Fix

Pass the profile-scoped path to `read_runtime_status()` at the three per-profile call sites — exactly as the topology enumerator a few lines up already does (`read_runtime_status(home / "gateway_state.json")`). `get_hermes_home()` is override-aware under the active profile scope, so this reads the requested profile's gateway state.

```python
- read_runtime_status()
+ read_runtime_status(get_hermes_home() / "gateway_state.json")
```

Three call sites: `get_status` (panel), `get_messaging_platforms` (Desktop), `test_messaging_platform`.

## Verification

Inside `_config_profile_scope("littleram")` on a live fleet where telegram/discord run on the littleram gateway:

| | before | after |
|---|---|---|
| configured seam | `{telegram, discord}` | `{telegram, discord}` |
| runtime seam | `{api_server, feishu}` (root file) | `{telegram, discord, api_server}` (profile file) |
| **panel result** | `∅` → shows only `api_server` | `{telegram, discord}` ✓ |

No behavior change for the default/machine view (which legitimately serves only `api_server`); the fix only affects requests scoped to a serving profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
