### PR TITLE
Harden MoA budgets, runtime status, and CUA targeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,10 @@ docs/superpowers/*
 # logs, and per-session caches are never artifacts of the codebase.
 .hermes/
 
+# Local PKS task capsule and generated working queue. These files describe the
+# operator's current session, not the Hermes source tree.
+.pks/
+
 # Desktop/bootstrap install marker written into the managed checkout root by the
 # bootstrap installer. It is Hermes-managed runtime state, never a code change —
 # ignore it so `hermes update`'s `git stash push --include-untracked` does not

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -223,6 +224,7 @@ def _run_reference(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    timeout: float | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, usage)``.
 
@@ -275,6 +277,7 @@ def _run_reference(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            timeout=timeout,
             **runtime,
         )
         usage = CanonicalUsage()
@@ -339,6 +342,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    timeout: float | None = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -375,6 +379,7 @@ def _run_references_parallel(
                     ref_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    timeout=timeout,
                 )
             ] = idx
         # Collect every reference before returning — the aggregator needs the
@@ -383,6 +388,70 @@ def _run_references_parallel(
             results[idx] = future.result()
 
     return [r for r in results if r is not None]
+
+
+def _select_references_for_budget(
+    reference_models: list[dict[str, str]],
+    ref_messages: list[dict[str, Any]],
+    *,
+    max_advisors: int | None,
+    max_cost_usd: float | None,
+    max_tokens: int | None,
+) -> tuple[list[dict[str, str]], dict[str, Any]]:
+    """Применить детерминированные лимиты числа советников и оценочной стоимости."""
+    selected = list(reference_models)
+    status: dict[str, Any] = {
+        "configured_advisors": len(reference_models),
+        "selected_advisors": len(reference_models),
+        "estimated_reference_cost_usd": 0.0,
+        "skipped_by_budget": [],
+        "exceeded": False,
+    }
+    if max_advisors is not None:
+        selected = selected[: max(0, int(max_advisors))]
+        status["skipped_by_budget"].extend(
+            _slot_label(slot) for slot in reference_models[len(selected):]
+        )
+
+    if max_cost_usd is not None and selected:
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+
+        prompt_chars = sum(len(str(message.get("content") or "")) for message in ref_messages)
+        estimated_usage = CanonicalUsage(
+            input_tokens=max(1, prompt_chars // 4),
+            output_tokens=max_tokens or 600,
+        )
+        within_budget: list[dict[str, str]] = []
+        estimated_total = 0.0
+        for slot in selected:
+            try:
+                runtime = _slot_runtime(slot)
+                estimate = estimate_usage_cost(
+                    slot.get("model") or "",
+                    estimated_usage,
+                    provider=runtime.get("provider"),
+                    base_url=runtime.get("base_url"),
+                    api_key=runtime.get("api_key"),
+                )
+                amount = (
+                    float(estimate.amount_usd)
+                    if estimate.amount_usd is not None
+                    else None
+                )
+            except Exception:
+                amount = None
+            if amount is not None and estimated_total + amount > float(max_cost_usd):
+                status["skipped_by_budget"].append(_slot_label(slot))
+                continue
+            within_budget.append(slot)
+            if amount is not None:
+                estimated_total += amount
+        selected = within_budget
+        status["estimated_reference_cost_usd"] = round(estimated_total, 6)
+
+    status["selected_advisors"] = len(selected)
+    status["exceeded"] = bool(status["skipped_by_budget"])
+    return selected, status
 
 
 def _truncate_tool_result(text: str, budget: int = _REFERENCE_TOOL_RESULT_BUDGET) -> str:
@@ -719,6 +788,7 @@ class MoAChatCompletions:
         # create(); read by session cost accounting to price the aggregator's
         # acting turn at its real model instead of the virtual preset name.
         self.last_aggregator_slot: Any = None
+        self.last_runtime_status: dict[str, Any] = {}
         # Full-turn trace parts stashed on a cache-MISS create(), awaiting the
         # caller to stitch in the live session_id + resolved aggregator output
         # and flush to the trace file (only when moa.save_traces is on).
@@ -799,12 +869,31 @@ class MoAChatCompletions:
 
     def create(self, **api_kwargs: Any) -> Any:
         from hermes_cli.config import load_config
-        from hermes_cli.moa_config import resolve_moa_preset
+        from hermes_cli.moa_config import (
+            resolve_available_moa_preset,
+            resolve_moa_preset_for_messages,
+        )
 
-        preset = resolve_moa_preset(load_config().get("moa") or {}, self.preset_name)
         messages = list(api_kwargs.get("messages") or [])
+        turn_started = time.monotonic()
+        resolved_preset_name, preset = resolve_moa_preset_for_messages(
+            load_config().get("moa") or {}, self.preset_name, messages
+        )
+        configured_aggregator = dict(preset.get("aggregator") or {})
+        preset, runtime_status = resolve_available_moa_preset(preset)
+        self.last_runtime_status = runtime_status
+        if runtime_status.get("degraded"):
+            logger.warning(
+                "MoA preset %s is degraded: %s",
+                resolved_preset_name,
+                ", ".join(runtime_status.get("unavailable") or []),
+            )
         reference_models = preset.get("reference_models") or []
         aggregator = preset.get("aggregator") or {}
+        if not runtime_status.get("aggregator_available"):
+            raise RuntimeError(
+                f"MoA preset {resolved_preset_name!r} has no available aggregator"
+            )
         # Expose the resolved aggregator slot so session cost accounting can
         # price the aggregator's acting turn at its REAL model/provider. The
         # agent's model/provider on the MoA path are the virtual preset name
@@ -823,6 +912,8 @@ class MoAChatCompletions:
         # The acting aggregator is never capped here (its output is the
         # user-visible answer).
         reference_max_tokens = preset.get("reference_max_tokens")
+        max_reference_cost_usd = preset.get("max_reference_cost_usd")
+        max_fanout_latency_seconds = preset.get("max_fanout_latency_seconds")
         # None (the default) = don't send temperature; provider default
         # applies, matching single-model agent behavior. Presets may pin
         # explicit values. See _preset_temperature.
@@ -843,6 +934,14 @@ class MoAChatCompletions:
 
         reference_outputs: list[tuple[str, str, Any]] = []
         ref_messages = _reference_messages(messages)
+        reference_models, budget_status = _select_references_for_budget(
+            reference_models,
+            ref_messages,
+            max_advisors=preset.get("max_advisors"),
+            max_cost_usd=max_reference_cost_usd,
+            max_tokens=reference_max_tokens,
+        )
+        self.last_runtime_status["budget"] = budget_status
 
         # Fan-out cadence. "per_iteration" (default): advisors re-run whenever
         # the advisory view changes — i.e. every tool iteration, since the
@@ -881,7 +980,7 @@ class MoAChatCompletions:
                 f"{m.get('role')}:{m.get('content')}" for m in sig_messages
             ).encode("utf-8", "replace")
         ).hexdigest()
-        _cache_key = (self.preset_name, _sig, tuple(_slot_label(s) for s in reference_models))
+        _cache_key = (resolved_preset_name, _sig, tuple(_slot_label(s) for s in reference_models))
         _refs_from_cache = _cache_key == self._ref_cache_key and bool(self._ref_cache_outputs)
 
         if _refs_from_cache:
@@ -902,6 +1001,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                timeout=max_fanout_latency_seconds,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -923,13 +1023,20 @@ class MoAChatCompletions:
                         _ref_cost = (_ref_cost or 0) + _acct.cost_usd
             self._pending_reference_usage = _ref_usage
             self._pending_reference_cost = _ref_cost
+            if (
+                max_reference_cost_usd is not None
+                and _ref_cost is not None
+                and float(_ref_cost) > float(max_reference_cost_usd)
+            ):
+                budget_status["exceeded"] = True
+                budget_status["actual_reference_cost_usd"] = round(float(_ref_cost), 6)
             # Stash the full reference fan-out for trace persistence. The
             # aggregator input/label are filled in below once agg_messages is
             # built; the aggregator OUTPUT is stitched in by the caller
             # (consume_and_save_trace) once the response resolves — the caller
             # holds the live session_id and the resolved aggregator response.
             self._pending_trace = {
-                "preset": self.preset_name,
+                "preset": resolved_preset_name,
                 "reference_outputs": list(reference_outputs),
                 "aggregator_slot": aggregator,
                 "aggregator_temperature": aggregator_temperature,
@@ -965,7 +1072,7 @@ class MoAChatCompletions:
             )
             guidance = (
                 "[Mixture of Agents reference context]\n"
-                f"Preset: {self.preset_name}\n"
+                f"Preset: {resolved_preset_name}\n"
                 f"Aggregator/acting model: {_slot_label(aggregator)}\n"
                 f"References: {', '.join(label for label, _, _ in reference_outputs)}\n\n"
                 "Use the reference responses below as private context. You are the aggregator and acting model: "
@@ -1010,16 +1117,122 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
-        _agg_response = call_llm(
-            task="moa_aggregator",
-            messages=agg_messages,
-            temperature=aggregator_temperature,
-            max_tokens=agg_kwargs.get("max_tokens"),
-            tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
-            **stream_kwargs,
-            **_slot_runtime(aggregator),
+        from agent.moa_runtime import (
+            circuit_status,
+            classify_moa_error,
+            mark_slot_failure,
+            mark_slot_success,
+            record_moa_telemetry,
+            should_failover_moa_error,
         )
+
+        initial_aggregator = configured_aggregator or dict(aggregator)
+        candidates: list[dict[str, str]] = []
+        for candidate in [aggregator, *(preset.get("fallback_aggregators") or [])]:
+            if candidate and candidate not in candidates:
+                candidates.append(candidate)
+
+        _agg_response: Any = None
+        last_error: Exception | None = None
+        attempts: list[dict[str, str]] = []
+        for candidate in candidates:
+            circuit = circuit_status(candidate)
+            if circuit.get("active"):
+                attempts.append({
+                    "slot": _slot_label(candidate),
+                    "status": "cooldown",
+                    "kind": str(circuit.get("reason") or "transient"),
+                })
+                continue
+            try:
+                _agg_response = call_llm(
+                    task="moa_aggregator",
+                    messages=agg_messages,
+                    temperature=aggregator_temperature,
+                    max_tokens=agg_kwargs.get("max_tokens"),
+                    tools=agg_kwargs.get("tools"),
+                    extra_body=agg_kwargs.get("extra_body"),
+                    **stream_kwargs,
+                    **_slot_runtime(candidate),
+                )
+            except Exception as exc:
+                last_error = exc
+                kind = classify_moa_error(exc)
+                attempts.append({
+                    "slot": _slot_label(candidate),
+                    "status": "failed",
+                    "kind": kind,
+                })
+                if not should_failover_moa_error(exc):
+                    record_moa_telemetry({
+                        "preset": resolved_preset_name,
+                        "status": "failed",
+                        "aggregator": _slot_label(candidate),
+                        "attempts": len(attempts),
+                        "latency_ms": int((time.monotonic() - turn_started) * 1000),
+                        "reference_count": len(reference_outputs),
+                        "reference_cost_usd": self._pending_reference_cost,
+                        "budget_exceeded": bool(budget_status.get("exceeded")),
+                        "failure_kind": kind,
+                    })
+                    raise
+                mark_slot_failure(
+                    candidate,
+                    exc,
+                    cooldown_seconds=preset.get("circuit_breaker_seconds"),
+                    quota_cooldown_seconds=preset.get("quota_cooldown_seconds"),
+                )
+                continue
+
+            mark_slot_success(candidate)
+            aggregator = candidate
+            self.last_aggregator_slot = dict(candidate)
+            attempts.append({
+                "slot": _slot_label(candidate),
+                "status": "ok",
+                "kind": "",
+            })
+            break
+
+        if _agg_response is None:
+            failure_kind = classify_moa_error(last_error) if last_error else "cooldown"
+            record_moa_telemetry({
+                "preset": resolved_preset_name,
+                "status": "failed",
+                "aggregator": "",
+                "attempts": len(attempts),
+                "latency_ms": int((time.monotonic() - turn_started) * 1000),
+                "reference_count": len(reference_outputs),
+                "reference_cost_usd": self._pending_reference_cost,
+                "budget_exceeded": bool(budget_status.get("exceeded")),
+                "failure_kind": failure_kind,
+            })
+            if last_error is not None:
+                raise RuntimeError("All MoA aggregators failed") from last_error
+            raise RuntimeError("All MoA aggregators are cooling down")
+
+        fallback_used = aggregator != initial_aggregator
+        self.last_runtime_status.update({
+            "aggregator": _slot_label(aggregator),
+            "fallback_used": fallback_used,
+            "attempts": attempts,
+            "latency_ms": int((time.monotonic() - turn_started) * 1000),
+        })
+        if self._pending_trace is not None:
+            self._pending_trace["aggregator_slot"] = aggregator
+            self._pending_trace["aggregator_label"] = _slot_label(aggregator)
+        record_moa_telemetry({
+            "preset": resolved_preset_name,
+            "status": "stream_started" if stream else "ok",
+            "aggregator": _slot_label(aggregator),
+            "fallback_used": fallback_used,
+            "attempts": len(attempts),
+            "latency_ms": self.last_runtime_status["latency_ms"],
+            "reference_count": len(reference_outputs),
+            "reference_cost_usd": self._pending_reference_cost,
+            "budget_exceeded": bool(budget_status.get("exceeded")),
+            "failure_kind": "",
+        })
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.
         # Streaming path: the aggregator's raw token stream is returned to the

--- a/agent/moa_runtime.py
+++ b/agent/moa_runtime.py
@@ -1,0 +1,299 @@
+"""Runtime resilience и telemetry без содержимого для Mixture of Agents.
+
+Модуль намеренно хранит только метки provider/model и числовые runtime-метрики.
+Prompts, outputs, credentials, тексты исключений и сессий никогда не попадают
+в telemetry или feedback-файлы.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CIRCUIT_LOCK = threading.Lock()
+_CIRCUITS: dict[str, dict[str, Any]] = {}
+_FILE_LOCK = threading.Lock()
+
+_DEFAULT_COOLDOWNS = {
+    "rate_limit": 60.0,
+    "quota": 900.0,
+    "timeout": 30.0,
+    "transient": 30.0,
+    "auth": 60.0,
+}
+_TELEMETRY_MAX_BYTES = 2 * 1024 * 1024
+_TELEMETRY_BACKUPS = 3
+
+
+def slot_label(slot: dict[str, Any]) -> str:
+    return f"{slot.get('provider', '')}:{slot.get('model', '')}"
+
+
+def classify_moa_error(exc: Exception) -> str:
+    """Классифицировать исключение provider в очищенную failover-категорию."""
+    try:
+        from agent.auxiliary_client import (
+            _is_payment_error,
+            _is_rate_limit_error,
+            _is_timeout_error,
+            _is_transient_transport_error,
+        )
+
+        if _is_payment_error(exc):
+            return "quota"
+        if _is_rate_limit_error(exc):
+            return "rate_limit"
+        if _is_timeout_error(exc):
+            return "timeout"
+        if _is_transient_transport_error(exc):
+            return "transient"
+    except Exception:
+        pass
+
+    status = getattr(exc, "status_code", None)
+    message = str(exc).casefold()
+    if status in {500, 502, 503, 504}:
+        return "transient"
+    if status in {401, 403} and any(
+        token in message
+        for token in ("oauth", "token expired", "temporarily unavailable", "refresh")
+    ):
+        return "auth"
+    return "fatal"
+
+
+def should_failover_moa_error(exc: Exception) -> bool:
+    return classify_moa_error(exc) != "fatal"
+
+
+def circuit_status(slot: dict[str, Any], *, now: float | None = None) -> dict[str, Any]:
+    label = slot_label(slot)
+    current = time.time() if now is None else now
+    with _CIRCUIT_LOCK:
+        state = dict(_CIRCUITS.get(label) or {})
+        until = float(state.get("until") or 0.0)
+        if until <= current:
+            if label in _CIRCUITS:
+                _CIRCUITS.pop(label, None)
+            return {"active": False, "retry_after_seconds": 0, "reason": "", "failures": 0}
+    return {
+        "active": True,
+        "retry_after_seconds": max(0, int(until - current + 0.999)),
+        "reason": str(state.get("reason") or "transient"),
+        "failures": int(state.get("failures") or 1),
+    }
+
+
+def mark_slot_failure(
+    slot: dict[str, Any],
+    exc: Exception,
+    *,
+    cooldown_seconds: float | None = None,
+    quota_cooldown_seconds: float | None = None,
+) -> dict[str, Any]:
+    kind = classify_moa_error(exc)
+    if kind == "fatal":
+        return {"active": False, "reason": kind, "retry_after_seconds": 0, "failures": 0}
+    base = (
+        quota_cooldown_seconds
+        if kind == "quota" and quota_cooldown_seconds is not None
+        else cooldown_seconds
+    )
+    duration = max(1.0, float(base if base is not None else _DEFAULT_COOLDOWNS[kind]))
+    label = slot_label(slot)
+    now = time.time()
+    with _CIRCUIT_LOCK:
+        previous = _CIRCUITS.get(label) or {}
+        failures = int(previous.get("failures") or 0) + 1
+        # Повторные сбои продлевают cooldown, но не создают постоянную блокировку.
+        duration = min(duration * (2 ** min(failures - 1, 3)), 3600.0)
+        _CIRCUITS[label] = {
+            "until": now + duration,
+            "reason": kind,
+            "failures": failures,
+        }
+    return circuit_status(slot, now=now)
+
+
+def mark_slot_success(slot: dict[str, Any]) -> None:
+    with _CIRCUIT_LOCK:
+        _CIRCUITS.pop(slot_label(slot), None)
+
+
+def reset_runtime_state_for_tests() -> None:
+    with _CIRCUIT_LOCK:
+        _CIRCUITS.clear()
+
+
+def _hermes_home() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home()
+
+
+def _telemetry_path() -> Path:
+    return _hermes_home() / "logs" / "moa_runtime.jsonl"
+
+
+def _feedback_path() -> Path:
+    return _hermes_home() / "state" / "moa_router_feedback.json"
+
+
+def _rotate_jsonl(path: Path) -> None:
+    if not path.exists() or path.stat().st_size < _TELEMETRY_MAX_BYTES:
+        return
+    oldest = path.with_suffix(path.suffix + f".{_TELEMETRY_BACKUPS}")
+    if oldest.exists():
+        oldest.unlink()
+    for idx in range(_TELEMETRY_BACKUPS - 1, 0, -1):
+        source = path.with_suffix(path.suffix + f".{idx}")
+        if source.exists():
+            source.replace(path.with_suffix(path.suffix + f".{idx + 1}"))
+    path.replace(path.with_suffix(path.suffix + ".1"))
+
+
+def record_moa_telemetry(event: dict[str, Any]) -> None:
+    """Добавить ограниченное runtime-событие без содержимого задачи."""
+    allowed = {
+        "preset",
+        "status",
+        "aggregator",
+        "fallback_used",
+        "attempts",
+        "latency_ms",
+        "reference_count",
+        "reference_cost_usd",
+        "budget_exceeded",
+        "failure_kind",
+    }
+    clean = {key: event[key] for key in allowed if key in event}
+    for key in ("attempts", "latency_ms", "reference_count"):
+        if key in clean and clean[key] is not None:
+            clean[key] = int(clean[key])
+    if clean.get("reference_cost_usd") is not None:
+        clean["reference_cost_usd"] = float(clean["reference_cost_usd"])
+    for key in ("fallback_used", "budget_exceeded"):
+        if key in clean:
+            clean[key] = bool(clean[key])
+    clean["timestamp"] = int(time.time())
+    path = _telemetry_path()
+    try:
+        with _FILE_LOCK:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _rotate_jsonl(path)
+            with path.open("a", encoding="utf-8", newline="\n") as handle:
+                handle.write(json.dumps(clean, ensure_ascii=True, separators=(",", ":")) + "\n")
+    except Exception as exc:  # pragma: no cover - telemetry never breaks a turn
+        logger.debug("MoA telemetry write skipped: %s", type(exc).__name__)
+
+
+def read_moa_telemetry(limit: int = 100) -> dict[str, Any]:
+    """Вернуть компактный агрегат без prompts и текстов исключений."""
+    path = _telemetry_path()
+    if not path.exists():
+        return {"events": 0, "presets": {}}
+    try:
+        with _FILE_LOCK:
+            with path.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                size = handle.tell()
+                handle.seek(max(0, size - 256 * 1024))
+                raw = handle.read().decode("utf-8", "replace")
+        rows: list[dict[str, Any]] = []
+        for line in raw.splitlines()[-max(1, min(limit, 500)):]:
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict) and value.get("preset"):
+                rows.append(value)
+        presets: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            name = str(row["preset"])
+            item = presets.setdefault(name, {
+                "turns": 0,
+                "failures": 0,
+                "fallbacks": 0,
+                "average_latency_ms": 0,
+                "known_reference_cost_usd": 0.0,
+                "last": {},
+            })
+            item["turns"] += 1
+            item["failures"] += int(row.get("status") == "failed")
+            item["fallbacks"] += int(bool(row.get("fallback_used")))
+            item["average_latency_ms"] += int(row.get("latency_ms") or 0)
+            if row.get("reference_cost_usd") is not None:
+                item["known_reference_cost_usd"] += float(row["reference_cost_usd"])
+            item["last"] = row
+        for item in presets.values():
+            turns = max(1, int(item["turns"]))
+            item["average_latency_ms"] = int(item["average_latency_ms"] / turns)
+            item["known_reference_cost_usd"] = round(item["known_reference_cost_usd"], 6)
+        return {"events": len(rows), "presets": presets}
+    except Exception as exc:
+        logger.debug("MoA telemetry read skipped: %s", type(exc).__name__)
+        return {"events": 0, "presets": {}}
+
+
+def _load_feedback() -> dict[str, Any]:
+    path = _feedback_path()
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def record_route_feedback(suggested_route: str, chosen_route: str) -> dict[str, Any]:
+    valid = {"fast", "balanced", "research", "code_heavy", "max"}
+    suggested = str(suggested_route or "").strip()
+    chosen = str(chosen_route or "").strip()
+    if suggested not in valid or chosen not in valid:
+        raise ValueError("unsupported MoA route feedback")
+    path = _feedback_path()
+    with _FILE_LOCK:
+        data = _load_feedback()
+        routes = data.setdefault("routes", {})
+        choices = routes.setdefault(suggested, {})
+        choices[chosen] = int(choices.get(chosen) or 0) + 1
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(data, ensure_ascii=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    return route_feedback_summary()
+
+
+def apply_route_feedback(suggested_route: str) -> str:
+    suggested = str(suggested_route or "").strip()
+    choices = ((_load_feedback().get("routes") or {}).get(suggested) or {})
+    if not isinstance(choices, dict):
+        return suggested
+    total = sum(max(0, int(value or 0)) for value in choices.values())
+    if total < 3:
+        return suggested
+    chosen, count = max(choices.items(), key=lambda item: int(item[1] or 0))
+    return str(chosen) if int(count or 0) / total >= 0.67 else suggested
+
+
+def route_feedback_summary() -> dict[str, Any]:
+    routes = _load_feedback().get("routes") or {}
+    summary: dict[str, Any] = {}
+    for suggested, choices in routes.items():
+        if not isinstance(choices, dict):
+            continue
+        total = sum(max(0, int(value or 0)) for value in choices.values())
+        summary[str(suggested)] = {
+            "samples": total,
+            "effective_route": apply_route_feedback(str(suggested)),
+        }
+    return summary

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2054,10 +2054,10 @@ def get_model_context_length(
 
     # 0a. MoA virtual provider — ``model`` is a preset name, not a real model,
     # and ``base_url`` is the local virtual endpoint, so every probe below would
-    # miss and fall through to the 256K default. The aggregator is the acting
-    # model, so resolve the context window from the aggregator slot's real
-    # provider+model instead. References are advisory-only and never bound the
-    # acting context, so they're ignored here.
+    # miss and fall through to the 256K default. Prefer an explicit per-preset
+    # working budget: reference models receive the same conversation view and
+    # the narrowest one can therefore bound a safe MoA window. Without a preset
+    # budget, fall back to the acting aggregator's real provider+model window.
     if (provider or "").strip().lower() == "moa":
         try:
             from hermes_cli.config import load_config
@@ -2065,6 +2065,12 @@ def get_model_context_length(
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
             preset = resolve_moa_preset(load_config().get("moa") or {}, model)
+            preset_context_length = preset.get("context_length")
+            if (
+                isinstance(preset_context_length, int)
+                and preset_context_length > 0
+            ):
+                return preset_context_length
             agg = preset.get("aggregator") or {}
             agg_provider = str(agg.get("provider") or "").strip()
             agg_model = str(agg.get("model") or "").strip()

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Radix Select calls scrollIntoView on its items when the content opens; jsdom
@@ -30,6 +31,7 @@ vi.mock('@/hermes', () => ({
   setModelAssignment: (body: unknown) => setModelAssignment(body),
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
+  setApiRequestProfile: vi.fn(),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config)
@@ -71,11 +73,78 @@ afterEach(() => {
 
 async function renderModelSettings() {
   const { ModelSettings } = await import('./model-settings')
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  })
 
-  return render(<ModelSettings />)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ModelSettings />
+    </QueryClientProvider>
+  )
 }
 
 describe('ModelSettings', () => {
+  it('shows MoA readiness, telemetry, and budget controls', async () => {
+    getMoaModels.mockResolvedValueOnce({
+      revision: '1234567890abcdef',
+      default_preset: 'balanced',
+      active_preset: 'balanced',
+      presets: {
+        balanced: {
+          aggregator: { provider: 'openai-codex', model: 'gpt-5.6-terra' },
+          aggregator_temperature: 0.2,
+          enabled: true,
+          max_tokens: 4096,
+          max_advisors: 1,
+          max_reference_cost_usd: 0.2,
+          max_fanout_latency_seconds: 45,
+          reference_models: [],
+          reference_temperature: 0.3
+        }
+      },
+      aggregator: { provider: 'openai-codex', model: 'gpt-5.6-terra' },
+      aggregator_temperature: 0.2,
+      enabled: true,
+      max_tokens: 4096,
+      reference_models: [],
+      reference_temperature: 0.3,
+      runtime_status: {
+        degraded: false,
+        presets: {
+          balanced: {
+            degraded: false,
+            unavailable: [],
+            reference_count: 1,
+            aggregator_available: true,
+            aggregator: 'openai-codex:gpt-5.6-terra'
+          }
+        },
+        telemetry: {
+          events: 1,
+          presets: {
+            balanced: {
+              turns: 1,
+              failures: 0,
+              fallbacks: 0,
+              average_latency_ms: 420,
+              known_reference_cost_usd: 0,
+              last: { latency_ms: 420, reference_count: 1 }
+            }
+          }
+        }
+      }
+    })
+
+    await renderModelSettings()
+
+    expect(await screen.findByText('ready')).toBeTruthy()
+    expect(screen.getByText(/openai-codex:gpt-5.6-terra/)).toBeTruthy()
+    expect(screen.getByText('Last: 420 ms')).toBeTruthy()
+    expect(screen.getByText('Max advisors')).toBeTruthy()
+    expect(screen.getByText('Reference budget, USD')).toBeTruthy()
+  })
+
   it('loads the current main model and lists configured providers only', async () => {
     await renderModelSettings()
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -333,6 +333,22 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     }, 600)
   }, [])
 
+  const currentMoaRuntime = useMemo(() => {
+    if (!moa?.runtime_status) {
+      return null
+    }
+    const name = selectedMoaPreset || moa.default_preset
+    return moa.runtime_status.presets[name] || null
+  }, [moa, selectedMoaPreset])
+
+  const currentMoaTelemetry = useMemo(() => {
+    if (!moa?.runtime_status?.telemetry) {
+      return null
+    }
+    const name = selectedMoaPreset || moa.default_preset
+    return moa.runtime_status.telemetry.presets[name] || null
+  }, [moa, selectedMoaPreset])
+
   const updateMoaPreset = useCallback(
     (updater: (preset: NonNullable<typeof currentMoaPreset>) => NonNullable<typeof currentMoaPreset>) => {
       const prev = moaRef.current
@@ -380,7 +396,21 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
       setMoa(saved)
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('moa_revision_conflict') || message.includes('409')) {
+        try {
+          const current = await getMoaModels()
+          if (profileEpoch.current === epoch) {
+            setMoa(current)
+            setSelectedMoaPreset(prev => (prev && current.presets[prev] ? prev : current.default_preset))
+          }
+        } catch {
+          // Исходная ошибка конфликта важнее вторичной ошибки refresh.
+        }
+        setError('MoA config changed in another client. The latest revision was loaded; review and save again.')
+      } else {
+        setError(message)
+      }
     } finally {
       setApplying(false)
     }
@@ -971,6 +1001,28 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
           <div className="mb-2 text-xs text-muted-foreground">
             Default: <span className="font-mono">{moa.default_preset}</span>
           </div>
+          {currentMoaRuntime && (
+            <div className="mb-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Pill>{currentMoaRuntime.degraded ? 'degraded' : 'ready'}</Pill>
+              <span>
+                Aggregator: <span className="font-mono">{currentMoaRuntime.aggregator || 'unavailable'}</span>
+              </span>
+              <span>Advisors: {currentMoaRuntime.reference_count}</span>
+              {!!currentMoaRuntime.cooling_down?.length && (
+                <Pill>{currentMoaRuntime.cooling_down.length} cooling down</Pill>
+              )}
+              {currentMoaTelemetry && (
+                <>
+                  <span>Last: {currentMoaTelemetry.last.latency_ms ?? 0} ms</span>
+                  <span>Fallbacks: {currentMoaTelemetry.fallbacks}</span>
+                  {currentMoaTelemetry.last.reference_cost_usd != null && (
+                    <span>References: ${currentMoaTelemetry.last.reference_cost_usd.toFixed(4)}</span>
+                  )}
+                  {currentMoaTelemetry.last.budget_exceeded && <Pill>budget capped</Pill>}
+                </>
+              )}
+            </div>
+          )}
           <div className="grid gap-1">
             {currentMoaPreset.reference_models.map((slot, index) => (
               <ListRow
@@ -1109,6 +1161,51 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               }
               title="Aggregator"
             />
+            <div className="mt-2 grid gap-2 sm:grid-cols-3">
+              <label className="grid gap-1 text-xs text-muted-foreground">
+                Max advisors
+                <Input
+                  min={1}
+                  onChange={event =>
+                    updateMoaPreset(prev => ({
+                      ...prev,
+                      max_advisors: event.target.value ? Number(event.target.value) : null
+                    }))
+                  }
+                  type="number"
+                  value={currentMoaPreset.max_advisors ?? ''}
+                />
+              </label>
+              <label className="grid gap-1 text-xs text-muted-foreground">
+                Reference budget, USD
+                <Input
+                  min={0.0001}
+                  onChange={event =>
+                    updateMoaPreset(prev => ({
+                      ...prev,
+                      max_reference_cost_usd: event.target.value ? Number(event.target.value) : null
+                    }))
+                  }
+                  step="0.01"
+                  type="number"
+                  value={currentMoaPreset.max_reference_cost_usd ?? ''}
+                />
+              </label>
+              <label className="grid gap-1 text-xs text-muted-foreground">
+                Fan-out timeout, sec
+                <Input
+                  min={1}
+                  onChange={event =>
+                    updateMoaPreset(prev => ({
+                      ...prev,
+                      max_fanout_latency_seconds: event.target.value ? Number(event.target.value) : null
+                    }))
+                  }
+                  type="number"
+                  value={currentMoaPreset.max_fanout_latency_seconds ?? ''}
+                />
+              </label>
+            </div>
           </div>
         </section>
       )}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -858,25 +858,91 @@ export interface MoaModelSlot {
 }
 
 export interface MoaConfigResponse {
+  revision?: string
   default_preset: string
   active_preset: string
+  excluded_providers?: string[]
   presets: Record<
     string,
     {
       aggregator: MoaModelSlot
+      fallback_aggregators?: MoaModelSlot[]
       aggregator_temperature: number
       enabled: boolean
       max_tokens: number
+      reference_max_tokens?: number | null
+      context_length?: number | null
+      max_advisors?: number | null
+      max_reference_cost_usd?: number | null
+      max_fanout_latency_seconds?: number | null
+      circuit_breaker_seconds?: number | null
+      quota_cooldown_seconds?: number | null
+      fanout?: 'per_iteration' | 'user_turn'
+      auto_routes?: Partial<Record<'fast' | 'balanced' | 'research' | 'code_heavy' | 'max', string>>
       reference_models: MoaModelSlot[]
       reference_temperature: number
     }
   >
   aggregator: MoaModelSlot
+  fallback_aggregators?: MoaModelSlot[]
   aggregator_temperature: number
   enabled: boolean
   max_tokens: number
+  reference_max_tokens?: number | null
+  context_length?: number | null
+  max_advisors?: number | null
+  max_reference_cost_usd?: number | null
+  max_fanout_latency_seconds?: number | null
+  circuit_breaker_seconds?: number | null
+  quota_cooldown_seconds?: number | null
+  fanout?: 'per_iteration' | 'user_turn'
+  auto_routes?: Partial<Record<'fast' | 'balanced' | 'research' | 'code_heavy' | 'max', string>>
   reference_models: MoaModelSlot[]
   reference_temperature: number
+  runtime_status?: {
+    degraded: boolean
+    presets: Record<
+      string,
+      {
+        degraded: boolean
+        unavailable: string[]
+        reference_count: number
+        aggregator_available: boolean
+        aggregator: string
+        configured_aggregator?: string
+        fallback_used?: boolean
+        cooling_down?: Array<{
+          slot: string
+          retry_after_seconds: number
+          reason: string
+        }>
+      }
+    >
+    telemetry?: {
+      events: number
+      presets: Record<
+        string,
+        {
+          turns: number
+          failures: number
+          fallbacks: number
+          average_latency_ms: number
+          known_reference_cost_usd: number
+          last: {
+            aggregator?: string
+            fallback_used?: boolean
+            latency_ms?: number
+            reference_count?: number
+            reference_cost_usd?: number | null
+            budget_exceeded?: boolean
+            status?: string
+          }
+        }
+      >
+    }
+    router_feedback?: Record<string, { samples: number; effective_route: string }>
+  }
+  validation_issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string }>
 }
 
 export interface ModelAssignmentRequest {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4711,22 +4711,12 @@ def _normalize_custom_provider_entry(
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
     }
+    mapped_aliases: List[Tuple[str, str]] = []
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
-            _warn_once_per_provider(
-                provider_key, f"camel:{camel}",
-                "providers.%s: camelCase key '%s' auto-mapped to '%s' "
-                "(use snake_case to avoid this warning)",
-                provider_key or "?", camel, snake,
-            )
             entry[snake] = entry[camel]
+            mapped_aliases.append((camel, snake))
     unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
-    if unknown:
-        _warn_once_per_provider(
-            provider_key, "unknown:" + ",".join(sorted(unknown)),
-            "providers.%s: unknown config keys ignored: %s",
-            provider_key or "?", ", ".join(sorted(unknown)),
-        )
 
     from urllib.parse import urlparse
 
@@ -4764,6 +4754,25 @@ def _normalize_custom_provider_entry(
         name = provider_key.strip()
     if not name:
         return None
+
+    # ``providers`` contains both custom OpenAI-compatible endpoints and
+    # built-in provider settings. Only entries with a valid endpoint reach
+    # this point, so warn about custom-provider schema here instead of
+    # producing false warnings for built-in-only keys such as ``enabled`` or
+    # ``auth_type`` that are intentionally ignored by this compatibility view.
+    for camel, snake in mapped_aliases:
+        _warn_once_per_provider(
+            provider_key, f"camel:{camel}",
+            "providers.%s: camelCase key '%s' auto-mapped to '%s' "
+            "(use snake_case to avoid this warning)",
+            provider_key or "?", camel, snake,
+        )
+    if unknown:
+        _warn_once_per_provider(
+            provider_key, "unknown:" + ",".join(sorted(unknown)),
+            "providers.%s: unknown config keys ignored: %s",
+            provider_key or "?", ", ".join(sorted(unknown)),
+        )
 
     normalized: Dict[str, Any] = {
         "name": name,

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import re
 from copy import deepcopy
 from typing import Any
 
@@ -67,6 +69,16 @@ def _coerce_int_or_none(value: Any) -> int | None:
     return n if n > 0 else None
 
 
+def _coerce_positive_float_or_none(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if result > 0 else None
+
+
 def _coerce_fanout(value: Any) -> str:
     """Normalize the fan-out cadence; unknown values fall back to default."""
     mode = str(value or "").strip().lower()
@@ -90,42 +102,101 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     return {"provider": provider, "model": model}
 
 
+def _clean_provider_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        name = str(item or "").strip().lower()
+        if name and name not in result:
+            result.append(name)
+    return result
+
+
+def _clean_slot_list(value: Any, excluded: set[str]) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, str]] = []
+    for item in value:
+        slot = _clean_slot(item)
+        if slot is None or slot["provider"].lower() in excluded:
+            continue
+        if slot not in result:
+            result.append(slot)
+    return result
+
+
 def _default_preset() -> dict[str, Any]:
     return {
         "reference_models": deepcopy(DEFAULT_MOA_REFERENCE_MODELS),
         "aggregator": deepcopy(DEFAULT_MOA_AGGREGATOR),
+        "fallback_aggregators": [],
         # None = temperature omitted from API calls (provider default),
         # matching single-model agent behavior.
         "reference_temperature": None,
         "aggregator_temperature": None,
         "max_tokens": 4096,
         "reference_max_tokens": None,
+        "context_length": None,
+        "max_advisors": None,
+        "max_reference_cost_usd": None,
+        "max_fanout_latency_seconds": None,
+        "circuit_breaker_seconds": 60.0,
+        "quota_cooldown_seconds": 900.0,
         "fanout": "per_iteration",
+        "auto_routes": {},
         "enabled": True,
     }
 
 
-def _normalize_preset(raw: Any) -> dict[str, Any]:
+def _clean_auto_routes(value: Any) -> dict[str, str]:
+    """Нормализовать необязательную таблицу маршрутов auto-пресета."""
+    if not isinstance(value, dict):
+        return {}
+    routes: dict[str, str] = {}
+    for key in ("fast", "balanced", "research", "code_heavy", "max"):
+        target = str(value.get(key) or "").strip()
+        if target:
+            routes[key] = target
+    return routes
+
+
+def _normalize_preset(raw: Any, excluded_providers: set[str] | None = None) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raw = {}
+    excluded = excluded_providers or set()
 
+    refs_explicitly_empty = raw.get("reference_models") == []
     raw_refs = raw.get("reference_models")
     if not isinstance(raw_refs, list):
         # A hand-edited scalar / single mapping (or a bad type) must degrade to
         # defaults instead of crashing the iteration, mirroring the tolerance
         # for the scalar fields below (reference_temperature / max_tokens).
         raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
-    refs = [_clean_slot(item) for item in raw_refs]
-    refs = [item for item in refs if item is not None]
-    if not refs:
-        refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)
+    cleaned_refs = [_clean_slot(item) for item in raw_refs]
+    cleaned_refs = [item for item in cleaned_refs if item is not None]
+    refs = [item for item in cleaned_refs if item["provider"].lower() not in excluded]
+    # Явный пустой список означает одиночный маршрут: агрегатор работает без
+    # fan-out. Отсутствующее/повреждённое значение сохраняет старый безопасный
+    # fallback на стандартных советников.
+    if not refs and not refs_explicitly_empty and not cleaned_refs:
+        refs = [
+            item for item in deepcopy(DEFAULT_MOA_REFERENCE_MODELS)
+            if item["provider"].lower() not in excluded
+        ]
 
-    aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
+    aggregator = _clean_slot(raw.get("aggregator"))
+    if aggregator and aggregator["provider"].lower() in excluded:
+        aggregator = None
+    if aggregator is None:
+        aggregator = deepcopy(DEFAULT_MOA_AGGREGATOR)
+    fallback_aggregators = _clean_slot_list(raw.get("fallback_aggregators"), excluded)
 
     return {
         "enabled": bool(raw.get("enabled", True)),
         "reference_models": refs,
         "aggregator": aggregator,
+        "fallback_aggregators": fallback_aggregators,
         "reference_temperature": _coerce_float_or_none(raw.get("reference_temperature")),
         "aggregator_temperature": _coerce_float_or_none(raw.get("aggregator_temperature")),
         "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
@@ -138,6 +209,22 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # judgement, so capping roughly halves per-turn wall time. Does NOT cap
         # the acting aggregator (its output is the user-visible answer).
         "reference_max_tokens": _coerce_int_or_none(raw.get("reference_max_tokens")),
+        # Полный рабочий бюджет хода (input + output). Для MoA он не должен
+        # превышать окно самого узкого постоянного советника.
+        "context_length": _coerce_int_or_none(raw.get("context_length")),
+        "max_advisors": _coerce_int_or_none(raw.get("max_advisors")),
+        "max_reference_cost_usd": _coerce_positive_float_or_none(
+            raw.get("max_reference_cost_usd")
+        ),
+        "max_fanout_latency_seconds": _coerce_positive_float_or_none(
+            raw.get("max_fanout_latency_seconds")
+        ),
+        "circuit_breaker_seconds": (
+            _coerce_positive_float_or_none(raw.get("circuit_breaker_seconds")) or 60.0
+        ),
+        "quota_cooldown_seconds": (
+            _coerce_positive_float_or_none(raw.get("quota_cooldown_seconds")) or 900.0
+        ),
         # When the reference fan-out runs. "per_iteration" (default) re-runs
         # the advisors whenever the advisory view changes — i.e. every tool
         # iteration, so advice tracks live task state. "user_turn" runs the
@@ -145,6 +232,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # aggregator gets their upfront plan-level advice, then acts alone
         # for the rest of the tool loop.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        "auto_routes": _clean_auto_routes(raw.get("auto_routes")),
     }
 
 
@@ -157,17 +245,20 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raw = {}
 
+    excluded_providers = _clean_provider_names(raw.get("excluded_providers"))
+    excluded_set = set(excluded_providers)
+
     presets_raw = raw.get("presets")
     presets: dict[str, dict[str, Any]] = {}
     if isinstance(presets_raw, dict):
         for name, preset in presets_raw.items():
             clean_name = str(name or "").strip()
             if clean_name:
-                presets[clean_name] = _normalize_preset(preset)
+                presets[clean_name] = _normalize_preset(preset, excluded_set)
 
     # Legacy flat config becomes the default preset.
     if not presets:
-        presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(raw)
+        presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(raw, excluded_set)
 
     default_name = str(raw.get("default_preset") or "").strip()
     if not default_name or default_name not in presets:
@@ -183,17 +274,247 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
     return {
         "default_preset": default_name,
         "active_preset": active_name,
+        "excluded_providers": excluded_providers,
         "presets": presets,
         # Compatibility/flattened view for existing dashboard/desktop callers.
         "reference_models": deepcopy(active["reference_models"]),
         "aggregator": deepcopy(active["aggregator"]),
+        "fallback_aggregators": deepcopy(active.get("fallback_aggregators") or []),
         "reference_temperature": active["reference_temperature"],
         "aggregator_temperature": active["aggregator_temperature"],
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
+        "context_length": active.get("context_length"),
+        "max_advisors": active.get("max_advisors"),
+        "max_reference_cost_usd": active.get("max_reference_cost_usd"),
+        "max_fanout_latency_seconds": active.get("max_fanout_latency_seconds"),
+        "circuit_breaker_seconds": active.get("circuit_breaker_seconds"),
+        "quota_cooldown_seconds": active.get("quota_cooldown_seconds"),
         "fanout": active.get("fanout", "per_iteration"),
         "enabled": active["enabled"],
     }
+
+
+def validate_moa_config(raw: Any) -> list[dict[str, str]]:
+    """Проверить связи пресетов без сетевых вызовов и раскрытия credentials."""
+    issues: list[dict[str, str]] = []
+    if not isinstance(raw, dict):
+        return [{"severity": "error", "code": "moa_not_mapping", "message": "moa must be a mapping"}]
+
+    excluded = set(_clean_provider_names(raw.get("excluded_providers")))
+    presets = raw.get("presets")
+    if not isinstance(presets, dict) or not presets:
+        return issues  # legacy flat config remains supported
+
+    for name, value in presets.items():
+        if not isinstance(value, dict):
+            issues.append({
+                "severity": "error", "code": "preset_not_mapping",
+                "message": f"preset {name!r} must be a mapping",
+            })
+            continue
+        refs = value.get("reference_models", [])
+        if not isinstance(refs, list):
+            issues.append({
+                "severity": "error", "code": "reference_models_not_list",
+                "message": f"preset {name!r} reference_models must be a list",
+            })
+            refs = []
+        seen: set[tuple[str, str]] = set()
+        for item in refs:
+            slot = _clean_slot(item)
+            if slot is None:
+                issues.append({
+                    "severity": "error", "code": "invalid_reference_slot",
+                    "message": f"preset {name!r} contains an invalid reference slot",
+                })
+                continue
+            key = (slot["provider"].lower(), slot["model"].lower())
+            if key in seen:
+                issues.append({
+                    "severity": "warning", "code": "duplicate_reference_slot",
+                    "message": f"preset {name!r} contains duplicate reference {slot['provider']}:{slot['model']}",
+                })
+            seen.add(key)
+            if key[0] in excluded:
+                issues.append({
+                    "severity": "warning", "code": "excluded_reference_provider",
+                    "message": f"preset {name!r} reference provider {slot['provider']} is excluded",
+                })
+
+        aggregator = _clean_slot(value.get("aggregator"))
+        if aggregator is None:
+            issues.append({
+                "severity": "error", "code": "invalid_aggregator_slot",
+                "message": f"preset {name!r} requires a valid aggregator",
+            })
+        elif aggregator["provider"].lower() in excluded:
+            issues.append({
+                "severity": "error", "code": "excluded_aggregator_provider",
+                "message": f"preset {name!r} aggregator provider {aggregator['provider']} is excluded",
+            })
+
+        for route, target in _clean_auto_routes(value.get("auto_routes")).items():
+            target_cfg = presets.get(target)
+            if not isinstance(target_cfg, dict) or not bool(target_cfg.get("enabled", True)):
+                issues.append({
+                    "severity": "error", "code": "invalid_auto_route",
+                    "message": f"preset {name!r} route {route!r} targets unavailable preset {target!r}",
+                })
+        for field in (
+            "max_advisors",
+            "max_reference_cost_usd",
+            "max_fanout_latency_seconds",
+            "circuit_breaker_seconds",
+            "quota_cooldown_seconds",
+        ):
+            if field in value and value.get(field) not in {None, ""}:
+                try:
+                    valid = float(value[field]) > 0
+                except (TypeError, ValueError):
+                    valid = False
+                if not valid:
+                    issues.append({
+                        "severity": "error",
+                        "code": "invalid_budget_value",
+                        "message": f"preset {name!r} field {field!r} must be positive",
+                    })
+    return issues
+
+
+def moa_config_revision(raw: Any) -> str:
+    """Вернуть стабильную revision для optimistic concurrency MoA-конфига."""
+    normalized = normalize_moa_config(raw)
+    payload = json.dumps(
+        normalized,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _slot_runtime_available(slot: dict[str, str]) -> bool:
+    """Проверить локальную runtime-конфигурацию, не выполняя модельный запрос."""
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=slot.get("provider"), target_model=slot.get("model")
+        )
+        # Одного синтаксически корректного endpoint недостаточно: OpenRouter
+        # может разрешиться в публичный base URL с пустым API key. Локальные
+        # no-auth providers уже получают от resolver SDK-заглушку
+        # ``no-key-required``, поэтому проверка auth carrier их не отключает.
+        has_auth = bool(runtime.get("api_key") or runtime.get("credential_pool"))
+        return bool(runtime.get("provider") and runtime.get("base_url") and has_auth)
+    except Exception:
+        return False
+
+
+def resolve_available_moa_preset(
+    preset: dict[str, Any], availability_check: Any = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Отфильтровать недоступных советников и выбрать безопасный агрегатор."""
+    check = availability_check or _slot_runtime_available
+    resolved = deepcopy(preset)
+    unavailable: list[str] = []
+    cooling_down: list[dict[str, Any]] = []
+
+    def slot_ready(slot: dict[str, str]) -> bool:
+        try:
+            from agent.moa_runtime import circuit_status
+
+            circuit = circuit_status(slot)
+        except Exception:
+            circuit = {"active": False}
+        if circuit.get("active"):
+            cooling_down.append({
+                "slot": f"{slot.get('provider')}:{slot.get('model')}",
+                "retry_after_seconds": int(circuit.get("retry_after_seconds") or 0),
+                "reason": str(circuit.get("reason") or "transient"),
+            })
+            return False
+        return bool(check(slot))
+
+    refs: list[dict[str, str]] = []
+    for slot in resolved.get("reference_models") or []:
+        if slot_ready(slot):
+            refs.append(slot)
+        else:
+            unavailable.append(f"reference:{slot['provider']}:{slot['model']}")
+    resolved["reference_models"] = refs
+
+    primary = resolved.get("aggregator") or {}
+    candidates = [primary, *(resolved.get("fallback_aggregators") or [])]
+    selected = next((slot for slot in candidates if slot and slot_ready(slot)), None)
+    if selected is None:
+        unavailable.append("aggregator:no_available_candidate")
+    elif selected != primary:
+        unavailable.append(f"aggregator:{primary.get('provider', '')}:{primary.get('model', '')}")
+        resolved["aggregator"] = selected
+        refs = [slot for slot in refs if slot != selected]
+        resolved["reference_models"] = refs
+
+    status = {
+        "degraded": bool(unavailable),
+        "unavailable": unavailable,
+        "reference_count": len(refs),
+        "aggregator_available": selected is not None,
+        "aggregator": (
+            f"{selected.get('provider')}:{selected.get('model')}" if selected else ""
+        ),
+        "configured_aggregator": (
+            f"{primary.get('provider')}:{primary.get('model')}" if primary else ""
+        ),
+        "fallback_used": bool(selected is not None and selected != primary),
+        "cooling_down": cooling_down,
+    }
+    return resolved, status
+
+
+def evaluate_moa_runtime_config(raw: Any) -> dict[str, Any]:
+    """Сформировать очищенный startup/status отчёт по всем включённым пресетам."""
+    cfg = normalize_moa_config(raw)
+    cache: dict[tuple[str, str], bool] = {}
+
+    def cached_check(slot: dict[str, str]) -> bool:
+        key = (slot.get("provider", ""), slot.get("model", ""))
+        if key not in cache:
+            cache[key] = _slot_runtime_available(slot)
+        return cache[key]
+
+    presets: dict[str, Any] = {}
+    for name, preset in cfg["presets"].items():
+        if not preset.get("enabled", True):
+            continue
+        _resolved, status = resolve_available_moa_preset(preset, cached_check)
+        presets[name] = status
+    return {
+        "degraded": any(item["degraded"] for item in presets.values()),
+        "presets": presets,
+        "validation_issues": validate_moa_config(raw),
+        "telemetry": _safe_moa_telemetry(),
+        "router_feedback": _safe_route_feedback(),
+    }
+
+
+def _safe_moa_telemetry() -> dict[str, Any]:
+    try:
+        from agent.moa_runtime import read_moa_telemetry
+
+        return read_moa_telemetry()
+    except Exception:
+        return {"events": 0, "presets": {}}
+
+
+def _safe_route_feedback() -> dict[str, Any]:
+    try:
+        from agent.moa_runtime import route_feedback_summary
+
+        return route_feedback_summary()
+    except Exception:
+        return {}
 
 
 def list_moa_presets(config: Any) -> list[str]:
@@ -208,6 +529,114 @@ def resolve_moa_preset(config: Any, name: str | None = None) -> dict[str, Any]:
     if preset is None:
         raise KeyError(preset_name)
     return deepcopy(preset)
+
+
+def _message_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            text = item.get("text") or item.get("content")
+            if isinstance(text, str):
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def classify_moa_auto_route(messages: Any) -> str:
+    """Выбрать семантический маршрут без дополнительного LLM-вызова.
+
+    Классификатор намеренно консервативен: специализированные дорогие маршруты
+    включаются только по ясным признакам, всё неоднозначное остаётся balanced.
+    """
+    user_texts: list[str] = []
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            text = _message_text(message.get("content")).strip()
+            if text and not text.startswith("[Mixture of Agents"):
+                user_texts.append(text)
+    if not user_texts:
+        return "balanced"
+
+    text = user_texts[-1]
+    if (
+        len(user_texts) > 1
+        and re.fullmatch(
+            r"\s*(продолжай|дальше|давай дальше|дожми|continue|go on|proceed)\s*[.!]?\s*",
+            text,
+            flags=re.IGNORECASE,
+        )
+    ):
+        text = user_texts[-2]
+    lowered = text.casefold()
+
+    if re.search(
+        r"(?:\b(?:preset|пресет|режим)\s*[:=-]?\s*max\b|"
+        r"максимальн(?:ое качество|ая глубина|о тщательно)|"
+        r"maximum quality|deepest possible)",
+        lowered,
+    ):
+        return "max"
+
+    if re.search(
+        r"(?:https?://|\b(?:web|internet|online|latest|current|news)\b|"
+        r"в интернете|актуальн|свеж(?:ие|ая|ую)|новост|"
+        r"с источниками|первичн(?:ые|ых) источник|официальн(?:ая|ую|ые) документац)",
+        lowered,
+    ):
+        return "research"
+
+    if re.search(
+        r"(?:\b(?:repo|repository|code|bug|fix|refactor|implement|pytest|test|"
+        r"lint|build|stack trace|traceback|api)\b|"
+        r"репозитор|код|баг|ошибк|исправ|рефактор|реализ|тест|сборк|архитектур|"
+        r"\.(?:py|ts|tsx|js|jsx|rs|go|java|kt|cs|cpp|c|yaml|yml|json|toml)\b)",
+        lowered,
+    ):
+        return "code_heavy"
+
+    if len(text) <= 220 and re.search(
+        r"(?:перевед|переформулир|сократи|исправь текст|форматир|одной строкой|"
+        r"кратко объясни|что значит|translate|rewrite|rephrase|format|one line|"
+        r"briefly explain)",
+        lowered,
+    ):
+        return "fast"
+    return "balanced"
+
+
+def resolve_moa_preset_for_messages(
+    config: Any, name: str | None, messages: Any
+) -> tuple[str, dict[str, Any]]:
+    """Разрешить обычный или настраиваемый auto-пресет для текущего хода."""
+    cfg = normalize_moa_config(config)
+    selected_name = str(name or cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME).strip()
+    selected = cfg["presets"].get(selected_name)
+    if selected is None:
+        raise KeyError(selected_name)
+
+    routes = selected.get("auto_routes") or {}
+    if not routes:
+        return selected_name, deepcopy(selected)
+
+    route_key = classify_moa_auto_route(messages)
+    try:
+        from agent.moa_runtime import apply_route_feedback
+
+        route_key = apply_route_feedback(route_key)
+    except Exception:
+        pass
+    target_name = routes.get(route_key) or routes.get("balanced")
+    target = cfg["presets"].get(target_name)
+    if not target or not target.get("enabled", True):
+        return selected_name, deepcopy(selected)
+    return target_name, deepcopy(target)
 
 
 def exact_moa_preset_name(config: Any, text: str) -> str | None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -973,27 +973,69 @@ class MoaModelSlot(BaseModel):
 class MoaPresetPayload(BaseModel):
     reference_models: list[MoaModelSlot] = []
     aggregator: MoaModelSlot = MoaModelSlot()
+    fallback_aggregators: list[MoaModelSlot] = []
     # None = temperature omitted from API calls (provider default), matching
     # single-model agent behavior.
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
+    reference_max_tokens: Optional[int] = None
+    context_length: Optional[int] = None
+    max_advisors: Optional[int] = None
+    max_reference_cost_usd: Optional[float] = None
+    max_fanout_latency_seconds: Optional[float] = None
+    circuit_breaker_seconds: Optional[float] = None
+    quota_cooldown_seconds: Optional[float] = None
+    fanout: str = "per_iteration"
+    auto_routes: dict[str, str] = {}
     enabled: bool = True
 
 
 class MoaConfigPayload(BaseModel):
+    revision: str = ""
     default_preset: str = "default"
     active_preset: str = ""
+    excluded_providers: list[str] = []
     presets: dict[str, MoaPresetPayload] = {}
     # Backward-compatible flat payload fields used by older dashboard/desktop
     # clients during this PR's transition window.
     reference_models: list[MoaModelSlot] = []
     aggregator: MoaModelSlot = MoaModelSlot()
+    fallback_aggregators: list[MoaModelSlot] = []
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
+    reference_max_tokens: Optional[int] = None
+    context_length: Optional[int] = None
+    max_advisors: Optional[int] = None
+    max_reference_cost_usd: Optional[float] = None
+    max_fanout_latency_seconds: Optional[float] = None
+    circuit_breaker_seconds: Optional[float] = None
+    quota_cooldown_seconds: Optional[float] = None
+    fanout: str = "per_iteration"
+    auto_routes: dict[str, str] = {}
     enabled: bool = True
     profile: Optional[str] = None
+
+
+class MoaRouteFeedbackPayload(BaseModel):
+    suggested_route: str
+    chosen_route: str
+    profile: Optional[str] = None
+
+
+def _pydantic_fields_set(model: BaseModel) -> set[str]:
+    """Вернуть явно переданные поля без deprecated API Pydantic v2."""
+    if hasattr(model, "model_fields_set"):
+        return set(model.model_fields_set)
+    return set(getattr(model, "__fields_set__", set()))
+
+
+def _pydantic_dump(model: BaseModel) -> dict[str, Any]:
+    """Сериализовать модель Pydantic v1/v2 через актуальный public API."""
+    if hasattr(model, "model_dump"):
+        return model.model_dump()
+    return model.dict()
 
 
 def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, str]:
@@ -5513,11 +5555,22 @@ def get_auxiliary_models(profile: Optional[str] = None):
 def get_moa_models(profile: Optional[str] = None):
     """Return the configured Mixture-of-Agents provider/model slots."""
     try:
-        from hermes_cli.moa_config import normalize_moa_config
+        from hermes_cli.moa_config import (
+            evaluate_moa_runtime_config,
+            moa_config_revision,
+            normalize_moa_config,
+            validate_moa_config,
+        )
 
         with _profile_scope(profile):
             cfg = load_config()
-            return normalize_moa_config(cfg.get("moa") if isinstance(cfg, dict) else {})
+            raw = cfg.get("moa") if isinstance(cfg, dict) else {}
+            return {
+                **normalize_moa_config(raw),
+                "revision": moa_config_revision(raw),
+                "runtime_status": evaluate_moa_runtime_config(raw),
+                "validation_issues": validate_moa_config(raw),
+            }
     except HTTPException:
         raise
     except Exception:
@@ -5529,44 +5582,153 @@ def get_moa_models(profile: Optional[str] = None):
 def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
     """Persist the Mixture-of-Agents provider/model slots."""
     try:
-        from hermes_cli.moa_config import normalize_moa_config
+        from hermes_cli.moa_config import (
+            evaluate_moa_runtime_config,
+            moa_config_revision,
+            normalize_moa_config,
+            validate_moa_config,
+        )
 
         with _profile_scope(body.profile or profile):
             cfg = load_config()
+            existing_moa = cfg.get("moa") if isinstance(cfg.get("moa"), dict) else {}
+            current_revision = moa_config_revision(existing_moa)
+            if body.revision and body.revision != current_revision:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "moa_revision_conflict",
+                        "message": "MoA config changed since it was loaded; refresh before saving",
+                        "current_revision": current_revision,
+                    },
+                )
+            body_fields = _pydantic_fields_set(body)
+            excluded_providers = (
+                body.excluded_providers
+                if "excluded_providers" in body_fields
+                else existing_moa.get("excluded_providers", [])
+            )
             if body.presets:
+                existing_presets = existing_moa.get("presets") or {}
+                merged_presets: dict[str, dict[str, Any]] = {}
+                for name, preset in body.presets.items():
+                    preset_fields = _pydantic_fields_set(preset)
+                    existing_preset = existing_presets.get(name) or {}
+
+                    def supplied_or_existing(field: str, value: Any) -> Any:
+                        return value if field in preset_fields else existing_preset.get(field, value)
+
+                    fallback_slots = supplied_or_existing(
+                        "fallback_aggregators", preset.fallback_aggregators
+                    )
+                    merged_presets[name] = {
+                        "reference_models": [
+                            _pydantic_dump(slot) for slot in preset.reference_models
+                        ],
+                        "aggregator": _pydantic_dump(preset.aggregator),
+                        "fallback_aggregators": [
+                            _pydantic_dump(slot) if isinstance(slot, BaseModel) else dict(slot)
+                            for slot in fallback_slots
+                        ],
+                        "reference_temperature": preset.reference_temperature,
+                        "aggregator_temperature": preset.aggregator_temperature,
+                        "max_tokens": preset.max_tokens,
+                        "reference_max_tokens": supplied_or_existing(
+                            "reference_max_tokens", preset.reference_max_tokens
+                        ),
+                        "context_length": supplied_or_existing(
+                            "context_length", preset.context_length
+                        ),
+                        "max_advisors": supplied_or_existing(
+                            "max_advisors", preset.max_advisors
+                        ),
+                        "max_reference_cost_usd": supplied_or_existing(
+                            "max_reference_cost_usd", preset.max_reference_cost_usd
+                        ),
+                        "max_fanout_latency_seconds": supplied_or_existing(
+                            "max_fanout_latency_seconds", preset.max_fanout_latency_seconds
+                        ),
+                        "circuit_breaker_seconds": supplied_or_existing(
+                            "circuit_breaker_seconds", preset.circuit_breaker_seconds
+                        ),
+                        "quota_cooldown_seconds": supplied_or_existing(
+                            "quota_cooldown_seconds", preset.quota_cooldown_seconds
+                        ),
+                        "fanout": supplied_or_existing("fanout", preset.fanout),
+                        "auto_routes": supplied_or_existing(
+                            "auto_routes", preset.auto_routes
+                        ),
+                        "enabled": preset.enabled,
+                    }
                 raw = {
                     "default_preset": body.default_preset,
                     "active_preset": body.active_preset,
-                    "presets": {
-                        name: {
-                            "reference_models": [slot.dict() for slot in preset.reference_models],
-                            "aggregator": preset.aggregator.dict(),
-                            "reference_temperature": preset.reference_temperature,
-                            "aggregator_temperature": preset.aggregator_temperature,
-                            "max_tokens": preset.max_tokens,
-                            "enabled": preset.enabled,
-                        }
-                        for name, preset in body.presets.items()
-                    },
+                    "excluded_providers": excluded_providers,
+                    "presets": merged_presets,
                 }
             else:
                 raw = {
-                    "reference_models": [slot.dict() for slot in body.reference_models],
-                    "aggregator": body.aggregator.dict(),
+                    "excluded_providers": excluded_providers,
+                    "reference_models": [_pydantic_dump(slot) for slot in body.reference_models],
+                    "aggregator": _pydantic_dump(body.aggregator),
+                    "fallback_aggregators": [_pydantic_dump(slot) for slot in body.fallback_aggregators],
                     "reference_temperature": body.reference_temperature,
                     "aggregator_temperature": body.aggregator_temperature,
                     "max_tokens": body.max_tokens,
+                    "reference_max_tokens": body.reference_max_tokens,
+                    "context_length": body.context_length,
+                    "max_advisors": body.max_advisors,
+                    "max_reference_cost_usd": body.max_reference_cost_usd,
+                    "max_fanout_latency_seconds": body.max_fanout_latency_seconds,
+                    "circuit_breaker_seconds": body.circuit_breaker_seconds,
+                    "quota_cooldown_seconds": body.quota_cooldown_seconds,
+                    "fanout": body.fanout,
+                    "auto_routes": body.auto_routes,
                     "enabled": body.enabled,
                 }
+            validation_issues = validate_moa_config(raw)
+            errors = [item for item in validation_issues if item.get("severity") == "error"]
+            if errors:
+                raise HTTPException(status_code=422, detail={"issues": errors})
             normalized = normalize_moa_config(raw)
             cfg["moa"] = normalized
             save_config(cfg)
-            return {"ok": True, **normalized}
+            return {
+                "ok": True,
+                **normalized,
+                "revision": moa_config_revision(normalized),
+                "runtime_status": evaluate_moa_runtime_config(normalized),
+                "validation_issues": validation_issues,
+            }
     except HTTPException:
         raise
     except Exception:
         _log.exception("PUT /api/model/moa failed")
         raise HTTPException(status_code=500, detail="Failed to save MoA config")
+
+
+@app.post("/api/model/moa/feedback")
+def record_moa_router_feedback(
+    body: MoaRouteFeedbackPayload, profile: Optional[str] = None,
+):
+    """Записать только route feedback без сохранения prompts и outputs."""
+    try:
+        from agent.moa_runtime import record_route_feedback
+
+        with _profile_scope(body.profile or profile):
+            return {
+                "ok": True,
+                "router_feedback": record_route_feedback(
+                    body.suggested_route, body.chosen_route
+                ),
+            }
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/model/moa/feedback failed")
+        raise HTTPException(status_code=500, detail="Failed to save MoA route feedback")
 
 
 @app.post("/api/model/set")
@@ -5932,7 +6094,9 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
             # frontend can only overwrite what it explicitly sends.
             existing = read_raw_config()
             incoming = _denormalize_config_from_web(body.config)
-            save_config(_deep_merge(existing, incoming))
+            merged = _deep_merge(existing, incoming)
+            _normalize_embedded_moa_config(merged)
+            save_config(merged)
         return {"ok": True}
     except HTTPException:
         raise
@@ -13898,6 +14062,22 @@ class RawConfigUpdate(BaseModel):
     profile: Optional[str] = None
 
 
+def _normalize_embedded_moa_config(config: dict[str, Any]) -> None:
+    """Канонизировать MoA независимо от того, какой config endpoint выполняет запись."""
+    raw = config.get("moa")
+    if not isinstance(raw, dict):
+        return
+    from hermes_cli.moa_config import normalize_moa_config, validate_moa_config
+
+    errors = [
+        issue for issue in validate_moa_config(raw)
+        if issue.get("severity") == "error"
+    ]
+    if errors:
+        raise HTTPException(status_code=422, detail={"issues": errors})
+    config["moa"] = normalize_moa_config(raw)
+
+
 @app.get("/api/config/raw")
 async def get_config_raw(profile: Optional[str] = None):
     """Raw config.yaml text plus its resolved path.
@@ -13921,6 +14101,7 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
         if not isinstance(parsed, dict):
             raise HTTPException(status_code=400, detail="YAML must be a mapping")
         with _profile_scope(body.profile or profile):
+            _normalize_embedded_moa_config(parsed)
             save_config(parsed)
         return {"ok": True}
     except yaml.YAMLError as e:
@@ -17007,6 +17188,21 @@ def start_server(
         start_nous_auth_keepalive()
     except Exception as exc:
         _log.debug("Nous auth keepalive did not start: %s", exc)
+
+    try:
+        from hermes_cli.moa_config import evaluate_moa_runtime_config
+
+        moa_status = evaluate_moa_runtime_config(load_config().get("moa") or {})
+        if moa_status.get("degraded"):
+            degraded = [
+                name for name, status in moa_status.get("presets", {}).items()
+                if status.get("degraded")
+            ]
+            _log.warning("MoA startup validation: degraded presets=%s", ",".join(degraded))
+        else:
+            _log.info("MoA startup validation: all enabled presets ready")
+    except Exception as exc:
+        _log.warning("MoA startup validation failed safely: %s", type(exc).__name__)
 
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
     # injection / WS-auth paths can branch on it consistently.  Phase 3.5

--- a/scripts/moa_benchmark.py
+++ b/scripts/moa_benchmark.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Локальный воспроизводимый benchmark маршрутизации и готовности MoA.
+
+По умолчанию не выполняет модельных запросов. Live-режим требует одновременно
+``--live`` и ``--confirm-live``, запрещает MoA traces, проверяет суммарный
+reference budget до первого provider call и сохраняет только обезличенные
+метрики и hash ответа.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.config import load_config, reload_env
+from hermes_cli.moa_config import (
+    classify_moa_auto_route,
+    evaluate_moa_runtime_config,
+    resolve_moa_preset_for_messages,
+    validate_moa_config,
+)
+
+
+CASES = [
+    ("translate", "Translate this short sentence into Spanish.", "fast"),
+    ("rewrite", "Rewrite this paragraph in one concise sentence.", "fast"),
+    ("format", "Format these three values as a Markdown table.", "fast"),
+    ("current_docs", "Check the latest official API documentation and cite sources.", "research"),
+    ("news", "Find current news about this product and compare primary sources.", "research"),
+    ("paper", "Research this paper online and verify its main claim.", "research"),
+    ("bug", "Fix the bug in parser.py and run targeted tests.", "code_heavy"),
+    ("refactor", "Refactor this TypeScript API without changing its public contract.", "code_heavy"),
+    ("traceback", "Diagnose this traceback and implement a verified fix.", "code_heavy"),
+    ("architecture", "Review the repository architecture and propose a migration.", "code_heavy"),
+    ("max_explicit", "Use preset max and provide the deepest possible analysis.", "max"),
+    ("maximum_quality", "I need maximum quality and the most thorough cross-check.", "max"),
+    ("product_plan", "Prepare a practical launch plan for a new market.", "balanced"),
+    ("decision", "Compare these options and recommend one with tradeoffs.", "balanced"),
+    ("analysis", "Analyze the proposal and identify the main risks.", "balanced"),
+    ("summary", "Summarize the supplied report and suggest next actions.", "balanced"),
+    ("email", "Draft a professional response to this customer request.", "balanced"),
+    ("strategy", "Develop a strategy for improving retention next quarter.", "balanced"),
+    ("requirements", "Turn this idea into a clear implementation plan.", "balanced"),
+    ("review", "Review this decision memo for weak assumptions.", "balanced"),
+]
+LIVE_CASE_IDS = ["translate", "current_docs", "bug", "max_explicit", "product_plan"]
+DEFAULT_REFERENCE_BUDGET_USD = 0.75
+
+
+def _response_text(response: Any) -> str:
+    try:
+        return str(response.choices[0].message.content or "")
+    except Exception:
+        return ""
+
+
+def selected_live_cases(max_cases: int) -> list[tuple[str, str, str]]:
+    """Вернуть стабильный ограниченный набор только синтетических кейсов."""
+    limit = max(1, min(int(max_cases), len(LIVE_CASE_IDS)))
+    return [case for case in CASES if case[0] in LIVE_CASE_IDS][:limit]
+
+
+def validate_live_preflight(
+    config: dict[str, Any],
+    preset: str,
+    max_cases: int,
+    reference_budget_usd: float = DEFAULT_REFERENCE_BUDGET_USD,
+) -> dict[str, Any]:
+    """Fail closed до provider call, если budget/privacy нельзя доказать."""
+    if bool(config.get("save_traces", False)):
+        raise ValueError(
+            "live benchmark requires moa.save_traces=false because responses "
+            "must not be persisted"
+        )
+    if not math.isfinite(reference_budget_usd) or reference_budget_usd < 0:
+        raise ValueError("reference budget must be finite and non-negative")
+
+    errors = [
+        issue
+        for issue in validate_moa_config(config)
+        if issue.get("severity") == "error"
+    ]
+    if errors:
+        raise ValueError("MoA config has validation errors")
+
+    allocations = []
+    total = 0.0
+    for case_id, prompt, _expected in selected_live_cases(max_cases):
+        try:
+            resolved_name, resolved = resolve_moa_preset_for_messages(
+                config,
+                preset,
+                [{"role": "user", "content": prompt}],
+            )
+        except KeyError as exc:
+            raise ValueError(f"unknown MoA preset: {preset}") from exc
+        references = resolved.get("reference_models") or []
+        configured_cap = resolved.get("max_reference_cost_usd")
+        if references and configured_cap is None:
+            raise ValueError(
+                f"preset {resolved_name!r} has references but no "
+                "max_reference_cost_usd"
+            )
+        case_budget = float(configured_cap or 0.0)
+        total += case_budget
+        allocations.append({
+            "id": case_id,
+            "resolved_preset": resolved_name,
+            "reference_budget_usd": round(case_budget, 6),
+        })
+
+    if total > reference_budget_usd + 1e-9:
+        raise ValueError(
+            f"planned reference budget ${total:.6f} exceeds limit "
+            f"${reference_budget_usd:.6f}"
+        )
+    return {
+        "planned_reference_budget_usd": round(total, 6),
+        "reference_budget_limit_usd": round(float(reference_budget_usd), 6),
+        "cases": allocations,
+        "save_traces": False,
+    }
+
+
+def run_dry(config: dict[str, Any]) -> dict[str, Any]:
+    rows = []
+    for case_id, prompt, expected in CASES:
+        predicted = classify_moa_auto_route([{"role": "user", "content": prompt}])
+        rows.append({
+            "id": case_id,
+            "expected": expected,
+            "predicted": predicted,
+            "pass": predicted == expected,
+        })
+    runtime = evaluate_moa_runtime_config(config)
+    passed = sum(int(row["pass"]) for row in rows)
+    return {
+        "mode": "dry-run",
+        "cases": len(rows),
+        "route_accuracy": round(passed / max(1, len(rows)), 4),
+        "route_failures": [row for row in rows if not row["pass"]],
+        "validation_issues": validate_moa_config(config),
+        "runtime_degraded": runtime["degraded"],
+        "degraded_presets": [
+            name for name, status in runtime["presets"].items() if status["degraded"]
+        ],
+    }
+
+
+def run_live(config: dict[str, Any], preset: str, max_cases: int) -> dict[str, Any]:
+    from agent.moa_loop import MoAChatCompletions
+
+    rows = []
+    live_cases = selected_live_cases(max_cases)
+    for case_id, prompt, expected in live_cases:
+        resolved_name, _resolved = resolve_moa_preset_for_messages(
+            config,
+            preset,
+            [{"role": "user", "content": prompt}],
+        )
+        started = time.monotonic()
+        facade = MoAChatCompletions(preset)
+        try:
+            response = facade.create(
+                messages=[{"role": "user", "content": prompt}],
+                tools=None,
+                stream=False,
+            )
+            text = _response_text(response)
+            status = "ok" if text.strip() else "empty"
+        except Exception as exc:
+            text = ""
+            status = f"error:{type(exc).__name__}"
+        rows.append({
+            "id": case_id,
+            "expected_route": expected,
+            "resolved_preset": resolved_name,
+            "status": status,
+            "latency_ms": int((time.monotonic() - started) * 1000),
+            "response_chars": len(text),
+            "response_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest()[:16] if text else "",
+            "runtime": facade.last_runtime_status,
+        })
+    return {
+        "mode": "live",
+        "preset": preset,
+        "cases": len(rows),
+        "successful": sum(int(row["status"] == "ok") for row in rows),
+        "results": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--confirm-live", action="store_true")
+    parser.add_argument("--preset", default="auto")
+    parser.add_argument("--max-cases", type=int, default=3)
+    parser.add_argument(
+        "--reference-budget-usd",
+        type=float,
+        default=DEFAULT_REFERENCE_BUDGET_USD,
+        help="maximum summed per-preset reference budget for this live run",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    reload_env()
+    config = load_config().get("moa") or {}
+    if args.live and not args.confirm_live:
+        parser.error("--live requires --confirm-live because it performs billed/provider requests")
+    if args.live:
+        try:
+            preflight = validate_live_preflight(
+                config,
+                args.preset,
+                args.max_cases,
+                args.reference_budget_usd,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        result = run_live(config, args.preset, args.max_cases)
+        result["preflight"] = preflight
+    else:
+        result = run_dry(config)
+    rendered = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    if any(
+        issue.get("severity") == "error"
+        for issue in result.get("validation_issues", [])
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -260,6 +260,8 @@ def _run_one_file(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         # skipping writing bytecode because we're running a bunch of parallel python processes on the same code
         env={**os.environ, 'PYTHONDONTWRITEBYTECODE': '1'},
         # POSIX: place the child at the head of its own process group so

--- a/tests/agent/test_moa_aggregator_cost_slot.py
+++ b/tests/agent/test_moa_aggregator_cost_slot.py
@@ -17,6 +17,15 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _mock_moa_runtime_availability(monkeypatch):
+    """Cost tests mock call_llm and therefore do not exercise provider auth."""
+    monkeypatch.setattr(
+        "hermes_cli.moa_config._slot_runtime_available",
+        lambda _slot: True,
+    )
+
+
 def _response(content="ok"):
     message = SimpleNamespace(content=content, tool_calls=[])
     choice = SimpleNamespace(message=message, finish_reason="stop")

--- a/tests/agent/test_moa_runtime.py
+++ b/tests/agent/test_moa_runtime.py
@@ -1,0 +1,77 @@
+import json
+import os
+from pathlib import Path
+from decimal import Decimal
+
+import pytest
+
+from agent.moa_runtime import (
+    apply_route_feedback,
+    circuit_status,
+    mark_slot_failure,
+    mark_slot_success,
+    read_moa_telemetry,
+    record_moa_telemetry,
+    record_route_feedback,
+    reset_runtime_state_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    reset_runtime_state_for_tests()
+    yield
+    reset_runtime_state_for_tests()
+
+
+class RateLimitError(Exception):
+    status_code = 429
+
+
+def test_circuit_breaker_opens_and_success_closes_it():
+    slot = {"provider": "xai-oauth", "model": "grok-4.5"}
+
+    opened = mark_slot_failure(slot, RateLimitError("rate limit"), cooldown_seconds=20)
+
+    assert opened["active"] is True
+    assert opened["reason"] == "rate_limit"
+    assert circuit_status(slot)["retry_after_seconds"] > 0
+
+    mark_slot_success(slot)
+    assert circuit_status(slot)["active"] is False
+
+
+def test_telemetry_drops_content_and_error_text():
+    record_moa_telemetry({
+        "preset": "max",
+        "status": "ok",
+        "aggregator": "openai-codex:gpt-5.6-sol",
+        "latency_ms": 1200,
+        "reference_cost_usd": Decimal("0.125"),
+        "prompt": "private prompt",
+        "output": "private output",
+        "error": "secret exception",
+    })
+
+    summary = read_moa_telemetry()
+    assert summary["events"] == 1
+    assert summary["presets"]["max"]["average_latency_ms"] == 1200
+    assert summary["presets"]["max"]["known_reference_cost_usd"] == 0.125
+
+    path = Path(os.environ["HERMES_HOME"]) / "logs" / "moa_runtime.jsonl"
+    raw = path.read_text(encoding="utf-8")
+    assert "private prompt" not in raw
+    assert "private output" not in raw
+    assert "secret exception" not in raw
+
+
+def test_route_feedback_changes_route_only_after_stable_signal():
+    assert apply_route_feedback("balanced") == "balanced"
+    for _ in range(3):
+        record_route_feedback("balanced", "research")
+
+    assert apply_route_feedback("balanced") == "research"
+    feedback_path = Path(os.environ["HERMES_HOME"]) / "state" / "moa_router_feedback.json"
+    data = json.loads(feedback_path.read_text(encoding="utf-8"))
+    assert data == {"routes": {"balanced": {"research": 3}}}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -296,6 +296,30 @@ class TestDefaultContextLengths:
             assert get_model_context_length("glm-5") == 202752
             assert get_model_context_length("glm-5.1") == 202752
 
+    def test_moa_preset_context_length_overrides_aggregator_window(self):
+        """MoA использует рабочий бюджет пресета, а не максимум агрегатора."""
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        config = {
+            "moa": {
+                "presets": {
+                    "balanced": {
+                        "reference_models": [
+                            {"provider": "xai-oauth", "model": "grok-4.5"}
+                        ],
+                        "aggregator": {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.6-terra",
+                        },
+                        "context_length": 372000,
+                    }
+                }
+            }
+        }
+        with mock_patch("hermes_cli.config.load_config", return_value=config):
+            assert get_model_context_length("balanced", provider="moa") == 372000
+
     def test_openrouter_live_metadata_beats_hardcoded_catchall(self):
         """OpenRouter-routed slugs resolve via the live OR catalog before the
         hardcoded family catch-all.

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -2,12 +2,18 @@ from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
     DEFAULT_MOA_REFERENCE_MODELS,
+    _slot_runtime_available,
     build_moa_turn_prompt,
+    classify_moa_auto_route,
     decode_moa_turn,
     exact_moa_preset_name,
+    moa_config_revision,
     normalize_moa_config,
+    resolve_available_moa_preset,
     resolve_moa_preset,
+    resolve_moa_preset_for_messages,
     set_active_moa_preset,
+    validate_moa_config,
 )
 
 
@@ -87,6 +93,21 @@ def test_normalize_moa_config_tolerates_non_list_reference_models():
         {"presets": {"broken": {"reference_models": 2}}}
     )
     assert cfg["presets"]["broken"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+
+
+def test_normalize_moa_config_preserves_explicit_empty_reference_models():
+    """Явный пустой список создаёт одиночный маршрут без скрытого fan-out."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "fast": {
+                    "reference_models": [],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+                }
+            }
+        }
+    )
+    assert cfg["presets"]["fast"]["reference_models"] == []
 
 
 def test_normalize_moa_config_wraps_bare_dict_reference_models():
@@ -178,6 +199,74 @@ def test_resolve_moa_preset_returns_requested_model_set():
     assert resolve_moa_preset(cfg, "review")["reference_models"] == [
         {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
     ]
+
+
+def test_classify_moa_auto_route_is_conservative_and_task_aware():
+    cases = {
+        "Переведи эту фразу на английский": "fast",
+        "Проверь актуальные официальные источники и дай ссылки": "research",
+        "Исправь баг в parser.py и запусти тесты": "code_heavy",
+        "Используй режим max, нужна максимальная глубина": "max",
+        "Подготовь план запуска продукта на новый рынок": "balanced",
+    }
+    for prompt, expected in cases.items():
+        assert classify_moa_auto_route([{"role": "user", "content": prompt}]) == expected
+
+
+def test_classify_moa_auto_route_continuation_keeps_previous_task_kind():
+    messages = [
+        {"role": "user", "content": "Исправь архитектурную ошибку в репозитории"},
+        {"role": "assistant", "content": "Начинаю."},
+        {"role": "user", "content": "Продолжай"},
+    ]
+    assert classify_moa_auto_route(messages) == "code_heavy"
+
+
+def test_resolve_moa_preset_for_messages_uses_configured_auto_routes():
+    cfg = {
+        "default_preset": "auto",
+        "presets": {
+            "auto": {
+                "reference_models": [{"provider": "xai-oauth", "model": "grok-4.5"}],
+                "auto_routes": {
+                    "fast": "quick",
+                    "balanced": "normal",
+                    "research": "sources",
+                    "code_heavy": "coding",
+                    "max": "deep",
+                },
+            },
+            "quick": {"reference_models": []},
+            "normal": {"reference_models": []},
+            "sources": {"reference_models": []},
+            "coding": {"reference_models": []},
+            "deep": {"reference_models": []},
+        },
+    }
+    name, preset = resolve_moa_preset_for_messages(
+        cfg,
+        "auto",
+        [{"role": "user", "content": "Реализуй поддержку нового API и тесты"}],
+    )
+    assert name == "coding"
+    assert preset["reference_models"] == []
+
+
+def test_resolve_moa_preset_for_messages_leaves_regular_preset_unchanged():
+    cfg = {
+        "presets": {
+            "balanced": {
+                "reference_models": [{"provider": "xai-oauth", "model": "grok-4.5"}],
+            }
+        }
+    }
+    name, preset = resolve_moa_preset_for_messages(
+        cfg,
+        "balanced",
+        [{"role": "user", "content": "Проверь свежие новости"}],
+    )
+    assert name == "balanced"
+    assert preset["reference_models"] == [{"provider": "xai-oauth", "model": "grok-4.5"}]
 
 
 def test_build_moa_turn_prompt_encodes_one_shot_default_preset():
@@ -281,3 +370,136 @@ def test_reference_max_tokens_in_flattened_view():
     active preset's reference_max_tokens."""
     cfg = normalize_moa_config(_preset(reference_max_tokens=750))
     assert cfg["reference_max_tokens"] == 750
+
+
+def test_context_length_is_normalized_and_exposed_in_flattened_view():
+    cfg = normalize_moa_config(_preset(context_length="450000"))
+    assert cfg["presets"]["p"]["context_length"] == 450000
+    assert cfg["context_length"] == 450000
+
+
+def test_invalid_context_length_falls_back_to_auto_detection():
+    for bad in (0, -1, "invalid", "", None):
+        preset = resolve_moa_preset(_preset(context_length=bad), "p")
+        assert preset["context_length"] is None, bad
+
+
+def test_excluded_provider_is_removed_without_restoring_default_fanout():
+    cfg = normalize_moa_config({
+        "excluded_providers": ["antigravity_cli"],
+        "presets": {
+            "max": {
+                "reference_models": [
+                    {"provider": "antigravity_cli", "model": "legacy"},
+                    {"provider": "openrouter", "model": "z-ai/glm-5.2"},
+                ],
+                "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+            },
+        },
+    })
+
+    assert cfg["excluded_providers"] == ["antigravity_cli"]
+    assert cfg["presets"]["max"]["reference_models"] == [
+        {"provider": "openrouter", "model": "z-ai/glm-5.2"},
+    ]
+
+
+def test_runtime_resolution_uses_available_fallback_and_deduplicates_reference():
+    preset = {
+        "reference_models": [
+            {"provider": "xai-oauth", "model": "grok-4.5"},
+            {"provider": "openrouter", "model": "z-ai/glm-5.2"},
+        ],
+        "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+        "fallback_aggregators": [
+            {"provider": "xai-oauth", "model": "grok-4.5"},
+        ],
+    }
+
+    resolved, status = resolve_available_moa_preset(
+        preset,
+        availability_check=lambda slot: slot["provider"] == "xai-oauth",
+    )
+
+    assert resolved["aggregator"] == {"provider": "xai-oauth", "model": "grok-4.5"}
+    assert resolved["reference_models"] == []
+    assert status["degraded"] is True
+    assert status["aggregator_available"] is True
+    assert status["aggregator"] == "xai-oauth:grok-4.5"
+    assert status["configured_aggregator"] == "openai-codex:gpt-5.6-sol"
+    assert status["fallback_used"] is True
+    assert all("xai-oauth:grok-4.5" not in item for item in status["unavailable"])
+
+
+def test_validator_rejects_excluded_aggregator_and_broken_auto_route():
+    issues = validate_moa_config({
+        "excluded_providers": ["antigravity_cli"],
+        "presets": {
+            "auto": {
+                "reference_models": [],
+                "aggregator": {"provider": "antigravity_cli", "model": "legacy"},
+                "auto_routes": {"research": "missing"},
+            },
+        },
+    })
+
+    error_codes = {
+        item["code"] for item in issues if item["severity"] == "error"
+    }
+    assert error_codes == {"excluded_aggregator_provider", "invalid_auto_route"}
+
+
+def test_runtime_availability_rejects_endpoint_without_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "",
+        },
+    )
+
+    assert _slot_runtime_available({
+        "provider": "openrouter",
+        "model": "z-ai/glm-5.2",
+    }) is False
+
+
+def test_budget_and_circuit_fields_are_normalized():
+    cfg = normalize_moa_config({
+        "presets": {
+            "bounded": {
+                "reference_models": [],
+                "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+                "max_advisors": "2",
+                "max_reference_cost_usd": "0.25",
+                "max_fanout_latency_seconds": "15",
+                "circuit_breaker_seconds": "45",
+                "quota_cooldown_seconds": "600",
+            },
+        },
+    })
+    preset = cfg["presets"]["bounded"]
+
+    assert preset["max_advisors"] == 2
+    assert preset["max_reference_cost_usd"] == 0.25
+    assert preset["max_fanout_latency_seconds"] == 15.0
+    assert preset["circuit_breaker_seconds"] == 45.0
+    assert preset["quota_cooldown_seconds"] == 600.0
+
+
+def test_revision_is_stable_and_changes_with_config():
+    base = {
+        "presets": {
+            "p": {
+                "reference_models": [],
+                "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+            },
+        },
+    }
+    same = normalize_moa_config(base)
+    changed = normalize_moa_config(base)
+    changed["presets"]["p"]["max_advisors"] = 1
+
+    assert moa_config_revision(base) == moa_config_revision(same)
+    assert moa_config_revision(base) != moa_config_revision(changed)

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -186,6 +186,25 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is None
 
+    def test_builtin_provider_entry_without_url_does_not_warn(self, caplog):
+        """Built-in settings are not malformed custom-provider entries."""
+        entry = {
+            "enabled": True,
+            "auth_type": "oauth",
+            "max_concurrency": 2,
+            "timeout_sec": 30,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(
+                entry,
+                provider_key="antigravity_cli",
+            )
+        assert result is None
+        assert not any(
+            "unknown config keys" in record.message.lower()
+            for record in caplog.records
+        )
+
     def test_no_name_returns_none(self):
         """Entry with no name and no provider_key should return None."""
         entry = {

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -789,6 +789,8 @@ class TestWebServerEndpoints:
         assert data["reference_models"]
         assert all(set(slot) == {"provider", "model"} for slot in data["reference_models"])
         assert set(data["aggregator"]) == {"provider", "model"}
+        assert len(data["revision"]) == 16
+        assert "telemetry" in data["runtime_status"]
 
     def test_put_moa_models_persists_provider_model_slots(self):
         from hermes_cli.config import load_config
@@ -811,6 +813,179 @@ class TestWebServerEndpoints:
         cfg = load_config()
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
+
+    def test_put_named_moa_presets_round_trips_routing_and_context_fields(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "default_preset": "auto",
+            "active_preset": "auto",
+            "excluded_providers": ["antigravity_cli"],
+            "presets": {
+                "auto": {
+                    "reference_models": [{"provider": "xai-oauth", "model": "grok-4.5"}],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+                    "fallback_aggregators": [
+                        {"provider": "xai-oauth", "model": "grok-4.5"},
+                    ],
+                    "reference_temperature": 0.35,
+                    "aggregator_temperature": 0.2,
+                    "max_tokens": 4096,
+                    "reference_max_tokens": 500,
+                    "context_length": 450000,
+                    "max_advisors": 2,
+                    "max_reference_cost_usd": 0.2,
+                    "max_fanout_latency_seconds": 15,
+                    "circuit_breaker_seconds": 45,
+                    "quota_cooldown_seconds": 600,
+                    "fanout": "user_turn",
+                    "auto_routes": {
+                        "fast": "fast",
+                    },
+                    "enabled": True,
+                },
+                "fast": {
+                    "reference_models": [],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+                    "reference_max_tokens": 250,
+                    "context_length": 128000,
+                    "fanout": "user_turn",
+                    "enabled": True,
+                },
+            },
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        saved = resp.json()
+        assert saved["presets"]["auto"]["auto_routes"] == payload["presets"]["auto"]["auto_routes"]
+        assert saved["presets"]["auto"]["context_length"] == 450000
+        assert saved["presets"]["auto"]["max_advisors"] == 2
+        assert saved["presets"]["auto"]["max_reference_cost_usd"] == 0.2
+        assert saved["excluded_providers"] == ["antigravity_cli"]
+        assert saved["presets"]["auto"]["fallback_aggregators"] == [
+            {"provider": "xai-oauth", "model": "grok-4.5"},
+        ]
+        assert saved["presets"]["fast"]["reference_models"] == []
+
+        persisted = load_config()["moa"]["presets"]
+        assert persisted["auto"]["fanout"] == "user_turn"
+        assert persisted["auto"]["reference_max_tokens"] == 500
+        assert persisted["fast"]["context_length"] == 128000
+
+    def test_put_moa_rejects_stale_revision(self):
+        current = self.client.get("/api/model/moa").json()
+        stale = dict(current)
+        stale["revision"] = "0" * 16
+
+        response = self.client.put("/api/model/moa", json=stale)
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert detail["code"] == "moa_revision_conflict"
+        assert detail["current_revision"] == current["revision"]
+
+    def test_moa_route_feedback_is_content_free(self):
+        for _ in range(3):
+            response = self.client.post("/api/model/moa/feedback", json={
+                "suggested_route": "balanced",
+                "chosen_route": "research",
+            })
+            assert response.status_code == 200
+
+        feedback = response.json()["router_feedback"]
+        assert feedback["balanced"] == {
+            "samples": 3,
+            "effective_route": "research",
+        }
+
+    def test_generic_config_save_canonicalizes_excluded_moa_references(self):
+        from hermes_cli.config import load_config
+
+        response = self.client.put("/api/config", json={"config": {
+            "moa": {
+                "excluded_providers": ["antigravity_cli"],
+                "presets": {
+                    "safe": {
+                        "reference_models": [
+                            {"provider": "antigravity_cli", "model": "legacy"},
+                        ],
+                        "aggregator": {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.6-terra",
+                        },
+                    },
+                },
+            },
+        }})
+
+        assert response.status_code == 200
+        assert load_config()["moa"]["presets"]["safe"]["reference_models"] == []
+
+    def test_put_from_stale_client_preserves_provider_exclusions_and_fallbacks(self):
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["moa"] = {
+            "default_preset": "default",
+            "excluded_providers": ["antigravity_cli"],
+            "presets": {
+                "default": {
+                    "reference_models": [],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+                    "fallback_aggregators": [
+                        {"provider": "xai-oauth", "model": "grok-4.5"},
+                    ],
+                    "reference_max_tokens": 500,
+                    "context_length": 450000,
+                    "fanout": "user_turn",
+                    "auto_routes": {"research": "default"},
+                },
+            },
+        }
+        save_config(cfg)
+
+        stale_payload = {
+            "default_preset": "default",
+            "presets": {
+                "default": {
+                    "reference_models": [
+                        {"provider": "antigravity_cli", "model": "legacy"},
+                    ],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+                },
+            },
+        }
+        response = self.client.put("/api/model/moa", json=stale_payload)
+
+        assert response.status_code == 200
+        saved = response.json()
+        assert saved["excluded_providers"] == ["antigravity_cli"]
+        assert saved["presets"]["default"]["reference_models"] == []
+        assert saved["presets"]["default"]["fallback_aggregators"] == [
+            {"provider": "xai-oauth", "model": "grok-4.5"},
+        ]
+        assert saved["presets"]["default"]["reference_max_tokens"] == 500
+        assert saved["presets"]["default"]["context_length"] == 450000
+        assert saved["presets"]["default"]["fanout"] == "user_turn"
+        assert saved["presets"]["default"]["auto_routes"] == {
+            "research": "default",
+        }
+
+    def test_put_moa_rejects_invalid_auto_route(self):
+        response = self.client.put("/api/model/moa", json={
+            "default_preset": "auto",
+            "presets": {
+                "auto": {
+                    "reference_models": [],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-terra"},
+                    "auto_routes": {"research": "missing"},
+                },
+            },
+        })
+
+        assert response.status_code == 422
+        assert response.json()["detail"]["issues"][0]["code"] == "invalid_auto_route"
 
     # ── GET /api/media (remote image display) ───────────────────────────
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -6,6 +6,15 @@ import pytest
 from run_agent import AIAgent
 
 
+@pytest.fixture(autouse=True)
+def _mock_moa_runtime_availability(monkeypatch):
+    """These unit tests mock call_llm, so provider auth is intentionally out of scope."""
+    monkeypatch.setattr(
+        "hermes_cli.moa_config._slot_runtime_available",
+        lambda _slot: True,
+    )
+
+
 def _response(content="done", *, tool_calls=None):
     message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
     choice = SimpleNamespace(message=message, finish_reason="stop")
@@ -1059,3 +1068,119 @@ def test_reference_guidance_merges_into_trailing_user_in_plain_chat():
     assert len(messages) == 2
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "hello\n\nREFERENCE BLOCK"
+
+
+def test_aggregator_rate_limit_uses_fallback_and_opens_circuit(monkeypatch, tmp_path):
+    from agent.moa_runtime import circuit_status, reset_runtime_state_for_tests
+    from agent.moa_loop import MoAChatCompletions
+
+    class RateLimitError(Exception):
+        status_code = 429
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: resilient
+  presets:
+    resilient:
+      reference_models: []
+      aggregator: {provider: openrouter, model: primary-model}
+      fallback_aggregators:
+        - {provider: openai-codex, model: fallback-model}
+      circuit_breaker_seconds: 30
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    reset_runtime_state_for_tests()
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["model"] == "primary-model":
+            raise RateLimitError("rate limit")
+        return _response("fallback acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    facade = MoAChatCompletions("resilient")
+
+    response = facade.create(messages=[{"role": "user", "content": "solve"}])
+
+    assert response.choices[0].message.content == "fallback acted"
+    assert [call["model"] for call in calls] == ["primary-model", "fallback-model"]
+    assert facade.last_aggregator_slot["model"] == "fallback-model"
+    assert facade.last_runtime_status["fallback_used"] is True
+    assert circuit_status({"provider": "openrouter", "model": "primary-model"})["active"] is True
+    reset_runtime_state_for_tests()
+
+
+def test_reference_budgets_limit_advisors_and_forward_timeout(monkeypatch, tmp_path):
+    from agent.moa_loop import MoAChatCompletions
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: bounded
+  presets:
+    bounded:
+      reference_models:
+        - {provider: openai-codex, model: advisor-one}
+        - {provider: openai-codex, model: advisor-two}
+      aggregator: {provider: openrouter, model: aggregator}
+      max_advisors: 1
+      max_fanout_latency_seconds: 12
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("ok")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    facade = MoAChatCompletions("bounded")
+
+    facade.create(messages=[{"role": "user", "content": "solve"}])
+
+    reference_calls = [call for call in calls if call["task"] == "moa_reference"]
+    assert len(reference_calls) == 1
+    assert reference_calls[0]["model"] == "advisor-one"
+    assert reference_calls[0]["timeout"] == 12.0
+    assert facade.last_runtime_status["budget"]["selected_advisors"] == 1
+    assert facade.last_runtime_status["budget"]["exceeded"] is True
+
+
+def test_reference_cost_budget_uses_known_pricing(monkeypatch):
+    from agent import moa_loop
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "base_url": "https://example.test"},
+    )
+    monkeypatch.setattr(
+        "agent.usage_pricing.estimate_usage_cost",
+        lambda *_args, **_kwargs: SimpleNamespace(amount_usd=0.1),
+    )
+    models = [
+        {"provider": "p", "model": "one"},
+        {"provider": "p", "model": "two"},
+    ]
+
+    selected, status = moa_loop._select_references_for_budget(
+        models,
+        [{"role": "user", "content": "question"}],
+        max_advisors=None,
+        max_cost_usd=0.15,
+        max_tokens=500,
+    )
+
+    assert selected == [models[0]]
+    assert status["estimated_reference_cost_usd"] == 0.1
+    assert status["skipped_by_budget"] == ["p:two"]

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -10,6 +10,15 @@ from types import SimpleNamespace
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _mock_moa_runtime_availability(monkeypatch):
+    """Streaming tests replace call_llm and must not depend on local credentials."""
+    monkeypatch.setattr(
+        "hermes_cli.moa_config._slot_runtime_available",
+        lambda _slot: True,
+    )
+
+
 def _response(content="done", *, tool_calls=None):
     message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
     choice = SimpleNamespace(message=message, finish_reason="stop")

--- a/tests/scripts/test_moa_benchmark.py
+++ b/tests/scripts/test_moa_benchmark.py
@@ -1,0 +1,144 @@
+"""Contract-тесты безопасного MoA benchmark."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import agent.moa_loop as moa_loop
+from scripts import moa_benchmark
+
+
+def _slot(provider: str, model: str) -> dict[str, str]:
+    return {"provider": provider, "model": model}
+
+
+def _preset(
+    *,
+    references: list[dict[str, str]] | None = None,
+    budget: float | None = None,
+    auto_routes: dict[str, str] | None = None,
+) -> dict:
+    return {
+        "enabled": True,
+        "reference_models": references or [],
+        "aggregator": _slot("openai-codex", "gpt-test"),
+        "fallback_aggregators": [],
+        "max_reference_cost_usd": budget,
+        "auto_routes": auto_routes or {},
+    }
+
+
+def _config(*, save_traces: bool = False) -> dict:
+    grok = _slot("xai-oauth", "grok-test")
+    glm = _slot("openrouter", "glm-test")
+    routes = {
+        "fast": "fast",
+        "balanced": "balanced",
+        "research": "research",
+        "code_heavy": "code-heavy",
+        "max": "max",
+    }
+    return {
+        "default_preset": "auto",
+        "active_preset": "auto",
+        "save_traces": save_traces,
+        "presets": {
+            "auto": _preset(auto_routes=routes),
+            "fast": _preset(),
+            "balanced": _preset(references=[grok], budget=0.10),
+            "research": _preset(references=[grok, glm], budget=0.40),
+            "code-heavy": _preset(references=[glm, grok], budget=0.35),
+            "max": _preset(references=[grok, glm], budget=0.75),
+        },
+    }
+
+
+def test_live_preflight_accepts_three_cases_at_budget_limit():
+    result = moa_benchmark.validate_live_preflight(
+        _config(),
+        "auto",
+        3,
+        reference_budget_usd=0.75,
+    )
+    assert result["planned_reference_budget_usd"] == 0.75
+    assert [case["resolved_preset"] for case in result["cases"]] == [
+        "fast",
+        "research",
+        "code-heavy",
+    ]
+
+
+def test_live_preflight_rejects_total_budget_before_provider_call():
+    with pytest.raises(ValueError, match="exceeds limit"):
+        moa_benchmark.validate_live_preflight(
+            _config(),
+            "auto",
+            4,
+            reference_budget_usd=0.75,
+        )
+
+
+def test_live_preflight_rejects_enabled_traces():
+    with pytest.raises(ValueError, match="save_traces=false"):
+        moa_benchmark.validate_live_preflight(_config(save_traces=True), "auto", 3)
+
+
+@pytest.mark.parametrize("limit", [float("nan"), float("inf"), -0.01])
+def test_live_preflight_rejects_invalid_budget_limit(limit):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        moa_benchmark.validate_live_preflight(
+            _config(),
+            "auto",
+            3,
+            reference_budget_usd=limit,
+        )
+
+
+def test_live_preflight_rejects_unbounded_reference_preset():
+    config = _config()
+    config["presets"]["research"]["max_reference_cost_usd"] = None
+    with pytest.raises(ValueError, match="no max_reference_cost_usd"):
+        moa_benchmark.validate_live_preflight(config, "auto", 3)
+
+
+def test_live_result_does_not_contain_prompt_or_response(monkeypatch):
+    secret_response = "response-body-must-not-be-persisted"
+
+    class FakeCompletions:
+        def __init__(self, _preset_name: str):
+            self.last_runtime_status = {"degraded": False}
+
+        def create(self, **_kwargs):
+            message = SimpleNamespace(content=secret_response)
+            return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    monkeypatch.setattr(moa_loop, "MoAChatCompletions", FakeCompletions)
+    result = moa_benchmark.run_live(_config(), "auto", 1)
+    rendered = json.dumps(result)
+    assert secret_response not in rendered
+    assert moa_benchmark.CASES[0][1] not in rendered
+    assert result["results"][0]["response_chars"] == len(secret_response)
+    assert result["results"][0]["response_sha256"]
+
+
+def test_main_budget_failure_does_not_start_live_calls(monkeypatch):
+    called = False
+
+    def fail_if_called(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("provider path must not start")
+
+    monkeypatch.setattr(moa_benchmark, "reload_env", lambda: None)
+    monkeypatch.setattr(moa_benchmark, "load_config", lambda: {"moa": _config()})
+    monkeypatch.setattr(moa_benchmark, "run_live", fail_if_called)
+    with pytest.raises(SystemExit) as exc_info:
+        moa_benchmark.main([
+            "--live",
+            "--confirm-live",
+            "--max-cases",
+            "4",
+        ])
+    assert exc_info.value.code == 2
+    assert called is False

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -204,7 +204,10 @@ class TestDispatch:
     def test_type_action_routes_to_type_text_backend(self, noop_backend):
         """type action must call backend.type_text, not type_text_chars (issue #24170, bug 3)."""
         from tools.computer_use.tool import handle_computer_use
-        out = handle_computer_use({"action": "type", "text": "hello"})
+        out = handle_computer_use({
+            "action": "type", "text": "hello", "app": "TestApp",
+            "window_title": "Test Window", "window_id": 202, "element": 1,
+        })
         parsed = json.loads(out)
         assert "error" not in parsed
         call_names = [c[0] for c in noop_backend.calls]
@@ -254,7 +257,10 @@ class TestDispatch:
     def test_set_value_routes_to_backend(self, noop_backend):
         """set_value must reach the backend — regression for missing _NoopBackend stub."""
         from tools.computer_use.tool import handle_computer_use
-        out = handle_computer_use({"action": "set_value", "value": "Option A", "element": 5})
+        out = handle_computer_use({
+            "action": "set_value", "value": "Option A", "element": 1,
+            "app": "TestApp", "window_title": "Test Window", "window_id": 202,
+        })
         parsed = json.loads(out)
         assert parsed.get("ok") is True
         assert parsed.get("action") == "set_value"
@@ -334,15 +340,81 @@ class TestSafetyGuards:
 
     def test_safe_key_combos_pass(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
-        out = handle_computer_use({"action": "key", "keys": "cmd+s"})
+        out = handle_computer_use({
+            "action": "key", "keys": "cmd+s", "app": "TestApp",
+            "window_title": "Test Window", "window_id": 202,
+        })
         parsed = json.loads(out)
         assert "error" not in parsed
 
     def test_type_with_empty_string_is_allowed(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
-        out = handle_computer_use({"action": "type", "text": ""})
+        out = handle_computer_use({
+            "action": "type", "text": "", "app": "TestApp",
+            "window_title": "Test Window", "window_id": 202, "element": 1,
+        })
         parsed = json.loads(out)
         assert "error" not in parsed
+
+    @pytest.mark.parametrize("text", [
+        "-----BEGIN PRIVATE KEY-----",
+        "<tls-auth>",
+        "api_key=abcdefghijklmnopqrstuvwxyz0123456789",
+        "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo0123456789abcd",
+    ])
+    def test_sensitive_gui_text_is_blocked(self, text, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "type", "text": text})
+        assert "sensitive GUI input blocked" in json.loads(out)["error"]
+
+    @pytest.mark.parametrize("keys", ["ctrl+v", "cmd+v", "shift+insert"])
+    def test_clipboard_paste_is_blocked(self, keys, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "key", "keys": keys})
+        assert "blocked key combo" in json.loads(out)["error"]
+
+    def test_type_requires_exact_target(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "type", "text": "safe"})
+        assert "requires explicit `app` and `window_title`" in json.loads(out)["error"]
+
+    def test_type_refuses_other_window_of_same_app(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({
+            "action": "type", "text": "safe", "app": "TestApp",
+            "window_title": "Different Chat", "window_id": 202, "element": 1,
+        })
+        assert "target window changed" in json.loads(out)["error"]
+        assert not any(name == "type" for name, _args in noop_backend.calls)
+
+    def test_keyboard_audit_does_not_log_text_or_raw_window_title(
+        self, noop_backend, caplog, tmp_path, monkeypatch,
+    ):
+        from tools.computer_use.tool import handle_computer_use
+
+        home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        secret_marker = "api_key=abcdefghijklmnopqrstuvwxyz0123456789"
+        raw_title = "Private customer conversation"
+        with caplog.at_level("INFO", logger="tools.computer_use.tool"):
+            out = handle_computer_use({
+                "action": "type",
+                "text": secret_marker,
+                "app": "TestApp",
+                "window_title": raw_title,
+                "window_id": 202,
+                "element": 1,
+            })
+
+        assert "sensitive GUI input blocked" in json.loads(out)["error"]
+        assert "computer_use audit" in caplog.text
+        assert secret_marker not in caplog.text
+        assert raw_title not in caplog.text
+        assert "title_hash=" in caplog.text
+        audit_text = (home / "logs" / "computer_use_audit.log").read_text(encoding="utf-8")
+        assert "target_id=" in audit_text
+        assert secret_marker not in audit_text
+        assert raw_title not in audit_text
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +422,34 @@ class TestSafetyGuards:
 # ---------------------------------------------------------------------------
 
 class TestCaptureResponse:
+    def test_capture_exposes_stable_window_identity(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        payload = json.loads(handle_computer_use({
+            "action": "capture",
+            "mode": "ax",
+            "app": "TestApp",
+        }))
+
+        assert payload["pid"] == 101
+        assert payload["window_id"] == 202
+        assert len(payload["target_id"]) == 16
+
+    def test_keyboard_refuses_reused_window_id(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        payload = json.loads(handle_computer_use({
+            "action": "type",
+            "text": "safe",
+            "app": "TestApp",
+            "window_title": "Test Window",
+            "window_id": 999,
+            "element": 1,
+        }))
+
+        assert "window_id changed" in payload["error"]
+        assert not any(name == "type" for name, _args in noop_backend.calls)
+
     def test_capture_ax_mode_returns_text_json(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "capture", "mode": "ax"})
@@ -1421,6 +1521,52 @@ def _make_cua_backend_with_windows(windows: List[Dict[str, Any]]):
     return backend
 
 
+class TestKeyboardTargetBinding:
+    def _armed_backend(self):
+        from tools.computer_use.backend import ActionResult
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._active_pid = 101
+        backend._active_window_id = 202
+        backend._keyboard_target_armed = True
+        backend._action = MagicMock(
+            side_effect=lambda name, args: ActionResult(ok=True, action=name, meta=args),
+        )
+        return backend
+
+    def test_type_text_passes_window_and_element(self):
+        backend = self._armed_backend()
+        result = backend.type_text("safe", element=7)
+        assert result.ok
+        backend._action.assert_called_once_with("type_text", {
+            "pid": 101, "window_id": 202, "text": "safe", "element_index": 7,
+        })
+        assert backend._keyboard_target_armed is False
+
+    def test_type_text_refuses_unaddressed_input(self):
+        backend = self._armed_backend()
+        result = backend.type_text("safe")
+        assert result.ok is False
+        backend._action.assert_not_called()
+
+    def test_key_passes_exact_window(self):
+        backend = self._armed_backend()
+        result = backend.key("ctrl+s")
+        assert result.ok
+        backend._action.assert_called_once_with("hotkey", {
+            "pid": 101, "window_id": 202, "keys": ["ctrl", "s"],
+        })
+        assert backend._keyboard_target_armed is False
+
+    def test_keyboard_input_requires_fresh_explicit_capture(self):
+        backend = self._armed_backend()
+        backend._keyboard_target_armed = False
+        assert backend.type_text("safe", element=7).ok is False
+        assert backend.key("return").ok is False
+        backend._action.assert_not_called()
+
+
 class TestCuaDriverSessionReconnect:
     """Verify reconnect-once on a closed-resource error. After the
     lifecycle-owner refactor (Sun Jun 21 2026) the session no longer goes
@@ -1572,8 +1718,11 @@ class TestCuaDriverSessionReconnect:
             returncode = 0
             stderr = ""
             # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run
@@ -2621,6 +2770,35 @@ class TestElementTokenAttachment:
         name, args = backend._session.call_tool.call_args.args
         assert name == "set_value"
         assert args["element_token"] == "sff00:3"
+
+    def test_token_attached_to_type_text(self):
+        backend = self._backend_with_session({
+            "type_text": {"accessibility.element_tokens", "input.keyboard.type"},
+        })
+        backend._keyboard_target_armed = True
+        backend._snapshot_tokens = {7: "sff00:7"}
+
+        result = backend.type_text("safe", element=7)
+
+        assert result.ok
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "type_text"
+        assert args["pid"] == 111
+        assert args["window_id"] == 222
+        assert args["element_index"] == 7
+        assert args["element_token"] == "sff00:7"
+
+    def test_public_capture_payload_exposes_element_token(self):
+        from tools.computer_use.backend import UIElement
+        from tools.computer_use.tool import _element_to_dict
+
+        payload = _element_to_dict(UIElement(
+            index=4,
+            role="AXTextField",
+            element_token="snapshot:4",
+        ))
+
+        assert payload["element_token"] == "snapshot:4"
 
     def test_token_attached_to_scroll(self):
         backend = self._backend_with_session({

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -57,6 +57,8 @@ class CaptureResult:
     # Optional: the target app/window the elements were captured for.
     app: str = ""
     window_title: str = ""
+    pid: int = 0
+    window_id: int = 0
     # Raw bytes we sent to Anthropic, for token estimation.
     png_bytes_len: int = 0
     # Explicit MIME type for `png_b64` when the backend supplied it
@@ -99,7 +101,12 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod
@@ -140,7 +147,14 @@ class ComputerUseBackend(ABC):
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
-    def type_text(self, text: str) -> ActionResult: ...
+    def type_text(
+        self,
+        text: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+    ) -> ActionResult: ...
 
     @abstractmethod
     def key(self, keys: str) -> ActionResult:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1158,6 +1158,7 @@ class CuaDriverBackend(ComputerUseBackend):
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
+        self._keyboard_target_armed = False
         # Surface 6 of NousResearch/hermes-agent#47072: per-snapshot
         # `element_index -> element_token` map populated on capture().
         # Action tools (click/scroll/set_value/...) attach the matching
@@ -1244,12 +1245,20 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
         """
+        # Every capture invalidates the previous keyboard destination first.
+        # It is re-armed only after an explicit app window resolves completely.
+        self._keyboard_target_armed = False
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         # Surface 3 of NousResearch/hermes-agent#47072: read the canonical
         # `structuredContent.windows` array directly. Pre-fix the wrapper
@@ -1353,10 +1362,27 @@ class CuaDriverBackend(ComputerUseBackend):
                 )
             windows = filtered
 
+        if window_id is not None:
+            exact = [window for window in windows if window["window_id"] == int(window_id)]
+            if not exact:
+                return CaptureResult(
+                    mode=mode,
+                    width=0,
+                    height=0,
+                    png_b64=None,
+                    elements=[],
+                    app=app or "",
+                    window_title=f"<no on-screen window matched window_id={window_id}>",
+                    window_id=0,
+                    png_bytes_len=0,
+                )
+            windows = exact
+
         # Pick first on-screen window (sorted by z_index / z-order above).
         target = next((w for w in windows if not w["off_screen"]), windows[0])
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
+        self._keyboard_target_armed = False
         app_name = target["app_name"]
         # Record the resolved app name so capture_after= follow-ups can re-target
         # the same app rather than falling back to the frontmost window.
@@ -1368,7 +1394,7 @@ class CuaDriverBackend(ComputerUseBackend):
         image_mime_type: Optional[str] = None
         elements: List[UIElement] = []
         width = height = 0
-        window_title = ""
+        window_title = target.get("title", "")
 
         if mode == "vision":
             # Plain screenshot, no AX walk. cua-driver dropped the standalone
@@ -1556,6 +1582,7 @@ class CuaDriverBackend(ComputerUseBackend):
             except Exception:
                 png_bytes_len = len(png_b64) * 3 // 4
 
+        self._keyboard_target_armed = bool(app and app_name and window_title)
         return CaptureResult(
             mode=mode,
             width=width,
@@ -1564,6 +1591,8 @@ class CuaDriverBackend(ComputerUseBackend):
             elements=elements,
             app=app_name,
             window_title=window_title,
+            pid=int(self._active_pid or 0),
+            window_id=int(self._active_window_id or 0),
             png_bytes_len=png_bytes_len,
             image_mime_type=image_mime_type,
         )
@@ -1674,16 +1703,35 @@ class CuaDriverBackend(ComputerUseBackend):
         return self._action("scroll", args)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str) -> ActionResult:
+    def type_text(
+        self,
+        text: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+    ) -> ActionResult:
         pid = self._active_pid
-        if pid is None:
+        window_id = self._active_window_id
+        if pid is None or window_id is None or not self._keyboard_target_armed:
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
-        return self._action("type_text", {"pid": pid, "text": text})
+        if element is None and (x is None or y is None):
+            return ActionResult(ok=False, action="type_text",
+                                message="type_text requires element= or x=/y=.")
+        self._keyboard_target_armed = False
+        args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
+        if element is not None:
+            args["element_index"] = element
+        else:
+            args["x"] = x
+            args["y"] = y
+        return self._action("type_text", args)
 
     def key(self, keys: str) -> ActionResult:
         pid = self._active_pid
-        if pid is None:
+        window_id = self._active_window_id
+        if pid is None or window_id is None or not self._keyboard_target_armed:
             return ActionResult(ok=False, action="key",
                                 message="No active window — call capture() first.")
 
@@ -1692,11 +1740,16 @@ class CuaDriverBackend(ComputerUseBackend):
             return ActionResult(ok=False, action="key",
                                 message=f"Could not parse key from '{keys}'.")
 
+        self._keyboard_target_armed = False
         if modifiers:
             # hotkey requires at least one modifier + one key.
-            return self._action("hotkey", {"pid": pid, "keys": modifiers + [key_name]})
+            return self._action("hotkey", {
+                "pid": pid, "window_id": window_id, "keys": modifiers + [key_name],
+            })
         else:
-            return self._action("press_key", {"pid": pid, "key": key_name})
+            return self._action("press_key", {
+                "pid": pid, "window_id": window_id, "key": key_name,
+            })
 
     # ── Value setter ────────────────────────────────────────────────
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
@@ -1766,6 +1819,7 @@ class CuaDriverBackend(ComputerUseBackend):
         if target:
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
+            self._keyboard_target_armed = False
             self._last_app = target["app_name"]  # preserve for capture_after= follow-ups
             return ActionResult(
                 ok=True, action="focus_app",

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -81,6 +81,23 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "one window or display at a time."
                 ),
             },
+            "window_title": {
+                "type": "string",
+                "description": (
+                    "For action='type' or action='key': exact window_title "
+                    "returned by the prior capture of `app`. Hermes performs "
+                    "a fresh capture and refuses input if the title changed."
+                ),
+            },
+            "window_id": {
+                "type": "integer",
+                "description": (
+                    "For action='type', action='key', or action='set_value': "
+                    "exact window_id returned by the prior capture. Hermes "
+                    "performs a fresh capture and refuses input if the window "
+                    "identity changed, even when another window has the same title."
+                ),
+            },
             "max_elements": {
                 "type": "integer",
                 "description": (
@@ -179,13 +196,18 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             # ── type / key / wait ──────────────────────────────────
             "text": {
                 "type": "string",
-                "description": "Text to type (respects the current layout).",
+                "description": (
+                    "Text to type. Requires exact `app`, `window_title`, and "
+                    "`element` or `coordinate`. Secrets, key material, and "
+                    "encoded credential blobs are blocked."
+                ),
             },
             "keys": {
                 "type": "string",
                 "description": (
                     "Key combo, e.g. 'cmd+s', 'ctrl+alt+t', 'return', "
-                    "'escape', 'tab'. Use '+' to combine."
+                    "'escape', 'tab'. Use '+' to combine. Requires exact "
+                    "`app` and `window_title`; clipboard paste is blocked."
                 ),
             },
             "seconds": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -39,6 +39,7 @@ For captures / actions with `capture_after=True`:
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -46,6 +47,7 @@ import re
 import struct
 import sys
 import threading
+from logging.handlers import RotatingFileHandler
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
@@ -56,6 +58,11 @@ from tools.computer_use.backend import (
 )
 
 logger = logging.getLogger(__name__)
+_audit_handler_lock = threading.Lock()
+_audit_handler_path = ""
+_audit_file_logger = logging.getLogger("hermes.computer_use.audit")
+_audit_file_logger.setLevel(logging.INFO)
+_audit_file_logger.propagate = False
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +107,11 @@ _BLOCKED_KEY_COMBOS = {
     frozenset({"ctrl", "option", "delete"}),
     frozenset({"ctrl", "option", "del"}),
     frozenset({"option", "f4"}),
+    # Содержимое clipboard непрозрачно для guard. Текст должен проходить через
+    # `type`, где проверяются содержимое и точное место назначения.
+    frozenset({"ctrl", "v"}),
+    frozenset({"cmd", "v"}),
+    frozenset({"shift", "insert"}),
 }
 
 _KEY_ALIASES = {
@@ -124,12 +136,101 @@ _BLOCKED_TYPE_PATTERNS = [
     re.compile(r":\s*\(\)\s*\{\s*:\|:\s*&\s*\}", re.IGNORECASE),  # fork bomb
 ]
 
+_SENSITIVE_TYPE_PATTERNS = [
+    ("PEM material", re.compile(
+        r"-{2,}(?:BEGIN|END)\s+(?:CERTIFICATE|PRIVATE KEY|PUBLIC KEY|OPENVPN STATIC KEY)",
+        re.IGNORECASE,
+    )),
+    ("VPN key block", re.compile(
+        r"<?/?(?:tls-auth|tls-crypt(?:-v2)?|pkcs12|key)>?",
+        re.IGNORECASE,
+    )),
+    ("credential-like value", re.compile(
+        r"\b(?:api[_-]?key|access[_-]?token|client[_-]?secret|password)\s*[:=]\s*\S{12,}",
+        re.IGNORECASE,
+    )),
+    ("encoded key material", re.compile(
+        r"(?m)^[A-Za-z0-9+/]{40,}={0,2}$",
+    )),
+]
+
 
 def _is_blocked_type(text: str) -> Optional[str]:
     for pat in _BLOCKED_TYPE_PATTERNS:
         if pat.search(text):
             return pat.pattern
     return None
+
+
+def _sensitive_type_category(text: str) -> Optional[str]:
+    for category, pattern in _SENSITIVE_TYPE_PATTERNS:
+        if pattern.search(text):
+            return category
+    return None
+
+
+def _target_id(app: str, title: str, window_id: Any) -> str:
+    material = f"{app.casefold()}|{window_id}|{title}"
+    return hashlib.sha256(material.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _ensure_audit_file_handler() -> None:
+    """Подключить ограниченный локальный audit без записи содержимого действий."""
+    global _audit_handler_path
+    try:
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "logs" / "computer_use_audit.log"
+        desired = str(path)
+        with _audit_handler_lock:
+            if _audit_handler_path == desired and _audit_file_logger.handlers:
+                return
+            for handler in list(_audit_file_logger.handlers):
+                _audit_file_logger.removeHandler(handler)
+                handler.close()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                path,
+                maxBytes=1024 * 1024,
+                backupCount=5,
+                encoding="utf-8",
+            )
+            handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+            _audit_file_logger.addHandler(handler)
+            _audit_handler_path = desired
+    except Exception as exc:  # pragma: no cover - audit file must not break CUA
+        logger.debug("computer_use audit file unavailable: %s", type(exc).__name__)
+
+
+def _audit_keyboard_event(
+    action: str, args: Dict[str, Any], outcome: str, reason: str = "",
+    backend: Optional[ComputerUseBackend] = None,
+) -> None:
+    """Записать локальное audit-событие CUA без содержимого ввода."""
+    title = str(args.get("window_title") or "")
+    title_hash = hashlib.sha256(title.encode("utf-8", "replace")).hexdigest()[:12] if title else ""
+    app = str(args.get("app") or "")
+    window_id = args.get("window_id")
+    if window_id is None and backend is not None:
+        window_id = getattr(backend, "_active_window_id", None)
+    target_id = _target_id(app, title, window_id)
+    audit_message = (
+        "computer_use audit action=%s outcome=%s app=%s title_hash=%s "
+        "target_id=%s pid=%s window_id=%s reason=%s"
+    )
+    audit_args = (
+        action,
+        outcome,
+        app,
+        title_hash,
+        target_id,
+        getattr(backend, "_active_pid", None) if backend is not None else None,
+        window_id,
+        reason,
+    )
+    logger.info(audit_message, *audit_args)
+    _ensure_audit_file_handler()
+    _audit_file_logger.info(audit_message, *audit_args)
 
 
 # ---------------------------------------------------------------------------
@@ -193,10 +294,17 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        self.calls.append(("capture", {"mode": mode, "app": app}))
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult:
+        self.calls.append(("capture", {"mode": mode, "app": app, "window_id": window_id}))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
-                             elements=[], app=app or "", window_title="")
+                             elements=[UIElement(index=1, role="AXTextField")],
+                             app=app or "", window_title="Test Window",
+                             pid=101, window_id=202)
 
     def click(self, **kw) -> ActionResult:
         self.calls.append(("click", kw))
@@ -210,8 +318,17 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("scroll", kw))
         return ActionResult(ok=True, action="scroll")
 
-    def type_text(self, text: str) -> ActionResult:
-        self.calls.append(("type", {"text": text}))
+    def type_text(
+        self,
+        text: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+    ) -> ActionResult:
+        self.calls.append(("type", {
+            "text": text, "element": element, "x": x, "y": y,
+        }))
         return ActionResult(ok=True, action="type")
 
     def key(self, keys: str) -> ActionResult:
@@ -254,16 +371,76 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
                 "error": f"blocked pattern in type text: {pat!r}",
                 "hint": "Dangerous shell patterns cannot be typed via computer_use.",
             })
+        category = _sensitive_type_category(text)
+        if category:
+            _audit_keyboard_event(action, args, "blocked", category)
+            return json.dumps({
+                "error": f"sensitive GUI input blocked: {category}",
+                "hint": "Write secrets through a protected file or secret manager, never through CUA.",
+            })
+        if not args.get("app") or not args.get("window_title"):
+            _audit_keyboard_event(action, args, "blocked", "missing_target")
+            return json.dumps({
+                "error": "type requires explicit `app` and `window_title` from a prior capture",
+                "hint": "Capture the exact app window, then retry with its returned app and window_title.",
+            })
+        if args.get("window_id") is None:
+            _audit_keyboard_event(action, args, "blocked", "missing_window_id")
+            return json.dumps({
+                "error": "type requires exact `window_id` from a prior capture",
+                "hint": "Capture the intended window again and pass its returned window_id.",
+            })
+        if args.get("element") is None and not args.get("coordinate"):
+            _audit_keyboard_event(action, args, "blocked", "missing_element")
+            return json.dumps({
+                "error": "type requires exact `element` or `coordinate`",
+                "hint": "Use a target returned by a prior capture of the same app window.",
+            })
 
     if action == "key":
         keys = args.get("keys", "")
         combo = _canon_key_combo(keys)
         for blocked in _BLOCKED_KEY_COMBOS:
             if blocked.issubset(combo) and len(blocked) <= len(combo):
+                _audit_keyboard_event(action, args, "blocked", "blocked_key_combo")
                 return json.dumps({
                     "error": f"blocked key combo: {sorted(blocked)}",
-                    "hint": "Destructive system shortcuts are hard-blocked.",
+                    "hint": "Destructive shortcuts and opaque clipboard paste are hard-blocked.",
                 })
+        if not args.get("app") or not args.get("window_title"):
+            _audit_keyboard_event(action, args, "blocked", "missing_target")
+            return json.dumps({
+                "error": "key requires explicit `app` and `window_title` from a prior capture",
+                "hint": "Capture the exact app window before sending keys.",
+            })
+        if args.get("window_id") is None:
+            _audit_keyboard_event(action, args, "blocked", "missing_window_id")
+            return json.dumps({
+                "error": "key requires exact `window_id` from a prior capture",
+                "hint": "Capture the intended window again and pass its returned window_id.",
+            })
+
+    if action == "set_value":
+        value = str(args.get("value", ""))
+        category = _sensitive_type_category(value)
+        if category:
+            _audit_keyboard_event(action, args, "blocked", category)
+            return json.dumps({
+                "error": f"sensitive GUI input blocked: {category}",
+                "hint": "Write secrets through a protected file or secret manager, never through CUA.",
+            })
+        if not args.get("app") or not args.get("window_title"):
+            _audit_keyboard_event(action, args, "blocked", "missing_target")
+            return json.dumps({
+                "error": "set_value requires explicit `app` and `window_title` from a prior capture",
+                "hint": "Capture the exact app window before changing a value.",
+            })
+        if args.get("window_id") is None:
+            _audit_keyboard_event(action, args, "blocked", "missing_window_id")
+            return json.dumps({
+                "error": "set_value requires exact `window_id` from a prior capture",
+                "hint": "Capture the intended window again and pass its returned window_id.",
+            })
 
     # Approval gate (destructive actions only).
     if action in _DESTRUCTIVE_ACTIONS:
@@ -332,12 +509,69 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
         return f"scroll {args.get('direction', '?')} x{args.get('amount', 3)}"
     if action == "type":
         text = args.get("text", "")
-        return f"type {text[:60]!r}" + ("..." if len(text) > 60 else "")
+        title_hash = hashlib.sha256(
+            str(args.get("window_title") or "").encode("utf-8", "replace")
+        ).hexdigest()[:12]
+        return (
+            f"type {len(text)} character(s) into verified target "
+            f"{args.get('app', '')!r} / title_hash={title_hash}"
+        )
     if action == "key":
         return f"key {args.get('keys', '')!r}"
     if action == "focus_app":
         return f"focus {args.get('app', '')!r}" + (" (raise)" if args.get("raise_window") else "")
     return action
+
+
+def _verify_keyboard_target(
+    backend: ComputerUseBackend, args: Dict[str, Any],
+) -> Optional[str]:
+    """Повторно снять состояние и привязать ввод к точному окну."""
+    expected_app = str(args.get("app", "")).strip()
+    expected_title = str(args.get("window_title", "")).strip()
+    try:
+        expected_window_id = int(args.get("window_id"))
+    except (TypeError, ValueError):
+        _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "blocked", "invalid_window_id", backend)
+        return json.dumps({"error": "keyboard target window_id is invalid"})
+    cap = backend.capture(mode="ax", app=expected_app, window_id=expected_window_id)
+
+    actual_app = (cap.app or "").strip()
+    actual_title = (cap.window_title or "").strip()
+    actual_window_id = int(cap.window_id or 0)
+    if not actual_app or actual_app.casefold() != expected_app.casefold():
+        _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "blocked", "app_mismatch", backend)
+        return json.dumps({
+            "error": "keyboard target app changed or could not be verified",
+            "expected_app": expected_app,
+            "actual_app": actual_app,
+        })
+    if not actual_title or actual_title != expected_title:
+        _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "blocked", "window_mismatch", backend)
+        return json.dumps({
+            "error": "keyboard target window changed or could not be verified",
+            "expected_window_title": expected_title,
+            "actual_window_title": actual_title,
+            "hint": "Capture the intended window again; do not retry against the new title automatically.",
+        })
+    if not actual_window_id or actual_window_id != expected_window_id:
+        _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "blocked", "window_id_mismatch", backend)
+        return json.dumps({
+            "error": "keyboard target window_id changed or could not be verified",
+            "expected_window_id": expected_window_id,
+            "actual_window_id": actual_window_id,
+            "hint": "Capture the intended window again; never reuse a window_id across captures.",
+        })
+
+    element = args.get("element")
+    if element is not None and not any(item.index == element for item in cap.elements):
+        _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "blocked", "element_missing", backend)
+        return json.dumps({
+            "error": f"keyboard target element #{element} is absent from the fresh capture",
+            "hint": "Capture the intended window again and select a fresh element index.",
+        })
+    _audit_keyboard_event(str(args.get("action") or "keyboard"), args, "verified", backend=backend)
+    return None
 
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
@@ -347,7 +581,10 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        capture_kwargs: Dict[str, Any] = {"mode": mode, "app": args.get("app")}
+        if args.get("window_id") is not None:
+            capture_kwargs["window_id"] = args.get("window_id")
+        cap = backend.capture(**capture_kwargs)
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
     if action == "wait":
@@ -417,19 +654,36 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
-        res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        guard_error = _verify_keyboard_target(backend, args)
+        if guard_error:
+            return guard_error
+        coord = args.get("coordinate") or (None, None)
+        res = backend.type_text(
+            args.get("text", ""),
+            element=args.get("element"),
+            x=coord[0] if coord and coord[0] is not None else None,
+            y=coord[1] if coord and coord[1] is not None else None,
+        )
+        return _maybe_follow_capture(backend, res, True)
 
     if action == "key":
+        guard_error = _verify_keyboard_target(backend, args)
+        if guard_error:
+            return guard_error
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, True)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
+        if args.get("element") is None:
+            return json.dumps({"error": "set_value requires exact `element`"})
+        guard_error = _verify_keyboard_target(backend, args)
+        if guard_error:
+            return guard_error
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, True)
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -558,7 +812,8 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
     summary_lines = [
         f"capture mode={cap.mode} {response_width}x{response_height}"
         + (f" app={cap.app}" if cap.app else "")
-        + (f" window={cap.window_title!r}" if cap.window_title else ""),
+        + (f" window={cap.window_title!r}" if cap.window_title else "")
+        + (f" window_id={cap.window_id}" if cap.window_id else ""),
         f"{total_elements} interactable element(s):",
     ]
     if element_index:
@@ -610,6 +865,9 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
                 "height": response_height,
                 "app": cap.app,
                 "window_title": cap.window_title,
+                "pid": cap.pid,
+                "window_id": cap.window_id,
+                "target_id": _target_id(cap.app, cap.window_title, cap.window_id),
                 "elements": [_element_to_dict(e) for e in visible_elements],
                 "total_elements": total_elements,
                 "summary": "\n".join(summary_lines),
@@ -640,7 +898,9 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             ],
             "text_summary": summary,
             "meta": {"mode": cap.mode, "width": response_width, "height": response_height,
-                     "elements": total_elements, "png_bytes": cap.png_bytes_len},
+                     "elements": total_elements, "png_bytes": cap.png_bytes_len,
+                     "pid": cap.pid, "window_id": cap.window_id,
+                     "target_id": _target_id(cap.app, cap.window_title, cap.window_id)},
         }
     # AX-only (or image-missing fallback): text path actually carries the
     # `elements` array, so the truncation note applies here.
@@ -656,6 +916,9 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         "height": response_height,
         "app": cap.app,
         "window_title": cap.window_title,
+        "pid": cap.pid,
+        "window_id": cap.window_id,
+        "target_id": _target_id(cap.app, cap.window_title, cap.window_id),
         "elements": [_element_to_dict(e) for e in visible_elements],
         "total_elements": total_elements,
         "summary": summary,
@@ -883,13 +1146,20 @@ def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str
 
 
 def _element_to_dict(e: UIElement) -> Dict[str, Any]:
-    return {
+    payload = {
         "index": e.index,
         "role": e.role,
         "label": e.label,
         "bounds": list(e.bounds),
         "app": e.app,
     }
+    if e.pid:
+        payload["pid"] = e.pid
+    if e.window_id:
+        payload["window_id"] = e.window_id
+    if e.element_token:
+        payload["element_token"] = e.element_token
+    return payload
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- harden MoA reference routing with bounded cost/latency budgets, aggregator failover, circuit breakers, cooldowns, content-free telemetry, and router feedback
- expose MoA readiness, degraded state, runtime telemetry, budget, fallback, and optimistic config revision handling in Hermes Desktop
- add a default-dry-run, fail-closed, private-safe MoA benchmark harness
- require fresh exact `pid + window_id` targeting for CUA input and reject high-entropy secret-like text
- decode parallel-test subprocess output as UTF-8 on Windows

## Why

The existing MoA path had no end-to-end reference budget enforcement, runtime health feedback, or reliable aggregator fallback. Desktop config writes could race and local policy writers could silently restore stale presets. CUA input also needed a fail-closed target contract after a wrong-window text-injection incident.

## User impact

MoA presets can use Grok/GLM as bounded advisers while keeping the primary aggregator in control. Users get visible runtime health and cost state, safer config persistence, and stricter computer-use input targeting without storing prompts or responses.

## Validation

- `scripts/run_tests.sh` over 10 affected Python test files: **786 passed, 0 failed**
- Desktop model-settings UI: **8 passed**
- Desktop TypeScript typecheck: passed
- Desktop production build and postbuild assertion: passed
- `git diff --check`: passed
- secret/high-entropy scan: no credentials; the only private-key marker is an intentional negative-test string
- no dependency or lockfile changes

A full Windows suite was also attempted as a baseline audit. The upstream runner exited non-zero without a final summary after 74.2% (29,495 passes / 358 failures shown). Failures were distributed across unrelated Windows/WSL/non-TTY areas; affected MoA/CUA suites were rerun independently and are green as reported above.

## Safety boundaries

No live model requests, prompt/response traces, credentials, VPN, billing, deployment, or force-push were used.