### PR TITLE
feat: add read-only Reddit access skill

### DIFF
--- a/optional-skills/research/reddit-access/SKILL.md
+++ b/optional-skills/research/reddit-access/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: reddit-access
+description: Research public Reddit content without account actions.
+version: 1.0.0
+author: Jesse Gonzalez (@ctwhome), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [reddit, research, rss, mcp, social-research, monitoring]
+    related_skills: [duckduckgo-search, scrapling]
+---
+
+# Reddit Access Skill
+
+Research public Reddit content when direct HTML or `.json` endpoints return an anti-bot challenge. Start with RSS, then use approved read-only backends when RSS lacks needed coverage.
+
+## When to Use
+
+- Research a known subreddit or exact keyword without signing in.
+- Use semantic search, comments, or cross-subreddit discovery through an approved read-only backend.
+- Read public content only; never post, comment, vote, message, subscribe, moderate, or automate account actions.
+- Prefer RSS and approved APIs over CAPTCHA solving, stealth fingerprints, or rotating anonymous proxies.
+
+## Prerequisites
+
+- Python 3; bundled RSS client uses only standard library.
+- Installed skill at `${HERMES_HOME:-$HOME/.hermes}/skills/research/reddit-access`.
+- For MCP, verify server operator, freshness, privacy policy, terms, and read-only scope.
+- Put behavioral configuration in `config.yaml`; use `.env` only for secret credentials.
+
+## How to Run
+
+Subreddit:
+
+```bash
+SKILL_DIR="${HERMES_HOME:-$HOME/.hermes}/skills/research/reddit-access"
+python3 "$SKILL_DIR/scripts/reddit_rss.py" --subreddit phones --limit 10
+```
+
+Keyword search:
+
+```bash
+SKILL_DIR="${HERMES_HOME:-$HOME/.hermes}/skills/research/reddit-access"
+python3 "$SKILL_DIR/scripts/reddit_rss.py" --query '8 inch phone' --limit 10
+```
+
+Output is normalized JSON containing `title`, `url`, `author`, `published`, `text`, `subreddit`, and `source`.
+
+## Quick Reference
+
+Backend order:
+
+1. **RSS** — default; needs no credentials and supports subreddit or keyword searches.
+2. **Configured MCP server** — use for semantic search, comments, or cross-subreddit discovery.
+3. **Official Reddit OAuth MCP/server** — preferred durable integration when credentials and app approval are available.
+4. **Browser session** — interactive, user-approved lookup only; never use a personal session for unattended crawling.
+
+Direct feeds:
+
+```text
+https://www.reddit.com/r/phones/.rss
+https://www.reddit.com/search.rss?q=8%20inch%20phone
+```
+
+Add a vetted remote MCP server with `hermes mcp add reddit-research --url <server-url>`, or use a self-hosted server. Start a fresh Hermes session afterward so tools are discovered.
+
+## Procedure
+
+1. Start with RSS for a known subreddit or exact keyword.
+2. If RSS is insufficient, use a configured read-only Reddit MCP for semantic discovery or comments.
+3. Cross-check consequential claims against the original Reddit permalink and at least one non-Reddit source.
+4. Record `source` and retrieval time.
+5. Keep queries narrow and cache repeated monitoring results.
+6. Respect Reddit terms, rate limits, robots directives, and provider terms.
+
+## Pitfalls
+
+| Symptom | Action |
+|---|---|
+| Reddit `.json` or HTML returns 403 | Use RSS; do not retry rapidly |
+| RSS returns 403 | Do not hammer it; use an approved MCP/API backend or report the blocker |
+| RSS works but comments are missing | Use an approved MCP/OAuth backend |
+| MCP is unavailable | Run `hermes mcp list`, then `hermes mcp test reddit-research` |
+| Results look stale | Show retrieval time and verify the original permalink |
+| OAuth is rejected | Check Reddit app credentials, User-Agent, scopes, and rate limits |
+
+RSS does not promise complete search, historical coverage, or full comment trees. Third-party indexes may be stale, so cite original Reddit URLs and retrieval times. For large-scale or commercial collection, use a provider with an explicit contract and review its Reddit data terms first.
+
+## Verification
+
+- Confirm output is valid JSON and each record contains an original Reddit `url` plus `source`.
+- Open important permalinks and record retrieval time before citing results.
+- Confirm configured MCP tools are read-only before use.

--- a/optional-skills/research/reddit-access/scripts/reddit_rss.py
+++ b/optional-skills/research/reddit-access/scripts/reddit_rss.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Fetch public Reddit RSS feeds and emit normalized JSON.
+
+This is deliberately RSS-only: it avoids authenticated actions and does not
+attempt to bypass Reddit's anti-bot controls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from typing import Any
+
+DEFAULT_USER_AGENT = "hermes-agent-reddit-access/1.0 (read-only research)"
+ATOM = "http://www.w3.org/2005/Atom"
+MEDIA = "http://search.yahoo.com/mrss/"
+CONTENT = "http://purl.org/rss/1.0/modules/content/"
+
+
+def _clean_text(value: str | None) -> str:
+    if not value:
+        return ""
+    value = html.unescape(value)
+    value = re.sub(r"<br\s*/?>", "\n", value, flags=re.I)
+    value = re.sub(r"</p\s*>", "\n", value, flags=re.I)
+    value = re.sub(r"<[^>]+>", "", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _text(element: ET.Element, *names: str) -> str:
+    for name in names:
+        child = element.find(name)
+        if child is not None and child.text:
+            return child.text.strip()
+    return ""
+
+
+def _link(element: ET.Element) -> str:
+    atom_link = element.find(f"{{{ATOM}}}link")
+    if atom_link is not None and atom_link.get("href"):
+        return atom_link.get("href", "")
+    return _text(element, "link")
+
+
+def parse_feed(payload: bytes, source_url: str) -> list[dict[str, Any]]:
+    root = ET.fromstring(payload)
+    entries = root.findall(f"{{{ATOM}}}entry") or root.findall(".//item")
+    results: list[dict[str, Any]] = []
+    for entry in entries:
+        link = _link(entry)
+        title = _text(entry, f"{{{ATOM}}}title", "title")
+        author = _text(entry, f"{{{ATOM}}}author/{{{ATOM}}}name", "author")
+        published = _text(entry, f"{{{ATOM}}}published", f"{{{ATOM}}}updated", "pubDate")
+        text = _text(
+            entry,
+            f"{{{CONTENT}}}encoded",
+            f"{{{ATOM}}}content",
+            f"{{{MEDIA}}}description",
+            "description",
+        )
+        subreddit = ""
+        match = re.search(r"/r/([^/]+)", link)
+        if match:
+            subreddit = f"r/{match.group(1)}"
+        results.append(
+            {
+                "title": _clean_text(title),
+                "url": link,
+                "author": author.removeprefix("/u/"),
+                "published": published,
+                "text": _clean_text(text),
+                "subreddit": subreddit,
+                "source": source_url,
+            }
+        )
+    return results
+
+
+def feed_url(subreddit: str | None, query: str | None) -> str:
+    if bool(subreddit) == bool(query):
+        raise ValueError("provide exactly one of --subreddit or --query")
+    if subreddit:
+        subreddit = subreddit.strip().removeprefix("r/").strip("/")
+        if not re.fullmatch(r"[A-Za-z0-9_+-]+", subreddit):
+            raise ValueError("invalid subreddit name")
+        return f"https://www.reddit.com/r/{subreddit}/.rss"
+    return "https://www.reddit.com/search.rss?" + urllib.parse.urlencode({"q": query})
+
+
+def fetch(url: str, timeout: float, user_agent: str) -> list[dict[str, Any]]:
+    request = urllib.request.Request(url, headers={"User-Agent": user_agent, "Accept": "application/atom+xml"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"Reddit RSS returned HTTP {response.status}")
+        return parse_feed(response.read(), url)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--subreddit")
+    group.add_argument("--query")
+    parser.add_argument("--limit", type=int, default=25)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--user-agent", default=DEFAULT_USER_AGENT)
+    args = parser.parse_args(argv)
+    if not 1 <= args.limit <= 100:
+        parser.error("--limit must be between 1 and 100")
+    try:
+        url = feed_url(args.subreddit, args.query)
+        print(json.dumps(fetch(url, args.timeout, args.user_agent)[: args.limit], ensure_ascii=False, indent=2))
+        return 0
+    except (OSError, ET.ParseError, RuntimeError, ValueError) as exc:
+        print(f"reddit_rss: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_reddit_access_skill.py
+++ b/tests/skills/test_reddit_access_skill.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "research"
+    / "reddit-access"
+    / "scripts"
+    / "reddit_rss.py"
+)
+spec = importlib.util.spec_from_file_location("reddit_rss", SCRIPT)
+assert spec and spec.loader
+reddit_rss = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reddit_rss)
+
+
+ATOM = b'''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Eight inch phone</title>
+    <link href="https://www.reddit.com/r/phones/comments/abc/example/" />
+    <author><name>/u/curi</name></author>
+    <published>2026-07-11T00:00:00Z</published>
+    <content type="html">A &lt;b&gt;useful&lt;/b&gt; device&lt;br/&gt;with space.</content>
+  </entry>
+</feed>'''
+
+EXPECTED_RECORD = {
+    "title": "Eight inch phone",
+    "url": "https://www.reddit.com/r/phones/comments/abc/example/",
+    "author": "curi",
+    "published": "2026-07-11T00:00:00Z",
+    "text": "A useful device with space.",
+    "subreddit": "r/phones",
+    "source": "https://www.reddit.com/r/phones/.rss",
+}
+
+
+def test_feed_url_for_subreddit_and_query():
+    assert reddit_rss.feed_url("r/phones", None) == "https://www.reddit.com/r/phones/.rss"
+    assert reddit_rss.feed_url(None, "8 inch phone") == "https://www.reddit.com/search.rss?q=8+inch+phone"
+
+
+def test_feed_url_requires_exactly_one_source():
+    for subreddit, query in [(None, None), ("phones", "phone")]:
+        with pytest.raises(ValueError):
+            reddit_rss.feed_url(subreddit, query)
+
+
+def test_parse_atom_normalizes_read_only_record():
+    result = reddit_rss.parse_feed(ATOM, "https://www.reddit.com/r/phones/.rss")
+    assert result == [EXPECTED_RECORD]
+
+
+def test_fetch_sends_request_and_parses_response():
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = ATOM
+    response.__enter__.return_value = response
+
+    with patch.object(reddit_rss.urllib.request, "urlopen", return_value=response) as urlopen:
+        result = reddit_rss.fetch(
+            "https://www.reddit.com/r/phones/.rss",
+            timeout=7.5,
+            user_agent="test-agent",
+        )
+
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://www.reddit.com/r/phones/.rss"
+    assert request.get_header("User-agent") == "test-agent"
+    assert request.get_header("Accept") == "application/atom+xml"
+    assert urlopen.call_args.kwargs == {"timeout": 7.5}
+    assert result == [EXPECTED_RECORD]
+
+
+def test_fetch_rejects_non_200_response():
+    response = MagicMock()
+    response.status = 503
+    response.__enter__.return_value = response
+
+    with patch.object(reddit_rss.urllib.request, "urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match=r"Reddit RSS returned HTTP 503"):
+            reddit_rss.fetch(
+                "https://www.reddit.com/r/phones/.rss",
+                timeout=15.0,
+                user_agent="test-agent",
+            )


### PR DESCRIPTION
## Summary

- add an RSS-first, read-only Reddit research skill
- use profile-aware installed paths in examples
- include mocked coverage for the stdlib RSS client

## Scope

Optional skill only. No core tool surface or Reddit account actions.

## Verification

- `scripts/run_tests.sh tests/skills/test_reddit_access_skill.py -q` — 5 passed
- `python3 -m py_compile optional-skills/research/reddit-access/scripts/reddit_rss.py tests/skills/test_reddit_access_skill.py`
- `git diff --check`
