### PR TITLE
fix(mcp): handle EmbeddedResource tool results

### DIFF
--- a/tests/tools/test_mcp_embedded_resource.py
+++ b/tests/tools/test_mcp_embedded_resource.py
@@ -1,0 +1,396 @@
+"""Regression tests for MCP EmbeddedResource block handling.
+
+Background
+==========
+MCP servers — most visibly QMD's ``mcp_qmd_get`` / ``mcp_qmd_multi_get`` —
+ship a document's content back as an ``EmbeddedResource`` content block
+(``type="resource"``) inside the ``CallToolResult``. The previous handler
+in ``tools/mcp_tool.py`` iterated content blocks looking only for
+``block.text`` and image blocks, silently dropping EmbeddedResource. The
+agent saw ``{"result": ""}`` for a successful lookup, while QMD's
+``mcp_qmd_query`` worked fine because it returns plain ``TextContent``
+blocks. The fix adds a focused ``_extract_embedded_resource_parts``
+helper and threads it into both the success path and the error path.
+
+What this file locks in
+-----------------------
+- EmbeddedResource with TextResourceContents is surfaced in ``result``.
+- Multiple blocks (TextContent + EmbeddedResource) all flow through.
+- The error path merges EmbeddedResource text into the error message.
+- BlobResourceContents with an image MIME → ``MEDIA:<path>`` tag.
+- BlobResourceContents with a text-ish MIME (json/xml/yaml/text) → text.
+- BlobResourceContents with a non-textish binary MIME → ``[omitted]`` marker.
+- A non-EmbeddedResource block still produces no parts (helper is a no-op).
+- structuredContent is preserved alongside the embedded resource text.
+- Missing MCP SDK on the import path doesn't NameError (defensive).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import mcp_tool
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (mirrors tests/tools/test_mcp_structured_content.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTextContentBlock:
+    """Plain ``TextContent`` block — the shape the old handler knew about."""
+
+    def __init__(self, text: str, block_type: str = "text"):
+        self.text = text
+        self.type = block_type
+
+
+def _build_embedded_resource_block(uri: str, text: str, mime_type: str = "text/plain"):
+    """Build a real MCP SDK ``EmbeddedResource`` block with a TextResource.
+
+    Falls back to a duck-typed SimpleNamespace if the SDK import fails —
+    keeps the high-level handler tests running even in stripped envs.
+    """
+    try:
+        from mcp.types import EmbeddedResource, TextResourceContents
+
+        resource = TextResourceContents(uri=uri, text=text, mimeType=mime_type)
+        return EmbeddedResource(type="resource", resource=resource)
+    except ImportError:
+        # Duck-typed fallback matching the helper's geta\r getters.
+        return SimpleNamespace(
+            type="resource",
+            resource=SimpleNamespace(uri=uri, text=text, mimeType=mime_type),
+        )
+
+
+def _build_blob_embedded_resource_block(uri: str, blob_b64: str, mime_type: str):
+    try:
+        from mcp.types import BlobResourceContents, EmbeddedResource
+
+        resource = BlobResourceContents(uri=uri, blob=blob_b64, mimeType=mime_type)
+        return EmbeddedResource(type="resource", resource=resource)
+    except ImportError:
+        return SimpleNamespace(
+            type="resource",
+            resource=SimpleNamespace(uri=uri, blob=blob_b64, mimeType=mime_type),
+        )
+
+
+class _FakeCallToolResult:
+    """Minimal CallToolResult stand-in.
+
+    camelCase attributes to match the real MCP SDK Pydantic model.
+    """
+
+    def __init__(self, content, is_error=False, structuredContent=None):
+        self.content = content
+        self.isError = is_error
+        self.structuredContent = structuredContent
+
+
+def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+
+    loop = asyncio.new_event_loop()
+    try:
+
+        async def _install_lock_and_run():
+            for srv in list(mcp_tool._servers.values()):
+                if getattr(srv, "_rpc_lock", None) is None:
+                    srv._rpc_lock = asyncio.Lock()
+            return await coro
+
+        return loop.run_until_complete(_install_lock_and_run())
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def _patch_mcp_server():
+    fake_session = MagicMock()
+    fake_server = SimpleNamespace(session=fake_session, _rpc_lock=None)
+    with patch.dict(mcp_tool._servers, {"qmd": fake_server}), \
+         patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
+        yield fake_session
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through _make_tool_handler
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddedResourceInResult:
+    """A successful ``mcp_qmd_get`` should surface the document body."""
+
+    def test_text_embedded_resource_returns_document_body(self, _patch_mcp_server):
+        """TextResourceContents (the QMD shape) must land in result text.
+
+        Without the fix this assertion is empty: ``{"result": ""}``.
+        """
+        session = _patch_mcp_server
+        doc_body = "# Jane's Diary\n\nDay 1: ships in the harbor.\n"
+        embedded = _build_embedded_resource_block(
+            "qmd://docs/janes-diary",
+            doc_body,
+            "text/plain",
+        )
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[embedded])
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "qmd_get", 30.0)
+        raw = handler({"uri": "qmd://docs/janes-diary"})
+        data = json.loads(raw)
+        assert doc_body in data["result"], (
+            f"document body missing from result: {data!r}"
+        )
+
+    def test_uri_header_included_when_available(self, _patch_mcp_server):
+        """Multi-resource calls should keep resources distinguishable.
+
+        The helper prefixes the document body with ``# <uri>`` so the
+        agent can tell multiple embedded resources apart.
+        """
+        session = _patch_mcp_server
+        blocks = [
+            _build_embedded_resource_block(
+                "qmd://docs/a", "==alpha==\nfirst body", "text/plain",
+            ),
+            _build_embedded_resource_block(
+                "qmd://docs/b", "==bravo==\nsecond body", "text/plain",
+            ),
+        ]
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=blocks)
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "multi_get", 30.0)
+        raw = handler({"uris": ["qmd://docs/a", "qmd://docs/b"]})
+        data = json.loads(raw)
+        text = data["result"]
+        assert "qmd://docs/a" in text, f"missing URI a header: {text!r}"
+        assert "qmd://docs/b" in text, f"missing URI b header: {text!r}"
+        assert "first body" in text and "second body" in text
+
+    def test_mixed_text_and_embedded_resource_concatenate(self, _patch_mcp_server):
+        """A typical tool result has prose around the document body."""
+        session = _patch_mcp_server
+        doc_body = "doc body content here"
+        blocks = [
+            _FakeTextContentBlock("Header prose\n"),
+            _build_embedded_resource_block("qmd://x", doc_body, "text/plain"),
+            _FakeTextContentBlock("Footer prose\n"),
+        ]
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=blocks)
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "qmd_get", 30.0)
+        raw = handler({"uri": "qmd://x"})
+        data = json.loads(raw)
+        text = data["result"]
+        assert "Header prose" in text
+        assert doc_body in text
+        assert "Footer prose" in text
+        # Order is preserved by the loop order.
+        assert text.index("Header prose") < text.index(doc_body)
+        assert text.index(doc_body) < text.index("Footer prose")
+
+    def test_structured_content_preserved_with_embedded_resource(
+        self, _patch_mcp_server,
+    ):
+        """QMD-style ``mcp_qmd_get`` may carry metadata alongside the body."""
+        session = _patch_mcp_server
+        metadata = {"id": "abc", "score": 0.97, "tags": ["nostalgia"]}
+        blocks = [
+            _build_embedded_resource_block("qmd://x", "body text", "text/plain"),
+        ]
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=blocks, structuredContent=metadata,
+            )
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "qmd_get", 30.0)
+        raw = handler({"uri": "qmd://x"})
+        data = json.loads(raw)
+        assert "body text" in data["result"]
+        assert data["structuredContent"] == metadata
+
+
+class TestEmbeddedResourceOnErrorPath:
+    """An error result that arrives as EmbeddedResource must surface text."""
+
+    def test_error_path_includes_embedded_resource_text(self, _patch_mcp_server):
+        """Some servers return ``isError=True`` with the failure reason
+        inside an EmbeddedResource. The agent should see the reason."""
+        session = _patch_mcp_server
+        embedded = _build_embedded_resource_block(
+            "qmd://docs/missing",
+            "doc not found in collection",
+            "text/plain",
+        )
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[embedded], is_error=True)
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "qmd_get", 30.0)
+        raw = handler({"uri": "qmd://docs/missing"})
+        data = json.loads(raw)
+        assert "error" in data
+        assert "doc not found in collection" in data["error"], (
+            f"reason missing from error envelope: {data!r}"
+        )
+
+
+class TestBlobResourceContents:
+    """Binary blobs land inside BlobResourceContents — needs safe handling."""
+
+    def test_image_blob_returns_media_tag(self, _patch_mcp_server, tmp_path, monkeypatch):
+        """An image blob goes through the existing image pipeline."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Minimal 1x1 transparent PNG.
+        png = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        )
+        embedded = _build_blob_embedded_resource_block(
+            "qmd://rendered/page-1.png",
+            base64.b64encode(png).decode("ascii"),
+            "image/png",
+        )
+        session = _patch_mcp_server
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[embedded])
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "render", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+        assert "MEDIA:" in data["result"], f"expected MEDIA: tag, got {data!r}"
+        # Result should also include the URI header so the agent can
+        # match render output to its source.
+        assert "qmd://rendered/page-1.png" in data["result"]
+
+    def test_text_blob_decoded_safely(self, _patch_mcp_server):
+        """A text-ish blob (json/xml/yaml/text) decodes and lands in result."""
+        session = _patch_mcp_server
+        payload = '{"items": [1, 2, 3], "ok": true}'
+        embedded = _build_blob_embedded_resource_block(
+            "qmd://export/manifest.json",
+            base64.b64encode(payload.encode("utf-8")).decode("ascii"),
+            "application/json",
+        )
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[embedded])
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "export", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+        text = data["result"]
+        assert "items" in text and "1, 2, 3" in text
+
+    def test_binary_blob_emits_omitted_marker(self, _patch_mcp_server):
+        """A non-textish binary blob (e.g. application/pdf) returns a
+        clear marker instead of crashing or silently dropping."""
+        session = _patch_mcp_server
+        embedded = _build_blob_embedded_resource_block(
+            "qmd://file/report.pdf",
+            base64.b64encode(b"%PDF-1.4 fake bytes").decode("ascii"),
+            "application/pdf",
+        )
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[embedded])
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "fetch_pdf", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+        text = data["result"]
+        assert "omitted" in text.lower()
+        assert "application/pdf" in text or "pdf" in text.lower()
+        # The URI should still be referenced so the agent can route
+        # around the binary.
+        assert "qmd://file/report.pdf" in text
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests (no server, no event loop)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmbeddedResourcePartsHelper:
+    """Direct helper-level tests that don't depend on the SDK SDK being
+    installed. These mirror the focus of the ImageContent tests."""
+
+    def test_non_embedded_block_returns_empty(self):
+        """A plain TextContent has a .text attr, but it's not an
+        EmbeddedResource — should produce no parts (the caller's loop
+        handles it via the existing text branch)."""
+        from tools.mcp_tool import _extract_embedded_resource_parts
+
+        block = SimpleNamespace(text="hello")  # not type=resource
+        assert _extract_embedded_resource_parts(block) == []
+
+    def test_handles_missing_sdk_types_gracefully(self, monkeypatch):
+        """If MCP SDK types aren't importable (e.g., cron-only install),
+        the helper must return ``[]`` rather than ``NameError``.
+
+        This is the regression for the missing module-level initializer.
+        """
+        from tools import mcp_tool
+        monkeypatch.setattr(
+            mcp_tool, "_MCP_EMBEDDED_RESOURCE_TYPES", False, raising=False,
+        )
+        # Even if EmbeddedResource reference is None, the helper short-
+        # circuits cleanly.
+        from tools.mcp_tool import _extract_embedded_resource_parts
+
+        fake = SimpleNamespace(type="resource", resource=SimpleNamespace(uri="x", text="hi"))
+        assert _extract_embedded_resource_parts(fake) == []
+
+    def test_looks_textish_classifier(self):
+        from tools.mcp_tool import _looks_textish
+
+        assert _looks_textish("text/plain")
+        assert _looks_textish("TEXT/HTML")  # case insensitive
+        assert _looks_textish("application/json")
+        assert _looks_textish("application/json; charset=utf-8")
+        assert _looks_textish("application/yaml")
+        assert not _looks_textish("application/pdf")
+        assert not _looks_textish("image/png")
+        assert not _looks_textish("")  # empty → falsy
+
+
+# ---------------------------------------------------------------------------
+# Existing-behaviour preservation (regression guards)
+# ---------------------------------------------------------------------------
+
+
+class TestExistingBehaviorPreserved:
+    """Make sure the fix didn't regress the existing happy paths."""
+
+    def test_plain_text_block_still_works(self, _patch_mcp_server):
+        """No embedded resource — plain text still flows through unchanged."""
+        session = _patch_mcp_server
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[_FakeTextContentBlock("OK")],
+            )
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "ping", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+        assert data == {"result": "OK"}
+
+    def test_empty_content_with_structured_falls_back(self, _patch_mcp_server):
+        """The pre-existing structuredContent fall-back still fires when
+        there are no content blocks AND no embedded resources."""
+        session = _patch_mcp_server
+        payload = {"status": "ok"}
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(content=[], structuredContent=payload)
+        )
+        handler = mcp_tool._make_tool_handler("qmd", "q", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+        assert data["result"] == payload

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -201,6 +201,10 @@ _MCP_SAMPLING_TYPES = False
 _MCP_NOTIFICATION_TYPES = False
 _MCP_ELICITATION_TYPES = False
 _MCP_MESSAGE_HANDLER_SUPPORTED = False
+# Whether ``mcp.types.EmbeddedResource`` (and friends) are importable. Gated
+# so a stripped SDK doesn't NameError when the generic MCP tool handler
+# iterates content blocks.
+_MCP_EMBEDDED_RESOURCE_TYPES = False
 # Conservative fallback for SDK builds that don't export LATEST_PROTOCOL_VERSION.
 # Streamable HTTP was introduced by 2025-03-26, so this remains valid for the
 # HTTP transport path even on older-but-supported SDK versions.
@@ -266,6 +270,20 @@ try:
         _MCP_NOTIFICATION_TYPES = True
     except ImportError:
         logger.debug("MCP notification types not available -- dynamic tool discovery disabled")
+    # EmbeddedResource is the block type QMD (and other document servers) use
+    # to ship a document's text back inside a CallToolResult. Older SDKs may
+    # not have the union narrowed — gated separately so a missing import
+    # degrades gracefully (we just skip embedded-resource extraction).
+    try:
+        from mcp.types import (
+            EmbeddedResource,
+            TextResourceContents,
+            BlobResourceContents,
+        )
+        _MCP_EMBEDDED_RESOURCE_TYPES = True
+    except ImportError:
+        _MCP_EMBEDDED_RESOURCE_TYPES = False
+        logger.debug("MCP embedded-resource types not available -- embedded resource extraction disabled")
 except ImportError:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
@@ -712,6 +730,178 @@ def _cache_mcp_image_block(block) -> str:
         return ""
 
     return f"MEDIA:{image_path}"
+
+
+# ---------------------------------------------------------------------------
+# MCP EmbeddedResource block → Hermes result-text
+# ---------------------------------------------------------------------------
+
+
+_TEXTISH_MIME_PREFIXES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-yaml",
+    "application/yaml",
+    "application/toml",
+    "application/markdown",
+)
+_MAX_EMBEDDED_RESOURCE_DECODE_BYTES = 256 * 1024  # 256 KiB cap on decoded text
+
+
+def _looks_textish(mime_type: str) -> bool:
+    """True for MIME types we should attempt to decode as text."""
+    if not mime_type:
+        return False
+    normalized = mime_type.split(";", 1)[0].strip().lower()
+    return any(normalized.startswith(prefix) for prefix in _TEXTISH_MIME_PREFIXES)
+
+
+def _extract_embedded_resource_parts(block) -> List[str]:
+    """Convert an MCP ``EmbeddedResource`` content block into result-text parts.
+
+    MCP servers (notably QMD's ``mcp_qmd_get`` / ``mcp_qmd_multi_get``) return
+    the requested document's content as an ``EmbeddedResource`` block
+    (``type="resource"``) rather than a plain ``TextContent`` block. Before
+    this helper existed, ``_make_tool_handler`` iterated content blocks
+    looking only for ``block.text`` and silently dropped the embedded
+    resource, so the agent got back ``{"result":""}`` for a successful
+    lookup — see the QMD EmbeddedResource regression reported in
+    https://github.com/NousResearch/hermes-agent.
+
+    This helper extracts the resource text the same way the ACP adapter
+    does (see ``acp_adapter/server.py::_embedded_resource_to_parts``) but
+    with a smaller, more reviewable scope suited to the generic MCP tool
+    result path:
+
+    - ``TextResourceContents`` (what QMD uses) → returns the document text
+      unchanged, prefixed with a short ``# <uri>`` header so the agent can
+      tell multiple embedded resources apart.
+    - ``BlobResourceContents`` with an image MIME → routed through the
+      existing ``_cache_mcp_image_block`` helper so a ``MEDIA:<path>`` tag
+      flows through Hermes' image pipeline (preserves the image-content
+      contract from #17915 / #10848).
+    - ``BlobResourceContents`` with a text-ish MIME (json/xml/yaml/text/...)
+      → decoded from base64 conservatively, capped at
+      ``_MAX_EMBEDDED_RESOURCE_DECODE_BYTES``. Decode errors fall through
+      to a clear omitted marker rather than crashing the tool result.
+    - ``BlobResourceContents`` with a non-textish binary MIME → returned as
+      an ``[Embedded binary omitted: N bytes, mime=...]`` marker so the
+      agent can see the block existed and decide whether to fall back.
+    - Anything that doesn't quack like an embedded resource → returns an
+      empty list; the caller's loop moves on to the next handler.
+
+    Defensive throughout: malformed base64, oversized payloads, and
+    unexpected attribute shapes are logged and skipped. The agent's text
+    result for a malformed block may end up empty, but the tool call
+    itself never raises.
+    """
+    if not _MCP_EMBEDDED_RESOURCE_TYPES:
+        return []
+    # Resolve the block/resource classes via globals() so Pyright doesn't
+    # complain about possibly-unbound names — the imports are gated on
+    # ``_MCP_EMBEDDED_RESOURCE_TYPES`` above, and the missing-import path
+    # already short-circuits the rest of this function.
+    _er = globals().get("EmbeddedResource")
+    _text_res = globals().get("TextResourceContents")
+    _blob_res = globals().get("BlobResourceContents")
+    if _er is None or _text_res is None or _blob_res is None:
+        return []
+
+    if not isinstance(block, _er):
+        return []
+
+    resource = getattr(block, "resource", None)
+    if resource is None:
+        return []
+
+    uri = str(getattr(resource, "uri", "") or "").strip()
+    mime_type = (
+        str(getattr(resource, "mimeType", None)
+            or getattr(resource, "mime_type", None)
+            or "").strip() or None
+    )
+
+    # TextResourceContents: most common case for QMD get/multi_get.
+    if isinstance(resource, _text_res):
+        text = getattr(resource, "text", "") or ""
+        if not text:
+            return []
+        if uri:
+            return [f"# {uri}\n{text}"]
+        return [text]
+
+    # BlobResourceContents: base64-encoded bytes inside the resource payload.
+    if isinstance(resource, _blob_res):
+        blob = getattr(resource, "blob", "") or ""
+        if not blob:
+            return []
+
+        # Image blob: defer to the existing image cache + MEDIA: tag pipeline.
+        if mime_type and mime_type.lower().split(";", 1)[0].strip().startswith("image/"):
+            # Build a block-shaped SimpleNamespace so the existing helper
+            # (which reads .data and .mimeType) works without changes.
+            from types import SimpleNamespace
+            image_block = SimpleNamespace(data=blob, mimeType=mime_type)
+            tag = _cache_mcp_image_block(image_block)
+            if tag:
+                if uri:
+                    return [f"# {uri}", tag]
+                return [tag]
+            # Image cache rejected the payload; surface a clear marker
+            # rather than letting the block vanish.
+            return [f"[Embedded image omitted: uri={uri or 'unknown'}, mime={mime_type}]"]
+
+        # Text-ish blob: decode conservatively.
+        if _looks_textish(mime_type or ""):
+            import base64
+            try:
+                raw = base64.b64decode(blob, validate=True)
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "MCP embedded resource decode failed (uri=%s, mime=%s): %s",
+                    uri or "unknown", mime_type, exc,
+                )
+                return [f"[Embedded text resource omitted: uri={uri or 'unknown'}, decode failed]"]
+
+            if len(raw) > _MAX_EMBEDDED_RESOURCE_DECODE_BYTES:
+                raw = raw[:_MAX_EMBEDDED_RESOURCE_DECODE_BYTES]
+                truncated_note = f"\n\n[Truncated to {_MAX_EMBEDDED_RESOURCE_DECODE_BYTES} of {len(raw)} bytes]"
+            else:
+                truncated_note = ""
+
+            try:
+                text = raw.decode("utf-8", errors="replace")
+            except Exception as exc:  # pragma: no cover -- decode("replace") is total
+                logger.warning(
+                    "MCP embedded resource utf-8 decode failed (uri=%s): %s",
+                    uri or "unknown", exc,
+                )
+                return [f"[Embedded text resource omitted: uri={uri or 'unknown'}, decode failed]"]
+
+            if uri:
+                return [f"# {uri}\n{text}{truncated_note}"]
+            return [f"{text}{truncated_note}"]
+
+        # Non-textish binary blob: clear omitted marker.
+        # We log the size at debug only — the omitted marker already gives
+        # the agent enough context to decide whether to ask for a different
+        # tool.
+        logger.debug(
+            "MCP embedded resource is non-textish binary (uri=%s, mime=%s); emitting omitted marker",
+            uri or "unknown", mime_type,
+        )
+        size = len(blob)  # base64 length — close enough as a hint
+        return [f"[Embedded binary omitted: uri={uri or 'unknown'}, mime={mime_type or 'unknown'}, ~{size} base64 bytes]"]
+
+    # Unknown resource subclass with a .text attribute — best-effort.
+    text = getattr(resource, "text", None)
+    if text:
+        if uri:
+            return [f"# {uri}\n{text}"]
+        return [str(text)]
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -3949,6 +4139,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 for block in (result.content or []):
                     if hasattr(block, "text"):
                         error_text += block.text
+                        continue
+                    # If a server reports an error via an EmbeddedResource
+                    # block (rare, but allowed by the spec), surface the
+                    # resource text in the error message so the model can
+                    # see the reason rather than getting a generic fallback.
+                    for part in _extract_embedded_resource_parts(block):
+                        error_text += part
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"
@@ -3962,6 +4159,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # adapters that render images natively. Without this, image blocks
             # were silently dropped and the agent got an empty response.
             #
+            # We also extract EmbeddedResource blocks (type="resource"), which
+            # some MCP servers — notably QMD's mcp_qmd_get / mcp_qmd_multi_get
+            # — use to ship document content back inside a CallToolResult.
+            # Before this branch landed, embedded resources were silently
+            # dropped and the agent saw ``{"result":""}`` for a successful
+            # lookup. QMD's mcp_qmd_query returns plain text blocks so it
+            # worked; the document-fetch tools did not.
+            #
             # Distilled from #17915 (c3115644151) and #10848 (gnanirahulnutakki),
             # both too stale to cherry-pick. #10848's approach (integrate with
             # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
@@ -3970,6 +4175,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             for block in (result.content or []):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
+                    continue
+                # EmbeddedResource: QMD-style document payloads (text or
+                # image-or-binary blob). Helper is defensive — it returns
+                # a list of parts (may be empty if the block is malformed),
+                # or a single "omitted" marker for binary blobs we don't
+                # want to inline.
+                embedded_parts = _extract_embedded_resource_parts(block)
+                if embedded_parts:
+                    parts.extend(embedded_parts)
                     continue
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:


### PR DESCRIPTION
## Summary
- add EmbeddedResource extraction for MCP tool-call results in `tools/mcp_tool.py`
- preserve existing TextContent, ImageContent, and structuredContent behavior
- cover text resources, image blobs, text-ish blobs, binary omitted markers, error-path extraction, and missing-SDK guardrails

## Tests
- `python -m pytest tests/tools/test_mcp_embedded_resource.py tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_image_content.py tests/tools/test_mcp_tool.py -q -o 'addopts='`
- Result: `239 passed in 15.72s`

## Context
QMD MCP `get`/`multi_get` returned empty through Hermes because QMD correctly returns documents as MCP `EmbeddedResource` blocks (`block.resource.text`) and Hermes' generic MCP adapter only collected direct text/image blocks.
