### PR TITLE
fix(kanban): reject stale board websocket subscriptions

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2398,6 +2398,22 @@ async def stream_events(ws: WebSocket):
     if not _ws_upgrade_authorized(ws):
         await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
         return
+
+    # Validate an explicit board before accepting or opening SQLite. A browser
+    # tab can retain an archived board slug in localStorage and keep retrying
+    # this websocket after the board directory has moved. ``connect()`` creates
+    # parent directories by design, so skipping this guard resurrects an empty
+    # active board on every reconnect.
+    ws_board_raw = ws.query_params.get("board")
+    try:
+        ws_board = kanban_db._normalize_board_slug(ws_board_raw) if ws_board_raw else None
+    except ValueError:
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+    if ws_board and ws_board != kanban_db.DEFAULT_BOARD and not kanban_db.board_exists(ws_board):
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+
     await ws.accept()
     try:
         since_raw = ws.query_params.get("since", "0")
@@ -2406,15 +2422,9 @@ async def stream_events(ws: WebSocket):
         except ValueError:
             cursor = 0
 
-        # Board selection — pinned at the WS handshake; re-subscribe to
-        # switch boards. Changing boards mid-stream would require
-        # reconciling two cursors, so the UI just opens a new WS on
-        # board change.
-        ws_board_raw = ws.query_params.get("board")
-        try:
-            ws_board = kanban_db._normalize_board_slug(ws_board_raw) if ws_board_raw else None
-        except ValueError:
-            ws_board = None
+        # Board selection was validated and pinned before the handshake;
+        # re-subscribe to switch boards. Changing boards mid-stream would
+        # require reconciling two cursors, so the UI opens a new WS instead.
 
         def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
             conn = kanban_db.connect(board=ws_board)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -843,6 +843,46 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
         assert ws is not None  # handshake succeeded
 
 
+def test_ws_events_rejects_missing_board_without_recreating_it(tmp_path, monkeypatch):
+    """A stale dashboard tab must not resurrect an archived board.
+
+    The HTTP endpoints validate explicit board slugs before opening SQLite, but
+    the websocket used to connect directly.  Its reconnect loop therefore
+    recreated ``boards/<archived-slug>/kanban.db`` after the directory moved.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    import hermes_cli
+    import types
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _ws_auth_ok=lambda ws: ws.query_params.get("token", "") == "secret-xyz",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    c = TestClient(app)
+
+    from starlette.websockets import WebSocketDisconnect
+
+    ghost_dir = home / "kanban" / "boards" / "archived-board"
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with c.websocket_connect(
+            "/api/plugins/kanban/events?token=secret-xyz&board=archived-board"
+        ):
+            pass
+
+    assert exc.value.code == 1008
+    assert not ghost_dir.exists()
+
+
 def test_ws_events_accepts_gated_ticket(tmp_path, monkeypatch):
     """Gated OAuth mode: the WS must accept a single-use ?ticket= (and reject
     a bare ?token=, even one matching _SESSION_TOKEN). This is the regression

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -883,6 +883,49 @@ def test_ws_events_rejects_missing_board_without_recreating_it(tmp_path, monkeyp
     assert not ghost_dir.exists()
 
 
+def test_ws_events_rejects_malformed_board_before_accept_or_connect(tmp_path, monkeypatch):
+    """Malformed explicit slugs fail the handshake without touching storage."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    import hermes_cli
+    import types
+    from starlette.websockets import WebSocket, WebSocketDisconnect
+
+    stub = types.SimpleNamespace(
+        _SESSION_TOKEN="secret-xyz",
+        _ws_auth_ok=lambda ws: ws.query_params.get("token", "") == "secret-xyz",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    async def _unexpected_accept(_self):
+        pytest.fail("malformed board slug was accepted")
+
+    def _unexpected_connect(*_args, **_kwargs):
+        pytest.fail("malformed board slug reached kanban_db.connect()")
+
+    monkeypatch.setattr(WebSocket, "accept", _unexpected_accept)
+    monkeypatch.setattr(kb, "connect", _unexpected_connect)
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    c = TestClient(app)
+    fs_before = {path.relative_to(home) for path in home.rglob("*")}
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with c.websocket_connect(
+            "/api/plugins/kanban/events?token=secret-xyz&board=../malformed"
+        ):
+            pass
+
+    assert exc.value.code == 1008
+    assert {path.relative_to(home) for path in home.rglob("*")} == fs_before
+
+
 def test_ws_events_accepts_gated_ticket(tmp_path, monkeypatch):
     """Gated OAuth mode: the WS must accept a single-use ?ticket= (and reject
     a bare ?token=, even one matching _SESSION_TOKEN). This is the regression


### PR DESCRIPTION
## Summary
- reject malformed or missing explicit board slugs before accepting the Kanban event websocket
- prevent stale dashboard localStorage/reconnect loops from recreating archived board directories
- add regression coverage proving the missing board directory stays absent

## Tests
- scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py (99 passed)
- SonarQube analysis completed; no new violations, overall gate remains ERROR only because existing file coverage is 64.8% vs repository-local 80% threshold

## Runtime evidence
A stale dashboard websocket repeatedly recreated an empty profile-architecture DB after archival. The guard closes it with WS 1008 before kanban_db.connect() can mkdir/open SQLite.