### PR TITLE
fix(kanban): make Telegram task notifications durable

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -268,7 +268,7 @@ class GatewayKanbanWatchersMixin:
                                         sub.get("task_id"), platform or "<missing>",
                                     )
                                     continue
-                                old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
+                                old_cursor, cursor, events = _kb.claim_unseen_lineage_events_for_sub(
                                     conn,
                                     task_id=sub["task_id"],
                                     platform=sub["platform"],
@@ -279,6 +279,17 @@ class GatewayKanbanWatchersMixin:
                                 if not events:
                                     continue
                                 task = _kb.get_task(conn, sub["task_id"])
+                                outboxes = {}
+                                for ev in events:
+                                    event_task = _kb.get_task(conn, ev.task_id)
+                                    visible = ev.kind in {"blocked", "gave_up", "crashed", "timed_out"} or (
+                                        ev.kind == "completed" and ev.task_id == sub["task_id"]
+                                    )
+                                    if visible and event_task is not None:
+                                        lineage_sub = dict(sub, root_task_id=sub["task_id"], event_task_id=ev.task_id)
+                                        outboxes[ev.id] = _kb.enqueue_notify_outbox(
+                                            conn, sub=lineage_sub, event=ev, tenant=event_task.tenant,
+                                        )
                                 logger.debug(
                                     "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
                                     len(events), sub["task_id"], slug, old_cursor, cursor,
@@ -289,6 +300,7 @@ class GatewayKanbanWatchersMixin:
                                     "cursor": cursor,
                                     "events": events,
                                     "task": task,
+                                    "outboxes": outboxes,
                                     "board": slug,
                                 })
                         finally:
@@ -338,10 +350,35 @@ class GatewayKanbanWatchersMixin:
                     board_tag = f"[{board_slug}] " if board_slug else ""
                     for ev in d["events"]:
                         kind = ev.kind
+                        outbox = d.get("outboxes", {}).get(ev.id)
+                        if outbox and outbox["state"] in {"sent", "acknowledged", "dead_letter"}:
+                            continue
+                        if (
+                            outbox and outbox["state"] == "failed"
+                            and int(outbox["next_attempt_at"] or 0) > int(time.time())
+                        ):
+                            await asyncio.to_thread(
+                                self._kanban_rewind, sub, d["cursor"],
+                                d.get("old_cursor", 0), board_slug,
+                            )
+                            break
+                        event_task = task
+                        if ev.task_id != sub["task_id"]:
+                            def _load_event_task():
+                                conn = _kb.connect(board=board_slug)
+                                try:
+                                    return _kb.get_task(conn, ev.task_id)
+                                finally:
+                                    conn.close()
+                            event_task = await asyncio.to_thread(_load_event_task)
+                        if kind == "completed" and ev.task_id != sub["task_id"]:
+                            continue
+                        if kind in {"status", "archived", "unblocked"}:
+                            continue
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
-                        who = (task.assignee if task and task.assignee else None)
+                        who = (event_task.assignee if event_task and event_task.assignee else None)
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
                             # Prefer the run's summary (the worker's
@@ -369,7 +406,14 @@ class GatewayKanbanWatchersMixin:
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
+                            child_context = (
+                                f" on {event_task.title[:120]}"
+                                if event_task and ev.task_id != sub["task_id"] else ""
+                            )
+                            msg = (
+                                f"⏸ {board_tag}{tag}Kanban blocked — needs your input"
+                                f"{child_context}{reason}\nReply to this message with the answer."
+                            )
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
@@ -413,9 +457,22 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            outbox = d.get("outboxes", {}).get(ev.id)
+                            if outbox:
+                                receipt = getattr(send_result, "message_id", None)
+                                def _mark_sent():
+                                    conn = _kb.connect(board=board_slug)
+                                    try:
+                                        _kb.mark_notify_outbox(
+                                            conn, outbox["id"], state="sent",
+                                            receipt=str(receipt) if receipt else None,
+                                        )
+                                    finally:
+                                        conn.close()
+                                await asyncio.to_thread(_mark_sent)
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
@@ -446,6 +503,18 @@ class GatewayKanbanWatchersMixin:
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
                         except Exception as exc:
+                            outbox = d.get("outboxes", {}).get(ev.id)
+                            if outbox:
+                                def _mark_failed():
+                                    conn = _kb.connect(board=board_slug)
+                                    try:
+                                        _kb.mark_notify_outbox(
+                                            conn, outbox["id"], state="failed",
+                                            error=str(exc)[:500],
+                                        )
+                                    finally:
+                                        conn.close()
+                                await asyncio.to_thread(_mark_failed)
                             fails = sub_fail_counts.get(sub_key, 0) + 1
                             sub_fail_counts[sub_key] = fails
                             logger.warning(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4593,6 +4593,46 @@ class BasePlatformAdapter(ABC):
         if not self._message_handler:
             return
 
+        # A reply to a durable Kanban blocker notification is an explicit,
+        # narrow correlation signal. Never consume arbitrary chat messages:
+        # require a reply to this bot's exact recorded outbound receipt.
+        if (
+            event.message_type == MessageType.TEXT
+            and event.reply_to_is_own_message
+            and event.reply_to_message_id
+            and event.text.strip()
+        ):
+            def _consume_kanban_reply():
+                try:
+                    from hermes_cli import kanban_db as _kb
+                    platform = _platform_name(event.source.platform)
+                    for meta in _kb.list_boards(include_archived=False):
+                        conn = _kb.connect(board=meta.get("slug"))
+                        try:
+                            task_id = _kb.acknowledge_notify_reply(
+                                conn, platform=platform,
+                                chat_id=str(event.source.chat_id),
+                                thread_id=event.source.thread_id,
+                                receipt=str(event.reply_to_message_id),
+                                reply=event.text,
+                                user_id=event.source.user_id,
+                            )
+                            if task_id:
+                                return task_id
+                        finally:
+                            conn.close()
+                except Exception:
+                    logger.warning("kanban blocker reply correlation failed", exc_info=True)
+                return None
+            answered_task = await asyncio.to_thread(_consume_kanban_reply)
+            if answered_task:
+                await self.send(
+                    event.source.chat_id,
+                    "Thanks — I attached your answer and resumed the blocked task.",
+                    metadata=_thread_metadata_for_source(event.source, event.message_id),
+                )
+                return
+
         coerce_plaintext_gateway_command(event)
 
         # Rewrite ``event.source.thread_id`` via the installed recovery hook

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1263,6 +1263,27 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+CREATE TABLE IF NOT EXISTS kanban_notify_outbox (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    root_task_id     TEXT NOT NULL,
+    task_id          TEXT NOT NULL,
+    event_id         INTEGER NOT NULL,
+    event_kind       TEXT NOT NULL,
+    platform         TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    thread_id        TEXT NOT NULL DEFAULT '',
+    notifier_profile TEXT,
+    tenant           TEXT,
+    state            TEXT NOT NULL DEFAULT 'pending',
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at  INTEGER NOT NULL DEFAULT 0,
+    message_receipt  TEXT,
+    last_error       TEXT,
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    UNIQUE(root_task_id, task_id, event_id, platform, chat_id, thread_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1273,6 +1294,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_notify_outbox_pending ON kanban_notify_outbox(state, next_attempt_at);
 """
 
 
@@ -2898,6 +2920,68 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
         (task_id,),
     ).fetchall()
     return [r["child_id"] for r in rows]
+
+
+def root_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    """Return every root ancestor, preserving board and tenant isolation."""
+    row = conn.execute("SELECT tenant FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row is None:
+        return []
+    rows = conn.execute(
+        """
+        WITH RECURSIVE ancestors(id) AS (
+            SELECT ? UNION SELECT l.parent_id FROM task_links l
+            JOIN ancestors a ON l.child_id = a.id
+            JOIN tasks p ON p.id = l.parent_id WHERE p.tenant IS ?
+        )
+        SELECT a.id FROM ancestors a
+        WHERE NOT EXISTS (SELECT 1 FROM task_links l WHERE l.child_id = a.id)
+        ORDER BY a.id
+        """, (task_id, row["tenant"]),
+    ).fetchall()
+    return [r["id"] for r in rows] or [task_id]
+
+
+def task_rollup(conn: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    """Summarize descendant progress and the deepest actionable blocker."""
+    task = get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"unknown task {task_id}")
+    rows = conn.execute(
+        """
+        WITH RECURSIVE descendants(id, depth) AS (
+            SELECT child_id, 1 FROM task_links WHERE parent_id = ?
+            UNION ALL SELECT l.child_id, d.depth + 1 FROM task_links l
+            JOIN descendants d ON l.parent_id = d.id
+        )
+        SELECT t.*, d.depth FROM descendants d JOIN tasks t ON t.id = d.id
+        WHERE t.tenant IS ? ORDER BY d.depth DESC, t.created_at ASC
+        """, (task_id, task.tenant),
+    ).fetchall()
+    active = [r for r in rows if r["status"] not in {"done", "archived"}]
+    blockers = [r for r in active if r["status"] in {"blocked", "review"}]
+    blocker = blockers[0] if blockers else None
+    reason = None
+    if blocker:
+        ev = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked' ORDER BY id DESC LIMIT 1",
+            (blocker["id"],),
+        ).fetchone()
+        if ev and ev["payload"]:
+            try:
+                reason = json.loads(ev["payload"]).get("reason")
+            except Exception:
+                pass
+    return {
+        "total_workstreams": len(rows),
+        "completed_workstreams": sum(r["status"] == "done" for r in rows),
+        "active_descendants": [r["id"] for r in active],
+        "effective_status": "blocked" if blocker else task.status,
+        "actionable_blocker": ({"task_id": blocker["id"], "title": blocker["title"],
+                                "status": blocker["status"], "reason": reason}
+                               if blocker else None),
+        "required_action": reason,
+    }
 
 
 def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
@@ -8281,6 +8365,104 @@ def list_notify_subs(
     return [dict(r) for r in rows]
 
 
+def notify_subs_for_task_lineage(conn: sqlite3.Connection, task_id: str) -> list[dict]:
+    """Subscriptions on this task or any root ancestor.
+
+    Returned rows carry ``root_task_id`` and ``event_task_id`` so the gateway
+    can report the child while retaining the originating subscription.
+    """
+    out: list[dict] = []
+    for root_id in root_ids(conn, task_id):
+        for sub in list_notify_subs(conn, root_id):
+            sub["root_task_id"] = root_id
+            sub["event_task_id"] = task_id
+            out.append(sub)
+    return out
+
+
+def enqueue_notify_outbox(
+    conn: sqlite3.Connection, *, sub: dict, event: Event, tenant: Optional[str]
+) -> dict:
+    """Persist a deduplicated notification before any network attempt."""
+    now = int(time.time())
+    root_id = sub.get("root_task_id") or sub["task_id"]
+    event_task_id = sub.get("event_task_id") or event.task_id
+    with write_txn(conn):
+        conn.execute(
+            """INSERT OR IGNORE INTO kanban_notify_outbox
+               (root_task_id, task_id, event_id, event_kind, platform, chat_id,
+                thread_id, notifier_profile, tenant, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (root_id, event_task_id, event.id, event.kind, sub["platform"],
+             sub["chat_id"], sub.get("thread_id") or "",
+             sub.get("notifier_profile"), tenant, now, now),
+        )
+        row = conn.execute(
+            """SELECT * FROM kanban_notify_outbox WHERE root_task_id=? AND task_id=?
+               AND event_id=? AND platform=? AND chat_id=? AND thread_id=?""",
+            (root_id, event_task_id, event.id, sub["platform"], sub["chat_id"],
+             sub.get("thread_id") or ""),
+        ).fetchone()
+    return dict(row)
+
+
+def mark_notify_outbox(
+    conn: sqlite3.Connection, outbox_id: int, *, state: str,
+    receipt: Optional[str] = None, error: Optional[str] = None,
+) -> None:
+    """Record an attempt outcome with bounded exponential retry timing."""
+    if state not in {"pending", "sent", "failed", "acknowledged", "dead_letter"}:
+        raise ValueError(f"invalid notification state {state!r}")
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute("SELECT attempts FROM kanban_notify_outbox WHERE id=?", (outbox_id,)).fetchone()
+        if row is None:
+            return
+        attempts = int(row["attempts"]) + 1
+        if state == "failed" and attempts >= 5:
+            state = "dead_letter"
+        next_attempt = now + min(3600, 5 * (2 ** min(attempts - 1, 8))) if state == "failed" else 0
+        conn.execute(
+            """UPDATE kanban_notify_outbox SET state=?, attempts=?, next_attempt_at=?,
+               message_receipt=COALESCE(?, message_receipt), last_error=?, updated_at=? WHERE id=?""",
+            (state, attempts, next_attempt, receipt, error, now, outbox_id),
+        )
+
+
+def list_notify_outbox(conn: sqlite3.Connection, *, state: Optional[str] = None) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM kanban_notify_outbox" + (" WHERE state=?" if state else "") + " ORDER BY id",
+        ((state,) if state else ()),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def acknowledge_notify_reply(
+    conn: sqlite3.Connection, *, platform: str, chat_id: str,
+    thread_id: Optional[str], receipt: str, reply: str, user_id: Optional[str] = None,
+) -> Optional[str]:
+    """Correlate an explicit reply to a sent blocker, comment, and unblock it."""
+    if not reply.strip() or not receipt:
+        return None
+    row = conn.execute(
+        """SELECT o.* FROM kanban_notify_outbox o JOIN tasks t ON t.id=o.task_id
+           WHERE o.platform=? AND o.chat_id=? AND o.thread_id=?
+             AND o.message_receipt=? AND o.event_kind='blocked' AND o.state='sent'
+             AND t.status IN ('blocked', 'review') ORDER BY o.id DESC LIMIT 1""",
+        (platform, chat_id, thread_id or "", receipt),
+    ).fetchone()
+    if row is None:
+        return None
+    add_comment(conn, row["task_id"], f"gateway:{user_id or 'user'}", reply.strip())
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_notify_outbox SET state='acknowledged', updated_at=? WHERE id=?",
+            (int(time.time()), row["id"]),
+        )
+    unblock_task(conn, row["task_id"])
+    return row["task_id"]
+
+
 def remove_notify_sub(
     conn: sqlite3.Connection,
     *,
@@ -8396,6 +8578,49 @@ def claim_unseen_events_for_sub(
             (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
         )
         return old_cursor, new_cursor, events
+
+
+def claim_unseen_lineage_events_for_sub(
+    conn: sqlite3.Connection, *, task_id: str, platform: str, chat_id: str,
+    thread_id: Optional[str] = None, kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, int, list[Event]]:
+    """Claim relevant events from a subscribed root and all descendants."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_subs WHERE task_id=? AND platform=? AND chat_id=? AND thread_id=?",
+            (task_id, platform, chat_id, thread_id or ""),
+        ).fetchone()
+        if row is None:
+            return 0, 0, []
+        old = int(row["last_event_id"])
+        kind_list = list(kinds) if kinds else []
+        placeholders = ",".join("?" for _ in kind_list)
+        rows = conn.execute(
+            """WITH RECURSIVE lineage(id) AS (
+                   SELECT ? UNION SELECT l.child_id FROM task_links l JOIN lineage x ON l.parent_id=x.id
+                   JOIN tasks child ON child.id=l.child_id
+                   JOIN tasks root ON root.id=? AND child.tenant IS root.tenant
+               ) SELECT e.* FROM task_events e JOIN lineage x ON x.id=e.task_id
+               WHERE e.id > ? """ + (f"AND e.kind IN ({placeholders}) " if kind_list else "") +
+            "ORDER BY e.id ASC",
+            [task_id, task_id, old, *kind_list],
+        ).fetchall()
+        events = []
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            events.append(Event(id=r["id"], task_id=r["task_id"], kind=r["kind"],
+                                payload=payload, created_at=r["created_at"], run_id=r["run_id"]))
+        if not events:
+            return old, old, []
+        new = max(e.id for e in events)
+        conn.execute(
+            "UPDATE kanban_notify_subs SET last_event_id=? WHERE task_id=? AND platform=? AND chat_id=? AND thread_id=? AND last_event_id=?",
+            (new, task_id, platform, chat_id, thread_id or "", old),
+        )
+        return old, new, events
 
 
 def advance_notify_cursor(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7964,8 +7964,15 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        reply_to_is_own = False
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
+            replied_user = getattr(message.reply_to_message, "from_user", None)
+            reply_to_is_own = bool(
+                replied_user is not None
+                and self._bot is not None
+                and getattr(replied_user, "id", None) == getattr(self._bot, "id", None)
+            )
             quote = getattr(message, "quote", None)
             quote_text = getattr(quote, "text", None) if quote is not None else None
             if quote_text:
@@ -8008,6 +8015,7 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/tests/gateway/test_kanban_descendant_notifications.py
+++ b/tests/gateway/test_kanban_descendant_notifications.py
@@ -1,0 +1,180 @@
+import asyncio
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    def __init__(self, *, fail=False):
+        self.sent = []
+        self.fail = fail
+
+    async def send(self, chat_id, text, metadata=None):
+        if self.fail:
+            raise RuntimeError("temporary telegram failure")
+        self.sent.append((chat_id, text, metadata or {}))
+        return type("Receipt", (), {"message_id": "tg-42"})()
+
+
+async def _tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def sleep(delay):
+        if delay == 5:
+            return
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+def _graph(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "board.db"))
+    kb.init_db()
+    conn = kb.connect()
+    root = kb.create_task(conn, title="Root project", assignee="orchestrator", tenant="acme")
+    child = kb.create_task(conn, title="Configure production", assignee="engineer", tenant="acme")
+    kb.link_tasks(conn, root, child)
+    # Model a child already claimed by a worker. The parent/child edge normally
+    # comes from decomposition before the worker reaches this state.
+    conn.execute("UPDATE tasks SET status='running' WHERE id=?", (child,))
+    kb.add_notify_sub(conn, task_id=root, platform="telegram", chat_id="chat", thread_id="topic")
+    return conn, root, child
+
+
+def test_child_blocker_rolls_up_and_delivers_once(tmp_path, monkeypatch):
+    conn, root, child = _graph(tmp_path, monkeypatch)
+    kb.block_task(conn, child, reason="Which region should be used?", kind="needs_input")
+    rollup = kb.task_rollup(conn, root)
+    assert rollup["effective_status"] == "blocked"
+    assert rollup["actionable_blocker"]["task_id"] == child
+    conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0][2]["thread_id"] == "topic"
+    assert "Which region" in adapter.sent[0][1]
+    assert "Configure production" in adapter.sent[0][1]
+
+    conn = kb.connect()
+    outbox = kb.list_notify_outbox(conn)
+    assert [(r["state"], r["message_receipt"], r["task_id"]) for r in outbox] == [("sent", "tg-42", child)]
+    conn.close()
+
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+    assert len(adapter.sent) == 1
+
+
+def test_changed_blocker_gets_new_version_and_child_success_is_silent(tmp_path, monkeypatch):
+    conn, root, child = _graph(tmp_path, monkeypatch)
+    kb.block_task(conn, child, reason="first question", kind="needs_input")
+    conn.close()
+    adapter = RecordingAdapter()
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+
+    conn = kb.connect()
+    kb.unblock_task(conn, child)
+    conn.execute("UPDATE tasks SET status='running' WHERE id=?", (child,))
+    kb.block_task(conn, child, reason="different question", kind="capability")
+    conn.close()
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+    assert len(adapter.sent) == 2
+    assert "different question" in adapter.sent[-1][1]
+
+
+def test_failed_send_is_durable_and_tenant_is_stamped(tmp_path, monkeypatch):
+    conn, _, child = _graph(tmp_path, monkeypatch)
+    kb.block_task(conn, child, reason="need approval", kind="needs_input")
+    conn.close()
+    asyncio.run(_tick(monkeypatch, _runner(RecordingAdapter(fail=True))))
+    conn = kb.connect()
+    rows = kb.list_notify_outbox(conn)
+    assert len(rows) == 1
+    assert rows[0]["state"] == "failed"
+    assert rows[0]["attempts"] == 1
+    assert rows[0]["next_attempt_at"] > rows[0]["updated_at"]
+    assert rows[0]["tenant"] == "acme"
+    conn.close()
+
+
+def test_failed_send_retries_after_restart_when_backoff_is_due(tmp_path, monkeypatch):
+    conn, _, child = _graph(tmp_path, monkeypatch)
+    kb.block_task(conn, child, reason="retry this question", kind="needs_input")
+    conn.close()
+    asyncio.run(_tick(monkeypatch, _runner(RecordingAdapter(fail=True))))
+
+    conn = kb.connect()
+    conn.execute("UPDATE kanban_notify_outbox SET next_attempt_at=0 WHERE task_id=?", (child,))
+    conn.close()
+
+    replacement_adapter = RecordingAdapter()
+    asyncio.run(_tick(monkeypatch, _runner(replacement_adapter)))
+    assert len(replacement_adapter.sent) == 1
+    conn = kb.connect()
+    row = kb.list_notify_outbox(conn)[0]
+    assert (row["state"], row["attempts"], row["message_receipt"]) == ("sent", 2, "tg-42")
+    conn.close()
+
+
+def test_correlated_reply_comments_unblocks_and_acknowledges(tmp_path, monkeypatch):
+    conn, _, child = _graph(tmp_path, monkeypatch)
+    kb.block_task(conn, child, reason="Which region?", kind="needs_input")
+    conn.close()
+    asyncio.run(_tick(monkeypatch, _runner(RecordingAdapter())))
+
+    conn = kb.connect()
+    answered = kb.acknowledge_notify_reply(
+        conn, platform="telegram", chat_id="chat", thread_id="topic",
+        receipt="tg-42", reply="Use eu-west-1", user_id="sam",
+    )
+    assert answered == child
+    task = kb.get_task(conn, child)
+    assert task is not None
+    assert task.status == "todo"  # dependency remains; the blocker itself is cleared
+    assert kb.list_notify_outbox(conn)[0]["state"] == "acknowledged"
+    assert kb.list_comments(conn, child)[-1].body == "Use eu-west-1"
+    assert kb.acknowledge_notify_reply(
+        conn, platform="telegram", chat_id="other", thread_id="topic",
+        receipt="tg-42", reply="wrong chat",
+    ) is None
+    conn.close()
+
+
+def test_root_completion_notifies_but_child_completion_does_not(tmp_path, monkeypatch):
+    conn, root, child = _graph(tmp_path, monkeypatch)
+    kb.complete_task(conn, child, summary="child done")
+    conn.close()
+    adapter = RecordingAdapter()
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+    assert adapter.sent == []
+
+    conn = kb.connect()
+    kb.complete_task(conn, root, summary="all done")
+    conn.close()
+    asyncio.run(_tick(monkeypatch, _runner(adapter)))
+    assert len(adapter.sent) == 1
+    assert "all done" in adapter.sent[0][1]
+
+
+def test_cross_tenant_linkage_does_not_roll_up(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolation.db"))
+    kb.init_db()
+    conn = kb.connect()
+    root = kb.create_task(conn, title="A", assignee="x", tenant="a")
+    child = kb.create_task(conn, title="B", assignee="x", tenant="b")
+    # Simulate a malformed legacy link; lineage queries must still isolate.
+    conn.execute("INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)", (root, child))
+    kb.block_task(conn, child, reason="secret tenant question", kind="needs_input")
+    assert kb.task_rollup(conn, root)["actionable_blocker"] is None
+    conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -411,6 +411,7 @@ def _handle_show(args: dict, **kw) -> str:
 
             return json.dumps({
                 "task": _task_dict(task),
+                "rollup": kb.task_rollup(conn, tid),
                 "parents": parents,
                 "children": children,
                 "comments": [


### PR DESCRIPTION
## Summary
- persist Kanban notification attempts in a deduplicated outbox with bounded retries
- roll descendant blockers up to subscribed root tasks while keeping child completions quiet
- correlate replies to exact Telegram bot receipts, attach answers, and resume blocked tasks
- expose descendant rollup state from `kanban_show`

## Verification
- `scripts/run_tests.sh tests/gateway/test_kanban_descendant_notifications.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_platform_base.py tests/gateway/test_telegram_reply_quote.py tests/hermes_cli/test_kanban_core_functionality.py -q` (365 passed)
- `scripts/run_tests.sh tests/gateway/test_kanban_descendant_notifications.py -q -k child_blocker_rolls_up_and_delivers_once` (1 passed; safe recording-adapter Telegram fixture)
- `git diff --check`