### PR TITLE
fix(matrix): convert TTS replies to Opus voice notes

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,33 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_matrix_converts_local_tts_to_opus_voice(tmp_path, monkeypatch):
+    out = tmp_path / "speech.wav"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    def fake_generate(_text: str, path: str, _config: dict) -> str:
+        Path(path).write_bytes(b"wav")
+        return path
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "matrix")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "kittentts"})
+    monkeypatch.setattr(tts_tool, "_import_kittentts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_kittentts", fake_generate)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -889,7 +889,7 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
 
 
 # ===========================================================================
-# ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
+# ffmpeg Opus conversion (local/cloud audio -> OGG Opus for voice bubbles)
 # ===========================================================================
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
@@ -2194,12 +2194,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and Matrix voice messages require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed). Edge TTS always
+    # outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "matrix"}
 
     # Determine output path
     if output_path:
@@ -2236,8 +2236,9 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
+        # Use .ogg for Telegram or Matrix with providers that support native
+        # Opus output, otherwise fall back to .mp3 (other providers will be
+        # converted later when voice delivery requires it).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
@@ -2390,7 +2391,7 @@ def text_to_speech_tool(
                 "error": f"TTS generation produced no output (provider: {provider})"
             }, ensure_ascii=False)
 
-        # Try Opus conversion for Telegram compatibility.
+        # Try Opus conversion for Telegram and Matrix voice compatibility.
         # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV. Keep those native
         # formats for local/CLI playback and only convert when the current
         # platform actually needs Opus voice delivery.


### PR DESCRIPTION
## Summary
- convert Matrix TTS replies to OGG/Opus, matching Matrix native voice-message requirements
- keep existing Telegram routing unchanged
- add a regression test for local TTS providers such as KittenTTS

## Root cause
The shared TTS dispatcher only requested/constrained Opus output for Telegram. Matrix voice replies therefore kept KittenTTS WAV or other provider MP3 output while the Matrix adapter tagged the upload as an MSC3245 native voice message. Element clients may not render or play that payload as a voice note.

## Test plan
- `python -m pytest tests/tools/test_tts_opus_routing.py -q` — 3 passed
- `python -m pytest tests/tools/test_tts_kittentts.py tests/tools/test_tts_opus_routing.py tests/tools/test_tts_path_traversal.py tests/tools/test_tts_speed.py -q` — 36 passed
- real ffmpeg conversion verified with `ffprobe`: OGG container, Opus codec
