### PR TITLE
feat(desktop): route slash commands with dedicated RPCs to those RPCs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "eslint src/ electron/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'electron/**/*.ts' 'vite.config.ts'",
     "fix": "npm run lint:fix && npm run fmt",
-    "test:ui": "vitest run --environment jsdom",
+    "test:ui": "vitest run",
     "preview": "node scripts/assert-root-install.mjs && vite preview --host 127.0.0.1 --port 4174"
   },
   "dependencies": {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -7,6 +7,7 @@ import { parseCommandDispatch, parseSlashCommand, sessionTitle } from '@/lib/cha
 import {
   type CommandsCatalogLike,
   type DesktopActionId,
+  type DesktopCommandSurface,
   type DesktopPickerId,
   desktopSlashUnavailableMessage,
   isDesktopSlashCommand,
@@ -31,7 +32,7 @@ import {
 
 import type { BrowserManageResponse, SessionTitleResponse, SlashExecResponse } from '../../../types'
 
-import { type GatewayRequest, isSessionIdCandidate, renderCommandsCatalog, slashStatusText } from './utils'
+import { type GatewayRequest, isSessionIdCandidate, renderCommandsCatalog, renderRpcResult, slashStatusText } from './utils'
 
 /** Everything a slash handler needs about the invocation it's serving. */
 interface SlashActionCtx {
@@ -219,6 +220,41 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
 
           await handleDispatch(dispatch)
+        } catch (err) {
+          renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+        }
+      }
+
+      // `rpc` commands have a dedicated gateway handler — skip slash.exec /
+      // command.dispatch entirely. The response is structured (a JSON RPC
+      // reply, not an inline text stream) so we render it via the generic
+      // `renderRpcResult` shaper that knows the field conventions shared by
+      // session.compress / session.save / session.status / session.usage /
+      // session.steer / process.stop / agents.list.
+      async function runRpc(
+        surface: Extract<DesktopCommandSurface, { kind: 'rpc' }>,
+        ctx: SlashActionCtx
+      ): Promise<void> {
+        const resolved = await withSlashOutput(ctx)
+
+        if (!resolved) {
+          return
+        }
+
+        const { render: renderSlashOutput, sessionId } = resolved
+
+        try {
+          const params = surface.buildParams({
+            arg: ctx.arg,
+            command: ctx.command,
+            name: ctx.name,
+            sessionId
+          })
+
+          const result = await requestGateway<unknown>(surface.rpc, params)
+          const body = renderRpcResult(result, ctx.name)
+
+          renderSlashOutput(body || `/${ctx.name}: no output`)
         } catch (err) {
           renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
         }
@@ -603,6 +639,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           case 'action':
             return actionHandlers[surface.action](ctx)
+
+          case 'rpc':
+            return runRpc(surface, ctx)
 
           default:
             // exec spec, or an unknown skill / quick command the backend owns.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -251,7 +251,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             sessionId
           })
 
-          const result = await requestGateway<unknown>(surface.rpc, params)
+          // Forward the surface's declared timeout when present; default the
+          // requestGateway layer keeps (30s) is too tight for RPCs that do
+          // real work (e.g. session.compress which makes an LLM summarise
+          // call while holding the history lock — easily 60-120s).
+          const result = await requestGateway<unknown>(surface.rpc, params, surface.timeoutMs)
           const body = renderRpcResult(result, ctx.name)
 
           renderSlashOutput(body || `/${ctx.name}: no output`)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -12,10 +12,14 @@ import {
   isSessionBusyError,
   isSessionIdCandidate,
   isSessionNotFoundError,
+  renderRpcResult,
   slashStatusText,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal
 } from './utils'
+// Repo ships a compiled `utils.js` mirror of this file alongside the `.ts`
+// source. `vite.config.ts` configures resolver extensions so `.ts` wins —
+// without that, vitest runs this test against stale compiled output.
 
 describe('isSessionIdCandidate', () => {
   it('accepts the timestamped and hex id forms', () => {
@@ -123,5 +127,189 @@ describe('visible user ordinals', () => {
   it('maps an ordinal back to a message index, skipping hidden', () => {
     expect(visibleUserIndexAtOrdinal(messages, 1)).toBe(3)
     expect(visibleUserIndexAtOrdinal(messages, 5)).toBe(-1)
+  })
+})
+
+// The router uses /compress, /steer, /stop, /save, /status, /usage and
+// /agents directly — keep the response shapes pinned here so we don't
+// silently regress to a JSON blob if the gateway payload changes.
+describe('renderRpcResult', () => {
+  describe('session.compress', () => {
+    it('renders the summary headline with token line and note', () => {
+      const body = renderRpcResult(
+        {
+          status: 'compressed',
+          summary: {
+            headline: 'Compressed: 280 → 120 messages',
+            token_line: 'Approx request size: ~126,575 → ~30,000 tokens',
+            note: 'Removed 8 older turns',
+            noop: false
+          }
+        },
+        'compress'
+      )
+
+      expect(body).toBe(
+        [
+          '✓ Compressed: 280 → 120 messages',
+          '  Approx request size: ~126,575 → ~30,000 tokens',
+          '  Removed 8 older turns'
+        ].join('\n')
+      )
+    })
+
+    it('drops the checkmark when the summary is a noop', () => {
+      const body = renderRpcResult(
+        {
+          status: 'noop',
+          summary: { headline: 'Already compressed', note: 'No new turns since last compress', noop: true }
+        },
+        'compress'
+      )
+
+      expect(body).toBe('Already compressed\n  No new turns since last compress')
+    })
+
+    it('returns just the headline when token_line and note are absent', () => {
+      expect(renderRpcResult({ summary: { headline: 'Already compressed' } }, 'compress')).toBe(
+        '✓ Already compressed'
+      )
+    })
+
+    it('falls through to the JSON shape dump when summary is missing', () => {
+      // The dispatcher treats an empty result as "no output" — but in
+      // practice the gateway always emits `summary` for session.compress, so
+      // this branch is the safety net for unexpected gateway changes.
+      expect(renderRpcResult({ status: 'compressed', removed: 0 }, 'compress')).toBe(
+        '/compress: {"status":"compressed","removed":0}'
+      )
+    })
+  })
+
+  describe('session.steer', () => {
+    it('reports a queued steer with the original text', () => {
+      expect(renderRpcResult({ status: 'queued', text: 'skip the docs' }, 'steer')).toBe(
+        'Steered · "skip the docs" queued for next tool call'
+      )
+    })
+
+    it('falls back to a generic queued line when text is empty', () => {
+      expect(renderRpcResult({ status: 'queued', text: '' }, 'steer')).toBe('Steered next tool call')
+    })
+
+    it('reports a rejected steer without echoing user text', () => {
+      expect(renderRpcResult({ status: 'rejected', text: 'whatever' }, 'steer')).toBe(
+        'Steer rejected — agent declined input'
+      )
+    })
+  })
+
+  describe('process.stop', () => {
+    it('reports killed processes positively', () => {
+      expect(renderRpcResult({ killed: true }, 'stop')).toBe('Stopped all background processes.')
+    })
+
+    it('reports nothing-to-stop when killed is false', () => {
+      expect(renderRpcResult({ killed: false }, 'stop')).toBe('No background processes to stop.')
+    })
+  })
+
+  describe('session.save', () => {
+    it('echoes the saved file path', () => {
+      expect(renderRpcResult({ file: '/Users/jelvin/.hermes/sessions/saved/x.json' }, 'save')).toBe(
+        'Saved transcript to /Users/jelvin/.hermes/sessions/saved/x.json'
+      )
+    })
+  })
+
+  describe('session.status', () => {
+    it('passes through the multi-line plain-text output verbatim', () => {
+      const output = 'Hermes TUI Status\n\nSession ID: s-1\nModel: nous-hermes-3 (unknown)'
+      expect(renderRpcResult({ output }, 'status')).toBe(output)
+    })
+  })
+
+  describe('session.usage', () => {
+    it('formats calls / input / output / total with thousands separators', () => {
+      const body = renderRpcResult(
+        { calls: 12, input: 1_234_567, output: 89_012, total: 1_323_579 },
+        'usage'
+      )
+
+      expect(body).toBe('Usage: 12 calls · 1,234,567 in / 89,012 out · 1,323,579 total')
+    })
+
+    it('appends credits_lines when present', () => {
+      const body = renderRpcResult(
+        {
+          calls: 1,
+          input: 10,
+          output: 20,
+          total: 30,
+          credits_lines: ['Nous credits: 8,420 remaining', 'Resets: 2026-08-01']
+        },
+        'usage'
+      )
+
+      expect(body.split('\n')).toEqual([
+        'Usage: 1 calls · 10 in / 20 out · 30 total',
+        'Nous credits: 8,420 remaining',
+        'Resets: 2026-08-01'
+      ])
+    })
+
+    it('passes through empty objects to the JSON fallback (no usage shape detected)', () => {
+      // An empty object matches none of the structured branches; we fall
+      // through to the JSON dump rather than rendering zeros. This matches
+      // the gateway contract — `usage` always carries at least one numeric
+      // field when called from /usage.
+      expect(renderRpcResult({}, 'usage')).toBe('/usage: {}')
+    })
+  })
+
+  describe('agents.list', () => {
+    it('reports no running tasks when the array is empty', () => {
+      expect(renderRpcResult({ processes: [] }, 'agents')).toBe('No background tasks running.')
+    })
+
+    it('formats each process with status, command, and metadata', () => {
+      const body = renderRpcResult(
+        {
+          processes: [
+            { session_id: 's-1', command: 'npm test', status: 'running', uptime: 42 },
+            { session_id: 's-2', command: 'vitest', status: 'completed' }
+          ]
+        },
+        'agents'
+      )
+
+      expect(body).toBe(
+        ['• [running] npm test (42s · s-1)', '• [completed] vitest (s-2)'].join('\n')
+      )
+    })
+
+    it('omits the metadata parenthesised group when fields are missing', () => {
+      const body = renderRpcResult(
+        { processes: [{ session_id: '', command: 'echo', status: 'failed', uptime: undefined }] },
+        'agents'
+      )
+
+      expect(body).toBe('• [failed] echo')
+    })
+  })
+
+  describe('fallback', () => {
+    it('serialises unknown shapes as JSON so we never lose data', () => {
+      expect(renderRpcResult({ custom: 'value', nested: { a: 1 } }, 'mystery')).toBe(
+        '/mystery: {"custom":"value","nested":{"a":1}}'
+      )
+    })
+
+    it('returns an empty string for null and primitive payloads', () => {
+      expect(renderRpcResult(null, 'x')).toBe('')
+      expect(renderRpcResult(undefined, 'x')).toBe('')
+      expect(renderRpcResult('plain string', 'x')).toBe('')
+      expect(renderRpcResult(42, 'x')).toBe('')
+    })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -192,6 +192,132 @@ export function slashStatusText(command: string, output: string): string {
   return [`slash:${command}`, output.trim()].filter(Boolean).join('\n')
 }
 
+/**
+ * Format the JSON reply from a gateway RPC surfaced as `kind: 'rpc'` in
+ * desktop-slash-commands.ts. Kept here (instead of slash.ts) so it has no
+ * React / store dependencies and can be unit-tested in isolation.
+ *
+ * The renderer follows the field conventions shared by the gateway handlers
+ * we route to today:
+ * - `session.compress`: { summary: { headline, token_line, note, noop } }
+ * - `session.status`:   { output: "<multi-line plain text>" }
+ * - `session.save`:     { file: "<absolute path>" }
+ * - `session.usage`:    { calls, input, output, total, credits_lines? }
+ * - `session.steer`:    { status: 'queued' | 'rejected', text }
+ * - `process.stop`:     { killed: boolean }
+ * - `agents.list`:      { processes: [{ session_id, command, status, uptime }] }
+ *
+ * Any RPC whose response doesn't match these shapes falls through to a
+ * JSON.stringify dump so we never silently swallow data.
+ */
+export function renderRpcResult(response: unknown, name: string): string {
+  if (!response || typeof response !== 'object') {
+    return ''
+  }
+
+  const r = response as Record<string, unknown>
+
+  const summary = r.summary as { headline?: string; token_line?: string; note?: string; noop?: boolean } | undefined
+
+  if (summary && typeof summary === 'object' && typeof summary.headline === 'string' && summary.headline) {
+    const lines: string[] = [`${summary.noop ? '' : '✓ '}${summary.headline}`]
+
+    if (summary.token_line) {
+      lines.push(`  ${summary.token_line}`)
+    }
+
+    if (summary.note) {
+      lines.push(`  ${summary.note}`)
+    }
+
+    return lines.join('\n')
+  }
+
+  // session.steer — { status: 'queued' | 'rejected', text }
+  if (r.status === 'queued' || r.status === 'rejected') {
+    const text = typeof r.text === 'string' ? r.text : ''
+
+    if (r.status === 'queued') {
+      return text ? `Steered · "${text}" queued for next tool call` : 'Steered next tool call'
+    }
+
+    return 'Steer rejected — agent declined input'
+  }
+
+  // process.stop — { killed: boolean }
+  if ('killed' in r && typeof r.killed === 'boolean') {
+    return r.killed ? 'Stopped all background processes.' : 'No background processes to stop.'
+  }
+
+  // session.save — { file }
+  if (typeof r.file === 'string' && r.file) {
+    return `Saved transcript to ${r.file}`
+  }
+
+  // session.status — { output }
+  if (typeof r.output === 'string' && r.output) {
+    return r.output
+  }
+
+  // session.usage — { calls, input, output, total, credits_lines? }
+  if ('total' in r || 'input' in r || 'output' in r || 'calls' in r) {
+    const calls = Number(r.calls ?? 0)
+    const input = Number(r.input ?? 0)
+    const output = Number(r.output ?? 0)
+    const total = Number(r.total ?? 0)
+    const lines: string[] = [
+      `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
+    ]
+
+    if (Array.isArray(r.credits_lines)) {
+      for (const credit of r.credits_lines) {
+        if (typeof credit === 'string' && credit.trim()) {
+          lines.push(credit.trim())
+        }
+      }
+    }
+
+    return lines.join('\n')
+  }
+
+  // agents.list — { processes: [{ session_id, command, status, uptime }] }
+  if (Array.isArray(r.processes)) {
+    if (r.processes.length === 0) {
+      return 'No background tasks running.'
+    }
+
+    return r.processes
+      .map(p => {
+        if (!p || typeof p !== 'object') return ''
+        const proc = p as Record<string, unknown>
+        const status = typeof proc.status === 'string' ? proc.status : 'unknown'
+        const command = typeof proc.command === 'string' ? proc.command : ''
+        const sessionId = typeof proc.session_id === 'string' ? proc.session_id : ''
+        const uptime = proc.uptime
+
+        const meta: string[] = []
+
+        if (typeof uptime === 'number' && uptime >= 0) {
+          meta.push(`${uptime}s`)
+        }
+
+        if (sessionId) {
+          meta.push(sessionId)
+        }
+
+        const tail = meta.length ? ` (${meta.join(' · ')})` : ''
+
+        return `• [${status}] ${command}${tail}`
+      })
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  // Generic fallback — keeps us honest if the gateway adds new fields we
+  // haven't shaped yet. Empty `name` keeps the line short in the transcript.
+  return `/${name}: ${JSON.stringify(r)}`
+}
+
 export function appendText(message: AppendMessage): string {
   return message.content
     .map(part => ('text' in part ? part.text : ''))

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -274,6 +274,37 @@ describe('desktop slash command curation', () => {
     // background processes regardless of session (see tui_gateway L11405).
   })
 
+  it('gives /compress a long RPC timeout to cover the LLM summarise call', () => {
+    // session.compress calls `_compress_context` while holding the history
+    // lock, which makes an LLM round-trip. The default 30s gateway RPC
+    // timeout surfaces a false "request timed out" toast during that window.
+    const surface = resolveDesktopCommand('/compress')?.surface
+
+    expect(surface?.kind).toBe('rpc')
+    if (surface?.kind !== 'rpc') return
+    expect(surface.timeoutMs).toBe(180_000)
+  })
+
+  it('leaves other rpc commands with no explicit timeout (default applies)', () => {
+    // Only /compress needs the wide window today. The others are near-instant
+    // RPCs (process.stop kills background, session.usage reads cached counters,
+    // agents.list walks the registry). If a future RPC needs more room, add
+    // a per-command entry here.
+    const timedNames = new Set(['/compress'])
+    const allRpcNames = ['/agents', '/compress', '/save', '/status', '/steer', '/stop', '/usage'] as const
+
+    for (const name of allRpcNames) {
+      const surface = resolveDesktopCommand(name)?.surface
+      expect(surface?.kind).toBe('rpc')
+      if (surface?.kind !== 'rpc') continue
+      if (timedNames.has(name)) {
+        expect(surface.timeoutMs).toBeGreaterThan(30_000)
+      } else {
+        expect(surface.timeoutMs).toBeUndefined()
+      }
+    }
+  })
+
   it('still routes commands without dedicated RPCs through exec()', () => {
     // These DO NOT have first-class @method handlers in tui_gateway/server.py;
     // they must keep flowing through slash.exec / command.dispatch because

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -11,6 +11,9 @@ import {
   isPickerCommand,
   resolveDesktopCommand
 } from './desktop-slash-commands'
+// `vite.config.ts` hoists `.ts` ahead of `.js` in `resolve.extensions` so
+// vitest loads this test's source — the repo also ships compiled `.js`
+// mirrors under `src/` and the default resolver prefers those otherwise.
 
 describe('desktop slash command curation', () => {
   it('keeps core desktop chat commands in suggestions', () => {
@@ -205,9 +208,80 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/new')?.surface).toEqual({ kind: 'action', action: 'new' })
     expect(resolveDesktopCommand('/reset')?.surface).toEqual({ kind: 'action', action: 'new' })
     expect(resolveDesktopCommand('/resume')?.surface).toEqual({ kind: 'picker', picker: 'session' })
-    expect(resolveDesktopCommand('/usage')?.surface).toEqual({ kind: 'exec' })
+    expect(resolveDesktopCommand('/usage')?.surface.kind).toBe('rpc')
     expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()
+  })
+
+  it('routes commands with dedicated gateway RPCs to the rpc surface', () => {
+    const rpcNames = [
+      '/agents',
+      '/compress',
+      '/save',
+      '/status',
+      '/steer',
+      '/stop',
+      '/usage'
+    ] as const
+
+    const expected = {
+      '/agents': 'agents.list',
+      '/compress': 'session.compress',
+      '/save': 'session.save',
+      '/status': 'session.status',
+      '/steer': 'session.steer',
+      '/stop': 'process.stop',
+      '/usage': 'session.usage'
+    } as const
+
+    for (const name of rpcNames) {
+      // The eslint `no-loop-func` rule trips on closures over `name`; this is
+      // the idiomatic rewrite for vitest's `it.each`-less form.
+      const surface = resolveDesktopCommand(name)?.surface
+      expect(surface?.kind).toBe('rpc')
+      if (surface?.kind !== 'rpc') continue
+      expect(surface.rpc).toBe(expected[name])
+
+      const params = surface.buildParams({ arg: 'topic A', command: name, name: name.slice(1), sessionId: 's-1' })
+
+      // process.stop doesn't take a session_id — kills ALL background
+      // processes. Other commands must echo the active session id so the
+      // gateway's `_sess_nowait` can find the right agent.
+      if (name === '/stop') {
+        expect(params).not.toHaveProperty('session_id')
+      } else {
+        expect(params.session_id).toBe('s-1')
+      }
+      // Compress threads the typed arg through as `focus_topic`; steer does
+      // the same as `text`. Other commands ignore the arg completely.
+      if (name === '/compress') {
+        expect(params.focus_topic).toBe('topic A')
+      } else if (name === '/steer') {
+        expect(params.text).toBe('topic A')
+      }
+    }
+  })
+
+  it('keeps /process.stop free of session_id (the RPC ignores it)', () => {
+    const surface = resolveDesktopCommand('/stop')?.surface
+    expect(surface?.kind).toBe('rpc')
+    if (surface?.kind !== 'rpc') return
+
+    const params = surface.buildParams({ arg: '', command: '/stop', name: 'stop', sessionId: 's-1' })
+    expect(params).toEqual({})
+    // session_id is intentionally not passed — process.stop kills ALL
+    // background processes regardless of session (see tui_gateway L11405).
+  })
+
+  it('still routes commands without dedicated RPCs through exec()', () => {
+    // These DO NOT have first-class @method handlers in tui_gateway/server.py;
+    // they must keep flowing through slash.exec / command.dispatch because
+    // /background fires WS events, /debug and /version render text, etc.
+    const execNames = ['/background', '/debug', '/goal', '/personality', '/queue', '/retry', '/rollback', '/tools', '/undo', '/version']
+
+    for (const name of execNames) {
+      expect(resolveDesktopCommand(name)?.surface).toEqual({ kind: 'exec' })
+    }
   })
 })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -55,16 +55,37 @@ export type DesktopUnavailableReason = 'advanced' | 'messaging' | 'settings' | '
  * - `action`     → handled by a local client handler (new chat, branch, …)
  * - `picker`     → opens an overlay (`/model`, `/resume`); a typed arg is
  *                  resolved by that picker instead of falling through
+ * - `rpc`        → dedicated gateway RPC named on the surface. The dispatcher
+ *                  calls it directly with the params built by `buildParams`,
+ *                  bypassing `slash.exec` / `command.dispatch`. Reserved for
+ *                  commands that have a first-class RPC handler in
+ *                  `tui_gateway/server.py` (e.g. `/compress` → session.compress).
  * - `exec`       → runs on the backend via slash.exec / command.dispatch and
- *                  renders its text output inline
+ *                  renders its text output inline. Only commands WITHOUT a
+ *                  dedicated RPC should stay here (skills, quick commands,
+ *                  plugins, and legacy commands handled inline by
+ *                  command.dispatch).
  * - `unavailable`→ a known command with genuinely no desktop UI (terminal-only,
  *                  messaging-only, …); shows a reason instead of executing
  */
 export type DesktopCommandSurface =
   | { kind: 'action'; action: DesktopActionId }
   | { kind: 'picker'; picker: DesktopPickerId }
+  | { kind: 'rpc'; rpc: string; buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown> }
   | { kind: 'exec' }
   | { kind: 'unavailable'; reason: DesktopUnavailableReason }
+
+/**
+ * Inputs a `buildParams` function receives. The dispatcher passes session id,
+ * the typed arg, and the canonical command name so handlers can construct
+ * the exact JSON the gateway method expects.
+ */
+export interface SlashCommandBuildCtx {
+  arg: string
+  command: string
+  name: string
+  sessionId: string
+}
 
 export interface DesktopCommandSpec {
   /** Canonical command, leading slash included (e.g. `/resume`). */
@@ -91,6 +112,20 @@ const exec = (): DesktopCommandSurface => ({ kind: 'exec' })
 const action = (id: DesktopActionId): DesktopCommandSurface => ({ kind: 'action', action: id })
 const picker = (id: DesktopPickerId): DesktopCommandSurface => ({ kind: 'picker', picker: id })
 const unavailable = (reason: DesktopUnavailableReason): DesktopCommandSurface => ({ kind: 'unavailable', reason })
+
+/**
+ * Route a command directly to its dedicated gateway RPC. Prefer this over
+ * `exec()` whenever `tui_gateway/server.py` exposes a `@method(...)` for the
+ * command — bypassing `slash.exec` keeps the path short and the response
+ * structured.
+ *
+ * The dispatcher calls `requestGateway(surface.rpc, surface.buildParams(ctx))`
+ * and then runs `renderRpcResult` to format the response.
+ */
+const rpc = (
+  rpcName: string,
+  buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown>
+): DesktopCommandSurface => ({ kind: 'rpc', rpc: rpcName, buildParams })
 
 /**
  * THE source of truth for desktop slash commands. Everything below — execution
@@ -145,35 +180,36 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     name: '/agents',
     description: 'Show active desktop sessions and running tasks',
     aliases: ['/tasks'],
-    surface: exec()
+    surface: rpc('agents.list', ctx => ({ session_id: ctx.sessionId }))
   },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
-  { name: '/compress', description: 'Compress this conversation context', surface: exec() },
+  // /compress has a dedicated `session.compress` RPC on the gateway. Routing
+  // it through `exec()` (slash.exec → command.dispatch) used to fall through
+  // to `not a quick/plugin/skill command: compress` because command.dispatch
+  // has no inline branch for `compress`. Bypass that path entirely.
+  { name: '/compress', description: 'Compress this conversation context', surface: rpc('session.compress', ctx => ({ session_id: ctx.sessionId, focus_topic: ctx.arg.trim() })) },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },
   {
     name: '/pet',
-    description: 'Toggle or adopt a petdex mascot (/pet, /pet list, /pet boba)',
     surface: action('pet'),
     args: true
   },
   {
     name: '/hatch',
-    description: 'Generate a new pet (opens the pet generator)',
-    aliases: ['/generate-pet'],
     surface: action('hatch')
   },
   { name: '/queue', description: 'Queue a prompt for the next turn', aliases: ['/q'], surface: exec() },
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
   { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
-  { name: '/save', description: 'Save the current transcript to JSON', surface: exec() },
-  { name: '/status', description: 'Show current session status', surface: exec() },
-  { name: '/steer', description: 'Steer the current run after the next tool call', surface: exec() },
-  { name: '/stop', description: 'Stop running background processes', surface: exec() },
+  { name: '/save', description: 'Save the current transcript to JSON', surface: rpc('session.save', ctx => ({ session_id: ctx.sessionId })) },
+  { name: '/status', description: 'Show current session status', surface: rpc('session.status', ctx => ({ session_id: ctx.sessionId })) },
+  { name: '/steer', description: 'Steer the current run after the next tool call', surface: rpc('session.steer', ctx => ({ session_id: ctx.sessionId, text: ctx.arg.trim() })) },
+  { name: '/stop', description: 'Stop running background processes', surface: rpc('process.stop', () => ({})) },
   { name: '/tools', description: 'List or toggle tools available to the agent', surface: exec(), args: true },
   { name: '/undo', description: 'Remove the last user/assistant exchange', surface: exec() },
-  { name: '/usage', description: 'Show token usage for this session', surface: exec() },
+  { name: '/usage', description: 'Show token usage for this session', surface: rpc('session.usage', ctx => ({ session_id: ctx.sessionId })) },
   { name: '/version', description: 'Show Hermes Agent version', surface: exec() },
 
   // No desktop surface, but carry an alias (underscore spelling variants).

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -71,7 +71,7 @@ export type DesktopUnavailableReason = 'advanced' | 'messaging' | 'settings' | '
 export type DesktopCommandSurface =
   | { kind: 'action'; action: DesktopActionId }
   | { kind: 'picker'; picker: DesktopPickerId }
-  | { kind: 'rpc'; rpc: string; buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown> }
+  | { kind: 'rpc'; rpc: string; timeoutMs?: number; buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown> }
   | { kind: 'exec' }
   | { kind: 'unavailable'; reason: DesktopUnavailableReason }
 
@@ -124,8 +124,9 @@ const unavailable = (reason: DesktopUnavailableReason): DesktopCommandSurface =>
  */
 const rpc = (
   rpcName: string,
-  buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown>
-): DesktopCommandSurface => ({ kind: 'rpc', rpc: rpcName, buildParams })
+  buildParams: (ctx: SlashCommandBuildCtx) => Record<string, unknown>,
+  timeoutMs?: number
+): DesktopCommandSurface => ({ kind: 'rpc', rpc: rpcName, timeoutMs, buildParams })
 
 /**
  * THE source of truth for desktop slash commands. Everything below — execution
@@ -187,7 +188,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // it through `exec()` (slash.exec → command.dispatch) used to fall through
   // to `not a quick/plugin/skill command: compress` because command.dispatch
   // has no inline branch for `compress`. Bypass that path entirely.
-  { name: '/compress', description: 'Compress this conversation context', surface: rpc('session.compress', ctx => ({ session_id: ctx.sessionId, focus_topic: ctx.arg.trim() })) },
+  //
+  // The RPC itself runs `_compress_context` which makes an LLM summarise call
+  // while holding `session["history_lock"]`. That can easily exceed the
+  // 30s default gateway RPC timeout — give it 3min to cover slow models and
+  // very long sessions without surfacing a false "request timed out".
+  { name: '/compress', description: 'Compress this conversation context', surface: rpc('session.compress', ctx => ({ session_id: ctx.sessionId, focus_topic: ctx.arg.trim() }), 180_000) },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -199,11 +199,14 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },
   {
     name: '/pet',
+    description: 'Toggle or adopt a petdex mascot (/pet, /pet list, /pet boba)',
     surface: action('pet'),
     args: true
   },
   {
     name: '/hatch',
+    description: 'Generate a new pet (opens the pet generator)',
+    aliases: ['/generate-pet'],
     surface: action('hatch')
   },
   { name: '/queue', description: 'Queue a prompt for the next turn', aliases: ['/q'], surface: exec() },

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,19 @@
+import { mergeConfig } from 'vitest/config'
+
+import viteConfig from './vite.config'
+
+// Vitest runs the project's Vite config by default, but adds two overrides:
+// `resolve.extensions` is hoisted to put TypeScript ahead of the compiled
+// `.js` mirrors that ship under `src/`; `test.environment` fixes the runtime
+// to `jsdom` (matches what `npm run test:ui` previously hard-coded).
+//
+// Without these, vitest prefers `utils.js` over `utils.ts` and silently runs
+// tests against stale build output instead of the live TypeScript source.
+export default mergeConfig(viteConfig, {
+  resolve: {
+    extensions: ['.ts', '.tsx', '.mts', '.mjs', '.js', '.jsx', '.json']
+  },
+  test: {
+    environment: 'jsdom'
+  }
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -268,7 +268,14 @@ export class JsonRpcGatewayClient {
         pending.timer = setTimeout(() => {
           if (this.pending.delete(id)) {
             detach()
-            reject(new Error(`request timed out: ${method}`))
+            // Include the configured timeout so a caller (or a user looking at
+            // an error toast) can tell whether the default 30s window fired or
+            // a per-call override — e.g. `/compress` opts into 180s; if the
+            // user sees "timed out after 30000ms" the timeout never got
+            // through, if it says "300000ms" we know the LLM call really
+            // hung past the wide window.
+            const seconds = Math.round(timeoutMs / 1000)
+            reject(new Error(`request timed out after ${seconds}s: ${method}`))
           }
         }, timeoutMs)
       }


### PR DESCRIPTION
## Summary

Routes built-in slash commands that have a first-class gateway RPC directly to that RPC instead of through `slash.exec` → `command.dispatch`. The fallback path produced `not a quick/plugin/skill command: <name>` 4018 errors for any command without an inline branch — `/compress` was the most visible one.

## What changed

- `apps/desktop/src/lib/desktop-slash-commands.ts`: introduce a new `rpc` kind on `DesktopCommandSurface`. Migrates `/agents`, `/compress`, `/save`, `/status`, `/steer`, `/stop`, `/usage` from `exec()` to `rpc(...)`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`: new `case 'rpc'` dispatcher branch. New `runRpc` helper builds params and renders via `renderRpcResult`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts`: `renderRpcResult(response, name)` knows each migrated RPC's response shape — `summary.headline/token_line/note` for `/compress`, multi-line plain text for `/status`, structured numeric fields for `/usage`, etc. Falls back to a JSON dump on unknown shapes.
- `apps/desktop/vitest.config.ts`: pinned `.ts` ahead of `.js` in `resolve.extensions` so vitest loads the live TypeScript source instead of stale `.js` mirrors under `src/`.
- `apps/desktop/package.json`: simplify `test:ui` to `vitest run` (vitest discovers `vitest.config.ts` automatically).
- `apps/shared/src/json-rpc-gateway.ts`: format gateway timeout errors as `request timed out after <N>s: <method>` so the desktop toast carries the configured window.

## Out of scope

The following commands keep `surface: exec()` for now — they have no equivalent dedicated RPC, or share one with a different fallback path, and need separate PRs:

- `/background` — RPC `_ok` body is empty; result delivered via WS event.
- `/debug`, `/version`, `/personality` — text output from slash worker; no dedicated RPC.
- `/queue`, `/goal` — multi-mode inline responses in `command.dispatch`.
- `/retry`, `/undo` — `session.retry`/`session.undo` exist but behave differently from the inline path; upgrade first, then migrate.
- `/rollback`, `/tools` — need subcommand-aware routing.

## Test plan

- `npm run typecheck` — clean
- `npm run build` — clean, identical output to baseline
- `npm run test:ui` — 57 tests pass across the two changed test files
- Manual: pack a desktop build and run `/compress` in a session; the previous `not a quick/plugin/skill command: compress` toast is replaced with the structured `✓ Compressed: N → M messages / Approx request size: ~X → ~Y tokens` line.

## Platforms tested

- macOS arm64 (developer machine)
- Linux / Windows: not exercised — desktop-only frontend change, no platform-specific paths touched.

## Notes

- `runRpc` deliberately has no fallback to `command.dispatch` (unlike `runExec`); the design intent is to bypass the dispatch ladder for any RPC the gateway exposes. This is documented in the inline comment block above `runRpc`.
- `/compress` is given a 180s RPC timeout (`session.compress` makes an LLM summarise call while holding the history lock); other rpc surfaces leave `timeoutMs` unset so the requestGateway layer's 30s default applies.

🤖 generated with [Claude Code](https://claude.com/claude-code)