### PR TITLE
fix(desktop): render local-path markdown images

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -202,6 +202,75 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://example.com/a_b/c~d/page>')
   })
 
+  it('rewrites windows-path image embeds to media links', () => {
+    const output = preprocessMarkdown(
+      'Here you go!\n\n![cute kitten](C:\\Users\\me\\AppData\\Local\\hermes\\cache\\images\\generated.jpg)'
+    )
+
+    expect(output).toContain(
+      '[Image: generated.jpg](#media:C%3A%5CUsers%5Cme%5CAppData%5CLocal%5Chermes%5Ccache%5Cimages%5Cgenerated.jpg)'
+    )
+    expect(output).not.toContain('![cute kitten]')
+  })
+
+  it('rewrites windows-path image embeds containing spaces', () => {
+    const output = preprocessMarkdown('![shot](C:\\Users\\John Smith\\Pictures\\screen shot.png)')
+
+    expect(output).toContain(
+      '[Image: screen shot.png](#media:C%3A%5CUsers%5CJohn%20Smith%5CPictures%5Cscreen%20shot.png)'
+    )
+  })
+
+  it('rewrites posix, file://, UNC, and home-path image embeds', () => {
+    expect(preprocessMarkdown('![cat](/home/me/.hermes/cache/images/cat.png)')).toContain(
+      '[Image: cat.png](#media:%2Fhome%2Fme%2F.hermes%2Fcache%2Fimages%2Fcat.png)'
+    )
+    expect(preprocessMarkdown('![cat](file:///tmp/cat.png)')).toContain(
+      '[Image: cat.png](#media:file%3A%2F%2F%2Ftmp%2Fcat.png)'
+    )
+    expect(preprocessMarkdown('![cat](\\\\server\\share\\cat.png)')).toContain(
+      '[Image: cat.png](#media:%5C%5Cserver%5Cshare%5Ccat.png)'
+    )
+    expect(preprocessMarkdown('![cat](~/Pictures/cat.png)')).toContain(
+      '[Image: cat.png](#media:~%2FPictures%2Fcat.png)'
+    )
+  })
+
+  it('rewrites angle-bracketed local image srcs and drops quoted titles', () => {
+    expect(preprocessMarkdown('![cat](</tmp/my file.png>)')).toContain(
+      '[Image: my file.png](#media:%2Ftmp%2Fmy%20file.png)'
+    )
+    expect(preprocessMarkdown('![cat](/tmp/cat.png "a title")')).toContain('[Image: cat.png](#media:%2Ftmp%2Fcat.png)')
+  })
+
+  it('rewrites local non-image files in image position to file links', () => {
+    expect(preprocessMarkdown('![doc](C:\\files\\report.pdf)')).toContain(
+      '[File: report.pdf](#media:C%3A%5Cfiles%5Creport.pdf)'
+    )
+  })
+
+  it('leaves web, data, relative, and protocol-relative image embeds untouched', () => {
+    expect(preprocessMarkdown('![k](https://cdn.example/x.png)')).toContain('![k](https://cdn.example/x.png)')
+    expect(preprocessMarkdown('![k](data:image/png;base64,AAA)')).toContain('![k](data:image/png;base64,AAA)')
+    expect(preprocessMarkdown('![k](images/cat.png)')).toContain('![k](images/cat.png)')
+    expect(preprocessMarkdown('![k](//cdn.example/x.png)')).toContain('![k](//cdn.example/x.png)')
+  })
+
+  it('leaves local image embeds inside code untouched', () => {
+    expect(preprocessMarkdown('use `![k](C:\\x\\y.png)` syntax')).toContain('`![k](C:\\x\\y.png)`')
+
+    const fenced = preprocessMarkdown('```md\n![k](C:\\x\\y.png)\n```')
+
+    expect(fenced).toContain('![k](C:\\x\\y.png)')
+    expect(fenced).not.toContain('#media:')
+  })
+
+  it('does not rewrite an incomplete streaming image embed', () => {
+    const output = preprocessMarkdown('Here you go!\n\n![cute kitten](C:\\Users\\me\\AppData\\Local\\her')
+
+    expect(output).not.toContain('#media:')
+  })
+
   it('handles a fenced block larger than V8 spread-argument limit', () => {
     // A single huge code block (e.g. a logged minified bundle) used to throw
     // `RangeError: Maximum call stack size exceeded` via `out.push(...lines)`.

--- a/apps/desktop/src/lib/markdown-preprocess.streamdown.test.tsx
+++ b/apps/desktop/src/lib/markdown-preprocess.streamdown.test.tsx
@@ -1,0 +1,54 @@
+// Streamdown-integration regression tests for issue #38786: a markdown image
+// whose src is a raw local path (image_generate on Windows returns C:\… paths
+// the model embeds verbatim) can never render as <img> — Streamdown's
+// sanitize pass strips the non-http(s) src and its harden pass then replaces
+// the node with an "[Image blocked: …]" placeholder. preprocessMarkdown
+// rewrites such embeds to `#media:` links, and these tests pin the assumption
+// that form survives the real sanitize + harden rehype pipeline and reaches
+// the `a` component (mapped to MarkdownLink → MediaAttachment in the app).
+import { render } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { Streamdown } from 'streamdown'
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+import { mediaPathFromMarkdownHref } from '@/lib/media'
+
+const ISSUE_MARKDOWN =
+  'Here you go!\n\n![cute kitten](C:\\Users\\me\\AppData\\Local\\hermes\\cache\\images\\generated.jpg)'
+
+describe('issue #38786 end-to-end', () => {
+  it('reproduces the blocked placeholder without the preprocess rewrite', () => {
+    const { container } = render(<Streamdown mode="static">{ISSUE_MARKDOWN}</Streamdown>)
+
+    expect(container.textContent).toContain('[Image blocked: cute kitten]')
+  })
+
+  it('delivers the intact #media: href to the a component after the rewrite', () => {
+    const seen: (string | undefined)[] = []
+
+    const CaptureLink = ({ children, href }: ComponentProps<'a'>) => {
+      seen.push(href)
+
+      return <a href={href}>{children}</a>
+    }
+
+    // Same cast the app uses for its own overrides (markdown-text.tsx casts to
+    // StreamdownTextComponents) — the Components type's index signature and
+    // element-specific props don't unify for plain function components.
+    const components = { a: CaptureLink } as ComponentProps<typeof Streamdown>['components']
+
+    const { container } = render(
+      <Streamdown components={components} mode="static">
+        {preprocessMarkdown(ISSUE_MARKDOWN)}
+      </Streamdown>
+    )
+
+    expect(container.textContent).not.toContain('[Image blocked')
+    expect(container.textContent).toContain('Image: generated.jpg')
+    expect(seen).toHaveLength(1)
+    expect(mediaPathFromMarkdownHref(seen[0])).toBe(
+      'C:\\Users\\me\\AppData\\Local\\hermes\\cache\\images\\generated.jpg'
+    )
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -1,4 +1,5 @@
 import { isLikelyProseFence, sanitizeLanguageTag } from '@/lib/markdown-code'
+import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
 import { stripPreviewTargets } from '@/lib/preview-targets'
 
 const REASONING_BLOCK_RE = /<(think|thinking|reasoning|scratchpad|analysis)>[\s\S]*?<\/\1>\s*/gi
@@ -125,6 +126,38 @@ function isUrlOnlyBlock(lines: string[]): boolean {
   return nonEmpty.length > 0 && nonEmpty.every(line => URL_ONLY_LINE_RE.test(line))
 }
 
+// A complete markdown image embed: `![alt](src)`, `![alt](<src>)`, or either
+// with a trailing quoted title. `src` stays on one line; the bare (unbracketed)
+// form may contain spaces (common in Windows paths) but no parens — matching
+// stops at the first `)` like the markdown parser would.
+const IMAGE_EMBED_RE = /!\[[^\]\n]*\]\(\s*(?:<([^<>\n]+)>|([^()\n]+?))(?:\s+"[^"\n]*")?\s*\)/g
+
+// Srcs that point at the local filesystem rather than the web: file:// URLs,
+// Windows drive paths (C:\ or C:/), UNC shares (\\server), POSIX absolute
+// paths, and ~/ home paths. Relative paths stay untouched — they have no
+// resolvable base in a chat transcript.
+const LOCAL_FILE_SRC_RE = /^(?:file:\/\/|[a-z]:[\\/]|\\\\|\/(?!\/)|~[\\/])/i
+
+// Markdown images whose src is a local file path can never render as <img>:
+// Streamdown's sanitize pass strips non-http(s)/data image srcs and its harden
+// pass then replaces the src-less node with an "[Image blocked: …]"
+// placeholder (issue #38786 — image_generate and other tools return host
+// paths, which models embed verbatim). Rewrite complete local-path image
+// embeds to the same `#media:` link form MEDIA: tags use; MarkdownLink renders
+// those as MediaAttachment, which loads the file through the desktop FS
+// bridge (and falls back to an open-file link for non-image files).
+function rewriteLocalImageEmbeds(text: string): string {
+  return text.replace(IMAGE_EMBED_RE, (match, angled: string | undefined, bare: string | undefined) => {
+    const src = (angled ?? bare ?? '').trim()
+
+    if (!LOCAL_FILE_SRC_RE.test(src)) {
+      return match
+    }
+
+    return `[${mediaDisplayLabel(src)}](${mediaMarkdownHref(src)})`
+  })
+}
+
 function autoLinkRawUrls(text: string): string {
   return text.replace(RAW_URL_RE, (url: string, index: number) => {
     const previous = text[index - 1] || ''
@@ -145,7 +178,9 @@ function normalizeVisibleProse(text: string): string {
       part.startsWith('`')
         ? part
         : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            rewriteLocalImageEmbeds(part.replace(/`{3,}/g, ''))
+              .replace(LOCAL_PREVIEW_URL_RE, '$1')
+              .replace(CITATION_MARKER_RE, '')
           )
     )
     .join('')

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -9,7 +9,9 @@ import {
   filePathFromMediaPath,
   gatewayMediaDataUrl,
   isRemoteGateway,
-  mediaExternalUrl
+  mediaExternalUrl,
+  mediaMarkdownHref,
+  mediaName
 } from './media'
 
 describe('isRemoteGateway', () => {
@@ -40,6 +42,34 @@ describe('filePathFromMediaPath', () => {
 
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
+  })
+
+  it('strips the leading slash from a Windows drive file:// URL', () => {
+    expect(filePathFromMediaPath('file:///C:/Users/me/cat.png')).toBe('C:/Users/me/cat.png')
+    expect(filePathFromMediaPath('file:///C:/Users/John%20Smith/cat.png')).toBe('C:/Users/John Smith/cat.png')
+  })
+
+  it('passes through a plain Windows path', () => {
+    expect(filePathFromMediaPath('C:\\Users\\me\\cat.png')).toBe('C:\\Users\\me\\cat.png')
+  })
+})
+
+describe('mediaName', () => {
+  it('takes the basename of a Windows drive path', () => {
+    expect(mediaName('C:\\Users\\me\\cache\\images\\generated.jpg')).toBe('generated.jpg')
+    expect(mediaName('C:/Users/me/cache/images/generated.jpg')).toBe('generated.jpg')
+  })
+
+  it('takes the basename of posix paths and URLs', () => {
+    expect(mediaName('/tmp/cat.png')).toBe('cat.png')
+    expect(mediaName('file:///tmp/cat.png')).toBe('cat.png')
+    expect(mediaName('https://cdn.example/a/b/cat.png')).toBe('cat.png')
+  })
+})
+
+describe('mediaMarkdownHref', () => {
+  it('percent-encodes parens so the markdown link destination stays intact', () => {
+    expect(mediaMarkdownHref('/tmp/img (1).png')).toBe('#media:%2Ftmp%2Fimg%20%281%29.png')
   })
 })
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -45,6 +45,13 @@ export function mediaMime(path: string): string {
 }
 
 export function mediaName(path: string): string {
+  // Windows drive paths (C:\… or C:/…) parse as URLs with a "c:" protocol,
+  // so the URL branch would return everything after the drive letter as the
+  // name — treat them as plain filesystem paths instead.
+  if (/^[a-z]:[\\/]/i.test(path)) {
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
+  }
+
   try {
     const url = new URL(path)
 
@@ -55,7 +62,10 @@ export function mediaName(path: string): string {
 }
 
 export function mediaMarkdownHref(path: string): string {
-  return `#media:${encodeURIComponent(path)}`
+  // encodeURIComponent leaves ( and ) alone, but an unescaped paren ends a
+  // markdown link destination early — paths like "img (1).png" would split
+  // the link. %28/%29 still round-trip through decodeURIComponent.
+  return `#media:${encodeURIComponent(path).replace(/\(/g, '%28').replace(/\)/g, '%29')}`
 }
 
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
@@ -104,7 +114,11 @@ export function filePathFromMediaPath(path: string): string {
   }
 
   try {
-    return decodeURIComponent(new URL(path).pathname)
+    const pathname = decodeURIComponent(new URL(path).pathname)
+
+    // Windows file URLs parse with a leading slash before the drive letter
+    // (file:///C:/… → /C:/…), which no Windows fs API accepts — strip it.
+    return /^\/[a-z]:[\\/]/i.test(pathname) ? pathname.slice(1) : pathname
   } catch {
     return path.replace(/^file:\/\//, '')
   }


### PR DESCRIPTION
## What does this PR do?

I reproduced the Windows Desktop failure from NousResearch/hermes-agent#38786 with the same shape of response shown in the report:

```md
![Hermes icon](C:\dev\projects\hermes-agent\apps\desktop\assets\icon.png)
```

The image generator had already written a valid file and returned a successful result. The failure happened later in the Desktop markdown renderer. Streamdown removes local filesystem paths from image `src` attributes during sanitization, then its hardening pass replaces the empty image node with `[Image blocked: cute kitten]`. The app's custom image component runs after those passes, so it never receives the original path.

This change converts complete local-path image embeds into the `#media:` links that Desktop already uses for `MEDIA:` attachments. `MarkdownLink` sends those links through `MediaAttachment`, which reads the file through the existing Desktop filesystem bridge. Streamdown keeps its current URL restrictions.

I put the conversion in the markdown preprocessor because that is the last point where the raw path is available. The preprocessor handles Windows drive paths, UNC paths, POSIX paths, `file://` URLs, and home-relative paths. It leaves web URLs, data URLs, relative paths, code spans, fenced code, and incomplete streaming markdown alone.

The same route exposed three Windows path details in the existing media helpers. Drive-letter paths need basename handling before `new URL()` treats the drive as a protocol. Parentheses need percent encoding so Markdown does not end the link destination early. Windows `file:///C:/...` URLs need the leading slash removed before the filesystem bridge receives them.

## Related Issue

Fixes NousResearch/hermes-agent#38786

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`
  - Converts complete local image embeds into existing Desktop media links before Streamdown sanitizes them.
  - Limits the conversion to visible prose so code examples and partial streamed markdown stay unchanged.
- `apps/desktop/src/lib/media.ts`
  - Extracts the correct filename from Windows drive paths.
  - Encodes parentheses in media-link destinations.
  - Normalizes Windows drive paths parsed from `file://` URLs.
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
  - Covers Windows, UNC, POSIX, `file://`, and home-relative paths plus the inputs that must remain unchanged.
- `apps/desktop/src/lib/markdown-preprocess.streamdown.test.tsx`
  - Reproduces the report through Streamdown's sanitizer and hardener.
  - Confirms the converted link reaches the app's `a` component with the original Windows path intact.
- `apps/desktop/src/lib/media.remote.test.ts`
  - Covers the Windows media helper behavior used by the conversion.

## How to Test

1. On Windows, configure an image generation provider in Hermes Desktop.
2. Ask Hermes to generate an image, such as "Generate an image of a cute kitten."
3. Confirm that Desktop renders the generated file in the transcript instead of showing `[Image blocked: cute kitten]`.
4. Run the focused tests:

   ```bash
   cd apps/desktop
   npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts src/lib/markdown-preprocess.streamdown.test.tsx src/lib/media.remote.test.ts
   npm run typecheck
   ```

5. Run ESLint and Prettier against the five changed files.

Focused result on Windows 11:

```text
Test Files  3 passed (3)
Tests      43 passed (43)
```

I also ran the full `npm run test:ui` command. Current `main` does not pass that command in this Windows checkout because Vitest collects Electron `node:test` files as empty suites and several unrelated Desktop tests fail. None of those failures touches the markdown or media files in this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Python is untouched, so I did not run the Python suite.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, using the renderer regression tests and static checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A. N/A for this renderer behavior fix.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A. No config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A. No architecture or workflow changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A. Windows, UNC, POSIX, and home-relative path forms have coverage.
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A. No tool schema changed.

## Screenshots / Logs

I could not capture a provider-backed Desktop screenshot from this checkout without adding test-only media to the branch. The end-to-end test records the relevant rendered result without adding an unrelated image asset:

| Before preprocessing | After preprocessing |
| --- | --- |
| `[Image blocked: cute kitten]` | `<a href="#media:C%3A%5CUsers%5C...%5Cgenerated.jpg">Image: generated.jpg</a>` |
| <img width="769" height="149" alt="image" src="https://github.com/user-attachments/assets/9ca83729-4239-49d5-a1c6-c51f513dd2ce" /> | <img width="744" height="515" alt="image" src="https://github.com/user-attachments/assets/326530dc-7462-43c8-86a3-9f366fa22e63" /> |

Desktop maps the link in the second column to `MediaAttachment`, which reads and displays the generated file through the filesystem bridge.