### PR TITLE
fix(desktop): order project-tree lanes by recency in the overview, not alphabetically

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -105,6 +105,42 @@ def test_linked_worktrees_fold_under_their_common_repo_root():
     assert linked["path"] == "/elsewhere/wt"
 
 
+def test_overview_orders_lanes_by_recency_not_alphabetically():
+    # Two linked-worktree lanes under one common repo root whose ALPHABETICAL
+    # order (wt-aaa, wt-zzz) is the OPPOSITE of their activity order (wt-zzz is
+    # the more recently active). The overview (hydrate=False) empties lane
+    # session arrays for payload slimness — but the lane sort must still run on
+    # real recency, matching the drill-in (hydrate=True) order, not collapse to
+    # alphabetical because the rows were dropped before sorting.
+    resolve = _resolver(
+        {
+            "/repo": ("/repo", "/repo"),
+            "/wt-aaa": ("/repo", "/wt-aaa"),
+            "/wt-zzz": ("/repo", "/wt-zzz"),
+        }
+    )
+    sessions = [
+        _session("/repo", branch="main", last_active=5000),
+        _session("/wt-aaa", last_active=1000),  # alphabetically first, older
+        _session("/wt-zzz", last_active=9000),  # alphabetically last, newer
+    ]
+
+    def _non_trunk_labels(hydrate):
+        tree = pt.build_tree([], sessions, [], resolve, hydrate=hydrate)
+        project = tree["projects"][0]
+        return [
+            g["label"]
+            for repo in project["repos"]
+            for g in repo["groups"]
+            if not g["isMain"]
+        ]
+
+    # Overview path: recency order (newer first), NOT alphabetical.
+    assert _non_trunk_labels(hydrate=False) == ["wt-zzz", "wt-aaa"]
+    # Drill-in path already sorts by recency — the two paths must agree.
+    assert _non_trunk_labels(hydrate=True) == ["wt-zzz", "wt-aaa"]
+
+
 def test_kanban_task_worktrees_collapse_into_one_bucket():
     resolve = _resolver(
         {

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -309,8 +309,6 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
         group = entry["group"]
         group["sessions"].sort(key=_session_time, reverse=True)
         count = len(group["sessions"])
-        if not hydrate:
-            group["sessions"] = []
 
         repo_identity = _path_key(entry["repo_key"])
         repo = repos.get(repo_identity)
@@ -330,6 +328,15 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
     for repo in repo_list:
         repo["groups"] = _sort_lanes(repo["groups"])
         _disambiguate_labels(repo["groups"])
+        # Drop per-lane session rows only AFTER sorting: _lane_sort_key ranks
+        # non-trunk lanes by most-recent activity, which it derives from the
+        # session rows. Clearing them earlier makes every lane look inactive on
+        # the overview (hydrate=False) path and collapses the sort to
+        # alphabetical. Counts were already captured above, so the payload stays
+        # slim without losing the recency order.
+        if not hydrate:
+            for group in repo["groups"]:
+                group["sessions"] = []
     _disambiguate_labels(repo_list)
     return repo_list
 


### PR DESCRIPTION
## What does this PR do?

Fixes a lane-ordering bug in the desktop project-tree overview. `_build_repos`
(in `tui_gateway/project_tree.py`) empties each lane's `sessions` array for the
overview payload (`hydrate=False`) **before** `_sort_lanes` runs. But
`_lane_sort_key` derives a lane's activity from the session rows:

```python
activity = max((_session_time(s) for s in group.get("sessions") or []), default=0.0)
return (0 if is_trunk else 1, 1 if is_kanban else 0, -activity, group["label"].lower())
```

With the rows already cleared, every non-trunk lane scored `activity == 0.0`, so
the sort key collapsed to **alphabetical-by-label**. The documented intent
(branches + linked worktrees sort by most-recent activity, then label) was
silently defeated on the `projects.tree` RPC (`tui_gateway/server.py`), which
calls with `hydrate=False` and feeds the desktop sidebar overview.

The drill-in path (`hydrate=True`) keeps the rows and sorts correctly by
recency — so any repo with two or more non-trunk lanes showed a **different
order in the overview than when opened**.

The fix moves the session-clearing to run *after* `_sort_lanes` /
`_disambiguate_labels`, so the sort reads real recency. Lane counts are captured
before clearing, so `sessionCount` and the slim overview payload are unchanged —
only the order is fixed, and the overview now matches the drill-in.

## Related Issue

<!-- No filed issue; author-found overview-vs-drill-in ordering inconsistency. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/project_tree.py`: in `_build_repos`, remove the early
  `if not hydrate: group["sessions"] = []` from the lane-assembly loop and clear
  the session arrays in the repo loop *after* `_sort_lanes` /
  `_disambiguate_labels` instead.
- `tests/tui_gateway/test_project_tree.py`: added
  `test_overview_orders_lanes_by_recency_not_alphabetically`, with two
  linked-worktree lanes whose alphabetical order is the reverse of their
  activity order; asserts recency order on both the `hydrate=False` overview and
  the `hydrate=True` drill-in.

## How to Test

1. On `main`, run the new test — it FAILS: the overview returns
   `['wt-aaa', 'wt-zzz']` (alphabetical) instead of `['wt-zzz', 'wt-aaa']`
   (recency).
2. Apply this PR and run
   `pytest tests/tui_gateway/test_project_tree.py -q` → 27 passed.
3. The new test also pins the overview order to the drill-in order, so the two
   code paths can't drift again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comment added at the fix site
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure ordering, no path logic touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
