### PR TITLE
fix(cron): one-shot jobs report 'failed' after successful completion

### DIFF
--- a/tests/tools/test_oneshot_status_fix.py
+++ b/tests/tools/test_oneshot_status_fix.py
@@ -1,0 +1,73 @@
+"""Tests for _execute_job_now one-shot status reporting fix.
+
+Verifies that one-shot jobs (repeat=1) which are auto-removed by mark_job_run
+after completion correctly report success instead of failure.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def _job_oneshot():
+    return {"id": "oneshot-1", "name": "test-oneshot", "schedule": {"kind": "once", "at": "2099-01-01T00:00:00"}, "repeat": {"times": 1, "completed": 0}}
+
+
+@pytest.fixture()
+def _job_recurring():
+    return {"id": "recurring-1", "name": "test-recurring"}
+
+
+class TestExecuteJobNowOneShot:
+    """One-shot jobs auto-removed after success should report success."""
+
+    def test_oneshot_removed_after_success(self, _job_oneshot):
+        """When mark_job_run removes a one-shot, _execute_job_now should
+        return success=True (the job ran and completed)."""
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value=None), \
+             patch("cron.scheduler.run_one_job", return_value=True):
+            from tools.cronjob_tools import _execute_job_now
+            result = _execute_job_now(_job_oneshot)
+            assert result["claimed"] is True
+            assert result["success"] is True
+            assert result["error"] is None
+
+    def test_oneshot_agent_failure(self, _job_oneshot):
+        """When the agent fails but job still exists, report failure."""
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value={"id": "oneshot-1", "last_status": "error", "last_error": "bad"}), \
+             patch("cron.scheduler.run_one_job", return_value=True):
+            from tools.cronjob_tools import _execute_job_now
+            result = _execute_job_now(_job_oneshot)
+            assert result["success"] is False
+            assert result["error"] == "bad"
+
+    def test_recurring_success(self, _job_recurring):
+        """Recurring jobs that still exist after run report normally."""
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value={"id": "recurring-1", "last_status": "ok"}), \
+             patch("cron.scheduler.run_one_job", return_value=True):
+            from tools.cronjob_tools import _execute_job_now
+            result = _execute_job_now(_job_recurring)
+            assert result["success"] is True
+            assert result["error"] is None
+
+    def test_processing_failure_job_gone(self, _job_recurring):
+        """When run_one_job returns False and job is gone, report failure."""
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value=None), \
+             patch("cron.scheduler.run_one_job", return_value=False):
+            from tools.cronjob_tools import _execute_job_now
+            result = _execute_job_now(_job_recurring)
+            assert result["success"] is False
+
+    def test_claim_failed(self, _job_recurring):
+        """When claim fails, report not-claimed."""
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+             patch("tools.cronjob_tools.get_job", return_value=None):
+            from tools.cronjob_tools import _execute_job_now
+            result = _execute_job_now(_job_recurring)
+            assert result["claimed"] is False
+            assert result["success"] is False

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -639,12 +639,18 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
         processed = run_one_job(job)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
+        refreshed = get_job(job_id)
+        if refreshed is None and processed:
+            # One-shot jobs (repeat=1) are auto-removed by mark_job_run after
+            # a successful completion.  Absence after a processed run means the
+            # job completed and was cleaned up — not a failure.
+            return {"claimed": True, "success": True, "error": None}
+        _r = refreshed or {}
+        ok = _r.get("last_status") == "ok"
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": _r.get("last_error"),
         }
 
     except Exception as e:


### PR DESCRIPTION
## Symptom

`hermes cron run <job-id>` on a one-shot job (`repeat=1`) prints `Ran now: failed` even though:
- Agent completed and produced correct output
- Output file was written to `~/.hermes/cron/output/`
- Scheduler logged `Job '...' completed successfully`

## Root cause

`mark_job_run()` in `cron/jobs.py` **removes** one-shot jobs from `jobs.json` when the repeat limit is reached (line ~1544). It sets `last_status="ok"` on the in-memory dict first, but that dict is then popped from the list and discarded — the job no longer exists on disk.

`_execute_job_now()` in `tools/cronjob_tools.py` then reads the job back via `get_job(job_id)` to check `last_status`. For one-shot jobs this returns `None`, so `ok = False` and `execution_success` is incorrectly set to `False`.

```
mark_job_run(success=True)
  → sets last_status="ok" in memory
  → completed >= times → jobs.pop(i) → save_jobs  ← job deleted
  → return

_execute_job_now:
  → get_job(job_id) → None  (job removed)
  → ok = ({}).get("last_status") == "ok" → False
  → returns success=False  ← WRONG
```

## Fix

In `_execute_job_now`, after `run_one_job` returns `True`, treat a missing job as one-shot completion rather than failure:

```python
refreshed = get_job(job_id)
if refreshed is None and processed:
    # One-shot auto-removed after success — absence = completion
    return {"claimed": True, "success": True, "error": None}
_r = refreshed or {}
```

Also uses the `_r` fallback dict consistently for `last_error` access (defensive against a `None` refreshed in the error path).

## Scope

- **1 file changed** (`tools/cronjob_tools.py`, 6 lines net)
- No schema changes, no new dependencies
- Does not affect recurring jobs (they still exist after `mark_job_run`)
- Does not affect delivery semantics

## Tests

- 5 new tests in `tests/tools/test_oneshot_status_fix.py` covering:
  - One-shot removed after success → `success=True`
  - One-shot agent failure → `success=False`
  - Recurring success → `success=True` (unchanged)
  - Processing failure + job gone → `success=False` (unchanged)
  - Claim failed → `claimed=False` (unchanged)
- All existing `test_cronjob_run_immediate` tests pass (5/5)

## Edge cases

| Scenario | `processed` | `get_job` | Result |
|---|---|---|---|
| One-shot success | True | None (removed) | **success=True** (fix) |
| One-shot agent failure | True | exists, status=error | success=False |
| Recurring success | True | exists, status=ok | success=True |
| Processing failure | False | None | success=False |
