### PR TITLE
fix(cron): deliver manual runs on gateway loop

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -7,6 +7,8 @@ last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
 blocking a concurrent tick) and fires it inline via the shared run_one_job body.
 """
 import json
+import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tools.cronjob_tools import cronjob, _execute_job_now
@@ -67,6 +69,39 @@ class TestCronjobRunExecutesImmediately:
         assert res["claimed"] is False
         assert res["success"] is False
         m_run.assert_not_called()
+
+    def test_execute_job_now_passes_live_gateway_context_to_delivery(self):
+        """Manual runs must deliver on the live gateway adapter's owning loop."""
+        adapters = {"matrix": object()}
+        gateway_loop = object()
+        runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(
+            _JOB,
+            adapters=adapters,
+            loop=gateway_loop,
+        )
+
+    def test_execute_job_now_remains_standalone_without_gateway(self):
+        """CLI-only runs retain the standalone delivery path."""
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch.dict(sys.modules, {"gateway.run": None}), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(_JOB, adapters=None, loop=None)
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -638,7 +638,20 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        # Manual runs invoked from a gateway agent execute outside the scheduler
+        # ticker, but they still share the process with the live platform
+        # adapters.  Pass the gateway-owned adapter map and event loop through to
+        # run_one_job so delivery is scheduled on the loop that owns clients such
+        # as Matrix/aiohttp.  Calling those clients from run_one_job's standalone
+        # asyncio.run() loop raises errors like "Timeout context manager should be
+        # used inside a task" and can break encrypted Matrix delivery.
+        gateway_module = sys.modules.get("gateway.run")
+        runner_ref = getattr(gateway_module, "_gateway_runner_ref", None)
+        runner = runner_ref() if callable(runner_ref) else None
+        adapters = getattr(runner, "adapters", None) if runner is not None else None
+        gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
+
+        processed = run_one_job(job, adapters=adapters, loop=gateway_loop)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {


### PR DESCRIPTION
## Summary
- pass the live gateway adapter map and owning event loop into immediate/manual cron execution
- keep CLI-only manual runs on the existing standalone delivery path without importing the gateway
- add regressions for both live-gateway and standalone contexts

Fixes #61495.

## Why
`cronjob(action="run")` called `run_one_job(job)` without the gateway context. Matrix then reused a live mautrix/aiohttp adapter from a fresh `asyncio.run()` loop and failed with `Timeout context manager should be used inside a task`. Scheduled gateway ticks already pass `adapters` and `loop`; this makes the manual path do the same.

## Tests
- `uv run --extra dev python -m pytest tests/tools/test_cronjob_run_immediate.py tests/tools/test_cronjob_tools.py -q` (84 passed)
- `uv run --extra dev python -m pytest tests/tools/test_windows_native_support.py -q` (66 passed)
- `uvx ruff check tools/cronjob_tools.py tests/tools/test_cronjob_run_immediate.py`
