### PR TITLE
fix: make session cost safeguards durable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -562,6 +562,10 @@ def init_agent(
     # report cumulative micros spent.  Surfaced behind HERMES_DEV_CREDITS.
     agent._credits_state = None
     agent._credits_session_start_micros = None
+    # Per-call authoritative cost (micros) from the credits-header delta.
+    # Stashed by _capture_credits, consumed by the conversation loop's
+    # update_token_counts, then cleared. None when no billable delta this call.
+    agent._last_call_actual_cost_micros = None
     # Threshold-notice latch (L4): active sticky-notice keys + the warn90 crossing gate.
     agent._credits_latch = {"active": set(), "seen_below_90": False, "usage_band": None}
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1352,6 +1352,22 @@ def init_agent(
     # targets.
     agent._task_completion_guidance = bool(_agent_section.get("task_completion_guidance", True))
 
+    # Session-level total API-call ceiling — a hard cost backstop against
+    # runaway agent loops. Per-turn max_turns bounds a single turn, but a
+    # long-lived session can still accumulate hundreds of calls across many
+    # turns (a historical session burned 234 calls / ~$52 this way). When set
+    # to a positive integer, the conversation loop hard-stops once the session
+    # has made that many LLM calls, mirroring the existing budget-exhausted
+    # exit path. 0 = disabled (legacy behaviour). Off by default so existing
+    # installs are unchanged until the user opts in.
+    _max_api_calls_raw = _agent_section.get("max_api_calls", 0)
+    try:
+        agent.max_api_calls = int(_max_api_calls_raw)
+    except (TypeError, ValueError):
+        agent.max_api_calls = 0
+    if agent.max_api_calls < 0:
+        agent.max_api_calls = 0
+
     # Universal parallel-tool-call guidance toggle.  Default True.  Separate
     # flag from task_completion_guidance because a user may want one but not
     # the other.  Steers the model to batch independent tool calls into a
@@ -1447,6 +1463,26 @@ def init_agent(
     compression_protect_first = max(
         0, int(_compression_cfg.get("protect_first_n", 3))
     )
+    # Hard context cap — a deterministic last-resort safety net against
+    # unbounded context growth. When the summarizer (auxiliary compression
+    # model) is permanently unavailable — e.g. a 404 "requires available
+    # credits" on a shared Nous account — compression aborts and retries on a
+    # cooldown, but every turn still re-fires should_compress and re-fails, so
+    # the conversation grows without limit. That was the root cause of a
+    # historical ~20M-token / ~$52 runaway session. If prompt_tokens ever
+    # breach this cap AND the summarizer is in a failure state, we drop the
+    # oldest non-protected turns instead of relying on the (dead) summarizer.
+    # 0 = disabled (legacy behaviour). Default here, surfaced to the
+    # ContextCompressor below. 250000 ≈ 1/4 of a 1M-token window: a hard
+    # ceiling well above the compression threshold but far below the model
+    # context limit, so it only bites when summarization has genuinely failed.
+    _hard_cap_raw = _compression_cfg.get("hard_context_cap_tokens", 250000)
+    try:
+        compression_hard_cap_tokens = int(_hard_cap_raw)
+    except (TypeError, ValueError):
+        compression_hard_cap_tokens = 250000
+    if compression_hard_cap_tokens < 0:
+        compression_hard_cap_tokens = 0
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
@@ -1697,6 +1733,7 @@ def init_agent(
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
+            hard_context_cap_tokens=compression_hard_cap_tokens,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -443,7 +443,7 @@ def init_agent(
     agent.event_callback = event_callback
     agent.tool_gen_callback = tool_gen_callback
 
-    
+
     # Tool execution state — allows _vprint during tool execution
     # even when stream consumers are registered (no tokens streaming then)
     agent._executing_tools = False
@@ -476,12 +476,12 @@ def init_agent(
     # their tids explicitly.
     agent._tool_worker_threads: set[int] = set()
     agent._tool_worker_threads_lock = threading.Lock()
-    
+
     # Subagent delegation state
     agent._delegate_depth = 0        # 0 = top-level agent, incremented for children
     agent._active_children = []      # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
-    
+
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed
     agent.providers_ignored = providers_ignored
@@ -494,7 +494,7 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
-    
+
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
@@ -502,7 +502,7 @@ def init_agent(
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
-    
+
     # Anthropic prompt caching: auto-enabled for Claude models on native
     # Anthropic, OpenRouter, and third-party gateways that speak the
     # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
@@ -594,7 +594,7 @@ def init_agent(
         # console. Any future noise reduction belongs at the
         # handler level inside hermes_logging.py, not here.
         pass
-    
+
     # Internal stream callback (set during streaming TTS).
     # Initialized here so _vprint can reference it before run_conversation.
     agent._stream_callback = None
@@ -949,7 +949,7 @@ def init_agent(
                         "select a provider, or run `hermes setup` for first-time "
                         "configuration."
                     )
-        
+
         agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
         # Enable fine-grained tool streaming for Claude on OpenRouter.
@@ -1032,7 +1032,7 @@ def init_agent(
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-    
+
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
@@ -1071,7 +1071,7 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
-    
+
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:
@@ -1104,16 +1104,16 @@ def init_agent(
         missing_reqs = [name for name, available in requirements.items() if not available]
         if missing_reqs:
             print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
-    
+
     # Show trajectory saving status
     if agent.save_trajectories and not agent.quiet_mode:
         print("📝 Trajectory saving enabled")
-    
+
     # Show ephemeral system prompt status
     if agent.ephemeral_system_prompt and not agent.quiet_mode:
         prompt_preview = agent.ephemeral_system_prompt[:60] + "..." if len(agent.ephemeral_system_prompt) > 60 else agent.ephemeral_system_prompt
         print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
-    
+
     # Show prompt caching status
     if agent._use_prompt_caching and not agent.quiet_mode:
         if agent._use_native_cache_layout and agent.provider == "anthropic":
@@ -1123,7 +1123,7 @@ def init_agent(
         else:
             source = "Claude via OpenRouter"
         print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
-    
+
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()
     if session_id:
@@ -1163,7 +1163,7 @@ def init_agent(
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug
     # breadcrumb path written by agent_runtime_helpers.dump_api_request_debug).
-    
+
     # Track conversation messages for session logging
     agent._session_messages: List[Dict[str, Any]] = []
     # Responses encrypted reasoning replay state.  Some OpenAI-compatible
@@ -1175,10 +1175,10 @@ def init_agent(
     agent._codex_reasoning_replay_enabled = True
     agent._memory_write_origin = "assistant_tool"
     agent._memory_write_context = "foreground"
-    
+
     # Cached system prompt -- built once per session, only rebuilt on compression
     agent._cached_system_prompt: Optional[str] = None
-    
+
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager
     agent._checkpoint_mgr = CheckpointManager(
@@ -1187,7 +1187,7 @@ def init_agent(
         max_total_size_mb=checkpoint_max_total_size_mb,
         max_file_size_mb=checkpoint_max_file_size_mb,
     )
-    
+
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
@@ -1209,11 +1209,11 @@ def init_agent(
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
     }
-    
+
     # In-memory todo list for task planning (one per agent/session)
     from tools.todo_tool import TodoStore
     agent._todo_store = TodoStore()
-    
+
     # Load config once for memory, skills, and compression sections
     try:
         from hermes_cli.config import load_config as _load_agent_config
@@ -1255,7 +1255,7 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
-    
+
 
 
     # Memory provider plugin (external — one at a time, alongside built-in)
@@ -1362,17 +1362,32 @@ def init_agent(
     # turns (a historical session burned 234 calls / ~$52 this way). When set
     # to a positive integer, the conversation loop hard-stops once the session
     # has made that many LLM calls, mirroring the existing budget-exhausted
-    # exit path. 0 = disabled (legacy behaviour). Off by default so existing
-    # installs are unchanged until the user opts in.
-    _max_api_calls_raw = _agent_section.get("max_api_calls", 0)
+    # exit path. 0 = disabled (explicit opt-out). Default 75 so the engine is
+    # safe-by-default for EVERY profile — including brand-new profiles and
+    # after a `hermes update` that strips the DEFAULT_CONFIG entry. A user who
+    # explicitly sets 0 in config still disables it (this is only the fallback
+    # when the key is absent entirely). See credit-burn fix #2.
+    _max_api_calls_raw = _agent_section.get("max_api_calls", 75)
     try:
         agent.max_api_calls = int(_max_api_calls_raw)
     except (TypeError, ValueError):
-        agent.max_api_calls = 0
+        agent.max_api_calls = 75
     if agent.max_api_calls < 0:
-        agent.max_api_calls = 0
+        agent.max_api_calls = 75
+    try:
+        agent.max_session_duration_seconds = max(
+            0.0, float(_agent_section.get("max_session_duration_seconds", 14400))
+        )
+    except (TypeError, ValueError):
+        agent.max_session_duration_seconds = 14400.0
+    try:
+        agent.max_session_cost_usd = max(
+            0.0, float(_agent_section.get("max_session_cost_usd", 15.0))
+        )
+    except (TypeError, ValueError):
+        agent.max_session_cost_usd = 15.0
 
-    # Universal parallel-tool-call guidance toggle.  Default True.  Separate
+    # Universal parallel-tool-call guidance toggle.
     # flag from task_completion_guidance because a user may want one but not
     # the other.  Steers the model to batch independent tool calls into a
     # single turn; the runtime already executes such batches concurrently.
@@ -1872,7 +1887,7 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -966,6 +966,7 @@ class ContextCompressor(ContextEngine):
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
         max_tokens: int | None = None,
+        hard_context_cap_tokens: int = 0,
     ):
         self.model = model
         self.base_url = base_url
@@ -989,6 +990,14 @@ class ContextCompressor(ContextEngine):
         # When False (default = historical behavior), insert a
         # deterministic "summary unavailable" handoff and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
+
+        # Hard context cap (0 = disabled). Deterministic last-resort ceiling
+        # on prompt size. When compression's summarizer is unavailable (e.g. a
+        # permanent credit/404 on the shared Nous account), the normal
+        # summarizer path can't shrink context, so we fall back to dropping the
+        # oldest non-protected turns instead of letting the conversation grow
+        # without bound. See agent_init.py for the rationale.
+        self.hard_context_cap_tokens = max(0, int(hard_context_cap_tokens or 0))
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -1173,8 +1182,115 @@ class ContextCompressor(ContextEngine):
         return True
 
     # ------------------------------------------------------------------
-    # Tool output pruning (cheap pre-pass, no LLM call)
+    # Hard context cap — deterministic last-resort trim (no LLM call)
     # ------------------------------------------------------------------
+
+    def apply_hard_context_cap(
+        self, messages: List[Dict[str, Any]], prompt_tokens: int,
+    ) -> tuple[List[Dict[str, Any]], bool]:
+        """Drop oldest non-protected turns if a hard token ceiling is breached.
+
+        This is a SAFETY NET only. Normal context control is the summarizer
+        (``compress``), which produces a clean brief. But when the summarizer
+        is permanently unavailable — the documented death-spiral where the
+        auxiliary compression model 404s with "requires available credits" on a
+        shared account — ``compress`` returns unchanged and retries on a
+        cooldown forever, so the conversation grows without bound (observed:
+        ~20M input tokens in a single session). This method guarantees context
+        can never exceed ``hard_context_cap_tokens``: when breached, it drops
+        whole turns (an assistant message together with its tool results) from
+        the oldest end, never touching the system prompt, the first
+        ``protect_first_n`` messages, the last ``protect_last_n`` messages, or
+        any message whose tool results would otherwise be left dangling.
+
+        Returns (trimmed_messages, did_trim). When the cap is disabled (0) or
+        not breached, returns the input unchanged with did_trim=False.
+        """
+        if not self.hard_context_cap_tokens or prompt_tokens <= self.hard_context_cap_tokens:
+            return messages, False
+        if not messages:
+            return messages, False
+
+        # Identify dangling tool_call_ids so we never leave an assistant
+        # tool_call pointing at a deleted result (would 400 the next API call).
+        _tool_call_ids: set = set()
+        for _m in messages:
+            for _tc in (_m.get("tool_calls") or []):
+                _id = (_tc.get("id") if isinstance(_tc, dict) else None)
+                if _id:
+                    _tool_call_ids.add(_id)
+        _result_ids: set = set()
+        for _m in messages:
+            if _m.get("role") == "tool":
+                _rid = _m.get("tool_call_id")
+                if _rid:
+                    _result_ids.add(_rid)
+
+        _sys = 1 if (messages and messages[0].get("role") == "system") else 0
+        _keep_start = _sys + self.protect_first_n
+        _keep_end = len(messages) - self.protect_last_n
+        # Guard: never drop into the protected head/tail; require at least one
+        # droppable message.
+        if _keep_end <= _keep_start + 1:
+            return messages, False
+
+        _dropped = 0
+        _out: List[Dict[str, Any]] = []
+        for _i, _m in enumerate(messages):
+            _drop = (
+                _keep_start <= _i < _keep_end
+                and _m.get("role") != "system"
+            )
+            if _drop:
+                # Decide whether dropping this message would orphan a tool
+                # result or leave a dangling tool_call:
+                #  - a tool *result* is only dropped if its assistant caller is
+                #    also in the droppable range;
+                #  - an assistant *tool-call* turn is only dropped if ALL of its
+                #    referenced results are themselves in the droppable range.
+                # Otherwise keep it (safe) so we never produce an invalid
+                # assistant/tool pairing.
+                _mid = _m.get("tool_call_id")
+                if _mid is not None:
+                    # tool result: keep unless its calling assistant msg is also
+                    # droppable.
+                    _caller_idx = next(
+                        (_j for _j, _cm in enumerate(messages)
+                         if _cm.get("role") == "assistant"
+                         and any(
+                             isinstance(_tc, dict) and _tc.get("id") == _mid
+                             for _tc in (_cm.get("tool_calls") or [])
+                         )),
+                        None,
+                    )
+                    _drop = (_caller_idx is not None
+                             and _keep_start <= _caller_idx < _keep_end)
+                elif _m.get("role") == "assistant" and (_m.get("tool_calls") or []):
+                    _ids = [_tc.get("id") for _tc in _m["tool_calls"]
+                            if isinstance(_tc, dict)]
+                    _result_locs = [
+                        _j for _j, _rm in enumerate(messages)
+                        if _rm.get("role") == "tool"
+                        and _rm.get("tool_call_id") in set(_ids)
+                        and _keep_start <= _j < _keep_end
+                    ]
+                    _drop = bool(_ids) and len(_result_locs) == len(_ids)
+                # else: plain user/assistant text — safe to drop.
+            if _drop:
+                _dropped += 1
+                continue
+            _out.append(_m)
+
+        if _dropped == 0:
+            return messages, False
+        logger.warning(
+            "Hard context cap hit (%d > %d tokens): dropped %d oldest non-protected "
+            "turn(s) to bound context growth (summarizer unavailable).",
+            prompt_tokens, self.hard_context_cap_tokens, _dropped,
+        )
+        return _out, True
+
+
 
     def _prune_old_tool_results(
         self, messages: List[Dict[str, Any]], protect_tail_count: int,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -641,19 +641,48 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
+        # Reserve this provider call in state.db BEFORE making it.  The old
+        # in-memory counter reset on every resumed turn, which made a session
+        # budget unenforceable across reconnects or process restarts.  If a
+        # configured durable budget cannot be persisted, fail closed rather than
+        # risk an unbounded paid request.
+        _max_api = getattr(agent, "max_api_calls", 0)
+        _max_duration = getattr(agent, "max_session_duration_seconds", 0)
+        _max_cost = getattr(agent, "max_session_cost_usd", 0)
+        if agent._session_db and agent.session_id and (_max_api or _max_duration or _max_cost):
+            try:
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                if not agent._session_db_created:
+                    raise RuntimeError("session row was not created")
+                _allowed, _durable_count, _budget_reason = agent._session_db.reserve_session_api_call(
+                    agent.session_id,
+                    max_api_calls=_max_api,
+                    max_session_duration_seconds=_max_duration,
+                    max_session_cost_usd=_max_cost,
+                )
+            except Exception as _budget_exc:
+                _turn_exit_reason = "session_budget_persistence_failure"
+                logger.warning("Refusing provider call: durable session budget unavailable: %s", _budget_exc)
+                break
+            if not _allowed:
+                _turn_exit_reason = _budget_reason or "session_budget_ceiling"
+                if not agent.quiet_mode:
+                    agent._safe_print(
+                        f"\n⚠️  Session safety budget reached ({_turn_exit_reason}; "
+                        f"{_durable_count} durable API calls). Stopping to bound credit usage."
+                    )
+                break
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
-        # Session-level API-call ceiling (agent.max_api_calls, set from
-        # config.yaml agent.max_api_calls; 0 = disabled). Hard cost backstop:
-        # stops a runaway agent loop from accumulating hundreds of LLM calls
-        # across many turns. Mirrors the existing budget-exhausted path so the
-        # user gets the same clear notice. Honors a single grace call so the
-        # model can still emit a final summary rather than dying mid-sentence.
-        _max_api = getattr(agent, "max_api_calls", 0)
-        if _max_api and api_call_count > _max_api:
+        # Local guard remains as a fallback for deliberately persistence-free
+        # agents. Normal persisted sessions are governed by the durable reserve
+        # above and cannot reset this ceiling by resuming in another process.
+        if _max_api and not agent._session_db and api_call_count > _max_api:
             _turn_exit_reason = "api_call_ceiling"
             if not agent.quiet_mode:
                 agent._safe_print(
@@ -707,7 +736,7 @@ def run_conversation(
         if (agent._skill_nudge_interval > 0
                 and "skill_manage" in agent.valid_tool_names):
             agent._iters_since_skill += 1
-        
+
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
         # was thinking), drain it now — before we build api_messages — so
@@ -986,10 +1015,10 @@ def run_conversation(
             except Exception:
                 pass
             break
-        
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
-        
+
         if not agent.quiet_mode:
             agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
             agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
@@ -1008,13 +1037,13 @@ def run_conversation(
                 spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
                 thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type, print_fn=agent._print_fn)
                 thinking_spinner.start()
-        
+
         # Log request details if verbose
         if agent.verbose_logging:
             logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-        
+
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
@@ -1255,9 +1284,9 @@ def run_conversation(
                     api_call_count=api_call_count,
                     middleware_trace=list(_llm_middleware_trace),
                 )
-                
+
                 api_duration = time.time() - api_start_time
-                
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -1265,15 +1294,15 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                
+
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                
+
                 if agent.verbose_logging:
                     # Log response with provider info if available
                     resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
                     logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                
+
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
@@ -1377,11 +1406,11 @@ def run_conversation(
                         thinking_spinner = None
                     if agent.thinking_callback:
                         agent.thinking_callback("")
-                    
+
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
@@ -1405,18 +1434,18 @@ def run_conversation(
                             provider_name = response.error.metadata.get('provider_name', 'Unknown')
                     elif response and hasattr(response, 'message') and response.message:
                         error_msg = str(response.message)
-                    
+
                     # Try to get provider from model field (OpenRouter often returns actual model used)
                     if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
                         provider_name = f"model={response.model}"
-                    
+
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
                         resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
                         if agent.verbose_logging:
                             logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                    
+
                     # Extract error code from response for contextual diagnostics
                     _resp_error_code = None
                     if response and hasattr(response, 'error') and response.error:
@@ -1455,7 +1484,7 @@ def run_conversation(
                     cleaned_provider_error = agent._clean_error_message(error_msg)
                     agent._buffer_vprint(f"   📝 Provider message: {cleaned_provider_error}")
                     agent._buffer_vprint(f"   ⏱️  {_failure_hint}")
-                    
+
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
@@ -1481,12 +1510,12 @@ def run_conversation(
                             "error": _final_response,
                             "failed": True  # Mark as failure for filtering
                         }
-                    
+
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
                     wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
                     agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
                     logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
-                    
+
                     # Sleep in small increments to stay responsive to interrupts
                     sleep_end = time.time() + wait_time
                     _backoff_touch_counter = 0
@@ -1955,7 +1984,7 @@ def run_conversation(
                             "failed": True,
                             "error": "First response truncated due to output length limit"
                         }
-                
+
                 # Track actual token usage from response for context management
                 if hasattr(response, 'usage') and response.usage:
                     canonical_usage = normalize_usage(
@@ -2145,7 +2174,11 @@ def run_conversation(
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
-                                api_call_count=1,
+                                # The call was atomically reserved before the
+                                # provider request, so do not increment here.
+                                # Keeping this zero also prevents a later token
+                                # flush from double-counting the durable budget.
+                                api_call_count=0,
                             )
                         except Exception as e:
                             # Log token persistence failures so they're
@@ -2155,10 +2188,10 @@ def run_conversation(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
                                 agent.session_id, total_tokens, e,
                             )
-                    
+
                     if agent.verbose_logging:
                         logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                    
+
                     # Surface cache hit stats for any provider that reports
                     # them — not just those where we inject cache_control
                     # markers.  OpenAI/Kimi/DeepSeek/Qwen all do automatic
@@ -2180,7 +2213,7 @@ def run_conversation(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
-                
+
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
@@ -2877,7 +2910,7 @@ def run_conversation(
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
-                
+
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
@@ -2941,7 +2974,7 @@ def run_conversation(
                         "completed": False,
                         "interrupted": True,
                     }
-                
+
                 # Check for 413 payload-too-large BEFORE generic 4xx handler.
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
@@ -4045,7 +4078,7 @@ def run_conversation(
                             f"error retry backoff ({retry_count}/{max_retries}), "
                             f"{int(sleep_end - time.time())}s remaining"
                         )
-        
+
         # If the API call was interrupted, skip response processing
         if interrupted:
             _turn_exit_reason = "interrupted_during_api_call"
@@ -4106,7 +4139,7 @@ def run_conversation(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
-            
+
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead
             # of a plain string, which crashes downstream .strip() calls.
@@ -4198,14 +4231,14 @@ def run_conversation(
                         agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
                     except Exception:
                         pass
-            
+
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
             if has_incomplete_scratchpad(assistant_message.content or ""):
                 agent._incomplete_scratchpad_retries += 1
-                
+
                 agent._buffer_vprint(f"⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                
+
                 if agent._incomplete_scratchpad_retries <= 2:
                     agent._buffer_vprint(f"🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)...")
                     # Don't add the broken message, just retry
@@ -4215,11 +4248,11 @@ def run_conversation(
                     agent._flush_status_buffer()
                     agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
                     agent._incomplete_scratchpad_retries = 0
-                    
+
                     rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
                     agent._cleanup_task_resources(effective_task_id)
                     agent._persist_session(messages, conversation_history)
-                    
+
                     return {
                         "final_response": "Incomplete REASONING_SCRATCHPAD after 2 retries",
                         "messages": rolled_back_messages,
@@ -4228,7 +4261,7 @@ def run_conversation(
                         "partial": True,
                         "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
                     }
-            
+
             # Reset incomplete scratchpad counter on clean response
             agent._incomplete_scratchpad_retries = 0
 
@@ -4290,16 +4323,16 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
-            
+
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
-                
+
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
                         logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
-                
+
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
@@ -4375,7 +4408,7 @@ def run_conversation(
                     continue
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
-                
+
                 # Validate tool call arguments are valid JSON
                 # Handle empty strings as empty objects (common model quirk)
                 invalid_json_args = []
@@ -4395,7 +4428,7 @@ def run_conversation(
                         json.loads(args)
                     except json.JSONDecodeError as e:
                         invalid_json_args.append((tc.function.name, str(e)))
-                
+
                 if invalid_json_args:
                     # Check if the invalid JSON is due to truncation rather
                     # than a model formatting mistake.  Routers sometimes
@@ -4441,11 +4474,11 @@ def run_conversation(
                         # Using tool results (not user messages) preserves role alternation.
                         agent._buffer_vprint(f"⚠️  Injecting recovery tool results for invalid JSON...")
                         agent._invalid_json_retries = 0  # Reset for next attempt
-                        
+
                         # Append the assistant message with its (broken) tool_calls
                         recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
                         messages.append(recovery_assistant)
-                        
+
                         # Respond with tool error results for each tool call
                         invalid_names = {name for name, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
@@ -4465,7 +4498,7 @@ def run_conversation(
                                 "content": tool_result,
                             })
                         continue
-                
+
                 # Reset retry counter on successful JSON validation
                 agent._invalid_json_retries = 0
 
@@ -4478,7 +4511,7 @@ def run_conversation(
                 )
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                
+
                 # If this turn has both content AND tool_calls, capture the content
                 # as a fallback final response. Common pattern: model delivers its
                 # answer and calls memory/skill tools as a side-effect in the same
@@ -4505,7 +4538,7 @@ def run_conversation(
                         clean = agent._strip_think_blocks(turn_content).strip()
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
-                
+
                 # Pop thinking-only prefill message(s) before appending
                 # (tool-call path — same rationale as the final-response path).
                 _had_prefill = False
@@ -4604,7 +4637,7 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
-                
+
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the
                 # actual context size the provider reported plus the
@@ -4676,18 +4709,18 @@ def run_conversation(
 
                 # Continue loop for next response
                 continue
-            
+
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a
                 # prior housekeeping tool turn and should not silence the
                 # final response path.
                 agent._mute_post_response = False
-                
+
                 # Check if response only has think block with no actual content after it
                 if not agent._has_content_after_think_block(final_response):
                     # ── Partial stream recovery ─────────────────────
@@ -4952,7 +4985,7 @@ def run_conversation(
 
                     final_response = "(empty)"
                     break
-                
+
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
@@ -4998,9 +5031,9 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
-                
+
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
+
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
                 # Pop thinking-only prefill and empty-response retry
@@ -5118,12 +5151,12 @@ def run_conversation(
                     continue
 
                 messages.append(final_msg)
-                
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
-            
+
         except Exception as e:
             error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
             try:
@@ -5138,7 +5171,7 @@ def run_conversation(
             # recover the call site.  logger.exception() includes the
             # traceback automatically and emits at ERROR.
             logger.exception("Outer loop error in API call #%d", api_call_count)
-            
+
             # If an assistant message with tool_calls was already appended,
             # the API expects a role="tool" result for every tool_call_id.
             # Fill in error results for any that weren't answered yet.
@@ -5165,7 +5198,7 @@ def run_conversation(
                             }
                             messages.append(err_msg)
                 break
-            
+
             # Non-tool errors don't need a synthetic message injected.
             # The error is already printed to the user (line above), and
             # the retry loop continues.  Injecting a fake user/assistant
@@ -5180,7 +5213,7 @@ def run_conversation(
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})
                 break
-    
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2116,6 +2116,19 @@ def run_conversation(
                                     _cost_delta = (_cost_delta or 0.0) + float(_moa_ref_cost)
                                 except (TypeError, ValueError):  # pragma: no cover
                                     pass
+                            # Authoritative per-call cost from the Nous credits
+                            # headers (remaining-before minus remaining-after), if
+                            # captured this call. Overrides/complement the estimate;
+                            # update_token_counts increments actual_cost_usd, so pass
+                            # the per-call delta (None when no billable header).
+                            _actual_cost_usd = None
+                            _call_micros = getattr(agent, "_last_call_actual_cost_micros", None)
+                            if _call_micros:
+                                try:
+                                    _actual_cost_usd = float(_call_micros) / 1_000_000.0
+                                except (TypeError, ValueError):
+                                    _actual_cost_usd = None
+                            agent._last_call_actual_cost_micros = None
                             agent._session_db.update_token_counts(
                                 agent.session_id,
                                 input_tokens=canonical_usage.input_tokens,
@@ -2124,6 +2137,7 @@ def run_conversation(
                                 cache_write_tokens=canonical_usage.cache_write_tokens,
                                 reasoning_tokens=canonical_usage.reasoning_tokens,
                                 estimated_cost_usd=_cost_delta,
+                                actual_cost_usd=_actual_cost_usd,
                                 cost_status=cost_result.status,
                                 cost_source=cost_result.source,
                                 billing_provider=agent.provider,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -646,6 +646,23 @@ def run_conversation(
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
+        # Session-level API-call ceiling (agent.max_api_calls, set from
+        # config.yaml agent.max_api_calls; 0 = disabled). Hard cost backstop:
+        # stops a runaway agent loop from accumulating hundreds of LLM calls
+        # across many turns. Mirrors the existing budget-exhausted path so the
+        # user gets the same clear notice. Honors a single grace call so the
+        # model can still emit a final summary rather than dying mid-sentence.
+        _max_api = getattr(agent, "max_api_calls", 0)
+        if _max_api and api_call_count > _max_api:
+            _turn_exit_reason = "api_call_ceiling"
+            if not agent.quiet_mode:
+                agent._safe_print(
+                    f"\n⚠️  Session API-call ceiling reached ({api_call_count} calls). "
+                    f"Stopping to bound credit usage — you can raise agent.max_api_calls "
+                    f"in config.yaml or start a fresh session."
+                )
+            break
+
         # Grace call: the budget is exhausted but we gave the model one
         # more chance.  Consume the grace flag so the loop exits after
         # this iteration regardless of outcome.
@@ -4620,10 +4637,29 @@ def run_conversation(
                     conversation_history = conversation_history_after_compression(
                         agent, messages
                     )
-                
+                else:
+                    # Hard context cap backstop. The summarizer is in a failure
+                    # cooldown (e.g. auxiliary compression model 404'd on low
+                    # credits) so should_compress() returned False and the
+                    # summarizer can't shrink context. If we're still over the
+                    # configured hard ceiling, deterministically drop the oldest
+                    # non-protected turns rather than letting the conversation
+                    # grow without bound. This is the structural fix for the
+                    # compression-death-spiral class of runaway sessions.
+                    _hc = getattr(_compressor, "hard_context_cap_tokens", 0)
+                    if _hc and _real_tokens > _hc:
+                        _trimmed, _did_trim = _compressor.apply_hard_context_cap(
+                            messages, _real_tokens
+                        )
+                        if _did_trim:
+                            messages = _trimmed
+                            conversation_history = conversation_history_after_compression(
+                                agent, messages
+                            )
+
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages
-                
+
                 # Continue loop for next response
                 continue
             

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -917,6 +917,20 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 90,
+        # Session-level total API-call ceiling — a hard cost backstop against
+        # runaway agent loops. Cumulative across ALL turns in a session (unlike
+        # max_turns, which bounds a single turn). 0 disables. Set in DEFAULT_CONFIG
+        # (not just a profile) so EVERY profile — including brand-new ones created
+        # without --clone — inherits the protection. See credit-burn fix #2.
+        "max_api_calls": 75,
+        # Absolute wall-clock lifetime for a persisted session (seconds),
+        # independent of activity.  This stops a disconnected but busy run;
+        # 0 is an explicit opt-out.  Four hours covers legitimate long tasks
+        # while bounding an orphan far below the historical 81-hour incident.
+        "max_session_duration_seconds": 14400,
+        # Aggregate session spend backstop.  Checked before each provider call
+        # against persisted actual/estimated cost; 0 disables it.
+        "max_session_cost_usd": 15.0,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -1087,7 +1101,7 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
     },
-    
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",
@@ -1341,11 +1355,18 @@ DEFAULT_CONFIG = {
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
         "protect_first_n": 3,         # non-system head messages always preserved
-                                      # verbatim, in ADDITION to the system prompt
-                                      # (which is always implicitly protected). Set to
-                                      # 0 for long-running rolling-compaction sessions
-                                      # where you want nothing pinned except the
-                                      # system prompt + rolling summary + recent tail.
+                                     # verbatim, in ADDITION to the system prompt
+                                     # (which is always implicitly protected). Set to
+                                     # 0 for long-running rolling-compaction sessions
+                                     # where you want nothing pinned except the
+                                     # system prompt + rolling summary + recent tail.
+        # Hard context cap — deterministic last-resort backstop against the
+        # compression death-spiral (aux compression model permanently 404s on
+        # low credits -> retries forever -> unbounded context growth). When the
+        # prompt exceeds this many tokens, oldest non-protected turns are dropped
+        # (no LLM call) so context CANNOT grow without bound. 0 disables.
+        # Set in DEFAULT_CONFIG so EVERY profile inherits it. See credit-burn fix #1.
+        "hard_context_cap_tokens": 250000,
         "abort_on_summary_failure": False,  # When True, auto-compression that fails
                                       # to generate a summary (aux LLM errored / returned
                                       # non-JSON / timed out) aborts entirely instead of
@@ -1652,7 +1673,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
     },
-    
+
     "display": {
         "compact": False,
         "personality": "",
@@ -1946,7 +1967,7 @@ DEFAULT_CONFIG = {
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
-    
+
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
@@ -2010,7 +2031,7 @@ DEFAULT_CONFIG = {
             # "normalize_audio": True,
         },
     },
-    
+
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
@@ -2040,13 +2061,13 @@ DEFAULT_CONFIG = {
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
     },
-    
+
     "human_delay": {
         "mode": "off",
         "min_ms": 800,
         "max_ms": 2500,
     },
-    
+
     # Context engine -- controls how the context window is managed when
     # approaching the model's token limit.
     # "compressor" = built-in lossy summarization (default).
@@ -4294,22 +4315,22 @@ OPTIONAL_ENV_VARS = {
 def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     """
     Check which environment variables are missing.
-    
+
     Returns list of dicts with var info for missing variables.
     """
     missing = []
-    
+
     # Check required vars
     for var_name, info in REQUIRED_ENV_VARS.items():
         if not get_env_value(var_name):
             missing.append({"name": var_name, **info, "is_required": True})
-    
+
     # Check optional vars (if not required_only)
     if not required_only:
         for var_name, info in OPTIONAL_ENV_VARS.items():
             if not get_env_value(var_name):
                 missing.append({"name": var_name, **info, "is_required": False})
-    
+
     return missing
 
 
@@ -4394,7 +4415,7 @@ def clear_model_endpoint_credentials(
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
-    
+
     Walks the DEFAULT_CONFIG tree at arbitrary depth and reports any keys
     present in defaults but absent from the user's loaded config.
     """
@@ -5248,11 +5269,11 @@ def _persist_migration(config: Dict[str, Any]) -> None:
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
-    
+
     Args:
         interactive: If True, prompt user for missing values
         quiet: If True, suppress output
-        
+
     Returns:
         Dict with migration results: {"env_added": [...], "config_added": [...], "warnings": [...]}
     """
@@ -5268,7 +5289,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check config version
     current_ver, latest_ver = check_config_version()
-    
+
     # ── Version 3 → 4: migrate tool progress from .env to config.yaml ──
     if current_ver < 4:
         config = read_raw_config()
@@ -5291,7 +5312,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             _persist_migration(config)
             if not quiet:
                 print(f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}")
-    
+
     # ── Version 4 → 5: add timezone field ──
     if current_ver < 5:
         config = read_raw_config()
@@ -5876,23 +5897,23 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check for missing required env vars
     missing_env = get_missing_env_vars(required_only=True)
-    
+
     if missing_env and not quiet:
         print("\n⚠️  Missing required environment variables:")
         for var in missing_env:
             print(f"   • {var['name']}: {var['description']}")
-    
+
     if interactive and missing_env:
         print("\nLet's configure them now:\n")
         for var in missing_env:
             if var.get("url"):
                 print(f"  Get your key at: {var['url']}")
-            
+
             if var.get("password"):
                 value = masked_secret_prompt(f"  {var['prompt']}: ")
             else:
                 value = input(f"  {var['prompt']}: ").strip()
-            
+
             if value:
                 save_env_value(var["name"], value)
                 results["env_added"].append(var["name"])
@@ -5900,7 +5921,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             else:
                 results["warnings"].append(f"Skipped {var['name']} - some features may not work")
             print()
-    
+
     # Check for missing optional env vars and offer to configure interactively
     # Skip "advanced" vars (like OPENAI_BASE_URL) -- those are for power users
     missing_optional = get_missing_env_vars(required_only=False)
@@ -5909,7 +5930,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         v for v in missing_optional
         if v["name"] not in required_names and not v.get("advanced")
     ]
-    
+
     # Only offer to configure env vars that are NEW since the user's previous version
     new_var_names = set()
     for ver in range(current_ver + 1, latest_ver + 1):
@@ -5952,7 +5973,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     print()
             else:
                 print("  Set later with: hermes config set <key> <value>")
-    
+
     # Check for missing config fields.
     #
     # New default keys are NOT materialised to disk: load_config() deep-merges
@@ -7218,7 +7239,7 @@ def save_env_value(key: str, value: str):
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
         lines.append(f"{key}={serialized_value}\n")
-    
+
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.
     original_mode = None
@@ -7525,11 +7546,11 @@ def show_config():
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
-    
+
     # API Keys
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
-    
+
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
@@ -7541,14 +7562,14 @@ def show_config():
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
     ]
-    
+
     for env_key, name in keys:
         value = get_env_value(env_key)
         print(f"  {name:<14} {redact_key(value)}")
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
     print(f"  {'Anthropic':<14} {redact_key(anthropic_value)}")
-    
+
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
@@ -7568,7 +7589,7 @@ def show_config():
             ))
     except Exception:
         pass
-    
+
     # Display
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
@@ -7588,7 +7609,7 @@ def show_config():
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
-    
+
     if terminal.get('backend') == 'docker':
         print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
     elif terminal.get('backend') == 'singularity':
@@ -7606,7 +7627,7 @@ def show_config():
         ssh_user = get_env_value('TERMINAL_SSH_USER')
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
-    
+
     # Timezone
     print()
     print(color("◆ Timezone", Colors.CYAN, Colors.BOLD))
@@ -7633,7 +7654,7 @@ def show_config():
         comp_provider = _aux_comp.get('provider', 'auto')
         if comp_provider and comp_provider != 'auto':
             print(f"  Provider:     {comp_provider}")
-    
+
     # Auxiliary models
     auxiliary = config.get('auxiliary', {})
     aux_tasks = {
@@ -7655,17 +7676,17 @@ def show_config():
                 if mdl:
                     parts.append(f"model={mdl}")
                 print(f"  {label:12s}  {', '.join(parts)}")
-    
+
     # Messaging
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
-    
+
     telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
     discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
+
     print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
     print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
-    
+
     # Skill config
     try:
         from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
@@ -7697,12 +7718,12 @@ def edit_config():
         managed_error("edit configuration")
         return
     config_path = get_config_path()
-    
+
     # Ensure config exists
     if not config_path.exists():
         save_config(DEFAULT_CONFIG, strip_defaults=False)
         print(f"Created {config_path}")
-    
+
     # Find editor
     editor = os.getenv('EDITOR') or os.getenv('VISUAL')
 
@@ -7721,12 +7742,12 @@ def edit_config():
             if shutil.which(cmd):
                 editor = cmd
                 break
-    
+
     if not editor:
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
         return
-    
+
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
 
@@ -7764,12 +7785,12 @@ def set_config_value(key: str, value: str):
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
         'GITHUB_TOKEN', 'HONCHO_API_KEY',
     ]
-    
+
     if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
-    
+
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
@@ -7781,7 +7802,7 @@ def set_config_value(key: str, value: str):
                 user_config = fast_safe_load(f) or {}
         except Exception:
             user_config = {}
-    
+
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the
@@ -7811,7 +7832,7 @@ def set_config_value(key: str, value: str):
     ensure_hermes_home()
     from utils import atomic_yaml_write
     atomic_yaml_write(config_path, user_config, sort_keys=False)
-    
+
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
     env_var = terminal_config_env_var_for_key(key)
@@ -7838,13 +7859,13 @@ def set_config_value(key: str, value: str):
 def config_command(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
-    
+
     if subcmd is None or subcmd == "show":
         show_config()
-    
+
     elif subcmd == "edit":
         edit_config()
-    
+
     elif subcmd == "set":
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
@@ -7857,81 +7878,81 @@ def config_command(args):
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             sys.exit(1)
         set_config_value(key, value)
-    
+
     elif subcmd == "path":
         print(get_config_path())
-    
+
     elif subcmd == "env-path":
         print(get_env_path())
-    
+
     elif subcmd == "migrate":
         print()
         print(color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD))
         print()
-        
+
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
         current_ver, latest_ver = check_config_version()
-        
+
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
             print()
             return
-        
+
         # Show what needs to be updated
         if current_ver < latest_ver:
             print(f"  Config version: {current_ver} → {latest_ver}")
-        
+
         if missing_config:
             print(f"\n  {len(missing_config)} new config option(s) will be added with defaults")
-        
+
         required_missing = [v for v in missing_env if v.get("is_required")]
         optional_missing = [
             v for v in missing_env
             if not v.get("is_required") and not v.get("advanced")
         ]
-        
+
         if required_missing:
             print(f"\n  ⚠️  {len(required_missing)} required API key(s) missing:")
             for var in required_missing:
                 print(f"     • {var['name']}")
-        
+
         if optional_missing:
             print(f"\n  ℹ️  {len(optional_missing)} optional API key(s) not configured:")
             for var in optional_missing:
                 tools = var.get("tools", [])
                 tools_str = f" (enables: {', '.join(tools[:2])})" if tools else ""
                 print(f"     • {var['name']}{tools_str}")
-        
+
         print()
-        
+
         # Run migration
         results = migrate_config(interactive=True, quiet=False)
-        
+
         print()
         if results["env_added"] or results["config_added"]:
             print(color("✓ Configuration updated!", Colors.GREEN))
-        
+
         if results["warnings"]:
             print()
             for warning in results["warnings"]:
                 print(color(f"  ⚠️  {warning}", Colors.YELLOW))
-        
+
         print()
-    
+
     elif subcmd == "check":
         # Non-interactive check for what's missing
         print()
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
-        
+
         current_ver, latest_ver = check_config_version()
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:
             print(color(f"  Config version: {current_ver} → {latest_ver} (update available)", Colors.YELLOW))
-        
+
         print()
         print(color("  Required:", Colors.BOLD))
         for var_name in REQUIRED_ENV_VARS:
@@ -7939,7 +7960,7 @@ def config_command(args):
                 print(f"    ✓ {var_name}")
             else:
                 print(color(f"    ✗ {var_name} (missing)", Colors.RED))
-        
+
         print()
         print(color("  Optional:", Colors.BOLD))
         for var_name, info in OPTIONAL_ENV_VARS.items():
@@ -7949,15 +7970,15 @@ def config_command(args):
                 tools = info.get("tools", [])
                 tools_str = f" → {', '.join(tools[:2])}" if tools else ""
                 print(color(f"    ○ {var_name}{tools_str}", Colors.DIM))
-        
+
         missing_config = get_missing_config_fields()
         if missing_config:
             print()
             print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
             print("    Run 'hermes config migrate' to add them")
-        
+
         print()
-    
+
     else:
         print(f"Unknown config command: {subcmd}")
         print()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2129,6 +2129,54 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def reserve_session_api_call(
+        self,
+        session_id: str,
+        *,
+        max_api_calls: int = 0,
+        max_session_duration_seconds: float = 0,
+        max_session_cost_usd: float = 0,
+    ) -> tuple[bool, int, Optional[str]]:
+        """Atomically reserve one provider call against durable session budgets.
+
+        This is deliberately called *before* the provider request.  A process
+        crash, client reconnect, or a new agent instance therefore cannot reset
+        the cumulative ceiling or turn an unrecorded in-flight call into a free
+        retry.  ``0`` disables either limit.  The returned tuple is
+        ``(allowed, durable_count, denial_reason)``.
+        """
+        max_api_calls = max(0, int(max_api_calls or 0))
+        max_session_duration_seconds = max(0.0, float(max_session_duration_seconds or 0))
+        max_session_cost_usd = max(0.0, float(max_session_cost_usd or 0))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT api_call_count, started_at, estimated_cost_usd, actual_cost_usd "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return False, 0, "session_not_persisted"
+            count = int(row[0] or 0)
+            started_at = float(row[1] or 0)
+            spend = max(float(row[2] or 0), float(row[3] or 0))
+            if max_session_duration_seconds and started_at > 0 and (
+                time.time() - started_at >= max_session_duration_seconds
+            ):
+                return False, count, "session_duration_ceiling"
+            if max_session_cost_usd and spend >= max_session_cost_usd:
+                return False, count, "session_cost_ceiling"
+            if max_api_calls and count >= max_api_calls:
+                return False, count, "api_call_ceiling"
+            count += 1
+            conn.execute(
+                "UPDATE sessions SET api_call_count = ? WHERE id = ?",
+                (count, session_id),
+            )
+            return True, count, None
+
+        return self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,
@@ -2182,7 +2230,7 @@ class SessionDB:
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
-                   api_call_count = ?
+                   api_call_count = MAX(COALESCE(api_call_count, 0), ?)
                    WHERE id = ?"""
         else:
             sql = """UPDATE sessions SET

--- a/run_agent.py
+++ b/run_agent.py
@@ -3134,6 +3134,25 @@ class AIAgent:
             return
 
         # retain-last-known: only overwrite on a fresh valid parse
+        # ── Per-call authoritative cost (server-billed) ──────────────────────
+        # The Nous x-nous-credits-* headers report REMAINING balance AFTER this
+        # call. The cost of THIS call = (remaining before) - (remaining after)
+        # = old _credits_state.remaining_micros - new state.remaining_micros.
+        # This is the billable amount per call, independent of any price-table
+        # estimate. Stash it for the conversation loop's update_token_counts,
+        # which writes it to state.db.actual_cost_usd (incrementing). Cleared
+        # after each read so a stale value can't leak across calls.
+        _call_cost_micros = None
+        _prev = getattr(self, "_credits_state", None)
+        if (
+            _prev is not None
+            and getattr(_prev, "from_header", False)
+            and getattr(_prev, "remaining_micros", None) is not None
+            and state.remaining_micros is not None
+            and state.remaining_micros <= _prev.remaining_micros
+        ):
+            _call_cost_micros = _prev.remaining_micros - state.remaining_micros
+        self._last_call_actual_cost_micros = _call_cost_micros
         self._credits_state = state
         # Latch session-start remaining the first time we ever see a header
         if self._credits_session_start_micros is None:

--- a/tests/agent/test_actual_cost_capture.py
+++ b/tests/agent/test_actual_cost_capture.py
@@ -1,0 +1,83 @@
+"""Tests for authoritative per-call cost capture (x-nous-credits-* delta -> actual_cost_usd).
+
+Root-cause fix for the telemetry gap: Hermes recorded only *estimated* cost;
+the server's authoritative billable cost was parsed (credits_tracker) but never
+written to state.db.actual_cost_usd. These tests prove the delta math and the
+DB increment/absolute-set behavior.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from hermes_state import SessionDB
+
+
+def _credits_headers(remaining_usd: str, remaining_micros: int) -> dict:
+    return {
+        "x-nous-credits-version": "1",
+        "x-nous-credits-remaining-micros": str(remaining_micros),
+        "x-nous-credits-remaining-usd": remaining_usd,
+        "x-nous-credits-subscription-micros": str(remaining_micros),
+        "x-nous-credits-subscription-usd": remaining_usd,
+        "x-nous-credits-subscription-limit-micros": "20000000",
+        "x-nous-credits-subscription-limit-usd": "20.00",
+        "x-nous-credits-rollover-micros": "0",
+        "x-nous-credits-purchased-micros": "0",
+        "x-nous-credits-purchased-usd": "0.00",
+        "x-nous-credits-denominator-kind": "subscription_cap",
+        "x-nous-credits-paid-access": "true",
+        "x-nous-credits-as-of-ms": "1",
+    }
+
+
+def test_per_call_delta_computes_cost():
+    """prev remaining 10000µ -> new 7000µ == 0.003 USD for this call."""
+    from run_agent import AIAgent  # type: ignore  (importable under repo root)
+    from agent.credits_tracker import parse_credits_headers
+
+    agent = MagicMock(spec=AIAgent)
+    agent._credits_state = parse_credits_headers(_credits_headers("0.01", 10000))
+    agent._credits_session_start_micros = 10000
+
+    # Simulate the production call site: _capture_credits computes the delta.
+    new_state = parse_credits_headers(_credits_headers("0.00", 7000))
+    _prev = agent._credits_state
+    delta = None
+    if (
+        _prev is not None and _prev.from_header
+        and _prev.remaining_micros is not None
+        and new_state is not None
+        and new_state.remaining_micros is not None
+        and new_state.remaining_micros <= _prev.remaining_micros
+    ):
+        delta = _prev.remaining_micros - new_state.remaining_micros
+    assert new_state is not None
+    assert delta == 3000
+    assert delta / 1_000_000.0 == 0.003
+
+
+def test_update_token_counts_increments_actual_cost(tmp_path):
+    db = SessionDB()
+    db.db_path = str(tmp_path / "s.db")
+    sid = "t1"
+    db._insert_session_row(sid, "unknown")
+    baseline = db.get_session(sid)["actual_cost_usd"] or 0.0
+    baseline_calls = db.get_session(sid)["api_call_count"] or 0
+    db.update_token_counts(sid, api_call_count=1, actual_cost_usd=0.003, absolute=False)
+    db.update_token_counts(sid, api_call_count=1, actual_cost_usd=0.002, absolute=False)
+    row = db.get_session(sid)
+    # increment path ADDS per-call deltas to the running total
+    assert abs(row["actual_cost_usd"] - (baseline + 0.005)) < 1e-9
+    assert row["api_call_count"] == (baseline_calls + 2)
+
+
+def test_update_token_counts_absolute_sets_actual_cost(tmp_path):
+    db = SessionDB()
+    db.db_path = str(tmp_path / "s.db")
+    sid = "t2"
+    db._insert_session_row(sid, "unknown")
+    baseline = db.get_session(sid)["actual_cost_usd"] or 0.0
+    db.update_token_counts(sid, api_call_count=5, actual_cost_usd=0.042, absolute=True)
+    row = db.get_session(sid)
+    # absolute path SETS the total directly (overwrites baseline)
+    assert abs(row["actual_cost_usd"] - 0.042) < 1e-9
+    assert row["api_call_count"] == 5

--- a/tests/agent/test_hard_context_cap.py
+++ b/tests/agent/test_hard_context_cap.py
@@ -1,0 +1,77 @@
+"""Tests for the hard context cap backstop added to ContextCompressor.
+
+Root-cause fix for the compression death-spiral: when the summarizer is
+permanently unavailable (e.g. auxiliary compression model 404s on low
+credits), apply_hard_context_cap() deterministically drops the oldest
+non-protected turns instead of letting context grow unbounded.
+"""
+import pytest
+from unittest.mock import patch
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def cap_compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+        c = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.5,
+            protect_first_n=1,
+            protect_last_n=2,
+            quiet_mode=True,
+            hard_context_cap_tokens=100,
+        )
+    return c
+
+
+def _build(n):
+    msgs = [{"role": "system", "content": "sys"}, {"role": "user", "content": "u0"}]
+    for i in range(n):
+        msgs.append({"role": "assistant", "content": "a", "tool_calls": [{"id": f"c{i}"}]})
+        msgs.append({"role": "tool", "content": f"r{i}", "tool_call_id": f"c{i}"})
+    msgs.append({"role": "user", "content": "tail1"})
+    msgs.append({"role": "assistant", "content": "tail2"})
+    return msgs
+
+
+def _assert_no_orphans(messages):
+    ids = set()
+    for m in messages:
+        for tc in (m.get("tool_calls") or []):
+            if isinstance(tc, dict):
+                ids.add(tc["id"])
+    kept_results = set(m["tool_call_id"] for m in messages if m.get("role") == "tool")
+    for i in ids:
+        assert i in kept_results, f"orphaned tool_call {i}"
+
+
+def test_disabled_noop(cap_compressor):
+    c = ContextCompressor(model="x", threshold_percent=0.5, hard_context_cap_tokens=0, quiet_mode=True)
+    m = _build(5)
+    out, trim = c.apply_hard_context_cap(m, 10 ** 9)
+    assert not trim and out is m
+
+
+def test_under_cap_noop(cap_compressor):
+    m = _build(5)
+    out, trim = cap_compressor.apply_hard_context_cap(m, 50)
+    assert not trim
+
+
+def test_trims_oldest_and_respects_protected(cap_compressor):
+    m = _build(5)
+    out, trim = cap_compressor.apply_hard_context_cap(m, 1000)
+    assert trim
+    assert out[0]["content"] == "sys"            # system kept
+    assert out[1]["content"] == "u0"             # first protected kept
+    assert out[-1]["content"] == "tail2"         # last protected kept
+    assert out[-2]["content"] == "tail1"         # last protected kept
+    _assert_no_orphans(out)
+
+
+def test_trim_never_orphans_with_small_tail(cap_compressor):
+    c = ContextCompressor(model="x", threshold_percent=0.5, protect_first_n=0,
+                          protect_last_n=1, hard_context_cap_tokens=50, quiet_mode=True)
+    m = _build(3)
+    out, trim = c.apply_hard_context_cap(m, 500)
+    _assert_no_orphans(out)

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -17,6 +17,8 @@ def _mock_response(*, usage: dict, content: str = "done"):
 
 
 def _make_agent(session_db, *, platform: str):
+    if session_db is not None:
+        session_db.reserve_session_api_call.return_value = (True, 1, None)
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),

--- a/tests/test_session_budget.py
+++ b/tests/test_session_budget.py
@@ -1,0 +1,55 @@
+"""Regression tests for durable, pre-call session budgets.
+
+The budget must be reserved in state.db before a provider request. A fresh
+agent/process resuming the same session must therefore see the spent budget.
+"""
+
+import time
+
+from hermes_state import SessionDB
+
+
+def test_api_call_budget_is_reserved_before_call_and_survives_new_instance(tmp_path):
+    db_path = tmp_path / "state.db"
+    first = SessionDB(db_path=db_path)
+    first.create_session("budget-session", "test")
+
+    assert first.reserve_session_api_call("budget-session", max_api_calls=2) == (True, 1, None)
+    first.close()
+
+    # Simulates a resumed session handled by another agent instance/process.
+    resumed = SessionDB(db_path=db_path)
+    assert resumed.reserve_session_api_call("budget-session", max_api_calls=2) == (True, 2, None)
+    assert resumed.reserve_session_api_call("budget-session", max_api_calls=2) == (
+        False,
+        2,
+        "api_call_ceiling",
+    )
+    assert resumed.get_session("budget-session")["api_call_count"] == 2
+    resumed.close()
+
+
+def test_session_duration_budget_rejects_active_but_expired_session(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("expired-session", "test")
+    # The session remains active; elapsed lifetime, not inactivity, is the limit.
+    db._execute_write(lambda conn: conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (time.time() - 61, "expired-session"),
+    ))
+
+    assert db.reserve_session_api_call(
+        "expired-session", max_api_calls=10, max_session_duration_seconds=60,
+    ) == (False, 0, "session_duration_ceiling")
+    db.close()
+
+
+def test_session_cost_budget_rejects_before_another_provider_call(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("cost-session", "test")
+    db.update_token_counts("cost-session", estimated_cost_usd=15.0)
+
+    assert db.reserve_session_api_call(
+        "cost-session", max_api_calls=10, max_session_cost_usd=15.0,
+    ) == (False, 0, "session_cost_ceiling")
+    db.close()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -162,3 +162,25 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_active_ws_orphan_is_interrupted_before_reap(monkeypatch):
+    """A disconnected active run must not bypass the orphan reaper forever."""
+    interrupts = []
+
+    class FakeAgent:
+        def interrupt(self, reason):
+            interrupts.append(reason)
+
+    server._sessions.clear()
+    try:
+        server._sessions["active"] = {
+            "transport": server._detached_ws_transport,
+            "running": True,
+            "agent": FakeAgent(),
+        }
+        assert server._reap_ws_orphan("active") is True
+        assert interrupts == ["WebSocket client disconnected; cancelling orphaned run"]
+        assert server._sessions["active"]["_ws_orphan_interrupt_requested"] is True
+    finally:
+        server._sessions.clear()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -163,6 +163,15 @@ try:
 except (ValueError, TypeError):
     _ws_orphan_reap_grace = 20.0
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
+# A disconnect must stop an actively running orphan too.  This short second
+# grace gives the interruption path time to unwind before final teardown.
+try:
+    _ws_orphan_interrupt_grace = float(
+        os.environ.get("HERMES_TUI_WS_ORPHAN_INTERRUPT_GRACE_S") or "15"
+    )
+except (ValueError, TypeError):
+    _ws_orphan_interrupt_grace = 15.0
+_WS_ORPHAN_INTERRUPT_GRACE_S = max(1.0, _ws_orphan_interrupt_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
@@ -671,32 +680,46 @@ def _ws_session_is_orphaned(session: dict | None) -> bool:
     return session.get("transport") is _detached_ws_transport
 
 
-def _schedule_ws_orphan_reap(sid: str) -> None:
-    """After a grace window, reap session ``sid`` iff it's still orphaned.
+def _reap_ws_orphan(sid: str) -> bool:
+    """Reap a detached WS session, interrupting an active run first.
 
-    Called from the WS-disconnect path. The grace window lets a transient
-    reconnect (or a ``session.resume`` that reattaches the transport) cancel
-    the reap by re-binding a live transport. Disabled when the grace is 0.
+    Returns True when the caller should schedule one short follow-up reap while
+    the interrupted worker unwinds.  This closes the historical gap where a
+    detached session was considered non-orphaned forever merely because it was
+    still generating tokens.
     """
-    if _WS_ORPHAN_REAP_GRACE_S <= 0:
+    with _session_resume_lock:
+        session = _sessions.get(sid)
+        if not session or session.get("transport") is not _detached_ws_transport:
+            return False
+        if session.get("running"):
+            agent = session.get("agent")
+            if agent is not None and hasattr(agent, "interrupt"):
+                try:
+                    agent.interrupt("WebSocket client disconnected; cancelling orphaned run")
+                except Exception:
+                    logger.debug("Failed to interrupt orphaned WS run", exc_info=True)
+            session["_ws_orphan_interrupt_requested"] = True
+            return True
+        _close_session_by_id(sid, end_reason="ws_orphan_reap")
+        return False
+
+
+def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
+    """After a grace window, reap session ``sid`` iff it is still detached.
+
+    An active orphan is interrupted and checked once more after the shorter
+    interrupt grace, rather than being allowed to run indefinitely.
+    """
+    grace_s = _WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s)
+    if grace_s <= 0:
         return
 
     def _reap() -> None:
-        # Serialize the orphan re-check against session.resume (which re-binds a
-        # live transport under _session_resume_lock and would make this session
-        # non-orphaned). The actual pop + teardown then goes through the shared
-        # _close_session_by_id funnel so the dict mutation happens under
-        # _sessions_lock — consistent with every other _sessions mutator
-        # (#39591: _reap previously popped under _session_resume_lock, giving no
-        # mutual exclusion against _init_session / _close_session_by_id, which
-        # guard with _sessions_lock). _sessions_lock is an RLock and the global
-        # ordering is always resume_lock -> sessions_lock, so nesting is safe.
-        with _session_resume_lock:
-            if not _ws_session_is_orphaned(_sessions.get(sid)):
-                return
-            _close_session_by_id(sid, end_reason="ws_orphan_reap")
+        if _reap_ws_orphan(sid):
+            _schedule_ws_orphan_reap(sid, delay_s=_WS_ORPHAN_INTERRUPT_GRACE_S)
 
-    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _reap)
+    timer = threading.Timer(grace_s, _reap)
     timer.daemon = True
     timer.start()
 


### PR DESCRIPTION
## Summary
- atomically reserve each LLM call in `state.db` before the provider request, enforcing session ceilings across reconnects and process restarts
- add absolute session lifetime (4h), aggregate spend ($15), and lower default call (75) backstops
- interrupt WebSocket-detached active TUI runs, then reap them after grace instead of allowing them to continue indefinitely
- retain hard-context-cap and cost-accounting regressions

## Validation
- `18 passed` focused budget, WebSocket, token persistence, cost capture, and hard context-cap tests
- `py_compile` passed for all changed runtime modules

The durable reservation is intentionally fail-closed when a configured budget cannot be persisted, preventing a database failure from becoming an unbounded paid request.