### PR TITLE
fix(tui_gateway): preserve interim assistant message boundaries

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -335,6 +335,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             busy: true,
             awaitingResponse: true,
             sawAssistantPayload: false,
+            interimBoundaryPending: false,
             interrupted: false,
             turnStartedAt: Date.now()
           }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -72,6 +72,7 @@ interface GatewayEventDeps {
   appendAssistantDelta: (sessionId: string, delta: string) => void
   appendReasoningDelta: (sessionId: string, delta: string, replace?: boolean) => void
   completeAssistantMessage: (sessionId: string, text: string) => void
+  finalizeInterimAssistantMessage: (sessionId: string, text: string) => void
   failAssistantMessage: (sessionId: string, errorMessage: string) => void
   flushQueuedDeltas: (sessionId?: string) => void
   queryClient: QueryClient
@@ -100,6 +101,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     lastCwdInfoSessionRef,
     nativeSubagentSessionsRef,
     completeAssistantMessage,
+    finalizeInterimAssistantMessage,
     failAssistantMessage,
     flushQueuedDeltas,
     queryClient,
@@ -344,6 +346,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       } else if (event.type === 'message.delta') {
         if (sessionId) {
           appendAssistantDelta(sessionId, coerceGatewayText(payload?.text))
+        }
+      } else if (event.type === 'message.interim') {
+        if (sessionId) {
+          flushQueuedDeltas(sessionId)
+          finalizeInterimAssistantMessage(sessionId, coerceGatewayText(payload?.text))
         }
       } else if (event.type === 'thinking.delta') {
         // thinking.delta carries the kawaii spinner status (face + verb from
@@ -750,6 +757,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       activeSessionIdRef,
       compactedTurnRef,
       completeAssistantMessage,
+      finalizeInterimAssistantMessage,
       failAssistantMessage,
       flushQueuedDeltas,
       lastCwdInfoSessionRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -347,6 +347,7 @@ export function useMessageStream({
           ...state,
           messages: nextMessages,
           streamId: null,
+          interimBoundaryPending: true,
           sawAssistantPayload: state.sawAssistantPayload || Boolean(authoritativeText)
         }
       })
@@ -416,12 +417,14 @@ export function useMessageStream({
             busy: false,
             needsInput: false,
             pendingBranchGroup: null,
+            interimBoundaryPending: false,
             streamId: null,
             turnStartedAt: null
           }
         }
 
         const streamId = state.streamId
+        const interimBoundaryPending = state.interimBoundaryPending
         const finalText = renderMediaTags(text).trim()
         const completionError = completionErrorText(finalText)
         const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
@@ -484,7 +487,7 @@ export function useMessageStream({
             const existing = prev[index]
             const existingText = chatMessageText(existing).trim()
 
-            if (existing.pending || (finalText && existingText === finalText)) {
+            if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
@@ -506,6 +509,7 @@ export function useMessageStream({
           ...state,
           messages: nextMessages,
           streamId: null,
+          interimBoundaryPending: false,
           pendingBranchGroup: null,
           awaitingResponse: false,
           busy: false,
@@ -571,6 +575,7 @@ export function useMessageStream({
           ...state,
           messages: nextMessages,
           streamId: null,
+          interimBoundaryPending: false,
           pendingBranchGroup: null,
           sawAssistantPayload: true,
           awaitingResponse: false,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -62,6 +62,8 @@ export function useMessageStream({
   sessionStateByRuntimeIdRef,
   updateSessionState
 }: MessageStreamOptions) {
+  const streamSequenceRef = useRef(0)
+
   const sessionInterrupted = useCallback(
     (sessionId: string) => sessionStateByRuntimeIdRef.current.get(sessionId)?.interrupted ?? false,
     [sessionStateByRuntimeIdRef]
@@ -88,7 +90,7 @@ export function useMessageStream({
             return state
           }
 
-          const streamId = state.streamId ?? `assistant-stream-${Date.now()}`
+          const streamId = state.streamId ?? `assistant-stream-${Date.now()}-${++streamSequenceRef.current}`
           const groupId = state.pendingBranchGroup ?? undefined
           const prev = state.messages
           let nextMessages: ChatMessage[]
@@ -282,6 +284,74 @@ export function useMessageStream({
       )
     },
     [flushQueuedDeltas, mutateStream, queueDelta]
+  )
+
+  const finalizeInterimAssistantMessage = useCallback(
+    (sessionId: string, text: string) => {
+      updateSessionState(sessionId, state => {
+        if (state.interrupted) {
+          return state
+        }
+
+        const authoritativeText = renderMediaTags(text).trim()
+
+        if (!authoritativeText) {
+          return state
+        }
+
+        const streamId = state.streamId
+        const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+        const replaceTextPart = (parts: ChatMessagePart[]) => {
+          const visibleText = stripGeneratedImageEchoes(authoritativeText, generatedImageEchoSources(parts)).trim()
+
+          const dedupeReference = normalize(visibleText)
+
+          const kept = parts.filter(part => {
+            if (part.type === 'text') {
+              return false
+            }
+
+            if (part.type !== 'reasoning' || !dedupeReference) {
+              return true
+            }
+
+            const reasoning = normalize(part.text)
+
+            return !(reasoning && (dedupeReference.startsWith(reasoning) || reasoning.startsWith(dedupeReference)))
+          })
+
+          return visibleText ? [...kept, assistantTextPart(visibleText)] : kept
+        }
+
+        let nextMessages = state.messages
+
+        if (streamId && nextMessages.some(message => message.id === streamId)) {
+          nextMessages = nextMessages.map(message =>
+            message.id === streamId ? { ...message, parts: replaceTextPart(message.parts), pending: false } : message
+          )
+        } else if (authoritativeText) {
+          nextMessages = [
+            ...nextMessages,
+            {
+              id: `assistant-interim-${Date.now()}-${++streamSequenceRef.current}`,
+              role: 'assistant',
+              parts: [assistantTextPart(authoritativeText)],
+              pending: false,
+              branchGroupId: state.pendingBranchGroup ?? undefined
+            }
+          ]
+        }
+
+        return {
+          ...state,
+          messages: nextMessages,
+          streamId: null,
+          sawAssistantPayload: state.sawAssistantPayload || Boolean(authoritativeText)
+        }
+      })
+    },
+    [updateSessionState]
   )
 
   const upsertToolCall = useCallback(
@@ -521,6 +591,7 @@ export function useMessageStream({
     lastCwdInfoSessionRef,
     nativeSubagentSessionsRef,
     completeAssistantMessage,
+    finalizeInterimAssistantMessage,
     failAssistantMessage,
     flushQueuedDeltas,
     queryClient,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-message.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-message.test.tsx
@@ -141,6 +141,7 @@ describe('useMessageStream message.interim', () => {
     expect(currentState).toMatchObject({
       awaitingResponse: false,
       busy: true,
+      interimBoundaryPending: true,
       pendingBranchGroup: BRANCH_GROUP,
       streamId: null,
       turnStartedAt
@@ -160,10 +161,34 @@ describe('useMessageStream message.interim', () => {
     expect(currentState).toMatchObject({
       awaitingResponse: false,
       busy: false,
+      interimBoundaryPending: false,
       pendingBranchGroup: null,
       streamId: null,
       turnStartedAt: null
     })
+    expectCompletionSideEffects(1)
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps an identical final completion distinct from an already-streamed interim reply', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('message.delta', { text: 'same reply' })
+    emit('message.interim', { already_streamed: true, text: 'same reply' })
+
+    expect(assistantMessages()).toHaveLength(1)
+    expect(chatMessageText(assistantMessages()[0]!)).toBe('same reply')
+    expect(assistantMessages()[0]!.pending).toBe(false)
+    expect(currentState!.interimBoundaryPending).toBe(true)
+    const interimId = assistantMessages()[0]!.id
+
+    emit('message.complete', { text: 'same reply' })
+
+    expect(assistantMessages()).toHaveLength(2)
+    expect(assistantMessages().map(chatMessageText)).toEqual(['same reply', 'same reply'])
+    expect(assistantMessages()[1]!.id).not.toBe(interimId)
+    expect(currentState).toMatchObject({ busy: false, interimBoundaryPending: false, streamId: null })
     expectCompletionSideEffects(1)
     expect(hydrateFromStoredSession).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-message.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-message.test.tsx
@@ -1,0 +1,170 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { chatMessageText } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import { $activeSessionId } from '@/store/session'
+import { $todosBySession, clearSessionTodos, setSessionTodos } from '@/store/todos'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const sideEffects = vi.hoisted(() => ({
+  broadcastSessionsChanged: vi.fn(),
+  dispatchNativeNotification: vi.fn(),
+  flashPetActivity: vi.fn(),
+  markPetUnread: vi.fn(),
+  playCompletionSound: vi.fn(),
+  setPetActivity: vi.fn()
+}))
+
+vi.mock('@/lib/completion-sound', () => ({ playCompletionSound: sideEffects.playCompletionSound }))
+vi.mock('@/store/native-notifications', () => ({
+  dispatchNativeNotification: sideEffects.dispatchNativeNotification
+}))
+vi.mock('@/store/pet', () => ({
+  flashPetActivity: sideEffects.flashPetActivity,
+  markPetUnread: sideEffects.markPetUnread,
+  setPetActivity: sideEffects.setPetActivity
+}))
+vi.mock('@/store/session-sync', () => ({ broadcastSessionsChanged: sideEffects.broadcastSessionsChanged }))
+
+const SID = 'session-1'
+const BRANCH_GROUP = 'branch-group-1'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let currentState: ClientSessionState | null = null
+const hydrateFromStoredSession = vi.fn(async () => undefined)
+const refreshSessions = vi.fn(async () => undefined)
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+
+  const sessionStateByRuntimeIdRef = useRef(
+    new Map<string, ClientSessionState>([[SID, { ...createClientSessionState(), pendingBranchGroup: BRANCH_GROUP }]])
+  )
+
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession,
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions,
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      currentState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+    currentState = sessionStateByRuntimeIdRef.current.get(SID) ?? null
+  }, [stream.handleGatewayEvent, sessionStateByRuntimeIdRef])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+const emit = (type: string, payload?: Record<string, unknown>) =>
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+
+const assistantMessages = () => currentState!.messages.filter(message => message.role === 'assistant')
+
+const expectCompletionSideEffects = (count: number) => {
+  expect(sideEffects.playCompletionSound).toHaveBeenCalledTimes(count)
+  expect(sideEffects.flashPetActivity).toHaveBeenCalledTimes(count)
+  expect(sideEffects.dispatchNativeNotification).toHaveBeenCalledTimes(count)
+  expect(sideEffects.broadcastSessionsChanged).toHaveBeenCalledTimes(count)
+  expect(refreshSessions).toHaveBeenCalledTimes(count)
+}
+
+describe('useMessageStream message.interim', () => {
+  beforeEach(() => {
+    handleEvent = null
+    currentState = null
+    $activeSessionId.set(SID)
+    clearAllPrompts()
+    clearSessionTodos(SID)
+    setApprovalRequest({ command: 'echo ok', description: 'test prompt', sessionId: SID })
+    setSessionTodos(SID, [{ content: 'verify result', id: 'verify', status: 'in_progress' }])
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllPrompts()
+    clearSessionTodos(SID)
+    $activeSessionId.set(null)
+    hydrateFromStoredSession.mockClear()
+    refreshSessions.mockClear()
+    vi.restoreAllMocks()
+    Object.values(sideEffects).forEach(mock => mock.mockClear())
+  })
+
+  it('finalizes an interim segment without settling the turn, then completes a distinct reply', async () => {
+    await mountStream()
+
+    emit('message.start')
+    const turnStartedAt = currentState!.turnStartedAt
+    emit('message.delta', { text: 'full attempted reply' })
+
+    // A malformed boundary without authoritative text must not erase or
+    // finalize the streamed draft.
+    emit('message.interim')
+    expect(assistantMessages()).toHaveLength(1)
+    expect(chatMessageText(assistantMessages()[0]!)).toBe('full attempted reply')
+    expect(assistantMessages()[0]!.pending).toBe(true)
+    expect(currentState!.streamId).not.toBeNull()
+
+    emit('message.interim', { already_streamed: false, text: 'full attempted reply' })
+
+    expect(assistantMessages()).toHaveLength(1)
+    expect(chatMessageText(assistantMessages()[0]!)).toBe('full attempted reply')
+    expect(assistantMessages()[0]!.pending).toBe(false)
+    const interimId = assistantMessages()[0]!.id
+
+    expect(currentState).toMatchObject({
+      awaitingResponse: false,
+      busy: true,
+      pendingBranchGroup: BRANCH_GROUP,
+      streamId: null,
+      turnStartedAt
+    })
+    expect($approvalRequest.get()).not.toBeNull()
+    expect($todosBySession.get()[SID]).toHaveLength(1)
+    expectCompletionSideEffects(0)
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+
+    emit('message.delta', { text: 'verified final reply' })
+    emit('message.complete', { text: 'verified final reply' })
+
+    expect(assistantMessages()).toHaveLength(2)
+    expect(assistantMessages().map(chatMessageText)).toEqual(['full attempted reply', 'verified final reply'])
+    expect(assistantMessages().map(message => message.pending ?? false)).toEqual([false, false])
+    expect(assistantMessages()[1]!.id).not.toBe(interimId)
+    expect(currentState).toMatchObject({
+      awaitingResponse: false,
+      busy: false,
+      pendingBranchGroup: null,
+      streamId: null,
+      turnStartedAt: null
+    })
+    expectCompletionSideEffects(1)
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -416,6 +416,7 @@ describe('resumeSession failure recovery', () => {
             busy: false,
             cwd: '',
             fast: false,
+            interimBoundaryPending: false,
             interrupted: false,
             messages: [],
             model: '',

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -152,6 +152,8 @@ export interface ClientSessionState {
   awaitingResponse: boolean
   streamId: string | null
   sawAssistantPayload: boolean
+  /** True after message.interim finalized a bubble in the still-running turn. */
+  interimBoundaryPending: boolean
   pendingBranchGroup: string | null
   interrupted: boolean
   /** A blocking clarify prompt is waiting on the user for this session. Drives

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -24,6 +24,7 @@ export type ChatMessage = {
 export type GatewayEventPayload = {
   text?: string
   rendered?: string
+  already_streamed?: boolean
   status?: string
   message?: string
   id?: string

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -52,6 +52,7 @@ export function createClientSessionState(
     awaitingResponse: false,
     streamId: null,
     sawAssistantPayload: false,
+    interimBoundaryPending: false,
     pendingBranchGroup: null,
     interrupted: false,
     needsInput: false,

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -3,6 +3,7 @@ export type GatewayEventName =
   | 'session.info'
   | 'message.start'
   | 'message.delta'
+  | 'message.interim'
   | 'message.complete'
   | 'thinking.delta'
   | 'reasoning.delta'

--- a/tests/tui_gateway/test_interim_assistant_callback.py
+++ b/tests/tui_gateway/test_interim_assistant_callback.py
@@ -41,6 +41,7 @@ def test_agent_callback_emits_interim_message_without_settling_turn(server, monk
         "_emit",
         lambda event, sid, payload=None: emitted.append((event, sid, payload)),
     )
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda: True)
 
     callback = server._agent_cbs("sid-1")["interim_assistant_callback"]
     callback("full attempted reply", already_streamed=False)
@@ -54,3 +55,26 @@ def test_agent_callback_emits_interim_message_without_settling_turn(server, monk
     ]
     assert server._sessions["sid-1"]["inflight_turn"] is inflight_turn
     assert server._sessions["sid-1"]["running"] is True
+
+
+@pytest.mark.parametrize(
+    ("display", "expected"),
+    [
+        ({}, True),
+        ({"interim_assistant_messages": True}, True),
+        ({"interim_assistant_messages": False}, False),
+        ({"interim_assistant_messages": "off"}, False),
+    ],
+)
+def test_load_interim_assistant_messages_honors_display_config(
+    server, monkeypatch, display, expected
+):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"display": display})
+
+    assert server._load_interim_assistant_messages() is expected
+
+
+def test_agent_callbacks_omit_interim_delivery_when_disabled(server, monkeypatch):
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda: False)
+
+    assert "interim_assistant_callback" not in server._agent_cbs("sid-1")

--- a/tests/tui_gateway/test_interim_assistant_callback.py
+++ b/tests/tui_gateway/test_interim_assistant_callback.py
@@ -1,0 +1,56 @@
+"""Tests for mid-turn assistant message delivery over the TUI gateway."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_interim_message")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+def test_agent_callback_emits_interim_message_without_settling_turn(server, monkeypatch):
+    inflight_turn = {"assistant_text": "full attempted reply"}
+    server._sessions["sid-1"] = {
+        "inflight_turn": inflight_turn,
+        "running": True,
+    }
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    callback = server._agent_cbs("sid-1")["interim_assistant_callback"]
+    callback("full attempted reply", already_streamed=False)
+
+    assert emitted == [
+        (
+            "message.interim",
+            "sid-1",
+            {"text": "full attempted reply", "already_streamed": False},
+        )
+    ]
+    assert server._sessions["sid-1"]["inflight_turn"] is inflight_turn
+    assert server._sessions["sid-1"]["running"] is True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4185,6 +4185,11 @@ def _agent_cbs(sid: str) -> dict:
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
         and _emit("tool.generating", sid, {"name": name}),
+        "interim_assistant_callback": lambda text, *, already_streamed=False: _emit(
+            "message.interim",
+            sid,
+            {"text": str(text), "already_streamed": bool(already_streamed)},
+        ),
         "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts. Core-detected, so
         # the TUI heart and desktop floating hearts share one signal.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2869,6 +2869,14 @@ def _load_show_reasoning() -> bool:
     return bool((_load_cfg().get("display") or {}).get("show_reasoning", True))
 
 
+def _load_interim_assistant_messages() -> bool:
+    """Whether Desktop/Ink should surface complete assistant messages mid-turn."""
+    display = _load_cfg().get("display")
+    if not isinstance(display, dict):
+        return True
+    return is_truthy_value(display.get("interim_assistant_messages", True))
+
+
 def _load_memory_notifications() -> str:
     """Self-improvement review notification mode from config.yaml.
 
@@ -4173,7 +4181,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
 
 
 def _agent_cbs(sid: str) -> dict:
-    return {
+    callbacks = {
         "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
             sid, tc_id, name, args
         ),
@@ -4185,11 +4193,6 @@ def _agent_cbs(sid: str) -> dict:
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
         and _emit("tool.generating", sid, {"name": name}),
-        "interim_assistant_callback": lambda text, *, already_streamed=False: _emit(
-            "message.interim",
-            sid,
-            {"text": str(text), "already_streamed": bool(already_streamed)},
-        ),
         "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts. Core-detected, so
         # the TUI heart and desktop floating hearts share one signal.
@@ -4232,6 +4235,17 @@ def _agent_cbs(sid: str) -> dict:
             timeout=30,
         ),
     }
+
+    if _load_interim_assistant_messages():
+        callbacks["interim_assistant_callback"] = (
+            lambda text, *, already_streamed=False: _emit(
+                "message.interim",
+                sid,
+                {"text": str(text), "already_streamed": bool(already_streamed)},
+            )
+        )
+
+    return callbacks
 
 
 def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -570,6 +570,7 @@ describe('createGatewayEventHandler', () => {
 
     onEvent({ type: 'message.start' })
     onEvent({ payload: { text: 'full attempted reply' }, type: 'message.delta' })
+    expect(() => onEvent({ type: 'message.interim' } as any)).not.toThrow()
     onEvent({
       payload: { already_streamed: false, text: 'full attempted reply' },
       type: 'message.interim'

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -15,6 +15,16 @@ vi.mock('../lib/openExternalUrl.js', () => ({
   openExternalUrl: (url: string) => openExternalUrlMock(url)
 }))
 
+const { flashGoodVibesMock, flashPetMock } = vi.hoisted(() => ({
+  flashGoodVibesMock: vi.fn(),
+  flashPetMock: vi.fn()
+}))
+
+vi.mock('../app/petFlashStore.js', () => ({
+  flashGoodVibes: flashGoodVibesMock,
+  flashPet: flashPetMock
+}))
+
 const ref = <T>(current: T) => ({ current })
 
 const buildCtx = (appended: Msg[]) =>
@@ -547,6 +557,46 @@ describe('createGatewayEventHandler', () => {
 
     const assistant = appended.find(msg => msg.role === 'assistant')
     expect(assistant?.text).toBe('First. second.')
+  })
+
+  it('finalizes an interim assistant segment without settling the turn', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const bellWrite = vi.fn()
+    ctx.system.bellOnComplete = true
+    ctx.system.stdout = { isTTY: true, write: bellWrite }
+    const onEvent = createGatewayEventHandler(ctx)
+    flashPetMock.mockClear()
+
+    onEvent({ type: 'message.start' })
+    onEvent({ payload: { text: 'full attempted reply' }, type: 'message.delta' })
+    onEvent({
+      payload: { already_streamed: false, text: 'full attempted reply' },
+      type: 'message.interim'
+    })
+
+    expect(
+      getTurnState()
+        .streamSegments.filter(message => message.role === 'assistant')
+        .map(message => message.text)
+    ).toEqual(['full attempted reply'])
+    expect(turnController.bufRef).toBe('')
+    expect(getUiState().busy).toBe(true)
+    expect(appended).toEqual([])
+    expect(bellWrite).not.toHaveBeenCalled()
+    expect(flashPetMock).not.toHaveBeenCalled()
+
+    onEvent({ payload: { text: 'verified final reply' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'verified final reply' }, type: 'message.complete' })
+
+    expect(appended.filter(message => message.role === 'assistant').map(message => message.text)).toEqual([
+      'full attempted reply',
+      'verified final reply'
+    ])
+    expect(getUiState().busy).toBe(false)
+    expect(bellWrite).toHaveBeenCalledTimes(1)
+    expect(bellWrite).toHaveBeenCalledWith('\x07')
+    expect(flashPetMock).toHaveBeenCalledTimes(1)
   })
 
   it('anchors inline_diff as its own segment where the edit happened', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -569,7 +569,8 @@ describe('createGatewayEventHandler', () => {
     flashPetMock.mockClear()
 
     onEvent({ type: 'message.start' })
-    onEvent({ payload: { text: 'full attempted reply' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'full attempted ' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'reply' }, type: 'message.delta' })
     expect(() => onEvent({ type: 'message.interim' } as any)).not.toThrow()
     onEvent({
       payload: { already_streamed: false, text: 'full attempted reply' },
@@ -587,7 +588,8 @@ describe('createGatewayEventHandler', () => {
     expect(bellWrite).not.toHaveBeenCalled()
     expect(flashPetMock).not.toHaveBeenCalled()
 
-    onEvent({ payload: { text: 'verified final reply' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'verified ' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'final reply' }, type: 'message.delta' })
     onEvent({ payload: { text: 'verified final reply' }, type: 'message.complete' })
 
     expect(appended.filter(message => message.role === 'assistant').map(message => message.text)).toEqual([
@@ -598,6 +600,54 @@ describe('createGatewayEventHandler', () => {
     expect(bellWrite).toHaveBeenCalledTimes(1)
     expect(bellWrite).toHaveBeenCalledWith('\x07')
     expect(flashPetMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps identical interim and terminal replies as separate assistant messages', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ type: 'message.start' })
+    onEvent({ payload: { text: 'same ' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'reply' }, type: 'message.delta' })
+    onEvent({ payload: { already_streamed: true, text: 'same reply' }, type: 'message.interim' })
+    onEvent({ payload: { text: 'same reply' }, type: 'message.complete' })
+
+    expect(appended.filter(message => message.role === 'assistant').map(message => message.text)).toEqual([
+      'same reply',
+      'same reply'
+    ])
+  })
+
+  it('deduplicates a terminal reply against flushed segments without an interim boundary', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ type: 'message.start' })
+    onEvent({ payload: { text: 'same reply' }, type: 'message.delta' })
+    turnController.flushStreamingSegment()
+    onEvent({ payload: { text: 'same reply' }, type: 'message.complete' })
+
+    expect(appended.filter(message => message.role === 'assistant').map(message => message.text)).toEqual([
+      'same reply'
+    ])
+  })
+
+  it('deduplicates flushed chunks within the terminal message after an interim boundary', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ type: 'message.start' })
+    onEvent({ payload: { text: 'interim reply' }, type: 'message.delta' })
+    onEvent({ payload: { already_streamed: true, text: 'interim reply' }, type: 'message.interim' })
+    onEvent({ payload: { text: 'same ' }, type: 'message.delta' })
+    onEvent({ payload: { text: 'reply' }, type: 'message.delta' })
+    turnController.flushStreamingSegment()
+    onEvent({ payload: { text: 'same reply' }, type: 'message.complete' })
+
+    expect(appended.filter(message => message.role === 'assistant').map(message => message.text)).toEqual([
+      'interim reply',
+      'same reply'
+    ])
   })
 
   it('anchors inline_diff as its own segment where the edit happened', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -946,6 +946,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         turnController.recordMessageDelta(ev.payload ?? {})
 
         return
+
+      case 'message.interim':
+        turnController.recordInterimMessage(ev.payload.text)
+
+        return
       case 'message.complete': {
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -946,11 +946,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         turnController.recordMessageDelta(ev.payload ?? {})
 
         return
+      case 'message.interim': {
+        const text = ev.payload?.text
 
-      case 'message.interim':
-        turnController.recordInterimMessage(ev.payload.text)
+        if (typeof text === 'string' && text.trim()) {
+          turnController.recordInterimMessage(text)
+        }
 
         return
+      }
+
       case 'message.complete': {
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -554,6 +554,24 @@ class TurnController {
     this.flushPendingNotice()
   }
 
+  recordInterimMessage(text: string) {
+    if (this.interrupted) {
+      return
+    }
+
+    const authoritativeText = text.trimStart()
+
+    if (!authoritativeText) {
+      return
+    }
+
+    if (this.bufRef.trimStart() !== authoritativeText) {
+      this.bufRef = authoritativeText
+    }
+
+    this.flushStreamingSegment()
+  }
+
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
     this.closeReasoningSegment()
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -127,6 +127,7 @@ class TurnController {
   private activeReasoningText = ''
   private reasoningSegmentIndex: null | number = null
   private activityId = 0
+  private interimBoundaryIndex: null | number = null
   private reasoningStreamingTimer: Timer = null
   private reasoningTimer: Timer = null
   private streamTimer: Timer = null
@@ -275,6 +276,7 @@ class TurnController {
     this.bufRef = ''
     this.pendingSegmentTools = []
     this.segmentMessages = []
+    this.interimBoundaryIndex = null
 
     patchTurnState({
       streamPendingTools: [],
@@ -570,6 +572,7 @@ class TurnController {
     }
 
     this.flushStreamingSegment()
+    this.interimBoundaryIndex = this.segmentMessages.length
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
@@ -583,7 +586,8 @@ class TurnController {
     // only when the gateway elected not to send any (#16391).
     const rawText = (payload.text ?? payload.rendered ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
-    const finalText = finalTail(split.text, this.segmentMessages)
+    const dedupeStart = this.interimBoundaryIndex ?? 0
+    const finalText = finalTail(split.text, this.segmentMessages.slice(dedupeStart))
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
     const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedToolTokens = this.toolTokenAcc
@@ -962,6 +966,7 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.interrupted = false
+    this.interimBoundaryIndex = null
     this.persistedToolLabels.clear()
     // "Flash and yield" notices clear when a new turn starts: a usage-band heads-up
     // (credits.usage, 50/75/90%) and the one-time "grant spent" transition

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -841,6 +841,11 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
+      payload: { already_streamed: boolean; text: string }
+      session_id?: string
+      type: 'message.interim'
+    }
+  | {
       payload?: { reasoning?: string; rendered?: string; text?: string; usage?: Usage }
       session_id?: string
       type: 'message.complete'


### PR DESCRIPTION
## Problem

The TUI gateway streams every model pass into one live assistant bubble and emits only one terminal `message.complete`. Although the agent core already exposes `interim_assistant_callback`, `tui_gateway` does not register it. A complete assistant reply produced mid-turn (for example before a verification continuation) can therefore be persisted in `state.db` and briefly streamed, then visually replaced when a later model pass completes.

This is a presentation-boundary bug: the backend knows an assistant message ended, but Desktop and Ink receive no event that distinguishes **message complete inside a still-running turn** from **turn complete**.

## Fix

Add an explicit `message.interim` gateway event:

```
message.start
message.delta("full attempted reply")
message.interim({ text: "full attempted reply", already_streamed: false })
message.delta("verified final reply")
message.complete({ text: "verified final reply" })
```

- `tui_gateway` wires `interim_assistant_callback` when `display.interim_assistant_messages` is enabled (default), and emits authoritative text plus `already_streamed` without settling the inflight turn.
- Desktop synchronously flushes queued deltas, finalizes the current assistant bubble, rotates only its stream ID, and keeps the turn busy. An explicit boundary marker keeps an identical final completion distinct from that bubble. It does not clear prompts/todos, play completion cues, refresh sessions, or hydrate.
- Ink finalizes its current streaming segment while keeping the turn active.
- Shared and Ink gateway event types document the new contract.

The final `message.complete` still owns turn completion and all completion-only side effects.

## Related work

This PR is intentionally independent and does not copy code from the related open PRs:

| PR | Scope | Relationship |
|---|---|---|
| #61447 | Desktop `message.complete` merge policy honoring `display.interim_assistant_messages` | Complementary accumulator-based Desktop fix; does not add a backend message boundary |
| #56104 | Desktop suffix guard during final text replacement | Complementary Desktop-only heuristic |
| #41049 | Desktop assistant text-part finalization helper | Complementary Desktop-only merge approach |
| #62676 | Persist and emit verification-stop responses in the agent core | Complementary producer-side fix; this PR supplies the missing `tui_gateway` transport/UI boundary |

Unlike the Desktop-only merge PRs, `message.interim` preserves the semantic boundary between two complete assistant messages and gives every live TUI surface the same lifecycle signal. This PR does **not** change verification persistence, continuation roles, or API message sequencing from #62676.

Related reports: #40903, #61297, and #61822. These are already referenced by #61447, so this PR deliberately does not claim to close them.

## Tests

Strict RED → GREEN coverage was added at each layer:

| Layer | RED | GREEN |
|---|---|---|
| Python gateway callback | `KeyError: 'interim_assistant_callback'` | callback emits `message.interim`, honors enabled/disabled config, and leaves inflight/running state intact |
| Desktop hook | no assistant bubble after interim event; same-text final collapsed into interim | two distinct finalized assistant messages, including identical text; completion side effects fire once |
| Ink event handler | no finalized interim segment; malformed payload threw | interim + final messages remain ordered; malformed payload is ignored; busy clears only at final completion |
| Ink event contract | TS2678 / TS2339 for unknown event | typed payload accepted |

Verification run:

- `405 passed` — gateway callback/config + `test_tui_gateway_server.py` + protocol tests
- `29 passed` — Desktop message-stream and session-action tests
- `79 passed` — Ink gateway-event tests
- Desktop, Ink, and shared TypeScript typechecks passed
- Focused Desktop and Ink ESLint passed with zero warnings
- Ink production build passed
- Desktop production build passed (`assert-dist-built` succeeded)
- `ruff check` and Python `py_compile` passed
- `git diff --check` passed
- Independent OMP review found two lifecycle/config blockers; both were fixed and the focused re-review passed with no logic or security errors

## Scope

No persistence schema, provider wire format, verification policy, or configuration default is changed. The event is a live presentation contract only.
