### PR TITLE
fix(gateway): preserve continuable cron replies across resets

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -68,6 +68,13 @@ def mirror_to_session(
             )
             return False
 
+        # Resolve against the live SessionStore BEFORE appending: the
+        # background expiry watcher may have already finalized/ended this
+        # session at an idle/daily boundary, in which case the live store
+        # redirects the mirror into the post-reset session the user's next
+        # reply will route to (see _resolve_live_session).
+        session_id = _resolve_live_session(session_id) or session_id
+
         mirror_msg = {
             "role": role,
             "content": message_text,
@@ -186,6 +193,37 @@ def _find_session_id(
     best_entry = max(candidates, key=lambda entry: entry.get("updated_at", ""))
     return best_entry.get("session_id")
 
+
+
+def _resolve_live_session(session_id: str) -> Optional[str]:
+    """Resolve the live routing target for *session_id* before appending.
+
+    The mirror append lands only in state.db; the gateway's in-memory
+    ``SessionEntry.updated_at`` still reflects the last real turn.  If the
+    mirror arrives after an idle/daily reset boundary (e.g. an early-morning
+    cron brief with ``attach_to_session=true``), the user's immediate reply
+    would trigger an auto-reset into a fresh session and lose the mirrored
+    context.  While the routed session is still live, the store refreshes
+    its ``updated_at`` so the reply stays associated with it.
+
+    When the background expiry watcher already finalized the session — or
+    the session was ended in state.db — before the mirror arrived, a touch
+    is not enough: the reply's ``get_or_create_session`` self-heals/resets
+    away from the ended session regardless of ``updated_at``.  The store
+    instead resolves/creates the post-reset session that reply will land in
+    and returns its id, so the mirror is appended there.
+
+    Best-effort — returns None (the caller keeps the id it found) when no
+    live SessionStore routes to *session_id* (CLI/cron standalone) or on any
+    error; a resolution failure must never block the mirror itself.
+    """
+    try:
+        from gateway.session import resolve_live_mirror_session
+
+        return resolve_live_mirror_session(session_id)
+    except Exception as e:
+        logger.debug("Mirror live-session resolve failed for %s: %s", session_id, e)
+        return None
 
 
 def _append_to_sqlite(session_id: str, message: dict) -> None:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -15,6 +15,7 @@ import os
 import json
 import threading
 import uuid
+import weakref
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass
@@ -983,14 +984,55 @@ class AsyncSessionStore:
         return _offloaded
 
 
+# Live SessionStore instances in this process, so out-of-band transcript
+# writers (gateway/mirror.py — cron delivery mirrors, send_message mirrors)
+# can refresh the in-memory routing entry they appended to.  Weak so test /
+# short-lived stores never pin themselves here.
+_LIVE_STORES: "weakref.WeakSet[SessionStore]" = weakref.WeakSet()
+
+
+def resolve_live_mirror_session(session_id: str) -> Optional[str]:
+    """Resolve the live session a mirror routed to *session_id* should target.
+
+    Called by ``gateway.mirror.mirror_to_session`` BEFORE it appends a mirror
+    message to state.db.  The mirror bypasses ``update_session``, so without
+    this the routing entry's ``updated_at`` stays at the last real turn; if
+    the mirror lands after an idle/daily reset boundary, the user's immediate
+    reply auto-resets into a fresh session and orphans the mirrored context.
+
+    Two cases per live store (see ``SessionStore.resolve_mirror_session``):
+    the routed entry is still live → refresh its ``updated_at`` and keep the
+    id; the background expiry watcher already finalized it (or the session
+    was ended in state.db) → return the post-reset session the user's next
+    reply will route to, so the mirror is appended there instead of into the
+    ended session.
+
+    Returns the session_id the mirror should append to, or None when no live
+    store routes to *session_id* (CLI/cron standalone — the caller keeps the
+    id it found itself).
+    """
+    resolved = None
+    for store in list(_LIVE_STORES):
+        try:
+            candidate = store.resolve_mirror_session(session_id)
+        except Exception as exc:
+            logger.debug(
+                "resolve_live_mirror_session failed for %s: %s", session_id, exc
+            )
+            continue
+        if candidate and resolved is None:
+            resolved = candidate
+    return resolved
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
-    
+
     Uses SQLite (via SessionDB) for session metadata and message transcripts.
     Falls back to legacy JSONL files if SQLite is unavailable.
     """
-    
+
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
                  has_active_processes_fn=None):
         self.sessions_dir = sessions_dir
@@ -1021,6 +1063,8 @@ class SessionStore:
             self._db = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+
+        _LIVE_STORES.add(self)
     
     def _ensure_loaded(self) -> None:
         """Load sessions index from disk if not already loaded."""
@@ -2017,6 +2061,78 @@ class SessionStore:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
         return entry
+
+    def touch_session_by_id(self, session_id: str) -> bool:
+        """Refresh ``updated_at`` for the entry currently routed to *session_id*.
+
+        A delivery mirror (cron ``attach_to_session`` brief, ``send_message``
+        echo) is real activity in the session's transcript, but it is written
+        straight to state.db without an inbound turn, so nothing bumps the
+        routing entry.  Bumping it here keeps ``_should_reset`` (and the
+        expiry watcher's ``_is_session_expired``) from treating the freshly
+        mirrored session as idle/stale and resetting away the mirrored
+        context on the user's next reply.
+
+        Returns True if an entry mapped to *session_id* was found and bumped.
+        Persists the routing index so the bump survives a gateway restart.
+        """
+        if not session_id:
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = next(
+                (
+                    e for e in self._entries.values()
+                    if e.session_id == session_id
+                ),
+                None,
+            )
+            if entry is None:
+                return False
+            entry.updated_at = _now()
+            self._save()
+        return True
+
+    def resolve_mirror_session(self, session_id: str) -> Optional[str]:
+        """Return the session a delivery mirror routed to *session_id* should target.
+
+        Live entry: behave like ``touch_session_by_id`` (bump ``updated_at``
+        so the mirrored session isn't treated as idle/stale) and keep the id.
+
+        Finalized/ended entry: the background expiry watcher marked the entry
+        ``expiry_finalized`` — or the session was ended in state.db — before
+        the mirror arrived.  Appending there would strand the mirror: the
+        user's next reply routes through ``get_or_create_session``, which
+        self-heals away from the ended session (#54878) or applies the reset
+        policy, and the mirrored context is lost.  Instead run that same
+        routing transition NOW (``get_or_create_session(entry.origin)``) and
+        return the post-reset session id, so mirror and reply land together.
+
+        Returns None when this store has no entry routed to *session_id*.
+        """
+        if not session_id:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = next(
+                (
+                    e for e in self._entries.values()
+                    if e.session_id == session_id
+                ),
+                None,
+            )
+        if entry is None:
+            return None
+        if not entry.expiry_finalized and not self._is_session_ended_in_db(
+            session_id
+        ):
+            self.touch_session_by_id(session_id)
+            return session_id
+        if entry.origin is None:
+            # No routing source to rebuild from — keep the old id rather
+            # than dropping the mirror entirely.
+            return session_id
+        return self.get_or_create_session(entry.origin).session_id
 
     def update_session(
         self,

--- a/tests/gateway/test_mirror_session_touch.py
+++ b/tests/gateway/test_mirror_session_touch.py
@@ -1,0 +1,244 @@
+"""Regression: a mirrored delivery must refresh the live session entry.
+
+A cron job with ``attach_to_session=true`` mirrors its brief into the origin
+chat's transcript via ``gateway.mirror.mirror_to_session``, which appends to
+state.db only.  Before the fix nothing refreshed the live
+``SessionEntry.updated_at``, so when the brief landed after an idle/daily
+reset boundary the user's immediate reply auto-reset into a fresh session and
+lost the mirrored context (observed on a Weixin DM).
+
+The fix: before appending, ``mirror_to_session`` resolves the live routing
+target (``gateway.session.resolve_live_mirror_session``).  While the routed
+session is still live the store refreshes ``SessionEntry.updated_at`` (and
+persists it to the routing index), so the reply stays associated both in the
+live gateway and across a restart.  When the background expiry watcher
+already finalized the session — or it was ended in state.db — before the
+mirror arrived, a touch cannot help (``get_or_create_session`` self-heals /
+resets away from ended sessions regardless of ``updated_at``); the store
+instead runs the same routing transition the reply will take and the mirror
+is appended into the resulting post-reset session.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+import gateway.mirror as mirror_mod
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore, _now
+
+
+@pytest.fixture()
+def hermes_tmp(tmp_path, monkeypatch):
+    """Isolate state.db and the mirror's legacy sessions.json fallback."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(mirror_mod, "_SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(mirror_mod, "_SESSIONS_INDEX", sessions_dir / "sessions.json")
+    return tmp_path
+
+
+def _make_store(tmp_path, policy):
+    config = GatewayConfig()
+    config.default_reset_policy = policy
+    return SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+
+
+def _weixin_dm_source():
+    return SessionSource(
+        platform=Platform.WEIXIN,
+        chat_id="wx_lulu_dm",
+        chat_type="dm",
+        user_id="lulu",
+        user_name="Lulu",
+    )
+
+
+class TestMirrorRefreshesLiveSession:
+    def test_reply_after_mirrored_cron_delivery_stays_in_session(self, hermes_tmp):
+        """Idle boundary crossed, then cron mirrors its brief: the user's
+        immediate reply must resolve to the mirrored session, not a reset."""
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        store = _make_store(
+            hermes_tmp, SessionResetPolicy(mode="idle", idle_minutes=60)
+        )
+        source = _weixin_dm_source()
+        entry = store.get_or_create_session(source)
+        original_session_id = entry.session_id
+
+        # Session goes quiet past the idle boundary.
+        entry.updated_at = _now() - timedelta(minutes=180)
+
+        job = {"id": "job_brief", "name": "Morning brief", "attach_to_session": True}
+        _maybe_mirror_cron_delivery(
+            job,
+            "weixin",
+            "wx_lulu_dm",
+            "Task #2 is due today.",
+            user_id="lulu",
+            enabled=True,
+        )
+
+        # The brief landed in the original session's transcript...
+        transcript = store.load_transcript(original_session_id)
+        assert any("Task #2" in str(m.get("content")) for m in transcript)
+
+        # ...and the reply right after it joins that same session.
+        reply_entry = store.get_or_create_session(source)
+        assert reply_entry.session_id == original_session_id
+        assert not reply_entry.was_auto_reset
+
+    def test_reply_after_mirror_survives_daily_boundary(self, hermes_tmp):
+        """Same association guarantee for a daily reset policy, exercised via
+        mirror_to_session directly (the shared choke point send_message and
+        all cron mirror paths ride)."""
+        from gateway.mirror import mirror_to_session
+
+        store = _make_store(hermes_tmp, SessionResetPolicy(mode="daily", at_hour=4))
+        source = _weixin_dm_source()
+        entry = store.get_or_create_session(source)
+        original_session_id = entry.session_id
+
+        # Last activity two days ago -- unambiguously before today's reset.
+        entry.updated_at = _now() - timedelta(days=2)
+
+        assert mirror_to_session(
+            "weixin",
+            "wx_lulu_dm",
+            "[Cron delivery: Morning brief]\nTask #2 is due today.",
+            source_label="cron",
+            user_id="lulu",
+            role="user",
+        )
+
+        reply_entry = store.get_or_create_session(source)
+        assert reply_entry.session_id == original_session_id
+
+    def test_mirror_touch_persists_across_gateway_restart(self, hermes_tmp):
+        """The touch is written to the routing index, so a gateway restarted
+        between the mirrored delivery and the user's reply still routes the
+        reply into the mirrored session."""
+        from gateway.mirror import mirror_to_session
+
+        policy = SessionResetPolicy(mode="idle", idle_minutes=60)
+        store = _make_store(hermes_tmp, policy)
+        source = _weixin_dm_source()
+        entry = store.get_or_create_session(source)
+        original_session_id = entry.session_id
+
+        # Persist the stale timestamp, as a real idle gateway would have.
+        entry.updated_at = _now() - timedelta(minutes=180)
+        store._save_entries()
+
+        assert mirror_to_session(
+            "weixin",
+            "wx_lulu_dm",
+            "[Cron delivery: Morning brief]\nTask #2 is due today.",
+            source_label="cron",
+            user_id="lulu",
+            role="user",
+        )
+
+        restarted = _make_store(hermes_tmp, policy)
+        reply_entry = restarted.get_or_create_session(source)
+        assert reply_entry.session_id == original_session_id
+
+    def test_touch_returns_false_for_unknown_session(self, hermes_tmp):
+        store = _make_store(
+            hermes_tmp, SessionResetPolicy(mode="idle", idle_minutes=60)
+        )
+        assert store.touch_session_by_id("no_such_session") is False
+        assert store.touch_session_by_id("") is False
+
+
+class TestMirrorAfterSessionFinalized:
+    """The expiry watcher can beat the mirror to the reset boundary.
+
+    ``GatewayRunner._session_expiry_watcher`` runs every 5 minutes: at a
+    daily/idle boundary it finalizes the routed session (marks
+    ``expiry_finalized``, fires hooks, evicts the agent) before an
+    early-morning cron mirror arrives.  Merely appending + touching would
+    resurrect or strand the mirror in that session — ``get_or_create_session``
+    self-heals/resets away from finalized/ended sessions on the user's reply.
+    The mirror must instead land in the post-reset session the reply routes to.
+    """
+
+    def test_mirror_after_watcher_finalized_redirects_to_post_reset_session(
+        self, hermes_tmp
+    ):
+        """expiry watcher finalized at the daily boundary → the mirror must
+        resolve/create the post-reset session and append there, and the
+        user's reply must join that same session."""
+        from gateway.mirror import mirror_to_session
+
+        store = _make_store(hermes_tmp, SessionResetPolicy(mode="daily", at_hour=4))
+        source = _weixin_dm_source()
+        entry = store.get_or_create_session(source)
+        original_session_id = entry.session_id
+
+        # Two days quiet, then the background expiry watcher finalizes the
+        # session at the daily boundary — before the cron mirror arrives.
+        entry.updated_at = _now() - timedelta(days=2)
+        store.set_expiry_finalized(entry)
+
+        assert mirror_to_session(
+            "weixin",
+            "wx_lulu_dm",
+            "[Cron delivery: Morning brief]\nTask #2 is due today.",
+            source_label="cron",
+            user_id="lulu",
+            role="user",
+        )
+
+        # The reply routes into a fresh post-reset session (the daily reset
+        # still applies)...
+        reply_entry = store.get_or_create_session(source)
+        assert reply_entry.session_id != original_session_id
+        assert reply_entry.was_auto_reset
+
+        # ...and the mirrored brief is in THAT session, not the finalized one.
+        new_transcript = store.load_transcript(reply_entry.session_id)
+        assert any("Task #2" in str(m.get("content")) for m in new_transcript)
+        old_transcript = store.load_transcript(original_session_id)
+        assert not any("Task #2" in str(m.get("content")) for m in old_transcript)
+
+    def test_mirror_into_db_ended_session_redirects(self, hermes_tmp):
+        """The routed session was already ended in state.db (end_reason set)
+        while the routing entry survived — the mirror must not append into
+        the ended session the reply will self-heal away from (#54878)."""
+        import hermes_state
+        from gateway.mirror import mirror_to_session
+
+        store = _make_store(
+            hermes_tmp, SessionResetPolicy(mode="idle", idle_minutes=60)
+        )
+        source = _weixin_dm_source()
+        entry = store.get_or_create_session(source)
+        original_session_id = entry.session_id
+
+        # Session ended in state.db out-of-band (non-recoverable reason), the
+        # in-memory/sessions.json routing entry still points at it.
+        db = hermes_state.SessionDB()
+        try:
+            db.end_session(original_session_id, "session_reset")
+        finally:
+            db.close()
+
+        assert mirror_to_session(
+            "weixin",
+            "wx_lulu_dm",
+            "[Cron delivery: Morning brief]\nTask #2 is due today.",
+            source_label="cron",
+            user_id="lulu",
+            role="user",
+        )
+
+        reply_entry = store.get_or_create_session(source)
+        assert reply_entry.session_id != original_session_id
+        new_transcript = store.load_transcript(reply_entry.session_id)
+        assert any("Task #2" in str(m.get("content")) for m in new_transcript)
+        old_transcript = store.load_transcript(original_session_id)
+        assert not any("Task #2" in str(m.get("content")) for m in old_transcript)


### PR DESCRIPTION
## What does this PR do?

Fixes a continuable cron delivery losing its reply context when the target gateway session crosses an idle or daily reset boundary.

A cron job with `attach_to_session: true` could mirror its output into the current transcript without refreshing the live `SessionEntry`. The next user reply could then trigger an automatic reset and enter a new session that did not contain the cron delivery. If the expiry watcher had already finalized the session, the mirror could also be appended to an ended session that reply routing would immediately abandon.

The fix resolves the live routing target before appending the mirror. It refreshes a still-live session, or redirects the mirror into the same post-reset session that the next reply will use.

## Related Issue

No existing issue or PR found after searching for continuable cron, mirror delivery, and session reset reports. The bug was reproduced in a live Weixin DM.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/mirror.py`
  - resolve a mirror against the live gateway session before writing it
  - preserve best-effort mirror behavior when no live store is available
- `gateway/session.py`
  - track live `SessionStore` instances with weak references
  - refresh activity for a valid mirrored session
  - route mirrors away from finalized or DB-ended sessions into the post-reset session
- `tests/gateway/test_mirror_session_touch.py`
  - add regressions for idle reset, daily reset, gateway restart, expiry finalization, and DB-ended sessions

## How to Test

1. Configure a gateway session with `session_reset.mode: daily`, `idle`, or `both`.
2. Create a cron job with `attach_to_session: true`, then let the target session cross the reset boundary before delivery.
3. Deliver the cron output and reply immediately; verify the mirror and reply resolve to the same live/post-reset session.
4. Run the focused regression suite:

```bash
HERMES_HOME="$(mktemp -d)" env -u WEIXIN_HOME_CHANNEL \
  uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/gateway/test_mirror.py \
  tests/gateway/test_mirror_session_touch.py \
  tests/cron/test_scheduler.py \
  -o 'addopts=' -q
```

Focused result: `236 passed`.

CI-parity command `scripts/run_tests.sh` was also attempted on macOS. It completed with 70 failures across 19 unrelated existing test files; none were in the changed or focused gateway/cron tests. The failures include macOS `/tmp` vs `/private/tmp`, local browser/DNS routing, credential mocks, and service-manager assumptions, so the full-suite checkbox remains intentionally unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon), live Weixin DM reproduction plus automated regression suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; expected continuable-cron behavior is already documented, implementation docstrings were added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python session routing; no OS-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

Focused regression suite:

```text
236 passed in 4.10s
```

Live reproduction before the fix:

```text
cron delivery mirrored into session A
immediate Weixin reply triggered daily reset into session B
reply had no cron-delivery context
```
