### PR TITLE
chore(release): map jethachan@gmail.com to jethac in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -854,6 +854,7 @@ LEGACY_AUTHOR_MAP = {
     "tony@tonysimons.dev": "asimons81",
     "jetha@google.com": "jethac",
     "vishal.dharm@gmail.com": "vishal-dharm",
+    "jethachan@gmail.com": "jethac",
     "jani@0xhoneyjar.xyz": "deep-name",
     # LINE messaging plugin (synthesis PR)
     "32443648+leepoweii@users.noreply.github.com": "leepoweii",


### PR DESCRIPTION
Adds `jethachan@gmail.com` → `jethac` to `AUTHOR_MAP` in `scripts/release.py`.

The `check contributors / check-attribution` job validates that every commit-author
email in a PR is mapped in `AUTHOR_MAP`. Commits authored by `jethachan@gmail.com`
currently fail that check on any branch off `main`, because the mapping only exists
inside the in-flight multi-agent PR (#62944) rather than on `main`.

Splitting it into this standalone one-liner so it can land independently and unblock
attribution for all the related PRs. #62944, #63522, and #63523 depend on this.
