### PR TITLE
feat(cli): load /goal text from file

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1996,7 +1996,7 @@ class CLICommandsMixin:
             print()
 
     def _handle_goal_command(self, cmd: str) -> None:
-        """Dispatch /goal subcommands: set / draft / show / status / pause / resume / clear."""
+        """Dispatch /goal subcommands, including loading goal text from a file."""
         from cli import _DIM, _RST, _cprint
         parts = (cmd or "").strip().split(None, 1)
         arg = parts[1].strip() if len(parts) > 1 else ""
@@ -2007,6 +2007,34 @@ class CLICommandsMixin:
             return
 
         lower = arg.lower()
+
+        # /goal --file <path> reads a long goal from disk without forcing the
+        # user to paste multi-page text into the TUI. File contents are always
+        # treated as goal text, even when they happen to equal a subcommand
+        # such as "status" or "pause".
+        if lower == "--file" or lower.startswith("--file "):
+            import shlex
+            from pathlib import Path
+
+            try:
+                file_args = shlex.split(arg)
+            except ValueError as exc:
+                _cprint(f"  /goal --file: invalid path: {exc}")
+                return
+            if len(file_args) != 2 or file_args[0] != "--file":
+                _cprint("  Usage: /goal --file <path>")
+                return
+
+            goal_path = Path(file_args[1]).expanduser()
+            try:
+                arg = goal_path.read_text(encoding="utf-8").strip()
+            except (OSError, UnicodeError) as exc:
+                _cprint(f"  /goal --file: could not read {goal_path}: {exc}")
+                return
+            if not arg:
+                _cprint(f"  /goal --file: {goal_path} is empty.")
+                return
+            lower = ""
 
         # Bare /goal or /goal status → show current state
         if not arg or lower == "status":

--- a/tests/hermes_cli/test_goal_file_command.py
+++ b/tests/hermes_cli/test_goal_file_command.py
@@ -1,0 +1,91 @@
+from queue import Queue
+from types import SimpleNamespace
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _GoalManager:
+    def __init__(self):
+        self.calls = []
+
+    def set(self, goal, *, contract=None):
+        self.calls.append((goal, contract))
+        return SimpleNamespace(
+            goal=goal,
+            max_turns=10,
+            has_contract=lambda: contract is not None,
+            contract=contract,
+        )
+
+
+class _CLI(CLICommandsMixin):
+    def __init__(self, manager):
+        self._manager = manager
+        self._pending_input = Queue()
+
+    def _get_goal_manager(self):
+        return self._manager
+
+
+def _capture_output(monkeypatch):
+    output = []
+    monkeypatch.setattr("cli._cprint", output.append)
+    return output
+
+
+def test_goal_file_loads_quoted_utf8_path_and_starts_goal(tmp_path, monkeypatch):
+    manager = _GoalManager()
+    cli = _CLI(manager)
+    output = _capture_output(monkeypatch)
+    goal_path = tmp_path / "release goal.txt"
+    goal_path.write_text("Ship café support\n\nverify: pytest -q\n", encoding="utf-8")
+
+    cli._handle_goal_command(f'/goal --file "{goal_path}"')
+
+    assert len(manager.calls) == 1
+    goal, contract = manager.calls[0]
+    assert goal == "Ship café support"
+    assert contract is not None
+    assert contract.verification == "pytest -q"
+    assert cli._pending_input.get_nowait() == goal
+    assert any("Goal set" in line for line in output)
+
+
+def test_goal_file_content_is_not_reinterpreted_as_subcommand(tmp_path, monkeypatch):
+    manager = _GoalManager()
+    cli = _CLI(manager)
+    _capture_output(monkeypatch)
+    goal_path = tmp_path / "goal.txt"
+    goal_path.write_text("status", encoding="utf-8")
+
+    cli._handle_goal_command(f"/goal --file {goal_path}")
+
+    assert manager.calls[0][0] == "status"
+    assert cli._pending_input.get_nowait() == "status"
+
+
+def test_goal_file_read_error_does_not_replace_goal(tmp_path, monkeypatch):
+    manager = _GoalManager()
+    cli = _CLI(manager)
+    output = _capture_output(monkeypatch)
+    missing = tmp_path / "missing.txt"
+
+    cli._handle_goal_command(f"/goal --file {missing}")
+
+    assert manager.calls == []
+    assert cli._pending_input.empty()
+    assert any("could not read" in line for line in output)
+
+
+def test_goal_file_rejects_empty_file(tmp_path, monkeypatch):
+    manager = _GoalManager()
+    cli = _CLI(manager)
+    output = _capture_output(monkeypatch)
+    goal_path = tmp_path / "empty.txt"
+    goal_path.write_text(" \n", encoding="utf-8")
+
+    cli._handle_goal_command(f"/goal --file {goal_path}")
+
+    assert manager.calls == []
+    assert cli._pending_input.empty()
+    assert any("is empty" in line for line in output)


### PR DESCRIPTION
## Summary

Add `/goal --file <path>` for loading long goal text from a UTF-8 file instead of pasting multi-page content into the CLI/TUI.

Quoted paths and `~` expansion are supported. File contents are always treated as goal text, while missing, unreadable, and empty files leave the active goal unchanged.

## Related issue

Closes #63341

## Verification

- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_goal_file_command.py tests/hermes_cli/test_goals.py -q` (105 passed)
- `uv tool run ruff check hermes_cli/cli_commands_mixin.py tests/hermes_cli/test_goal_file_command.py`
- `python3 scripts/check-windows-footguns.py --all`
- `git diff --check`

Signed-off-by: Ho Lim <subhoya@gmail.com>