### PR TITLE
fix(gateway): idle session reaper never fires while a client stays connected

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -865,8 +865,12 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
     # so their forever-unset agent_ready must not make them immortal.
     if ready is not None and not ready.is_set() and not session.get("lazy"):
         return False
-    if not _transport_is_dead(session.get("transport")):
-        return False
+    # NB: no transport-liveness gate here. A client WebSocket is shared across ALL
+    # of that client's sessions, and prompt.submit re-binds the live transport onto
+    # every session it touches, so "transport is alive" only means "some client is
+    # connected to the gateway" -- never "this session is in use". Gating on it made
+    # every session immortal for as long as the app stayed open. The correct
+    # per-session activity signal is last_active, checked below.
     last_active = float(session.get("last_active") or 0.0)
     created_at = float(session.get("created_at") or 0.0)
     return (now - last_active) > _SESSION_TTL_S and (now - created_at) > _SESSION_TTL_S

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -865,12 +865,20 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
     # so their forever-unset agent_ready must not make them immortal.
     if ready is not None and not ready.is_set() and not session.get("lazy"):
         return False
-    # NB: no transport-liveness gate here. A client WebSocket is shared across ALL
-    # of that client's sessions, and prompt.submit re-binds the live transport onto
-    # every session it touches, so "transport is alive" only means "some client is
-    # connected to the gateway" -- never "this session is in use". Gating on it made
-    # every session immortal for as long as the app stayed open. The correct
-    # per-session activity signal is last_active, checked below.
+    # Transport liveness is only a valid proxy for THIS session's liveness when the
+    # transport is 1:1 with it. That holds for stdio (a standalone `hermes --tui`
+    # owns its transport), so keep protecting those sessions from the reaper.
+    #
+    # It does NOT hold for a WebSocket: one client WS is shared across ALL of that
+    # client's sessions, and prompt.submit re-binds it onto every session it touches
+    # (see the `session["transport"] = t` there). So a live WS only means "some
+    # client is connected to the gateway" -- never "this session is in use". Gating
+    # on it made every session immortal for as long as the app stayed open, which is
+    # the leak in #46082. For those, fall through to the last_active check below,
+    # which is the correct per-session activity signal.
+    transport = session.get("transport")
+    if transport is _stdio_transport and not _transport_is_dead(transport):
+        return False
     last_active = float(session.get("last_active") or 0.0)
     created_at = float(session.get("created_at") or 0.0)
     return (now - last_active) > _SESSION_TTL_S and (now - created_at) > _SESSION_TTL_S


### PR DESCRIPTION
**Fixes #46082**

### Summary

The idle-TTL session reaper in `tui_gateway/server.py` can **never** evict a session while any client
stays connected. With a long-lived client (the Hermes Desktop app holds a single WebSocket open all
day), `_sessions` grows without bound — each entry retaining the full message history (tool results
included) plus a resident `AIAgent`.

This is the amplifier behind #46082, and it makes every *per-session* leak unbounded, because
`_teardown_session` — the path that calls `agent.close()` and shuts the slash worker down — **is never
reached**.

### Root cause: transport liveness is not session liveness

All three reclaim paths gate on `_transport_is_dead()`:

| Reaper | Line | Gate |
|---|---|---|
| Idle TTL (6h) | `server.py:767` | `if not _transport_is_dead(...): return False` |
| LRU cap | `server.py:816` | `return _transport_is_dead(...)` |
| WS-orphan | `server.py:661` | `transport is _detached_ws_transport` |

But `prompt.submit` **re-binds the live client transport onto every session it touches**
(`server.py:8126-8130`):

```python
# Re-bind to the current client transport for this request.
if (t := current_transport()) is not None:
    session["transport"] = t
```

A single client WebSocket is shared across **all** of that client's sessions. So a live
`session["transport"]` means *"some client is connected to the gateway"* — it does **not** mean *"this
session is in use"*. Using it as a **per-session** liveness signal is a category error.

The correct per-session activity signal is `last_active`, which the TTL reaper **already checks**
(`> TTL` idle **and** `> TTL` since creation). The `_transport_is_dead()` gate is redundant at best, and
in practice it makes every session immortal for as long as the app stays open.

### Why it lands on the dashboard specifically

`web_server.py:12421-12428` — a chat with **no profile** attaches to the `tui_gateway` instance running
**in-process inside the dashboard**; profile-scoped chats spawn `tui_gateway.entry` as a separate
process. The desktop app uses the default (profile-less) chat, so the accumulation lands in the
dashboard process.

Measured on a self-hosted deployment (containerised, 3 GiB cgroup limit):

| Process | fresh | after 34h | growth |
|---|---|---|---|
| **`hermes dashboard --port 9119`** | **141 MiB** | **1335 MiB** | **+1194 MiB (9.5×)** |
| `hermes gateway run` (default profile) | 165 MiB | 410 MiB | +245 MiB (2.5×) |
| `hermes -p <profile> gateway run` ×3 | ~159 MiB each | ~175–273 MiB | 1.1–1.7× |

The contrast is the tell: the in-process gateway (dashboard) grows 9.5×; the out-of-process ones barely
move.

### Growth signature: only while in use, never released

Prometheus, 1-hour resolution:

```
overnight (8h+ idle)   ~2100 MiB   ────────  flat
workday (12h)          2121 → 2793 MiB  ▲▲▲  +672 MiB
```

Consistent with per-turn retention (`session["history"] = result["messages"]`, `server.py:8645-8651`)
and *never* released — not with a background-timer leak.

### The damage starts well before OOM

From the container's cgroup counters:

```
memory.events:  max = 12872    oom_kill = 0
```

The container hit its memory ceiling **12,872 times — each a direct-reclaim stall — without ever being
OOM-killed**. Those stalls block the event loop; the client's liveness probe times out; the desktop
drops the connection and reconnects in a loop. Users see a misleading `Timed out connecting to backend`
/ `gateway session expired`, so it is routinely misdiagnosed as a network or auth problem.

This is why raising the memory limit does not help: the pain comes from *living at the ceiling*, not
from crossing it.

### The fix

Drop the `_transport_is_dead()` gate from the idle TTL reaper. Every safety exemption is preserved —
`running`, `_session_pending_kind`, `agent_ready` — as is the dual age check.

```diff
 def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
     if session.get("running") or _session_pending_kind(sid):
         return False
     ready = session.get("agent_ready")
     if ready is not None and not ready.is_set() and not session.get("lazy"):
         return False
-    if not _transport_is_dead(session.get("transport")):
-        return False
     last_active = float(session.get("last_active") or 0.0)
     created_at = float(session.get("created_at") or 0.0)
     return (now - last_active) > _SESSION_TTL_S and (now - created_at) > _SESSION_TTL_S
```

A session idle for 6+ hours is not in use, regardless of whether a shared WebSocket happens to be alive.
Eviction is already safe by the codebase's own design: `_close_session_by_id` pops the session and calls
`_teardown_session` (which closes the agent and the slash worker), and reopening re-resumes from SQLite
— as the LRU cap's own comment says: *"reopening re-resumes them from the DB"*. The focused chat has the
most recent `last_active`, so it can never satisfy the idle condition.

**This restores the behaviour the code already documented.** The 6h TTL was always the declared policy;
it simply never applied while a client was connected.

### Relationship to other open issues

This is not "one more leak" — it is the **amplifier** underneath several:

- **#46082** (this PR fixes it) — dashboard grows to 5.2 GB and gets OOM-killed.
- **#53303** — `_SlashWorker.close()` leaks 2 threads *per dashboard session*.
- **#48287** — `_agent_cache` leaks *per long-running gateway session*.
- **#22071** — sessions leak with `ended_at=NULL`.

Every one of those is a **per-session** leak. While sessions are never evicted, each of them grows
without bound and their cleanup paths never run.

**Honest scope**: this PR removes the amplifier — it does **not** claim to fix the individual leaks
above. Those cleanup paths (e.g. the Honcho memory-provider threads described in @pasevin's comment on
#46082) still deserve their own fixes; this change simply ensures they are actually *reached*.

### Testing

Behavioural — the bug only manifests over hours of real use, so there is no meaningful unit test. The
decisive signal is the gateway's own log line: `reaped_sessions` goes from a constant `0` to a non-zero
count once idle sessions start being reclaimed, and memory plateaus instead of climbing monotonically.

