### PR TITLE
fix: preserve pending MCP approval resumes

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -738,6 +738,103 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_approval_required_is_awaited_inside_original_call(self, tmp_path, monkeypatch):
+        from tools.mcp_tool import _make_tool_handler, _servers
+        import tools.mcp_tool as mcp_tool
+
+        pending = _make_call_result(json.dumps({
+            "status": "approval_required",
+            "await_tool": {"name": "approval_await", "arguments": {
+                "approval_id": "a1", "resume_token": "secret", "args_hash": "h"
+            }},
+        }))
+        approved = _make_call_result(json.dumps({
+            "status": "approved", "provider_result": {"id": "sent-1"}
+        }))
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(side_effect=[pending, approved])
+        server = _make_mock_server("approval_srv", session=mock_session)
+        _servers["approval_srv"] = server
+        monkeypatch.setattr(mcp_tool, "_approval_resume_path", lambda: tmp_path / "resume.json")
+        try:
+            handler = _make_tool_handler("approval_srv", "send", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"body": "hello"}))
+            assert json.loads(result["result"])["provider_result"]["id"] == "sent-1"
+            assert [call.args[0] for call in mock_session.call_tool.await_args_list] == [
+                "send", "approval_await"
+            ]
+            assert json.loads((tmp_path / "resume.json").read_text()) == {}
+        finally:
+            _servers.pop("approval_srv", None)
+
+    def test_saved_approval_resumes_without_reissuing_original(self, tmp_path, monkeypatch):
+        from tools.mcp_tool import _approval_call_key, _make_tool_handler, _servers
+        import tools.mcp_tool as mcp_tool
+
+        args = {"body": "hello"}
+        key = _approval_call_key("resume_srv", "send", args)
+        resume_path = tmp_path / "resume.json"
+        resume_path.write_text(json.dumps({key: {"await_tool": {
+            "name": "approval_await", "arguments": {"approval_id": "a1", "args_hash": "h"}
+        }}}))
+        monkeypatch.setattr(mcp_tool, "_approval_resume_path", lambda: resume_path)
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=_make_call_result(json.dumps({"status": "denied"})))
+        server = _make_mock_server("resume_srv", session=mock_session)
+        _servers["resume_srv"] = server
+        try:
+            handler = _make_tool_handler("resume_srv", "send", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler(args))
+            assert json.loads(result["result"])["status"] == "denied"
+            mock_session.call_tool.assert_awaited_once_with(
+                "approval_await", arguments={"approval_id": "a1", "args_hash": "h"}
+            )
+            assert json.loads(resume_path.read_text()) == {}
+        finally:
+            _servers.pop("resume_srv", None)
+
+    def test_pending_approval_keeps_resume_handle_for_identical_retry(self, tmp_path, monkeypatch):
+        from tools.mcp_tool import _approval_call_key, _make_tool_handler, _servers
+        import tools.mcp_tool as mcp_tool
+
+        args = {"body": "hello"}
+        pending = _make_call_result(json.dumps({
+            "status": "approval_required",
+            "await_tool": {"name": "approval_await", "arguments": {
+                "approval_id": "a1", "resume_token": "secret", "args_hash": "h"
+            }},
+        }))
+        poll_timeout = _make_call_result(
+            "Approval request is still pending: a1", is_error=True
+        )
+        approved = _make_call_result(json.dumps({
+            "status": "approved", "provider_result": {"id": "sent-1"}
+        }))
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(side_effect=[pending, poll_timeout, approved])
+        server = _make_mock_server("pending_srv", session=mock_session)
+        _servers["pending_srv"] = server
+        resume_path = tmp_path / "resume.json"
+        monkeypatch.setattr(mcp_tool, "_approval_resume_path", lambda: resume_path)
+        try:
+            handler = _make_tool_handler("pending_srv", "send", 120)
+            with self._patch_mcp_loop():
+                first = json.loads(handler(args))
+                stored = json.loads(resume_path.read_text())
+                second = json.loads(handler(args))
+
+            assert first["error"] == "Approval request is still pending: a1"
+            assert _approval_call_key("pending_srv", "send", args) in stored
+            assert json.loads(second["result"])["provider_result"]["id"] == "sent-1"
+            assert [call.args[0] for call in mock_session.call_tool.await_args_list] == [
+                "send", "approval_await", "approval_await"
+            ]
+            assert json.loads(resume_path.read_text()) == {}
+        finally:
+            _servers.pop("pending_srv", None)
+
     def test_mcp_error_result(self):
         from tools.mcp_tool import _make_tool_handler, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -92,6 +92,7 @@ Thread safety:
 import asyncio
 import contextvars
 import concurrent.futures
+import hashlib
 import inspect
 import json
 import logging
@@ -3856,6 +3857,81 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
+def _decode_mcp_json_result(result: Any) -> Optional[dict]:
+    """Decode a JSON object from a structured result or one text block."""
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+    texts = [block.text for block in (getattr(result, "content", None) or [])
+             if isinstance(getattr(block, "text", None), str)]
+    if len(texts) != 1:
+        return None
+    try:
+        decoded = json.loads(texts[0])
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _approval_result_is_pending(result: Any) -> bool:
+    """Return whether an approval await result is the server's poll timeout."""
+    if not getattr(result, "isError", False):
+        return False
+    text = "\n".join(
+        block.text for block in (getattr(result, "content", None) or [])
+        if isinstance(getattr(block, "text", None), str)
+    )
+    return "Approval request is still pending:" in text
+
+
+def _approval_resume_path() -> Any:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "state" / "mcp-approval-resume.json"
+
+
+def _approval_call_key(server_name: str, tool_name: str, args: dict) -> str:
+    canonical = json.dumps(args, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(f"{server_name}\0{tool_name}\0{canonical}".encode()).hexdigest()
+
+
+def _load_approval_resumes() -> dict:
+    try:
+        data = json.loads(_approval_resume_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_approval_resumes(data: dict) -> None:
+    path = _approval_resume_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+
+
+def _remember_approval_resume(key: str, await_tool: dict, expires_at: Any) -> None:
+    with _lock:
+        data = _load_approval_resumes()
+        data[key] = {"await_tool": await_tool, "expires_at": expires_at}
+        _write_approval_resumes(data)
+
+
+def _forget_approval_resume(key: str) -> None:
+    with _lock:
+        data = _load_approval_resumes()
+        if data.pop(key, None) is not None:
+            _write_approval_resumes(data)
+
+
+def _saved_approval_resume(key: str) -> Optional[dict]:
+    with _lock:
+        item = _load_approval_resumes().get(key)
+    return item if isinstance(item, dict) else None
+
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -3939,8 +4015,40 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # task, which doesn't inherit our contextvars) can replay
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
+                call_key = _approval_call_key(server_name, tool_name, args)
+                saved = _saved_approval_resume(call_key)
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    if saved:
+                        await_spec = saved.get("await_tool") or {}
+                        result = await server.session.call_tool(
+                            await_spec.get("name", "approval_await"),
+                            arguments=await_spec.get("arguments") or {},
+                        )
+                    else:
+                        result = await server.session.call_tool(tool_name, arguments=args)
+
+                    envelope = _decode_mcp_json_result(result)
+                    if envelope and envelope.get("status") == "approval_required":
+                        await_spec = envelope.get("await_tool")
+                        if not isinstance(await_spec, dict) or not isinstance(await_spec.get("arguments"), dict):
+                            return result
+                        await_name = await_spec.get("name")
+                        if not isinstance(await_name, str) or not await_name:
+                            return result
+                        _remember_approval_resume(
+                            call_key, await_spec, envelope.get("expires_at")
+                        )
+                        result = await server.session.call_tool(
+                            await_name, arguments=await_spec["arguments"]
+                        )
+
+                    if saved or (envelope and envelope.get("status") == "approval_required"):
+                        # approval_await is a bounded poll. OneMCP reports an
+                        # undecided approval as an MCP error after that poll;
+                        # keep the opaque handle so an identical retry resumes
+                        # instead of creating a duplicate gated operation.
+                        if not _approval_result_is_pending(result):
+                            _forget_approval_resume(call_key)
                 finally:
                     server._pending_call_context = None
             # MCP CallToolResult has .content (list of content blocks) and .isError


### PR DESCRIPTION
## Summary
- persist opaque MCP approval await handles
- retain them while bounded approval polls are still pending
- resume identical calls without recreating consequential operations
- clear handles after terminal approval outcomes

## Test plan
- [x] `python -m pytest tests/tools/test_mcp_tool.py -q -o "addopts="` (215 passed)
- [x] `git diff --check`

Authorized by Sam for merge and deployment.