### PR TITLE
fix(config): match custom-provider base_url case-insensitively for context_length lookup

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5106,7 +5106,8 @@ def get_custom_provider_context_length(
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
     Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
-    insensitive) and returns ``custom_providers[i].models.<model>.context_length``
+    and case insensitive, mirroring :func:`get_custom_provider_tls_settings`)
+    and returns ``custom_providers[i].models.<model>.context_length``
     if present and valid.  Returns ``None`` when no override applies.
 
     This is the single source of truth for custom-provider context overrides,
@@ -5134,14 +5135,14 @@ def get_custom_provider_context_length(
     if not isinstance(custom_providers, list):
         return None
 
-    target_url = (base_url or "").rstrip("/")
+    target_url = (base_url or "").rstrip("/").lower()
     if not target_url:
         return None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
-        entry_url = (entry.get("base_url") or "").rstrip("/")
+        entry_url = (entry.get("base_url") or "").rstrip("/").lower()
         if not entry_url or entry_url != target_url:
             continue
         models = entry.get("models")

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -55,6 +55,24 @@ class TestGetCustomProviderContextLength:
             == 500_000
         )
 
+    def test_matches_case_insensitively(self):
+        # A config entry written with a mixed-case host must still match a
+        # lowercased runtime base_url — parity with get_custom_provider_tls_settings
+        # and get_custom_provider_extra_headers, which both lowercase before compare.
+        custom = [
+            {
+                "name": "my-endpoint",
+                "base_url": "https://Ollama.Example.com/v1",
+                "models": {"llama3": {"context_length": 32768}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "llama3", "https://ollama.example.com/v1", custom
+            )
+            == 32768
+        )
+
     def test_returns_none_when_url_does_not_match(self):
         custom = [
             {


### PR DESCRIPTION
## This is a sibling follow-up to the case-insensitive `base_url` matching in `get_custom_provider_tls_settings` / `get_custom_provider_extra_headers`

- **What the sibling helpers cover:** both `get_custom_provider_tls_settings` (`676236bb1`) and `get_custom_provider_extra_headers` (`b98baa303`) normalize `base_url` with `rstrip("/").lower()`, so a config entry written as `https://Ollama.Example.com/v1` still matches a lowercased runtime `base_url`. Their comments/docstrings call this out explicitly.
- **What they did NOT touch:** `get_custom_provider_context_length`, the third helper in the same family, still compared with `rstrip("/")` only — no `.lower()`.
- **What this adds:** lowercases both sides of the `base_url` comparison in `get_custom_provider_context_length`, bringing it to parity with its two siblings.

## What does this PR do?

`get_custom_provider_context_length` looks up a per-model `context_length` override from `custom_providers` by matching on `base_url`. It normalized both the runtime and config URLs with `rstrip("/")` but — unlike its two sibling helpers — never `.lower()`-ed them.

As a result, a user whose config declares a mixed-case host, e.g.:

```yaml
custom_providers:
  - name: my-endpoint
    base_url: https://Ollama.Example.com/v1
    models:
      llama3:
        context_length: 32768
```

got their TLS knobs and `extra_headers` resolved correctly (those helpers lowercase), but their per-model `context_length` override was **silently dropped** — the lookup fell through to the default context window. Scheme/host are case-insensitive by RFC, and `custom_providers` are already keyed on a lowercased `base_url` in the `get_compatible_custom_providers` dedup, so the case-sensitive comparison here was the sole outlier.

The fix lowercases both sides of the comparison, mirroring the two sibling helpers exactly.

## Related Issue

<!-- No filed issue; author-found consistency bug within the custom_providers helper family. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: in `get_custom_provider_context_length`, normalize both `target_url` and `entry_url` with `rstrip("/").lower()` (was `rstrip("/")` only). Updated the docstring to say "trailing-slash and case insensitive, mirroring `get_custom_provider_tls_settings`."
- `tests/hermes_cli/test_custom_provider_context_length.py`: added `test_matches_case_insensitively`, mirroring the existing `test_get_custom_provider_tls_settings_matches_case_insensitively`.

## How to Test

1. Check out `main` and run the new test — it FAILS: the lookup returns `None` because `https://ollama.example.com/v1` != `https://Ollama.Example.com/v1`.
2. Apply this PR and run `pytest tests/hermes_cli/test_custom_provider_context_length.py -q` — the new case-insensitive test PASSES.
3. Full family stays green: `pytest tests/hermes_cli/test_custom_provider_context_length.py tests/hermes_cli/test_custom_provider_tls.py tests/hermes_cli/test_custom_provider_extra_headers.py -q` → 27 passed.

## Related / Positioning

Open PR #36852 (banditburai) also edits `get_custom_provider_context_length`, but a **separate** concern: publisher/slug model-id resolution in the `models.get(model)` lookup. This PR touches only the `base_url` case comparison (the two normalization lines) and does not overlap those edited lines.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure string normalization)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
