### PR TITLE
fix(whatsapp): authorize first-contact LID senders via senderPn (#63415)

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -78,3 +78,22 @@ test('matchesAllowedUser rejects everyone when allowlist is empty (#8389)', () =
     rmSync(sessionDir, { recursive: true, force: true });
   }
 });
+
+test('matchesAllowedUser accepts phone JID from senderPn when no lid-mapping file exists (#63415)', () => {
+  // Regression for #63415: a first-contact LID sender arrives with
+  // msg.key.senderPn = "19175395595" but no lid-mapping file exists
+  // yet.  The bridge constructs "19175395595@s.whatsapp.net" from
+  // senderPn and passes it through matchesAllowedUser as a fallback.
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    // Allowlist contains the phone number, but NO lid-mapping files exist.
+    const allowedUsers = parseAllowedUsers('19175395595');
+    // This simulates the phone JID the bridge constructs from msg.key.senderPn
+    assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', allowedUsers, sessionDir), true);
+    // Unlisted phone still rejected
+    assert.equal(matchesAllowedUser('188012763865257@s.whatsapp.net', allowedUsers, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -532,8 +532,16 @@ async function startSocket() {
 
       const chatId = msg.key.remoteJid;
       const senderId = msg.key.participant || chatId;
+      // Baileys provides the authenticated phone JID as msg.key.senderPn on
+      // multi-device LID chats.  When present, treat it as the canonical
+      // sender identity — opaque LIDs are ephemeral and no lid-mapping file
+      // may exist yet on first contact (fixes #63415).
+      const senderPnRaw = msg.key.senderPn || null;
+      const senderPnJid = senderPnRaw
+        ? (senderPnRaw.includes('@') ? normalizeWhatsAppId(senderPnRaw) : `${senderPnRaw}@s.whatsapp.net`)
+        : null;
       const isGroup = chatId.endsWith('@g.us');
-      const senderNumber = senderId.replace(/@.*/, '');
+      const senderNumber = (senderPnJid || senderId).replace(/@.*/, '');
       emitDebugEvent({
         stage: 'upsert',
         type,
@@ -635,15 +643,20 @@ async function startSocket() {
           continue;
         }
         if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
-          try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'allowlist_mismatch',
-              chatId,
-              senderId,
-            }));
-          } catch {}
-          continue;
+          // Fall back to senderPn when no lid-mapping file exists yet for
+          // first-contact LID senders (#63415).
+          const senderPnOk = senderPnJid && matchesAllowedUser(senderPnJid, ALLOWED_USERS, SESSION_DIR);
+          if (!senderPnOk) {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'allowlist_mismatch',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+            continue;
+          }
         }
       }
 
@@ -710,7 +723,7 @@ async function startSocket() {
       const event = await extractBridgeEvent({
         msg,
         chatId,
-        senderId,
+        senderId: senderPnJid || senderId,
         senderNumber,
         botIds,
         isGroup,


### PR DESCRIPTION
## Summary

Authorize first-contact WhatsApp LID senders by falling back to `msg.key.senderPn` (authenticated phone JID) when no lid-mapping file exists yet.

## Root Cause

When WhatsApp delivers a first-contact message, `msg.key.participant` is an opaque LID. The allowlist check only tested the LID, but no lid-mapping file exists yet on first contact. `msg.key.senderPn` was never consulted.

## Change

- Extract `senderPn` from `msg.key.senderPn`, construct phone JID
- Fallback allowlist check if LID doesn't match
- Pass phone JID (not opaque LID) to downstream event

Fixes #63415