### PR TITLE
fix: keep kanban completion previews markdown-safe

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,117 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _is_escaped(text: str, index: int) -> bool:
+    preceding_backslashes = 0
+    index -= 1
+    while index >= 0 and text[index] == "\\":
+        preceding_backslashes += 1
+        index -= 1
+    return preceding_backslashes % 2 == 1
+
+
+def _has_balanced_markdown_spans(text: str) -> bool:
+    """Return whether truncation left any Markdown span delimiter open."""
+    open_code_run = 0
+    bracket_depth = 0
+    angle_depth = 0
+    link_destination_depth = 0
+    emphasis_stack: list[str] = []
+    i = 0
+    while i < len(text):
+        if _is_escaped(text, i):
+            i += 1
+            continue
+
+        marker = text[i]
+        if marker == "`":
+            end = i + 1
+            while end < len(text) and text[end] == "`":
+                end += 1
+            run_length = end - i
+            if open_code_run == 0:
+                open_code_run = run_length
+            elif run_length == open_code_run:
+                open_code_run = 0
+            i = end
+            continue
+
+        if open_code_run:
+            i += 1
+            continue
+
+        if link_destination_depth:
+            if marker == "(":
+                link_destination_depth += 1
+            elif marker == ")":
+                link_destination_depth -= 1
+            i += 1
+            continue
+
+        if marker == "[":
+            bracket_depth += 1
+        elif marker == "]" and bracket_depth:
+            bracket_depth -= 1
+        elif marker == "(" and i and text[i - 1] == "]":
+            link_destination_depth = 1
+        elif marker == "<" and i + 1 < len(text) and not text[i + 1].isspace():
+            angle_depth += 1
+        elif marker == ">" and angle_depth:
+            angle_depth -= 1
+        elif marker in {"*", "_", "~"}:
+            end = i + 1
+            while end < len(text) and text[end] == marker:
+                end += 1
+            delimiter = text[i:end]
+            if marker == "~" and len(delimiter) < 2:
+                i = end
+                continue
+            previous = text[i - 1] if i else ""
+            following = text[end] if end < len(text) else ""
+            if marker == "_" and previous.isalnum() and following.isalnum():
+                i = end
+                continue
+            can_open = bool(following) and not following.isspace()
+            can_close = bool(previous) and not previous.isspace()
+            if emphasis_stack and emphasis_stack[-1] == delimiter and can_close:
+                emphasis_stack.pop()
+            elif can_open:
+                emphasis_stack.append(delimiter)
+            i = end
+            continue
+        i += 1
+
+    return not (
+        open_code_run
+        or bracket_depth
+        or angle_depth
+        or link_destination_depth
+        or emphasis_stack
+    )
+
+
+def _markdown_safe_first_line_preview(text: str, max_length: int = 200) -> str:
+    """Return a concise first-line preview without splitting words or Markdown spans."""
+    if max_length < 1:
+        raise ValueError("max_length must be at least 1")
+
+    lines = text.strip().splitlines()
+    if not lines:
+        return ""
+    first_line = lines[0]
+    if len(first_line) <= max_length and _has_balanced_markdown_spans(first_line):
+        return first_line
+
+    content_limit = max_length - 1  # Reserve one character for the ellipsis.
+    for cut_at in range(min(content_limit, len(first_line)), -1, -1):
+        if cut_at and cut_at < len(first_line) and not first_line[cut_at].isspace():
+            continue
+        candidate = first_line[:cut_at].rstrip()
+        if candidate and _has_balanced_markdown_spans(candidate):
+            return candidate + "…"
+    return "…"
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -354,12 +465,10 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
+                                h = _markdown_safe_first_line_preview(payload_summary)
                                 handoff = f"\n{h}"
                             elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
+                                r = _markdown_safe_first_line_preview(task.result, 160)
                                 handoff = f"\n{r}"
                             msg = (
                                 f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,9 +2,95 @@ import asyncio
 from pathlib import Path
 
 
+from gateway import kanban_watchers
 from gateway.config import Platform
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
+
+
+REAL_COMPLETION_SUMMARY = (
+    "운영 DB read-only 조사 결과, 구미 구평점과 평택 죽백점 후보는 각각 "
+    "`autostay.stores.id=78`, `79`이며 둘 다 `status=1`, `is_display=0`, "
+    "이미지 0개로 현재 기본 홈페이지 export 조건을 충족하지 않습니다. "
+    "브레인시티·안중 후보는 확인되지 않았고, 데이터 경로·중복·필드·SELECT 근거는 "
+    "`investigation.md`에 정리했습니다."
+)
+
+
+def test_completion_preview_keeps_real_summary_markdown_balanced():
+    preview = kanban_watchers._markdown_safe_first_line_preview(REAL_COMPLETION_SUMMARY)
+
+    assert preview.endswith("근거는…")
+    assert len(preview) <= 200
+    assert preview.count("`") % 2 == 0
+
+
+def test_completion_preview_leaves_short_first_line_unchanged():
+    summary = "Short `inline code` handoff.\nDetails stay out of the notification."
+
+    assert (
+        kanban_watchers._markdown_safe_first_line_preview(summary)
+        == "Short `inline code` handoff."
+    )
+
+
+def test_completion_preview_leaves_intraword_underscore_unchanged():
+    summary = "Status is_display remains visible"
+
+    assert kanban_watchers._markdown_safe_first_line_preview(summary) == summary
+
+
+def test_completion_preview_does_not_split_a_long_plain_word():
+    summary = "Useful prefix " + ("x" * 250)
+
+    assert kanban_watchers._markdown_safe_first_line_preview(summary) == "Useful prefix…"
+
+
+def test_completion_preview_treats_inline_code_with_spaces_as_atomic():
+    prefix = "word " * 37
+    summary = prefix + "`inline code with spaces near boundary` trailing text"
+
+    preview = kanban_watchers._markdown_safe_first_line_preview(summary)
+
+    assert preview == prefix.rstrip() + "…"
+    assert preview.count("`") % 2 == 0
+
+
+def test_completion_preview_treats_fenced_code_as_atomic():
+    prefix = "word " * 37
+    summary = prefix + "```python sample with spaces``` trailing text"
+
+    preview = kanban_watchers._markdown_safe_first_line_preview(summary)
+
+    assert preview == prefix.rstrip() + "…"
+    assert preview.count("```") % 2 == 0
+
+
+def test_completion_preview_treats_markdown_link_as_atomic():
+    prefix = "word " * 37
+    summary = prefix + "[linked words near boundary](https://example.com) trailing text"
+
+    preview = kanban_watchers._markdown_safe_first_line_preview(summary)
+
+    assert preview == prefix.rstrip() + "…"
+
+
+def test_completion_preview_tracks_link_destination_and_title_parentheses():
+    prefix = "word " * 32
+    summary = prefix + '[label](https://example.com "descriptive title words") trailing text'
+
+    preview = kanban_watchers._markdown_safe_first_line_preview(summary)
+
+    assert preview == prefix.rstrip() + "…"
+
+
+def test_completion_preview_treats_emphasis_as_atomic():
+    prefix = "word " * 37
+    summary = prefix + "**emphasized words near boundary** trailing text"
+
+    preview = kanban_watchers._markdown_safe_first_line_preview(summary)
+
+    assert preview == prefix.rstrip() + "…"
 
 
 class RecordingAdapter:
@@ -67,6 +153,21 @@ def _unseen_terminal_events(tid):
         return events
     finally:
         conn.close()
+
+
+def test_kanban_notifier_uses_markdown_safe_completion_preview(tmp_path, monkeypatch):
+    db_path = tmp_path / "markdown-safe-preview.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_completed_subscription(REAL_COMPLETION_SUMMARY)
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    preview = adapter.sent[0]["text"].splitlines()[-1]
+    assert preview.endswith("근거는…")
+    assert len(preview) <= 200
+    assert preview.count("`") % 2 == 0
 
 
 def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Keep Slack Kanban completion previews within the display budget without emitting broken Markdown.
- Cover links, emphasis, inline code, and fenced code while preserving existing notifier behavior.

## AS-IS
Long completion summaries are truncated by raw character count and can end inside a Markdown construct, producing malformed Slack previews.

## TO-BE
The preview parser truncates only at Markdown-safe boundaries and preserves balanced formatting within the same output budget.

## Verification
- Kanban notifier tests: 17 passed
- Slack tests: 246 passed
- Ruff: passed
- `git diff --check`: passed
- 38 pre-existing RuntimeWarnings remain unchanged