### PR TITLE
fix(browser): fail closed when URL safety probe fails

### DIFF
--- a/tests/tools/test_browser_eval_ssrf.py
+++ b/tests/tools/test_browser_eval_ssrf.py
@@ -264,8 +264,8 @@ class TestPostEvalPageRecheck:
         assert result["success"] is True
         assert result["result"] == "public DOM text"
 
-    def test_fail_open_when_url_probe_fails(self, monkeypatch):
-        """If the window.location.href probe errors, don't block (fail-open)."""
+    def test_fails_closed_when_url_probe_fails(self, monkeypatch):
+        """If the window.location.href probe errors, withhold eval output."""
         self._guard_on(monkeypatch)
         monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
         monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
@@ -278,8 +278,9 @@ class TestPostEvalPageRecheck:
         monkeypatch.setattr(browser_tool, "_run_browser_command", _run)
 
         result = _eval("document.body.innerText")
-        assert result["success"] is True
-        assert result["result"] == "dom text"
+        assert result["success"] is False
+        assert "could not verify the current page URL" in result["error"]
+        assert "dom text" not in json.dumps(result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -59,6 +59,38 @@ def test_click_still_runs_when_current_page_is_public(monkeypatch):
     assert calls == [("task-1", "click", ["@e1"])]
 
 
+@pytest.mark.parametrize(
+    ("tool_call", "args", "command"),
+    [
+        (browser_tool.browser_click, ("@e1",), "click"),
+        (browser_tool.browser_type, ("@e1", "do-not-send-this"), "fill"),
+        (browser_tool.browser_press, ("Enter",), "press"),
+    ],
+)
+def test_private_page_probe_failure_blocks_state_changing_actions(
+    monkeypatch, tool_call, args, command
+):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(
+        browser_tool,
+        "_current_page_private_url",
+        lambda task_id: browser_tool._URL_PROBE_FAILED,
+    )
+
+    def fail_run(task_id, actual_command, actual_args):
+        if actual_command == command:
+            raise AssertionError("browser command should not run when URL probe fails")
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fail_run)
+
+    out = json.loads(tool_call(*args, task_id="task-1"))
+
+    assert out["success"] is False
+    assert "could not verify the current page URL" in out["error"]
+    assert "do-not-send-this" not in json.dumps(out)
+
+
 def test_guard_inactive_does_not_block_or_probe(monkeypatch):
     """When the SSRF guard is inactive (local backend / allow_private_urls),
     the action must proceed WITHOUT even probing the page URL — a private-looking

--- a/tests/tools/test_browser_snapshot_ssrf.py
+++ b/tests/tools/test_browser_snapshot_ssrf.py
@@ -105,6 +105,28 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         assert result["success"] is True
         assert "snapshot" in result
 
+    def test_fails_closed_when_url_probe_fails(self, monkeypatch):
+        """Snapshot content must not be returned when the URL probe fails."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_local_sidecar_key", lambda key: False)
+
+        def mock_run_browser_command(task_id, command, args=None, **kwargs):
+            if command == "snapshot":
+                return _make_snapshot_result("private-looking page content")
+            if command == "eval":
+                return {"success": False, "error": "CDP probe failed"}
+            return {"success": False, "error": "unknown command"}
+
+        monkeypatch.setattr(
+            browser_tool, "_run_browser_command", mock_run_browser_command
+        )
+
+        result = json.loads(browser_browser_snapshot(task_id="test"))
+        assert result["success"] is False
+        assert "could not verify the current page URL" in result["error"]
+        assert "private-looking page content" not in json.dumps(result)
+
     def test_skips_check_in_local_backend_mode(self, monkeypatch):
         """Local backend mode skips SSRF check entirely."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
@@ -161,8 +183,8 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         assert result["success"] is True
         assert "snapshot" in result
 
-    def test_handles_eval_failure_gracefully(self, monkeypatch):
-        """If URL eval fails, snapshot should still succeed (fail-open)."""
+    def test_fails_closed_on_eval_failure(self, monkeypatch):
+        """If URL eval fails, snapshot content must be withheld."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
 
@@ -178,8 +200,8 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         )
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
-        # Should succeed — eval failure means we can't determine URL, fail-open
-        assert result["success"] is True
+        assert result["success"] is False
+        assert "could not verify the current page URL" in result["error"]
 
     def test_handles_empty_url_result(self, monkeypatch):
         """If URL eval returns empty string, snapshot should succeed."""
@@ -200,8 +222,8 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         result = json.loads(browser_browser_snapshot(task_id="test"))
         assert result["success"] is True
 
-    def test_handles_eval_exception(self, monkeypatch):
-        """If URL eval raises an exception, snapshot should succeed."""
+    def test_fails_closed_on_eval_exception(self, monkeypatch):
+        """If URL eval raises an exception, snapshot content must be withheld."""
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
         monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
 
@@ -217,7 +239,8 @@ class TestBrowserSnapshotPrivateNetworkGuard:
         )
 
         result = json.loads(browser_browser_snapshot(task_id="test"))
-        assert result["success"] is True
+        assert result["success"] is False
+        assert "could not verify the current page URL" in result["error"]
 
     def test_blocks_loopback_url(self, monkeypatch):
         """Loopback URLs (localhost) must be blocked."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2955,32 +2955,19 @@ def browser_snapshot(
         # After any eval (browser_console) that may have changed location.href to a
         # private/internal address, the snapshot would expose private page content.
         # Re-check the current URL before returning the snapshot.
-        if (
-            not _is_local_backend()
-            and not _is_local_sidecar_key(effective_task_id)
-            and not _allow_private_urls()
-        ):
-            try:
-                _url_result = _run_browser_command(
-                    effective_task_id, "eval", ["window.location.href"],
-                    timeout=5, _engine_override="auto",
-                )
-                if _url_result.get("success"):
-                    _current_url = (
-                        _url_result.get("data", {}).get("result", "")
-                        .strip().strip('"').strip("'")
-                    )
-                    if _current_url and not _is_safe_url(_current_url):
-                        return json.dumps({
-                            "success": False,
-                            "error": (
-                                "Blocked: page URL targets a private or internal address "
-                                f"({_current_url}). This may have been caused by a "
-                                "JavaScript navigation via browser_console."
-                            ),
-                        }, ensure_ascii=False)
-            except Exception as _url_exc:
-                logger.debug("browser_snapshot: URL safety check failed (%s)", _url_exc)
+        if _eval_ssrf_guard_active(effective_task_id):
+            _blocked_url = _current_page_private_url(effective_task_id)
+            if _blocked_url:
+                if _blocked_url == _URL_PROBE_FAILED:
+                    return _browser_url_probe_failed_response("returning a browser snapshot")
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "Blocked: page URL targets a private or internal address "
+                        f"({_blocked_url}). This may have been caused by a "
+                        "JavaScript navigation via browser_console."
+                    ),
+                }, ensure_ascii=False)
 
         # Check if snapshot needs summarization
         if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD and user_task:
@@ -3193,6 +3180,8 @@ def browser_back(task_id: Optional[str] = None) -> str:
         if _eval_ssrf_guard_active(effective_task_id):
             _blocked_url = _current_page_private_url(effective_task_id)
             if _blocked_url:
+                if _blocked_url == _URL_PROBE_FAILED:
+                    return _browser_url_probe_failed_response("returning from browser history")
                 return json.dumps({
                     "success": False,
                     "error": (
@@ -3257,6 +3246,8 @@ def _blocked_private_page_action(effective_task_id: str, action: str) -> Optiona
     blocked_url = _current_page_private_url(effective_task_id)
     if not blocked_url:
         return None
+    if blocked_url == _URL_PROBE_FAILED:
+        return _browser_url_probe_failed_response(f"attempting to {action}")
     return json.dumps({
         "success": False,
         "error": (
@@ -3299,6 +3290,8 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     if _eval_ssrf_guard_active(effective_task_id):
         _blocked_url = _current_page_private_url(effective_task_id)
         if _blocked_url:
+            if _blocked_url == _URL_PROBE_FAILED:
+                return _browser_url_probe_failed_response("returning browser console output")
             return json.dumps({
                 "success": False,
                 "error": (
@@ -3384,14 +3377,29 @@ def _expression_targets_private_url(expression: str) -> Optional[str]:
     return None
 
 
+_URL_PROBE_FAILED = "<url safety probe failed>"
+
+
+def _browser_url_probe_failed_response(action: str) -> str:
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: could not verify the current page URL before "
+            f"{action}. Refusing to continue in this browser mode because "
+            "the page may be private or internal."
+        ),
+    }, ensure_ascii=False)
+
+
 def _current_page_private_url(effective_task_id: str) -> Optional[str]:
     """Return the current page URL when it targets a private/internal address.
 
     Reads ``window.location.href`` via a low-cost eval and returns it when the
     page has been navigated (e.g. via ``location.href = '...'`` in a prior
     eval) to an address the SSRF guard would reject.  Returns ``None`` when the
-    page is public, the URL can't be determined, or the check errors (fail-open
-    on probe failure, matching the snapshot/vision guards).
+    page is public. Returns ``_URL_PROBE_FAILED`` when the current URL cannot be
+    verified so callers fail closed instead of exposing a potentially private
+    page after an eval-driven navigation.
     """
     try:
         url_result = _run_browser_command(
@@ -3407,8 +3415,15 @@ def _current_page_private_url(effective_task_id: str) -> Optional[str]:
                 _is_always_blocked_url(current_url) or not _is_safe_url(current_url)
             ):
                 return current_url
+        else:
+            logger.debug(
+                "_current_page_private_url: probe failed (%s)",
+                url_result.get("error", "unknown error"),
+            )
+            return _URL_PROBE_FAILED
     except Exception as exc:
         logger.debug("_current_page_private_url: probe failed (%s)", exc)
+        return _URL_PROBE_FAILED
     return None
 
 
@@ -3590,6 +3605,8 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
                 if _eval_ssrf_guard_active(effective_task_id):
                     _blocked_url = _current_page_private_url(effective_task_id)
                     if _blocked_url:
+                        if _blocked_url == _URL_PROBE_FAILED:
+                            return _browser_url_probe_failed_response("returning browser eval output")
                         return json.dumps({
                             "success": False,
                             "error": (
@@ -3679,6 +3696,8 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     if _eval_ssrf_guard_active(effective_task_id):
         _blocked_url = _current_page_private_url(effective_task_id)
         if _blocked_url:
+            if _blocked_url == _URL_PROBE_FAILED:
+                return _browser_url_probe_failed_response("returning browser eval output")
             return json.dumps({
                 "success": False,
                 "error": (
@@ -3844,6 +3863,8 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         if _eval_ssrf_guard_active(effective_task_id):
             _blocked_url = _current_page_private_url(effective_task_id)
             if _blocked_url:
+                if _blocked_url == _URL_PROBE_FAILED:
+                    return _browser_url_probe_failed_response("returning browser image data")
                 return json.dumps({
                     "success": False,
                     "error": (
@@ -3923,32 +3944,19 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     # After any eval (browser_console) that may have changed location.href to a
     # private/internal address, the screenshot would expose private page content
     # to the vision model.  Re-check the current URL before capturing anything.
-    if (
-        not _is_local_backend()
-        and not _is_local_sidecar_key(effective_task_id)
-        and not _allow_private_urls()
-    ):
-        try:
-            _url_result = _run_browser_command(
-                effective_task_id, "eval", ["window.location.href"],
-                timeout=5, _engine_override="auto",
-            )
-            if _url_result.get("success"):
-                _current_url = (
-                    _url_result.get("data", {}).get("result", "")
-                    .strip().strip('"').strip("'")
-                )
-                if _current_url and not _is_safe_url(_current_url):
-                    return json.dumps({
-                        "success": False,
-                        "error": (
-                            "Blocked: page URL targets a private or internal address "
-                            f"({_current_url}). This may have been caused by a "
-                            "JavaScript navigation via browser_console."
-                        ),
-                    }, ensure_ascii=False)
-        except Exception as _url_exc:
-            logger.debug("browser_vision: URL safety check failed (%s)", _url_exc)
+    if _eval_ssrf_guard_active(effective_task_id):
+        _blocked_url = _current_page_private_url(effective_task_id)
+        if _blocked_url:
+            if _blocked_url == _URL_PROBE_FAILED:
+                return _browser_url_probe_failed_response("capturing browser vision")
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "Blocked: page URL targets a private or internal address "
+                    f"({_blocked_url}). This may have been caused by a "
+                    "JavaScript navigation via browser_console."
+                ),
+            }, ensure_ascii=False)
 
     # Lightpanda has no graphical renderer — pre-route screenshots to Chrome
     # via the fallback helper instead of letting the normal path fail with a


### PR DESCRIPTION
## Summary

Fail closed when the browser private-page URL safety probe cannot verify the current page URL.

The browser SSRF/private-page guard protects cloud/non-local browser backends after JavaScript navigation. Several read/action paths checked the current page with `window.location.href`, but treated probe failure as public/safe state. That meant a backend/probe failure could let Hermes return browser content or send page actions even though the current page URL could not be verified.

## Why

For non-local browser backends, the URL probe is the safety boundary between a public page and a private/internal page reached through eval-driven navigation. If that probe fails, continuing is unsafe: the page may be private, and the tool would otherwise return snapshot/eval/image/console/vision data or send actions into it.

## Changes

- Add a fail-closed sentinel for current-page URL probe failures.
- Return a blocked error when the URL cannot be verified before:
  - `browser_snapshot`
  - `browser_console` output
  - browser eval output
  - `browser_get_images`
  - `browser_vision`
  - `browser_back`
  - `browser_click`
  - `browser_type`
  - `browser_press`
- Preserve the existing local backend, local sidecar, and `allow_private_urls` bypass behavior.
- Add/adjust regression tests for snapshot, eval, and state-changing actions.

## Tests

```text
python -m pytest tests/tools/test_browser_snapshot_ssrf.py -q --timeout-method=thread
18 passed

python -m pytest tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_private_page_action_guard.py tests/tools/test_browser_console_ssrf.py tests/tools/test_browser_get_images_ssrf.py -q --timeout-method=thread
39 passed