### PR TITLE
fix(computer_use): normalize cua 0.7.1 windows and raise on 0x0 capture after reconnect

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -579,6 +579,9 @@ class _CuaDriverSession:
         self._shutdown_event: Optional[asyncio.Event] = None  # created on bridge loop
         self._lifecycle_future = None  # concurrent.futures.Future
         self._setup_error: Optional[BaseException] = None
+        # Track the backend's session id so _restart_session_locked
+        # can re-declare it after transport reconnect (#63428).
+        self._session_id: Optional[str] = None
 
     def _require_started(self) -> None:
         if not self._started:
@@ -878,6 +881,14 @@ class _CuaDriverSession:
         self._capability_version = ""
         self._start_lifecycle_locked()
         self._started = True
+        # Re-declare the session identity after transport reconnect.
+        # cua-driver expects start_session once per transport lifetime;
+        # skipping it leaves subsequent calls tombstoned (#63428).
+        if self._session_id:
+            try:
+                self.call_tool("start_session", {"session": self._session_id})
+            except Exception as e:
+                logger.debug("cua-driver start_session after reconnect failed (continuing anonymous): %s", e)
 
     def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
         """Fallback transport: invoke ``cua-driver call <tool> <json>`` as a
@@ -1133,8 +1144,17 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             pid_int, window_id_int = int(pid), int(window_id)
         except (TypeError, ValueError):
             continue
+        # Try exact key names first (app, app_name, name), then fall
+        # back to keys whose name contains "app" or "name" (case-insensitive)
+        # via regex — cua-driver 0.7.1 may use alternative naming.
+        app_name = w.get("app") or w.get("app_name") or w.get("name") or ""
+        if not app_name:
+            for k, v in w.items():
+                if isinstance(v, str) and re.search(r"(app|name)", k, re.IGNORECASE):
+                    app_name = v
+                    break
         windows.append({
-            "app_name": w.get("app_name", ""),
+            "app_name": app_name,
             "pid": pid_int,
             "window_id": window_id_int,
             "off_screen": not w.get("is_on_screen", True),
@@ -1213,6 +1233,7 @@ class CuaDriverBackend(ComputerUseBackend):
         # to start the session is non-fatal — cua-driver's tools
         # accept anonymous calls (the cursor just won't render),
         # so we degrade rather than abort.
+        self._session._session_id = self._session_id
         try:
             self._session.call_tool("start_session", {"session": self._session_id})
         except Exception as e:
@@ -1291,8 +1312,11 @@ class CuaDriverBackend(ComputerUseBackend):
                 logger.error("cua-driver CLI re-fetch for list_windows failed: %s", cli_exc)
 
         if not windows:
-            return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
-                                 elements=[], app="", window_title="", png_bytes_len=0)
+            raise RuntimeError(
+                "cua-driver returned an empty window inventory — "
+                "the session may be dead or the daemon needs restart. "
+                "Run `hermes computer-use doctor` to diagnose."
+            )
 
         # Filter by app name (case-insensitive substring) if requested.
         # When the filter matches nothing, surface that explicitly instead of
@@ -1731,7 +1755,8 @@ class CuaDriverBackend(ComputerUseBackend):
             for line in data.splitlines():
                 m = re.search(r'(.+?)\s+\(pid\s+(\d+)\)', line)
                 if m:
-                    apps.append({"name": m.group(1).strip(), "pid": int(m.group(2))})
+                    name = m.group(1).strip().lstrip("- ").strip()
+                    apps.append({"name": name, "pid": int(m.group(2))})
             return apps
         return []
 


### PR DESCRIPTION
Closes #63428

## Summary

Four fixes in `tools/computer_use/cua_backend.py` addressing app-scoped capture returning `0x0` after reconnect and cua-driver 0.7.1 window field normalization.

## Changes

### 1. `list_apps()` — strip bullet prefix from app names
The driver returns app lines with a `- ` bullet prefix (e.g. `- Safari (pid 1234)`). The regex was capturing the bullet into the app name, causing `capture(app="Safari")` to not match `list_windows[*].app_name` because the stored name was `- Safari`.

**Fix:** `lstrip("- ").strip()` on the parsed name before emitting it.

### 2. `_ingest_windows()` — try multiple app-name keys
cua-driver 0.7.1 may return the app name under `app`, `app_name`, or `name`. The wrapper only checked `app_name`.

**Fix:** Try `w.get("app")`, then `w.get("app_name")`, then `w.get("name")`, falling back to `""`.

### 3. `_ingest_windows()` — regex fallback for field name
When none of the exact keys match, iterate the raw window dict and use `re.search(r"(app|name)", k, re.IGNORECASE)` to discover alternative field names. This covers drivers that use keys like `displayName`, `applicationName`, or locale-specific variants.

### 4. Raise RuntimeError on empty/degenerate capture; re-issue `start_session` on reconnect
- The `return CaptureResult(width=0, height=0)` at the end of the window-fetch chain (after both MCP and CLI retries) now raises `RuntimeError` with an actionable diagnostic message instead of silently returning a degenerate capture to the model.
- `_restart_session_locked()` now re-issues `start_session` after recreating the MCP transport. Previously the transport was restarted but the session identity was never re-declared, leaving subsequent tool calls tombstoned on the daemon side. A `_session_id` field tracks the backend's session id for this purpose.

## Testing
- [x] Syntax verified with `ast.parse`
- All existing test patterns in `tests/tools/test_computer_use.py` are unchanged — the `_ingest_windows` normalization is a strict superset of the previous field lookup, and the 0x0 RuntimeError replaces a path that was already described as "silent failure" in the existing comments.