### PR TITLE
Fix timeout classification and add proxy failure-path tests

### DIFF
--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -169,6 +169,21 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 return await _send_upstream(active_cred)
             except RuntimeError as exc:
                 return _json_error(500, str(exc)), None
+            except asyncio.TimeoutError:
+                # aiohttp's own sock_connect/sock_read timeout errors (e.g.
+                # ServerTimeoutError) subclass *both* asyncio.TimeoutError and
+                # aiohttp.ClientError, so this must be checked first or every
+                # real timeout would be swallowed by the ClientError branch
+                # below and misreported as upstream_unreachable instead of
+                # upstream_timeout.
+                return (
+                    _json_error(
+                        504,
+                        "upstream request timed out",
+                        code="upstream_timeout",
+                    ),
+                    None,
+                )
             except aiohttp.ClientError as exc:
                 logger.warning("proxy: upstream connection failed: %s", exc)
                 return (
@@ -176,15 +191,6 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                         502,
                         f"upstream connection failed: {exc}",
                         code="upstream_unreachable",
-                    ),
-                    None,
-                )
-            except asyncio.TimeoutError:
-                return (
-                    _json_error(
-                        504,
-                        "upstream request timed out",
-                        code="upstream_timeout",
                     ),
                     None,
                 )

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -174,6 +174,49 @@ class _FakeBlueBubblesRequest:
         return self._body
 
 
+class _FakeRawBlueBubblesRequest:
+    """Like _FakeBlueBubblesRequest but with a raw (possibly unparsable) body."""
+
+    def __init__(self, raw_body: bytes, password="secret"):
+        self.query = {"password": password}
+        self.headers = {}
+        self._body = raw_body
+
+    async def read(self):
+        return self._body
+
+
+class TestBlueBubblesWebhookAuth:
+    @pytest.mark.asyncio
+    async def test_wrong_password_is_rejected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message"}, password="wrong")
+        )
+
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_password_is_rejected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message"}, password=None)
+        )
+
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_unparsable_body_returns_400(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        # Neither valid JSON nor a form body whose `payload`/`data`/`message`
+        # field decodes as JSON -> falls through both parse attempts.
+        response = await adapter._handle_webhook(
+            _FakeRawBlueBubblesRequest(b"payload=not-valid-json{{{")
+        )
+
+        assert response.status == 400
+
+
 class TestBlueBubblesMentionGating:
     @pytest.mark.asyncio
     async def test_group_message_without_mention_is_acknowledged_and_skipped(self, monkeypatch):

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -882,7 +882,14 @@ def test_server_returns_502_when_upstream_unreachable():
 
 
 def test_server_returns_504_when_upstream_times_out():
-    """A hung upstream (sock_connect/sock_read timeout) must surface as 504."""
+    """A hung upstream (sock_connect/sock_read timeout) must surface as 504.
+
+    Raises aiohttp.ServerTimeoutError rather than a bare asyncio.TimeoutError:
+    that's what aiohttp's own sock_connect/sock_read timeouts actually raise,
+    and it subclasses *both* asyncio.TimeoutError and aiohttp.ClientError, so
+    it's the case that would previously have been misrouted to the 502
+    branch if the two except clauses in _open_upstream were ordered wrong.
+    """
     async def run():
         adapter = FakeAdapter("http://unused.example/v1")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
@@ -891,7 +898,7 @@ def test_server_returns_504_when_upstream_times_out():
 
         async def _raise_timeout(self, method, url, *args, **kwargs):
             if "unused.example" in str(url):
-                raise asyncio.TimeoutError()
+                raise aiohttp.ServerTimeoutError("simulated upstream timeout")
             return await original_request(self, method, url, *args, **kwargs)
 
         try:

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -846,20 +846,35 @@ def test_server_strips_client_auth_header():
 
 
 def test_server_returns_502_when_upstream_unreachable():
-    """A refused TCP connection to the upstream must surface as 502, not a 500/crash."""
+    """A failed upstream connection must surface as 502, not a 500/crash.
+
+    Patches ClientSession.request (rather than pointing at a real closed
+    port) so the test is deterministic regardless of how the CI/container
+    network handles connections to unused ports (refuse vs. silently drop
+    -> timeout). Only requests to the fake upstream URL are intercepted;
+    everything else (the test client's own call into the proxy) falls
+    through to the real implementation.
+    """
     async def run():
-        # Nothing is listening on this port -> aiohttp.ClientConnectorError
-        # (an aiohttp.ClientError subclass) when the proxy tries to connect.
-        adapter = FakeAdapter("http://127.0.0.1:1/v1")
+        adapter = FakeAdapter("http://unused.example/v1")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+
+        original_request = aiohttp.ClientSession.request
+
+        async def _raise_conn_error(self, method, url, *args, **kwargs):
+            if "unused.example" in str(url):
+                raise aiohttp.ClientError("simulated connection refused")
+            return await original_request(self, method, url, *args, **kwargs)
+
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{proxy_base}/v1/chat/completions", json={},
-                ) as resp:
-                    assert resp.status == 502
-                    body = await resp.json()
-                    assert body["error"]["type"] == "upstream_unreachable"
+            with patch("aiohttp.ClientSession.request", _raise_conn_error):
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{proxy_base}/v1/chat/completions", json={},
+                    ) as resp:
+                        assert resp.status == 502
+                        body = await resp.json()
+                        assert body["error"]["type"] == "upstream_unreachable"
         finally:
             await proxy_runner.cleanup()
 
@@ -872,8 +887,12 @@ def test_server_returns_504_when_upstream_times_out():
         adapter = FakeAdapter("http://unused.example/v1")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
 
-        async def _raise_timeout(self, *args, **kwargs):
-            raise asyncio.TimeoutError()
+        original_request = aiohttp.ClientSession.request
+
+        async def _raise_timeout(self, method, url, *args, **kwargs):
+            if "unused.example" in str(url):
+                raise asyncio.TimeoutError()
+            return await original_request(self, method, url, *args, **kwargs)
 
         try:
             with patch("aiohttp.ClientSession.request", _raise_timeout):

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -845,6 +845,51 @@ def test_server_strips_client_auth_header():
     asyncio.run(run())
 
 
+def test_server_returns_502_when_upstream_unreachable():
+    """A refused TCP connection to the upstream must surface as 502, not a 500/crash."""
+    async def run():
+        # Nothing is listening on this port -> aiohttp.ClientConnectorError
+        # (an aiohttp.ClientError subclass) when the proxy tries to connect.
+        adapter = FakeAdapter("http://127.0.0.1:1/v1")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={},
+                ) as resp:
+                    assert resp.status == 502
+                    body = await resp.json()
+                    assert body["error"]["type"] == "upstream_unreachable"
+        finally:
+            await proxy_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_returns_504_when_upstream_times_out():
+    """A hung upstream (sock_connect/sock_read timeout) must surface as 504."""
+    async def run():
+        adapter = FakeAdapter("http://unused.example/v1")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+
+        async def _raise_timeout(self, *args, **kwargs):
+            raise asyncio.TimeoutError()
+
+        try:
+            with patch("aiohttp.ClientSession.request", _raise_timeout):
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{proxy_base}/v1/chat/completions", json={},
+                    ) as resp:
+                        assert resp.status == 504
+                        body = await resp.json()
+                        assert body["error"]["type"] == "upstream_timeout"
+        finally:
+            await proxy_runner.cleanup()
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes proxy error classification and adds deterministic failure-path tests.

`aiohttp.ServerTimeoutError` inherits from both `asyncio.TimeoutError` and `aiohttp.ClientError`. The existing exception order catches it as a generic client error first, returning HTTP 502 `upstream_unreachable` instead of HTTP 504 `upstream_timeout`.

This change checks `asyncio.TimeoutError` first and adds tests covering:

- wrong or missing BlueBubbles webhook password → 401;
- malformed webhook body → 400;
- unreachable upstream → 502 `upstream_unreachable`; and
- upstream timeout → 504 `upstream_timeout`.

The focused patch was reviewed in the fork and CodeRabbit reports success. The broader upstream suite should run in this repository's CI before merge.