### PR TITLE
fix: keep desktop backend ready token backward compatible

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19971,6 +19971,22 @@ def _write_dashboard_ready_file(actual_port: int) -> None:
         _log.warning("Failed to write dashboard ready file %r: %s", target, exc)
 
 
+def _emit_ready_tokens(actual_port: int, *, headless: bool) -> None:
+    """Print Desktop/backend port sentinels.
+
+    ``hermes serve`` is a plain headless backend, so current Desktop builds
+    listen for ``HERMES_BACKEND_READY``. Older installed Desktop shells only
+    understood the legacy dashboard sentinel, though, and can be left behind
+    when the backend updates first. Emit both for headless backends so a
+    backend-only update cannot strand an older native app on "Connecting…".
+    """
+    if headless:
+        print(f"HERMES_BACKEND_READY port={actual_port}", flush=True)
+        print(f"HERMES_DASHBOARD_READY port={actual_port}", flush=True)
+    else:
+        print(f"HERMES_DASHBOARD_READY port={actual_port}", flush=True)
+
+
 def _maybe_open_browser(
     host: str, actual_port: int, open_browser: bool, initial_profile: str
 ) -> None:
@@ -20222,11 +20238,7 @@ def start_server(
             app.state.bound_port = actual_port
 
             _write_dashboard_ready_file(actual_port)
-            # Port-discovery sentinel parsed by the desktop spawn. `serve` is a
-            # plain backend, not a dashboard, so it announces a neutral token;
-            # `dashboard` keeps the legacy one. The desktop matches either.
-            ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            _emit_ready_tokens(actual_port, headless=headless)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/test_desktop_ready_tokens.py
+++ b/tests/test_desktop_ready_tokens.py
@@ -1,0 +1,17 @@
+from hermes_cli import web_server
+
+
+def test_headless_ready_tokens_keep_legacy_desktop_compatibility(capsys):
+    web_server._emit_ready_tokens(45678, headless=True)
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines == [
+        "HERMES_BACKEND_READY port=45678",
+        "HERMES_DASHBOARD_READY port=45678",
+    ]
+
+
+def test_dashboard_ready_token_stays_legacy_only(capsys):
+    web_server._emit_ready_tokens(45678, headless=False)
+
+    assert capsys.readouterr().out.strip() == "HERMES_DASHBOARD_READY port=45678"


### PR DESCRIPTION
## Summary

Fixes a Desktop/backend compatibility gap where a backend-only update can strand an older native Hermes Desktop shell on `Connecting…`.

`hermes serve` now emits both readiness sentinels when running headless:

- `HERMES_BACKEND_READY port=<port>` for current Desktop builds
- `HERMES_DASHBOARD_READY port=<port>` for older installed Desktop shells

Dashboard launches remain legacy-only.

## Related issue

Closes #63567

## Tests

- `./venv/bin/python -m pytest tests/test_desktop_ready_tokens.py -q`
  - `2 passed`
- `(cd apps/desktop && npm exec -- tsx --test electron/backend-ready.test.ts)`
  - `17 passed`
