### PR TITLE
feat(codex): configure output verbosity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1446,6 +1446,14 @@ def init_agent(
     _agent_section = _agent_cfg.get("agent", {})
     if not isinstance(_agent_section, dict):
         _agent_section = {}
+    _output_verbosity = _agent_section.get("output_verbosity")
+    if isinstance(_output_verbosity, str):
+        _output_verbosity = _output_verbosity.strip().lower()
+    agent.output_verbosity = (
+        _output_verbosity
+        if _output_verbosity in {"low", "medium", "high"}
+        else None
+    )
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
     # Intent-ack continuation config: "auto" (default — codex_responses only,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -868,6 +868,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=_msgs_for_codex,
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
+            output_verbosity=getattr(agent, "output_verbosity", None),
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -829,6 +829,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        from agent.output_verbosity import supports_openai_output_verbosity
+
+        supports_output_verbosity = supports_openai_output_verbosity(
+            agent.model,
+            base_url_hostname=agent._base_url_hostname,
+            is_codex_backend=is_codex_backend,
+        )
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -869,6 +876,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
             output_verbosity=getattr(agent, "output_verbosity", None),
+            supports_output_verbosity=supports_output_verbosity,
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -911,7 +911,7 @@ def _preflight_codex_api_kwargs(
 
     allowed_keys = {
         "model", "instructions", "input", "tools", "store",
-        "reasoning", "include", "max_output_tokens", "temperature",
+        "reasoning", "include", "max_output_tokens", "temperature", "text",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
         "extra_headers", "extra_body", "timeout",
     }
@@ -934,6 +934,19 @@ def _preflight_codex_api_kwargs(
     service_tier = api_kwargs.get("service_tier")
     if isinstance(service_tier, str) and service_tier.strip():
         normalized["service_tier"] = service_tier.strip()
+
+    text = api_kwargs.get("text")
+    if text is not None:
+        if not isinstance(text, dict) or set(text) != {"verbosity"}:
+            raise ValueError(
+                "Codex Responses request 'text' must be an object containing only 'verbosity'."
+            )
+        verbosity = text.get("verbosity")
+        if verbosity not in {"low", "medium", "high"}:
+            raise ValueError(
+                "Codex Responses request 'text.verbosity' must be low, medium, or high."
+            )
+        normalized["text"] = {"verbosity": verbosity}
 
     # Pass through max_output_tokens and temperature
     max_output_tokens = api_kwargs.get("max_output_tokens")

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -937,16 +937,28 @@ def _preflight_codex_api_kwargs(
 
     text = api_kwargs.get("text")
     if text is not None:
-        if not isinstance(text, dict) or set(text) != {"verbosity"}:
-            raise ValueError(
-                "Codex Responses request 'text' must be an object containing only 'verbosity'."
-            )
-        verbosity = text.get("verbosity")
-        if verbosity not in {"low", "medium", "high"}:
-            raise ValueError(
-                "Codex Responses request 'text.verbosity' must be low, medium, or high."
-            )
-        normalized["text"] = {"verbosity": verbosity}
+        if not isinstance(text, dict):
+            raise ValueError("Codex Responses request 'text' must be an object.")
+        normalized_text: Dict[str, Any] = {}
+        for key, value in text.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("Codex Responses request 'text' keys must be non-empty strings.")
+            normalized_key = key.strip()
+            if normalized_key == "verbosity":
+                if value is None:
+                    continue
+                from agent.output_verbosity import parse_output_verbosity
+
+                verbosity = parse_output_verbosity(value)
+                if verbosity is None:
+                    raise ValueError(
+                        "Codex Responses request 'text.verbosity' must be low, medium, or high."
+                    )
+                normalized_text["verbosity"] = verbosity
+            else:
+                normalized_text[normalized_key] = value
+        if normalized_text:
+            normalized["text"] = normalized_text
 
     # Pass through max_output_tokens and temperature
     max_output_tokens = api_kwargs.get("max_output_tokens")

--- a/agent/output_verbosity.py
+++ b/agent/output_verbosity.py
@@ -1,0 +1,32 @@
+"""OpenAI Responses API output verbosity helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+VALID_OUTPUT_VERBOSITIES = frozenset({"low", "medium", "high"})
+
+
+def parse_output_verbosity(raw: Any) -> str | None:
+    """Return a normalized output verbosity value, or None for the provider default."""
+    value = str(raw or "").strip().lower()
+    return value if value in VALID_OUTPUT_VERBOSITIES else None
+
+
+def supports_openai_output_verbosity(
+    model: Any,
+    *,
+    base_url_hostname: str = "",
+    is_codex_backend: bool = False,
+) -> bool:
+    """Return whether the resolved GPT-5 Responses target supports this field."""
+    model_id = str(model or "").strip().lower().rsplit("/", 1)[-1]
+    is_gpt5 = (
+        model_id == "gpt-5"
+        or model_id.startswith("gpt-5.")
+        or model_id.startswith("gpt-5-")
+    )
+    if not is_gpt5:
+        return False
+    return is_codex_backend or base_url_hostname.strip().lower() == "api.openai.com"

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -121,6 +121,8 @@ class ResponsesApiTransport(ProviderTransport):
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
             github_reasoning_extra: dict | None — Copilot reasoning params
+            output_verbosity: str | None — OpenAI Codex output detail
+                (low, medium, or high)
         """
         from agent.codex_responses_adapter import (
             _chat_messages_to_responses_input,
@@ -299,6 +301,11 @@ class ResponsesApiTransport(ProviderTransport):
                 )
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
+
+        if is_codex_backend:
+            output_verbosity = str(params.get("output_verbosity") or "").strip().lower()
+            if output_verbosity in {"low", "medium", "high"}:
+                kwargs["text"] = {"verbosity": output_verbosity}
 
         request_overrides = params.get("request_overrides")
         if request_overrides:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -121,8 +121,9 @@ class ResponsesApiTransport(ProviderTransport):
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
             github_reasoning_extra: dict | None — Copilot reasoning params
-            output_verbosity: str | None — OpenAI Codex output detail
+            output_verbosity: str | None — OpenAI Responses output detail
                 (low, medium, or high)
+            supports_output_verbosity: bool — resolved GPT-5 OpenAI capability
         """
         from agent.codex_responses_adapter import (
             _chat_messages_to_responses_input,
@@ -302,14 +303,23 @@ class ResponsesApiTransport(ProviderTransport):
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 
-        if is_codex_backend:
-            output_verbosity = str(params.get("output_verbosity") or "").strip().lower()
-            if output_verbosity in {"low", "medium", "high"}:
-                kwargs["text"] = {"verbosity": output_verbosity}
-
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        output_verbosity = params.get("output_verbosity")
+        if output_verbosity and params.get("supports_output_verbosity") is True:
+            from agent.output_verbosity import parse_output_verbosity
+
+            verbosity = parse_output_verbosity(output_verbosity)
+            if verbosity:
+                override_text = kwargs.get("text")
+                if override_text is None:
+                    kwargs["text"] = {"verbosity": verbosity}
+                elif isinstance(override_text, dict):
+                    merged_text = dict(override_text)
+                    merged_text.setdefault("verbosity", verbosity)
+                    kwargs["text"] = merged_text
 
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -740,6 +740,10 @@ agent:
   # Controls how much "thinking" the model does before responding.
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
+
+  # OpenAI Codex Responses API output detail. Options: "low", "medium", "high".
+  # Empty preserves the provider default. Ignored by non-Codex backends.
+  output_verbosity: ""
   
   # Predefined personalities (use with /personality command)
   personalities:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -741,8 +741,9 @@ agent:
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
 
-  # OpenAI Codex Responses API output detail. Options: "low", "medium", "high".
-  # Empty preserves the provider default. Ignored by non-Codex backends.
+  # OpenAI Responses API output detail for GPT-5 models. Options: "low", "medium", "high".
+  # Empty preserves the provider default. Applied only to Codex OAuth or the exact
+  # api.openai.com host; ignored by xAI, GitHub Models, and custom endpoints.
   output_verbosity: ""
   
   # Predefined personalities (use with /personality command)

--- a/cli.py
+++ b/cli.py
@@ -427,6 +427,7 @@ def load_cli_config() -> Dict[str, Any]:
             "system_prompt": "",
             "prefill_messages_file": "",
             "reasoning_effort": "",
+            "output_verbosity": "",
             "service_tier": "",
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15749,6 +15749,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("agent", "output_verbosity"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1018,6 +1018,9 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # OpenAI Codex Responses API output detail: low, medium, high, or
+        # empty to preserve the provider default. Ignored by other backends.
+        "output_verbosity": "",
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1018,8 +1018,8 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
-        # OpenAI Codex Responses API output detail: low, medium, high, or
-        # empty to preserve the provider default. Ignored by other backends.
+        # OpenAI Responses API output detail for GPT-5 models. Empty preserves
+        # the provider default. Applied only to Codex OAuth or api.openai.com.
         "output_verbosity": "",
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from types import SimpleNamespace
 
+from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+from agent.output_verbosity import supports_openai_output_verbosity
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
 
@@ -310,6 +312,7 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             is_codex_backend=True,
+            supports_output_verbosity=True,
             output_verbosity=verbosity,
         )
 
@@ -338,6 +341,74 @@ class TestCodexBuildKwargs:
         )
 
         assert "text" not in kw
+
+    def test_output_verbosity_merges_with_request_override_text(self, transport):
+        request_overrides = {"text": {"format": {"type": "text"}}}
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_codex_backend=True,
+            supports_output_verbosity=True,
+            output_verbosity="low",
+            request_overrides=request_overrides,
+        )
+
+        assert kw["text"] == {
+            "format": {"type": "text"},
+            "verbosity": "low",
+        }
+        assert request_overrides == {"text": {"format": {"type": "text"}}}
+
+    def test_output_verbosity_explicit_request_override_wins(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_codex_backend=True,
+            output_verbosity="low",
+            request_overrides={"text": {"verbosity": "high"}},
+        )
+
+        assert kw["text"] == {"verbosity": "high"}
+
+    @pytest.mark.parametrize(
+        ("model", "hostname", "is_codex_backend", "expected"),
+        [
+            ("gpt-5.6-sol", "", True, True),
+            ("gpt-5.5", "api.openai.com", False, True),
+            ("gpt-4.1", "", True, False),
+            ("gpt-5.5", "proxy.example", False, False),
+            ("gpt-5.5", "api.x.ai", False, False),
+        ],
+    )
+    def test_output_verbosity_capability_boundary(
+        self, model, hostname, is_codex_backend, expected
+    ):
+        assert (
+            supports_openai_output_verbosity(
+                model,
+                base_url_hostname=hostname,
+                is_codex_backend=is_codex_backend,
+            )
+            is expected
+        )
+
+    def test_preflight_allows_output_verbosity_with_text_format(self):
+        payload = _preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.5",
+                "instructions": "system",
+                "input": [{"role": "user", "content": "hi"}],
+                "store": False,
+                "text": {"verbosity": "HIGH", "format": {"type": "text"}},
+            }
+        )
+
+        assert payload["text"] == {
+            "verbosity": "high",
+            "format": {"type": "text"},
+        }
 
     def test_codex_backend_sets_cache_routing_headers(self, transport):
         """Codex backend sends session_id / x-client-request-id as HTTP

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -303,6 +303,42 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    @pytest.mark.parametrize("verbosity", ["low", "medium", "high"])
+    def test_codex_backend_sets_output_verbosity(self, transport, verbosity):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_codex_backend=True,
+            output_verbosity=verbosity,
+        )
+
+        assert kw["text"] == {"verbosity": verbosity}
+
+        preflight = transport.preflight_kwargs(kw)
+        assert preflight["text"] == {"verbosity": verbosity}
+
+    def test_non_codex_responses_omit_output_verbosity(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            output_verbosity="low",
+        )
+
+        assert "text" not in kw
+
+    def test_codex_backend_omits_invalid_output_verbosity(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_codex_backend=True,
+            output_verbosity="extra-short",
+        )
+
+        assert "text" not in kw
+
     def test_codex_backend_sets_cache_routing_headers(self, transport):
         """Codex backend sends session_id / x-client-request-id as HTTP
         headers (via extra_headers) for cache-scope routing."""

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -243,6 +243,30 @@ class TestExtractCacheBustingConfig:
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"
 
+    def test_reads_agent_output_verbosity(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {"agent": {"output_verbosity": "low", "some_other_key": "ignored"}}
+        )
+
+        assert out["agent.output_verbosity"] == "low"
+
+    def test_output_verbosity_change_busts_cache(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.output_verbosity": "low"},
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.output_verbosity": "high"},
+        )
+
+        assert sig_before != sig_after
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1367,6 +1367,31 @@ class TestOutputVerbosityConfig:
 
         assert kwargs["text"] == {"verbosity": expected}
 
+    def test_direct_openai_gpt5_reaches_responses_request(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"output_verbosity": "low"}},
+            ),
+        ):
+            agent = AIAgent(
+                model="gpt-5.5",
+                provider="openai-api",
+                api_key="test-key-1234567890",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert kwargs["text"] == {"verbosity": "low"}
+
     @pytest.mark.parametrize("configured", ["", None, "extra-short", 42])
     def test_unset_or_invalid_config_preserves_provider_default(self, configured):
         agent = self._make_agent(configured)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1333,6 +1333,49 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
 
+class TestOutputVerbosityConfig:
+    """Tests for the agent.output_verbosity Codex request setting."""
+
+    def _make_agent(self, output_verbosity):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"output_verbosity": output_verbosity}},
+            ),
+        ):
+            return AIAgent(
+                model="gpt-5.6-sol",
+                provider="openai-codex",
+                api_key="test-key-1234567890",
+                base_url="https://chatgpt.com/backend-api/codex",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    @pytest.mark.parametrize(
+        "configured, expected",
+        [("low", "low"), (" Medium ", "medium"), ("HIGH", "high")],
+    )
+    def test_config_is_normalized_and_reaches_codex_request(self, configured, expected):
+        agent = self._make_agent(configured)
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert kwargs["text"] == {"verbosity": expected}
+
+    @pytest.mark.parametrize("configured", ["", None, "extra-short", 42])
+    def test_unset_or_invalid_config_preserves_provider_default(self, configured):
+        agent = self._make_agent(configured)
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert "text" not in kwargs
+
+
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1294,8 +1294,9 @@ native Anthropic provider already controls effort directly and is unaffected.
 ### OpenAI Codex output verbosity
 
 Reasoning effort controls how much the model thinks; output verbosity separately
-controls how detailed its final response is. For the `openai-codex` provider,
-set `agent.output_verbosity` to `low`, `medium`, or `high`:
+controls how detailed its final response is. For GPT-5 models on the Codex OAuth
+backend or the exact `api.openai.com` host, set `agent.output_verbosity` to
+`low`, `medium`, or `high`:
 
 ```yaml
 agent:
@@ -1304,8 +1305,8 @@ agent:
 ```
 
 An empty or omitted value preserves the provider default. Hermes sends this to
-the Codex Responses API as `text.verbosity`; it is ignored for other Responses
-API backends such as xAI and GitHub Models.
+OpenAI's Responses API as `text.verbosity`; it is ignored for xAI, GitHub Models,
+and arbitrary custom Responses endpoints.
 
 You can also change the reasoning effort at runtime with the `/reasoning` command:
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1291,6 +1291,22 @@ on its own adaptive default. The
 native Anthropic provider already controls effort directly and is unaffected.
 :::
 
+### OpenAI Codex output verbosity
+
+Reasoning effort controls how much the model thinks; output verbosity separately
+controls how detailed its final response is. For the `openai-codex` provider,
+set `agent.output_verbosity` to `low`, `medium`, or `high`:
+
+```yaml
+agent:
+  reasoning_effort: high
+  output_verbosity: low
+```
+
+An empty or omitted value preserves the provider default. Hermes sends this to
+the Codex Responses API as `text.verbosity`; it is ignored for other Responses
+API backends such as xAI and GitHub Models.
+
 You can also change the reasoning effort at runtime with the `/reasoning` command:
 
 ```


### PR DESCRIPTION
## Summary

- add `agent.output_verbosity` with `low`, `medium`, and `high` values
- send the setting to the OpenAI Codex Responses API as `text.verbosity`
- preserve provider defaults for empty or invalid values and omit the field for non-Codex Responses backends
- allow and validate `text.verbosity` in Codex request preflight
- document the setting in the example config and configuration guide

## Testing

- `scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/hermes_cli/test_config.py -q --tb=short` — 225 passed
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k OutputVerbosityConfig -q --tb=short` — 7 passed
- parsed `cli-config.yaml.example` with PyYAML
- `git diff --check`
- live `openai-codex/gpt-5.6-sol` request with `agent.output_verbosity: low` returned the requested `VERBOSITY_OK` response

## Behavior

```yaml
agent:
  reasoning_effort: high
  output_verbosity: low
```

Unset or empty values retain the provider default. The setting is intentionally limited to the OpenAI Codex backend.