### PR TITLE
fix(web_server): close log_file fd on Popen failure in _spawn_hermes_action

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3210,25 +3210,29 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_path = _ACTION_LOG_DIR / log_file_name
     log_file = open(log_path, "ab", buffering=0)
-    log_file.write(
-        f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
-    )
+    try:
+        log_file.write(
+            f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
+        )
 
-    cmd = [_dashboard_spawn_executable(), "-m", "hermes_cli.main", *subcommand]
+        cmd = [_dashboard_spawn_executable(), "-m", "hermes_cli.main", *subcommand]
 
-    popen_kwargs: Dict[str, Any] = {
-        "cwd": str(PROJECT_ROOT),
-        "stdin": subprocess.DEVNULL,
-        "stdout": log_file,
-        "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
-    }
-    if sys.platform == "win32":
-        popen_kwargs["creationflags"] = windows_detach_flags()
-    else:
-        popen_kwargs["start_new_session"] = True
+        popen_kwargs: Dict[str, Any] = {
+            "cwd": str(PROJECT_ROOT),
+            "stdin": subprocess.DEVNULL,
+            "stdout": log_file,
+            "stderr": subprocess.STDOUT,
+            "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = windows_detach_flags()
+        else:
+            popen_kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(cmd, **popen_kwargs)
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+    except BaseException:
+        log_file.close()
+        raise
     # The child inherits its own duplicated fd for stdout/stderr, so the
     # parent's handle can be released immediately — otherwise we leak one
     # fd per spawned action.


### PR DESCRIPTION
## Summary

Fix file descriptor leak in `_spawn_hermes_action` when `subprocess.Popen` raises.

## Problem

`log_file = open(...)` at line 3235 is followed by `subprocess.Popen(...)` at line 3254. If Popen raises (e.g. `OSError`), the function returns `False` implicitly without closing `log_file`, leaking a file descriptor. This is especially problematic because `_spawn_hermes_action` can be called from the dashboard for various actions, and each failure leaks one fd.

## Fix

Wrap the write + Popen block in a try/except `BaseException` that closes the fd before re-raising. The normal path (Popen succeeds) still closes the fd immediately after, as before — the child inherits a duplicated fd so releasing the parent handle is correct.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: fd closed on both success and exception paths