### PR TITLE
catalog: add Voicebox MCP server (optional-mcps)

### DIFF
--- a/optional-mcps/voicebox/manifest.yaml
+++ b/optional-mcps/voicebox/manifest.yaml
@@ -1,0 +1,36 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: voicebox
+description: Speak replies in the user's cloned Voicebox voices and transcribe audio locally (loopback HTTP, no cloud, no auth).
+source: https://docs.voicebox.sh/overview/mcp-server
+
+# Voicebox (https://voicebox.sh) is a local-first voice studio. Its desktop
+# app embeds an MCP server (Streamable HTTP) that only listens while the app
+# is running — nothing to install locally, nothing leaves the machine.
+# Tools: voicebox.speak, voicebox.transcribe, voicebox.list_profiles,
+# voicebox.list_captures (dotted names are sanitized by the MCP client to
+# mcp__voicebox__voicebox_speak etc.).
+transport:
+  type: http
+  url: http://127.0.0.1:17493/mcp
+
+# Loopback-only API with no credentials. The optional X-Voicebox-Client-Id
+# header (per-client voice bindings) is an identifier, not a secret; users
+# who want it can add `headers:` to the mcp_servers.voicebox block by hand.
+auth:
+  type: none
+
+post_install: |
+  Voicebox must be running for the connection probe and for tool calls —
+  the desktop app serves the API only while open. Docker users: the default
+  compose maps the API to http://127.0.0.1:17600; edit the URL in the
+  mcp_servers.voicebox block accordingly.
+
+  Pick a default voice for Hermes in Voicebox under Settings -> MCP clients
+  (per-client bindings), or pass a profile name in the speak tool call.
+
+  To also route Hermes's own voice pipeline (spoken replies, voice bubbles,
+  voice-message transcription) through Voicebox, install the companion
+  provider plugin: https://github.com/jamiepine/hermes-voicebox


### PR DESCRIPTION
One file: `optional-mcps/voicebox/manifest.yaml`.

[Voicebox](https://voicebox.sh) is an open-source, local-first voice studio (voice cloning TTS, 7 engines, local Whisper STT). Its desktop app embeds an MCP server on loopback — Streamable HTTP at `http://127.0.0.1:17493/mcp`, `auth: none`, nothing to install or download since the server lives inside the running app. It exposes 4 tools: `voicebox.speak`, `voicebox.transcribe`, `voicebox.list_profiles`, `voicebox.list_captures` — so a Hermes agent can speak in the user's cloned voices and transcribe audio without anything leaving the machine.

**Validation:**
- Manifest parses clean via `hermes_cli.mcp_catalog._parse_manifest` (name/transport/auth verified).
- Live end-to-end test on this branch: `hermes mcp install voicebox` → connected in 57ms, all 4 tools discovered and callable from an agent session.
- Voicebox's dotted tool names are handled by `sanitize_mcp_name_component` (`voicebox.speak` → `mcp__voicebox__voicebox_speak`).

`post_install` notes the app-must-be-running requirement, the Docker port difference (17600), and points users who also want Hermes's own TTS/STT pipeline routed through Voicebox at the standalone provider plugin ([hermes-voicebox](https://github.com/jamiepine/hermes-voicebox), on [PyPI](https://pypi.org/project/hermes-voicebox/)) — kept out of this repo per the third-party placement policy in CONTRIBUTING.md.