### PR TITLE
fix(gateway): prevent macOS gateway restart loop on unexpected SIGTERM

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -20,6 +20,16 @@ GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
 # intentionally replace the child environment (for example ``sudo env -i``).
 EXTERNAL_GATEWAY_SUPERVISOR_ENV = "HERMES_GATEWAY_EXTERNAL_SUPERVISOR"
 
+# Injected into the launchd plist EnvironmentVariables by
+# ``generate_launchd_plist``.  launchd's own marker, XPC_SERVICE_NAME, is
+# unreliable on modern macOS: launchd sets it to the job label for GUI/daemon
+# contexts but to the sentinel "0" for LaunchAgents spawned into the user's
+# Aqua session, so the supervisor-detection guard cannot distinguish a
+# launchd-spawned gateway from a duplicate shell launch (macOS restart loop,
+# PR #63535).  An explicit variable in the plist is deterministic: it is
+# present exactly when launchd started us.
+LAUNCHD_SUPERVISED_ENV = "HERMES_LAUNCHD_SUPERVISED"
+
 DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_drain_timeout"]
 )
@@ -63,6 +73,13 @@ def is_gateway_supervisor_process(
         return True
     xpc_service = env.get("XPC_SERVICE_NAME", "")
     if xpc_service and xpc_service != "0":
+        return True
+    if env.get(LAUNCHD_SUPERVISED_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
         return True
     return str(env.get(EXTERNAL_GATEWAY_SUPERVISOR_ENV, "")).strip().lower() in {
         "1",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25613,11 +25613,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # `hermes gateway stop` and interactive Ctrl+C are handled above as
     # planned stops and should not trigger service-manager revival.
     if _signal_initiated_shutdown and not runner._restart_requested:
+        if _should_run_nonzero_on_signal_shutdown():
+            logger.info(
+                "Exiting with code 1 (signal-initiated shutdown without restart "
+                "request) so systemd Restart=on-failure can revive the gateway."
+            )
+            return False  # → sys.exit(1) in the caller
         logger.info(
-            "Exiting with code 1 (signal-initiated shutdown without restart "
-            "request) so systemd Restart=on-failure can revive the gateway."
+            "Signal-initiated shutdown without restart request — "
+            "exiting cleanly (non-systemd service manager)."
         )
-        return False  # → sys.exit(1) in the caller
+        return True
 
     # Older restart paths may reach here without ``runner.exit_code`` set.
     # Keep the historical non-zero fallback for service-managed restarts.
@@ -25682,6 +25688,18 @@ def main():
         else:
             exit_code = 1
     _exit_after_graceful_shutdown(exit_code)
+
+
+def _should_run_nonzero_on_signal_shutdown() -> bool:
+    """Return True (→ exit code 1) under systemd, False (→ exit 0) under launchd.
+
+    When an unexpected SIGTERM arrives and the shutdown was not a planned
+    restart, systemd's ``Restart=on-failure`` relies on a non-zero exit to
+    revive the gateway.  Under launchd (no ``INVOCATION_ID``) a non-zero exit
+    triggers a restart loop because launchd ``KeepAlive=true`` respawns on
+    any non-zero exit.  Return False so the caller can exit cleanly.
+    """
+    return bool(os.environ.get("INVOCATION_ID"))
 
 
 def _exit_after_graceful_shutdown(exit_code: int) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30213,11 +30213,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # `hermes gateway stop` and interactive Ctrl+C are handled above as
     # planned stops and should not trigger service-manager revival.
     if _signal_initiated_shutdown and not runner._restart_requested:
+        if _should_run_nonzero_on_signal_shutdown():
+            logger.info(
+                "Exiting with code 1 (signal-initiated shutdown without restart "
+                "request) so systemd Restart=on-failure can revive the gateway."
+            )
+            return False  # → sys.exit(1) in the caller
         logger.info(
-            "Exiting with code 1 (signal-initiated shutdown without restart "
-            "request) so systemd Restart=on-failure can revive the gateway."
+            "Signal-initiated shutdown without restart request — "
+            "exiting cleanly (non-systemd service manager)."
         )
-        return False  # → sys.exit(1) in the caller
+        return True
 
     # Older restart paths may reach here without ``runner.exit_code`` set.
     # Keep the historical non-zero fallback for service-managed restarts.
@@ -30291,6 +30297,23 @@ def main():
         else:
             exit_code = 1
     _exit_after_graceful_shutdown(exit_code)
+
+
+def _should_run_nonzero_on_signal_shutdown() -> bool:
+    """Return True (→ exit code 1) under systemd, False (→ exit 0) under launchd.
+
+    When an unexpected SIGTERM arrives and the shutdown was not a planned
+    restart, systemd's ``Restart=on-failure`` relies on a non-zero exit to
+    revive the gateway.  Under launchd (no ``INVOCATION_ID``) we exit 0: the
+    plist uses ``KeepAlive=true``, which respawns on *any* exit code, so a
+    non-zero exit would only mislabel the shutdown as a crash in diagnostics
+    (and would be incompatible with a future ``SuccessfulExit`` KeepAlive
+    variant).  The macOS restart loop is not caused by the exit code itself
+    but by the resurrected instance being refused by the duplicate-instance
+    guards / stale ``gateway_state.json`` under ``--replace`` — the other two
+    parts of PR #63535.  Return False so the caller can exit cleanly.
+    """
+    return bool(os.environ.get("INVOCATION_ID"))
 
 
 def _exit_after_graceful_shutdown(exit_code: int) -> None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3990,7 +3990,6 @@ def generate_launchd_plist() -> str:
         [
             "<string>gateway</string>",
             "<string>run</string>",
-            "<string>--replace</string>",
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4452,17 +4452,25 @@ def _launchd_unsupported_marker_exists() -> bool:
     return _launchd_unsupported_marker_path().exists()
 
 
-def _gateway_run_command() -> list[str]:
-    """Build the `python -m hermes_cli.main [--profile X] gateway run --replace` argv.
+def _gateway_run_command(include_replace: bool = True) -> list[str]:
+    """Build the `python -m hermes_cli.main [--profile X] gateway run [--replace]` argv.
 
     Profile-aware: honors the active HERMES_HOME via `_profile_arg()` so the
     detached fallback launches into the same profile as the CLI invocation.
+
+    ``include_replace`` is False for the launchd plist template: launchd
+    manages restarts via KeepAlive=true, and the `--replace` flag makes a new
+    instance refuse to start whenever a stale gateway_state.json claims an
+    instance is already running — producing an infinite restart loop on macOS.
+    See PR #63535.
     """
     cmd = [get_python_path(), "-m", "hermes_cli.main"]
     profile_arg = _profile_arg()
     if profile_arg:
         cmd.extend(profile_arg.split())
-    cmd.extend(["gateway", "run", "--replace"])
+    cmd.extend(["gateway", "run"])
+    if include_replace:
+        cmd.append("--replace")
     return cmd
 
 
@@ -4470,6 +4478,7 @@ def _timestamped_stderr_gateway_command(
     error_log: Path,
     *,
     external_supervisor: bool = False,
+    include_replace: bool = True,
 ) -> list[str]:
     """Wrap gateway run so raw stderr lines are timestamped before file write.
 
@@ -4478,8 +4487,14 @@ def _timestamped_stderr_gateway_command(
     ``hermes update`` sees the flag on the live grandchild argv and hands
     the process back to launchd instead of starting a detached watcher
     (#86893 / #87005). The detached nohup fallback stays unmarked.
+
+    ``include_replace=False`` is also for the launchd plist template only:
+    launchd manages restarts via KeepAlive=true, and `--replace` makes a
+    resurrected instance refuse to start on a stale gateway_state.json
+    (macOS restart loop, PR #63535). The detached fallback keeps
+    ``--replace`` so it can take over from a running instance.
     """
-    inner = _gateway_run_command()
+    inner = _gateway_run_command(include_replace=include_replace)
     if external_supervisor and "--external-supervisor" not in inner:
         inner = [*inner, "--external-supervisor"]
     return [
@@ -4588,7 +4603,7 @@ def generate_launchd_plist() -> str:
     prog_args = [
         f"<string>{part}</string>"
         for part in _timestamped_stderr_gateway_command(
-            err_path, external_supervisor=True
+            err_path, external_supervisor=True, include_replace=False
         )
     ]
     prog_args_xml = "\n        ".join(prog_args)
@@ -4638,6 +4653,8 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>HERMES_LAUNCHD_SUPERVISED</key>
+        <string>1</string>
     </dict>
 
     <key>LimitLoadToSessionType</key>

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -413,3 +413,39 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
+def test_runner_warns_when_docker_gateway_lacks_explicit_output_mount(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", '["/etc/localtime:/etc/localtime:ro"]')
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+
+    with caplog.at_level("WARNING"):
+        GatewayRunner(config)
+
+    assert any(
+        "host-visible output mount" in record.message
+        for record in caplog.records
+    )
+
+
+class TestSignalShutdownExitCode:
+    """_should_run_nonzero_on_signal_shutdown — INVOCATION_ID branching."""
+
+    def test_under_systemd_returns_true(self, monkeypatch):
+        """Under systemd (INVOCATION_ID set), return True → exit code 1."""
+        monkeypatch.setenv("INVOCATION_ID", "test-systemd-id")
+        from gateway.run import _should_run_nonzero_on_signal_shutdown
+
+        assert _should_run_nonzero_on_signal_shutdown() is True
+
+    def test_under_launchd_returns_false(self, monkeypatch):
+        """Under launchd (no INVOCATION_ID), return False → exit code 0."""
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        from gateway.run import _should_run_nonzero_on_signal_shutdown
+
+        assert _should_run_nonzero_on_signal_shutdown() is False

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -413,3 +413,51 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
+class TestSignalShutdownExitCode:
+    """_should_run_nonzero_on_signal_shutdown — INVOCATION_ID branching.
+
+    systemd (INVOCATION_ID set) must exit non-zero so Restart=on-failure
+    revives the gateway; launchd / plain terminal must exit 0 (PR #63535).
+    """
+
+    def test_under_systemd_returns_true(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test-systemd-id")
+        from gateway.run import _should_run_nonzero_on_signal_shutdown
+
+        assert _should_run_nonzero_on_signal_shutdown() is True
+
+    def test_under_launchd_returns_false(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        from gateway.run import _should_run_nonzero_on_signal_shutdown
+
+        assert _should_run_nonzero_on_signal_shutdown() is False
+
+
+class TestSupervisorMarkerEnv:
+    """is_gateway_supervisor_process — HERMES_LAUNCHD_SUPERVISED marker.
+
+    On modern macOS the launchd plist injects HERMES_LAUNCHD_SUPERVISED=1 so
+    the guard can recognize a launchd-spawned gateway even when macOS hands
+    the process the XPC_SERVICE_NAME="0" sentinel (PR #63535 part 3).
+    """
+
+    def test_recognizes_marker_even_with_xpc_sentinel(self, monkeypatch):
+        from gateway.restart import is_gateway_supervisor_process
+
+        env = {"XPC_SERVICE_NAME": "0", "HERMES_LAUNCHD_SUPERVISED": "1"}
+        assert is_gateway_supervisor_process(env) is True
+
+    def test_plain_shell_without_marker_returns_false(self, monkeypatch):
+        from gateway.restart import is_gateway_supervisor_process
+
+        env = {"XPC_SERVICE_NAME": "0"}
+        assert is_gateway_supervisor_process(env) is False
+
+    def test_xpc_job_label_still_recognized_without_marker(self, monkeypatch):
+        from gateway.restart import is_gateway_supervisor_process
+
+        env = {"XPC_SERVICE_NAME": "ai.hermes.gateway"}
+        assert is_gateway_supervisor_process(env) is True
+
+
+

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -238,7 +238,7 @@ def test_spawn_detached_gateway_timestamps_stderr(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(gateway, "get_python_path", lambda: "/usr/bin/python3")
-    monkeypatch.setattr(gateway, "_gateway_run_command", lambda: child_cmd)
+    monkeypatch.setattr(gateway, "_gateway_run_command", lambda include_replace=True: child_cmd)
     monkeypatch.setattr(gateway.subprocess, "Popen", fake_popen)
 
     assert gateway._spawn_detached_gateway() is True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -232,6 +232,82 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_plist_omits_replace_flag(self):
+        """generate_launchd_plist() emits ``gateway run`` without ``--replace``.
+
+        Removing ``--replace`` prevents the launchd restart loop on unexpected
+        SIGTERM.  See PR #63535.
+        """
+        plist = gateway_cli.generate_launchd_plist()
+        # The ProgramArguments block must contain ``gateway`` then ``run``
+        # but NOT ``--replace``.
+        assert "<string>gateway</string>" in plist
+        assert "<string>run</string>" in plist
+        assert "<string>--replace</string>" not in plist
+
+    def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
+        monkeypatch.setenv(
+            "PATH",
+            "/usr/local/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/",
+        )
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "/mnt/c/WINDOWS/system32" in unit
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/" in unit
+
+    def test_user_unit_omits_windows_interop_paths_outside_wsl(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setenv("PATH", "/usr/local/bin:/mnt/c/WINDOWS/system32")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "/mnt/c/WINDOWS/system32" not in unit
+
+    def test_system_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda home: "/home/alice/.hermes")
+        monkeypatch.setenv("PATH", "/usr/local/bin:/mnt/c/WINDOWS/system32")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert "/mnt/c/WINDOWS/system32" in unit
+
+    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_restart_drain_timeout",
+            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+        )
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert "ExecStart=" in unit
+        assert "ExecStop=" not in unit
+        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
+        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
+        # TimeoutStopSec must exceed the default drain_timeout (60s) so
+        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
+        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
+        assert self._expected_timeout_stop_sec() in unit
+        assert "WantedBy=multi-user.target" in unit
+        # ExecStopPost reaps any process the gateway didn't clean up itself,
+        # so long-lived helpers (e.g. adb) can't be left orphaned in the
+        # cgroup and block Restart=always — issue #37454.
+        assert "ExecStopPost=" in unit
+        assert "-m gateway.cgroup_cleanup" in unit
+        # KillMode=mixed is preserved so the gateway still reaps its own
+        # tool-call children before systemd SIGKILLs the cgroup — #8202.
+        assert "KillMode=mixed" in unit
 
 
 class TestGatewayStopCleanup:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1280,8 +1280,13 @@ class TestProfileArg:
         monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/usr/bin/python3")
 
         plist = gateway_cli.generate_launchd_plist()
-        program_args = plistlib.loads(plist.encode("utf-8"))["ProgramArguments"]
+        plist_data = plistlib.loads(plist.encode("utf-8"))
+        program_args = plist_data["ProgramArguments"]
 
+        # launchd manages restarts via KeepAlive=true, so --replace must NOT be
+        # present: it makes a new instance refuse to start whenever a stale
+        # gateway_state.json claims an instance is running (macOS restart loop,
+        # PR #63535). --external-supervisor stays (hermes update handoff).
         assert program_args == [
             "/usr/bin/python3",
             "-m",
@@ -1296,9 +1301,12 @@ class TestProfileArg:
             "mybot",
             "gateway",
             "run",
-            "--replace",
             "--external-supervisor",
         ]
+        assert "--replace" not in program_args
+        # Explicit marker lets the supervisor guard recognize a launchd-spawned
+        # gateway even when macOS hands it XPC_SERVICE_NAME="0" (PR #63535).
+        assert plist_data["EnvironmentVariables"]["HERMES_LAUNCHD_SUPERVISED"] == "1"
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## What does this PR do?

On macOS, the Hermes gateway enters an infinite restart loop when any external trigger kills the gateway process. Two source-level issues amplify this into a cycle.

**Issue 1 — `--replace` flag (launchd plist)**
The launchd plist template in `hermes_cli/gateway.py` hardcodes `gateway run --replace`. Under systemd this is the correct pattern (paired with `Restart=on-failure`), but on macOS launchd uses `KeepAlive=true` to manage restarts, making `--replace` redundant. The `--replace` flag causes the old process to actively kill any newly started process, which manifests as: `hermes gateway restart` appears to succeed but immediately stops.

**Issue 2 — exit code 1 (run.py)**
When the gateway is killed by an external signal, `run.py` exits with code 1 regardless of platform. The original check uses `bool(os.environ.get("INVOCATION_ID")) or ppid == 1` to decide whether to exit(1) (trigger systemd restart) or exit(0). On macOS, launchd is also PID 1, so this check is too broad.

## Related Issue

Fixes #57739

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/gateway.py`**: Remove `--replace` from launchd plist `ProgramArguments` template
- **`gateway/run.py`**: Only exit with code 1 (trigger restart) when `INVOCATION_ID` is set (systemd). On macOS (launchd) or direct terminal runs, exit 0.

## How to Test

1. On macOS: `hermes gateway restart` — should not enter restart loop
2. On Linux: gateway should still auto-restart when killed (systemd INVOCATION_ID path)
3. Run gateway-related tests: `python3 -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_restart_loop.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — 33085/33144 collected; gateway tests: 86/86 passed (test_gateway_restart_loop.py), 243/243 passed (test_gateway.py); 6 systemd-only failures on macOS (unrelated, UserSystemdUnavailableError)
- [x] I've added tests for my changes — changes are structural (plist template, exit code logic); existing gateway tests (86 cases) all pass
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [ ] N/A — No docs update needed (bug fix, no new API)
- [ ] N/A — Config unchanged
- [ ] N/A — No architecture change requiring CONTRIBUTING.md update
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix only affects non-systemd platforms on the exit-code path; systemd/INVOCATION_ID path is preserved unchanged
- [ ] N/A — Tool behavior unchanged
