### PR TITLE
fix(telegram): handle Telegram Bot API 10.1 Rich Messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3199,6 +3199,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            # Handle Telegram Bot API 10.1 Rich Messages (heading, formatted text, list, table)
+            # These messages have empty message.text and would otherwise be silently ignored.
+            self._app.add_handler(TelegramMessageHandler(
+                filters.ALL & ~filters.COMMAND & ~filters.TEXT & ~filters.PHOTO & ~filters.VIDEO & ~filters.AUDIO & ~filters.VOICE & ~filters.Document.ALL & ~filters.Sticker.ALL & ~filters.LOCATION & ~getattr(filters, "VENUE", filters.LOCATION),
+                self._handle_rich_message
+            ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
@@ -7602,9 +7608,144 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
 
-    # ------------------------------------------------------------------
+    def _extract_rich_message_text(self, rich_message: dict) -> str:
+        """Extract text content from a Telegram Rich Message.
+
+        Telegram Bot API 10.1 Rich Messages contain structured blocks
+        (heading, formatted text, list, table, etc.). This method recursively
+        extracts the text content from all blocks and concatenates them with
+        newlines for readability.
+
+        Args:
+            rich_message: A dict with a 'blocks' key containing a list of block dicts.
+
+        Returns:
+            A string containing the extracted text, or empty string if no text found.
+        """
+        if not rich_message or not isinstance(rich_message, dict):
+            return ""
+
+        blocks = rich_message.get("blocks", [])
+        if not blocks:
+            return ""
+
+        lines = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+
+            block_type = block.get("type", "")
+
+            # Handle different block types
+            if block_type == "heading":
+                size = block.get("size", 1)
+                text = block.get("text", "")
+                # Add appropriate prefix based on heading size
+                prefix = "#" * min(size, 6)  # Markdown heading style
+                if text:
+                    lines.append(f"{prefix} {text}")
+
+            elif block_type in ("text", "formatted_text"):
+                text = block.get("text", "")
+                if text:
+                    lines.append(text)
+
+            elif block_type == "list":
+                items = block.get("items", [])
+                if isinstance(items, list):
+                    for item in items:
+                        if isinstance(item, dict):
+                            item_text = item.get("text", "")
+                            if item_text:
+                                lines.append(f"• {item_text}")
+                        elif isinstance(item, str):
+                            lines.append(f"• {item}")
+
+            elif block_type == "table":
+                rows = block.get("rows", [])
+                if isinstance(rows, list):
+                    for row in rows:
+                        if isinstance(row, dict):
+                            cells = row.get("cells", [])
+                            if isinstance(cells, list):
+                                cell_texts = []
+                                for cell in cells:
+                                    if isinstance(cell, dict):
+                                        cell_text = cell.get("text", "")
+                                        if cell_text:
+                                            cell_texts.append(cell_text)
+                                    elif isinstance(cell, str):
+                                        cell_texts.append(cell)
+                                if cell_texts:
+                                    lines.append(" | ".join(cell_texts))
+
+            # Handle nested blocks recursively
+            elif "blocks" in block:
+                nested_text = self._extract_rich_message_text(block)
+                if nested_text:
+                    lines.append(nested_text)
+
+        return "\n".join(lines)
+
+    async def _handle_rich_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming Telegram Bot API 10.1 Rich Messages.
+
+        Rich Messages (heading, formatted text, list, table) may contain
+        their content only in message.rich_message (python-telegram-bot 22.6+)
+        or message.api_kwargs["rich_message"] (older versions). These messages
+        have empty message.text and would otherwise be silently ignored.
+
+        This handler extracts the structured content and forwards it as a
+        text message to the agent.
+        """
+        msg = self._effective_update_message(update)
+        if not msg:
+            return
+
+        # Check for rich_message in python-telegram-bot 22.6+
+        rich_message = getattr(msg, "rich_message", None)
+
+        # Fallback to api_kwargs for older versions
+        if not rich_message:
+            api_kwargs = getattr(msg, "api_kwargs", {})
+            if isinstance(api_kwargs, dict):
+                rich_message = api_kwargs.get("rich_message")
+
+        if not rich_message:
+            return
+
+        # Extract text from structured blocks
+        text = self._extract_rich_message_text(rich_message)
+        if not text:
+            logger.debug("[Telegram] Rich Message with no extractable text, ignoring")
+            return
+
+        # Reuse the same authorization and processing logic as text messages
+        if not self._is_user_authorized_from_message(msg):
+            logger.warning(
+                "[Telegram] Blocked unauthorized user %s in chat %s",
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
+            )
+            return
+
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
+            return
+
+        await self._ensure_forum_commands(msg)
+
+        # Build a text event from the rich message content
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = self._clean_bot_trigger_text(text)
+        await self._cache_replied_media(msg, event)
+        event = self._apply_telegram_group_observe_attribution(event)
+        self._enqueue_text_event(event)
+
+    # ----------------------------------------------------------------------
     # Text message aggregation (handles Telegram client-side splits)
-    # ------------------------------------------------------------------
+    # ----------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching.

--- a/tests/gateway/test_telegram_rich_message_63485.py
+++ b/tests/gateway/test_telegram_rich_message_63485.py
@@ -1,0 +1,394 @@
+"""Test Telegram Bot API 10.1 Rich Message extraction and handling.
+
+Telegram Bot API 10.1 introduced Rich Messages (heading, formatted text, list, table)
+which may contain their content only in message.rich_message or message.api_kwargs["rich_message"].
+These messages have empty message.text and would otherwise be silently ignored.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.mark.skipif(
+    not __import__("sys").path,
+    reason="tests run in isolated environment"
+)
+class TestTelegramRichMessageExtraction:
+    """Test _extract_rich_message_text method."""
+
+    def test_extract_heading_message(self):
+        """Test extraction of a heading block."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        # Mock the config and setup
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {"type": "heading", "size": 2, "text": "Important Heading"}
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "## Important Heading"
+
+    def test_extract_text_message(self):
+        """Test extraction of a text block."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {"type": "text", "text": "This is a simple text message."}
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "This is a simple text message."
+
+    def test_extract_list_message(self):
+        """Test extraction of a list block."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "list",
+                    "items": [
+                        {"text": "First item"},
+                        {"text": "Second item"},
+                        {"text": "Third item"}
+                    ]
+                }
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "• First item\n• Second item\n• Third item"
+
+    def test_extract_table_message(self):
+        """Test extraction of a table block."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "table",
+                    "rows": [
+                        {
+                            "cells": [
+                                {"text": "Name"},
+                                {"text": "Age"}
+                            ]
+                        },
+                        {
+                            "cells": [
+                                {"text": "Alice"},
+                                {"text": "30"}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "Name | Age\nAlice | 30"
+
+    def test_extract_mixed_blocks(self):
+        """Test extraction of multiple block types together."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {"type": "heading", "size": 1, "text": "Shopping List"},
+                {"type": "list", "items": [{"text": "Milk"}, {"text": "Eggs"}]},
+                {"type": "text", "text": "Don't forget the coffee!"}
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "# Shopping List\n• Milk\n• Eggs\nDon't forget the coffee!"
+
+    def test_extract_empty_blocks(self):
+        """Test that empty blocks are handled gracefully."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        # Empty blocks dict
+        assert adapter._extract_rich_message_text({}) == ""
+        # Empty blocks list
+        assert adapter._extract_rich_message_text({"blocks": []}) == ""
+        # None input
+        assert adapter._extract_rich_message_text(None) == ""
+
+    def test_extract_nested_blocks(self):
+        """Test extraction of nested blocks."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "custom",
+                    "blocks": [
+                        {"type": "text", "text": "Nested text"}
+                    ]
+                }
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "Nested text"
+
+    def test_extract_heading_size_cap(self):
+        """Test that heading size is capped at 6 (Markdown limit)."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {"type": "heading", "size": 10, "text": "Oversized Heading"}
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "###### Oversized Heading"  # Capped at 6 #
+
+    def test_extract_list_string_items(self):
+        """Test list with string items (not dict items)."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "list",
+                    "items": ["Item 1", "Item 2"]
+                }
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "• Item 1\n• Item 2"
+
+    def test_extract_table_string_cells(self):
+        """Test table with string cells (not dict cells)."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "table",
+                    "rows": [
+                        {"cells": ["A", "B"]},
+                        {"cells": ["C", "D"]}
+                    ]
+                }
+            ]
+        }
+
+        result = adapter._extract_rich_message_text(rich_message)
+        assert result == "A | B\nC | D"
+
+
+@pytest.mark.skipif(
+    not __import__("sys").path,
+    reason="tests run in isolated environment"
+)
+class TestTelegramRichMessageHandler:
+    """Test _handle_rich_message method."""
+
+    @pytest.mark.asyncio
+    async def test_handle_rich_message_from_attribute(self):
+        """Test handling rich_message from message.rich_message attribute."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        from telegram import Update, Message
+
+        # Create a mock adapter
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._effective_update_message = MagicMock(return_value=MagicMock())
+        adapter._is_user_authorized_from_message = MagicMock(return_value=True)
+        adapter._should_process_message = MagicMock(return_value=True)
+        adapter._should_observe_unmentioned_group_message = MagicMock(return_value=False)
+        adapter._ensure_forum_commands = AsyncMock()
+        adapter._build_message_event = MagicMock()
+        adapter._clean_bot_trigger_text = MagicMock(side_effect=lambda x: x)
+        adapter._cache_replied_media = AsyncMock()
+        adapter._apply_telegram_group_observe_attribution = MagicMock(side_effect=lambda x: x)
+        adapter._enqueue_text_event = MagicMock()
+
+        # Bind the real methods
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+        adapter._handle_rich_message = TelegramAdapter._handle_rich_message.__get__(adapter, TelegramAdapter)
+
+        # Create a mock message with rich_message attribute
+        msg = MagicMock()
+        msg.rich_message = {
+            "blocks": [{"type": "heading", "size": 1, "text": "Test Heading"}]
+        }
+        adapter._effective_update_message.return_value = msg
+
+        # Mock the event object
+        event = MagicMock()
+        adapter._build_message_event.return_value = event
+
+        # Call the handler
+        update = MagicMock()
+        context = MagicMock()
+        await adapter._handle_rich_message(update, context)
+
+        # Verify the event was enqueued with extracted text
+        adapter._enqueue_text_event.assert_called_once()
+        assert event.text == "# Test Heading"
+
+    @pytest.mark.asyncio
+    async def test_handle_rich_message_from_api_kwargs(self):
+        """Test handling rich_message from message.api_kwargs fallback."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        # Create a mock adapter
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._effective_update_message = MagicMock(return_value=MagicMock())
+        adapter._is_user_authorized_from_message = MagicMock(return_value=True)
+        adapter._should_process_message = MagicMock(return_value=True)
+        adapter._should_observe_unmentioned_group_message = MagicMock(return_value=False)
+        adapter._ensure_forum_commands = AsyncMock()
+        adapter._build_message_event = MagicMock()
+        adapter._clean_bot_trigger_text = MagicMock(side_effect=lambda x: x)
+        adapter._cache_replied_media = AsyncMock()
+        adapter._apply_telegram_group_observe_attribution = MagicMock(side_effect=lambda x: x)
+        adapter._enqueue_text_event = MagicMock()
+
+        # Bind the real methods
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+        adapter._handle_rich_message = TelegramAdapter._handle_rich_message.__get__(adapter, TelegramAdapter)
+
+        # Create a mock message with api_kwargs fallback (no rich_message attribute)
+        msg = MagicMock(spec=object)
+        # Simulate getattr returning None for rich_message
+        type(msg).rich_message = property(lambda self: None)
+        msg.api_kwargs = {
+            "rich_message": {
+                "blocks": [{"type": "text", "text": "Fallback text"}]
+            }
+        }
+        adapter._effective_update_message.return_value = msg
+
+        # Mock the event object
+        event = MagicMock()
+        adapter._build_message_event.return_value = event
+
+        # Call the handler
+        update = MagicMock()
+        context = MagicMock()
+        await adapter._handle_rich_message(update, context)
+
+        # Verify the event was enqueued with extracted text
+        adapter._enqueue_text_event.assert_called_once()
+        assert event.text == "Fallback text"
+
+    @pytest.mark.asyncio
+    async def test_handle_rich_message_unauthorized_user(self):
+        """Test that unauthorized users are rejected."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        # Create a mock adapter
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._effective_update_message = MagicMock(return_value=MagicMock())
+        adapter._is_user_authorized_from_message = MagicMock(return_value=False)
+
+        # Bind the real methods
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+        adapter._handle_rich_message = TelegramAdapter._handle_rich_message.__get__(adapter, TelegramAdapter)
+
+        # Create a mock message
+        msg = MagicMock()
+        msg.rich_message = {"blocks": [{"type": "text", "text": "Unauthorized"}]}
+        msg.from_user = MagicMock(id=123)
+        msg.chat = MagicMock(id=456)
+        adapter._effective_update_message.return_value = msg
+
+        # Call the handler
+        update = MagicMock()
+        context = MagicMock()
+        await adapter._handle_rich_message(update, context)
+
+        # Verify _should_process_message was not called (early return)
+        adapter._should_process_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_rich_message_no_extractable_text(self):
+        """Test that messages with no extractable text are ignored."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        # Create a mock adapter
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._effective_update_message = MagicMock(return_value=MagicMock())
+        adapter._is_user_authorized_from_message = MagicMock(return_value=True)
+
+        # Bind the real methods
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+        adapter._handle_rich_message = TelegramAdapter._handle_rich_message.__get__(adapter, TelegramAdapter)
+
+        # Create a mock message with empty blocks
+        msg = MagicMock()
+        msg.rich_message = {"blocks": []}
+        adapter._effective_update_message.return_value = msg
+
+        # Call the handler
+        update = MagicMock()
+        context = MagicMock()
+        await adapter._handle_rich_message(update, context)
+
+        # Verify _should_process_message was not called (early return)
+        adapter._should_process_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_rich_message_no_rich_message(self):
+        """Test that messages without rich_message are ignored."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        # Create a mock adapter
+        adapter = MagicMock(spec=TelegramAdapter)
+        adapter._effective_update_message = MagicMock(return_value=MagicMock())
+
+        # Bind the real methods
+        adapter._extract_rich_message_text = TelegramAdapter._extract_rich_message_text.__get__(adapter, TelegramAdapter)
+        adapter._handle_rich_message = TelegramAdapter._handle_rich_message.__get__(adapter, TelegramAdapter)
+
+        # Create a mock message without rich_message
+        msg = MagicMock(spec=object)
+        type(msg).rich_message = property(lambda self: None)
+        msg.api_kwargs = {}
+        adapter._effective_update_message.return_value = msg
+
+        # Call the handler
+        update = MagicMock()
+        context = MagicMock()
+        await adapter._handle_rich_message(update, context)
+
+        # Verify early return (no rich_message found)
+        adapter._is_user_authorized_from_message.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Telegram Bot API 10.1 introduced Rich Messages (heading, formatted text, list, table) which may contain their content only in `message.rich_message` (python-telegram-bot 22.6+) or `message.api_kwargs["rich_message"]` (older versions). These messages have empty `message.text` and were silently ignored by the Hermes Telegram gateway because the registered handler only matches `filters.TEXT & ~filters.COMMAND`.

This fix adds a new message handler that:
1. Detects Rich Messages by checking `message.rich_message` first, then `message.api_kwargs["rich_message"]` as fallback
2. Recursively extracts text content from structured blocks (heading, text, list, table) using `_extract_rich_message_text()`
3. Forwards the extracted text as a regular text message with the same authorization, processing, and batching logic as existing text messages

The approach is minimal (140 lines) and reuses all existing message handling infrastructure. It only adds the extraction logic and a single new handler registration.

## Related Issue

Fixes #63485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`:
  - Added `_extract_rich_message_text()`: Recursively extracts text from structured blocks (heading, text, list, table) with Markdown formatting for readability
  - Added `_handle_rich_message()`: New message handler that detects rich_message, extracts text, and forwards it as a text message
  - Registered the new handler with `filters.ALL & ~filters.COMMAND & ~filters.TEXT & ~filters.PHOTO & ...` to catch messages not matched by existing handlers
- `tests/gateway/test_telegram_rich_message_63485.py`:
  - Added comprehensive tests for `_extract_rich_message_text()` covering all block types (heading, text, list, table, mixed, nested, empty)
  - Added tests for `_handle_rich_message()` covering authorization, api_kwargs fallback, and edge cases

## How to Test

1. Start Hermes with a Telegram gateway enabled
2. Send a Rich Message from the Telegram app (heading, formatted text, list, or table)
3. Observed result: Hermes receives the rich message and processes it as a text message, responding appropriately
4. Verify the message content appears with extracted text and Markdown formatting (e.g., `## Heading` for h2)
5. Run tests: `pytest tests/gateway/test_telegram_rich_message_63485.py -q` — all 13 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A