### PR TITLE
feat: add trimmed Agent Wikis config defaults

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1262,6 +1262,100 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        "agentwikis": {
+            "enabled": False,
+            "shadow_mode": False,
+            "registry": {
+                "index_json_url": "https://agentwikis.com/index.json",
+                "llms_txt_url": "https://agentwikis.com/llms.txt",
+                "refresh_ttl_seconds": 86400,
+                "conditional_get": True,
+            },
+            "retrieval": {
+                "timeout_ms": 8000,
+                "max_pages_per_query": 6,
+                "retry_html_accept_markdown": True,
+            },
+            "routing": {
+                "min_select_score": 70,
+                "abstain_on_tie": True,
+                "freshness_trigger_terms": [
+                    "latest",
+                    "current",
+                    "recently",
+                    "recent",
+                    "today",
+                    "this week",
+                    "this month",
+                    "new",
+                    "just released",
+                    "roadmap",
+                    "upcoming",
+                ],
+            },
+            "domains": {
+                "hermes": {
+                    "wiki_slug": "hermes",
+                    "aliases": ["hermes", "hermes-agent"],
+                },
+                "gbrain": {
+                    "wiki_slug": "gbrain",
+                    "aliases": ["gbrain", "garrytan-gbrain", "agent-brain"],
+                },
+                "github": {
+                    "wiki_slug": "github",
+                    "aliases": [
+                        "github",
+                        "github-actions",
+                        "pull request",
+                        "pull requests",
+                        "actions",
+                        "codeql",
+                        "dependabot",
+                    ],
+                },
+                "vercel": {
+                    "wiki_slug": "vercel",
+                    "aliases": [
+                        "vercel",
+                        "nextjs-deploy",
+                        "next.js deploy",
+                        "edge function",
+                        "vercel.json",
+                    ],
+                },
+                "meta_ads": {
+                    "wiki_slug": "meta-ads",
+                    "aliases": [
+                        "meta ads",
+                        "facebook ads",
+                        "instagram ads",
+                        "ads manager",
+                        "advantage+",
+                    ],
+                },
+                "google_ads": {
+                    "wiki_slug": "google-ads",
+                    "aliases": [
+                        "google ads",
+                        "adwords",
+                        "ga4 import",
+                        "enhanced conversions",
+                        "quality score",
+                    ],
+                },
+                "claude_code": {
+                    "wiki_slug": "claude-code",
+                    "aliases": [
+                        "claude code",
+                        "claude-code",
+                        "claude mcp",
+                        "claude hooks",
+                        "claude subagents",
+                    ],
+                },
+            },
+        },
     },
 
     "browser": {


### PR DESCRIPTION
## Summary
- add the trimmed `web.agentwikis` default config surface in `hermes_cli/config.py`
- include only the first reland keys required for the config packet
- intentionally exclude `web.agentwikis.retrieval.prefer` and `web.agentwikis.retrieval.mcp_server_name`

## Packet scope
- packet: `agentwikis-config-surface-v1-trimmed`
- implementation card: `agentwikis/t_1bae9694`
- provenance references: `t_d902b8a4`, `t_d2baa075`, `t_1b395618`, `t_404db633`
- worktree branch: `fix/agentwikis-config-surface-v1-trimmed`
- no live-main apply performed

## Verification
```bash
cd /Users/alimai/.hermes/kanban/boards/agentwikis/workspaces/t_1bae9694/hermes-agent
python3 - <<'PY'
from pathlib import Path
text = Path('hermes_cli/config.py').read_text()
required = [
    '"enabled": False',
    '"shadow_mode": False',
    '"index_json_url": "https://agentwikis.com/index.json"',
    '"llms_txt_url": "https://agentwikis.com/llms.txt"',
    '"refresh_ttl_seconds": 86400',
    '"conditional_get": True',
    '"timeout_ms": 8000',
    '"max_pages_per_query": 6',
    '"retry_html_accept_markdown": True',
    '"min_select_score": 70',
    '"abstain_on_tie": True',
    '"freshness_trigger_terms": [',
    '"claude_code": {',
]
missing = [s for s in required if s not in text]
dropped = ['"prefer":', '"mcp_server_name":']
present_dropped = [s for s in dropped if s in text]
print({'missing': missing, 'present_dropped': present_dropped})
PY
/Users/alimai/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/config.py
```

## Upstream research
- `gh api 'search/issues?q=repo:NousResearch/hermes-agent+agentwiki' --jq '.total_count'` returned `0`
- broader web search found the Hermes repo and unrelated issues, but no existing Agent Wikis config-surface PR/issue in `NousResearch/hermes-agent`
