### PR TITLE
fix(desktop): re-baseline session-context drift after new-chat creation (#54527 regression)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1321,6 +1321,59 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
     expect(calls).not.toContain('session.resume')
   })
+
+  it('new-chat first message sends on the FIRST Enter (no double press) — #54527 regression (#62481)', async () => {
+    // The real createBackendSessionForSend repoints selectedStoredSessionIdRef
+    // (and the route token) when it mints the new session — that is the expected
+    // self-transition of a new chat, NOT a user switching sessions mid-submit.
+    // Simulate that mutation so the post-creation sessionContextDrifted() guard
+    // is exercised exactly as in production. Without the re-baseline fix, the
+    // self-induced drift trips the guard, aborts the submit, and a second Enter
+    // is required before the message actually sends.
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const createBackendSessionForSend = vi.fn(async () => {
+      selectedStoredSessionIdRef.current = 'stored-new-session'
+      activeSessionIdRef.current = RUNTIME_SESSION_ID
+
+      return RUNTIME_SESSION_ID
+    })
+    const calls: { method: string; params: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params: params ?? {} })
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => 'token'}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const ok = await handle!.submitText('hello from a brand new chat')
+
+    expect(ok).toBe(true)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+
+    const submit = calls.find(c => c.method === 'prompt.submit')
+
+    // The first Enter must reach prompt.submit with the user's text — the bug
+    // aborted before this, so a second press was needed.
+    expect(submit).toBeDefined()
+    expect(submit?.params).toMatchObject({ session_id: RUNTIME_SESSION_ID, text: 'hello from a brand new chat' })
+  })
 })
 
 describe('usePromptActions submit session-context isolation (#54527)', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -118,8 +118,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // Pin the session context for the whole async submit pipeline. Without
       // this, a fast session switch during session.resume / file.attach can
       // redirect the user's text into a different chat (#54527).
-      const startingActiveSessionId = activeSessionIdRef.current
-      const startingStoredSessionId = selectedStoredSessionIdRef.current
+      // `let` not `const`: createBackendSessionForSend legitimately rewrites
+      // these refs + the route token (it mints the new session and navigates),
+      // which is the expected self-transition for a new chat — not a user
+      // switch. We re-baseline after creation so the guard only catches a
+      // genuine drift that happens during the *rest* of the pipeline.
+      let startingActiveSessionId = activeSessionIdRef.current
+      let startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
 
       const sessionContextDrifted = (): boolean =>
@@ -280,6 +285,18 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
           return false
         }
+
+        // createBackendSessionForSend has now *legitimately* repointed the
+        // active/stored refs and changed the route token (it minted the new
+        // session and navigated to it). That is the expected self-transition of
+        // a new chat, not a user switching sessions mid-submit. Re-baseline the
+        // drift baseline to the post-creation state so the guard below only
+        // catches a genuine navigation that happens after creation — otherwise
+        // the very first message of a new chat trips sessionContextDrifted() on
+        // its own side effect, gets aborted, and requires a second Enter (#54527
+        // regression, see issue #62481).
+        startingActiveSessionId = activeSessionIdRef.current
+        startingStoredSessionId = selectedStoredSessionIdRef.current
 
         if (sessionContextDrifted()) {
           return abortForSessionSwitch(sessionId)


### PR DESCRIPTION
## Summary

- `createBackendSessionForSend` legitimately repoints `activeSessionIdRef` / `selectedStoredSessionIdRef` and changes the route token while minting the new session.
- Those self-induced mutations tripped the `sessionContextDrifted()` guard added in #54527, so the **first** prompt of a new chat was aborted and required a **second Enter** to actually send (the text only landed in the sidebar title/preview).
- Re-baseline the drift baseline immediately after creation so the guard still catches a genuine user session-switch during the rest of the pipeline (after `syncAttachmentsForSubmit`, after `session.resume`).

## Root cause

PR #54527 introduced `sessionContextDrifted()` in `useSubmitPrompt` (`apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts`) to prevent a fast user session-switch from redirecting text into the wrong chat. For a new chat, `submit.ts` calls `createBackendSessionForSend(visibleText)`, which rewrites the active/stored refs and navigates (changing `getRouteToken()`), seeding the title with the user's text. Because the baseline was captured as `const` *before* creation, the post-creation `sessionContextDrifted()` check became `true` on the submit's own side effect and called `abortForSessionSwitch` → returned `false`, which `dispatchSubmit` treated as a reject and re-stashed the draft. On the second Enter the session already existed, so creation was skipped and the send succeeded.

## Test plan

- Added regression test `new-chat first message sends on the FIRST Enter (no double press)` in `use-prompt-actions/index.test.tsx`, which simulates `createBackendSessionForSend` repointing the refs and asserts the first submit reaches `prompt.submit` with the user's text.
- `tsc -p . --noEmit` (apps/desktop): 0 errors.
- `vitest run use-prompt-actions/index.test.tsx`: 43/43 passing.

Fixes #62481