### PR TITLE
fix(state): enforce synchronous=FULL on macOS to prevent btree corruption

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -356,6 +356,34 @@ def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
         pass
 
 
+def _enforce_macos_synchronous_full(conn: sqlite3.Connection) -> None:
+    """Enforce ``PRAGMA synchronous=FULL`` on macOS to prevent btree corruption.
+
+    On Darwin, the default ``synchronous=NORMAL`` only calls ``fsync()``,
+    which Apple's fsync(2) man page explicitly states does *not* guarantee
+    data-on-platter or write-ordering. During a WAL checkpoint race with
+    process termination (e.g., launchd shutdown), this can leave the main
+    DB with half-written btree pages → ``btreeInitPage error 11``.
+
+    WAL mode's durability guarantee assumes the OS honors fsync barriers;
+    macOS does not unless we explicitly set ``synchronous=FULL`` (which
+    issues ``fsync()`` *and* ``F_FULLFSYNC`` via checkpoint_fullfsync=1).
+
+    This function is called after any successful WAL activation (either
+    from ``apply_wal_with_fallback()`` setting a fresh WAL or when probing
+    an existing WAL mode). It ensures macOS connections always use FULL
+    synchronous mode, even if a prior connection set ``synchronous=NORMAL``.
+
+    Best-effort: never raises.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        conn.execute("PRAGMA synchronous=FULL")
+    except sqlite3.OperationalError:
+        pass
+
+
 def apply_wal_with_fallback(
     conn: sqlite3.Connection,
     *,
@@ -387,6 +415,7 @@ def apply_wal_with_fallback(
         current_mode = conn.execute("PRAGMA journal_mode").fetchone()
         if current_mode and current_mode[0] == "wal":
             _apply_macos_checkpoint_barrier(conn)
+            _enforce_macos_synchronous_full(conn)
             return "wal"
     except sqlite3.OperationalError:
         pass
@@ -394,6 +423,7 @@ def apply_wal_with_fallback(
     try:
         conn.execute("PRAGMA journal_mode=WAL")
         _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
         return "wal"
     except sqlite3.OperationalError as exc:
         msg = str(exc).lower()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4965,6 +4965,75 @@ class TestApplyWalProbe:
         assert not any("checkpoint_fullfsync" in sql for sql in conn.executed), (
             "checkpoint_fullfsync must not be issued off macOS"
         )
+        assert not any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must not be issued off macOS"
+        )
+
+    def test_macos_synchronous_full_enforced_fresh(self, tmp_path, monkeypatch):
+        """On Darwin, apply_wal_with_fallback enforces synchronous=FULL (issue #63531)."""
+        import sqlite3
+        import hermes_state
+        from hermes_state import apply_wal_with_fallback
+
+        class _TracingConn(sqlite3.Connection):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.executed = []
+
+            def execute(self, sql, params=()):
+                self.executed.append(sql)
+                return super().execute(sql, params)
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+
+        db_path = tmp_path / "macos_fresh_sync.db"
+        conn = _TracingConn(str(db_path))
+        try:
+            result = apply_wal_with_fallback(conn)
+        finally:
+            conn.close()
+
+        assert result == "wal"
+        assert any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must be enforced on macOS"
+        )
+
+    def test_macos_synchronous_full_enforced_already_wal(self, tmp_path, monkeypatch):
+        """synchronous=FULL is enforced even when DB is already in WAL mode (issue #63531)."""
+        import sqlite3
+        import hermes_state
+        from hermes_state import apply_wal_with_fallback
+
+        class _TracingConn(sqlite3.Connection):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.executed = []
+
+            def execute(self, sql, params=()):
+                self.executed.append(sql)
+                return super().execute(sql, params)
+
+        # Prime the file into WAL mode first (simulating an existing WAL DB).
+        db_path = tmp_path / "macos_wal_sync.db"
+        with sqlite3.connect(str(db_path)) as seed:
+            seed.execute("PRAGMA journal_mode=WAL")
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+
+        conn = _TracingConn(str(db_path))
+        try:
+            result = apply_wal_with_fallback(conn)
+        finally:
+            conn.close()
+
+        assert result == "wal"
+        # The early-return path for existing WAL must also enforce synchronous=FULL.
+        assert any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must be enforced even on existing WAL DBs"
+        )
+        assert not any("journal_mode=WAL" in sql for sql in conn.executed), (
+            "set-pragma must not run when already in WAL mode"
+        )
 
     def test_apply_wal_concurrent_connects_no_eio(self, tmp_path):
         """20 threads calling connect() on the same DB must not see disk I/O error."""


### PR DESCRIPTION
## What does this PR do?

On macOS, `fsync()` does not guarantee data-on-platter (documented Darwin behavior). When a DB is in WAL mode and uses `synchronous=NORMAL`, a WAL checkpoint race with process termination (e.g., launchd shutdown) can leave the main DB with half-written btree pages → `btreeInitPage error 11` corruption. The corruption is on btree pages, not FTS indexes, so `repair_state_db_schema()` cannot fix it.

This fix adds `_enforce_macos_synchronous_full()` to always set `PRAGMA synchronous=FULL` on macOS after any WAL activation. WAL mode's durability guarantee assumes the OS honors fsync barriers; macOS does not unless we explicitly use `synchronous=FULL` (which issues `fsync()` and `F_FULLFSYNC` via `checkpoint_fullfsync=1`).

Previously, `apply_wal_with_fallback()` skipped setting `synchronous=FULL` when the DB was already in WAL mode, leaving connections at the unsafe `synchronous=NORMAL` default.

## Related Issue

Fixes #63531

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Added `_enforce_macos_synchronous_full()` function to enforce `PRAGMA synchronous=FULL` on macOS
- `hermes_state.py`: Modified `apply_wal_with_fallback()` to call `_enforce_macos_synchronous_full()` after setting WAL mode (both fresh and existing WAL paths)
- `tests/test_hermes_state.py`: Added `test_macos_synchronous_full_enforced_fresh` to verify synchronous=FULL is enforced on fresh connections
- `tests/test_hermes_state.py`: Added `test_macos_synchronous_full_enforced_already_wal` to verify synchronous=FULL is enforced even when DB is already in WAL mode
- `tests/test_hermes_state.py`: Updated `test_checkpoint_fullsync_barrier_skipped_off_darwin` to verify synchronous=FULL is not issued on non-macOS platforms

## How to Test

1. Run the new tests on macOS: `pytest tests/test_hermes_state.py::TestApplyWalProbe::test_macos_synchronous_full_enforced_fresh -xvs` — should pass
2. Run the existing-WAL test: `pytest tests/test_hermes_state.py::TestApplyWalProbe::test_macos_synchronous_full_enforced_already_wal -xvs` — should pass
3. Run the non-macOS test: `pytest tests/test_hermes_state.py::TestApplyWalProbe::test_checkpoint_fullsync_barrier_skipped_off_darwin -xvs` — should pass
4. Run the full WAL probe test suite: `pytest tests/test_hermes_state.py::TestApplyWalProbe -v` — all tests should pass
5. Observed result: The fix ensures `synchronous=FULL` is always set on macOS after WAL activation, preventing btree corruption during checkpoint races with process termination.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix is macOS-only and uses `sys.platform == "darwin"` guard
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A