### PR TITLE
fix(agent): finalize text tool calls and clear all sessions

### DIFF
--- a/agent/text_tool_calls.py
+++ b/agent/text_tool_calls.py
@@ -11,28 +11,44 @@ from agent.transports.types import ToolCall
 
 
 _TEXT_TOOL_CALL_BLOCK_RE = re.compile(
-    r"^\s*<(?P<tag>tool_?calls?)\b[^>]*>\s*(?P<payload>[\s\S]*?)\s*</(?P=tag)>\s*$",
+    r"<(?P<tag>tool_?calls?)\b[^>]*>\s*(?P<payload>[\s\S]*?)\s*</(?P=tag)>\s*$",
     re.IGNORECASE,
 )
 _TEXT_TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$")
 _MAX_TEXT_TOOL_CALLS = 8
 
 
-def parse_text_tool_calls(content: Any) -> list[ToolCall] | None:
-    """Promote an all-content tool-call block to structured calls.
+def parse_text_tool_calls(content: Any) -> tuple[str | None, list[ToolCall]] | None:
+    """Promote a terminal tool-call block to structured calls.
 
     Some OpenAI-compatible local models ignore the structured ``tool_calls``
     response field and instead emit a protocol block such as
     ``<TOOLCALL>[{"name": "skill_view", ...}]</TOOLCALL>``. Treat that as a
-    tool turn only when the block is the *entire* assistant message and every
-    call has a valid name plus object arguments. This keeps ordinary prose,
-    quoted examples, malformed JSON, and mixed text/tool responses inert.
+    tool turn when the block is either the entire assistant message or a
+    newline-delimited terminal suffix, and every call has a valid name plus
+    object arguments. Any preceding prose is preserved as assistant content.
+    Inline examples, fenced examples, malformed JSON, and text after the block
+    remain inert.
     """
     if not isinstance(content, str) or not content.strip():
         return None
-    match = _TEXT_TOOL_CALL_BLOCK_RE.fullmatch(content)
+    match = _TEXT_TOOL_CALL_BLOCK_RE.search(content)
     if not match:
         return None
+    prefix = content[: match.start()]
+    if prefix.strip():
+        # A mixed prose/tool response is only protocol when the opening tag is
+        # on its own new line. This rejects inline quoted examples while still
+        # accepting the exact shape emitted by qwen during real agent runs.
+        if not prefix.rstrip(" \t").endswith(("\n", "\r")):
+            return None
+        # A closing Markdown fence after the tag already prevents the regex
+        # match; reject an opening fence immediately before it as well.
+        if prefix.rstrip().endswith("```"):
+            return None
+        visible_content = prefix.rstrip() or None
+    else:
+        visible_content = None
     try:
         payload = json.loads(match.group("payload"))
     except (TypeError, ValueError):
@@ -71,4 +87,4 @@ def parse_text_tool_calls(content: Any) -> list[ToolCall] | None:
                 arguments=json.dumps(arguments, separators=(",", ":")),
             )
         )
-    return parsed
+    return visible_content, parsed

--- a/agent/text_tool_calls.py
+++ b/agent/text_tool_calls.py
@@ -1,0 +1,74 @@
+"""Compatibility parser for models that emit tool calls as assistant text."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+from agent.transports.types import ToolCall
+
+
+_TEXT_TOOL_CALL_BLOCK_RE = re.compile(
+    r"^\s*<(?P<tag>tool_?calls?)\b[^>]*>\s*(?P<payload>[\s\S]*?)\s*</(?P=tag)>\s*$",
+    re.IGNORECASE,
+)
+_TEXT_TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$")
+_MAX_TEXT_TOOL_CALLS = 8
+
+
+def parse_text_tool_calls(content: Any) -> list[ToolCall] | None:
+    """Promote an all-content tool-call block to structured calls.
+
+    Some OpenAI-compatible local models ignore the structured ``tool_calls``
+    response field and instead emit a protocol block such as
+    ``<TOOLCALL>[{"name": "skill_view", ...}]</TOOLCALL>``. Treat that as a
+    tool turn only when the block is the *entire* assistant message and every
+    call has a valid name plus object arguments. This keeps ordinary prose,
+    quoted examples, malformed JSON, and mixed text/tool responses inert.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return None
+    match = _TEXT_TOOL_CALL_BLOCK_RE.fullmatch(content)
+    if not match:
+        return None
+    try:
+        payload = json.loads(match.group("payload"))
+    except (TypeError, ValueError):
+        return None
+    raw_calls = payload if isinstance(payload, list) else [payload]
+    if not raw_calls or len(raw_calls) > _MAX_TEXT_TOOL_CALLS:
+        return None
+
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+    parsed: list[ToolCall] = []
+    for index, raw_call in enumerate(raw_calls):
+        if not isinstance(raw_call, dict):
+            return None
+        function = raw_call.get("function")
+        if function is not None and not isinstance(function, dict):
+            return None
+        source = function if isinstance(function, dict) else raw_call
+        name = source.get("name")
+        arguments = source.get("arguments", {})
+        if not isinstance(name, str) or not _TEXT_TOOL_NAME_RE.fullmatch(name.strip()):
+            return None
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (TypeError, ValueError):
+                return None
+        if not isinstance(arguments, dict):
+            return None
+        call_id = raw_call.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"text_call_{digest}_{index + 1}"
+        parsed.append(
+            ToolCall(
+                id=call_id,
+                name=name.strip(),
+                arguments=json.dumps(arguments, separators=(",", ":")),
+            )
+        )
+    return parsed

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -736,10 +736,9 @@ class ChatCompletionsTransport(ProviderTransport):
         # ``None`` for normal responses, so this is a no-op in the common case.
         content = msg.content
         if not tool_calls:
-            text_tool_calls = parse_text_tool_calls(content)
-            if text_tool_calls:
-                tool_calls = text_tool_calls
-                content = None
+            parsed_text_tool_calls = parse_text_tool_calls(content)
+            if parsed_text_tool_calls:
+                content, tool_calls = parsed_text_tool_calls
                 finish_reason = "tool_calls"
         refusal = getattr(msg, "refusal", None)
         if refusal is None and hasattr(msg, "model_extra"):

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -14,6 +14,7 @@ from typing import Any, Dict
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
+from agent.text_tool_calls import parse_text_tool_calls
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
@@ -734,6 +735,12 @@ class ChatCompletionsTransport(ProviderTransport):
         # loop's refusal handler surfaces it clearly and stops. ``refusal`` is
         # ``None`` for normal responses, so this is a no-op in the common case.
         content = msg.content
+        if not tool_calls:
+            text_tool_calls = parse_text_tool_calls(content)
+            if text_tool_calls:
+                tool_calls = text_tool_calls
+                content = None
+                finish_reason = "tool_calls"
         refusal = getattr(msg, "refusal", None)
         if refusal is None and hasattr(msg, "model_extra"):
             _msg_extra = getattr(msg, "model_extra", None) or {}

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -10,6 +10,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
+- DELETE /api/sessions             — delete every persisted session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
@@ -1847,6 +1848,42 @@ class APIServerAdapter(BasePlatformAdapter):
         db = self._ensure_session_db()
         deleted = db.delete_session(session_id)
         return web.json_response({"object": "hermes.session.deleted", "id": session_id, "deleted": bool(deleted)})
+
+    async def _handle_delete_sessions(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/sessions — delete every persisted session.
+
+        Mobile clients use this endpoint for the explicit, confirmed "Clear
+        all" action. Listing then deleting client-side is not equivalent: the
+        list API is paginated, so clients with more than one page leave older
+        sessions behind and make cleared threads appear to return.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error(
+                    "Session database unavailable",
+                    code="session_db_unavailable",
+                ),
+                status=503,
+            )
+        sessions = db.list_sessions_rich(
+            limit=1_000_000,
+            include_children=True,
+            project_compression_tips=False,
+            include_archived=True,
+            compact_rows=True,
+        )
+        session_ids = [session["id"] for session in sessions if session.get("id")]
+        deleted = db.delete_sessions(session_ids)
+        return web.json_response(
+            {
+                "object": "hermes.session.deleted_all",
+                "deleted": deleted,
+            }
+        )
 
     async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions/{session_id}/messages."""
@@ -4850,6 +4887,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)
             self._app.router.add_get("/api/sessions", self._handle_list_sessions)
             self._app.router.add_post("/api/sessions", self._handle_create_session)
+            self._app.router.add_delete("/api/sessions", self._handle_delete_sessions)
             self._app.router.add_get("/api/sessions/{session_id}", self._handle_get_session)
             self._app.router.add_patch("/api/sessions/{session_id}", self._handle_patch_session)
             self._app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -923,6 +923,66 @@ class TestChatCompletionsNormalize:
         assert nr.tool_calls[0].arguments == '{"name":"stripe-vault"}'
         assert nr.tool_calls[0].id.startswith("text_call_")
 
+    def test_promotes_observed_qwen_prose_then_terminal_text_tool_call(self, transport):
+        content = (
+            "Executing:\n\n"
+            "1. Reddit Buyer-Signal Scan\n"
+            "2. Processing Customer Assets\n"
+            "3. Automated Lead Follow-up\n"
+            '<TOOLCALL>[{"name":"read_file","arguments":'
+            '{"limit":50,"offset":1,"path":"outreach/pending-assets.md"}}]'
+            "</TOOLCALL>"
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == (
+            "Executing:\n\n"
+            "1. Reddit Buyer-Signal Scan\n"
+            "2. Processing Customer Assets\n"
+            "3. Automated Lead Follow-up"
+        )
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "read_file"
+        assert nr.tool_calls[0].arguments == (
+            '{"limit":50,"offset":1,"path":"outreach/pending-assets.md"}'
+        )
+
+    def test_does_not_promote_fenced_terminal_text_tool_call_example(self, transport):
+        content = (
+            "Example:\n```\n"
+            '<TOOLCALL>[{"name":"terminal","arguments":{}}]</TOOLCALL>'
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == content
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None
+
     def test_promotes_openai_shaped_text_tool_call(self, transport):
         r = SimpleNamespace(
             choices=[SimpleNamespace(

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -898,6 +898,109 @@ class TestChatCompletionsNormalize:
         assert nr.tool_calls[0].name == "terminal"
         assert nr.tool_calls[0].id == "call_123"
 
+    def test_promotes_observed_qwen_text_tool_call_block(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        '<TOOLCALL>[{"name":"skill_view",'
+                        '"arguments":{"name":"stripe-vault"}}]</TOOLCALL>'
+                    ),
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content is None
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "skill_view"
+        assert nr.tool_calls[0].arguments == '{"name":"stripe-vault"}'
+        assert nr.tool_calls[0].id.startswith("text_call_")
+
+    def test_promotes_openai_shaped_text_tool_call(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        '<tool_call>{"id":"call_text_1","function":'
+                        '{"name":"terminal","arguments":"{\\"command\\":\\"pwd\\"}"}}'
+                        '</tool_call>'
+                    ),
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content is None
+        assert nr.finish_reason == "tool_calls"
+        assert [(call.id, call.name, call.arguments) for call in nr.tool_calls] == [
+            ("call_text_1", "terminal", '{"command":"pwd"}')
+        ]
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            'Example: <TOOLCALL>[{"name":"terminal","arguments":{}}]</TOOLCALL>',
+            '<TOOLCALL>not-json</TOOLCALL>',
+            '<TOOLCALL>[{"name":"bad name","arguments":{}}]</TOOLCALL>',
+            '<TOOLCALL>[{"name":"terminal","arguments":[]}]</TOOLCALL>',
+        ],
+    )
+    def test_does_not_execute_mixed_or_malformed_text_tool_calls(self, transport, content):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == content
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None
+
+    def test_structured_tool_calls_take_precedence_over_text_protocol(self, transport):
+        tc = SimpleNamespace(
+            id="call_structured",
+            function=SimpleNamespace(name="terminal", arguments="{}"),
+        )
+        content = '<TOOLCALL>[{"name":"skill_view","arguments":{}}]</TOOLCALL>'
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=[tc],
+                    reasoning_content=None,
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == content
+        assert [(call.id, call.name) for call in nr.tool_calls] == [
+            ("call_structured", "terminal")
+        ]
+
     def test_tool_call_extra_content_preserved(self, transport):
         """Gemini 3 thinking models attach extra_content with thought_signature
         on tool_calls.  Without this replay on the next turn, the API rejects

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -41,6 +41,7 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/api/sessions", adapter._handle_list_sessions)
     app.router.add_post("/api/sessions", adapter._handle_create_session)
+    app.router.add_delete("/api/sessions", adapter._handle_delete_sessions)
     app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
@@ -167,6 +168,54 @@ async def test_session_crud_and_message_history(adapter, session_db):
         deleted = await delete_resp.json()
         assert deleted == {"object": "hermes.session.deleted", "id": session_id, "deleted": True}
         assert session_db.get_session(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_all_sessions_clears_more_than_one_list_page(adapter, session_db):
+    for index in range(205):
+        session_id = session_db.create_session(f"mobile-{index:03d}", "api_server")
+        session_db.append_message(session_id, "user", f"message {index}")
+    archived_id = session_db.create_session("archived-mobile", "api_server")
+    session_db.set_session_archived(archived_id, True)
+    child_id = session_db.create_session(
+        "child-mobile",
+        "subagent",
+        parent_session_id="mobile-000",
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        first_page = await cli.get("/api/sessions?limit=50")
+        assert first_page.status == 200
+        assert len((await first_page.json())["data"]) == 50
+
+        response = await cli.delete("/api/sessions")
+        assert response.status == 200
+        payload = await response.json()
+
+    assert payload == {
+        "object": "hermes.session.deleted_all",
+        "deleted": 207,
+    }
+    assert session_db.list_sessions_rich(
+        limit=1_000,
+        include_children=True,
+        project_compression_tips=False,
+        include_archived=True,
+    ) == []
+    assert session_db.get_session(child_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_all_sessions_requires_valid_api_key(auth_adapter, session_db):
+    session_db.create_session("keep-me", "api_server")
+    app = _create_session_app(auth_adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.delete("/api/sessions")
+
+    assert response.status == 401
+    assert session_db.get_session("keep-me") is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- promote whole-message or terminal-suffix `<TOOLCALL>` blocks into structured tool calls instead of exposing protocol text
- preserve preceding assistant prose while rejecting malformed, inline, fenced, or unsafe pseudo-calls
- add authenticated bulk `DELETE /api/sessions` so clients can clear the full session set rather than one paginated page

## Verification
- transport/autodetect suite: 394 passed
- combined API session + transport suite: 111 passed
- deployed-version session API suite: 14 passed
- bulk deletion test covers 207 sessions including archived and child sessions, plus unauthorized 401
- exact mixed prose + tool-call payload passed on two deployed hosts

This fixes two observed production failures: raw tool protocol leaking into chat, and mobile Clear all deleting only the first paginated page.