### PR TITLE
fix(config): reload_env() must never clobber or delete boot-injected env vars

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -38,6 +38,16 @@ logger = logging.getLogger(__name__)
 # every time. Cleared automatically when the file changes (different mtime).
 _CONFIG_PARSE_WARNED: set = set()
 
+# reload_env boot-env protection.
+# Keys present in the process environment at import time. A parent-process
+# secret injector (e.g. a secrets manager, systemd EnvironmentFile, Docker
+# --env-file) populates os.environ BEFORE this module is imported and BEFORE
+# any .env file is applied, so this snapshot is exactly the set of
+# externally-injected env vars. reload_env() must NEVER delete these: they are
+# not sourced from ~/.hermes/.env, and deleting them silently poisons provider
+# resolution for the rest of the process lifetime.
+_PROCESS_BOOT_ENV_KEYS = frozenset(os.environ.keys())
+
 
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
     """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
@@ -7734,11 +7744,27 @@ def reload_env() -> int:
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
     count = 0
     for key, value in env_vars.items():
+        # Never write an UNINTERPOLATED ${VAR} reference into the live env.
+        # load_env() is a literal parser -- it does NOT expand ${...}, unlike the
+        # boot-time python-dotenv loader (load_dotenv override=True) that
+        # resolves e.g. `SOME_KEY=${OTHER_KEY}` against the externally-injected
+        # env. Writing the literal "${OTHER_KEY}" here would clobber the
+        # correctly-expanded boot value and silently break key resolution after
+        # the first /reload. Skipping uninterpolated refs preserves the good
+        # boot value.
+        if "${" in value:
+            continue
         if os.environ.get(key) != value:
             os.environ[key] = value
             count += 1
-    # Remove known Hermes vars that are no longer in .env
+    # Remove known Hermes vars that .env previously owned but were deleted from
+    # it. Crucially, NEVER delete a key that was injected by the parent process
+    # environment at boot -- those are absent from .env by design, and deleting
+    # them silently poisons provider key resolution for the rest of the process
+    # lifetime.
     for key in known_keys:
+        if key in _PROCESS_BOOT_ENV_KEYS:
+            continue
         if key not in env_vars and key in os.environ:
             del os.environ[key]
             count += 1

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -18,6 +18,7 @@ from hermes_cli.config import (
     load_config,
     load_env,
     migrate_config,
+    reload_env,
     read_raw_config,
     remove_env_value,
     save_config,
@@ -671,6 +672,81 @@ class TestRemoveEnvValue:
         assert "DROP" not in env_path.read_text()
         env_mode = env_path.stat().st_mode & 0o777
         assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
+
+class TestReloadEnv:
+    """Regression coverage for reload_env() boot-env protection.
+
+    A parent-process secret injector (secrets manager, systemd
+    EnvironmentFile, Docker --env-file) can populate os.environ before
+    ~/.hermes/.env is ever read. reload_env() must not clobber or delete
+    those externally-injected values.
+    """
+
+    def test_skips_uninterpolated_env_var_reference(self, tmp_path):
+        """load_env() is a literal parser — it does not expand ${...}.
+
+        If .env contains ``KEY=${OTHER_KEY}`` (already expanded once by the
+        boot-time python-dotenv loader against the real environment),
+        reload_env() must not overwrite the correctly-expanded boot value
+        with the literal, uninterpolated string.
+        """
+        env_path = tmp_path / ".env"
+        env_path.write_text("SOME_KEY=${OTHER_KEY}\n")
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "SOME_KEY": "already-expanded-value"},
+        ):
+            reload_env()
+            assert os.environ["SOME_KEY"] == "already-expanded-value"
+
+    def test_writes_interpolated_values_normally(self, tmp_path):
+        """A plain (non-${}) value in .env is still applied as before."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("SOME_KEY=plain-value\n")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("SOME_KEY", None)
+            reload_env()
+            assert os.environ["SOME_KEY"] == "plain-value"
+
+    def test_deletes_known_key_removed_from_dotenv(self, tmp_path):
+        """A known Hermes var removed from .env is cleared from os.environ
+        (pre-existing behavior, unaffected by the boot-env guard)."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("UNRELATED=1\n")
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "OPENROUTER_API_KEY": "sk-stale"},
+        ):
+            reload_env()
+            assert "OPENROUTER_API_KEY" not in os.environ
+
+    def test_never_deletes_a_boot_injected_known_key(self, tmp_path, monkeypatch):
+        """A known key present in os.environ at process boot (simulated via
+        _PROCESS_BOOT_ENV_KEYS) must survive even though it is absent from
+        .env — deleting it would silently poison provider resolution for the
+        rest of the process lifetime.
+        """
+        import hermes_cli.config as config_module
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("UNRELATED=1\n")
+
+        monkeypatch.setattr(
+            config_module,
+            "_PROCESS_BOOT_ENV_KEYS",
+            frozenset({"OPENROUTER_API_KEY"}),
+        )
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "OPENROUTER_API_KEY": "sk-boot-injected"},
+        ):
+            reload_env()
+            assert os.environ["OPENROUTER_API_KEY"] == "sk-boot-injected"
 
 
 class TestSaveConfigAtomicity:


### PR DESCRIPTION
## Summary
`reload_env()` re-reads `~/.hermes/.env` into `os.environ`, but had two ways to silently poison boot-time environment state on a later reload:

1. **Uninterpolated `${VAR}` clobber.** A `.env` value containing an unresolved `${VAR}` reference (already expanded once by the boot-time python-dotenv loader against the real environment) would get written back literally on reload, clobbering the correctly-expanded boot value — `load_env()` is a literal parser and does not expand `${...}` itself.
2. **Boot-injected key deletion.** A known Hermes var present in `os.environ` only because a parent process (secrets manager, systemd `EnvironmentFile`, Docker `--env-file`) injected it at boot — never sourced from `.env` — would get deleted on reload, since it's absent from `.env` by definition. This silently breaks provider key resolution for the rest of the process lifetime.

This fixes both: skip writing any value containing `${`, and snapshot the boot-time environment keys (`_PROCESS_BOOT_ENV_KEYS`) so known-key deletion never touches one of them.

## Test plan
- [x] Added `TestReloadEnv` (4 cases) to `tests/hermes_cli/test_config.py`: uninterpolated `${VAR}` skip, normal interpolated write still applies, non-boot known-key deletion still works, boot-injected known key survives even when absent from `.env`.
- [x] Full `tests/hermes_cli/test_config.py`: 155/155 pass.
- [x] `ruff check` clean.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>