### PR TITLE
test(agent): pin Windows HOME variables in tilde-dependent tests

### DIFF
--- a/tests/agent/lsp/test_workspace.py
+++ b/tests/agent/lsp/test_workspace.py
@@ -133,7 +133,12 @@ def test_resolve_workspace_falls_back_to_file_location(tmp_path: Path, monkeypat
     assert gated is True
 
 
-def test_normalize_path_expands_tilde(monkeypatch):
-    monkeypatch.setenv("HOME", "/home/user")
+def test_normalize_path_expands_tilde(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     p = normalize_path("~/x.py")
-    assert p == os.path.abspath("/home/user/x.py")
+    assert p == os.path.join(str(home), "x.py")

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -332,6 +332,9 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     from agent.context_references import preprocess_context_references_async
 
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
 
     hermes_env = tmp_path / ".hermes" / ".env"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -539,10 +539,13 @@ class TestExtractImageRefs:
     def test_finds_home_relative_path(self, tmp_path: Path, monkeypatch):
         # Simulate ~/foo.png by pointing HOME at tmp_path and creating the file
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
         img = tmp_path / "foo.png"
         img.write_bytes(_png_bytes())
         paths, urls = extract_image_refs("see ~/foo.png please")
-        assert paths == [str(img)]
+        assert [Path(path) for path in paths] == [img]
         assert urls == []
 
     def test_skips_nonexistent_paths(self, tmp_path: Path):

--- a/tests/agent/test_shell_hooks_consent.py
+++ b/tests/agent/test_shell_hooks_consent.py
@@ -201,6 +201,9 @@ class TestAllowlistOps:
     def test_tilde_path_approval_records_resolvable_mtime(self, tmp_path, monkeypatch):
         """If the command uses ~ the approval must still find the file."""
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
         target = tmp_path / "hook.sh"
         target.write_text("#!/usr/bin/env bash\n")
         target.chmod(0o755)

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -212,6 +212,9 @@ class TestEscapedSpaces:
         img.parent.mkdir(parents=True, exist_ok=True)
         img.write_bytes(b"\x89PNG\r\n\x1a\n")
         monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
 
         result = _detect_file_drop("~/storage/shared/Pictures/cat.png what is this?")
 

--- a/tests/cli/test_cli_image_command.py
+++ b/tests/cli/test_cli_image_command.py
@@ -74,6 +74,9 @@ class TestCollectQueryImages:
         home = tmp_path / "home"
         img = _make_image(home / "storage" / "shared" / "Pictures" / "cat.png")
         monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
 
         message, images = _collect_query_images("describe this", "~/storage/shared/Pictures/cat.png")
 

--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -85,11 +86,14 @@ class TestResolveClientCert:
         from tools.mcp_tool import _resolve_client_cert
 
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
         pem = tmp_path / "client.pem"
         pem.write_text("dummy")
 
         result = _resolve_client_cert("srv", {"client_cert": "~/client.pem"})
-        assert result == str(pem)
+        assert Path(result) == pem
 
     def test_missing_file_raises(self, tmp_path):
         from tools.mcp_tool import _resolve_client_cert


### PR DESCRIPTION
## What & why

On POSIX, `expanduser("~")` honors `HOME`; on Windows it prefers `USERPROFILE`, then `HOMEDRIVE`/`HOMEPATH`. Tests that set only `HOME` can therefore resolve `~` against the real Windows profile instead of their temporary directory.

## Change

Apply the portable test-home setup to all seven reviewed tilde-dependent tests:

- set `HOME` and `USERPROFILE` to the temporary test directory;
- clear `HOMEDRIVE` and `HOMEPATH` fallbacks;
- compare the two mixed-separator path results semantically with `Path`.

No production code changes are involved.

## Validation

The seven focused behaviors pass on native Windows (six pytest targets plus direct MCP certificate-path verification); lint and diff checks pass.

## Related / duplicate analysis

Complementary to #67196, which changes canonical runner/Hindsight isolation. Not a duplicate of #34374/#61571/#61668: those change production image-routing recognition, while this PR only repairs test fixtures.