### PR TITLE
fix(computer-use): normalize Windows manifest paths in WSL

### DIFF
--- a/tests/computer_use/test_cua_wsl_manifest_path.py
+++ b/tests/computer_use/test_cua_wsl_manifest_path.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend
+
+
+def test_wsl_windows_manifest_path_translates_to_drvfs():
+    with patch("hermes_constants.is_wsl", return_value=True):
+        assert cua_backend._wsl_windows_path_to_posix(
+            r"C:\Users\Fernando\AppData\Local\cua-driver\cua-driver.exe"
+        ) == "/mnt/c/Users/Fernando/AppData/Local/cua-driver/cua-driver.exe"
+
+
+def test_non_windows_path_is_unchanged_in_wsl():
+    with patch("hermes_constants.is_wsl", return_value=True):
+        assert cua_backend._wsl_windows_path_to_posix(
+            "/usr/local/bin/cua-driver"
+        ) == "/usr/local/bin/cua-driver"
+
+
+def test_windows_manifest_path_is_unchanged_outside_wsl():
+    path = r"D:\Tools\cua-driver.exe"
+    with patch("hermes_constants.is_wsl", return_value=False):
+        assert cua_backend._wsl_windows_path_to_posix(path) == path
+
+
+def test_resolve_mcp_invocation_normalizes_windows_manifest_command_in_wsl():
+    manifest = {
+        "mcp_invocation": {
+            "command": r"C:\Users\Fernando\AppData\Local\cua-driver\cua-driver.exe",
+            "args": ["mcp"],
+        }
+    }
+    proc = SimpleNamespace(returncode=0, stdout=json.dumps(manifest))
+    with (
+        patch.object(cua_backend.subprocess, "run", return_value=proc),
+        patch("hermes_constants.is_wsl", return_value=True),
+    ):
+        command, args = cua_backend._resolve_mcp_invocation("cua-driver")
+
+    assert command == "/mnt/c/Users/Fernando/AppData/Local/cua-driver/cua-driver.exe"
+    assert args == ["mcp"]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -47,6 +47,7 @@ import subprocess
 import sys
 import threading
 import uuid
+from pathlib import PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
@@ -141,6 +142,30 @@ def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str,
     return env
 
 
+def _wsl_windows_path_to_posix(path: str) -> str:
+    """Translate a Windows absolute manifest command when Hermes runs in WSL.
+
+    Windows cua-driver manifests can report ``C:\\Users\\...\\cua-driver.exe``
+    even though the Hermes process uses POSIX subprocess spawning inside WSL.
+    The same file is reachable through DrvFS as ``/mnt/c/Users/...``.
+    Non-Windows paths and non-WSL hosts are returned unchanged.
+    """
+    if not re.match(r"^[A-Za-z]:[\\/]", path):
+        return path
+    try:
+        from hermes_constants import is_wsl
+
+        if not is_wsl():
+            return path
+    except Exception:
+        return path
+    win = PureWindowsPath(path)
+    drive = (win.drive or "").rstrip(":").lower()
+    if not drive:
+        return path
+    return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
+
+
 def _resolve_mcp_invocation(
     driver_cmd: str,
     *,
@@ -192,7 +217,7 @@ def _resolve_mcp_invocation(
         # The driver knows the subcommand but didn't surface its own path.
         # Keep our resolved driver_cmd; the args are still authoritative.
         return driver_cmd, args
-    return command, args
+    return _wsl_windows_path_to_posix(command), args
 
 # Regex to parse element lines from get_window_state AX tree markdown.
 #


### PR DESCRIPTION
## Summary

- normalize Windows absolute `mcp_invocation.command` paths returned by `cua-driver manifest` when Hermes runs inside WSL
- map `C:\\...` to `/mnt/c/...` before POSIX subprocess spawning
- preserve existing behavior for native Windows, Linux, and macOS
- add regression coverage for WSL translation and manifest resolution

## Why

A Windows-installed cua-driver can return a command such as `C:\\Users\\...\\cua-driver.exe` to a Hermes process running in WSL. Passing that raw Windows string to POSIX subprocess spawning fails even though the executable is available through DrvFS.

## Verification

- `16 passed` across the new regression tests plus CLI-fallback environment and telemetry tests
- direct production `computer_use(list_apps)` succeeded after a controlled gateway restart
- `py_compile` and `git diff --check` passed
