### PR TITLE
fix(browser): block private OOPIF CDP frame reads

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -494,6 +494,69 @@ def test_frame_id_route_allowed_when_page_is_not_private(monkeypatch):
     assert len(supervisor_calls) == 1
 
 
+def test_frame_id_route_blocks_private_child_frame(monkeypatch):
+    """A public top page must not make a private OOPIF readable via frame_id."""
+    supervisor_calls = []
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    class FakeSnapshot:
+        frame_tree = {
+            "top": {
+                "frame_id": "top",
+                "url": "https://example.com/",
+                "session_id": "top-sid",
+            },
+            "children": [
+                {
+                    "frame_id": "private-frame",
+                    "url": PRIVATE_URL,
+                    "origin": "http://169.254.169.254",
+                    "session_id": "child-sid",
+                }
+            ],
+        }
+
+    class FakeSupervisor:
+        _state_lock = None
+        _frames = {}
+
+        def snapshot(self):
+            return FakeSnapshot()
+
+    class FakeRegistry:
+        def get(self, task_id):
+            return FakeSupervisor()
+
+    monkeypatch.setattr(
+        "tools.browser_supervisor.SUPERVISOR_REGISTRY",
+        FakeRegistry(),
+    )
+
+    def fake_schedule(*args, **kwargs):
+        supervisor_calls.append((args, kwargs))
+        raise AssertionError("private child frame must not reach supervisor CDP")
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", fake_schedule)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="private-frame",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert "private or internal address" in result["error"]
+    assert supervisor_calls == []
+
+
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     calls = []
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -180,6 +180,31 @@ def _browser_cdp_private_guard(
     return None
 
 
+def _browser_cdp_frame_private_guard(
+    frame_info: Dict[str, Any],
+    method: str,
+) -> Optional[str]:
+    """Block page-content CDP calls when the selected OOPIF is private."""
+    if method in _CDP_PRIVATE_PAGE_ALLOWED_METHODS:
+        return None
+
+    try:
+        from tools import browser_tool as bt  # type: ignore[import-not-found]
+
+        for key in ("url", "origin"):
+            candidate = str(frame_info.get(key) or "").strip()
+            if not candidate:
+                continue
+            if (
+                bt._is_always_blocked_url(candidate)  # type: ignore[attr-defined]
+                or not bt._is_safe_url(candidate)  # type: ignore[attr-defined]
+            ):
+                return _private_page_guard_error(candidate, method)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("browser_cdp: frame private-page guard probe failed: %s", exc)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Core CDP call
 # ---------------------------------------------------------------------------
@@ -336,6 +361,10 @@ def _browser_cdp_via_supervisor(
             f"frame_id {frame_id!r} not found in supervisor state. "
             f"Call browser_snapshot to see current frame_tree."
         )
+
+    blocked = _browser_cdp_frame_private_guard(frame_info, method)
+    if blocked:
+        return blocked
 
     child_sid = frame_info.get("session_id")
     if not child_sid:


### PR DESCRIPTION
## Summary

This closes a residual private-network bypass in `browser_cdp` frame_id routing.

`browser_cdp` already blocks raw CDP reads when the top-level page is private/internal, and #57660 added that guard to the `frame_id` route. However, the `frame_id` path still only checked the top-level page before resolving the selected OOPIF frame. If the top page was public but the selected child frame had a private/internal URL, `browser_cdp(method="Runtime.evaluate", frame_id=...)` still dispatched into that child frame's CDP session.

## Why

`frame_id` routing is a live CDP escape hatch into a specific out-of-process iframe. The private-network invariant needs to apply to the selected frame, not only to the top page.

Without this, a public page containing or reaching a private OOPIF could expose private frame content through raw CDP methods even though the guarded browser tools block the same private-page content class.

## Changes

- Add a selected-frame private URL/origin guard inside `_browser_cdp_via_supervisor()`.
- Reuse the existing browser private URL policy (`_is_always_blocked_url` / `_is_safe_url`).
- Preserve allowed navigation/inspection methods from the existing CDP private-page allowlist.
- Add regression coverage for a public top page with a private child OOPIF frame.

## Testing

```text
ruff check --no-cache tools/browser_cdp_tool.py tests/tools/test_browser_cdp_tool.py