### PR TITLE
test(docker): poll for settled dashboard 'down' slot instead of racing boot

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -853,6 +853,7 @@ LEGACY_AUTHOR_MAP = {
     "tony@tonysimons.dev": "asimons81",
     "jetha@google.com": "jethac",
     "vishal.dharm@gmail.com": "vishal-dharm",
+    "jethachan@gmail.com": "jethac",
     "jani@0xhoneyjar.xyz": "deep-name",
     # LINE messaging plugin (synthesis PR)
     "32443648+leepoweii@users.noreply.github.com": "leepoweii",

--- a/tests/docker/test_dashboard.py
+++ b/tests/docker/test_dashboard.py
@@ -37,20 +37,30 @@ def test_dashboard_slot_reports_down_when_disabled(
     slot as DOWN (not up-with-sleep-infinity, which would
     false-positive `hermes doctor` and any other health check).
 
-    Locks the PR #30136 review item I3 fix: cont-init.d/03-dashboard-toggle
-    writes a `down` marker file in the live service-dir when
-    HERMES_DASHBOARD is unset, so the slot reflects reality.
+    The dashboard is always declared as a supervised s6 slot. When
+    HERMES_DASHBOARD is unset, ``run`` exits 0 immediately and ``finish``
+    exits 125 (s6's "permanent failure, do not restart" marker), so the
+    slot settles to 'down' with no dashboard process ever running. See
+    docker/s6-rc.d/dashboard/{run,finish}.
+
+    s6-rc exec's the ``run`` wrapper once when it brings the user bundle
+    up, so svstat can briefly report ``up (...) 0 seconds`` before ``run``
+    exits and ``finish`` settles the slot down. Poll for the settled
+    'down' state rather than checking once — symmetric to
+    test_dashboard_slot_reports_up_when_enabled — which also avoids racing
+    that one-time startup flap.
     """
     start_container(built_image, container_name, cmd="sleep 60")
     # /command/ isn't on PATH for docker-exec sessions, so call by
-    # absolute path.
-    r = docker_exec(
-        container_name, "/command/s6-svstat", "/run/service/dashboard",
+    # absolute path. Anchor on '^down' so a transitioning
+    # 'up (...) want down' line can't false-match a bare 'down'.
+    ok, last = poll_container(
+        container_name,
+        "/command/s6-svstat /run/service/dashboard | grep -q '^down'",
     )
-    assert r.returncode == 0, f"s6-svstat failed: {r.stderr!r} / {r.stdout!r}"
-    assert "down" in r.stdout, (
-        f"Dashboard slot should be 'down' without HERMES_DASHBOARD; "
-        f"svstat reports: {r.stdout!r}"
+    assert ok, (
+        f"Dashboard slot should settle to 'down' without HERMES_DASHBOARD; "
+        f"last svstat: {last!r}"
     )
 
 


### PR DESCRIPTION
## Problem

`tests/docker/test_dashboard.py::test_dashboard_slot_reports_down_when_disabled` is flaky in the Docker build/test job:

```
AssertionError: Dashboard slot should be 'down' without HERMES_DASHBOARD;
svstat reports: 'up (pid 155 pgid 155) 0 seconds'
assert 'down' in 'up (pid 155 pgid 155) 0 seconds'
tests/docker/test_dashboard.py:51
```

Note the `0 seconds` uptime — svstat is catching the service in its first moments.

## Root cause

The dashboard is an **always-declared supervised s6 longrun** (`docker/s6-rc.d/dashboard/`). When `HERMES_DASHBOARD` is unset:

- `run` exits 0 immediately — no dashboard process is ever exec'd;
- `finish` exits **125**, s6's "permanent failure, do not restart" marker (≈ `s6-svc -O`), so s6-supervise leaves the slot down and never restarts it.

So the slot's steady state is `down`, with no process running — corroborated by the sibling `test_dashboard_not_running_by_default` (a `pgrep` check) which passes.

But s6-rc **exec's the `run` wrapper once** when it brings the user-services bundle up, so `s6-svstat` can briefly report `up (...) 0 seconds` before `run` exits and `finish` settles the slot to `down`. The failing test did a **single immediate** `s6-svstat` check with no retry — unlike its sibling `test_dashboard_slot_reports_up_when_enabled`, which polls — so it intermittently reads that one-time boot flap.

## Fix

Poll for the settled `down` state (mirroring the "up" test), anchored on `^down` so a transitioning `up (...) want down` line can't false-match a bare `down`. Also corrects the docstring, which still described the deleted `cont-init.d/03-dashboard-toggle` down-marker mechanism (the real mechanism is the run-exit-0 / finish-exit-125 pair).

Test-only change — no s6 service or product code touched; it only relaxes an immediate check into a bounded poll for the same condition the service already guarantees in steady state.
