### PR TITLE
fix(tui): clear stale row tails after DECSTBM scroll

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -199,6 +199,41 @@ describe('LogUpdate.render diff contract', () => {
     expect(hasDecstbm(stdoutOnly(diff))).toBe(true)
   })
 
+  it.each([
+    { direction: 'up', delta: 1, oldRow: 2, newRow: 1 },
+    { direction: 'down', delta: -1, oldRow: 2, newRow: 3 }
+  ])('clears shifted row tails outside narrow damage when scrolling $direction', ({
+    delta,
+    oldRow,
+    newRow
+  }) => {
+    const w = 40
+    const h = 6
+    const oldText = 'this-is-a-much-longer-row'
+    const newText = 'short'
+    const prev = mkScreen(w, h)
+    const next = mkScreen(w, h)
+
+    paint(prev, oldRow, oldText)
+    // The old row settled in an earlier frame, so it no longer contributes
+    // damage when the terminal later shifts it into the dirty row.
+    prev.damage = undefined
+    paint(next, newRow, newText)
+    next.damage = { x: 0, y: newRow, width: newText.length, height: 1 }
+
+    const nextFrame: Frame = {
+      ...mkFrame(next, w, h),
+      scrollHint: { top: 1, bottom: 4, delta }
+    }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prev, w, h), nextFrame, true, true)
+    const written = stdoutOnly(diff)
+
+    expect(hasDecstbm(written)).toBe(true)
+    expect(written).toContain(' '.repeat(oldText.length - newText.length))
+  })
+
   it('skips DECSTBM when scroll region touches the bottom row', () => {
     const w = 12
     const h = 6

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.ts
@@ -3,7 +3,7 @@ import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi
 import { logForDebugging } from '../utils/debug.js'
 
 import type { Diff, FlickerReason, Frame } from './frame.js'
-import type { Point } from './layout/geometry.js'
+import { type Point, unionRect } from './layout/geometry.js'
 import {
   type Cell,
   cellAt,
@@ -178,6 +178,31 @@ export class LogUpdate {
       // it can leave transient ghosting/bleed artifacts until a later repaint.
       if (top >= 0 && bottom < prev.screen.height - 1 && bottom < next.screen.height - 1) {
         shiftRows(prev.screen, top, bottom, delta)
+
+        // DECSTBM shifts full-width terminal rows, but a shorter replacement
+        // can leave next.damage covering only its new text. Widen only the
+        // dirty rows inside the scroll region so diffEach also clears tails
+        // shifted in from settled rows whose previous damage is already gone.
+        const damage = next.screen.damage
+
+        if (damage) {
+          const dirtyTop = Math.max(top, damage.y)
+          const dirtyBottom = Math.min(bottom + 1, damage.y + damage.height)
+
+          if (dirtyTop < dirtyBottom) {
+            const shiftedDirtyRows = {
+              x: 0,
+              y: dirtyTop,
+              width: prev.screen.width,
+              height: dirtyBottom - dirtyTop
+            }
+
+            prev.screen.damage = prev.screen.damage
+              ? unionRect(prev.screen.damage, shiftedDirtyRows)
+              : shiftedDirtyRows
+          }
+        }
+
         scrollPatch = [
           {
             type: 'stdout',


### PR DESCRIPTION
## Summary

- clear stale right-hand row tails after DECSTBM scroll-region shifts
- preserve the DECSTBM hardware-scroll fast path while widening only affected dirty rows
- cover both scroll-up (`delta > 0`) and scroll-down (`delta < 0`) behavior

## Problem

A settled long transcript row can be shifted by DECSTBM into a position that is then repainted with a shorter tool/status row. The new frame's damage rectangle may cover only the shorter text, so the right-hand tail from the shifted row remains visible, including its previous background style.

The message data and ordering are correct; the artifact is caused by the terminal screen model and the physical terminal diverging during incremental repaint.

## Root cause

`shiftRows(prev.screen, ...)` mirrors the hardware scroll but intentionally does not update damage. `diffEach()` then scans only `prev.damage ∪ next.damage`.

When the old row settled in an earlier frame, `prev.damage` is empty. If `next.damage` is narrower than the shifted old row, cells to the right of the new content are never scanned and no clearing spaces are emitted.

## Fix

After applying an accepted DECSTBM scroll hint:

1. intersect `next.screen.damage` with the vertical scroll region;
2. widen only those intersecting dirty rows to the full terminal width through `prev.screen.damage`;
3. let the existing diff/style-reset path clear any shifted tail cells.

This keeps hardware scrolling enabled and does not dirty unrelated rows.

## Related work

Related to #26683, which prevents DECSTBM from touching the bottom status/cursor lane. This PR addresses a different remaining case inside an otherwise safe scroll region: a shifted long row being replaced by a shorter dirty row.

## Test plan

- `cd ui-tui && ../node_modules/.bin/vitest run packages/hermes-ink/src/ink/log-update.test.ts` — 10/10 passed
- `cd ui-tui && ../node_modules/.bin/tsc --noEmit -p tsconfig.json` — passed
- `cd ui-tui && ../node_modules/.bin/eslint packages/hermes-ink/src/ink/log-update.ts packages/hermes-ink/src/ink/log-update.test.ts` — passed
- `npm --prefix ui-tui run build` — passed
- independent Claude Opus final diff review — `PASS`, no must-fix or should-fix findings

The regression test is deterministic: without the fix, DECSTBM is emitted but the expected 20 clearing spaces are absent. With the fix, both SU and SD cases clear the shifted tail.

## Baseline notes

The full TUI suite reached 1110 passed / 4 skipped. Existing unrelated failures remained in `statusRule`, `virtualHeights`, and `ink-backpressure`; the backpressure failure reproduces on the unchanged main worktree. One `execFileNoThrow` timing threshold miss passed when rerun alone.
