### PR TITLE
feat: add pre-dispatch hook system for tool calls

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -40,6 +40,27 @@ _WARNED_DISABLED_BUNDLES: set = set()
 
 
 # =============================================================================
+# Pre-dispatch hooks — Jarvis behavior boundary engine
+# =============================================================================
+
+_TOOL_PRE_DISPATCH_HOOKS: list = []
+
+
+def register_pre_dispatch_hook(hook: callable) -> None:
+    """注册工具调用前置钩子。hook(tool_name, args) -> None 或抛出 ToolBlocked"""
+    _TOOL_PRE_DISPATCH_HOOKS.append(hook)
+
+
+class ToolBlocked(Exception):
+    """工具被前置钩子阻止"""
+
+    def __init__(self, reason: str, level: str = 'forbidden'):
+        self.reason = reason
+        self.level = level  # forbidden | admin_required
+        super().__init__(reason)
+
+
+# =============================================================================
 # Async Bridging  (single source of truth -- used by registry.dispatch too)
 # =============================================================================
 
@@ -1066,6 +1087,14 @@ def handle_function_call(
     function_args = coerce_tool_args(function_name, function_args)
     if not isinstance(function_args, dict):
         function_args = {}
+
+    # ── Pre-dispatch hooks (Jarvis behavior boundary engine) ───────
+    for hook in _TOOL_PRE_DISPATCH_HOOKS:
+        try:
+            hook(function_name, function_args)
+        except ToolBlocked as e:
+            return json.dumps({'blocked': True, 'level': e.level, 'reason': e.reason})
+
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
 
     # ── Tool Search bridge dispatch ──────────────────────────────────


### PR DESCRIPTION
## 概述 | Overview

为 `model_tools.py` 新增工具调用前置钩子（pre-dispatch hooks）机制，用于 **Jarvis 行为边界引擎** —— 在工具调用分派前注入安全检查，必要时可阻止工具执行。

Adds a lightweight pre-dispatch hook mechanism to `model_tools.py` that allows registering callables to inspect (and optionally block) tool calls before they are dispatched. Designed for the **Jarvis behavior boundary engine** to enforce tool-level access control and safety gating.

## 变更内容 | Changes

### 模块级新增（~21行）
- `_TOOL_PRE_DISPATCH_HOOKS: list = []` — 钩子注册表，默认为空列表
- `register_pre_dispatch_hook(hook)` — 注册一个前置钩子
- `ToolBlocked(reason, level)` — 异常类，携带阻止原因和级别（`forbidden` | `admin_required`）

### 函数内新增（~8行）
- `handle_function_call()` 内部：参数解析后、dispatch 前，遍历钩子列表
- 若钩子抛出 `ToolBlocked`，返回 JSON `{"blocked": true, "level": ..., "reason": ...}`

## 设计原则 | Design

- **零成本默认**：钩子列表默认为空，无注册时不执行任何操作
- **不影响现有行为**：所有 32 个现有测试全部通过，无回归
- **有具体消费者**：Jarvis 行为边界引擎会使用此钩子进行工具级访问控制（非推测性基础设施）

## 测试 | Testing

```
tests/test_model_tools.py: 32 passed in 14.75s
```

额外烟雾测试验证了钩子阻止 write_file 的工作流程，以及未阻止工具的正常通过。

## 回滚 | Rollback

```bash
cp model_tools.py.hermes-bak model_tools.py
git add model_tools.py && git commit -m "revert: remove pre-dispatch hooks" && git push
```