### PR TITLE
feat(telegram): add task status control primitives

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -119,8 +119,10 @@ class GatewayKanbanWatchersMixin:
         stored cursor with kind in the terminal set (``completed``,
         ``blocked``, ``gave_up``, ``crashed``, ``timed_out``). Sends one
         message per new event to ``(platform, chat_id, thread_id)``,
-        then advances the cursor. When a task reaches a terminal state
-        (``completed`` / ``archived``), the subscription is removed.
+        then advances the cursor. Legacy subscriptions are removed when a
+        task reaches a terminal state (``completed`` / ``archived``). In
+        task-status mode, the exact Telegram route remains until an explicit
+        accepted-completion publication succeeds.
 
         Runs in the gateway event loop; all SQLite work is pushed to a
         thread via ``asyncio.to_thread`` so the loop never blocks on the
@@ -155,6 +157,16 @@ class GatewayKanbanWatchersMixin:
                 "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
             )
             return
+        task_status_cfg = (
+            kanban_cfg.get("task_status", {})
+            if isinstance(kanban_cfg.get("task_status"), dict)
+            else {}
+        )
+        task_status_enabled = bool(task_status_cfg.get("enabled", False))
+        task_status_worker_noise_suppressed = task_status_enabled and (
+            not task_status_cfg.get("raw_event_pushes", False)
+            or not task_status_cfg.get("worker_lifecycle_pushes", False)
+        )
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -164,7 +176,10 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            "status", "archived", "unblocked",
+        ) + (("task_status",) if task_status_enabled else ())
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -336,8 +351,95 @@ class GatewayKanbanWatchersMixin:
                         continue
                     title = (task.title if task else sub["task_id"])[:120]
                     board_tag = f"[{board_slug}] " if board_slug else ""
+                    accepted_completion_published = False
                     for ev in d["events"]:
                         kind = ev.kind
+                        if task_status_enabled and kind == "task_status":
+                            if platform_str != "telegram":
+                                # Structured task-status events are Telegram-only;
+                                # other platform subscriptions retain legacy raw
+                                # lifecycle notifications and ignore this event.
+                                continue
+                            publication_result = None
+                            publication_error = None
+                            status_conn = None
+                            try:
+                                from gateway.task_status import (
+                                    PublicationKind,
+                                    TaskStatusPublication,
+                                    TaskStatusPublisher,
+                                )
+
+                                publication = TaskStatusPublication.from_event_payload(
+                                    ev.payload or {}
+                                )
+                                if publication.kanban_task_id != sub["task_id"]:
+                                    raise ValueError(
+                                        "task-status event task id does not match its subscription"
+                                    )
+                                if publication.destination is None:
+                                    raise ValueError(
+                                        "task-status event has no exact destination"
+                                    )
+                                if (
+                                    publication.destination.chat_id
+                                    != str(sub["chat_id"])
+                                    or publication.destination.message_thread_id
+                                    != str(sub.get("thread_id") or "")
+                                ):
+                                    # This event belongs to another explicitly
+                                    # bound Telegram subscription. Do not mirror.
+                                    continue
+                                status_conn = _kb.connect(board=board_slug)
+                                publication_result = await TaskStatusPublisher(
+                                    conn=status_conn,
+                                    adapter=adapter,
+                                    config=task_status_cfg,
+                                    profile_name=sub_profile or notifier_profile,
+                                ).publish(publication)
+                                if not publication_result.ok:
+                                    publication_error = publication_result.error
+                            except Exception as exc:
+                                publication_error = str(exc)
+                            finally:
+                                if status_conn is not None:
+                                    status_conn.close()
+                            if publication_error:
+                                logger.warning(
+                                    "kanban task-status publication failed closed for %s "
+                                    "on board %s: %s",
+                                    sub["task_id"], board_slug, publication_error,
+                                )
+                                await asyncio.to_thread(
+                                    self._kanban_rewind,
+                                    sub,
+                                    d["cursor"],
+                                    d.get("old_cursor", 0),
+                                    board_slug,
+                                )
+                                break
+                            logger.debug(
+                                "kanban task-status publication delivered for %s "
+                                "on board %s (deduplicated=%s pushed=%s)",
+                                sub["task_id"],
+                                board_slug,
+                                publication_result.deduplicated,
+                                publication_result.pushed,
+                            )
+                            if (
+                                publication.kind
+                                == PublicationKind.ACCEPTED_COMPLETION
+                            ):
+                                accepted_completion_published = True
+                            continue
+                        if (
+                            task_status_worker_noise_suppressed
+                            and platform_str == "telegram"
+                        ):
+                            # In living-card mode, raw worker/card transitions
+                            # remain Kanban evidence. Only explicit structured
+                            # task_status events may publish to Telegram.
+                            continue
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
@@ -481,16 +583,22 @@ class GatewayKanbanWatchersMixin:
                         await asyncio.to_thread(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
+                        # Legacy subscriptions end at done / archived. A
+                        # task-status Telegram route instead survives raw card
+                        # completion and ends only after explicit accepted
+                        # completion publishes successfully.
                         task_terminal = task and task.status in {"done", "archived"}
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        _wake_kinds = (
+                            set()
+                            if task_status_worker_noise_suppressed
+                            and platform_str == "telegram"
+                            else {
+                                ev.kind
+                                for ev in d["events"]
+                                if ev.kind in _WAKE_KINDS
+                            }
+                        )
                         if _wake_kinds:
                             try:
                                 _session_key = getattr(task, "session_id", None) or ""
@@ -561,7 +669,12 @@ class GatewayKanbanWatchersMixin:
                                     "kanban notifier: wakeup injection failed for %s: %s",
                                     sub["task_id"], _wk_err, exc_info=True,
                                 )
-                        if task_terminal:
+                        should_unsubscribe = (
+                            accepted_completion_published
+                            if task_status_enabled and platform_str == "telegram"
+                            else task_terminal
+                        )
+                        if should_unsubscribe:
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,
                             )

--- a/gateway/task_status.py
+++ b/gateway/task_status.py
@@ -1,0 +1,780 @@
+"""Opt-in living task-status publication for Telegram-backed Kanban work.
+
+The module is deliberately policy-neutral: callers supply card wording and
+recommended actions, while the primitive enforces exact task/message routing,
+monotonic versions, publication dedup, and callback correlation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
+
+from hermes_cli import kanban_db as kb
+
+
+TELEGRAM_CALLBACK_LIMIT_BYTES = 64
+_ACTION_RE = re.compile(r"^[a-z][a-z0-9_]{0,15}$")
+_TASK_ID_RE = re.compile(r"^t_[A-Za-z0-9_-]+$")
+
+
+class PublicationKind(str, Enum):
+    ROUTINE = "routine"
+    DECISION = "decision"
+    BLOCKER = "blocker"
+    MATERIAL_CHANGE = "material_change"
+    ACCEPTED_COMPLETION = "accepted_completion"
+
+
+class DeliveryRoute(str, Enum):
+    CONTROL = "control"
+    BRIEFINGS = "briefings"
+    PROJECT = "project"
+    SYSTEM = "system"
+
+
+PUSH_KINDS = frozenset(
+    {
+        PublicationKind.DECISION,
+        PublicationKind.BLOCKER,
+        PublicationKind.MATERIAL_CHANGE,
+        PublicationKind.ACCEPTED_COMPLETION,
+    }
+)
+
+
+@dataclass(frozen=True)
+class TaskStatusDestination:
+    chat_id: str
+    message_thread_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not str(self.chat_id).strip():
+            raise ValueError("task-status destination chat_id is required")
+        object.__setattr__(self, "chat_id", str(self.chat_id))
+        object.__setattr__(
+            self, "message_thread_id", str(self.message_thread_id or "")
+        )
+
+
+@dataclass(frozen=True)
+class TaskStatusButton:
+    label: str
+    action: str
+
+
+@dataclass(frozen=True)
+class TaskStatusPublication:
+    operation: str
+    kanban_task_id: str
+    session_id: str
+    lifecycle_state: str
+    state_version: int
+    content: str
+    kind: PublicationKind = PublicationKind.ROUTINE
+    destination: Optional[TaskStatusDestination] = None
+    linear_issue_key: Optional[str] = None
+    recommended_action: str = ""
+    buttons: Sequence[TaskStatusButton] = field(default_factory=tuple)
+    push_content: Optional[str] = None
+
+    @classmethod
+    def from_event_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> "TaskStatusPublication":
+        """Parse a policy-produced Kanban event without inferring any binding."""
+        raw_buttons = payload.get("buttons") or ()
+        if not isinstance(raw_buttons, Sequence) or isinstance(
+            raw_buttons, (str, bytes)
+        ):
+            raise ValueError("task-status buttons must be a list")
+        buttons: list[TaskStatusButton] = []
+        for raw in raw_buttons:
+            if not isinstance(raw, Mapping):
+                raise ValueError("task-status button entries must be objects")
+            buttons.append(
+                TaskStatusButton(
+                    label=str(raw.get("label") or ""),
+                    action=str(raw.get("action") or ""),
+                )
+            )
+        try:
+            kind = PublicationKind(str(payload.get("kind") or "routine"))
+        except ValueError as exc:
+            raise ValueError("unknown task-status publication kind") from exc
+        operation = str(payload.get("operation") or "")
+        raw_destination = payload.get("destination")
+        if not isinstance(raw_destination, Mapping) or (
+            "chat_id" not in raw_destination
+            or "message_thread_id" not in raw_destination
+        ):
+            raise ValueError(
+                "task-status event requires an exact destination with chat_id "
+                "and message_thread_id"
+            )
+        destination = TaskStatusDestination(
+            chat_id=str(raw_destination.get("chat_id") or ""),
+            message_thread_id=str(
+                raw_destination.get("message_thread_id") or ""
+            ),
+        )
+        return cls(
+            operation=operation,
+            kanban_task_id=str(payload.get("kanban_task_id") or ""),
+            session_id=str(payload.get("session_id") or ""),
+            linear_issue_key=(
+                str(payload["linear_issue_key"])
+                if payload.get("linear_issue_key") is not None
+                else None
+            ),
+            lifecycle_state=str(payload.get("lifecycle_state") or ""),
+            state_version=int(payload.get("state_version") or 0),
+            content=str(payload.get("content") or ""),
+            kind=kind,
+            destination=destination,
+            recommended_action=str(payload.get("recommended_action") or ""),
+            buttons=tuple(buttons),
+            push_content=(
+                str(payload["push_content"])
+                if payload.get("push_content") is not None
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PublicationResult:
+    ok: bool
+    message_id: Optional[str] = None
+    deduplicated: bool = False
+    pushed: bool = False
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CallbackResolution:
+    ok: bool
+    kanban_task_id: Optional[str] = None
+    state_version: Optional[int] = None
+    action: Optional[str] = None
+    error: Optional[str] = None
+
+
+def make_task_status_callback_data(
+    kanban_task_id: str, state_version: int, action: str
+) -> str:
+    task_id = str(kanban_task_id)
+    normalized_action = str(action).strip().lower()
+    if not _TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("invalid canonical Kanban task id for callback")
+    if not _ACTION_RE.fullmatch(normalized_action):
+        raise ValueError("invalid task-status callback action")
+    if int(state_version) < 1:
+        raise ValueError("task-status callback version must be at least 1")
+    data = f"ts:{normalized_action}:{task_id}:{int(state_version)}"
+    if len(data.encode("utf-8")) > TELEGRAM_CALLBACK_LIMIT_BYTES:
+        raise ValueError("task-status callback_data exceeds Telegram's 64-byte limit")
+    return data
+
+
+def parse_task_status_callback_data(data: str) -> tuple[str, int, str]:
+    raw = str(data or "")
+    if len(raw.encode("utf-8")) > TELEGRAM_CALLBACK_LIMIT_BYTES:
+        raise ValueError("task-status callback_data exceeds Telegram's 64-byte limit")
+    parts = raw.split(":")
+    if len(parts) != 4 or parts[0] != "ts":
+        raise ValueError("invalid task-status callback data")
+    action, task_id, version_raw = parts[1], parts[2], parts[3]
+    if not _ACTION_RE.fullmatch(action):
+        raise ValueError("unknown or invalid task-status callback action")
+    if not _TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("invalid canonical Kanban task id in callback")
+    try:
+        version = int(version_raw)
+    except ValueError as exc:
+        raise ValueError("invalid task-status callback version") from exc
+    if version < 1 or str(version) != version_raw:
+        raise ValueError("invalid task-status callback version")
+    return task_id, version, action
+
+
+def resolve_task_status_callback(
+    conn,
+    *,
+    callback_data: str,
+    chat_id: str,
+    message_thread_id: str,
+    message_id: str,
+    allowed_actions: Sequence[str],
+) -> CallbackResolution:
+    """Validate and at-most-once claim a consequential task callback."""
+    try:
+        task_id, version, action = parse_task_status_callback_data(callback_data)
+    except ValueError as exc:
+        return CallbackResolution(ok=False, error=str(exc))
+
+    allowed = {str(value).strip().lower() for value in allowed_actions}
+    if action not in allowed:
+        return CallbackResolution(
+            ok=False, error=f"unknown task-status action {action!r}"
+        )
+
+    binding = kb.get_task_status_binding(conn, task_id)
+    if binding is None:
+        return CallbackResolution(
+            ok=False, error=f"no task-status binding for Kanban task {task_id}"
+        )
+    if binding.state_version != version:
+        return CallbackResolution(
+            ok=False,
+            error=(
+                f"stale task-status callback for {task_id}: "
+                f"version {version}, current {binding.state_version}"
+            ),
+        )
+    living_message_matches = (
+        binding.message_id == str(message_id)
+        and binding.chat_id == str(chat_id)
+        and binding.message_thread_id == str(message_thread_id or "")
+    )
+    callback_message_matches = kb.matches_task_status_callback_message(
+        conn,
+        kanban_task_id=task_id,
+        state_version=version,
+        platform="telegram",
+        chat_id=str(chat_id),
+        message_thread_id=str(message_thread_id or ""),
+        message_id=str(message_id),
+    )
+    if not living_message_matches and not callback_message_matches:
+        return CallbackResolution(
+            ok=False,
+            error=(
+                "callback message/chat/topic does not match an exact "
+                "task-status callback destination"
+            ),
+        )
+    if not kb.claim_task_status_callback(
+        conn,
+        kanban_task_id=task_id,
+        state_version=version,
+        action=action,
+    ):
+        return CallbackResolution(
+            ok=False, error="this task-status decision was already resolved"
+        )
+    return CallbackResolution(
+        ok=True,
+        kanban_task_id=task_id,
+        state_version=version,
+        action=action,
+    )
+
+
+def resolve_task_status_callback_across_boards(
+    *,
+    callback_data: str,
+    chat_id: str,
+    message_thread_id: str,
+    message_id: str,
+    allowed_actions: Sequence[str],
+    board: Optional[str] = None,
+) -> CallbackResolution:
+    """Resolve an exact callback on one board, failing on cross-board ambiguity."""
+    try:
+        task_id, _version, _action = parse_task_status_callback_data(callback_data)
+    except ValueError as exc:
+        return CallbackResolution(ok=False, error=str(exc))
+
+    if board:
+        if not kb.board_exists(board):
+            return CallbackResolution(
+                ok=False, error=f"unknown task-status callback board {board!r}"
+            )
+        conn = kb.connect(board=board)
+        try:
+            return resolve_task_status_callback(
+                conn,
+                callback_data=callback_data,
+                chat_id=chat_id,
+                message_thread_id=message_thread_id,
+                message_id=message_id,
+                allowed_actions=allowed_actions,
+            )
+        finally:
+            conn.close()
+
+    candidates: list[str] = []
+    seen_paths: set[str] = set()
+    for metadata in kb.list_boards(include_archived=False):
+        slug = str(metadata.get("slug") or kb.DEFAULT_BOARD)
+        path = str(metadata.get("db_path") or kb.kanban_db_path(slug))
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        conn = kb.connect(board=slug)
+        try:
+            binding = kb.get_task_status_binding(conn, task_id)
+            if binding is None:
+                continue
+            living_message_matches = (
+                binding.chat_id == str(chat_id)
+                and binding.message_thread_id == str(message_thread_id or "")
+                and binding.message_id == str(message_id)
+            )
+            callback_message_matches = kb.matches_task_status_callback_message(
+                conn,
+                kanban_task_id=task_id,
+                state_version=_version,
+                platform="telegram",
+                chat_id=str(chat_id),
+                message_thread_id=str(message_thread_id or ""),
+                message_id=str(message_id),
+            )
+        finally:
+            conn.close()
+        if living_message_matches or callback_message_matches:
+            candidates.append(slug)
+
+    if not candidates:
+        return CallbackResolution(
+            ok=False,
+            error=(
+                f"no exact task-status binding for callback task {task_id} "
+                "and message destination"
+            ),
+        )
+    if len(candidates) != 1:
+        return CallbackResolution(
+            ok=False,
+            error=f"ambiguous task-status callback binding across boards: {candidates}",
+        )
+    conn = kb.connect(board=candidates[0])
+    try:
+        return resolve_task_status_callback(
+            conn,
+            callback_data=callback_data,
+            chat_id=chat_id,
+            message_thread_id=message_thread_id,
+            message_id=message_id,
+            allowed_actions=allowed_actions,
+        )
+    finally:
+        conn.close()
+
+
+def _dedup_key(
+    *,
+    task_id: str,
+    lifecycle_state: str,
+    state_version: int,
+    destination: TaskStatusDestination,
+    recommended_action: str,
+    channel: str,
+) -> str:
+    raw = json.dumps(
+        {
+            "task_id": task_id,
+            "lifecycle_state": lifecycle_state,
+            "state_version": int(state_version),
+            "chat_id": destination.chat_id,
+            "thread_id": destination.message_thread_id,
+            "recommended_action": recommended_action,
+            "channel": channel,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _configured_destination(config: Mapping[str, Any], route: str) -> TaskStatusDestination:
+    routes = config.get("routes")
+    route_cfg = routes.get(route) if isinstance(routes, Mapping) else None
+    if not isinstance(route_cfg, Mapping):
+        raise ValueError(f"task-status {route} destination is not configured")
+    if "chat_id" not in route_cfg or "thread_id" not in route_cfg:
+        raise ValueError(
+            f"task-status {route} destination requires exact chat_id and thread_id"
+        )
+    return TaskStatusDestination(
+        chat_id=str(route_cfg.get("chat_id") or ""),
+        message_thread_id=str(route_cfg.get("thread_id") or ""),
+    )
+
+
+def resolve_exact_task_status_destination(
+    route: DeliveryRoute,
+    *,
+    origin: TaskStatusDestination,
+    config: Mapping[str, Any],
+) -> TaskStatusDestination:
+    """Resolve one explicit route without topic, session, or recency inference."""
+    route = DeliveryRoute(route)
+    if route == DeliveryRoute.PROJECT:
+        return origin
+    return _configured_destination(config, route.value)
+
+
+def resolve_task_status_push_destination(
+    kind: PublicationKind,
+    *,
+    origin: TaskStatusDestination,
+    config: Mapping[str, Any],
+) -> TaskStatusDestination:
+    """Resolve exactly one push destination without title/recency inference."""
+    if kind in {PublicationKind.DECISION, PublicationKind.BLOCKER}:
+        return resolve_exact_task_status_destination(
+            DeliveryRoute.CONTROL, origin=origin, config=config
+        )
+    if kind in {
+        PublicationKind.MATERIAL_CHANGE,
+        PublicationKind.ACCEPTED_COMPLETION,
+    }:
+        return resolve_exact_task_status_destination(
+            DeliveryRoute.PROJECT, origin=origin, config=config
+        )
+    raise ValueError(f"publication kind {kind.value!r} does not permit a fresh push")
+
+
+class TaskStatusPublisher:
+    def __init__(
+        self,
+        *,
+        conn,
+        adapter,
+        config: Mapping[str, Any],
+        profile_name: str,
+    ) -> None:
+        self.conn = conn
+        self.adapter = adapter
+        self.config = config
+        self.profile_name = str(profile_name or "")
+
+    def _preflight(self) -> Optional[str]:
+        if not bool(self.config.get("enabled", False)):
+            return "task-status publication is disabled"
+        required_profile = str(self.config.get("publisher_profile") or "").strip()
+        if not required_profile:
+            return "task-status publisher_profile is not configured"
+        if self.profile_name != required_profile:
+            return (
+                f"task-status publisher profile mismatch: expected "
+                f"{required_profile!r}, got {self.profile_name!r}"
+            )
+        for method in (
+            "send_task_status",
+            "edit_task_status",
+            "send_task_status_push",
+        ):
+            if not callable(getattr(self.adapter, method, None)):
+                return f"configured adapter does not support {method}"
+        return None
+
+    @staticmethod
+    def _buttons(publication: TaskStatusPublication) -> list[dict[str, str]]:
+        return [
+            {
+                "label": str(button.label),
+                "callback_data": make_task_status_callback_data(
+                    publication.kanban_task_id,
+                    publication.state_version,
+                    button.action,
+                ),
+            }
+            for button in publication.buttons
+        ]
+
+    async def publish(self, publication: TaskStatusPublication) -> PublicationResult:
+        error = self._preflight()
+        if error:
+            return PublicationResult(ok=False, error=error)
+        if publication.operation not in {"create", "update"}:
+            return PublicationResult(ok=False, error="operation must be create or update")
+        if not publication.content or not publication.content.strip():
+            return PublicationResult(ok=False, error="task-status content is required")
+        if not publication.session_id or not publication.session_id.strip():
+            return PublicationResult(ok=False, error="task-status session_id is required")
+        try:
+            buttons = self._buttons(publication)
+        except ValueError as exc:
+            return PublicationResult(ok=False, error=str(exc))
+
+        if publication.operation == "create":
+            return await self._create(publication, buttons)
+        return await self._update(publication, buttons)
+
+    async def _create(
+        self, publication: TaskStatusPublication, buttons: list[dict[str, str]]
+    ) -> PublicationResult:
+        if publication.destination is None:
+            return PublicationResult(
+                ok=False, error="create requires an exact task-status destination"
+            )
+        if publication.state_version != 1:
+            return PublicationResult(
+                ok=False, error="task-status create must use state_version 1"
+            )
+        task = kb.get_task(self.conn, publication.kanban_task_id)
+        if task is None:
+            return PublicationResult(
+                ok=False,
+                error=f"unknown Kanban task {publication.kanban_task_id!r}",
+            )
+        if task.session_id and task.session_id != publication.session_id:
+            return PublicationResult(
+                ok=False, error="task-status session_id does not match the Kanban task"
+            )
+        try:
+            kb.reserve_task_status_binding(
+                self.conn,
+                kanban_task_id=publication.kanban_task_id,
+                platform="telegram",
+                chat_id=publication.destination.chat_id,
+                message_thread_id=publication.destination.message_thread_id,
+                session_id=publication.session_id,
+                linear_issue_key=publication.linear_issue_key,
+                lifecycle_state=publication.lifecycle_state,
+                state_version=publication.state_version,
+            )
+        except ValueError as exc:
+            return PublicationResult(ok=False, error=str(exc))
+
+        result = await self.adapter.send_task_status(
+            publication.destination.chat_id,
+            publication.content,
+            buttons=buttons,
+            metadata={
+                "thread_id": publication.destination.message_thread_id,
+                "notify": False,
+            },
+        )
+        if not getattr(result, "success", False) or not getattr(
+            result, "message_id", None
+        ):
+            kb.delete_pending_task_status_binding(
+                self.conn, publication.kanban_task_id
+            )
+            return PublicationResult(
+                ok=False,
+                error=(
+                    getattr(result, "error", None)
+                    or "task-status create returned no message_id"
+                ),
+            )
+        try:
+            binding = kb.finalize_task_status_binding(
+                self.conn,
+                kanban_task_id=publication.kanban_task_id,
+                message_id=str(result.message_id),
+            )
+        except ValueError as exc:
+            return PublicationResult(ok=False, error=str(exc))
+        return PublicationResult(ok=True, message_id=binding.message_id)
+
+    async def _update(
+        self, publication: TaskStatusPublication, buttons: list[dict[str, str]]
+    ) -> PublicationResult:
+        binding = kb.get_task_status_binding(
+            self.conn, publication.kanban_task_id
+        )
+        if binding is None or not binding.message_id:
+            return PublicationResult(
+                ok=False,
+                error=(
+                    f"no complete task-status binding for Kanban task "
+                    f"{publication.kanban_task_id}"
+                ),
+            )
+        if binding.session_id != publication.session_id:
+            return PublicationResult(
+                ok=False, error="task-status session_id does not match the binding"
+            )
+        if publication.destination is not None and (
+            publication.destination.chat_id != binding.chat_id
+            or publication.destination.message_thread_id
+            != binding.message_thread_id
+        ):
+            return PublicationResult(
+                ok=False, error="task-status update destination does not match the binding"
+            )
+        if publication.state_version < binding.state_version:
+            return PublicationResult(
+                ok=False,
+                error=(
+                    f"stale task-status update: version {publication.state_version}, "
+                    f"current {binding.state_version}"
+                ),
+            )
+        if publication.state_version > binding.state_version + 1:
+            return PublicationResult(
+                ok=False, error="task-status update would skip a state version"
+            )
+        if (
+            publication.state_version == binding.state_version
+            and publication.lifecycle_state != binding.lifecycle_state
+        ):
+            return PublicationResult(
+                ok=False,
+                error="task-status lifecycle change requires a new state version",
+            )
+
+        origin = TaskStatusDestination(
+            binding.chat_id, binding.message_thread_id
+        )
+        push_destination: Optional[TaskStatusDestination] = None
+        if publication.kind in PUSH_KINDS:
+            if not publication.push_content or not publication.push_content.strip():
+                return PublicationResult(
+                    ok=False,
+                    error=(
+                        f"{publication.kind.value} requires concise push_content"
+                    ),
+                )
+            try:
+                push_destination = resolve_task_status_push_destination(
+                    publication.kind,
+                    origin=origin,
+                    config=self.config,
+                )
+            except ValueError as exc:
+                return PublicationResult(ok=False, error=str(exc))
+        edit_key = _dedup_key(
+            task_id=publication.kanban_task_id,
+            lifecycle_state=publication.lifecycle_state,
+            state_version=publication.state_version,
+            destination=origin,
+            recommended_action=publication.recommended_action,
+            channel="living-card",
+        )
+        window = int(self.config.get("dedup_seconds", 180) or 180)
+        edit_claimed = kb.claim_task_status_publication(
+            self.conn,
+            dedup_key=edit_key,
+            kanban_task_id=publication.kanban_task_id,
+            window_seconds=window,
+        )
+        if edit_claimed:
+            result = await self.adapter.edit_task_status(
+                binding.chat_id,
+                binding.message_id,
+                publication.content,
+                buttons=buttons,
+                metadata={
+                    "thread_id": binding.message_thread_id,
+                    "notify": False,
+                },
+            )
+            if not getattr(result, "success", False):
+                kb.release_task_status_publication(self.conn, edit_key)
+                return PublicationResult(
+                    ok=False,
+                    error=(getattr(result, "error", None) or "task-status edit failed"),
+                )
+            if publication.state_version == binding.state_version + 1:
+                try:
+                    binding = kb.advance_task_status_binding(
+                        self.conn,
+                        kanban_task_id=publication.kanban_task_id,
+                        expected_version=binding.state_version,
+                        lifecycle_state=publication.lifecycle_state,
+                        state_version=publication.state_version,
+                    )
+                except ValueError as exc:
+                    return PublicationResult(ok=False, error=str(exc))
+
+        pushed = False
+        push_deduped = False
+        if publication.kind in PUSH_KINDS:
+            assert push_destination is not None
+            push_key = _dedup_key(
+                task_id=publication.kanban_task_id,
+                lifecycle_state=publication.lifecycle_state,
+                state_version=publication.state_version,
+                destination=push_destination,
+                recommended_action=publication.recommended_action,
+                channel="push",
+            )
+            push_claimed = kb.claim_task_status_publication(
+                self.conn,
+                dedup_key=push_key,
+                kanban_task_id=publication.kanban_task_id,
+                window_seconds=window,
+            )
+            if push_claimed:
+                push_result = await self.adapter.send_task_status_push(
+                    push_destination.chat_id,
+                    publication.push_content,
+                    buttons=buttons,
+                    metadata={
+                        "thread_id": push_destination.message_thread_id,
+                        "notify": True,
+                    },
+                )
+                if not getattr(push_result, "success", False):
+                    kb.release_task_status_publication(self.conn, push_key)
+                    return PublicationResult(
+                        ok=False,
+                        message_id=binding.message_id,
+                        error=(
+                            getattr(push_result, "error", None)
+                            or "task-status push failed"
+                        ),
+                    )
+                if buttons:
+                    push_message_id = getattr(push_result, "message_id", None)
+                    if not push_message_id:
+                        return PublicationResult(
+                            ok=False,
+                            message_id=binding.message_id,
+                            error=(
+                                "task-status decision push returned no message_id; "
+                                "callbacks were not enabled"
+                            ),
+                        )
+                    try:
+                        kb.register_task_status_callback_message(
+                            self.conn,
+                            kanban_task_id=publication.kanban_task_id,
+                            state_version=publication.state_version,
+                            platform="telegram",
+                            chat_id=push_destination.chat_id,
+                            message_thread_id=push_destination.message_thread_id,
+                            message_id=str(push_message_id),
+                        )
+                    except ValueError as exc:
+                        return PublicationResult(
+                            ok=False,
+                            message_id=binding.message_id,
+                            error=str(exc),
+                        )
+                pushed = True
+            else:
+                push_deduped = True
+
+        return PublicationResult(
+            ok=True,
+            message_id=binding.message_id,
+            deduplicated=(not edit_claimed and (not publication.kind in PUSH_KINDS or push_deduped)),
+            pushed=pushed,
+        )
+
+
+async def invoke_task_status_action(
+    handler: Callable[..., Any], resolution: CallbackResolution
+) -> Any:
+    """Invoke an injected consequential handler only after correlation passes."""
+    result = handler(
+        kanban_task_id=resolution.kanban_task_id,
+        state_version=resolution.state_version,
+        action=resolution.action,
+    )
+    if inspect.isawaitable(result):
+        return await result
+    return result

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2755,6 +2755,27 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # One persistent, explicitly bound task-status message. Disabled by
+        # default so existing Kanban terminal notifications remain unchanged.
+        "task_status": {
+            "enabled": False,
+            # Only this profile may publish living cards or correlated pushes.
+            # The generic core primitive owns no Donna-specific wording/policy.
+            "publisher_profile": "default",
+            "dedup_seconds": 180,
+            # Noise controls for opt-in mode: specialist stages and raw event
+            # summaries remain Kanban evidence instead of becoming Telegram
+            # push messages.
+            "worker_lifecycle_pushes": False,
+            "raw_event_pushes": False,
+            # Exact destinations. Empty chat ids deliberately fail closed.
+            # Root/system routing uses an explicit empty thread_id.
+            "routes": {
+                "control": {"chat_id": "", "thread_id": ""},
+                "briefings": {"chat_id": "", "thread_id": ""},
+                "system": {"chat_id": "", "thread_id": ""},
+            },
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1088,6 +1088,23 @@ class Event:
     run_id: Optional[int] = None
 
 
+@dataclass(frozen=True)
+class TaskStatusBinding:
+    """Persistent binding between one Kanban task and one living message."""
+
+    kanban_task_id: str
+    platform: str
+    chat_id: str
+    message_thread_id: str
+    message_id: str
+    session_id: str
+    linear_issue_key: Optional[str]
+    lifecycle_state: str
+    state_version: int
+    created_at: int
+    updated_at: int
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1263,6 +1280,56 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Opt-in living task-status messages. One canonical task owns one message;
+-- duplicate creates are rejected before transport so message ids cannot be
+-- orphaned by a last-write-wins race.
+CREATE TABLE IF NOT EXISTS task_status_bindings (
+    kanban_task_id    TEXT PRIMARY KEY,
+    platform          TEXT NOT NULL,
+    chat_id           TEXT NOT NULL,
+    message_thread_id TEXT NOT NULL DEFAULT '',
+    message_id        TEXT NOT NULL,
+    session_id        TEXT NOT NULL,
+    linear_issue_key  TEXT,
+    lifecycle_state   TEXT NOT NULL,
+    state_version     INTEGER NOT NULL,
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER NOT NULL
+);
+
+-- Composite publication dedup. Rows are short-lived and opportunistically
+-- pruned whenever a publisher claims a key.
+CREATE TABLE IF NOT EXISTS task_status_publication_dedup (
+    dedup_key       TEXT PRIMARY KEY,
+    kanban_task_id TEXT NOT NULL,
+    created_at      INTEGER NOT NULL
+);
+
+-- Exact non-living messages that carry task decision buttons (for example a
+-- decision push in the configured control topic). These rows let callbacks
+-- prove the Telegram message destination instead of accepting task/version
+-- correlation alone.
+CREATE TABLE IF NOT EXISTS task_status_callback_messages (
+    platform          TEXT NOT NULL,
+    chat_id           TEXT NOT NULL,
+    message_thread_id TEXT NOT NULL DEFAULT '',
+    message_id        TEXT NOT NULL,
+    kanban_task_id    TEXT NOT NULL,
+    state_version     INTEGER NOT NULL,
+    created_at        INTEGER NOT NULL,
+    PRIMARY KEY (platform, chat_id, message_id)
+);
+
+-- At-most-once claims for correlated decision callbacks. The exact task,
+-- state version, and action are claimed only after all binding checks pass.
+CREATE TABLE IF NOT EXISTS task_status_callback_claims (
+    kanban_task_id TEXT NOT NULL,
+    state_version  INTEGER NOT NULL,
+    action         TEXT NOT NULL,
+    created_at     INTEGER NOT NULL,
+    PRIMARY KEY (kanban_task_id, state_version)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1273,6 +1340,12 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_status_dedup_time ON task_status_publication_dedup(created_at);
+CREATE INDEX IF NOT EXISTS idx_task_status_callback_message_task
+    ON task_status_callback_messages(kanban_task_id, state_version);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_status_message
+    ON task_status_bindings(platform, chat_id, message_id)
+    WHERE message_id != '';
 """
 
 
@@ -3119,6 +3192,85 @@ def _append_event(
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+
+
+def append_task_status_publication(
+    conn: sqlite3.Connection,
+    task_id: str,
+    publication: dict,
+) -> None:
+    """Append one exact-destination task-status request to the native event log."""
+    if get_task(conn, task_id) is None:
+        raise ValueError(f"unknown Kanban task {task_id!r}")
+    if not isinstance(publication, dict):
+        raise ValueError("task-status publication must be an object")
+    payload_task_id = str(publication.get("kanban_task_id") or "")
+    if payload_task_id != task_id:
+        raise ValueError(
+            "task-status publication kanban_task_id must exactly match its event task"
+        )
+    operation = str(publication.get("operation") or "")
+    normalized = dict(publication)
+    destination = publication.get("destination")
+    if operation == "create":
+        if not isinstance(destination, dict) or (
+            "chat_id" not in destination
+            or "message_thread_id" not in destination
+        ):
+            raise ValueError(
+                "task-status create event requires an exact destination with "
+                "chat_id and message_thread_id"
+            )
+        chat_id = str(destination.get("chat_id") or "")
+        thread_id = str(destination.get("message_thread_id") or "")
+        if not chat_id.strip():
+            raise ValueError("task-status create event destination chat_id is required")
+    elif operation == "update":
+        binding = get_task_status_binding(conn, task_id)
+        if binding is None or not binding.message_id:
+            raise ValueError(
+                f"no complete task-status binding for Kanban task {task_id}"
+            )
+        chat_id = binding.chat_id
+        thread_id = binding.message_thread_id
+        if destination is not None:
+            if not isinstance(destination, dict) or (
+                "chat_id" not in destination
+                or "message_thread_id" not in destination
+            ):
+                raise ValueError(
+                    "task-status update destination requires exact chat_id "
+                    "and message_thread_id"
+                )
+            if (
+                str(destination.get("chat_id") or "") != chat_id
+                or str(destination.get("message_thread_id") or "")
+                != thread_id
+            ):
+                raise ValueError(
+                    "task-status update destination does not match the binding"
+                )
+    else:
+        raise ValueError("task-status event operation must be create or update")
+
+    exact_sub = conn.execute(
+        """
+        SELECT 1 FROM kanban_notify_subs
+         WHERE task_id = ? AND platform = 'telegram'
+           AND chat_id = ? AND thread_id = ?
+        """,
+        (task_id, chat_id, thread_id),
+    ).fetchone()
+    if exact_sub is None:
+        raise ValueError(
+            "task-status event has no exact Telegram subscription for its destination"
+        )
+    normalized["destination"] = {
+        "chat_id": chat_id,
+        "message_thread_id": thread_id,
+    }
+    with write_txn(conn):
+        _append_event(conn, task_id, "task_status", normalized)
 
 
 def _end_run(
@@ -5252,6 +5404,22 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+        conn.execute(
+            "DELETE FROM task_status_callback_claims WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_callback_messages WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_publication_dedup WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_bindings WHERE kanban_task_id = ?",
+            (task_id,),
+        )
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         return cur.rowcount == 1
 
@@ -5275,6 +5443,22 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+        conn.execute(
+            "DELETE FROM task_status_callback_claims WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_callback_messages WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_publication_dedup WHERE kanban_task_id = ?",
+            (task_id,),
+        )
+        conn.execute(
+            "DELETE FROM task_status_bindings WHERE kanban_task_id = ?",
+            (task_id,),
+        )
     recompute_ready(conn)
     return True
 
@@ -8254,6 +8438,310 @@ def task_age(task: Task) -> dict:
         "started_age_seconds": age_since_started,
         "time_to_complete_seconds": time_to_complete,
     }
+
+
+# ---------------------------------------------------------------------------
+# Living task-status bindings (opt-in gateway publication primitive)
+# ---------------------------------------------------------------------------
+
+def _task_status_binding_from_row(row: sqlite3.Row) -> TaskStatusBinding:
+    return TaskStatusBinding(
+        kanban_task_id=str(row["kanban_task_id"]),
+        platform=str(row["platform"]),
+        chat_id=str(row["chat_id"]),
+        message_thread_id=str(row["message_thread_id"] or ""),
+        message_id=str(row["message_id"] or ""),
+        session_id=str(row["session_id"]),
+        linear_issue_key=(
+            str(row["linear_issue_key"]) if row["linear_issue_key"] is not None else None
+        ),
+        lifecycle_state=str(row["lifecycle_state"]),
+        state_version=int(row["state_version"]),
+        created_at=int(row["created_at"]),
+        updated_at=int(row["updated_at"]),
+    )
+
+
+def get_task_status_binding(
+    conn: sqlite3.Connection, kanban_task_id: str,
+) -> Optional[TaskStatusBinding]:
+    row = conn.execute(
+        "SELECT * FROM task_status_bindings WHERE kanban_task_id = ?",
+        (kanban_task_id,),
+    ).fetchone()
+    return _task_status_binding_from_row(row) if row else None
+
+
+def reserve_task_status_binding(
+    conn: sqlite3.Connection,
+    *,
+    kanban_task_id: str,
+    platform: str,
+    chat_id: str,
+    message_thread_id: str,
+    session_id: str,
+    linear_issue_key: Optional[str],
+    lifecycle_state: str,
+    state_version: int,
+) -> TaskStatusBinding:
+    """Reserve a canonical binding before transport sends the first message.
+
+    ``message_id=''`` is an internal pending marker. A second creator loses the
+    primary-key race before it can send, preventing orphaned Telegram messages.
+    """
+    if get_task(conn, kanban_task_id) is None:
+        raise ValueError(f"unknown Kanban task {kanban_task_id!r}")
+    if not str(chat_id).strip():
+        raise ValueError("task-status chat_id is required")
+    if not str(session_id).strip():
+        raise ValueError("task-status session_id is required")
+    if not str(lifecycle_state).strip():
+        raise ValueError("task-status lifecycle_state is required")
+    if int(state_version) < 1:
+        raise ValueError("task-status state_version must be at least 1")
+    now = int(time.time())
+    try:
+        with write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO task_status_bindings (
+                    kanban_task_id, platform, chat_id, message_thread_id,
+                    message_id, session_id, linear_issue_key, lifecycle_state,
+                    state_version, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    kanban_task_id, platform, str(chat_id),
+                    str(message_thread_id or ""), str(session_id),
+                    linear_issue_key, str(lifecycle_state), int(state_version),
+                    now, now,
+                ),
+            )
+    except sqlite3.IntegrityError as exc:
+        raise ValueError(
+            f"Kanban task {kanban_task_id} is already bound to a task-status message"
+        ) from exc
+    binding = get_task_status_binding(conn, kanban_task_id)
+    if binding is None:  # pragma: no cover - defensive
+        raise RuntimeError("task-status binding reservation disappeared")
+    return binding
+
+
+def finalize_task_status_binding(
+    conn: sqlite3.Connection, *, kanban_task_id: str, message_id: str,
+) -> TaskStatusBinding:
+    if not str(message_id).strip():
+        raise ValueError("task-status transport returned no message_id")
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE task_status_bindings
+               SET message_id = ?, updated_at = ?
+             WHERE kanban_task_id = ? AND message_id = ''
+            """,
+            (str(message_id), int(time.time()), kanban_task_id),
+        )
+        if cur.rowcount != 1:
+            raise ValueError(
+                f"Kanban task {kanban_task_id} has no pending task-status binding"
+            )
+    binding = get_task_status_binding(conn, kanban_task_id)
+    if binding is None:  # pragma: no cover - defensive
+        raise RuntimeError("task-status binding finalization disappeared")
+    return binding
+
+
+def delete_pending_task_status_binding(
+    conn: sqlite3.Connection, kanban_task_id: str,
+) -> None:
+    with write_txn(conn):
+        conn.execute(
+            "DELETE FROM task_status_bindings "
+            "WHERE kanban_task_id = ? AND message_id = ''",
+            (kanban_task_id,),
+        )
+
+
+def advance_task_status_binding(
+    conn: sqlite3.Connection,
+    *,
+    kanban_task_id: str,
+    expected_version: int,
+    lifecycle_state: str,
+    state_version: int,
+) -> TaskStatusBinding:
+    """CAS-update a binding by exactly one monotonic state version."""
+    if int(state_version) != int(expected_version) + 1:
+        raise ValueError("task-status state_version must advance by exactly one")
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE task_status_bindings
+               SET lifecycle_state = ?, state_version = ?, updated_at = ?
+             WHERE kanban_task_id = ? AND state_version = ? AND message_id != ''
+            """,
+            (
+                str(lifecycle_state), int(state_version), int(time.time()),
+                kanban_task_id, int(expected_version),
+            ),
+        )
+        if cur.rowcount != 1:
+            raise ValueError(
+                f"stale task-status update for {kanban_task_id}: "
+                f"expected version {expected_version}"
+            )
+    binding = get_task_status_binding(conn, kanban_task_id)
+    if binding is None:  # pragma: no cover - defensive
+        raise RuntimeError("task-status binding update disappeared")
+    return binding
+
+
+def claim_task_status_publication(
+    conn: sqlite3.Connection,
+    *,
+    dedup_key: str,
+    kanban_task_id: str,
+    window_seconds: int = 180,
+    now: Optional[int] = None,
+) -> bool:
+    """Atomically accept the first composite publication key in the window."""
+    timestamp = int(time.time()) if now is None else int(now)
+    cutoff = timestamp - max(1, int(window_seconds))
+    with write_txn(conn):
+        conn.execute(
+            "DELETE FROM task_status_publication_dedup WHERE created_at <= ?",
+            (cutoff,),
+        )
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO task_status_publication_dedup
+                (dedup_key, kanban_task_id, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (dedup_key, kanban_task_id, timestamp),
+        )
+    return cur.rowcount == 1
+
+
+def release_task_status_publication(
+    conn: sqlite3.Connection, dedup_key: str,
+) -> None:
+    with write_txn(conn):
+        conn.execute(
+            "DELETE FROM task_status_publication_dedup WHERE dedup_key = ?",
+            (dedup_key,),
+        )
+
+
+def register_task_status_callback_message(
+    conn: sqlite3.Connection,
+    *,
+    kanban_task_id: str,
+    state_version: int,
+    platform: str,
+    chat_id: str,
+    message_thread_id: str,
+    message_id: str,
+) -> None:
+    """Persist one exact Telegram message that carries decision buttons."""
+    binding = get_task_status_binding(conn, kanban_task_id)
+    if binding is None or not binding.message_id:
+        raise ValueError(
+            f"no complete task-status binding for Kanban task {kanban_task_id}"
+        )
+    if binding.state_version != int(state_version):
+        raise ValueError(
+            f"callback message version {state_version} does not match current "
+            f"task-status version {binding.state_version}"
+        )
+    if not str(chat_id).strip() or not str(message_id).strip():
+        raise ValueError("callback message requires exact chat_id and message_id")
+    try:
+        with write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO task_status_callback_messages (
+                    platform, chat_id, message_thread_id, message_id,
+                    kanban_task_id, state_version, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(platform),
+                    str(chat_id),
+                    str(message_thread_id or ""),
+                    str(message_id),
+                    kanban_task_id,
+                    int(state_version),
+                    int(time.time()),
+                ),
+            )
+    except sqlite3.IntegrityError as exc:
+        row = conn.execute(
+            """
+            SELECT kanban_task_id, state_version, message_thread_id
+              FROM task_status_callback_messages
+             WHERE platform = ? AND chat_id = ? AND message_id = ?
+            """,
+            (str(platform), str(chat_id), str(message_id)),
+        ).fetchone()
+        if row and (
+            str(row["kanban_task_id"]) == kanban_task_id
+            and int(row["state_version"]) == int(state_version)
+            and str(row["message_thread_id"] or "")
+            == str(message_thread_id or "")
+        ):
+            return
+        raise ValueError(
+            "callback message is already correlated to a different task or version"
+        ) from exc
+
+
+def matches_task_status_callback_message(
+    conn: sqlite3.Connection,
+    *,
+    kanban_task_id: str,
+    state_version: int,
+    platform: str,
+    chat_id: str,
+    message_thread_id: str,
+    message_id: str,
+) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM task_status_callback_messages
+         WHERE platform = ? AND chat_id = ? AND message_thread_id = ?
+           AND message_id = ? AND kanban_task_id = ? AND state_version = ?
+        """,
+        (
+            str(platform),
+            str(chat_id),
+            str(message_thread_id or ""),
+            str(message_id),
+            kanban_task_id,
+            int(state_version),
+        ),
+    ).fetchone()
+    return row is not None
+
+
+def claim_task_status_callback(
+    conn: sqlite3.Connection,
+    *,
+    kanban_task_id: str,
+    state_version: int,
+    action: str,
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            INSERT OR IGNORE INTO task_status_callback_claims
+                (kanban_task_id, state_version, action, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (kanban_task_id, int(state_version), action, int(time.time())),
+        )
+    return cur.rowcount == 1
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -651,6 +651,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Optional policy-owned handler for exact task/status decision callbacks.
+        # Core validates correlation and authorization; it does not decide what
+        # approve/deny means. Without an injected handler callbacks fail closed.
+        self._task_status_action_handler = None
+        self._task_status_allowed_actions: tuple[str, ...] = ()
+        self._task_status_board: Optional[str] = None
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -765,6 +771,22 @@ class TelegramAdapter(BasePlatformAdapter):
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
+
+    def set_task_status_action_handler(
+        self,
+        handler,
+        *,
+        allowed_actions,
+        board: Optional[str] = None,
+    ) -> None:
+        """Install a policy-owned consequential task-status callback handler."""
+        self._task_status_action_handler = handler
+        self._task_status_allowed_actions = tuple(
+            str(action).strip().lower()
+            for action in allowed_actions
+            if str(action).strip()
+        )
+        self._task_status_board = str(board).strip() if board else None
 
     def _source_from_message_for_auth(self, message: Message):
         """Build the same Telegram source shape the gateway auth path expects.
@@ -3891,6 +3913,153 @@ class TelegramAdapter(BasePlatformAdapter):
                 error_kind=error_kind,
             )
 
+    @staticmethod
+    def _task_status_thread_metadata_error(
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return "task-status delivery requires exact thread_id metadata"
+        if "thread_id" not in metadata and "message_thread_id" not in metadata:
+            return "task-status delivery requires exact thread_id metadata"
+        return None
+
+    @staticmethod
+    def _task_status_markup(buttons: List[Dict[str, str]]):
+        if not buttons:
+            return None
+        rows = []
+        row = []
+        for button in buttons:
+            label = str(button.get("label") or "").strip()
+            callback_data = str(button.get("callback_data") or "")
+            if not label:
+                raise ValueError("task-status button label is required")
+            if not callback_data or len(callback_data.encode("utf-8")) > 64:
+                raise ValueError(
+                    "task-status callback_data must be between 1 and 64 bytes"
+                )
+            row.append(InlineKeyboardButton(label, callback_data=callback_data))
+            if len(row) == 2:
+                rows.append(row)
+                row = []
+        if row:
+            rows.append(row)
+        return InlineKeyboardMarkup(rows)
+
+    async def _send_exact_task_status(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        buttons: List[Dict[str, str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Send one exact-destination card without any topic fallback."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        metadata_error = self._task_status_thread_metadata_error(metadata)
+        if metadata_error:
+            return SendResult(success=False, error=metadata_error)
+        if not content or not content.strip():
+            return SendResult(success=False, error="task-status content is required")
+        if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
+            return SendResult(
+                success=False,
+                error="task-status content exceeds Telegram's single-message limit",
+            )
+        try:
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(
+                None, metadata, reply_to_mode=self._reply_to_mode
+            )
+            kwargs: Dict[str, Any] = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "text": self.format_message(content),
+                "parse_mode": ParseMode.MARKDOWN_V2,
+                "reply_markup": self._task_status_markup(buttons),
+                "reply_to_message_id": reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+                **self._notification_kwargs(metadata),
+            }
+            message = await self._bot.send_message(**kwargs)
+            return SendResult(success=True, message_id=str(message.message_id))
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_redact_telegram_error_text(exc),
+                retryable=False,
+            )
+
+    async def send_task_status(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        buttons: List[Dict[str, str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        return await self._send_exact_task_status(
+            chat_id, content, buttons=buttons, metadata=metadata
+        )
+
+    async def send_task_status_push(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        buttons: List[Dict[str, str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        return await self._send_exact_task_status(
+            chat_id, content, buttons=buttons, metadata=metadata
+        )
+
+    async def edit_task_status(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        buttons: List[Dict[str, str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Edit exactly the bound message; never create a fallback message."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        metadata_error = self._task_status_thread_metadata_error(metadata)
+        if metadata_error:
+            return SendResult(success=False, error=metadata_error)
+        if not content or not content.strip():
+            return SendResult(success=False, error="task-status content is required")
+        if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
+            return SendResult(
+                success=False,
+                error="task-status content exceeds Telegram's single-message limit",
+            )
+        try:
+            await self._bot.edit_message_text(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                message_id=int(message_id),
+                text=self.format_message(content),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=self._task_status_markup(buttons),
+                **self._link_preview_kwargs(),
+            )
+            return SendResult(success=True, message_id=str(message_id))
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_redact_telegram_error_text(exc),
+                retryable=False,
+            )
+
     async def send_or_update_status(
         self,
         chat_id: str,
@@ -5327,6 +5496,73 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Correlated task-status callbacks (ts:action:task_id:version) ---
+        if data.startswith("ts:"):
+            handler = getattr(self, "_task_status_action_handler", None)
+            allowed_actions = getattr(self, "_task_status_allowed_actions", ())
+            if not callable(handler) or not allowed_actions:
+                await query.answer(
+                    text="Task decision handling is not configured; no action was taken."
+                )
+                return
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=str(query_chat_id) if query_chat_id is not None else None,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(
+                    text="⛔ You are not authorized to decide this task."
+                )
+                return
+            if query_chat_id is None or query_message is None:
+                await query.answer(
+                    text="Task decision is missing its exact message destination."
+                )
+                return
+            from gateway.task_status import (
+                invoke_task_status_action,
+                resolve_task_status_callback_across_boards,
+            )
+
+            resolution = resolve_task_status_callback_across_boards(
+                callback_data=data,
+                chat_id=str(query_chat_id),
+                message_thread_id=str(query_thread_id or ""),
+                message_id=str(getattr(query_message, "message_id", "")),
+                allowed_actions=allowed_actions,
+                board=getattr(self, "_task_status_board", None),
+            )
+            if not resolution.ok:
+                await query.answer(
+                    text=f"No action taken: {(resolution.error or 'invalid task decision')[:160]}"
+                )
+                return
+            try:
+                await invoke_task_status_action(handler, resolution)
+            except Exception as exc:
+                logger.error(
+                    "[%s] task-status action handler failed for %s v%s: %s",
+                    self.name,
+                    resolution.kanban_task_id,
+                    resolution.state_version,
+                    exc,
+                    exc_info=True,
+                )
+                await query.answer(
+                    text="Task decision handler failed; the action was not retried."
+                )
+                return
+            await query.answer(
+                text=(
+                    f"Task {resolution.kanban_task_id} v{resolution.state_version}: "
+                    f"{resolution.action} recorded."
+                )[:180]
+            )
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):

--- a/tests/gateway/test_task_status.py
+++ b/tests/gateway/test_task_status.py
@@ -1,0 +1,955 @@
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+from gateway.platforms.base import SendResult
+from gateway.task_status import (
+    DeliveryRoute,
+    PublicationKind,
+    TaskStatusButton,
+    TaskStatusDestination,
+    TaskStatusPublication,
+    TaskStatusPublisher,
+    make_task_status_callback_data,
+    resolve_exact_task_status_destination,
+    resolve_task_status_callback,
+)
+from hermes_cli import kanban_db as kb
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+class FakeTelegramAdapter:
+    def __init__(self):
+        self.sends = []
+        self.edits = []
+        self.pushes = []
+        self.wakeups = []
+        self.next_message_id = 100
+
+    async def handle_message(self, event):
+        self.wakeups.append(event)
+
+    async def send_task_status(self, chat_id, content, *, buttons, metadata):
+        self.sends.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "buttons": buttons,
+                "metadata": metadata,
+            }
+        )
+        message_id = str(self.next_message_id)
+        self.next_message_id += 1
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_task_status(
+        self, chat_id, message_id, content, *, buttons, metadata
+    ):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "buttons": buttons,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_task_status_push(self, chat_id, content, *, buttons, metadata):
+        self.pushes.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "buttons": buttons,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="push-1")
+
+
+def test_task_status_defaults_are_opt_in_and_suppress_worker_noise():
+    config = DEFAULT_CONFIG["kanban"]["task_status"]
+
+    assert config["enabled"] is False
+    assert config["publisher_profile"] == "default"
+    assert config["dedup_seconds"] == 180
+    assert config["worker_lifecycle_pushes"] is False
+    assert config["raw_event_pushes"] is False
+
+
+def test_task_status_schema_migration_is_idempotent_and_profile_scoped(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "profile-home"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+
+    first = kb.init_db()
+    second = kb.init_db()
+
+    assert first == second
+    assert first.parent == home
+    conn = kb.connect()
+    try:
+        tables = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(task_status_bindings)")
+        }
+        callback_columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(task_status_callback_messages)")
+        }
+    finally:
+        conn.close()
+    assert "task_status_bindings" in tables
+    assert {
+        "chat_id",
+        "message_thread_id",
+        "message_id",
+        "session_id",
+        "kanban_task_id",
+        "linear_issue_key",
+        "lifecycle_state",
+        "state_version",
+    } <= columns
+    assert {
+        "kanban_task_id",
+        "state_version",
+        "chat_id",
+        "message_thread_id",
+        "message_id",
+    } <= callback_columns
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Ship task status",
+            assignee="coder",
+            session_id="session-1",
+        )
+        yield conn, task_id
+    finally:
+        conn.close()
+
+
+def test_board_fixture_ignores_inherited_live_board_pins(tmp_path, monkeypatch, request):
+    live_db = tmp_path.parent / "registered-live-board" / "kanban.db"
+    live_db.parent.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(live_db))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "registered-live-board")
+
+    conn, _ = request.getfixturevalue("board")
+
+    assert conn is not None
+    resolved = kb.kanban_db_path()
+    assert resolved == tmp_path / ".hermes" / "kanban.db"
+    assert resolved.is_relative_to(tmp_path)
+
+
+def _config():
+    return {
+        "enabled": True,
+        "publisher_profile": "default",
+        "dedup_seconds": 180,
+        "routes": {
+            "control": {"chat_id": "control-chat", "thread_id": "900"},
+            "briefings": {"chat_id": "brief-chat", "thread_id": "901"},
+            "system": {"chat_id": "system-chat", "thread_id": ""},
+        },
+    }
+
+
+def test_composite_dedup_window_accepts_again_after_180_seconds(board):
+    conn, task_id = board
+    key = "same-composite-publication"
+
+    first = kb.claim_task_status_publication(
+        conn,
+        dedup_key=key,
+        kanban_task_id=task_id,
+        window_seconds=180,
+        now=1_000,
+    )
+    within_window = kb.claim_task_status_publication(
+        conn,
+        dedup_key=key,
+        kanban_task_id=task_id,
+        window_seconds=180,
+        now=1_179,
+    )
+    after_window = kb.claim_task_status_publication(
+        conn,
+        dedup_key=key,
+        kanban_task_id=task_id,
+        window_seconds=180,
+        now=1_181,
+    )
+
+    assert first is True
+    assert within_window is False
+    assert after_window is True
+
+
+def test_destination_routes_are_exact_and_never_inferred():
+    config = _config()
+    origin = TaskStatusDestination("project-chat", "77")
+
+    assert resolve_exact_task_status_destination(
+        DeliveryRoute.CONTROL, origin=origin, config=config
+    ) == TaskStatusDestination("control-chat", "900")
+    assert resolve_exact_task_status_destination(
+        DeliveryRoute.BRIEFINGS, origin=origin, config=config
+    ) == TaskStatusDestination("brief-chat", "901")
+    assert resolve_exact_task_status_destination(
+        DeliveryRoute.PROJECT, origin=origin, config=config
+    ) == origin
+    assert resolve_exact_task_status_destination(
+        DeliveryRoute.SYSTEM, origin=origin, config=config
+    ) == TaskStatusDestination("system-chat", "")
+
+    del config["routes"]["briefings"]
+    with pytest.raises(ValueError, match="briefings destination"):
+        resolve_exact_task_status_destination(
+            DeliveryRoute.BRIEFINGS, origin=origin, config=config
+        )
+
+
+def test_structured_create_event_requires_exact_destination(board):
+    conn, task_id = board
+
+    with pytest.raises(ValueError, match="exact destination"):
+        kb.append_task_status_publication(
+            conn,
+            task_id,
+            {
+                "operation": "create",
+                "kanban_task_id": task_id,
+                "session_id": "session-1",
+                "lifecycle_state": "in_progress",
+                "state_version": 1,
+                "content": "Starting.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_persists_exact_binding_and_routine_update_edits_same_message(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publisher = TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=_config(),
+        profile_name="default",
+    )
+
+    created = await publisher.publish(
+        TaskStatusPublication(
+            operation="create",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            linear_issue_key="OPS-42",
+            lifecycle_state="in_progress",
+            state_version=1,
+            content="Implementation is in progress.",
+            kind=PublicationKind.ROUTINE,
+            destination=TaskStatusDestination(
+                chat_id="project-chat", message_thread_id="77"
+            ),
+        )
+    )
+
+    assert created.ok is True
+    assert created.message_id == "100"
+    assert len(adapter.sends) == 1
+    assert adapter.sends[0]["metadata"] == {"thread_id": "77", "notify": False}
+    binding = kb.get_task_status_binding(conn, task_id)
+    assert binding is not None
+    assert binding.chat_id == "project-chat"
+    assert binding.message_thread_id == "77"
+    assert binding.message_id == "100"
+    assert binding.session_id == "session-1"
+    assert binding.kanban_task_id == task_id
+    assert binding.linear_issue_key == "OPS-42"
+    assert binding.lifecycle_state == "in_progress"
+    assert binding.state_version == 1
+
+    updated = await publisher.publish(
+        TaskStatusPublication(
+            operation="update",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="qa_review",
+            state_version=2,
+            content="Independent QA is reviewing the implementation.",
+            kind=PublicationKind.ROUTINE,
+        )
+    )
+
+    assert updated.ok is True
+    assert len(adapter.sends) == 1
+    assert adapter.pushes == []
+    assert adapter.edits == [
+        {
+            "chat_id": "project-chat",
+            "message_id": "100",
+            "content": "Independent QA is reviewing the implementation.",
+            "buttons": [],
+            "metadata": {"thread_id": "77", "notify": False},
+        }
+    ]
+    binding = kb.get_task_status_binding(conn, task_id)
+    assert binding.lifecycle_state == "qa_review"
+    assert binding.state_version == 2
+
+
+@pytest.mark.asyncio
+async def test_duplicate_create_is_rejected_without_orphaning_another_message(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publisher = TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=_config(),
+        profile_name="default",
+    )
+    publication = TaskStatusPublication(
+        operation="create",
+        kanban_task_id=task_id,
+        session_id="session-1",
+        lifecycle_state="in_progress",
+        state_version=1,
+        content="Starting.",
+        kind=PublicationKind.ROUTINE,
+        destination=TaskStatusDestination("project-chat", "77"),
+    )
+
+    first = await publisher.publish(publication)
+    second = await publisher.publish(publication)
+
+    assert first.ok is True
+    assert second.ok is False
+    assert "already bound" in second.error.lower()
+    assert len(adapter.sends) == 1
+    assert kb.get_task_status_binding(conn, task_id).message_id == "100"
+
+
+async def _create_binding(conn, task_id, adapter):
+    publisher = TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=_config(),
+        profile_name="default",
+    )
+    result = await publisher.publish(
+        TaskStatusPublication(
+            operation="create",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="in_progress",
+            state_version=1,
+            content="Starting.",
+            kind=PublicationKind.ROUTINE,
+            destination=TaskStatusDestination("project-chat", "77"),
+        )
+    )
+    assert result.ok is True
+    return publisher
+
+
+def _seed_task_status_correlation_rows(conn, task_id, adapter):
+    asyncio.run(_create_binding(conn, task_id, adapter))
+    assert kb.claim_task_status_publication(
+        conn,
+        dedup_key=f"delete-regression:{task_id}",
+        kanban_task_id=task_id,
+    )
+    kb.register_task_status_callback_message(
+        conn,
+        kanban_task_id=task_id,
+        state_version=1,
+        platform="telegram",
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="callback-1",
+    )
+    assert kb.claim_task_status_callback(
+        conn,
+        kanban_task_id=task_id,
+        state_version=1,
+        action="approve",
+    )
+
+
+def _assert_no_task_status_correlation_rows(conn, task_id):
+    task_columns = {
+        "task_status_bindings": "kanban_task_id",
+        "task_status_publication_dedup": "kanban_task_id",
+        "task_status_callback_messages": "kanban_task_id",
+        "task_status_callback_claims": "kanban_task_id",
+    }
+    for table, column in task_columns.items():
+        count = conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {column} = ?", (task_id,)
+        ).fetchone()[0]
+        assert count == 0, f"{table} retained orphan rows for {task_id}"
+
+
+def test_delete_task_removes_all_task_status_correlation_rows(board):
+    conn, task_id = board
+    _seed_task_status_correlation_rows(conn, task_id, FakeTelegramAdapter())
+
+    assert kb.delete_task(conn, task_id) is True
+
+    _assert_no_task_status_correlation_rows(conn, task_id)
+
+
+def test_delete_archived_task_removes_all_task_status_correlation_rows(board):
+    conn, task_id = board
+    _seed_task_status_correlation_rows(conn, task_id, FakeTelegramAdapter())
+    assert kb.archive_task(conn, task_id) is True
+
+    assert kb.delete_archived_task(conn, task_id) is True
+
+    _assert_no_task_status_correlation_rows(conn, task_id)
+
+
+@pytest.mark.asyncio
+async def test_structured_update_event_rejects_destination_mismatch(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    await _create_binding(conn, task_id, adapter)
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="telegram",
+        chat_id="project-chat",
+        thread_id="77",
+        notifier_profile="default",
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        kb.append_task_status_publication(
+            conn,
+            task_id,
+            {
+                "operation": "update",
+                "kanban_task_id": task_id,
+                "session_id": "session-1",
+                "lifecycle_state": "qa_review",
+                "state_version": 2,
+                "content": "QA review.",
+                "destination": {
+                    "chat_id": "wrong-chat",
+                    "message_thread_id": "99",
+                },
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_composite_dedup_suppresses_equivalent_update_and_allows_change(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publisher = await _create_binding(conn, task_id, adapter)
+
+    qa = TaskStatusPublication(
+        operation="update",
+        kanban_task_id=task_id,
+        session_id="session-1",
+        lifecycle_state="qa_review",
+        state_version=2,
+        content="QA review.",
+        kind=PublicationKind.ROUTINE,
+        recommended_action="Wait for QA.",
+    )
+    first = await publisher.publish(qa)
+    duplicate = await publisher.publish(qa)
+    changed = await publisher.publish(
+        TaskStatusPublication(
+            operation="update",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="donna_review",
+            state_version=3,
+            content="Donna review.",
+            kind=PublicationKind.ROUTINE,
+            recommended_action="Wait for Donna.",
+        )
+    )
+    changed_action = await publisher.publish(
+        TaskStatusPublication(
+            operation="update",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="donna_review",
+            state_version=3,
+            content="Donna review; recommendation changed.",
+            kind=PublicationKind.ROUTINE,
+            recommended_action="Approve the pilot.",
+        )
+    )
+
+    assert first.ok is True
+    assert duplicate.ok is True and duplicate.deduplicated is True
+    assert changed.ok is True
+    assert changed_action.ok is True
+    assert len(adapter.edits) == 3
+
+
+@pytest.mark.asyncio
+async def test_decision_pushes_once_to_control_while_routine_never_pushes(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publisher = await _create_binding(conn, task_id, adapter)
+
+    decision = TaskStatusPublication(
+        operation="update",
+        kanban_task_id=task_id,
+        session_id="session-1",
+        lifecycle_state="waiting_for_approval",
+        state_version=2,
+        content="A decision is required.",
+        push_content="Approve or deny the protected pilot.",
+        kind=PublicationKind.DECISION,
+        recommended_action="Approve the protected pilot.",
+        buttons=(
+            TaskStatusButton("Approve", "approve"),
+            TaskStatusButton("Deny", "deny"),
+        ),
+    )
+
+    first = await publisher.publish(decision)
+    duplicate = await publisher.publish(decision)
+
+    assert first.ok is True and first.pushed is True
+    assert duplicate.ok is True and duplicate.deduplicated is True
+    assert len(adapter.pushes) == 1
+    assert adapter.pushes[0]["chat_id"] == "control-chat"
+    assert adapter.pushes[0]["metadata"] == {"thread_id": "900", "notify": True}
+    callback_data = adapter.pushes[0]["buttons"][0]["callback_data"]
+    assert callback_data == f"ts:approve:{task_id}:2"
+    assert len(callback_data.encode("utf-8")) <= 64
+    resolution = resolve_task_status_callback(
+        conn,
+        callback_data=callback_data,
+        chat_id="control-chat",
+        message_thread_id="900",
+        message_id="push-1",
+        allowed_actions=("approve", "deny"),
+    )
+    assert resolution.ok is True
+    assert resolution.kanban_task_id == task_id
+    assert resolution.state_version == 2
+
+
+@pytest.mark.asyncio
+async def test_accepted_completion_finalizes_card_and_pushes_to_origin_only(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publisher = await _create_binding(conn, task_id, adapter)
+
+    result = await publisher.publish(
+        TaskStatusPublication(
+            operation="update",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="complete",
+            state_version=2,
+            content="The accepted outcome is complete.",
+            push_content="Completed: the protected outcome was accepted.",
+            kind=PublicationKind.ACCEPTED_COMPLETION,
+        )
+    )
+
+    assert result.ok is True and result.pushed is True
+    assert len(adapter.edits) == 1
+    assert adapter.pushes == [
+        {
+            "chat_id": "project-chat",
+            "content": "Completed: the protected outcome was accepted.",
+            "buttons": [],
+            "metadata": {"thread_id": "77", "notify": True},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_control_destination_fails_closed_before_transport(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    await _create_binding(conn, task_id, adapter)
+    bad_config = _config()
+    del bad_config["routes"]["control"]
+    publisher = TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=bad_config,
+        profile_name="default",
+    )
+
+    result = await publisher.publish(
+        TaskStatusPublication(
+            operation="update",
+            kanban_task_id=task_id,
+            session_id="session-1",
+            lifecycle_state="blocked",
+            state_version=2,
+            content="Blocked.",
+            push_content="A blocker needs attention.",
+            kind=PublicationKind.BLOCKER,
+        )
+    )
+
+    assert result.ok is False
+    assert "control destination" in result.error
+    assert adapter.edits == []
+    assert adapter.pushes == []
+
+
+@pytest.mark.asyncio
+async def test_wrong_publisher_profile_and_missing_binding_fail_closed(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    publication = TaskStatusPublication(
+        operation="update",
+        kanban_task_id=task_id,
+        session_id="session-1",
+        lifecycle_state="qa_review",
+        state_version=2,
+        content="QA review.",
+    )
+
+    wrong_profile = await TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=_config(),
+        profile_name="coder",
+    ).publish(publication)
+    missing_binding = await TaskStatusPublisher(
+        conn=conn,
+        adapter=adapter,
+        config=_config(),
+        profile_name="default",
+    ).publish(publication)
+
+    assert wrong_profile.ok is False
+    assert "profile mismatch" in wrong_profile.error
+    assert missing_binding.ok is False
+    assert "no complete task-status binding" in missing_binding.error
+    assert adapter.sends == [] and adapter.edits == [] and adapter.pushes == []
+
+
+@pytest.mark.asyncio
+async def test_callbacks_require_exact_task_message_topic_and_current_version(board):
+    conn, task_id = board
+    adapter = FakeTelegramAdapter()
+    await _create_binding(conn, task_id, adapter)
+    valid = make_task_status_callback_data(task_id, 1, "approve")
+
+    stale = resolve_task_status_callback(
+        conn,
+        callback_data=make_task_status_callback_data(task_id, 2, "approve"),
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    wrong_message = resolve_task_status_callback(
+        conn,
+        callback_data=valid,
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="999",
+        allowed_actions=("approve", "deny"),
+    )
+    wrong_topic = resolve_task_status_callback(
+        conn,
+        callback_data=valid,
+        chat_id="project-chat",
+        message_thread_id="other",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    wrong_task = resolve_task_status_callback(
+        conn,
+        callback_data=make_task_status_callback_data(
+            "t_wrongtask", 1, "approve"
+        ),
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    unknown_action = resolve_task_status_callback(
+        conn,
+        callback_data=make_task_status_callback_data(task_id, 1, "continue"),
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    bare = resolve_task_status_callback(
+        conn,
+        callback_data="approve",
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    bare_number = resolve_task_status_callback(
+        conn,
+        callback_data="1",
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    accepted = resolve_task_status_callback(
+        conn,
+        callback_data=valid,
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    replay = resolve_task_status_callback(
+        conn,
+        callback_data=valid,
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+    conflicting_replay = resolve_task_status_callback(
+        conn,
+        callback_data=make_task_status_callback_data(task_id, 1, "deny"),
+        chat_id="project-chat",
+        message_thread_id="77",
+        message_id="100",
+        allowed_actions=("approve", "deny"),
+    )
+
+    assert stale.ok is False and "stale" in stale.error
+    assert wrong_message.ok is False and "message" in wrong_message.error
+    assert wrong_topic.ok is False and "topic" in wrong_topic.error
+    assert wrong_task.ok is False and "no task-status binding" in wrong_task.error
+    assert unknown_action.ok is False and "unknown" in unknown_action.error
+    assert bare.ok is False and bare_number.ok is False
+    assert accepted.ok is True
+    assert accepted.kanban_task_id == task_id
+    assert accepted.state_version == 1
+    assert accepted.action == "approve"
+    assert replay.ok is False and "already resolved" in replay.error
+    assert conflicting_replay.ok is False and "already resolved" in conflicting_replay.error
+
+
+@pytest.mark.asyncio
+async def test_gateway_notifier_integration_uses_structured_events_and_silences_raw_events(
+    board, monkeypatch
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    conn, task_id = board
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="telegram",
+        chat_id="project-chat",
+        thread_id="77",
+        notifier_profile="default",
+    )
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="telegram",
+        chat_id="other-chat",
+        thread_id="88",
+        notifier_profile="default",
+    )
+    kb.append_task_status_publication(
+        conn,
+        task_id,
+        {
+            "operation": "create",
+            "kanban_task_id": task_id,
+            "session_id": "session-1",
+            "lifecycle_state": "in_progress",
+            "state_version": 1,
+            "content": "Implementation is in progress.",
+            "kind": "routine",
+            "destination": {
+                "chat_id": "project-chat",
+                "message_thread_id": "77",
+            },
+        },
+    )
+
+    adapter = FakeTelegramAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+    real_sleep = asyncio.sleep
+
+    async def one_tick(delay):
+        if delay == 5:
+            return
+        runner._running = False
+        await real_sleep(0)
+
+    config = {
+        "kanban": {
+            "dispatch_in_gateway": True,
+            "task_status": _config(),
+        }
+    }
+    with patch("hermes_cli.config.load_config", return_value=config), patch(
+        "gateway.kanban_watchers.asyncio.sleep", side_effect=one_tick
+    ):
+        await runner._kanban_notifier_watcher(interval=1)
+
+    assert len(adapter.sends) == 1
+    assert kb.get_task_status_binding(conn, task_id).message_id == "100"
+
+    # A raw blocked event and a structured routine update arrive together.
+    # Living-card mode must suppress the raw terminal push and edit only.
+    kb.block_task(conn, task_id, reason="wait", kind="needs_input")
+    kb.append_task_status_publication(
+        conn,
+        task_id,
+        {
+            "operation": "update",
+            "kanban_task_id": task_id,
+            "session_id": "session-1",
+            "lifecycle_state": "qa_review",
+            "state_version": 2,
+            "content": "QA review is in progress.",
+            "kind": "routine",
+        },
+    )
+    runner._running = True
+    with patch("hermes_cli.config.load_config", return_value=config), patch(
+        "gateway.kanban_watchers.asyncio.sleep", side_effect=one_tick
+    ):
+        await runner._kanban_notifier_watcher(interval=1)
+
+    assert len(adapter.edits) == 1
+    assert adapter.sends[0]["chat_id"] == "project-chat"
+    assert adapter.pushes == []
+    assert adapter.wakeups == []
+
+
+@pytest.mark.asyncio
+async def test_worker_completion_keeps_route_until_explicit_accepted_completion(
+    board, monkeypatch
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    conn, task_id = board
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="telegram",
+        chat_id="project-chat",
+        thread_id="77",
+        notifier_profile="default",
+    )
+    kb.append_task_status_publication(
+        conn,
+        task_id,
+        {
+            "operation": "create",
+            "kanban_task_id": task_id,
+            "session_id": "session-1",
+            "lifecycle_state": "in_progress",
+            "state_version": 1,
+            "content": "Implementation is in progress.",
+            "kind": "routine",
+            "destination": {
+                "chat_id": "project-chat",
+                "message_thread_id": "77",
+            },
+        },
+    )
+
+    adapter = FakeTelegramAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+    config = {
+        "kanban": {
+            "dispatch_in_gateway": True,
+            "task_status": _config(),
+        }
+    }
+    real_sleep = asyncio.sleep
+
+    async def run_one_tick():
+        async def one_tick(delay):
+            if delay == 5:
+                return
+            runner._running = False
+            await real_sleep(0)
+
+        runner._running = True
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "gateway.kanban_watchers.asyncio.sleep", side_effect=one_tick
+        ):
+            await runner._kanban_notifier_watcher(interval=1)
+
+    await run_one_tick()
+    assert kb.get_task_status_binding(conn, task_id).message_id == "100"
+
+    assert kb.complete_task(conn, task_id, summary="Worker artifact is ready") is True
+    await run_one_tick()
+
+    assert len(kb.list_notify_subs(conn, task_id=task_id)) == 1
+    assert adapter.edits == []
+    assert adapter.pushes == []
+
+    kb.append_task_status_publication(
+        conn,
+        task_id,
+        {
+            "operation": "update",
+            "kanban_task_id": task_id,
+            "session_id": "session-1",
+            "lifecycle_state": "complete",
+            "state_version": 2,
+            "content": "The accepted outcome is complete.",
+            "push_content": "Completed: the protected outcome was accepted.",
+            "kind": "accepted_completion",
+        },
+    )
+    await run_one_tick()
+
+    assert len(adapter.edits) == 1
+    assert len(adapter.pushes) == 1
+    assert kb.list_notify_subs(conn, task_id=task_id) == []

--- a/tests/gateway/test_telegram_task_status.py
+++ b/tests/gateway/test_telegram_task_status.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.task_status import CallbackResolution
+
+
+class FakeButton:
+    def __init__(self, text, callback_data):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class FakeMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _install_fake_telegram(monkeypatch):
+    fake_telegram = types.ModuleType("telegram")
+    fake_telegram.Update = SimpleNamespace(ALL_TYPES=())
+    fake_telegram.Bot = object
+    fake_telegram.Message = object
+    fake_telegram.InlineKeyboardButton = FakeButton
+    fake_telegram.InlineKeyboardMarkup = FakeMarkup
+
+    fake_error = types.ModuleType("telegram.error")
+    fake_error.NetworkError = type("NetworkError", (Exception,), {})
+    fake_error.BadRequest = type("BadRequest", (Exception,), {})
+    fake_error.TimedOut = type("TimedOut", (Exception,), {})
+    fake_telegram.error = fake_error
+
+    fake_constants = types.ModuleType("telegram.constants")
+    fake_constants.ParseMode = SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    fake_constants.ChatType = SimpleNamespace(
+        GROUP="group", SUPERGROUP="supergroup", CHANNEL="channel", PRIVATE="private"
+    )
+    fake_telegram.constants = fake_constants
+
+    fake_ext = types.ModuleType("telegram.ext")
+    fake_ext.Application = object
+    fake_ext.CommandHandler = object
+    fake_ext.CallbackQueryHandler = object
+    fake_ext.MessageHandler = object
+    fake_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+    fake_ext.filters = object
+
+    fake_request = types.ModuleType("telegram.request")
+    fake_request.HTTPXRequest = object
+
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", fake_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", fake_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", fake_request)
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    instance = TelegramAdapter(PlatformConfig(enabled=True, token="x"))
+    instance._bot = MagicMock()
+    instance._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    instance._bot.edit_message_text = AsyncMock()
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_task_status_create_and_edit_preserve_exact_topic_and_keyboard(adapter):
+    buttons = [
+        {"label": "Approve", "callback_data": "ts:approve:t_12345678:2"},
+        {"label": "Deny", "callback_data": "ts:deny:t_12345678:2"},
+    ]
+
+    sent = await adapter.send_task_status(
+        "-1001",
+        "Task card",
+        buttons=buttons,
+        metadata={"thread_id": "77", "notify": False},
+    )
+    edited = await adapter.edit_task_status(
+        "-1001",
+        "123",
+        "Task card updated",
+        buttons=buttons,
+        metadata={"thread_id": "77", "notify": False},
+    )
+
+    assert sent.success is True and sent.message_id == "123"
+    assert edited.success is True and edited.message_id == "123"
+    send_kwargs = adapter._bot.send_message.call_args.kwargs
+    assert send_kwargs["chat_id"] == -1001
+    assert send_kwargs["message_thread_id"] == 77
+    assert send_kwargs["disable_notification"] is True
+    assert send_kwargs["reply_markup"].inline_keyboard[0][0].callback_data == buttons[0]["callback_data"]
+    edit_kwargs = adapter._bot.edit_message_text.call_args.kwargs
+    assert edit_kwargs["chat_id"] == -1001
+    assert edit_kwargs["message_id"] == 123
+    assert edit_kwargs["reply_markup"].inline_keyboard[0][1].callback_data == buttons[1]["callback_data"]
+
+
+@pytest.mark.asyncio
+async def test_task_status_push_is_not_silent_and_never_drops_exact_thread(adapter):
+    result = await adapter.send_task_status_push(
+        "-1001",
+        "Decision required",
+        buttons=[],
+        metadata={"thread_id": "900", "notify": True},
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args.kwargs
+    assert kwargs["message_thread_id"] == 900
+    assert "disable_notification" not in kwargs
+
+
+def test_telegram_important_notifications_use_display_platform_path(adapter):
+    from plugins.platforms.telegram.adapter import _resolve_notifications_mode
+
+    config = {
+        "display": {
+            "platforms": {"telegram": {"notifications": "important"}}
+        }
+    }
+    with patch.dict(
+        os.environ, {"HERMES_TELEGRAM_NOTIFICATIONS": ""}, clear=False
+    ), patch("gateway.config.load_gateway_config", return_value=config):
+        assert _resolve_notifications_mode() == "important"
+
+
+@pytest.mark.asyncio
+async def test_task_status_transport_rejects_missing_thread_metadata(adapter):
+    result = await adapter.send_task_status(
+        "-1001", "Task card", buttons=[], metadata={"notify": False}
+    )
+
+    assert result.success is False
+    assert "thread_id" in result.error
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_negative_resolution_never_invokes_action_handler(adapter):
+    handler = AsyncMock()
+    adapter.set_task_status_action_handler(
+        handler, allowed_actions=("approve", "deny"), board="project"
+    )
+    query = MagicMock()
+    query.data = "approve"
+    query.from_user = SimpleNamespace(id=7, first_name="Aja")
+    query.message = SimpleNamespace(
+        chat_id=-1001,
+        message_id=123,
+        message_thread_id=77,
+        chat=SimpleNamespace(type="supergroup"),
+    )
+    query.answer = AsyncMock()
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), MagicMock()
+    )
+
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_correlated_callback_invokes_handler_with_exact_task_and_version(adapter):
+    handler = AsyncMock()
+    adapter.set_task_status_action_handler(
+        handler, allowed_actions=("approve", "deny"), board="project"
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    query = MagicMock()
+    query.data = "ts:approve:t_12345678:4"
+    query.from_user = SimpleNamespace(id=7, first_name="Aja")
+    query.message = SimpleNamespace(
+        chat_id=-1001,
+        message_id=123,
+        message_thread_id=77,
+        chat=SimpleNamespace(type="supergroup"),
+    )
+    query.answer = AsyncMock()
+
+    with patch(
+        "gateway.task_status.resolve_task_status_callback_across_boards",
+        return_value=CallbackResolution(
+            ok=True,
+            kanban_task_id="t_12345678",
+            state_version=4,
+            action="approve",
+        ),
+    ):
+        await adapter._handle_callback_query(
+            SimpleNamespace(callback_query=query), MagicMock()
+        )
+
+    handler.assert_awaited_once_with(
+        kanban_task_id="t_12345678", state_version=4, action="approve"
+    )
+    query.answer.assert_awaited_once()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1304,6 +1304,121 @@ HERMES_TELEGRAM_NOTIFICATIONS=all
 
 Unknown values log a warning and fall back to `important`.
 
+## Opt-in living Kanban task-status messages
+
+Hermes can maintain one living Telegram status card for one canonical Kanban
+task. This is an opt-in control primitive for policy integrations; it does not
+turn Telegram topics into profiles, add topic-to-agent routing, or replace the
+Kanban board. A topic remains a conversation/session workspace, while Kanban
+remains the detailed execution and evidence source of truth.
+
+Only the configured publisher profile may create, edit, or push a task-status
+publication. Specialist workers should leave progress, test output, blockers,
+and terminal handoffs in Kanban. With `raw_event_pushes: false` (the default),
+the gateway does not copy raw worker/card events into Telegram while living-card
+mode is enabled.
+
+Each binding is stored in the task's board SQLite database with these fields:
+
+- Telegram `chat_id`, `message_thread_id`, and returned `message_id`
+- Hermes `session_id`
+- canonical `kanban_task_id`
+- optional Linear issue key
+- lifecycle state and monotonic state version
+
+Button-bearing decision pushes are additionally correlated in a small callback
+message table by task ID, state version, chat, topic, and returned message ID.
+This does not create a second living card; it lets a callback from the control
+topic prove which exact push message it came from.
+
+The first structured publication sends one card and stores Telegram's returned
+message ID. Routine updates edit exactly that message. A duplicate create is
+rejected before transport, and an update with a missing binding, mismatched
+session/destination, stale version, or skipped version fails closed. Schema
+creation is idempotent on existing boards; the feature is disabled by default,
+so migration does not change legacy notification behavior.
+
+Fresh pushes are restricted to four correlated publication kinds:
+
+| Kind | Destination |
+| --- | --- |
+| decision or blocker | Exact configured `control` chat/topic |
+| material scope/risk/outcome change | Exact originating project chat/topic |
+| accepted completion | Exact originating project chat/topic |
+| routine stage change | No fresh push; edit the living card only |
+
+Briefings and system/root routes are also configured explicitly for the policy
+layer. A missing `chat_id` or `thread_id` key is an error; root is represented
+by an explicit empty `thread_id`. Hermes never falls back to a topic title,
+color, current/latest session, latest chat, or newest task, and one publication
+is never mirrored to a second topic.
+
+Decision buttons use callback data in the form
+`ts:<action>:<kanban_task_id>:<state_version>`, bounded by Telegram's 64-byte
+limit. Before an injected policy handler runs, Hermes verifies the authorized
+caller, exact task, chat, topic, message ID, current state version, and allowed
+action. Bare replies such as `1`, `approve`, or `continue`, stale versions,
+wrong-task/wrong-message callbacks, unknown actions, ambiguous cross-board
+bindings, and callback replays take no consequential action.
+
+Equivalent publications are suppressed for 180 seconds using the canonical
+task ID, lifecycle state, state version, destination chat/topic, and recommended
+action. A changed state, version, destination, or recommended action is material
+and can publish.
+
+### Protected pilot setup
+
+Keep this disabled until the publisher profile and every destination have been
+reviewed:
+
+```yaml
+kanban:
+  task_status:
+    enabled: true
+    publisher_profile: default
+    dedup_seconds: 180
+    worker_lifecycle_pushes: false
+    raw_event_pushes: false
+    routes:
+      control:
+        chat_id: "-1001234567890"
+        thread_id: "900"
+      briefings:
+        chat_id: "-1001234567890"
+        thread_id: "901"
+      system:
+        chat_id: "-1001234567890"
+        thread_id: ""
+```
+
+The policy integration appends an explicit structured event with
+`hermes_cli.kanban_db.append_task_status_publication()`. A create event must
+carry `destination: {chat_id, message_thread_id}` and have an exact matching
+Telegram notification subscription for that task. Update events are normalized
+to the persisted binding before they enter the event log. The gateway publishes
+only through the matching subscription; another Telegram subscription is not a
+mirror destination, and non-Telegram subscriptions keep their legacy behavior.
+If decision buttons are used, the integration injects an allowed action handler
+with `TelegramAdapter.set_task_status_action_handler()`. Core does not assign
+business meaning to approve/deny and does not infer a handler. A missing handler
+fails closed.
+
+For a low-noise pilot, keep Telegram push behavior at the documented display
+path (not under `gateway.telegram`):
+
+```yaml
+display:
+  platforms:
+    telegram:
+      notifications: important
+```
+
+Restart the gateway after configuration changes and begin a fresh session.
+Validate with a non-production task and topic first. Transport success is not
+operational acceptance; the protected pilot still requires a real user-originated
+Telegram request and confirmation that the expected topic received exactly one
+living card, routine edits, and only the allowed correlated pushes.
+
 ## Status messages edited in place
 
 The Telegram adapter routes recurring agent status callbacks (e.g. "Compressing context…", "Calling tool…") through `send_or_update_status()`, which keeps a `{(chat_id, status_key) → message_id}` cache and **edits the existing bubble** on subsequent emits instead of appending a new one each time. Distinct `status_key` values get their own messages; distinct chats never collide. If the edit fails (e.g. the user deleted the message, or it's older than Telegram allows for edits), the cache entry is dropped and the next emit posts a fresh message and re-caches its ID. No config required — this is the default Telegram behavior. Other adapters that don't implement `send_or_update_status` fall through to plain `send()` unchanged.


### PR DESCRIPTION
## Summary
- add opt-in task-status control primitives for Telegram
- persist task-to-message routing and callback correlation
- add live-board-safe test isolation and focused coverage

## Validation
- 44 focused task-status/notifier tests passed
- compileall passed
- git diff --check passed

## Boundaries
- no live Telegram/device pilot
- task-status remains opt-in and production policy wiring is intentionally separate