### PR TITLE
test(gateway): preserve required Windows env in import subprocess

### DIFF
--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -56,8 +56,12 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
     )
     env = dict(initial_env)
     env["HERMES_HOME"] = str(hermes_home)
-    # Keep PATH / PYTHONPATH so venv imports resolve.
-    for k in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME"):
+    # Keep PATH / PYTHONPATH so venv imports resolve. SYSTEMROOT and USERPROFILE
+    # are required on Windows: without SYSTEMROOT the subprocess's socket
+    # provider fails to initialize (WinError 10106) the moment gateway.run
+    # imports and touches the network, and without USERPROFILE pathlib's
+    # Path.home() raises "Could not determine home directory".
+    for k in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME", "SYSTEMROOT", "USERPROFILE"):
         if k in os.environ and k not in env:
             env[k] = os.environ[k]
 


### PR DESCRIPTION
## What & why

`_run_gateway_import()` intentionally starts a clean subprocess with a small environment whitelist. On native Windows, removing `SYSTEMROOT` prevents WinSock/provider initialization, while removing `USERPROFILE` makes `Path.home()` fail before the config bridge assertions run.

## Change

Preserve `SYSTEMROOT` and `USERPROFILE` when present, alongside the existing `PATH`, `PYTHONPATH`, `VIRTUAL_ENV`, and `HOME` entries. POSIX behavior is unchanged because the variables are copied only when available.

## Validation

- `tests/gateway/test_config_env_bridge_authority.py`: 8 passed on native Windows.
- `ruff` and `git diff --check` pass.

This local inner-subprocess whitelist is complementary to broader canonical-runner work (#66496/#67387/#67512), not duplicate.