### PR TITLE
feat(config): add trimmed agentwikis defaults

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1269,6 +1269,68 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        "agentwikis": {
+            "enabled": False,  # feature flag: prefer configured Agent Wikis ahead of web search
+            "shadow_mode": False,  # evaluate + log routing decisions but still use web search
+            "registry": {
+                "index_json_url": "https://agentwikis.com/index.json",
+                "llms_txt_url": "https://agentwikis.com/llms.txt",
+                "refresh_ttl_seconds": 86400,
+                "conditional_get": True,
+            },
+            "retrieval": {
+                "timeout_ms": 8000,
+                "max_pages_per_query": 6,
+                "retry_html_accept_markdown": True,
+            },
+            "routing": {
+                "min_select_score": 70,
+                "abstain_on_tie": True,
+                "freshness_trigger_terms": [
+                    "latest",
+                    "current",
+                    "recently",
+                    "recent",
+                    "today",
+                    "this week",
+                    "this month",
+                    "new",
+                    "just released",
+                    "roadmap",
+                    "upcoming",
+                ],
+            },
+            "domains": {
+                "hermes": {
+                    "wiki_slug": "hermes",
+                    "aliases": ["hermes", "hermes-agent"],
+                },
+                "gbrain": {
+                    "wiki_slug": "gbrain",
+                    "aliases": ["gbrain", "garrytan-gbrain", "agent-brain"],
+                },
+                "github": {
+                    "wiki_slug": "github",
+                    "aliases": ["github", "github-actions", "pull request", "pull requests", "actions", "codeql", "dependabot"],
+                },
+                "vercel": {
+                    "wiki_slug": "vercel",
+                    "aliases": ["vercel", "nextjs-deploy", "next.js deploy", "edge function", "vercel.json"],
+                },
+                "meta_ads": {
+                    "wiki_slug": "meta-ads",
+                    "aliases": ["meta ads", "facebook ads", "instagram ads", "ads manager", "advantage+"],
+                },
+                "google_ads": {
+                    "wiki_slug": "google-ads",
+                    "aliases": ["google ads", "adwords", "ga4 import", "enhanced conversions", "quality score"],
+                },
+                "claude_code": {
+                    "wiki_slug": "claude-code",
+                    "aliases": ["claude code", "claude-code", "claude mcp", "claude hooks", "claude subagents"],
+                },
+            },
+        },
     },
 
     "browser": {


### PR DESCRIPTION
## What does this PR do?

Adds Agent Wikis configuration defaults under `web.agentwikis`, gated behind an `enabled: False` feature flag. **Off by default — no change to existing behavior** until a user opts in. These are the config keys read by the routing runtime in #63606.

## Related Issue

Pairs with #63606 (routing runtime that consumes these keys). Supersedes the earlier duplicate #63592 (closed).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — new `web.agentwikis` defaults block (index/llms URLs, per-wiki slugs, `enabled: False`). Purely additive; no existing keys changed (rebased onto current `main`).

## How to Test

1. `pytest tests/tools/test_web_tools_config.py -q` — 220 pass.
2. Load config: the new `web.agentwikis` keys are present and `enabled` defaults to `False`, so behavior is unchanged.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(config):`)
- [x] I searched for existing PRs (closed the duplicate #63592)
- [x] My PR contains only changes related to this feature
- [x] I've run the tests and they pass (220 passed)
- [x] I've added tests for my changes — N/A (config defaults; behavior covered by #63606)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — config defaults only; no doc/schema/architecture changes
