### PR TITLE
fix(kanban): dispatcher double-counts running workers when both max_spawn and max_in_progress are set

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7092,7 +7092,7 @@ def _dispatch_once_locked(
     # they sit in status='running' until the worker calls
     # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_spawn is not None or max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -7115,9 +7115,8 @@ def _dispatch_once_locked(
         if in_progress >= max_in_progress:
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        if max_spawn is None or max_spawn > max_in_progress:
+            max_spawn = max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3686,6 +3686,34 @@ def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_s
 
     assert len(spawns) == 4, f"expected 4 spawns (unlimited), got {len(spawns)}"
 
+
+def test_dispatch_combined_live_caps_leave_remaining_slot_spawnable(
+    kanban_home, all_assignees_spawnable
+):
+    """#63466: When both max_spawn and max_in_progress are set and a slot is
+    available, the dispatcher must not double-count the running task against
+    both caps and strand the ready queue."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        kb.claim_task(conn, running)
+        kb.create_task(conn, title="next", assignee="bob")
+        kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            max_spawn=2,
+            max_in_progress=2,
+        )
+
+    assert len(spawns) == 1, (
+        f"expected 1 spawn (1 running + 1 ready, cap 2), got {len(spawns)}"
+    )
+
+
 # Review column dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #63466 — Kanban dispatcher double-counts running workers when both `kanban.max_spawn` and `kanban.max_in_progress` are configured.

## Root cause

In `_dispatch_once_locked`, `running_count` was already tracked for the spawn-loop comparison. The `max_in_progress` block then computed `remaining = max_in_progress - in_progress` and clamped `max_spawn` to this remaining value. With 1 running task and both caps at 2, `max_spawn` became 1, then `running_count + spawned >= max_spawn` evaluated to `1 + 0 >= 1`, immediately breaking the loop — no worker spawned despite a slot being available.

## Fix

1. Track `running_count` whenever **either** `max_spawn` or `max_in_progress` is set (previously only when `max_spawn` was set).
2. Clamp `max_spawn` directly against `max_in_progress` (the absolute cap) instead of against `remaining = max_in_progress - in_progress`, avoiding the double-count.

## Changes

- **`hermes_cli/kanban_db.py`**: Two changes in `_dispatch_once_locked`:
  - Gate `running_count` query on `max_spawn is not None or max_in_progress is not None` (line 7095)
  - Replace `remaining = max_in_progress - in_progress` with direct cap comparison `max_spawn = max_in_progress` (lines 7117-7120)
- **`tests/hermes_cli/test_kanban_db.py`**: New regression test `test_dispatch_combined_live_caps_leave_remaining_slot_spawnable`

## Validation

- New regression test passes: 1 running + 1 ready with both caps at 2 → exactly 1 spawn.
- Existing 18+ dispatcher/per-profile tests continue to pass.
