### PR TITLE
fix(security): block terminal signals targeting PID 1

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -93,6 +93,24 @@ _HARDLINE_BLOCK = [
     # System-wide kill
     "kill -9 -1",
     "kill -1",
+    # Signaling PID 1 terminates the container init/supervisor when Hermes is
+    # deployed in a container and terminal() uses the local backend in the
+    # same PID namespace.  That drops the gateway and every active session.
+    "kill 1",
+    "kill -TERM 1",
+    "kill -15 1",
+    "kill -s TERM 1",
+    "kill --signal TERM 1",
+    "kill --signal=KILL 1",
+    "kill -- 1",
+    "kill 01",
+    "kill +1",
+    "kill -TERM -- 0001",
+    "/bin/kill -TERM 1",
+    "/usr/bin/kill -9 1",
+    "sudo kill -TERM 1",
+    "echo ready && kill -TERM 2 1",
+    "$(kill -TERM '1')",
     # Shutdown / reboot / halt
     "shutdown -h now",
     "shutdown -r now",
@@ -193,7 +211,23 @@ _HARDLINE_ALLOW = [
     # targeted kill
     "kill -9 12345",
     "kill -HUP 1234",
+    "kill -TERM 10",
+    "kill -TERM 11",
+    # Signal 0 and list/help modes inspect state without signaling PID 1.
+    "kill -0 1",
+    "kill -s 0 1",
+    "kill -n 0 1",
+    "kill --signal 0 1",
+    "kill --signal=0 1",
+    "kill -l 1",
+    "kill -L 1",
+    "kill --list 1",
+    "kill --list=1",
     "pkill python",
+    # A PID-1 command mentioned as quoted data is not executed.
+    "echo 'kill -TERM 1'",
+    "printf '%s' 'kill 1'",
+    "gh issue create --body 'kill -TERM 1'",
     # Ordinary ops
     "git status",
     "npm run build",
@@ -375,7 +409,8 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
 
     for cmd in ['rm -rf /', 'rm -rf "/"', 'rm -rf "$HOME"', "rm -rf ${HOME}",
-                "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot"]:
+                "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot",
+                "kill -TERM 1"]:
         r1 = check_dangerous_command(cmd, "local")
         assert r1["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_dangerous_command)"
         assert r1.get("hardline") is True
@@ -512,12 +547,16 @@ def test_container_backends_still_bypass(clean_session):
     """Containerized backends remain bypass-approved — they can't touch the host.
 
     Hardline only protects environments with real host impact (local, ssh).
+    The backend name describes the tool sandbox, not where Hermes itself is
+    deployed: a containerized Hermes using the local backend still shares its
+    PID namespace with the container init and therefore takes the local path.
     """
     for env in ("docker", "singularity", "modal", "daytona"):
-        r1 = check_dangerous_command("rm -rf /", env)
-        assert r1["approved"] is True, f"container {env} should still bypass"
-        r2 = check_all_command_guards("rm -rf /", env)
-        assert r2["approved"] is True, f"container {env} should still bypass"
+        for command in ("rm -rf /", "kill -TERM 1"):
+            r1 = check_dangerous_command(command, env)
+            assert r1["approved"] is True, f"container {env} should still bypass"
+            r2 = check_all_command_guards(command, env)
+            assert r2["approved"] is True, f"container {env} should still bypass"
 
 
 def test_hardline_runs_before_dangerous_detection(clean_session):

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -93,6 +93,33 @@ _HARDLINE_BLOCK = [
     # System-wide kill
     "kill -9 -1",
     "kill -1",
+    # Signaling PID 1 terminates the container init/supervisor when Hermes is
+    # deployed in a container and terminal() uses the local backend in the
+    # same PID namespace.  That drops the gateway and every active session.
+    "kill 1",
+    "kill -TERM 1",
+    "kill -15 1",
+    "kill -s TERM 1",
+    "kill --signal TERM 1",
+    "kill --signal=KILL 1",
+    "kill -- 1",
+    "kill 01",
+    "kill +1",
+    "kill -TERM -- 0001",
+    "/bin/kill -TERM 1",
+    "/usr/bin/kill -9 1",
+    "sudo kill -TERM 1",
+    # Wrappers that current shared `_CMDPOS` does not consume must still hit
+    # the PID-1 floor when this PR lands independently of #58643.
+    "command kill -TERM 1",
+    "command -p kill -9 1",
+    "env -- kill -TERM 1",
+    "env -i kill -TERM 1",
+    "/usr/bin/env -- kill -TERM 1",
+    "nice kill -TERM 1",
+    "nice -n 5 kill -TERM 1",
+    "echo ready && kill -TERM 2 1",
+    "$(kill -TERM '1')",
     # Shutdown / reboot / halt
     "shutdown -h now",
     "shutdown -r now",
@@ -193,7 +220,27 @@ _HARDLINE_ALLOW = [
     # targeted kill
     "kill -9 12345",
     "kill -HUP 1234",
+    "kill -TERM 10",
+    "kill -TERM 11",
+    # Signal 0 and list/help modes inspect state without signaling PID 1.
+    "kill -0 1",
+    "kill -s 0 1",
+    "kill -n 0 1",
+    "kill --signal 0 1",
+    "kill --signal=0 1",
+    "kill -l 1",
+    "kill -L 1",
+    "kill --list 1",
+    "kill --list=1",
     "pkill python",
+    # A PID-1 command mentioned as quoted data is not executed.
+    "echo 'kill -TERM 1'",
+    "printf '%s' 'kill 1'",
+    "gh issue create --body 'kill -TERM 1'",
+    # Wrappers in front of a non-PID-1 kill must not become false positives.
+    "command kill -TERM 10",
+    "env -- kill -TERM 10",
+    "nice kill -TERM 10",
     # Ordinary ops
     "git status",
     "npm run build",
@@ -436,7 +483,8 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
 
     for cmd in ['rm -rf /', 'rm -rf "/"', 'rm -rf "$HOME"', "rm -rf ${HOME}",
-                "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot"]:
+                "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot",
+                "kill -TERM 1"]:
         r1 = check_dangerous_command(cmd, "local")
         assert r1["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_dangerous_command)"
         assert r1.get("hardline") is True
@@ -573,12 +621,16 @@ def test_container_backends_still_bypass(clean_session):
     """Containerized backends remain bypass-approved — they can't touch the host.
 
     Hardline only protects environments with real host impact (local, ssh).
+    The backend name describes the tool sandbox, not where Hermes itself is
+    deployed: a containerized Hermes using the local backend still shares its
+    PID namespace with the container init and therefore takes the local path.
     """
     for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
-        r1 = check_dangerous_command("rm -rf /", env)
-        assert r1["approved"] is True, f"container {env} should still bypass"
-        r2 = check_all_command_guards("rm -rf /", env)
-        assert r2["approved"] is True, f"container {env} should still bypass"
+        for command in ("rm -rf /", "kill -TERM 1"):
+            r1 = check_dangerous_command(command, env)
+            assert r1["approved"] is True, f"container {env} should still bypass"
+            r2 = check_all_command_guards(command, env)
+            assert r2["approved"] is True, f"container {env} should still bypass"
 
 
 def test_hardline_runs_before_dangerous_detection(clean_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -364,6 +364,27 @@ _HARDLINE_SYSTEM_DIRS = (
 # catching `rm -rf "/"`.
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 
+# ``kill 1`` targets the init/supervisor process in the current PID namespace.
+# In container deployments where terminal() uses the local backend, that is
+# the container's PID 1: terminating it drops Hermes and every active session.
+# Match PID 1 as a complete numeric target anywhere in kill's target list,
+# including accepted signed/zero-padded spellings and path-qualified binaries,
+# while leaving PID 10/11 and quoted prose alone.
+# Signal 0 and kill's list/help modes are non-terminating probes, so they stay
+# available instead of being pulled onto the hardline floor.
+_PID1_KILL_PATTERN = (
+    _CMDPOS
+    + r'(?:[^\s;&|`]+/)?kill\s+'
+    + r'(?!(?:'
+      r'-0(?:\s|$)|'
+      r'-(?:s|n)\s+0(?:\s|$)|'
+      r'--signal(?:=|\s+)0(?:\s|$)|'
+      r'-(?:l|L)(?:\s|$)|'
+      r'--(?:list|table|help|version)(?:[=\s]|$)'
+      r'))'
+    + r'(?=[^;&|`\n]*(?<!\S)["\']?\+?0*1["\']?(?=\s|$|[;&|)`]))'
+)
+
 HARDLINE_PATTERNS = [
     # rm recursive targeting the root filesystem or protected roots.
     # `${HOME}` brace form and quoted paths (`rm -rf "/"`, `rm -rf "$HOME"`)
@@ -393,6 +414,8 @@ HARDLINE_PATTERNS = [
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system
     (r'\bkill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    # Killing a container's init/supervisor terminates the whole deployment.
+    (_PID1_KILL_PATTERN, "signal init/supervisor process (PID 1)"),
     # System shutdown / reboot — anchor to command position (start of line,
     # after a command separator, or after sudo/env wrappers) so we don't
     # false-positive on "echo reboot" or "grep 'shutdown' logs".

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -454,6 +454,50 @@ _HARDLINE_SYSTEM_DIRS = (
 # catching `rm -rf "/"`.
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 
+# ``kill 1`` targets the init/supervisor process in the current PID namespace.
+# In container deployments where terminal() uses the local backend, that is
+# the container's PID 1: terminating it drops Hermes and every active session.
+# Match PID 1 as a complete numeric target anywhere in kill's target list,
+# including accepted signed/zero-padded spellings and path-qualified binaries,
+# while leaving PID 10/11 and quoted prose alone.
+# Signal 0 and kill's list/help modes are non-terminating probes, so they stay
+# available instead of being pulled onto the hardline floor.
+#
+# Leading wrappers are intentionally broader than shared `_CMDPOS` so forms
+# like `command kill -TERM 1`, `env -- kill -TERM 1`, and path-qualified
+# wrappers (`/usr/bin/env …`, `nice …`) cannot walk past this floor when the
+# PR lands independently of #58643's shared stripper. Operand-taking wrapper
+# flags beyond these spellings remain #58643's job.
+_PID1_CMDPOS = (
+    r'(?:^|[\n`]|\$\()'  # same start class as _CMDPOS
+    r'\s*'
+    r'(?:'
+    r'(?:[^\s;&|`]+/)?'  # /usr/bin/env, ./nice, …
+    r'(?:'
+    r'sudo(?:\s+-[^\s]+)*'
+    r'|doas(?:\s+-[^\s]+)*'
+    r'|env(?:\s+(?:-\S+|\w+=\S*))*'  # env --, env -i, env FOO=1
+    r'|command(?:\s+-[pVv]+)*'
+    r'|builtin'
+    r'|exec|nohup|setsid|time'
+    r'|nice(?:\s+(?:-n\s+)?-?\d+)?'
+    r')'
+    r'\s+'
+    r')*'
+)
+_PID1_KILL_PATTERN = (
+    _PID1_CMDPOS
+    + r'(?:[^\s;&|`]+/)?kill\s+'
+    + r'(?!(?:'
+      r'-0(?:\s|$)|'
+      r'-(?:s|n)\s+0(?:\s|$)|'
+      r'--signal(?:=|\s+)0(?:\s|$)|'
+      r'-(?:l|L)(?:\s|$)|'
+      r'--(?:list|table|help|version)(?:[=\s]|$)'
+      r'))'
+    + r'(?=[^;&|`\n]*(?<!\S)["\']?\+?0*1["\']?(?=\s|$|[;&|)`]))'
+)
+
 HARDLINE_PATTERNS = [
     # rm recursive targeting the root filesystem or protected roots.
     # `${HOME}` brace form and quoted paths (`rm -rf "/"`, `rm -rf "$HOME"`)
@@ -483,6 +527,8 @@ HARDLINE_PATTERNS = [
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system
     (r'\bkill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    # Killing a container's init/supervisor terminates the whole deployment.
+    (_PID1_KILL_PATTERN, "signal init/supervisor process (PID 1)"),
     # System shutdown / reboot — anchor to command position (start of line,
     # after a command separator, or after sudo/env wrappers) so we don't
     # false-positive on "echo reboot" or "grep 'shutdown' logs".


### PR DESCRIPTION
## What does this PR do?

Hermes can itself run in a container while `terminal()` uses the `local` backend in the same PID namespace as the container init/supervisor. On current `main`, `check_all_command_guards("kill -TERM 1", "local")` returns `approved: true`. With a supervisor such as tini or s6 as PID 1, that signal can terminate the deployment and disconnect every active session.

This adds literal PID 1 targets to the existing unconditional hardline floor, before yolo, `approvals.mode: off`, and cron approve-mode can bypass softer approval checks. The matcher recognizes normal signal forms, path-qualified `kill`, target lists, and accepted signed/zero-padded PID spellings. It deliberately leaves non-signaling probes (`kill -0 1`), list/help modes, other PIDs, and quoted command prose runnable.

This is complementary to #43157, which protects the dynamic Hermes process/parent PIDs and intentionally excludes PID 1. It also composes with #58643, which broadens the shared command-position wrapper/path anchor. Patch replays against both open PR heads apply cleanly and pass their focused hardline suites.

## Related Issue

No dedicated issue. Related but non-duplicative work: #43157 and #58643.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`: add a command-position hardline matcher for nonzero `kill` signals whose literal numeric target resolves to PID 1. Preserve signal-zero probes, list/help modes, unrelated PIDs, and the existing isolated tool-container backend bypass.
- `tests/tools/test_hardline_blocklist.py`: cover signal spellings, `/bin/kill` and `/usr/bin/kill`, multi-target commands, shell command positions, signed/zero-padded PID 1, yolo non-bypass, false-positive guards, and the distinction between a containerized Hermes using `local` and an isolated `docker`/`modal` tool backend.

## How to Test

1. Reproduce the current-main gap:

   ```python
   from tools.approval import check_all_command_guards, detect_hardline_command

   print(detect_hardline_command("kill -TERM 1"))
   print(check_all_command_guards("kill -TERM 1", "local"))
   # main: (False, None), {"approved": True, "message": None}
   ```

2. On this branch, the same probe returns a hardline match and `approved: false`. Confirm precision with `kill -0 1`, `kill -TERM 10`, and `echo 'kill -TERM 1'`; all remain allowed.

3. Run the canonical focused suites:

   ```bash
   scripts/run_tests.sh \
     tests/tools/test_hardline_blocklist.py \
     tests/tools/test_command_guards.py \
     tests/tools/test_shell_bypass_denylist.py \
     tests/tools/test_yolo_mode.py \
     tests/tools/test_cron_approval_mode.py -q
   # 329 passed

   scripts/run_tests.sh tests/tools/test_approval.py -q -k hardline
   # 4 passed
   ```

4. A disposable container with tini as PID 1 changed from `running` to `exited` with exit code `143` after an in-container `kill -TERM 1`, confirming the deployment failure mode without touching a live Hermes instance.

5. Compatibility checks:

   - Replayed onto #43157 head: hardline suite `232 passed`; ruff clean.
   - Replayed onto #58643 head: hardline suite `297 passed`; wrapper probes (`command`, `builtin`, `env --`, `nice`, `timeout`, path-qualified wrappers) all block; ruff clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 arm64, Python 3.11.13; disposable Linux container with tini PID 1

The full canonical runner was attempted with the existing shared Hermes venv: 40,269 tests passed and 175 failed across 60 files outside this two-file diff. Representative failures were missing optional dependencies (`psutil`, `ruamel`, Pillow), installed-source skew, macOS live-system guard failures, and local network/integration cases. The changed hardline suite passed in that run and passes independently; this PR is left as a draft so upstream CI can provide the clean full-environment verdict.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline behavior comments and regression tests document the contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow changes)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — regex-only approval change; Windows footgun scan passed for both changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema or public tool-description change)

## Screenshots / Logs

```text
# current main
kill -TERM 1 -> detect_hardline_command: (False, None)
kill -TERM 1 -> check_all_command_guards(local): approved=true

# this branch
kill -TERM 1 -> signal init/supervisor process (PID 1), approved=false, hardline=true
kill -0 1    -> allowed (non-signaling liveness probe)
kill -TERM 10 -> allowed (different target PID)

# disposable tini container
before=running after=exited exit_code=143
```
