### PR TITLE
fix: parse JSON-string fallback_providers in YAML config

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -41,6 +41,19 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
 
 
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
+    # Hermes serializes list-valued config keys as JSON strings in YAML
+    # (``hermes config set fallback_providers '[{...}]'``).  The YAML
+    # parser gives us back a string.  Parse it so the fallback chain
+    # actually populates instead of silently returning empty (#61185).
+    if isinstance(raw, str) and raw.strip().startswith(("[", "{")):
+        import json
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+        else:
+            return _iter_fallback_entries(parsed)
+
     if isinstance(raw, dict):
         candidates = [raw]
     elif isinstance(raw, list):

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,4 +1,11 @@
-"""Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
+"""Tests for hermes_cli/fallback_config.py — API-key resolution and chain round-trip."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
 
 from agent.secret_scope import reset_secret_scope, set_secret_scope
 from hermes_cli.fallback_config import resolve_entry_api_key
@@ -37,3 +44,85 @@ class TestResolveEntryApiKey:
         # secret scope installed, resolution still reads os.environ.
         monkeypatch.setenv("FB_KEY", "env-key")
         assert resolve_entry_api_key({"key_env": "FB_KEY"}) == "env-key"
+
+
+@pytest.fixture()
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+class TestGetFallbackChainIntegration:
+    """set_config_value() persists fallback_providers as a JSON string; verify
+    get_fallback_chain() still returns the correct entries after reload."""
+
+    def test_json_string_round_trip(self, isolated_home):
+        """hermes config set serializes lists as JSON strings; chain must survive."""
+        from hermes_cli.config import set_config_value, load_config
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        entries = [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+            {"provider": "nous", "model": "Hermes-4-Llama-3.1-405B"},
+            {"provider": "llamacpp", "model": "local", "base_url": "http://localhost:8080/v1"},
+        ]
+        set_config_value("fallback_providers", json.dumps(entries))
+
+        cfg = load_config()
+        chain = get_fallback_chain(cfg)
+
+        assert len(chain) == 3
+        assert chain[0]["provider"] == "openrouter"
+        assert chain[0]["model"] == "anthropic/claude-sonnet-4.6"
+        assert chain[1]["provider"] == "nous"
+        assert chain[1]["model"] == "Hermes-4-Llama-3.1-405B"
+        assert chain[2]["provider"] == "llamacpp"
+        assert chain[2]["base_url"] == "http://localhost:8080/v1"
+
+    def test_order_preserved(self, isolated_home):
+        """Entry order from the JSON string must be preserved in the chain."""
+        from hermes_cli.config import set_config_value, load_config
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        entries = [
+            {"provider": "first", "model": "m1"},
+            {"provider": "second", "model": "m2"},
+            {"provider": "third", "model": "m3"},
+        ]
+        set_config_value("fallback_providers", json.dumps(entries))
+
+        chain = get_fallback_chain(load_config())
+
+        assert [e["provider"] for e in chain] == ["first", "second", "third"]
+
+    def test_native_list_still_works(self, isolated_home):
+        """YAML-native list format (written directly) must continue to work."""
+        import yaml
+        from hermes_cli.config import load_config
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        config_path = isolated_home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+        chain = get_fallback_chain(load_config())
+
+        assert len(chain) == 1
+        assert chain[0]["provider"] == "openrouter"
+
+    def test_empty_config_returns_empty_chain(self, isolated_home):
+        from hermes_cli.config import load_config
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        chain = get_fallback_chain(load_config())
+
+        assert chain == []


### PR DESCRIPTION
## Problem

When `hermes config set` writes a list-valued config key like `fallback_providers`, it serializes the list as a JSON string inside YAML:
```yaml
fallback_providers: '[{"provider":"opencode-zen","model":"deepseek-v4-flash-free"},...]'
```

The YAML parser returns this as a `str`, not a `list`. `_iter_fallback_entries()` in `fallback_config.py` only handled `dict` and `list` types — strings fell through to `else: return []`.

**The fallback chain was silently always empty**, even when users configured multiple fallback providers including a local llama.cpp model as a final safety net. Every rate limit from the primary provider (e.g., NVIDIA NIM) burned through all retries with zero fallback activation ever logged.

Users saw `"The model provider is rate-limiting requests..."` despite having a fully working llama.cpp local server running at `localhost:8080`.

## Fix

Added a `json.loads()` parse guard in `_iter_fallback_entries()` for strings that start with `[` or `{`. The parsed result is recursively fed back through the same function, so both the legacy single-dict `fallback_model` format and the multi-entry `fallback_providers` list format work transparently.

Non-JSON strings fall through to existing empty-return behavior unchanged. YAML-native lists/dicts continue to work as before.

## Verification

- Tested with actual `config.yaml` containing JSON-string `fallback_providers` → chain correctly returns 3 entries
- All existing code paths (dict, list, empty) unchanged
- `get_fallback_chain()` integration test passes with both string and list config values
- All 3 fallback providers resolve correctly via `resolve_provider_client()`