### PR TITLE
fix(test): isolate imported cron stores in hermetic fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,16 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
 
+    # ``cron.jobs`` may already be imported during test collection, before
+    # this fixture redirects HERMES_HOME. Rebind its cached default store.
+    cron_jobs = sys.modules.get("cron.jobs")
+    if cron_jobs is not None:
+        cron_dir = fake_hermes_home / "cron"
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", fake_hermes_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output")
+
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
     monkeypatch.setenv("TZ", "UTC")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,10 +365,10 @@ def _hermetic_environment(tmp_path, monkeypatch):
     cron_jobs = sys.modules.get("cron.jobs")
     if cron_jobs is not None:
         cron_dir = fake_hermes_home / "cron"
-        monkeypatch.setattr(cron_jobs, "HERMES_DIR", fake_hermes_home)
-        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
-        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json")
-        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output")
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", fake_hermes_home, raising=False)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir, raising=False)
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json", raising=False)
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output", raising=False)
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,6 +381,18 @@ def _hermetic_environment(tmp_path, monkeypatch):
             raising=False,
         )
         monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output", raising=False)
+        # Newer cron.jobs compares compatibility constants with an import snapshot;
+        # align it so this fixture rebind is not mistaken for a caller override.
+        if hasattr(cron_jobs, "_CronStorePaths") and hasattr(cron_jobs, "_IMPORT_STORE"):
+            monkeypatch.setattr(
+                cron_jobs,
+                "_IMPORT_STORE",
+                cron_jobs._CronStorePaths(
+                    cron_dir,
+                    cron_dir / "jobs.json",
+                    cron_dir / "output",
+                ),
+            )
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,18 @@ def _hermetic_environment(tmp_path, monkeypatch):
         monkeypatch.setattr(cron_jobs, "HERMES_DIR", fake_hermes_home, raising=False)
         monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir, raising=False)
         monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json", raising=False)
+        monkeypatch.setattr(
+            cron_jobs,
+            "TICKER_HEARTBEAT_FILE",
+            cron_dir / "ticker_heartbeat",
+            raising=False,
+        )
+        monkeypatch.setattr(
+            cron_jobs,
+            "TICKER_SUCCESS_FILE",
+            cron_dir / "ticker_last_success",
+            raising=False,
+        )
         monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output", raising=False)
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -15,7 +15,6 @@ Three fixes under test:
    "already being fired".
 """
 
-import json
 import os
 import threading
 import time
@@ -43,6 +42,20 @@ except ImportError:  # pragma: no cover - non-POSIX
 
 
 pytestmark = pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
+
+def test_cron_store_uses_hermetic_home():
+    hermes_home = Path(os.environ["HERMES_HOME"]).resolve()
+    assert (
+        jobs_mod.HERMES_DIR,
+        jobs_mod.CRON_DIR,
+        jobs_mod.JOBS_FILE,
+        jobs_mod.OUTPUT_DIR,
+    ) == (
+        hermes_home,
+        hermes_home / "cron",
+        hermes_home / "cron" / "jobs.json",
+        hermes_home / "cron" / "output",
+    )
 
 
 def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -44,7 +44,6 @@ except ImportError:  # pragma: no cover - non-POSIX
     fcntl = None
 
 
-pytestmark = pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
 
 def test_cron_store_uses_hermetic_home():
     hermes_home = Path(os.environ["HERMES_HOME"]).resolve()
@@ -109,6 +108,7 @@ def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event
         fd.close()
 
 
+@pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
 class TestBoundedJobsLock:
     def test_lock_acquisition_times_out_and_degrades(self, monkeypatch, caplog):
         """A foreign holder of .jobs.lock must NOT block _jobs_lock forever."""

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -34,6 +34,9 @@ from cron.jobs import (
     save_jobs,
 )
 
+_IMPORT_TIME_TICKER_HEARTBEAT_FILE = jobs_mod.TICKER_HEARTBEAT_FILE
+_IMPORT_TIME_TICKER_SUCCESS_FILE = jobs_mod.TICKER_SUCCESS_FILE
+
 
 try:
     import fcntl
@@ -50,12 +53,41 @@ def test_cron_store_uses_hermetic_home():
         jobs_mod.CRON_DIR,
         jobs_mod.JOBS_FILE,
         jobs_mod.OUTPUT_DIR,
+        jobs_mod.TICKER_HEARTBEAT_FILE,
+        jobs_mod.TICKER_SUCCESS_FILE,
     ) == (
         hermes_home,
         hermes_home / "cron",
         hermes_home / "cron" / "jobs.json",
         hermes_home / "cron" / "output",
+        hermes_home / "cron" / "ticker_heartbeat",
+        hermes_home / "cron" / "ticker_last_success",
     )
+
+
+def test_ticker_heartbeat_uses_hermetic_home():
+    hermes_home = Path(os.environ["HERMES_HOME"]).resolve()
+    heartbeat_file = hermes_home / "cron" / "ticker_heartbeat"
+    success_file = hermes_home / "cron" / "ticker_last_success"
+    original_files = (
+        _IMPORT_TIME_TICKER_HEARTBEAT_FILE,
+        _IMPORT_TIME_TICKER_SUCCESS_FILE,
+    )
+    assert heartbeat_file not in original_files
+    assert success_file not in original_files
+    original_contents = {
+        path: path.read_bytes() if path.exists() else None for path in original_files
+    }
+
+    jobs_mod.record_ticker_heartbeat()
+    assert heartbeat_file.is_file()
+    assert not success_file.exists()
+
+    jobs_mod.record_ticker_heartbeat(success=True)
+    assert success_file.is_file()
+    assert {
+        path: path.read_bytes() if path.exists() else None for path in original_files
+    } == original_contents
 
 
 def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):

--- a/tests/test_conftest_cron_store.py
+++ b/tests/test_conftest_cron_store.py
@@ -1,0 +1,51 @@
+"""Compatibility coverage for the suite's imported cron-store isolation."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import NamedTuple
+
+import pytest
+
+from tests.conftest import _hermetic_environment
+
+
+class _CronStorePaths(NamedTuple):
+    cron_dir: Path
+    jobs_file: Path
+    output_dir: Path
+
+
+@pytest.mark.parametrize(
+    "supports_import_store",
+    [True, False],
+    ids=["newer-module", "lightweight-stub"],
+)
+def test_hermetic_fixture_only_aligns_existing_import_store(
+    tmp_path, monkeypatch, supports_import_store
+):
+    cron_jobs = SimpleNamespace()
+    if supports_import_store:
+        import_dir = tmp_path / "imported" / "cron"
+        cron_jobs._CronStorePaths = _CronStorePaths
+        cron_jobs._IMPORT_STORE = _CronStorePaths(
+            import_dir,
+            import_dir / "jobs.json",
+            import_dir / "output",
+        )
+
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    fixture_tmp = tmp_path / "fixture"
+    fixture_tmp.mkdir()
+    _hermetic_environment.__wrapped__(fixture_tmp, monkeypatch)
+
+    if supports_import_store:
+        cron_dir = fixture_tmp / "hermes_test" / "cron"
+        assert cron_jobs._IMPORT_STORE == _CronStorePaths(
+            cron_dir,
+            cron_dir / "jobs.json",
+            cron_dir / "output",
+        )
+    else:
+        assert not hasattr(cron_jobs, "_CronStorePaths")
+        assert not hasattr(cron_jobs, "_IMPORT_STORE")


### PR DESCRIPTION
## Problem

`tests/conftest.py::_hermetic_environment` redirects `HERMES_HOME` inside an autouse fixture, but pytest imports test modules during collection **before** that fixture runs.

`cron.jobs` caches its default store at module import:

```python
HERMES_DIR = get_hermes_home().resolve()
CRON_DIR = HERMES_DIR / "cron"
JOBS_FILE = CRON_DIR / "jobs.json"
OUTPUT_DIR = CRON_DIR / "output"
```

Therefore, any test module importing `cron.jobs` at collection time can retain a developer's real profile paths after `HERMES_HOME` is redirected. Cron tests then create entries such as `claim job`, `paused job`, and `oneshot` in the real scheduler store.

## Fix

Strengthen the suite-wide hermetic fixture instead of adding per-file cleanup:

- After creating the per-test `fake_hermes_home`, check `sys.modules` for an already-imported `cron.jobs`.
- Rebind its four cached default-store constants through `monkeypatch`.
- Do not import `cron.jobs` from the fixture; tests that do not use cron remain unaffected.
- Let `monkeypatch` restore the previous values during teardown.

`test_ticker_stall_60703.py` adds one structural regression assertion proving all four cached paths match the active per-test `HERMES_HOME`.

No production code changes.

## TDD evidence

Before updating the global fixture, the regression assertion failed safely under an explicitly temporary outer `HERMES_HOME`:

```console
FAILED tests/cron/test_ticker_stall_60703.py::test_cron_store_uses_hermetic_home
collection-time outer HERMES_HOME != per-test .../hermes_test
1 failed
```

After the fix, four related cron files pass together in one pytest process:

```console
75 passed in 4.87s
```

Files covered:

- `tests/cron/test_ticker_stall_60703.py`
- `tests/cron/test_claim_job_for_fire.py`
- `tests/cron/test_cron_script.py`
- `tests/cron/test_cron_context_from.py`

The test command used an explicitly isolated outer `HERMES_HOME`. SHA-256 checks before and after confirmed both real stores were byte-for-byte unchanged:

- default profile: unchanged
- orchestrator profile: unchanged

## Impact

Prevents collection-time imports from bypassing the test suite's documented `HERMES_HOME` isolation invariant. This protects local developers' real cron stores without changing runtime behavior.