### PR TITLE
fix(lsp): contain server process trees safely

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -42,8 +42,10 @@ Implementation notes:
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -71,7 +73,53 @@ DIAGNOSTICS_DOCUMENT_WAIT = 5.0
 DIAGNOSTICS_FULL_WAIT = 10.0
 DIAGNOSTICS_REQUEST_TIMEOUT = 3.0
 PUSH_DEBOUNCE = 0.15
-SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
+SHUTDOWN_GRACE = 5.0  # seconds between SIGTERM and SIGKILL
+SHUTDOWN_VERIFY_TIMEOUT = 1.0
+
+_LINUX_PROCESS_GROUPS = os.name == "posix" and sys.platform.startswith("linux")
+_PROC_ROOT = Path("/proc")
+
+
+def _load_pidfd_bindings():
+    """Return safe Linux process-identity bindings, if this runtime has them."""
+    if not _LINUX_PROCESS_GROUPS:
+        return None, None
+    if hasattr(os, "pidfd_open") and hasattr(signal, "pidfd_send_signal"):
+        return os.pidfd_open, lambda pidfd, sig: signal.pidfd_send_signal(pidfd, sig)
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        pidfd_open = libc.pidfd_open
+        pidfd_open.argtypes = (ctypes.c_int, ctypes.c_uint)
+        pidfd_open.restype = ctypes.c_int
+        pidfd_send_signal = libc.pidfd_send_signal
+        pidfd_send_signal.argtypes = (
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint,
+        )
+        pidfd_send_signal.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return None, None
+
+    def open_pidfd(pid: int, flags: int) -> int:
+        fd = pidfd_open(pid, flags)
+        if fd < 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error))
+        return fd
+
+    def send_pidfd_signal(pidfd: int, sig: int) -> None:
+        if pidfd_send_signal(pidfd, sig, None, 0) < 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error))
+
+    return open_pidfd, send_pidfd_signal
+
+
+_PIDFD_OPEN, _PIDFD_SEND_SIGNAL = _load_pidfd_bindings()
 
 # Retry policy for transient ContentModified errors.
 MAX_CONTENT_MODIFIED_RETRIES = 3
@@ -162,8 +210,12 @@ class LSPClient:
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
+        self._process_group_id: Optional[int] = None
+        self._session_id: Optional[int] = None
+        self._leader_start_time: Optional[int] = None
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
+        self._server_request_tasks: Set[asyncio.Task] = set()
 
         # Request/response correlation
         self._next_id: int = 0
@@ -240,9 +292,15 @@ class LSPClient:
             await self._spawn()
             await self._initialize()
             self._state = "running"
-        except Exception:
+        except BaseException as exc:
             self._state = "error"
-            await self._cleanup_process()
+            if isinstance(exc, asyncio.CancelledError):
+                reason = "start_cancelled"
+            elif isinstance(exc, asyncio.TimeoutError):
+                reason = "start_timeout"
+            else:
+                reason = "start_failed"
+            await self._cleanup_process_cancellation_safe(reason=reason)
             raise
 
     @staticmethod
@@ -280,6 +338,22 @@ class LSPClient:
                 cwd=self._cwd,
                 start_new_session=True,
             )
+            if _LINUX_PROCESS_GROUPS:
+                # subprocess only reports a successful spawn after its child-side
+                # setsid() and exec complete. The resulting group is therefore
+                # owned by this client even if the leader exits before this task
+                # resumes and getpgid()/getsid() could no longer inspect it.
+                self._process_group_id = self._proc.pid
+                self._session_id = self._proc.pid
+                identity, readable = self._read_proc_identity(
+                    _PROC_ROOT / str(self._proc.pid)
+                )
+                if (
+                    readable
+                    and identity is not None
+                    and identity[1:3] == (self._proc.pid, self._proc.pid)
+                ):
+                    self._leader_start_time = identity[3]
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
@@ -318,7 +392,7 @@ class LSPClient:
                 if kind == "response":
                     self._dispatch_response(key, msg)
                 elif kind == "request":
-                    asyncio.create_task(self._dispatch_request(key, msg))
+                    self._start_server_request_task(key, msg)
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
                 else:
@@ -429,38 +503,340 @@ class LSPClient:
                     pass
         finally:
             self._state = "stopped"
-            await self._cleanup_process()
+            await self._cleanup_process_cancellation_safe(reason="shutdown")
 
-    async def _cleanup_process(self) -> None:
+    async def _cleanup_process_cancellation_safe(self, *, reason: str) -> None:
+        """Finish cleanup even if the lifecycle operation is cancelled."""
+        task = asyncio.create_task(self._cleanup_process(reason=reason))
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # The cleanup task is shielded from this cancellation. Wait for it
+            # before preserving cancellation for the caller.
+            await task
+            raise
+
+    def _safe_owned_process_group(self) -> Optional[int]:
+        """Return the isolated Linux session identifier recorded at spawn."""
+        if not _LINUX_PROCESS_GROUPS:
+            return None
+        pgid = self._process_group_id
+        session_id = self._session_id
+        if (
+            pgid is None
+            or session_id is None
+            or pgid != session_id
+            or pgid <= 1
+            or pgid == os.getpid()
+        ):
+            return None
+        try:
+            current_pgid = os.getpgrp()
+        except OSError:
+            return None
+        if pgid == current_pgid:
+            logger.error(
+                "[%s] refusing LSP cleanup for current process group pgid=%s",
+                self.server_id,
+                pgid,
+            )
+            return None
+        return pgid
+
+    @staticmethod
+    def _read_proc_identity(
+        entry: Path,
+    ) -> tuple[Optional[tuple[str, int, int, int]], bool]:
+        """Read ``(state, pgid, sid, start_time)`` and whether the read was safe."""
+        try:
+            stat = entry.joinpath("stat").read_text(encoding="ascii")
+            fields = stat[stat.rfind(")") + 2 :].split()
+            state = fields[0]
+            member_pgid = int(fields[2])
+            session_id = int(fields[3])
+            start_time = int(fields[19])
+        except FileNotFoundError:
+            return None, True
+        except (OSError, ValueError, IndexError):
+            return None, False
+        return (state, member_pgid, session_id, start_time), True
+
+    @staticmethod
+    def _identity_is_live_group_member(
+        identity: Optional[tuple[str, int, int, int]], pgid: int
+    ) -> bool:
+        return bool(
+            identity is not None
+            and identity[0] not in {"Z", "X"}
+            and identity[1] == pgid
+            and identity[2] == pgid
+        )
+
+    def _session_leader_ownership(self, pgid: int) -> tuple[Optional[bool], bool]:
+        """Return leader ownership, with ``None`` for an exited leader."""
+        identity, readable = self._read_proc_identity(_PROC_ROOT / str(pgid))
+        if not readable or identity is None:
+            return None, readable
+        owned = bool(
+            self._leader_start_time is not None
+            and identity[1] == pgid
+            and identity[2] == pgid
+            and identity[3] == self._leader_start_time
+        )
+        return owned, True
+
+    def _open_owned_process_group_members(
+        self, pgid: int
+    ) -> Optional[tuple[List[tuple[int, int]], bool]]:
+        """Pin and validate every visible member of this LSP launch.
+
+        Ownership is checked before and after opening each pidfd. PID reuse can
+        therefore only make validation fail or leave the pinned process dead;
+        it cannot redirect the signal to the replacement process.
+        """
+        if _PIDFD_OPEN is None or _PIDFD_SEND_SIGNAL is None:
+            return None
+        if self._session_id != pgid:
+            return ([], False)
+        leader_owned, leader_readable = self._session_leader_ownership(pgid)
+        if not leader_readable:
+            return ([], False)
+        if leader_owned is False:
+            # The numeric SID/PGID now names a different session leader.
+            return ([], True)
+        try:
+            entries = tuple(_PROC_ROOT.iterdir())
+        except OSError:
+            return ([], False)
+
+        members: List[tuple[int, int]] = []
+        scan_complete = True
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            initial_identity, readable = self._read_proc_identity(entry)
+            if not readable:
+                scan_complete = False
+                continue
+            if not self._identity_is_live_group_member(initial_identity, pgid):
+                continue
+            pid = int(entry.name)
+            try:
+                pidfd = _PIDFD_OPEN(pid, 0)
+            except ProcessLookupError:
+                continue
+            except OSError as exc:
+                scan_complete = False
+                if exc.errno == errno.ENOSYS:
+                    for _, opened_fd in members:
+                        try:
+                            os.close(opened_fd)
+                        except OSError:
+                            pass
+                    return None
+                continue
+            pinned_identity, readable = self._read_proc_identity(entry)
+            if not readable:
+                scan_complete = False
+            if (
+                pinned_identity == initial_identity
+                and self._identity_is_live_group_member(pinned_identity, pgid)
+            ):
+                members.append((pid, pidfd))
+            else:
+                try:
+                    os.close(pidfd)
+                except OSError:
+                    scan_complete = False
+        leader_owned, leader_readable = self._session_leader_ownership(pgid)
+        if not leader_readable:
+            scan_complete = False
+        if leader_owned is False:
+            for _, pidfd in members:
+                try:
+                    os.close(pidfd)
+                except OSError:
+                    pass
+            return ([], scan_complete)
+        return members, scan_complete
+
+    def _signal_owned_process_group_members(
+        self, pgid: int, sig: int
+    ) -> Optional[tuple[int, bool]]:
+        opened = self._open_owned_process_group_members(pgid)
+        if opened is None:
+            return None
+        members, complete = opened
+        try:
+            for pid, pidfd in members:
+                try:
+                    _PIDFD_SEND_SIGNAL(pidfd, sig)
+                except ProcessLookupError:
+                    continue
+                except OSError as exc:
+                    if exc.errno == errno.ENOSYS:
+                        return None
+                    complete = False
+                    logger.warning(
+                        "[%s] LSP pidfd signal failed pid=%s signal=%s error=%s",
+                        self.server_id,
+                        pid,
+                        signal.Signals(sig).name,
+                        type(exc).__name__,
+                    )
+        finally:
+            for _, pidfd in members:
+                try:
+                    os.close(pidfd)
+                except OSError:
+                    complete = False
+        return len(members), complete
+
+    async def _signal_process_group_until_empty(
+        self, pgid: int, sig: int, timeout: float
+    ) -> Optional[bool]:
+        """Repeatedly pin and signal members so late descendants are contained."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        complete = True
+        while True:
+            result = self._signal_owned_process_group_members(pgid, sig)
+            if result is None:
+                return None
+            member_count, scan_complete = result
+            complete = complete and scan_complete
+            if member_count == 0:
+                return complete
+            if loop.time() >= deadline:
+                return False
+            await asyncio.sleep(min(0.05, max(0.0, deadline - loop.time())))
+
+    async def _reap_leader(self, proc: asyncio.subprocess.Process) -> None:
+        if proc.returncode is not None:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_VERIFY_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] LSP leader pid=%s did not exit after cleanup",
+                self.server_id,
+                proc.pid,
+            )
+
+    async def _cleanup_process_group(
+        self,
+        proc: asyncio.subprocess.Process,
+        pgid: int,
+        *,
+        reason: str,
+    ) -> None:
+        terminated = await self._signal_process_group_until_empty(
+            pgid, signal.SIGTERM, SHUTDOWN_GRACE
+        )
+        if terminated is None:
+            logger.warning(
+                "[%s] pidfd signaling unavailable; skipping unsafe LSP descendant "
+                "cleanup reason=%s pgid=%s",
+                self.server_id,
+                reason,
+                pgid,
+            )
+            await self._cleanup_direct_process(proc, reason=reason)
+            return
+
+        logger.info(
+            "[%s] LSP pidfd cleanup reason=%s pgid=%s signal=SIGTERM",
+            self.server_id,
+            reason,
+            pgid,
+        )
+        complete = terminated
+        if not terminated:
+            logger.warning(
+                "[%s] LSP cleanup escalating reason=%s pgid=%s signal=SIGKILL",
+                self.server_id,
+                reason,
+                pgid,
+            )
+            killed = await self._signal_process_group_until_empty(
+                pgid, signal.SIGKILL, SHUTDOWN_VERIFY_TIMEOUT
+            )
+            complete = bool(killed)
+        await self._reap_leader(proc)
+        log = logger.info if complete else logger.warning
+        log(
+            "[%s] LSP cleanup %s reason=%s pgid=%s",
+            self.server_id,
+            "complete" if complete else "incomplete",
+            reason,
+            pgid,
+        )
+
+    async def _cleanup_direct_process(
+        self,
+        proc: asyncio.subprocess.Process,
+        *,
+        reason: str,
+    ) -> None:
+        """Terminate only the server process.
+
+        This conservative non-Linux or no-pidfd fallback cannot contain
+        descendants; Linux pidfd cleanup is required for safe tree containment.
+        """
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] LSP direct cleanup escalating reason=%s pid=%s signal=SIGKILL",
+                    self.server_id,
+                    reason,
+                    proc.pid,
+                )
+                proc.kill()
+                await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_VERIFY_TIMEOUT)
+        except (ProcessLookupError, asyncio.TimeoutError):
+            pass
+
+    async def _cleanup_process(self, *, reason: str = "cleanup") -> None:
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
             try:
                 await self._reader_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
+        self._reader_task = None
         if self._stderr_task is not None and not self._stderr_task.done():
             self._stderr_task.cancel()
             try:
                 await self._stderr_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
+        self._stderr_task = None
+        request_tasks = tuple(self._server_request_tasks)
+        for task in request_tasks:
+            if not task.done():
+                task.cancel()
+        if request_tasks:
+            await asyncio.gather(*request_tasks, return_exceptions=True)
+        self._server_request_tasks.clear()
         proc = self._proc
-        self._proc = None
         if proc is None:
             return
-        if proc.returncode is None:
-            try:
-                proc.terminate()
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
-                    try:
-                        proc.kill()
-                        await proc.wait()
-                    except ProcessLookupError:
-                        pass
-            except ProcessLookupError:
-                pass
+        pgid = self._safe_owned_process_group()
+        try:
+            if pgid is not None:
+                await self._cleanup_process_group(proc, pgid, reason=reason)
+            else:
+                await self._cleanup_direct_process(proc, reason=reason)
+        finally:
+            self._proc = None
+            self._process_group_id = None
+            self._session_id = None
+            self._leader_start_time = None
 
     # ------------------------------------------------------------------
     # request / notification plumbing
@@ -543,6 +919,11 @@ class LSPClient:
             )
         else:
             fut.set_result(msg.get("result"))
+
+    def _start_server_request_task(self, req_id: Any, msg: dict) -> None:
+        task = asyncio.create_task(self._dispatch_request(req_id, msg))
+        self._server_request_tasks.add(task)
+        task.add_done_callback(self._server_request_tasks.discard)
 
     async def _dispatch_request(self, req_id: Any, msg: dict) -> None:
         method = msg.get("method", "")
@@ -824,18 +1205,18 @@ class LSPClient:
             # Concurrent: document pull + push wait.
             pull_task = asyncio.create_task(self._pull_document_diagnostics(abs_path))
             push_task = asyncio.create_task(self._wait_for_fresh_push(abs_path, version, remaining))
-            done, pending = await asyncio.wait(
-                {pull_task, push_task},
-                timeout=remaining,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for t in pending:
-                t.cancel()
-            for t in pending:
-                try:
-                    await t
-                except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                    pass
+            diagnostic_tasks = (pull_task, push_task)
+            try:
+                await asyncio.wait(
+                    diagnostic_tasks,
+                    timeout=remaining,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for task in diagnostic_tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*diagnostic_tasks, return_exceptions=True)
 
             # If we got a fresh push for our version, we're done.
             current_v = self._published_version.get(abs_path)

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -39,6 +39,7 @@ import logging
 import os
 import threading
 import time
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from agent.lsp import eventlog
@@ -59,6 +60,13 @@ from agent.lsp.workspace import (
 logger = logging.getLogger("agent.lsp.manager")
 
 DEFAULT_IDLE_TIMEOUT = 600  # seconds; servers idle for >10min get reaped
+
+
+@dataclass
+class _SpawnState:
+    future: asyncio.Future
+    owner: asyncio.Task
+    client: Optional[LSPClient] = None
 
 
 class _BackgroundLoop:
@@ -173,9 +181,12 @@ class LSPService:
         # Per-(server_id, workspace_root) state
         self._clients: Dict[Tuple[str, str], LSPClient] = {}
         self._broken: set = set()
-        self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
+        self._spawning: Dict[Tuple[str, str], _SpawnState] = {}
         self._last_used: Dict[Tuple[str, str], float] = {}
         self._state_lock = threading.Lock()
+        self._shutdown_lock = threading.Lock()
+        self._shutting_down = False
+        self._shutdown_complete = False
 
         # Delta baseline: file path → snapshot of diagnostics taken
         # immediately before a write.  ``get_diagnostics_sync`` filters
@@ -411,15 +422,17 @@ class LSPService:
         except Exception:  # noqa: BLE001
             per_server_root = ws_root
         key = (srv.server_id, per_server_root)
-        already_broken = key in self._broken
-        self._broken.add(key)
 
         # Kill any client we managed to spawn before the timeout.  The
         # cancelled future never reached the broken-set add inside
         # ``_get_or_spawn`` so the client may still be hanging in
         # ``_clients`` with a half-initialized state.
         with self._state_lock:
-            client = self._clients.pop(key, None)
+            already_broken = key in self._broken
+            self._broken.add(key)
+            client = None
+            if not self._shutting_down:
+                client = self._clients.pop(key, None)
         if client is not None:
             try:
                 # Fire-and-forget shutdown — give it a second to cleanup,
@@ -435,12 +448,19 @@ class LSPService:
         """Tear down all clients and stop the background loop."""
         if not self._enabled:
             return
-        try:
-            self._loop.run(self._shutdown_async(), timeout=10.0)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("LSP shutdown error: %s", e)
-        self._loop.stop()
-        clear_cache()
+        with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+            with self._state_lock:
+                self._shutting_down = True
+            try:
+                self._loop.run(self._shutdown_async())
+            except Exception as e:  # noqa: BLE001
+                logger.debug("LSP shutdown error: %s", e)
+            finally:
+                self._loop.stop()
+                clear_cache()
+                self._shutdown_complete = True
 
     # ------------------------------------------------------------------
     # async internals
@@ -503,25 +523,30 @@ class LSPService:
             return None  # exclude marker hit, server gated off
 
         key = (srv.server_id, per_server_root)
-        if key in self._broken:
+        loop = asyncio.get_running_loop()
+        owner = asyncio.current_task()
+        if owner is None:
             return None
         with self._state_lock:
+            if self._shutting_down or key in self._broken:
+                return None
             client = self._clients.get(key)
             if client is not None and client.is_running:
                 eventlog.log_active(srv.server_id, per_server_root)
                 return client
-            spawning = self._spawning.get(key)
-        if spawning is not None:
+            spawn_state = self._spawning.get(key)
+            owns_spawn = spawn_state is None
+            if owns_spawn:
+                spawn_state = _SpawnState(future=loop.create_future(), owner=owner)
+                self._spawning[key] = spawn_state
+            spawn_future = spawn_state.future
+        if not owns_spawn:
             try:
-                return await spawning
+                return await asyncio.shield(spawn_future)
             except Exception:  # noqa: BLE001
                 return None
 
         # Begin spawn
-        loop = asyncio.get_running_loop()
-        spawn_future: asyncio.Future = loop.create_future()
-        with self._state_lock:
-            self._spawning[key] = spawn_future
         try:
             ctx = ServerContext(
                 workspace_root=per_server_root,
@@ -538,7 +563,8 @@ class LSPService:
                 # the structured logger so the user can act on it.
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
                 self._broken.add(key)
-                spawn_future.set_result(None)
+                if not spawn_future.done():
+                    spawn_future.set_result(None)
                 return None
             client = LSPClient(
                 server_id=srv.server_id,
@@ -549,27 +575,79 @@ class LSPService:
                 initialization_options=spec.initialization_options,
                 seed_diagnostics_on_first_push=spec.seed_diagnostics_on_first_push or srv.seed_first_push,
             )
+            with self._state_lock:
+                if self._spawning.get(key) is spawn_state:
+                    spawn_state.client = client
             try:
                 await client.start()
             except Exception as e:  # noqa: BLE001
                 eventlog.log_spawn_failed(srv.server_id, per_server_root, e)
                 self._broken.add(key)
-                spawn_future.set_result(None)
+                if not spawn_future.done():
+                    spawn_future.set_result(None)
                 return None
             with self._state_lock:
-                self._clients[key] = client
+                publish_client = not self._shutting_down
+                if publish_client:
+                    self._clients[key] = client
+            if not publish_client:
+                if not spawn_future.done():
+                    spawn_future.cancel()
+                await client.shutdown()
+                return None
             self._last_used[key] = time.time()
             eventlog.log_active(srv.server_id, per_server_root)
-            spawn_future.set_result(client)
+            if not spawn_future.done():
+                spawn_future.set_result(client)
             return client
+        except asyncio.CancelledError:
+            if not spawn_future.done():
+                spawn_future.cancel()
+            raise
+        except BaseException as exc:
+            if not spawn_future.done():
+                spawn_future.set_exception(exc)
+                spawn_future.exception()
+            raise
         finally:
             with self._state_lock:
-                self._spawning.pop(key, None)
+                if self._spawning.get(key) is spawn_state:
+                    self._spawning.pop(key, None)
 
     async def _shutdown_async(self) -> None:
         with self._state_lock:
-            clients = list(self._clients.values())
+            self._shutting_down = True
+            spawn_states = list(self._spawning.values())
+
+        for state in spawn_states:
+            if not state.future.done():
+                state.future.cancel()
+            if not state.owner.done():
+                state.owner.cancel()
+        if spawn_states:
+            await asyncio.gather(
+                *(state.owner for state in spawn_states),
+                return_exceptions=True,
+            )
+
+        partial_clients = [
+            state.client for state in spawn_states if state.client is not None
+        ]
+        if partial_clients:
+            await asyncio.gather(
+                *(client.shutdown() for client in partial_clients),
+                return_exceptions=True,
+            )
+
+        with self._state_lock:
+            partial_ids = {id(client) for client in partial_clients}
+            clients = [
+                client
+                for client in self._clients.values()
+                if id(client) not in partial_ids
+            ]
             self._clients.clear()
+            self._spawning.clear()
             self._broken.clear()
             self._last_used.clear()
         await asyncio.gather(

--- a/tests/agent/lsp/test_process_cleanup.py
+++ b/tests/agent/lsp/test_process_cleanup.py
@@ -1,0 +1,622 @@
+"""Process-tree containment tests for :mod:`agent.lsp.client`."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.lsp import client as client_module
+from agent.lsp.client import LSPClient
+
+
+requires_linux_groups = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="owned process-group integration tests require Linux /proc",
+)
+
+_CHILD_CODE = "import time; time.sleep(60)"
+_TERM_RESISTANT_CHILD_CODE = (
+    "import os,signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "open(os.environ['LSP_TEST_CHILD_READY_FILE'], 'w').close(); time.sleep(60)"
+)
+_SANITIZED_TERM_RESISTANT_CHILD_CODE = """
+import os
+import sys
+
+ready_file = os.environ["LSP_TEST_CHILD_READY_FILE"]
+code = (
+    "import signal,time; "
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    f"open({ready_file!r}, 'w').close(); "
+    "time.sleep(60)"
+)
+os.execve(sys.executable, [sys.executable, "-c", code], {})
+"""
+_LEADER_CODE = """
+import os
+import subprocess
+import sys
+import time
+
+child = subprocess.Popen(
+    [sys.executable, "-c", os.environ["LSP_TEST_CHILD_CODE"]],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+with open(os.environ["LSP_TEST_CHILD_PID_FILE"], "w", encoding="ascii") as fh:
+    fh.write(str(child.pid))
+if os.environ.get("LSP_TEST_LEADER_EXIT") == "1":
+    raise SystemExit(0)
+time.sleep(60)
+"""
+
+
+def _client(tmp_path: Path, *, child_code: str = _CHILD_CODE, leader_exit: bool = False) -> LSPClient:
+    env = {
+        "LSP_TEST_CHILD_CODE": child_code,
+        "LSP_TEST_CHILD_PID_FILE": str(tmp_path / "child.pid"),
+        "LSP_TEST_CHILD_READY_FILE": str(tmp_path / "child.ready"),
+        "LSP_TEST_LEADER_EXIT": "1" if leader_exit else "0",
+    }
+    return LSPClient(
+        server_id="process-tree-test",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, "-c", _LEADER_CODE, "sensitive-test-token"],
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+
+async def _wait_for_child_pid(tmp_path: Path) -> int:
+    path = tmp_path / "child.pid"
+    for _ in range(200):
+        try:
+            return int(path.read_text(encoding="ascii"))
+        except (FileNotFoundError, ValueError):
+            await asyncio.sleep(0.01)
+    raise AssertionError("test child did not start")
+
+
+async def _wait_for_path(path: Path) -> None:
+    for _ in range(200):
+        if path.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"{path.name} was not created")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    stat = Path(f"/proc/{pid}/stat")
+    if stat.exists():
+        try:
+            return stat.read_text(encoding="ascii").split()[2] != "Z"
+        except (OSError, IndexError):
+            pass
+    return True
+
+
+async def _assert_pid_exits(pid: int) -> None:
+    for _ in range(200):
+        if not _pid_alive(pid):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"process {pid} survived LSP cleanup")
+
+
+async def _cleanup_test_group(client: LSPClient) -> None:
+    """Keep a red regression test from leaking its test-owned process tree."""
+    proc = client._proc
+    pgid = getattr(client, "_process_group_id", None)
+    if pgid is None and proc is not None:
+        pgid = proc.pid
+    if pgid is not None and pgid > 1 and pgid != os.getpgrp():
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if proc is not None:
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except asyncio.TimeoutError:
+            pass
+
+
+def _write_proc_member(
+    proc_root: Path,
+    *,
+    pid: int,
+    pgid: int,
+    session_id: int,
+    start_time: int = 100,
+) -> None:
+    member = proc_root / str(pid)
+    member.mkdir()
+    member.joinpath("stat").write_text(
+        f"{pid} (lsp child) S 1 {pgid} {session_id} "
+        + "0 " * 15
+        + f"{start_time} 0",
+        encoding="ascii",
+    )
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_normal_shutdown_terminates_descendants(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path)
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+        client._state = "running"
+        client._send_request = AsyncMock(return_value=None)
+        client._send_notification = AsyncMock(return_value=None)
+
+        await client.shutdown()
+
+        await _assert_pid_exits(child_pid)
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_shutdown_timeout_still_terminates_descendants(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path)
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+        client._state = "running"
+        client._send_request = AsyncMock(side_effect=asyncio.TimeoutError)
+
+        await client.shutdown()
+
+        await _assert_pid_exits(child_pid)
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_cleanup_kills_descendant_after_leader_exits(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path, leader_exit=True)
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+        assert client._proc is not None
+        await asyncio.wait_for(client._proc.wait(), timeout=2.0)
+
+        await client._cleanup_process(reason="leader_exited")
+
+        await _assert_pid_exits(child_pid)
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_spawn_owns_group_when_leader_exits_before_subprocess_returns(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path, leader_exit=True)
+    create_subprocess_exec = asyncio.create_subprocess_exec
+
+    async def return_after_leader_exit(*args, **kwargs):
+        proc = await create_subprocess_exec(*args, **kwargs)
+        await asyncio.wait_for(proc.wait(), timeout=2.0)
+        with pytest.raises(ProcessLookupError):
+            os.getpgid(proc.pid)
+        with pytest.raises(ProcessLookupError):
+            os.getsid(proc.pid)
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", return_after_leader_exit)
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+
+        await client._cleanup_process(reason="post_spawn_capture_unavailable")
+
+        await _assert_pid_exits(child_pid)
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_cleanup_escalates_term_resistant_descendant(tmp_path: Path, monkeypatch, caplog):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.1)
+    client = _client(tmp_path, child_code=_TERM_RESISTANT_CHILD_CODE)
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+        await _wait_for_path(tmp_path / "child.ready")
+
+        with caplog.at_level(logging.INFO, logger="agent.lsp.client"):
+            await client._cleanup_process(reason="test_timeout")
+
+        await _assert_pid_exits(child_pid)
+        assert "SIGKILL" in caplog.text
+        assert "sensitive-test-token" not in caplog.text
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_cleanup_escalates_sanitized_descendant_after_leader_exit(
+    tmp_path: Path, monkeypatch, caplog
+):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.1)
+    client = _client(
+        tmp_path,
+        child_code=_SANITIZED_TERM_RESISTANT_CHILD_CODE,
+        leader_exit=True,
+    )
+    try:
+        await client._spawn()
+        child_pid = await _wait_for_child_pid(tmp_path)
+        await _wait_for_path(tmp_path / "child.ready")
+        assert client._proc is not None
+        await asyncio.wait_for(client._proc.wait(), timeout=2.0)
+
+        with caplog.at_level(logging.INFO, logger="agent.lsp.client"):
+            await client._cleanup_process(reason="sanitized_descendant")
+
+        await _assert_pid_exits(child_pid)
+        assert "SIGKILL" in caplog.text
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_start_failure_cleans_process_group(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path)
+
+    async def fail_initialize() -> None:
+        await _wait_for_child_pid(tmp_path)
+        raise RuntimeError("initialize failed")
+
+    client._initialize = fail_initialize
+    try:
+        with pytest.raises(RuntimeError, match="initialize failed"):
+            await client.start()
+        await _assert_pid_exits(await _wait_for_child_pid(tmp_path))
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_start_cancellation_cleans_process_group(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    client = _client(tmp_path)
+
+    async def blocked_initialize() -> None:
+        await _wait_for_child_pid(tmp_path)
+        await asyncio.Event().wait()
+
+    client._initialize = blocked_initialize
+    task = asyncio.create_task(client.start())
+    try:
+        child_pid = await _wait_for_child_pid(tmp_path)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await _assert_pid_exits(child_pid)
+    finally:
+        await _cleanup_test_group(client)
+
+
+@pytest.mark.asyncio
+@requires_linux_groups
+async def test_cleanup_never_signals_current_process_group(monkeypatch, tmp_path: Path):
+    client = _client(tmp_path)
+    proc = MagicMock()
+    proc.pid = os.getpid()
+    proc.returncode = None
+    proc.wait = AsyncMock(return_value=0)
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    client._proc = proc
+    client._process_group_id = os.getpgrp()
+    killpg = MagicMock()
+    monkeypatch.setattr(os, "killpg", killpg)
+
+    await client._cleanup_process(reason="safety_test")
+
+    killpg.assert_not_called()
+    proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_signal_reused_numeric_process_group(
+    monkeypatch, tmp_path: Path
+):
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    pgid = 41000
+    _write_proc_member(
+        proc_root,
+        pid=pgid,
+        pgid=pgid,
+        session_id=pgid,
+        start_time=200,
+    )
+    _write_proc_member(
+        proc_root,
+        pid=41001,
+        pgid=pgid,
+        session_id=pgid,
+        start_time=201,
+    )
+    client = _client(tmp_path)
+    proc = MagicMock(pid=pgid, returncode=0)
+    client._proc = proc
+    client._process_group_id = pgid
+    client._session_id = pgid
+    client._leader_start_time = 100
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", True)
+    monkeypatch.setattr(client_module, "_PROC_ROOT", proc_root)
+    monkeypatch.setattr(client_module, "_PIDFD_OPEN", MagicMock(return_value=71))
+    pidfd_send_signal = MagicMock()
+    monkeypatch.setattr(client_module, "_PIDFD_SEND_SIGNAL", pidfd_send_signal)
+    close = MagicMock()
+    monkeypatch.setattr(os, "close", close)
+
+    await client._cleanup_process(reason="reused_pgid")
+
+    pidfd_send_signal.assert_not_called()
+    close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pins_identity_before_numeric_pid_is_replaced(
+    monkeypatch, tmp_path: Path
+):
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    pgid = 42000
+    _write_proc_member(
+        proc_root,
+        pid=42001,
+        pgid=pgid,
+        session_id=pgid,
+    )
+    client = _client(tmp_path)
+    proc = MagicMock(pid=pgid, returncode=0)
+    client._proc = proc
+    client._process_group_id = pgid
+    client._session_id = pgid
+
+    def pidfd_open(pid, flags):
+        assert (pid, flags) == (42001, 0)
+        return 81
+
+    def pidfd_send_signal(pidfd, sig):
+        assert (pidfd, sig) == (81, signal.SIGTERM)
+
+    open_members = client._open_owned_process_group_members
+
+    def open_then_replace_numeric_identity(member_pgid):
+        opened = open_members(member_pgid)
+        member = proc_root / "42001"
+        member.joinpath("stat").write_text(
+            "42001 (replacement) S 1 99999 99999 " + "0 " * 16,
+            encoding="ascii",
+        )
+        return opened
+
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", True)
+    monkeypatch.setattr(client_module, "_PROC_ROOT", proc_root)
+    monkeypatch.setattr(client_module, "_PIDFD_OPEN", pidfd_open)
+    monkeypatch.setattr(
+        client, "_open_owned_process_group_members", open_then_replace_numeric_identity
+    )
+    pidfd_send_signal_mock = MagicMock(side_effect=pidfd_send_signal)
+    monkeypatch.setattr(
+        client_module, "_PIDFD_SEND_SIGNAL", pidfd_send_signal_mock
+    )
+    close = MagicMock()
+    monkeypatch.setattr(os, "close", close)
+    numeric_signal = MagicMock()
+    monkeypatch.setattr(os, "killpg", numeric_signal)
+
+    await client._cleanup_process(reason="leader_exited")
+
+    pidfd_send_signal_mock.assert_called_once_with(81, signal.SIGTERM)
+    close.assert_called_once_with(81)
+    numeric_signal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_every_pidfd_when_signaling_fails(
+    monkeypatch, tmp_path: Path
+):
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    pgid = 43000
+    for pid in (43001, 43002):
+        _write_proc_member(
+            proc_root,
+            pid=pid,
+            pgid=pgid,
+            session_id=pgid,
+        )
+    client = _client(tmp_path)
+    proc = MagicMock(pid=pgid, returncode=0)
+    client._proc = proc
+    client._process_group_id = pgid
+    client._session_id = pgid
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.01)
+    monkeypatch.setattr(client_module, "SHUTDOWN_VERIFY_TIMEOUT", 0.01)
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", True)
+    monkeypatch.setattr(client_module, "_PROC_ROOT", proc_root)
+    opened_fds = []
+
+    def pidfd_open(pid, _flags):
+        fd = pid + 100 + len(opened_fds) * 1000
+        opened_fds.append(fd)
+        return fd
+
+    monkeypatch.setattr(client_module, "_PIDFD_OPEN", pidfd_open)
+    monkeypatch.setattr(
+        client_module,
+        "_PIDFD_SEND_SIGNAL",
+        MagicMock(side_effect=PermissionError),
+    )
+    close = MagicMock()
+    monkeypatch.setattr(os, "close", close)
+
+    await client._cleanup_process(reason="signal_failure")
+
+    assert [call.args[0] for call in close.call_args_list] == opened_fds
+
+
+@pytest.mark.asyncio
+async def test_unavailable_pidfd_support_never_invokes_killpg(
+    monkeypatch, tmp_path: Path
+):
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    pgid = 44000
+    _write_proc_member(
+        proc_root,
+        pid=44001,
+        pgid=pgid,
+        session_id=pgid,
+    )
+    client = _client(tmp_path)
+    proc = MagicMock(pid=pgid, returncode=0)
+    client._proc = proc
+    client._process_group_id = pgid
+    client._session_id = pgid
+    killpg = MagicMock()
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", True)
+    monkeypatch.setattr(client_module, "_PROC_ROOT", proc_root)
+    monkeypatch.setattr(client_module, "_PIDFD_OPEN", None)
+    monkeypatch.setattr(client_module, "_PIDFD_SEND_SIGNAL", None)
+    monkeypatch.setattr(os, "killpg", killpg)
+
+    await client._cleanup_process(reason="pidfd_unavailable")
+
+    killpg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_falls_back_to_direct_process_without_groups(monkeypatch, tmp_path: Path):
+    client = _client(tmp_path)
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = None
+    proc.wait = AsyncMock(return_value=0)
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    client._proc = proc
+    client._process_group_id = 12345
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", False)
+
+    await client._cleanup_process(reason="fallback_test")
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_direct_process_fallback_escalates_only_direct_process(
+    monkeypatch, tmp_path: Path
+):
+    client = _client(tmp_path)
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = None
+    proc.wait = AsyncMock(side_effect=[asyncio.TimeoutError, 0])
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    client._proc = proc
+    monkeypatch.setattr(client_module, "_LINUX_PROCESS_GROUPS", False)
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.01)
+
+    await client._cleanup_process(reason="fallback_escalation_test")
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_and_awaits_server_request_tasks(tmp_path: Path):
+    client = _client(tmp_path)
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def blocked_handler(_params):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    client._request_handlers["test/blocked"] = blocked_handler
+    client._start_server_request_task(
+        1, {"method": "test/blocked", "params": None}
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await client._cleanup_process(reason="request_task_test")
+
+    assert cancelled.is_set()
+    assert not client._server_request_tasks
+
+
+@pytest.mark.asyncio
+async def test_wait_for_diagnostics_cancellation_awaits_child_tasks(tmp_path: Path):
+    client = _client(tmp_path)
+    pull_started = asyncio.Event()
+    push_started = asyncio.Event()
+    pull_cancelled = asyncio.Event()
+    push_cancelled = asyncio.Event()
+
+    async def blocked_pull(_path):
+        pull_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            pull_cancelled.set()
+
+    async def blocked_push(_path, _version, _timeout):
+        push_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            push_cancelled.set()
+
+    client._pull_document_diagnostics = blocked_pull
+    client._wait_for_fresh_push = blocked_push
+    task = asyncio.create_task(client.wait_for_diagnostics("x.py", 1))
+    await asyncio.wait_for(
+        asyncio.gather(pull_started.wait(), push_started.wait()), timeout=1.0
+    )
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert pull_cancelled.is_set()
+    assert push_cancelled.is_set()

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,11 +7,18 @@ on.
 """
 from __future__ import annotations
 
+import asyncio
+import os
+import signal
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
+from agent.lsp import client as client_module
+from agent.lsp import manager as manager_module
+from agent.lsp.client import LSPClient
 from agent.lsp.manager import LSPService
 from agent.lsp.servers import (
     SERVERS,
@@ -22,6 +29,58 @@ from agent.lsp.servers import (
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+
+_BLOCKED_START_LEADER = """
+import os
+import subprocess
+import sys
+import time
+
+child = subprocess.Popen(
+    [sys.executable, "-c", "import time; time.sleep(60)"],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+with open(os.environ["LSP_TEST_LEADER_PID"], "w", encoding="ascii") as fh:
+    fh.write(str(os.getpid()))
+with open(os.environ["LSP_TEST_CHILD_PID"], "w", encoding="ascii") as fh:
+    fh.write(str(child.pid))
+time.sleep(60)
+"""
+
+
+def _wait_for_pid_file(path: Path) -> int:
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        try:
+            return int(path.read_text(encoding="ascii"))
+        except (FileNotFoundError, ValueError):
+            time.sleep(0.01)
+    raise AssertionError(f"{path.name} was not created")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    stat = Path(f"/proc/{pid}/stat")
+    if stat.exists():
+        try:
+            return stat.read_text(encoding="ascii").split()[2] != "Z"
+        except (OSError, IndexError):
+            pass
+    return True
+
+
+def _wait_for_pid_exit(pid: int) -> None:
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"process {pid} survived service shutdown")
 
 
 def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "pyright"):
@@ -174,3 +233,282 @@ def test_service_status_includes_clients(mock_pyright):
         assert any(c["server_id"] == "pyright" for c in info["clients"])
     finally:
         svc.shutdown()
+
+
+def _concurrent_spawn_service(tmp_path: Path, monkeypatch, client_type):
+    root = str(tmp_path)
+    source = str(tmp_path / "x.py")
+    server = next(s for s in SERVERS if s.server_id == "pyright")
+    spawn = SpawnSpec(
+        command=["test-lsp"],
+        workspace_root=root,
+        cwd=root,
+        env={},
+        initialization_options={},
+    )
+    monkeypatch.setattr(manager_module, "find_server_for_file", lambda _path: server)
+    monkeypatch.setattr(
+        manager_module, "resolve_workspace_for_file", lambda _path: (root, True)
+    )
+    monkeypatch.setattr(server, "resolve_root", lambda _path, _root: root)
+    monkeypatch.setattr(server, "build_spawn", lambda _root, _ctx: spawn)
+    monkeypatch.setattr(manager_module, "LSPClient", client_type)
+    service = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+    )
+    return service, source, (server.server_id, root)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_spawn_waiter_is_cancelled_when_owner_is_cancelled(
+    tmp_path: Path, monkeypatch
+):
+    started = asyncio.Event()
+
+    class CancelledClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            started.set()
+            await asyncio.Event().wait()
+
+    service, source, key = _concurrent_spawn_service(
+        tmp_path, monkeypatch, CancelledClient
+    )
+    owner = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    waiter = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.sleep(0)
+
+    owner.cancel()
+    results = await asyncio.wait_for(
+        asyncio.gather(owner, waiter, return_exceptions=True), timeout=1.0
+    )
+
+    assert all(isinstance(result, asyncio.CancelledError) for result in results)
+    assert key not in service._spawning
+
+
+@pytest.mark.asyncio
+async def test_concurrent_spawn_failure_resolves_all_waiters(tmp_path: Path, monkeypatch):
+    started = asyncio.Event()
+    fail = asyncio.Event()
+
+    class FailingClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            started.set()
+            await fail.wait()
+            raise RuntimeError("spawn failed")
+
+    service, source, key = _concurrent_spawn_service(
+        tmp_path, monkeypatch, FailingClient
+    )
+    owner = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    waiter = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.sleep(0)
+    fail.set()
+
+    assert await asyncio.wait_for(asyncio.gather(owner, waiter), timeout=1.0) == [
+        None,
+        None,
+    ]
+    assert key not in service._spawning
+    assert key in service._broken
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_in_flight_spawn_and_settles_waiters(
+    tmp_path: Path, monkeypatch
+):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    shut_down = asyncio.Event()
+
+    class BlockedClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        async def shutdown(self):
+            shut_down.set()
+
+    service, source, key = _concurrent_spawn_service(
+        tmp_path, monkeypatch, BlockedClient
+    )
+    owner = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    waiter = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.sleep(0)
+
+    try:
+        await asyncio.wait_for(service._shutdown_async(), timeout=1.0)
+
+        results = await asyncio.wait_for(
+            asyncio.gather(owner, waiter, return_exceptions=True), timeout=1.0
+        )
+        assert cancelled.is_set()
+        assert shut_down.is_set()
+        assert all(isinstance(result, asyncio.CancelledError) for result in results)
+        assert key not in service._spawning
+    finally:
+        for task in (owner, waiter):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(owner, waiter, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_spawn_finishing_after_shutdown_begins_cleans_unpublished_client(
+    tmp_path: Path, monkeypatch
+):
+    started = asyncio.Event()
+    finish_start = asyncio.Event()
+    shut_down = asyncio.Event()
+
+    class FinishingClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            started.set()
+            await finish_start.wait()
+
+        async def shutdown(self):
+            shut_down.set()
+
+    service, source, key = _concurrent_spawn_service(
+        tmp_path, monkeypatch, FinishingClient
+    )
+    owner = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    waiter = asyncio.create_task(service._get_or_spawn(source))
+    await asyncio.sleep(0)
+
+    with service._state_lock:
+        service._shutting_down = True
+    finish_start.set()
+
+    results = await asyncio.wait_for(
+        asyncio.gather(owner, waiter, return_exceptions=True), timeout=1.0
+    )
+    assert results[0] is None
+    assert isinstance(results[1], asyncio.CancelledError)
+    assert shut_down.is_set()
+    assert key not in service._clients
+    assert key not in service._spawning
+
+
+@pytest.mark.asyncio
+async def test_mark_broken_leaves_registered_client_owned_by_shutdown(
+    tmp_path: Path, monkeypatch
+):
+    shut_down = asyncio.Event()
+
+    class RegisteredClient:
+        async def shutdown(self):
+            shut_down.set()
+
+    service, source, key = _concurrent_spawn_service(
+        tmp_path, monkeypatch, RegisteredClient
+    )
+    client = RegisteredClient()
+    with service._state_lock:
+        service._clients[key] = client
+        service._shutting_down = True
+
+    service._mark_broken_for_file(source, asyncio.TimeoutError())
+
+    assert service._clients[key] is client
+    await asyncio.wait_for(service._shutdown_async(), timeout=1.0)
+    assert shut_down.is_set()
+    assert key not in service._clients
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or client_module._PIDFD_OPEN is None,
+    reason="process-tree service shutdown requires Linux pidfds",
+)
+def test_service_shutdown_contains_real_in_flight_process_tree(
+    tmp_path: Path, monkeypatch
+):
+    root = str(tmp_path)
+    source = str(tmp_path / "x.py")
+    leader_pid_file = tmp_path / "leader.pid"
+    child_pid_file = tmp_path / "child.pid"
+    server = next(s for s in SERVERS if s.server_id == "pyright")
+    spawn = SpawnSpec(
+        command=[sys.executable, "-c", _BLOCKED_START_LEADER],
+        workspace_root=root,
+        cwd=root,
+        env={
+            "LSP_TEST_LEADER_PID": str(leader_pid_file),
+            "LSP_TEST_CHILD_PID": str(child_pid_file),
+        },
+        initialization_options={},
+    )
+
+    class BlockedStartClient(LSPClient):
+        async def _initialize(self):
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(client_module, "SHUTDOWN_GRACE", 0.2)
+    monkeypatch.setattr(manager_module, "find_server_for_file", lambda _path: server)
+    monkeypatch.setattr(
+        manager_module, "resolve_workspace_for_file", lambda _path: (root, True)
+    )
+    monkeypatch.setattr(server, "resolve_root", lambda _path, _root: root)
+    monkeypatch.setattr(server, "build_spawn", lambda _root, _ctx: spawn)
+    monkeypatch.setattr(manager_module, "LSPClient", BlockedStartClient)
+    service = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+    )
+    owner = None
+    waiter = None
+    leader_pid = None
+    child_pid = None
+    try:
+        loop = service._loop._loop
+        assert loop is not None
+        owner = asyncio.run_coroutine_threadsafe(service._get_or_spawn(source), loop)
+        leader_pid = _wait_for_pid_file(leader_pid_file)
+        child_pid = _wait_for_pid_file(child_pid_file)
+        waiter = asyncio.run_coroutine_threadsafe(service._get_or_spawn(source), loop)
+        asyncio.run_coroutine_threadsafe(asyncio.sleep(0), loop).result(timeout=1.0)
+
+        service.shutdown()
+
+        assert owner.done()
+        assert waiter.done()
+        assert owner.cancelled() or owner.result() is None
+        assert waiter.cancelled() or waiter.result() is None
+        assert service._spawning == {}
+        assert service._loop._loop is None
+        assert service._loop._thread is None
+        _wait_for_pid_exit(leader_pid)
+        _wait_for_pid_exit(child_pid)
+        service.shutdown()
+    finally:
+        service.shutdown()
+        for pid in (child_pid, leader_pid):
+            if pid is not None and _pid_alive(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass


### PR DESCRIPTION
## Summary
- contain LSP subprocess trees across graceful shutdown, cancellation, failed initialization, and manager shutdown races
- use Linux pidfds for identity-safe descendant signaling without numeric `killpg` reuse hazards
- track and await diagnostics, server-request, spawn-owner, and waiter tasks
- provide conservative direct-child fallback when pidfds are unavailable
- add deterministic real-subprocess coverage for leader exit, resistant descendants, sanitized exec environments, escalation, and shutdown-during-spawn

## Safety properties
- no process-name killing
- no production `killpg`
- no signaling based only on a reused numeric PID/PGID
- no live service/config/cgroup changes
- partial clients are cleaned before event-loop closure

## Verification
- full LSP suite: 182/182 passed
- focused lifecycle/process tests: 28/28 passed
- Ruff: passed
- `git diff --check`: passed
- independent final safety review: no blockers