### PR TITLE
fix(desktop): restore YouTube embeds in packaged app

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -165,6 +165,8 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import { startRendererServer } from './renderer-server'
+import { isRendererUrl } from './renderer-url'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -251,6 +253,7 @@ if (USER_DATA_OVERRIDE) {
 
 const DEV_SERVER = process.env.HERMES_DESKTOP_DEV_SERVER
 const IS_PACKAGED = app.isPackaged || Boolean(process.env.HERMES_DESKTOP_IS_PACKAGED)
+let packagedRendererServer: Awaited<ReturnType<typeof startRendererServer>> | null = null
 const IS_MAC = process.platform === 'darwin'
 const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
@@ -3638,6 +3641,10 @@ function resolveRendererIndex() {
   )
 
   return candidates[0]
+}
+
+function rendererBaseUrl() {
+  return DEV_SERVER || packagedRendererServer?.origin || pathToFileURL(resolveRendererIndex()).toString()
 }
 
 // True when `dir` lives inside the packaged app bundle / install tree.
@@ -8626,7 +8633,7 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     return { action: 'deny' }
   })
   win.webContents.on('will-navigate', (event, url) => {
-    if ((DEV_SERVER && url.startsWith(DEV_SERVER)) || (!DEV_SERVER && url.startsWith('file:'))) {
+    if (isRendererUrl(url, rendererBaseUrl())) {
       return
     }
 
@@ -8702,8 +8709,13 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
   loadWindowUrl(
     win,
     buildSessionWindowUrl(sessionId, {
-      devServer: DEV_SERVER,
-      rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
+      // Prefer the packaged renderer HTTP server when it is running: loading the
+      // renderer over http:// gives embeds a real origin, which `file://` cannot
+      // provide (YouTube rejects file-origin embeds). Fall back to upstream's
+      // rendererIndexPath path so the file:// URL is still built correctly --
+      // passing a file:// URL as `devServer` would yield `index.html/?win=...`.
+      devServer: DEV_SERVER || packagedRendererServer?.origin,
+      rendererIndexPath: DEV_SERVER || packagedRendererServer?.origin ? undefined : resolveRendererIndex(),
       watch
     }),
     'Session window'
@@ -8801,11 +8813,9 @@ function createInstanceWindow() {
 let petOverlayWindow = null
 
 function petOverlayUrl() {
-  if (DEV_SERVER) {
-    return `${DEV_SERVER.endsWith('/') ? DEV_SERVER.slice(0, -1) : DEV_SERVER}/?win=overlay#/`
-  }
+  const base = rendererBaseUrl().replace(/\/$/, '')
 
-  return `${pathToFileURL(resolveRendererIndex()).toString()}?win=overlay#/`
+  return `${base}/?win=overlay#/`
 }
 
 function spawnPetOverlayWindow(bounds) {
@@ -9344,7 +9354,7 @@ function createWindow() {
     rememberLog(`[renderer console] ${text} (${src}:${lineNo})`)
   })
 
-  loadWindowUrl(mainWindow, DEV_SERVER || pathToFileURL(resolveRendererIndex()).toString(), 'Renderer')
+  loadWindowUrl(mainWindow, rendererBaseUrl(), 'Renderer')
 
   // Start the Python backend NOW, in parallel with the renderer load — not on
   // did-finish-load. The backend cold boot (spawn → port announce → /api/status)
@@ -11654,7 +11664,11 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  if (!DEV_SERVER) {
+    packagedRendererServer = await startRendererServer(path.dirname(resolveRendererIndex()))
+  }
+
   const systemCa = installWindowsSystemCaTrust(tls)
 
   if (systemCa.applied) {
@@ -11811,6 +11825,7 @@ app.on('before-quit', event => {
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()
+  void packagedRendererServer?.close()
 
   // Same for the Quick Entry composer — and release its global accelerator so a
   // quitting Hermes never keeps another app's chord hostage.

--- a/apps/desktop/electron/renderer-server.test.ts
+++ b/apps/desktop/electron/renderer-server.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import http from 'node:http'
+import { createRequire } from 'node:module'
+import type { AddressInfo } from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const nodeRequire = createRequire(import.meta.url)
+const { rendererRequestPath, startRendererServer } = nodeRequire('./renderer-server.ts')
+
+test('serves the packaged renderer from a loopback HTTP origin', async t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-renderer-'))
+  fs.writeFileSync(path.join(root, 'index.html'), '<main>Hermes</main>')
+  fs.mkdirSync(path.join(root, 'assets'))
+  fs.writeFileSync(path.join(root, 'assets', 'app.js'), 'globalThis.loaded = true')
+  const server = await startRendererServer(root, { port: 0 })
+
+  t.onTestFinished(async () => {
+    await server.close()
+    fs.rmSync(root, { force: true, recursive: true })
+  })
+
+  assert.match(server.origin, /^http:\/\/127\.0\.0\.1:\d+$/)
+
+  const index = await fetch(`${server.origin}/`)
+  assert.equal(index.status, 200)
+  assert.equal(index.headers.get('content-type'), 'text/html; charset=utf-8')
+  assert.equal(await index.text(), '<main>Hermes</main>')
+
+  const asset = await fetch(`${server.origin}/assets/app.js`)
+  assert.equal(asset.status, 200)
+  assert.equal(asset.headers.get('content-type'), 'text/javascript; charset=utf-8')
+  assert.equal(await asset.text(), 'globalThis.loaded = true')
+})
+
+test('falls back to the SPA shell for extensionless paths', async t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-renderer-'))
+  fs.writeFileSync(path.join(root, 'index.html'), '<main>Hermes</main>')
+  const server = await startRendererServer(root, { port: 0 })
+
+  t.onTestFinished(async () => {
+    await server.close()
+    fs.rmSync(root, { force: true, recursive: true })
+  })
+
+  const response = await fetch(`${server.origin}/session/abc`)
+  assert.equal(response.status, 200)
+  assert.equal(await response.text(), '<main>Hermes</main>')
+})
+
+// Regression: the default port was fixed and any bind failure rejected. main.ts
+// awaits this server before createWindow(), so an occupied 47891 meant startup
+// never reached window creation — a blank launch with no clue why.
+test('falls back to an ephemeral port when the requested port is taken', async t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-renderer-'))
+  fs.writeFileSync(path.join(root, 'index.html'), '<main>Hermes</main>')
+
+  // Occupy a real port, then ask the renderer server for that exact port.
+  const squatter = http.createServer((_request, response) => response.end('squatter'))
+  await new Promise<void>(done => squatter.listen({ host: '127.0.0.1', port: 0 }, () => done()))
+  const takenPort = (squatter.address() as AddressInfo).port
+
+  const server = await startRendererServer(root, { port: takenPort })
+
+  t.onTestFinished(async () => {
+    await server.close()
+    await new Promise<void>(done => squatter.close(() => done()))
+    fs.rmSync(root, { force: true, recursive: true })
+  })
+
+  const boundPort = Number(new URL(server.origin).port)
+  assert.notEqual(boundPort, takenPort, 'must not claim the occupied port')
+  assert.ok(boundPort > 0, 'must bind a real port')
+
+  // The fallback server still serves the renderer, and the squatter is untouched.
+  const index = await fetch(`${server.origin}/`)
+  assert.equal(index.status, 200)
+  assert.equal(await index.text(), '<main>Hermes</main>')
+  assert.equal(await (await fetch(`http://127.0.0.1:${takenPort}/`)).text(), 'squatter')
+})
+
+test('rejects paths outside the renderer root', () => {
+  const root = path.resolve('/tmp/hermes-renderer')
+
+  assert.equal(rendererRequestPath(root, '/%E0%A4%A'), null)
+  assert.equal(rendererRequestPath(root, '/%2e%2e%2fetc/passwd'), null)
+})

--- a/apps/desktop/electron/renderer-server.ts
+++ b/apps/desktop/electron/renderer-server.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import path from 'node:path'
+
+const DEFAULT_PORT = 47891
+
+const MIME_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2'
+}
+
+interface RendererServer {
+  close: () => Promise<void>
+  origin: string
+}
+
+function rendererRequestPath(root: string, requestUrl: string): string | null {
+  let pathname
+
+  try {
+    pathname = decodeURIComponent(new URL(requestUrl, 'http://127.0.0.1').pathname)
+  } catch {
+    return null
+  }
+
+  const relative = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '')
+  const target = path.resolve(root, relative)
+
+  if (target !== root && !target.startsWith(`${root}${path.sep}`)) {
+    return null
+  }
+
+  return target
+}
+
+function listenOnce(server: http.Server, port: number): Promise<AddressInfo> {
+  return new Promise<AddressInfo>((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.removeListener('error', onError)
+      reject(error)
+    }
+
+    server.once('error', onError)
+    server.listen({ host: '127.0.0.1', port, exclusive: true }, () => {
+      server.removeListener('error', onError)
+      resolve(server.address() as AddressInfo)
+    })
+  })
+}
+
+// Bind failures that another free port would resolve. EADDRINUSE is the common
+// one (a second Hermes instance, or any unrelated listener); EACCES shows up on
+// Windows when a port sits in an excluded/reserved range.
+function isPortCollision(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+
+  return code === 'EADDRINUSE' || code === 'EACCES'
+}
+
+async function startRendererServer(
+  rootDir: string,
+  { port = DEFAULT_PORT }: { port?: number } = {}
+): Promise<RendererServer> {
+  const root = path.resolve(rootDir)
+  const indexPath = path.join(root, 'index.html')
+
+  const server = http.createServer(async (request, response) => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      response.writeHead(405, { Allow: 'GET, HEAD' })
+      response.end()
+
+      return
+    }
+
+    const requested = rendererRequestPath(root, request.url || '/')
+
+    if (!requested) {
+      response.writeHead(400)
+      response.end()
+
+      return
+    }
+
+    let filePath = requested
+
+    try {
+      const stat = await fs.promises.stat(filePath)
+
+      if (stat.isDirectory()) {
+        filePath = path.join(filePath, 'index.html')
+      }
+    } catch {
+      // HashRouter routes never reach the server, but an extensionless reload
+      // should still receive the SPA shell.
+      filePath = path.extname(filePath) ? filePath : indexPath
+    }
+
+    try {
+      const body = await fs.promises.readFile(filePath)
+      const extension = path.extname(filePath).toLowerCase()
+      const isIndex = filePath === indexPath
+      response.writeHead(200, {
+        'Cache-Control': isIndex ? 'no-store' : 'public, max-age=31536000, immutable',
+        'Content-Type': MIME_TYPES[extension] || 'application/octet-stream',
+        'X-Content-Type-Options': 'nosniff'
+      })
+      response.end(request.method === 'HEAD' ? undefined : body)
+    } catch {
+      response.writeHead(404)
+      response.end()
+    }
+  })
+
+  // Prefer the stable default port: the renderer's origin keys its localStorage /
+  // sessionStorage, so a port that changed between launches would silently orphan
+  // persisted renderer state. But a taken port must never block startup — main.ts
+  // awaits this before createWindow(), so rejecting here means no window at all.
+  // Fall back to an OS-assigned ephemeral port instead.
+  let address: AddressInfo
+
+  try {
+    address = await listenOnce(server, port)
+  } catch (error) {
+    if (port === 0 || !isPortCollision(error)) {
+      throw error
+    }
+
+    address = await listenOnce(server, 0)
+  }
+
+  return {
+    close: () => new Promise<void>(done => server.close(() => done())),
+    origin: `http://127.0.0.1:${address.port}`
+  }
+}
+
+export { DEFAULT_PORT, rendererRequestPath, startRendererServer }
+export type { RendererServer }

--- a/apps/desktop/electron/renderer-url.test.ts
+++ b/apps/desktop/electron/renderer-url.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { test } from 'vitest'
+
+import { isRendererUrl } from './renderer-url'
+
+const HTTP_BASE = 'http://127.0.0.1:47891'
+
+test('isRendererUrl accepts the renderer origin itself', () => {
+  assert.equal(isRendererUrl(`${HTTP_BASE}/`, HTTP_BASE), true)
+  assert.equal(isRendererUrl(`${HTTP_BASE}/?win=secondary#/abc123`, HTTP_BASE), true)
+})
+
+// Regression: a `startsWith(base)` guard accepted this because everything before
+// the `@` is userinfo, so the string shares our prefix while the real origin is
+// attacker.example. Loading it would hand the hermesDesktop preload bridge to an
+// attacker-controlled origin.
+test('isRendererUrl rejects a userinfo-prefixed lookalike origin', () => {
+  const hostile = 'http://127.0.0.1:47891@attacker.example/'
+
+  assert.equal(hostile.startsWith(HTTP_BASE), true, 'precondition: the old prefix check passed this')
+  assert.equal(isRendererUrl(hostile, HTTP_BASE), false)
+})
+
+test('isRendererUrl rejects other origins, ports, and schemes', () => {
+  assert.equal(isRendererUrl('http://attacker.example/', HTTP_BASE), false)
+  assert.equal(isRendererUrl('http://127.0.0.1:47892/', HTTP_BASE), false)
+  assert.equal(isRendererUrl('https://127.0.0.1:47891/', HTTP_BASE), false)
+  assert.equal(isRendererUrl('file:///etc/passwd', HTTP_BASE), false)
+})
+
+test('isRendererUrl fails closed on unparseable input', () => {
+  assert.equal(isRendererUrl('not a url', HTTP_BASE), false)
+  assert.equal(isRendererUrl(`${HTTP_BASE}/`, 'not a url'), false)
+})
+
+test('isRendererUrl compares paths for file: bases, whose origin is opaque', () => {
+  const index = path.join(path.sep, 'tmp', 'hermes-app', 'dist', 'index.html')
+  const other = path.join(path.sep, 'tmp', 'hermes-app', 'dist', 'other.html')
+  const base = pathToFileURL(index).toString()
+
+  // Same file, plus the query/hash routing the session windows append.
+  assert.equal(isRendererUrl(base, base), true)
+  assert.equal(isRendererUrl(`${base}?win=secondary#/abc123`, base), true)
+
+  // A different file under the same directory is NOT the renderer we loaded,
+  // and origin equality would have wrongly accepted it: both are "null".
+  assert.equal(isRendererUrl(pathToFileURL(other).toString(), base), false)
+  assert.equal(isRendererUrl('http://attacker.example/', base), false)
+})

--- a/apps/desktop/electron/renderer-url.ts
+++ b/apps/desktop/electron/renderer-url.ts
@@ -1,0 +1,44 @@
+// Same-renderer navigation guard. The pure, Electron-free piece lives here so it
+// can be unit-tested (mirroring how the rest of electron/*.ts splits testable
+// logic out of the main.ts monolith).
+
+import path from 'node:path'
+
+/**
+ * True when `url` belongs to the renderer we loaded ourselves.
+ *
+ * Compares PARSED ORIGINS, never string prefixes. A prefix compare
+ * (`url.startsWith(base)`) accepts `http://127.0.0.1:47891@attacker.example/`:
+ * everything before the `@` is userinfo, so that URL's real origin is
+ * `attacker.example` while still sharing a textual prefix with our base URL.
+ * Letting it through `will-navigate` would load hostile content into a window
+ * that carries the `hermesDesktop` preload bridge.
+ */
+function isRendererUrl(url: string, base: string): boolean {
+  let target: URL
+  let rendererBase: URL
+
+  try {
+    target = new URL(url)
+    rendererBase = new URL(base)
+  } catch {
+    // Unparseable on either side: fail closed rather than guessing.
+    return false
+  }
+
+  // `file:` URLs have an opaque ("null") origin, so origin equality is useless
+  // there — two unrelated files would both compare as "null". Compare the
+  // concrete path instead. Query/hash routing (`?win=secondary#/<id>`) does not
+  // change `pathname`, so ordinary in-app navigation still passes.
+  if (rendererBase.protocol === 'file:') {
+    if (target.protocol !== 'file:') {
+      return false
+    }
+
+    return path.resolve(decodeURIComponent(target.pathname)) === path.resolve(decodeURIComponent(rendererBase.pathname))
+  }
+
+  return target.origin === rendererBase.origin
+}
+
+export { isRendererUrl }

--- a/apps/desktop/src/components/assistant-ui/embeds/embed-consent.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/embed-consent.tsx
@@ -2,6 +2,9 @@
 
 import { type CSSProperties, useState } from 'react'
 
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { SplitButton } from '@/components/ui/split-button'
 import { Play } from '@/lib/icons'
 import { allowProvider } from '@/store/embed-consent'
@@ -24,19 +27,111 @@ export function EmbedFacade({ descriptor, onLoad }: { descriptor: EmbedDescripto
     { id: 'always', label: `Always allow ${descriptor.label}` }
   ]
 
+  if (descriptor.provider === 'youtube' && descriptor.previewUrl) {
+    return <YouTubeFacade descriptor={descriptor} onLoad={onLoad} style={style} />
+  }
+
   return (
     <span
-      className="flex size-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary)/30"
+      className="relative flex size-full flex-col items-center justify-center gap-2 overflow-hidden rounded-lg border border-dashed border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary)/30"
       style={style}
     >
-      <SplitButton
-        actions={actions}
-        onTrigger={id => (id === 'always' ? allowProvider(descriptor.provider) : onLoad())}
-        onValueChange={setChoice}
-        primaryIcon={<Play className="size-3 translate-x-px fill-current" />}
-        value={choice}
-      />
-      <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{hostOf(descriptor)}</span>
+      {descriptor.previewUrl ? (
+        <>
+          <img
+            alt=""
+            aria-hidden="true"
+            className="absolute inset-0 size-full object-cover"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            src={descriptor.previewUrl}
+          />
+          <span className="absolute inset-0 bg-black/25" />
+        </>
+      ) : null}
+      <span className="relative z-10 flex flex-col items-center gap-2">
+        <SplitButton
+          actions={actions}
+          onTrigger={id => (id === 'always' ? allowProvider(descriptor.provider) : onLoad())}
+          onValueChange={setChoice}
+          primaryIcon={<Play className="size-3 translate-x-px fill-current" />}
+          value={choice}
+        />
+        <span
+          className={
+            descriptor.previewUrl
+              ? 'rounded-full bg-black/55 px-2 py-0.5 text-[0.6875rem] text-white/85'
+              : 'text-[0.6875rem] text-(--ui-text-tertiary)'
+          }
+        >
+          {hostOf(descriptor)}
+        </span>
+      </span>
+    </span>
+  )
+}
+
+function YouTubeFacade({
+  descriptor,
+  onLoad,
+  style
+}: {
+  descriptor: EmbedDescriptor
+  onLoad: () => void
+  style: CSSProperties
+}) {
+  const allowAndLoad = () => {
+    allowProvider(descriptor.provider)
+    onLoad()
+  }
+
+  return (
+    <span
+      className="relative block size-full overflow-hidden rounded-lg border border-(--ui-stroke-tertiary) bg-black"
+      style={style}
+    >
+      <button
+        aria-label="Play YouTube video"
+        className="group absolute inset-0 size-full cursor-pointer"
+        onClick={onLoad}
+        type="button"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 size-full object-cover"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          src={descriptor.previewUrl}
+        />
+        <span className="absolute inset-0 bg-black/10 transition-colors group-hover:bg-black/20" />
+        <svg
+          aria-hidden="true"
+          className="absolute top-1/2 left-1/2 h-12 w-[4.25rem] -translate-x-1/2 -translate-y-1/2 drop-shadow-lg transition-transform group-hover:scale-105"
+          viewBox="0 0 68 48"
+        >
+          <rect fill="#ff0033" height="48" rx="12" width="68" />
+          <path d="M28 14 46 24 28 34Z" fill="white" />
+        </svg>
+        <span className="absolute right-3 bottom-3 rounded-md bg-black/70 px-2 py-1 text-xs font-medium text-white">
+          Watch on YouTube
+        </span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label="YouTube embed options"
+            className="absolute top-3 right-3 z-10 bg-black/65 text-white hover:bg-black/80 hover:text-white"
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name="chevron-down" size="0.8rem" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-44">
+          <DropdownMenuItem onSelect={allowAndLoad}>Always allow YouTube</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </span>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/embeds/providers/detect.test.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/providers/detect.test.ts
@@ -28,6 +28,7 @@ describe('detectEmbed — YouTube', () => {
     expect(embed.provider).toBe('youtube')
     expect(embed.id).toBe('youtube:dQw4w9WgXcQ')
     expect(embed.embedUrl).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+    expect(embed.previewUrl).toBe('https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg')
   })
 
   it('carries a start time from t/start through to the embed', () => {

--- a/apps/desktop/src/components/assistant-ui/embeds/providers/types.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/providers/types.ts
@@ -30,6 +30,8 @@ interface BaseEmbed extends EmbedLayout {
   id: string
   /** Human-facing provider name (e.g. "YouTube"). */
   label: string
+  /** Optional image shown before the user consents to load the full embed. */
+  previewUrl?: string
   provider: EmbedProvider
   renderer: EmbedRenderer
   /** Canonical URL opened in the system browser from the card. */

--- a/apps/desktop/src/components/assistant-ui/embeds/providers/youtube.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/providers/youtube.ts
@@ -58,6 +58,7 @@ export const youtube: EmbedMatcher = url => {
     id: `youtube:${id}`,
     label: 'YouTube',
     maxWidth: 640,
+    previewUrl: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
     provider: 'youtube',
     renderer: 'frame',
     sourceUrl: url.toString()

--- a/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
@@ -11,11 +11,11 @@ import { EMBED_MAX_H } from './embed-size'
 import { EmbedFail } from './fail'
 import type { EmbedDescriptor } from './providers/types'
 import { RichBoundary } from './rich-boundary'
+import YouTubeEmbedRenderer from './youtube-embed'
 
 const FrameEmbedRenderer = lazy(() => import('./frame-embed'))
 const SocialEmbedRenderer = lazy(() => import('./social-embed'))
 const SpotifyEmbedRenderer = lazy(() => import('./spotify-embed'))
-const YouTubeEmbedRenderer = lazy(() => import('./youtube-embed'))
 
 function intrinsicHeight(descriptor: EmbedDescriptor): number {
   if (descriptor.aspectRatio) {
@@ -25,7 +25,7 @@ function intrinsicHeight(descriptor: EmbedDescriptor): number {
   return descriptor.height ?? 320
 }
 
-function LazyRenderer({ descriptor }: { descriptor: EmbedDescriptor }) {
+function LazyRenderer({ autoplay, descriptor }: { autoplay: boolean; descriptor: EmbedDescriptor }) {
   // X and Instagram load their official blockquote script in-document. The tweet
   // check also narrows the union to FrameEmbed for the iframe renderers below.
   if (descriptor.renderer === 'tweet' || descriptor.provider === 'instagram') {
@@ -33,7 +33,7 @@ function LazyRenderer({ descriptor }: { descriptor: EmbedDescriptor }) {
   }
 
   if (descriptor.provider === 'youtube') {
-    return <YouTubeEmbedRenderer descriptor={descriptor} />
+    return <YouTubeEmbedRenderer autoplay={autoplay} descriptor={descriptor} />
   }
 
   if (descriptor.provider === 'spotify') {
@@ -47,6 +47,7 @@ export function UrlEmbed({ descriptor }: { descriptor: EmbedDescriptor }) {
   const mode = useStore($embedMode)
   const allowed = useStore($embedAllowed)
   const [loaded, setLoaded] = useState(false)
+  const [autoplay, setAutoplay] = useState(false)
 
   // Privacy gate: don't reach out to the provider until consented. `off` keeps
   // it a plain link; otherwise the placeholder shows until "Load" (this embed)
@@ -73,10 +74,16 @@ export function UrlEmbed({ descriptor }: { descriptor: EmbedDescriptor }) {
       <RichBoundary fallback={<EmbedFail label={descriptor.label} />} resetKey={descriptor.id}>
         {consented ? (
           <Suspense fallback={null}>
-            <LazyRenderer descriptor={descriptor} />
+            <LazyRenderer autoplay={autoplay} descriptor={descriptor} />
           </Suspense>
         ) : (
-          <EmbedFacade descriptor={descriptor} onLoad={() => setLoaded(true)} />
+          <EmbedFacade
+            descriptor={descriptor}
+            onLoad={() => {
+              setAutoplay(true)
+              setLoaded(true)
+            }}
+          />
         )}
       </RichBoundary>
     </span>

--- a/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.test.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { youtubeSrc } from './youtube-embed'
+
+describe('youtubeSrc', () => {
+  it('enables autoplay after the user clicks the privacy facade', () => {
+    const src = youtubeSrc('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0', true)
+
+    expect(src).toContain('autoplay=1')
+  })
+
+  it('does not autoplay embeds loaded by standing consent', () => {
+    const src = youtubeSrc('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0')
+
+    expect(src).not.toContain('autoplay=1')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.tsx
@@ -8,8 +8,12 @@ import { useIsDark } from './use-is-dark'
 const YOUTUBE_ALLOW =
   'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen'
 
-function youtubeSrc(embedUrl: string): string {
+export function youtubeSrc(embedUrl: string, autoplay = false): string {
   const url = new URL(embedUrl)
+
+  if (autoplay) {
+    url.searchParams.set('autoplay', '1')
+  }
 
   // Only pass origin when it is an HTTP(S) origin; custom schemes (app://,
   // file://) can make the player reject otherwise embeddable videos.
@@ -26,9 +30,9 @@ function youtubeSrc(embedUrl: string): string {
 }
 
 // Keep this as a plain iframe and let YouTube render its native player/error UI.
-export default function YouTubeEmbedRenderer({ descriptor }: { descriptor: FrameEmbed }) {
+export default function YouTubeEmbedRenderer({ autoplay, descriptor }: { autoplay: boolean; descriptor: FrameEmbed }) {
   const isDark = useIsDark()
-  const src = useMemo(() => youtubeSrc(descriptor.embedUrl), [descriptor.embedUrl])
+  const src = useMemo(() => youtubeSrc(descriptor.embedUrl, autoplay), [autoplay, descriptor.embedUrl])
 
   // Width is capped to the ratio by UrlEmbed, so aspect-video sizes height ≤ cap.
   return (


### PR DESCRIPTION
## Summary

YouTube embeds are dead in packaged builds while working in dev. Packaged builds load the renderer over `file:`, whose origin is opaque (`"null"`); YouTube rejects a null-origin embed. Dev works because Vite serves the renderer over http.

Root cause: `createWindow()` loaded `pathToFileURL(resolveRendererIndex())` when not running against a dev server, so the renderer had no real origin to present to an embed. This serves the packaged renderer from a loopback HTTP origin instead, and routes every window through one resolver so main, session and pet-overlay windows agree.

Also fixes both defects raised in the previous review of this PR (details under Validation).

## Changes

- `apps/desktop/electron/renderer-server.ts` (new): minimal static server for the packaged renderer — path traversal rejected, SPA fallback for extensionless routes, `no-store` on `index.html`, immutable caching for assets, `nosniff`. Prefers a stable port and falls back to an OS-assigned one on `EADDRINUSE`/`EACCES`.
- `apps/desktop/electron/renderer-url.ts` (new): pure same-origin check for the navigation guard. Compares parsed `URL.origin`; compares resolved paths for `file:` bases (whose origins are all `"null"`); fails closed on unparseable input.
- `apps/desktop/electron/main.ts`: `rendererBaseUrl()` becomes the single renderer-location resolver (dev server → packaged HTTP origin → `file:` fallback); `createWindow`, `spawnSecondaryWindow` and `petOverlayUrl` route through it; `will-navigate` now calls `isRendererUrl()`; server started in `whenReady`, closed on `before-quit`.
- `apps/desktop/src/components/assistant-ui/embeds/embed-consent.tsx`, `url-embed.tsx`, `youtube-embed.tsx`, `providers/{youtube,types,detect.test}.ts`: one-click play — the first click mounts the iframe with autoplay; "Always allow YouTube" stays a separate menu action; thumbnails autoload no-referrer ahead of consent.
- `apps/desktop/electron/renderer-url.test.ts` (new, 5 tests), `renderer-server.test.ts` (+1 test), `youtube-embed.test.ts` (new).

## Validation

| Check | Result |
|---|---|
| `vitest run --project electron electron/renderer-url.test.ts electron/renderer-server.test.ts` | 9/9 pass |
| `vitest run src/.../embeds/providers/detect.test.ts src/.../embeds/youtube-embed.test.ts` | 25/25 pass |
| `tsc -p tsconfig.electron.json --noEmit` and `tsc -p . --noEmit` | clean |
| Packaged macOS build: renderer origin | served from `http://127.0.0.1:47891` (`lsof` confirms the bind; renderer console resolves against it) |

**Review defect 1 — navigation guard compared URL strings.** Now compares parsed origins.

| `will-navigate` input | old `startsWith` | new `isRendererUrl` |
|---|---|---|
| `http://127.0.0.1:47891/?win=secondary#/id` | allow | allow |
| `http://127.0.0.1:47891@attacker.example/` | **allow** | reject |
| `http://127.0.0.1:47892/`, `https://…:47891/` | reject | reject |

Everything before an `@` is userinfo, so the hostile URL shares our textual prefix while its real origin is `attacker.example` — it would have loaded attacker content into a window carrying the `hermesDesktop` preload bridge. The regression asserts the old check *would* have accepted it before asserting the new one rejects it, so the test documents the bypass rather than merely covering the fix. Note this is stricter than `main` too: the pre-existing guard was `url.startsWith('file:')`, which admits **any** `file:` URL.

**Review defect 2 — fixed port, hard failure.** `whenReady` awaits the server before `createWindow()`, so an occupied 47891 meant startup never reached window creation.

| Port state | Before | After |
|---|---|---|
| free | binds 47891 | binds 47891 |
| occupied | reject → no window at all | ephemeral port, renderer served normally |

The test binds a squatter on the requested port first, then asserts the server came up elsewhere and the squatter is untouched. The fixed port is still *preferred* because the renderer's origin keys its `localStorage` — a port that changed per launch would orphan persisted renderer state.

## Notes

- **Scope**: this branch previously carried OAuth/boot-recovery commits unrelated to embeds; they are split out into #72128. Rebased onto current `main` (the previous revision was ~1867 commits behind).
- **Duplicate check**: searched open and merged PRs for renderer-server/YouTube-embed work; no other PR covers the packaged-renderer origin. Session windows retain upstream's `rendererIndexPath` for the `file:` fallback — passing a `file:` URL as `devServer` would produce `index.html/?win=secondary`.
- `npm run typecheck`'s third pass (`tsconfig.e2e.json`) needs `@playwright/test`; unrelated to this change.
