### PR TITLE
feat(desktop): add URL preview navigation

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
@@ -80,5 +80,157 @@ describe('PreviewPane console state', () => {
     })
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
+  })
+
+  it('uses the webview history and reload controls for URL previews', () => {
+    const rendered = render(
+      <PreviewPane
+        target={{
+          kind: 'url',
+          label: 'Preview',
+          source: 'http://localhost:5174',
+          url: 'http://localhost:5174'
+        }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview') as
+      | (HTMLElement & {
+          canGoBack?: () => boolean
+          canGoForward?: () => boolean
+          goBack?: () => void
+          goForward?: () => void
+          reload?: () => void
+        })
+      | null
+
+    const canGoBack = vi.fn(() => true)
+    const canGoForward = vi.fn(() => true)
+    const goBack = vi.fn()
+    const goForward = vi.fn()
+    const reload = vi.fn()
+
+    Object.assign(webview ?? {}, { canGoBack, canGoForward, goBack, goForward, reload })
+
+    act(() => {
+      webview?.dispatchEvent(new Event('did-navigate'))
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Go back' }))
+    fireEvent.click(rendered.getByRole('button', { name: 'Go forward' }))
+    fireEvent.click(rendered.getByRole('button', { name: 'Reload preview' }))
+
+    expect(goBack).toHaveBeenCalledOnce()
+    expect(goForward).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('synchronizes the address and history controls after navigation events', () => {
+    const rendered = render(
+      <PreviewPane
+        target={{
+          kind: 'url',
+          label: 'Preview',
+          source: 'http://localhost:5174',
+          url: 'http://localhost:5174'
+        }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview') as
+      | (HTMLElement & {
+          canGoBack?: () => boolean
+          canGoForward?: () => boolean
+        })
+      | null
+
+    let canGoBack = true
+    let canGoForward = false
+
+    Object.assign(webview ?? {}, {
+      canGoBack: () => canGoBack,
+      canGoForward: () => canGoForward
+    })
+
+    act(() => {
+      webview?.dispatchEvent(Object.assign(new Event('did-navigate'), { url: 'http://127.0.0.1:3104/' }))
+    })
+
+    expect((rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement).value).toBe(
+      'http://127.0.0.1:3104/'
+    )
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(true)
+
+    canGoBack = false
+    canGoForward = true
+
+    act(() => {
+      webview?.dispatchEvent(
+        Object.assign(new Event('did-navigate-in-page'), { url: 'http://127.0.0.1:3104/settings' })
+      )
+    })
+
+    expect((rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement).value).toBe(
+      'http://127.0.0.1:3104/settings'
+    )
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('loads an HTTP URL submitted from the preview address bar', () => {
+    const rendered = render(
+      <PreviewPane
+        target={{
+          kind: 'url',
+          label: 'Preview',
+          source: 'http://localhost:5174',
+          url: 'http://localhost:5174'
+        }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview') as
+      | (HTMLElement & { loadURL?: (url: string) => void })
+      | null
+
+    const loadURL = vi.fn()
+
+    Object.assign(webview ?? {}, { loadURL })
+
+    fireEvent.change(rendered.getByRole('textbox', { name: 'Preview URL' }), {
+      target: { value: 'http://127.0.0.1:3104/' }
+    })
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(loadURL).toHaveBeenCalledWith('http://127.0.0.1:3104/')
+  })
+
+  it('does not load non-HTTP addresses submitted from the preview address bar', () => {
+    const rendered = render(
+      <PreviewPane
+        target={{
+          kind: 'url',
+          label: 'Preview',
+          source: 'http://localhost:5174',
+          url: 'http://localhost:5174'
+        }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview') as
+      | (HTMLElement & { loadURL?: (url: string) => void })
+      | null
+
+    const loadURL = vi.fn()
+
+    Object.assign(webview ?? {}, { loadURL })
+
+    fireEvent.change(rendered.getByRole('textbox', { name: 'Preview URL' }), {
+      target: { value: 'file:///private/secret.txt' }
+    })
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(loadURL).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -1,12 +1,14 @@
 import { useStore } from '@nanostores/react'
-import type { PointerEvent as ReactPointerEvent } from 'react'
+import type { FormEvent, PointerEvent as ReactPointerEvent } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-controls'
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { Input } from '@/components/ui/input'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
-import { Bug } from '@/lib/icons'
+import { ArrowUpRight, Bug, ChevronLeft, ChevronRight, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import { $previewServerRestart, failPreviewServerRestart, type PreviewTarget } from '@/store/preview'
@@ -23,9 +25,14 @@ import { type ConsoleEntry, createPreviewConsoleState } from './preview-console-
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 
 type PreviewWebview = HTMLElement & {
+  canGoBack?: () => boolean
+  canGoForward?: () => boolean
   closeDevTools?: () => void
   getURL?: () => string
+  goBack?: () => void
+  goForward?: () => void
   isDevToolsOpened?: () => boolean
+  loadURL?: (url: string) => Promise<void> | void
   openDevTools?: () => void
   reload?: () => void
   reloadIgnoringCache?: () => void
@@ -47,6 +54,16 @@ interface PreviewLoadErrorState {
 
 const FILE_RELOAD_DEBOUNCE_MS = 200
 const SERVER_RESTART_TIMEOUT_MS = 45_000
+
+function normalizeWebAddress(raw: string): string | null {
+  try {
+    const url = new URL(raw.trim())
+
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null
+  } catch {
+    return null
+  }
+}
 
 function loadErrorTitle(error: PreviewLoadErrorState, copy: Translations['preview']['web']): string {
   const description = error.description.toLowerCase()
@@ -140,6 +157,9 @@ export function PreviewPane({
   const previewServerRestart = useStore($previewServerRestart)
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
+  const [address, setAddress] = useState(target.url)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
   const [currentUrl, setCurrentUrl] = useState(target.url)
   const [devtoolsOpen, setDevtoolsOpen] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -154,6 +174,16 @@ export function PreviewPane({
   const restartingServer =
     previewServerRestart?.status === 'running' &&
     (previewServerRestart.url === target.url || previewServerRestart.url === currentUrl)
+
+  const normalizedAddress = normalizeWebAddress(address)
+  const addressInvalid = address.trim().length > 0 && !normalizedAddress
+
+  const syncNavigationState = useCallback(() => {
+    const webview = webviewRef.current
+
+    setCanGoBack(Boolean(webview?.canGoBack?.()))
+    setCanGoForward(Boolean(webview?.canGoForward?.()))
+  }, [])
 
   const startConsoleResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -220,6 +250,51 @@ export function PreviewPane({
       webviewRef.current?.reload?.()
     }
   }, [isWebPreview])
+
+  const goBack = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoBack?.() || !webview.goBack) {
+      return
+    }
+
+    webview.goBack()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const goForward = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoForward?.() || !webview.goForward) {
+      return
+    }
+
+    webview.goForward()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const navigateToAddress = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!normalizedAddress) {
+        return
+      }
+
+      const webview = webviewRef.current
+
+      setLoadError(null)
+      setCurrentUrl(normalizedAddress)
+      setAddress(normalizedAddress)
+
+      if (webview?.loadURL) {
+        void Promise.resolve(webview.loadURL(normalizedAddress)).catch(() => undefined)
+      } else {
+        webview?.setAttribute('src', normalizedAddress)
+      }
+    },
+    [normalizedAddress]
+  )
 
   const appendConsoleEntry = useCallback(
     (entry: Omit<ConsoleEntry, 'id'>) => {
@@ -501,6 +576,9 @@ export function PreviewPane({
 
     host.replaceChildren()
     webviewRef.current = null
+    setAddress(target.url)
+    setCanGoBack(false)
+    setCanGoForward(false)
     setCurrentUrl(target.url)
     setDevtoolsOpen(false)
     setLoadError(null)
@@ -551,7 +629,10 @@ export function PreviewPane({
       if (detail.url) {
         setLoadError(null)
         setCurrentUrl(detail.url)
+        setAddress(detail.url)
       }
+
+      syncNavigationState()
     }
 
     const onFail = (event: Event) => {
@@ -580,7 +661,11 @@ export function PreviewPane({
     }
 
     const onStart = () => setLoading(true)
-    const onStop = () => setLoading(false)
+
+    const onStop = () => {
+      setLoading(false)
+      syncNavigationState()
+    }
 
     webview.addEventListener('console-message', onConsole)
     webview.addEventListener('did-fail-load', onFail)
@@ -600,7 +685,7 @@ export function PreviewPane({
       webview.removeEventListener('did-stop-loading', onStop)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isWebPreview, syncNavigationState, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
@@ -620,6 +705,35 @@ export function PreviewPane({
               </Tip>
             </div>
           </div>
+        )}
+
+        {target.kind === 'url' && (
+          <form
+            aria-label={copy.navigate}
+            className="flex shrink-0 items-center gap-0.5 border-b border-(--ui-stroke-tertiary) px-1 py-1"
+            onSubmit={navigateToAddress}
+          >
+            <TooltipIconButton disabled={!canGoBack} onClick={goBack} tooltip={copy.goBack} type="button">
+              <ChevronLeft />
+            </TooltipIconButton>
+            <TooltipIconButton disabled={!canGoForward} onClick={goForward} tooltip={copy.goForward} type="button">
+              <ChevronRight />
+            </TooltipIconButton>
+            <Input
+              aria-invalid={addressInvalid || undefined}
+              aria-label={copy.address}
+              inputMode="url"
+              onChange={event => setAddress(event.target.value)}
+              size="xs"
+              value={address}
+            />
+            <TooltipIconButton disabled={!normalizedAddress} tooltip={copy.navigate} type="submit">
+              <ArrowUpRight />
+            </TooltipIconButton>
+            <TooltipIconButton onClick={reloadPreview} tooltip={copy.reload} type="button">
+              <RefreshCw />
+            </TooltipIconButton>
+          </form>
         )}
 
         <div

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -540,8 +540,7 @@ export const en: Translations = {
       localDesc: 'Start a private Hermes backend on localhost. This is the default and works offline.',
       remoteTitle: 'Remote gateway',
       remoteDesc: 'Connect this desktop shell to a remote Hermes backend.',
-      remoteAuthHint:
-        'Hosted gateways use OAuth or a username and password; self-hosted ones may use a session token.',
+      remoteAuthHint: 'Hosted gateways use OAuth or a username and password; self-hosted ones may use a session token.',
       cloudTitle: 'Hermes Cloud',
       cloudDesc: 'Sign in once to Hermes Cloud and pick from the agents on your account — no URL to paste.',
       cloudSignInTitle: 'Hermes Cloud',
@@ -2263,7 +2262,12 @@ export const en: Translations = {
       loadFailedConsole: (code, message) => `Load failed${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'The preview page could not be reached.',
       openTarget: url => `Open ${url}`,
-      fallbackTitle: 'Preview'
+      fallbackTitle: 'Preview',
+      goBack: 'Go back',
+      goForward: 'Go forward',
+      reload: 'Reload preview',
+      address: 'Preview URL',
+      navigate: 'Navigate preview'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -97,7 +97,8 @@ export const ja = defineLocale({
       remoteSignInHint: signInLabel =>
         `保存済みのリモートブラウザセッションからサインアウトし、${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
       signOutAndSignIn: 'サインアウトして再サインイン',
-      remoteFailureHint: '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
+      remoteFailureHint:
+        '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
       hideRecentLogs: '最近のログを非表示',
       showRecentLogs: '最近のログを表示',
       signedInTitle: 'サインインしました',
@@ -2205,7 +2206,12 @@ export const ja = defineLocale({
       loadFailedConsole: (code, message) => `読み込みに失敗しました${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'プレビューページに到達できませんでした。',
       openTarget: url => `${url} を開く`,
-      fallbackTitle: 'プレビュー'
+      fallbackTitle: 'プレビュー',
+      goBack: '戻る',
+      goForward: '進む',
+      reload: 'プレビューを再読み込み',
+      address: 'プレビュー URL',
+      navigate: 'プレビューへ移動'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1892,6 +1892,11 @@ export interface Translations {
       unreachableDescription: string
       openTarget: (url: string) => string
       fallbackTitle: string
+      goBack: string
+      goForward: string
+      reload: string
+      address: string
+      navigate: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2138,7 +2138,12 @@ export const zhHant = defineLocale({
       loadFailedConsole: (code, message) => `載入失敗${code ? ` (${code})` : ''}：${message}`,
       unreachableDescription: '無法連線至預覽頁面。',
       openTarget: url => `開啟 ${url}`,
-      fallbackTitle: '預覽'
+      fallbackTitle: '預覽',
+      goBack: '返回',
+      goForward: '前進',
+      reload: '重新載入預覽',
+      address: '預覽網址',
+      navigate: '前往預覽'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2425,7 +2425,12 @@ export const zh: Translations = {
       loadFailedConsole: (code, message) => `加载失败${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: '无法访问预览页面。',
       openTarget: url => `打开 ${url}`,
-      fallbackTitle: '预览'
+      fallbackTitle: '预览',
+      goBack: '返回',
+      goForward: '前进',
+      reload: '重新加载预览',
+      address: '预览网址',
+      navigate: '导航到预览'
     }
   },
 


### PR DESCRIPTION
## Summary
- add browser-style back, forward, reload, and address controls to URL preview panes
- restrict manually entered addresses to HTTP(S), keeping file and custom protocols out of the embedded preview
- localize the controls across supported Desktop locales

Closes #60030

## Validation
- `npm run test:ui -- src/app/chat/right-rail/preview-pane.test.tsx`
- `npx eslint src/app/chat/right-rail/preview-pane.tsx src/app/chat/right-rail/preview-pane.test.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/types.ts src/i18n/zh.ts src/i18n/zh-hant.ts`
- `npx prettier --check` on the changed files
- `npm run typecheck`
- `npm run build`

`npm run test:ui` is currently red on clean `origin/main` (49 files / 25 tests fail, plus two unhandled errors), including unrelated Electron `node:test` resolution failures; the focused preview suite passes.