### PR TITLE
fix(pet): guard against IndexError on empty error in _humanize_image_error

### DIFF
--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -190,7 +190,8 @@ def _humanize_image_error(error: str) -> str:
     if "rate limit" in low or "429" in low:
         return "The image provider is rate-limiting — wait a moment and try again."
     # Otherwise the first line, trimmed of the noisy provider envelope.
-    return error.splitlines()[0].strip()[:200]
+    lines = error.splitlines()
+    return lines[0].strip()[:200] if lines else error.strip()[:200]
 
 
 def hatch_pet(


### PR DESCRIPTION
## Summary

Guard `error.splitlines()[0]` against empty strings in `_humanize_image_error`.

## Problem

`_humanize_image_error` (agent/pet/generate/orchestrate.py:193) does `error.splitlines()[0]` as a fallback for unknown error formats. When the error string is empty (`""`), `"".splitlines()` returns `[]` and `[][0]` raises an `IndexError`, which crashes the entire pet generation pipeline instead of returning a human-readable message.

## Fix

Split into a variable and return the fallback `error.strip()[:200]` when the list is empty — the same 200-char truncation budget, no crash.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: empty string, whitespace-only, and normal error strings all handled correctly