### PR TITLE
fix(web): route covered queries through Agent Wikis first

### DIFF
--- a/tests/tools/test_agentwiki_routing.py
+++ b/tests/tools/test_agentwiki_routing.py
@@ -1,0 +1,311 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from tools.agentwiki_routing import AgentWikiDecision, AgentWikiResult, maybe_agentwiki_route_search
+from tools.web_tools import web_search_tool
+
+
+def _web_config(**overrides):
+    cfg = {
+        "agentwikis": {
+            "enabled": True,
+            "shadow_mode": False,
+            "registry": {
+                "index_json_url": "https://agentwikis.test/index.json",
+                "llms_txt_url": "https://agentwikis.test/llms.txt",
+                "refresh_ttl_seconds": 0,
+                "conditional_get": True,
+            },
+            "retrieval": {
+                "timeout_ms": 2000,
+                "max_pages_per_query": 6,
+                "retry_html_accept_markdown": True,
+            },
+            "routing": {
+                "min_select_score": 70,
+                "abstain_on_tie": True,
+                "freshness_trigger_terms": ["latest", "current", "recent", "today", "this week", "new"],
+            },
+            "domains": {
+                "hermes": {"wiki_slug": "hermes", "aliases": ["hermes", "hermes-agent"]},
+                "github": {"wiki_slug": "github", "aliases": ["github", "github actions", "pull request"]},
+                "vercel": {"wiki_slug": "vercel", "aliases": ["vercel", "next.js deploy", "vercel.json"]},
+                "claude_code": {"wiki_slug": "claude-code", "aliases": ["claude code", "claude hooks", "claude mcp"]},
+            },
+        }
+    }
+    agentwikis = cfg["agentwikis"]
+    for key, value in overrides.items():
+        agentwikis[key] = value
+    return cfg
+
+
+def _index_payload():
+    return {
+        "name": "Agent Wikis",
+        "wikis": [
+            {
+                "slug": "hermes",
+                "title": "Hermes",
+                "description": "Hermes docs",
+                "tags": ["agents", "configuration", "workflows"],
+                "scope": {
+                    "covers": "Hermes Agent setup, configuration, CLI commands, features, skills, providers, deployment, integrations, and troubleshooting.",
+                    "notCovered": "Real-time community discussion, releases after the date below, and third-party pricing — use web search for those.",
+                    "currentAs": "2026-07-01 (v0.18.0)",
+                },
+                "raw_base": "/raw/hermes/",
+                "html_base": "/wiki/hermes/",
+            },
+            {
+                "slug": "github",
+                "title": "GitHub",
+                "description": "GitHub docs",
+                "tags": ["github", "actions"],
+                "scope": {
+                    "covers": "GitHub repos, pull requests, Actions, CodeQL, Dependabot, and collaboration workflows.",
+                    "notCovered": "Enterprise administration, billing, and pricing are out of scope.",
+                    "currentAs": "2026-06-19",
+                },
+                "raw_base": "/raw/github/",
+                "html_base": "/wiki/github/",
+            },
+            {
+                "slug": "vercel",
+                "title": "Vercel",
+                "description": "Vercel docs",
+                "tags": ["vercel", "deployments"],
+                "scope": {
+                    "covers": "Vercel deployments, preview deployments, routing, build output, serverless and edge runtime basics.",
+                    "notCovered": "Pricing/plans and AI SDK / AI Gateway specifics are out of scope.",
+                    "currentAs": "2026-06-19",
+                },
+                "raw_base": "/raw/vercel/",
+                "html_base": "/wiki/vercel/",
+            },
+            {
+                "slug": "claude-code",
+                "title": "Claude Code",
+                "description": "Claude Code docs",
+                "tags": ["claude-code", "coding-agent"],
+                "scope": {
+                    "covers": "Claude Code installation, configuration, permissions, hooks, MCP, subagents, and troubleshooting.",
+                    "notCovered": "Non-Claude-Code API/platform pricing and general Anthropic API questions are out of scope.",
+                    "currentAs": "2026-07-01 (2.1.198)",
+                },
+                "raw_base": "/raw/claude-code/",
+                "html_base": "/wiki/claude-code/",
+            },
+        ],
+    }
+
+
+def _client(routes):
+    def handler(request):
+        url = str(request.url)
+        if url not in routes:
+            raise AssertionError(f"Unexpected URL {url}")
+        spec = routes[url]
+        status = spec.get("status", 200)
+        headers = spec.get("headers", {})
+        body = spec.get("body", "")
+        if isinstance(body, (dict, list)):
+            return httpx.Response(status, headers=headers, json=body, request=request)
+        return httpx.Response(status, headers=headers, text=body, request=request)
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_agentwiki_route_returns_raw_markdown_backed_results():
+    client = _client(
+        {
+            "https://agentwikis.test/index.json": {
+                "body": _index_payload(),
+                "headers": {"etag": '"v1"', "last-modified": "Tue, 01 Jul 2026 00:00:00 GMT"},
+            },
+            "https://agentwikis.test/wiki/hermes/llms.txt": {
+                "body": "# Hermes\n- [Hermes Agent Knowledge Base](/raw/hermes/README.md)\n- [Cron & Scheduling](/raw/hermes/wiki/concepts/cron-scheduling.md)\n"
+            },
+            "https://agentwikis.test/raw/hermes/README.md": {
+                "body": "# Hermes Agent Knowledge Base\nHermes Agent docs root."
+            },
+            "https://agentwikis.test/raw/hermes/wiki/concepts/cron-scheduling.md": {
+                "body": "---\ntitle: \"Cron & Scheduling\"\nupdated: 2026-07-01\n---\n\n# Cron & Scheduling\nHermes cron jobs run on a durable scheduler and support recurring prompts."
+            },
+            "https://agentwikis.test/raw/hermes/wiki/index.md": {
+                "body": "# Hermes Index\nCron and scheduling pages are listed here."
+            },
+        }
+    )
+
+    result = maybe_agentwiki_route_search(
+        "How do I configure Hermes cron jobs?",
+        _web_config(),
+        limit=2,
+        client=client,
+    )
+
+    assert result.response_data is not None
+    assert result.decision.selected_source == "agentwikis"
+    assert result.decision.reason == "success"
+    urls = [item["url"] for item in result.response_data["data"]["web"]]
+    assert "https://agentwikis.test/raw/hermes/wiki/concepts/cron-scheduling.md" in urls
+    assert result.response_data["source_routing"]["selected_wiki_slug"] == "hermes"
+
+
+def test_agentwiki_route_rejects_out_of_scope_examples():
+    client = _client({"https://agentwikis.test/index.json": {"body": _index_payload()}})
+
+    github = maybe_agentwiki_route_search(
+        "How do I manage GitHub Enterprise billing?",
+        _web_config(),
+        client=client,
+    )
+    assert github.response_data is None
+    assert github.decision.reason == "out_of_scope"
+    assert github.decision.selected_wiki_slug == "github"
+
+    vercel = maybe_agentwiki_route_search(
+        "How do I use the Vercel AI SDK?",
+        _web_config(),
+        client=client,
+    )
+    assert vercel.response_data is None
+    assert vercel.decision.reason == "out_of_scope"
+    assert vercel.decision.selected_wiki_slug == "vercel"
+
+    claude = maybe_agentwiki_route_search(
+        "What does the Claude API cost?",
+        _web_config(),
+        client=client,
+    )
+    assert claude.response_data is None
+    assert claude.decision.reason == "out_of_scope"
+    assert claude.decision.selected_wiki_slug == "claude-code"
+
+
+def test_agentwiki_route_rejects_stale_or_time_sensitive_queries():
+    client = _client({"https://agentwikis.test/index.json": {"body": _index_payload()}})
+
+    later_date = maybe_agentwiki_route_search(
+        "What changed in Hermes after 2026-07-10?",
+        _web_config(),
+        client=client,
+    )
+    assert later_date.response_data is None
+    assert later_date.decision.reason == "stale_for_query"
+
+    latest = maybe_agentwiki_route_search(
+        "What is the latest Claude Code release?",
+        _web_config(),
+        client=client,
+    )
+    assert latest.response_data is None
+    assert latest.decision.reason == "stale_for_query"
+
+    pricing = maybe_agentwiki_route_search(
+        "What is Vercel pricing?",
+        _web_config(),
+        client=client,
+    )
+    assert pricing.response_data is None
+    assert pricing.decision.reason == "out_of_scope"
+
+
+def test_agentwiki_registry_falls_back_to_llms_txt_when_index_json_unavailable():
+    client = _client(
+        {
+            "https://agentwikis.test/index.json": {"status": 503, "body": "down"},
+            "https://agentwikis.test/llms.txt": {
+                "body": "# Agent Wikis\n\n## Hermes\n> Covers: Hermes Agent setup and configuration.\n> Not covered: pricing.\n> Current as of: 2026-07-01\n- [Hermes Agent Knowledge Base](/raw/hermes/README.md)\n"
+            },
+            "https://agentwikis.test/wiki/hermes/llms.txt": {
+                "body": "# Hermes\n- [Hermes Agent Knowledge Base](/raw/hermes/README.md)\n"
+            },
+            "https://agentwikis.test/raw/hermes/README.md": {
+                "body": "# Hermes Agent Knowledge Base\nHermes setup docs."
+            },
+            "https://agentwikis.test/raw/hermes/wiki/index.md": {
+                "body": "# Hermes Index\nHermes setup docs index."
+            },
+        }
+    )
+
+    result = maybe_agentwiki_route_search("Hermes setup", _web_config(), client=client)
+
+    assert result.response_data is not None
+    assert result.decision.selected_source == "agentwikis"
+
+
+def test_web_search_tool_uses_agentwiki_result_before_provider_search(monkeypatch):
+    agentwiki_payload = {
+        "success": True,
+        "data": {
+            "web": [
+                {
+                    "title": "Cron & Scheduling",
+                    "url": "https://agentwikis.test/raw/hermes/wiki/concepts/cron-scheduling.md",
+                    "description": "Agentwiki (hermes): cron docs",
+                    "position": 1,
+                }
+            ]
+        },
+        "source_routing": {"selected_source": "agentwikis"},
+    }
+    monkeypatch.setattr(
+        "tools.web_tools.maybe_agentwiki_route_search",
+        lambda query, web_config, limit=5: AgentWikiResult(
+            response_data=agentwiki_payload,
+            decision=AgentWikiDecision(selected_source="agentwikis", reason="success", selected_wiki_slug="hermes"),
+        ),
+    )
+    monkeypatch.setattr("tools.web_tools._load_web_config", lambda: _web_config())
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    with patch.object(__import__("tools.web_tools", fromlist=["_debug"])._debug, "log_call"), patch.object(
+        __import__("tools.web_tools", fromlist=["_debug"])._debug, "save"
+    ), patch("tools.web_tools._ensure_web_plugins_loaded") as ensure_loaded:
+        payload = json.loads(web_search_tool("Hermes cron jobs", limit=1))
+
+    ensure_loaded.assert_not_called()
+    assert payload["source_routing"]["selected_source"] == "agentwikis"
+    assert payload["data"]["web"][0]["url"].endswith("cron-scheduling.md")
+
+
+def test_web_search_tool_falls_back_to_provider_when_agentwiki_abstains(monkeypatch):
+    monkeypatch.setattr(
+        "tools.web_tools.maybe_agentwiki_route_search",
+        lambda query, web_config, limit=5: AgentWikiResult(
+            response_data=None,
+            decision=AgentWikiDecision(selected_source="web_search", reason="out_of_scope", selected_wiki_slug="github", fallback_occurred=True),
+        ),
+    )
+    monkeypatch.setattr("tools.web_tools._load_web_config", lambda: _web_config())
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    provider = MagicMock()
+    provider.supports_search.return_value = True
+    provider.name = "fake-search"
+    provider.search.return_value = {
+        "success": True,
+        "data": {"web": [{"title": "live", "url": "https://example.com", "description": "live", "position": 1}]},
+    }
+
+    with patch("tools.web_tools._ensure_web_plugins_loaded"), patch(
+        "tools.web_tools._get_search_backend", return_value="fake-search"
+    ), patch(
+        "agent.web_search_registry.get_provider", return_value=provider
+    ), patch(
+        "agent.web_search_registry.get_active_search_provider", return_value=provider
+    ), patch(
+        "agent.web_search_registry._disabled_web_plugin_for", return_value=None
+    ), patch.object(__import__("tools.web_tools", fromlist=["_debug"])._debug, "log_call"), patch.object(
+        __import__("tools.web_tools", fromlist=["_debug"])._debug, "save"
+    ):
+        payload = json.loads(web_search_tool("GitHub Enterprise billing", limit=1))
+
+    provider.search.assert_called_once()
+    assert payload["source_routing"]["selected_source"] == "web_search"
+    assert payload["source_routing"]["selection_reason"] == "out_of_scope"

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -487,7 +487,9 @@ class TestWebSearchSchema:
              patch.object(tools.web_tools._debug, "save"):
             result = json.loads(tools.web_tools.web_search_tool("docs", limit=500))
 
-        assert result == {"success": True, "data": {"web": []}}
+        assert result["success"] is True
+        assert result["data"] == {"web": []}
+        assert result["source_routing"]["selected_source"] == "web_search"
         fake_search.assert_called_once_with("docs", 100)
 
 

--- a/tools/agentwiki_routing.py
+++ b/tools/agentwiki_routing.py
@@ -1,0 +1,722 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urljoin
+
+import httpx
+
+from hermes_constants import get_hermes_dir
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_MS = 8000
+DEFAULT_REGISTRY_TTL_SECONDS = 86400
+DEFAULT_MAX_PAGES_PER_QUERY = 6
+DEFAULT_MIN_SELECT_SCORE = 70
+DEFAULT_FRESHNESS_TRIGGER_TERMS = [
+    "latest",
+    "current",
+    "recently",
+    "recent",
+    "today",
+    "this week",
+    "this month",
+    "new",
+    "just released",
+    "roadmap",
+    "upcoming",
+]
+DEFAULT_REGISTRY_INDEX_URL = "https://agentwikis.com/index.json"
+DEFAULT_REGISTRY_LLMSTXT_URL = "https://agentwikis.com/llms.txt"
+
+_MUTABLE_TOPIC_TERMS = {
+    "pricing",
+    "price",
+    "billing",
+    "cost",
+    "policy",
+    "policies",
+    "release",
+    "releases",
+    "roadmap",
+    "status",
+    "availability",
+    "plan",
+    "plans",
+}
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9+_.-]*")
+_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2}|20\d{2}-\d{2}|20\d{2})\b")
+_RAW_LINK_RE = re.compile(r"\((/raw/[^)]+)\)")
+
+
+@dataclass
+class AgentWikiDecision:
+    selected_source: str
+    reason: str
+    selected_wiki_slug: Optional[str] = None
+    current_as_used: Optional[str] = None
+    pages_fetched_count: int = 0
+    fallback_occurred: bool = False
+    metadata: Optional[Dict[str, Any]] = None
+
+    def log_record(self, query: str) -> Dict[str, Any]:
+        record = {
+            "query_hash": hashlib.sha256(_normalize_query(query).encode("utf-8")).hexdigest()[:12],
+            "selected_source": self.selected_source,
+            "selected_wiki_slug": self.selected_wiki_slug,
+            "selection_reason": self.reason,
+            "current_as_used": self.current_as_used,
+            "pages_fetched_count": self.pages_fetched_count,
+            "fallback_occurred": self.fallback_occurred,
+        }
+        if self.metadata:
+            record.update(self.metadata)
+        logger.info("agentwiki_routing_decision %s", json.dumps(record, sort_keys=True, ensure_ascii=False))
+        return record
+
+
+@dataclass
+class AgentWikiResult:
+    response_data: Optional[Dict[str, Any]]
+    decision: AgentWikiDecision
+
+
+class AgentWikiError(RuntimeError):
+    pass
+
+
+class AgentWikiRouter:
+    def __init__(self, web_config: Dict[str, Any], *, client: Optional[httpx.Client] = None):
+        self.web_config = web_config or {}
+        self.cfg = dict((self.web_config.get("agentwikis") or {}))
+        self.client = client
+        self.cache_dir = get_hermes_dir("cache/agentwikis", "agentwikis_cache")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def enabled(self) -> bool:
+        return bool(self.cfg.get("enabled", False))
+
+    def shadow_mode(self) -> bool:
+        return bool(self.cfg.get("shadow_mode", False))
+
+    def maybe_route_search(self, query: str, limit: int = 5) -> AgentWikiResult:
+        if not self.enabled() or not query or not query.strip():
+            return AgentWikiResult(None, AgentWikiDecision(selected_source="web_search", reason="disabled"))
+
+        try:
+            registry = self._load_registry()
+            selection = self._select_wiki(query, registry)
+            if selection["decision"].reason != "success":
+                return AgentWikiResult(None, selection["decision"])
+
+            wiki = selection["wiki"]
+            retrieval = self._retrieve_pages(query, wiki, limit=limit)
+            decision = selection["decision"]
+            decision.pages_fetched_count = len(retrieval["results"])
+            decision.metadata = {
+                **(decision.metadata or {}),
+                "retrieval_urls": [r.get("url") for r in retrieval["results"]],
+            }
+            if not retrieval["results"]:
+                decision.selected_source = "web_search"
+                decision.reason = retrieval.get("fallback_reason", "raw_unavailable")
+                decision.fallback_occurred = True
+                return AgentWikiResult(None, decision)
+
+            if self.shadow_mode():
+                decision.selected_source = "web_search"
+                decision.reason = "shadow_mode"
+                decision.fallback_occurred = True
+                return AgentWikiResult(None, decision)
+
+            response = {
+                "success": True,
+                "data": {"web": retrieval["results"]},
+                "source_routing": {
+                    "selected_source": "agentwikis",
+                    "selected_wiki_slug": wiki["slug"],
+                    "selection_reason": "success",
+                    "current_as_used": decision.current_as_used,
+                    "pages_fetched_count": len(retrieval["results"]),
+                    "fallback_occurred": False,
+                    "registry_metadata": {
+                        "title": wiki.get("title"),
+                        "raw_base": wiki.get("raw_base"),
+                        "html_base": wiki.get("html_base"),
+                    },
+                    "retrieval_plan": retrieval.get("retrieval_plan", []),
+                },
+            }
+            return AgentWikiResult(response, decision)
+        except AgentWikiError as exc:
+            return AgentWikiResult(None, AgentWikiDecision(selected_source="web_search", reason=str(exc), fallback_occurred=True))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Agentwiki routing failed open: %s", exc)
+            return AgentWikiResult(None, AgentWikiDecision(selected_source="web_search", reason="router_error", fallback_occurred=True))
+
+    def _timeout_s(self) -> float:
+        timeout_ms = ((self.cfg.get("retrieval") or {}).get("timeout_ms") or DEFAULT_TIMEOUT_MS)
+        try:
+            timeout_ms = int(timeout_ms)
+        except (TypeError, ValueError):
+            timeout_ms = DEFAULT_TIMEOUT_MS
+        return max(timeout_ms, 1000) / 1000.0
+
+    def _registry_urls(self) -> tuple[str, str]:
+        registry = self.cfg.get("registry") or {}
+        return (
+            registry.get("index_json_url") or DEFAULT_REGISTRY_INDEX_URL,
+            registry.get("llms_txt_url") or DEFAULT_REGISTRY_LLMSTXT_URL,
+        )
+
+    def _registry_ttl(self) -> int:
+        registry = self.cfg.get("registry") or {}
+        try:
+            return max(int(registry.get("refresh_ttl_seconds", DEFAULT_REGISTRY_TTL_SECONDS)), 0)
+        except (TypeError, ValueError):
+            return DEFAULT_REGISTRY_TTL_SECONDS
+
+    def _conditional_get_enabled(self) -> bool:
+        return bool((self.cfg.get("registry") or {}).get("conditional_get", True))
+
+    def _max_pages_per_query(self) -> int:
+        retrieval = self.cfg.get("retrieval") or {}
+        try:
+            return max(1, min(int(retrieval.get("max_pages_per_query", DEFAULT_MAX_PAGES_PER_QUERY)), 20))
+        except (TypeError, ValueError):
+            return DEFAULT_MAX_PAGES_PER_QUERY
+
+    def _retry_html_markdown(self) -> bool:
+        return bool((self.cfg.get("retrieval") or {}).get("retry_html_accept_markdown", True))
+
+    def _min_select_score(self) -> int:
+        routing = self.cfg.get("routing") or {}
+        try:
+            return max(0, int(routing.get("min_select_score", DEFAULT_MIN_SELECT_SCORE)))
+        except (TypeError, ValueError):
+            return DEFAULT_MIN_SELECT_SCORE
+
+    def _freshness_trigger_terms(self) -> List[str]:
+        routing = self.cfg.get("routing") or {}
+        terms = routing.get("freshness_trigger_terms")
+        if isinstance(terms, list) and terms:
+            return [str(t).strip().lower() for t in terms if str(t).strip()]
+        return list(DEFAULT_FRESHNESS_TRIGGER_TERMS)
+
+    def _domains_cfg(self) -> Dict[str, Dict[str, Any]]:
+        return dict((self.cfg.get("domains") or {}))
+
+    def _cache_paths(self) -> tuple[Path, Path]:
+        return self.cache_dir / "registry.json", self.cache_dir / "registry.meta.json"
+
+    def _load_registry(self) -> Dict[str, Any]:
+        body_path, meta_path = self._cache_paths()
+        cached_body = None
+        cached_meta: Dict[str, Any] = {}
+        if body_path.exists():
+            try:
+                cached_body = json.loads(body_path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                cached_body = None
+        if meta_path.exists():
+            try:
+                cached_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                cached_meta = {}
+
+        now_ts = datetime.utcnow().timestamp()
+        is_fresh = bool(cached_body) and cached_meta.get("fetched_at") and (now_ts - float(cached_meta["fetched_at"]) < self._registry_ttl())
+
+        if is_fresh:
+            registry = cached_body
+        else:
+            registry = self._refresh_registry(cached_body, cached_meta)
+
+        if not registry:
+            raise AgentWikiError("registry_unavailable")
+
+        self._warn_invalid_configured_slugs(registry)
+        return registry
+
+    def _refresh_registry(self, cached_body: Optional[Dict[str, Any]], cached_meta: Dict[str, Any]) -> Dict[str, Any]:
+        index_url, llms_url = self._registry_urls()
+        errors: List[str] = []
+        for kind, url in (("index_json", index_url), ("llms_txt", llms_url)):
+            try:
+                data, response_meta = self._fetch_registry_url(url, kind, cached_meta if kind == "index_json" else {})
+                if data:
+                    body_path, meta_path = self._cache_paths()
+                    body_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+                    response_meta["fetched_at"] = datetime.utcnow().timestamp()
+                    meta_path.write_text(json.dumps(response_meta, ensure_ascii=False, indent=2), encoding="utf-8")
+                    return data
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{kind}:{exc}")
+
+        if cached_body:
+            logger.warning("Agentwiki registry refresh failed; using cached registry (%s)", "; ".join(errors))
+            return cached_body
+        raise AgentWikiError("registry_unavailable")
+
+    def _fetch_registry_url(self, url: str, kind: str, cached_meta: Dict[str, Any]) -> tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+        headers: Dict[str, str] = {}
+        if kind == "index_json":
+            headers["Accept"] = "application/json"
+        else:
+            headers["Accept"] = "text/plain, text/markdown;q=0.9"
+        if self._conditional_get_enabled():
+            if cached_meta.get("etag"):
+                headers["If-None-Match"] = str(cached_meta["etag"])
+            if cached_meta.get("last_modified"):
+                headers["If-Modified-Since"] = str(cached_meta["last_modified"])
+
+        response = self._http_get(url, headers=headers)
+        if response.status_code == 304:
+            body_path, _ = self._cache_paths()
+            if body_path.exists():
+                return json.loads(body_path.read_text(encoding="utf-8")), cached_meta
+            raise AgentWikiError("registry_unavailable")
+        response.raise_for_status()
+        if kind == "index_json":
+            data = response.json()
+        else:
+            data = self._parse_global_llms_txt(response.text, base_url=url)
+        meta = {
+            "source_url": url,
+            "etag": response.headers.get("etag"),
+            "last_modified": response.headers.get("last-modified"),
+        }
+        return data, meta
+
+    def _select_wiki(self, query: str, registry: Dict[str, Any]) -> Dict[str, Any]:
+        domains = self._domains_cfg()
+        if not domains:
+            return {"decision": AgentWikiDecision(selected_source="web_search", reason="no_candidate")}
+
+        registry_wikis = {w.get("slug"): w for w in registry.get("wikis", []) if w.get("slug")}
+        query_norm = _normalize_query(query)
+        query_tokens = set(_tokenize(query_norm))
+        explicit_matches: List[str] = []
+        scores: Dict[str, Dict[str, Any]] = {}
+
+        for domain_name, domain_cfg in domains.items():
+            slug = str(domain_cfg.get("wiki_slug") or "").strip()
+            wiki = registry_wikis.get(slug)
+            if not wiki:
+                continue
+            aliases = [str(a).strip().lower() for a in domain_cfg.get("aliases", []) if str(a).strip()]
+            title = str(wiki.get("title") or "").strip().lower()
+            wiki_slug = slug.lower()
+            tags = [str(t).strip().lower() for t in wiki.get("tags", []) if str(t).strip()]
+
+            score = 0
+            matched_on: List[str] = []
+            explicit = False
+            explicit_targets = aliases + [wiki_slug, title]
+            for phrase in explicit_targets:
+                if phrase and phrase in query_norm:
+                    score = max(score, 100 if phrase in aliases or phrase == wiki_slug else 70)
+                    matched_on.append(phrase)
+                    explicit = True
+            for tag in tags:
+                if tag and tag in query_norm:
+                    score = max(score, 50)
+                    matched_on.append(tag)
+            if score == 0:
+                title_tokens = set(_tokenize(title))
+                if title_tokens and (title_tokens & query_tokens):
+                    score = max(score, 70)
+                    matched_on.append("title_token_overlap")
+            if score == 0:
+                alias_tokens = set()
+                for alias in aliases:
+                    alias_tokens.update(_tokenize(alias))
+                if alias_tokens and (alias_tokens & query_tokens):
+                    score = max(score, 30)
+                    matched_on.append("keyword_overlap")
+
+            if score > 0:
+                scores[str(slug)] = {
+                    "domain_name": domain_name,
+                    "wiki": wiki,
+                    "score": score,
+                    "matched_on": matched_on,
+                    "explicit": explicit,
+                }
+                if explicit:
+                    explicit_matches.append(str(slug))
+
+        if not scores:
+            return {"decision": AgentWikiDecision(selected_source="web_search", reason="no_candidate")}
+
+        ranked = sorted(scores.values(), key=lambda item: item["score"], reverse=True)
+        top = ranked[0]
+        top_score = top["score"]
+        min_score = self._min_select_score()
+        if top_score < min_score:
+            return {"decision": AgentWikiDecision(selected_source="web_search", reason="below_threshold", metadata={"top_score": top_score})}
+
+        tied = [item for item in ranked if item["score"] == top_score]
+        if len(tied) > 1 and len(set(explicit_matches)) != 1 and bool((self.cfg.get("routing") or {}).get("abstain_on_tie", True)):
+            return {"decision": AgentWikiDecision(selected_source="web_search", reason="tie", metadata={"tied_wikis": [item["wiki"]["slug"] for item in tied]})}
+
+        wiki = top["wiki"]
+        scope_ok, scope_reason = self._passes_scope_gate(query_norm, wiki)
+        if not scope_ok:
+            return {
+                "decision": AgentWikiDecision(
+                    selected_source="web_search",
+                    reason="out_of_scope",
+                    selected_wiki_slug=wiki.get("slug"),
+                    metadata={"scope_reason": scope_reason, "matched_on": top["matched_on"]},
+                )
+            }
+
+        current_as = str(((wiki.get("scope") or {}).get("currentAs") or "")).strip() or None
+        freshness_ok, freshness_reason = self._passes_freshness_gate(query_norm, wiki)
+        if not freshness_ok:
+            return {
+                "decision": AgentWikiDecision(
+                    selected_source="web_search",
+                    reason="stale_for_query",
+                    selected_wiki_slug=wiki.get("slug"),
+                    current_as_used=current_as,
+                    metadata={"freshness_reason": freshness_reason, "matched_on": top["matched_on"]},
+                )
+            }
+
+        return {
+            "wiki": wiki,
+            "decision": AgentWikiDecision(
+                selected_source="agentwikis",
+                reason="success",
+                selected_wiki_slug=wiki.get("slug"),
+                current_as_used=current_as,
+                metadata={"matched_on": top["matched_on"], "top_score": top_score},
+            ),
+        }
+
+    def _passes_scope_gate(self, query_norm: str, wiki: Dict[str, Any]) -> tuple[bool, str]:
+        scope = wiki.get("scope") or {}
+        covers = str(scope.get("covers") or "")
+        not_covered = str(scope.get("notCovered") or "")
+        query_tokens = set(_tokenize(query_norm))
+        not_covered_phrases = _split_scope_phrases(not_covered)
+        for phrase in not_covered_phrases:
+            phrase_tokens = set(_tokenize(phrase))
+            if phrase and phrase in query_norm:
+                return False, f"notCovered phrase match: {phrase}"
+            if phrase_tokens and len(phrase_tokens) >= 2 and phrase_tokens.issubset(query_tokens):
+                return False, f"notCovered token match: {phrase}"
+
+        # Heuristic for neighboring products: if the query explicitly mentions
+        # terms known to be excluded from scope, reject.
+        if any(term in query_tokens for term in {"pricing", "billing", "cost", "enterprise", "sdk", "gateway", "api"}):
+            lowered_not_covered = not_covered.lower()
+            if "pricing" in query_tokens and any(t in lowered_not_covered for t in ("pricing", "billing", "cost")):
+                return False, "pricing/billing excluded by notCovered"
+            if "enterprise" in query_tokens and "enterprise" in lowered_not_covered:
+                return False, "enterprise excluded by notCovered"
+            if "sdk" in query_tokens and "sdk" in lowered_not_covered:
+                return False, "sdk excluded by notCovered"
+            if "api" in query_tokens and "api" in lowered_not_covered:
+                return False, "api excluded by notCovered"
+            if "gateway" in query_tokens and "gateway" in lowered_not_covered:
+                return False, "gateway excluded by notCovered"
+
+        if covers:
+            cover_tokens = set(_tokenize(covers))
+            if cover_tokens & query_tokens:
+                return True, "covers overlap"
+
+        # Explicit domain selection is good enough once exclusions did not fire.
+        return True, "selected_domain"
+
+    def _passes_freshness_gate(self, query_norm: str, wiki: Dict[str, Any]) -> tuple[bool, str]:
+        scope = wiki.get("scope") or {}
+        current_as = str(scope.get("currentAs") or "")
+        current_date = _extract_date(current_as)
+        not_covered = str(scope.get("notCovered") or "").lower()
+
+        for trigger in self._freshness_trigger_terms():
+            if trigger and trigger in query_norm:
+                return False, f"trigger term: {trigger}"
+
+        query_dates = [_extract_date(match.group(1)) for match in _DATE_RE.finditer(query_norm)]
+        query_dates = [d for d in query_dates if d]
+        if current_date and query_dates and any(qd > current_date for qd in query_dates):
+            return False, f"query date newer than currentAs ({current_date.isoformat()})"
+
+        query_tokens = set(_tokenize(query_norm))
+        if query_tokens & _MUTABLE_TOPIC_TERMS and (query_tokens & set(_tokenize(not_covered)) or any(term in not_covered for term in _MUTABLE_TOPIC_TERMS)):
+            return False, "mutable topic guarded by notCovered/currentAs"
+
+        return True, "stable query"
+
+    def _retrieve_pages(self, query: str, wiki: Dict[str, Any], *, limit: int) -> Dict[str, Any]:
+        raw_base = _absolute_url(self._registry_urls()[0], wiki.get("raw_base") or "")
+        html_base = _absolute_url(self._registry_urls()[0], wiki.get("html_base") or "")
+        page_urls = []
+        llms_txt_url = urljoin(html_base.rstrip("/") + "/", "llms.txt") if html_base else None
+        if llms_txt_url:
+            try:
+                resp = self._http_get(llms_txt_url, headers={"Accept": "text/plain, text/markdown;q=0.9"})
+                resp.raise_for_status()
+                page_urls = self._parse_wiki_llms_txt(resp.text, base_url=llms_txt_url)
+            except Exception as exc:  # noqa: BLE001
+                logger.info("Agentwiki llms.txt fetch failed for %s: %s", wiki.get("slug"), exc)
+
+        candidates = []
+        for fallback in (urljoin(raw_base.rstrip("/") + "/", "README.md"), urljoin(raw_base.rstrip("/") + "/", "wiki/index.md")):
+            if fallback and fallback not in page_urls:
+                candidates.append(fallback)
+        page_urls = candidates + [u for u in page_urls if u not in candidates]
+        page_urls = page_urls[: self._max_pages_per_query()]
+        if not page_urls:
+            return {"results": [], "fallback_reason": "raw_unavailable", "retrieval_plan": []}
+
+        query_tokens = set(_tokenize(query))
+        pages: List[Dict[str, Any]] = []
+        for page_url in page_urls:
+            page = self._fetch_page_markdown(page_url)
+            if page:
+                pages.append(page)
+
+        if not pages:
+            return {"results": [], "fallback_reason": "raw_unavailable", "retrieval_plan": page_urls}
+
+        ranked_pages = sorted(pages, key=lambda page: self._score_page(page, query_tokens), reverse=True)
+        max_results = max(1, min(int(limit or 5), self._max_pages_per_query()))
+        selected_pages = ranked_pages[:max_results]
+        results = []
+        for idx, page in enumerate(selected_pages, start=1):
+            results.append(
+                {
+                    "title": page.get("title") or page.get("url"),
+                    "url": page.get("url"),
+                    "description": _summarize_page(page, wiki.get("slug") or "", wiki.get("title") or ""),
+                    "position": idx,
+                    "source": "agentwikis",
+                }
+            )
+        return {"results": results, "retrieval_plan": page_urls}
+
+    def _fetch_page_markdown(self, url: str) -> Optional[Dict[str, Any]]:
+        try:
+            response = self._http_get(url, headers={"Accept": "text/markdown, text/plain;q=0.9"})
+            if response.status_code == 402:
+                logger.info("Agentwiki page %s gated behind payment/auth", url)
+                return None
+            response.raise_for_status()
+            return _parse_markdown_page(url, response.text)
+        except Exception:
+            if self._retry_html_markdown() and "/raw/" in url:
+                html_url = url.replace("/raw/", "/wiki/", 1)
+                try:
+                    response = self._http_get(html_url, headers={"Accept": "text/markdown"})
+                    if response.status_code == 402:
+                        return None
+                    response.raise_for_status()
+                    return _parse_markdown_page(str(response.url), response.text)
+                except Exception:
+                    return None
+            return None
+
+    def _score_page(self, page: Dict[str, Any], query_tokens: set[str]) -> int:
+        haystacks = [
+            str(page.get("title") or "").lower(),
+            str(page.get("content") or "").lower(),
+            str(page.get("url") or "").lower(),
+        ]
+        score = 0
+        for token in query_tokens:
+            if len(token) < 3:
+                continue
+            for hay in haystacks:
+                if token in hay:
+                    score += 5 if hay is haystacks[0] else 1
+                    break
+        if str(page.get("url") or "").endswith("README.md"):
+            score += 1
+        if str(page.get("url") or "").endswith("wiki/index.md"):
+            score += 2
+        return score
+
+    def _warn_invalid_configured_slugs(self, registry: Dict[str, Any]) -> None:
+        registry_slugs = {w.get("slug") for w in registry.get("wikis", [])}
+        invalid = []
+        for domain_name, domain_cfg in self._domains_cfg().items():
+            slug = domain_cfg.get("wiki_slug")
+            if slug and slug not in registry_slugs:
+                invalid.append({"domain": domain_name, "wiki_slug": slug})
+        if invalid:
+            logger.warning("Agentwiki config has unknown wiki slugs: %s", json.dumps(invalid, ensure_ascii=False))
+
+    def _http_get(self, url: str, *, headers: Optional[Dict[str, str]] = None) -> httpx.Response:
+        timeout = self._timeout_s()
+        if self.client is not None:
+            return self.client.get(url, headers=headers or {}, timeout=timeout, follow_redirects=True)
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            return client.get(url, headers=headers or {})
+
+    @staticmethod
+    def _parse_global_llms_txt(text: str, *, base_url: str) -> Dict[str, Any]:
+        wikis: List[Dict[str, Any]] = []
+        sections = re.split(r"^## ", text, flags=re.MULTILINE)
+        for section in sections[1:]:
+            lines = [line.rstrip() for line in section.splitlines()]
+            if not lines:
+                continue
+            title = lines[0].strip()
+            body = lines[1:]
+            covers = _strip_quote_prefix(_find_line_value(body, "> Covers:"))
+            not_covered = _strip_quote_prefix(_find_line_value(body, "> Not covered:"))
+            current_as = _strip_quote_prefix(_find_line_value(body, "> Current as of:"))
+            links = _RAW_LINK_RE.findall("\n".join(body))
+            if not links:
+                continue
+            first_link = links[0]
+            slug_match = re.search(r"/raw/([^/]+)/", first_link)
+            if not slug_match:
+                continue
+            slug = slug_match.group(1)
+            wikis.append(
+                {
+                    "slug": slug,
+                    "title": title,
+                    "description": title,
+                    "tags": _tokenize(title),
+                    "category": "unknown",
+                    "scope": {
+                        "covers": covers,
+                        "notCovered": not_covered,
+                        "currentAs": current_as,
+                    },
+                    "lastUpdated": None,
+                    "documentCount": len(links),
+                    "llms_txt": "/llms.txt",
+                    "raw_base": f"/raw/{slug}/",
+                    "html_base": f"/wiki/{slug}/",
+                }
+            )
+        return {"name": "Agent Wikis", "wikis": wikis}
+
+    @staticmethod
+    def _parse_wiki_llms_txt(text: str, *, base_url: str) -> List[str]:
+        urls = []
+        for path in _RAW_LINK_RE.findall(text):
+            urls.append(_absolute_url(base_url, path))
+        return urls
+
+
+def maybe_agentwiki_route_search(query: str, web_config: Dict[str, Any], *, limit: int = 5, client: Optional[httpx.Client] = None) -> AgentWikiResult:
+    router = AgentWikiRouter(web_config, client=client)
+    return router.maybe_route_search(query, limit=limit)
+
+
+def _parse_markdown_page(url: str, text: str) -> Dict[str, Any]:
+    frontmatter: Dict[str, str] = {}
+    body = text
+    if text.startswith("---\n"):
+        parts = text.split("\n---\n", 1)
+        if len(parts) == 2:
+            _, fm_body = parts
+            fm_text = text[4 : len(text) - len(fm_body) - 5]
+            body = fm_body
+            for line in fm_text.splitlines():
+                if ":" not in line:
+                    continue
+                key, value = line.split(":", 1)
+                frontmatter[key.strip()] = value.strip().strip('"')
+    title = frontmatter.get("title")
+    if not title:
+        for line in body.splitlines():
+            if line.startswith("# "):
+                title = line[2:].strip()
+                break
+    return {
+        "url": url,
+        "title": title or url,
+        "content": body,
+        "frontmatter": frontmatter,
+    }
+
+
+def _summarize_page(page: Dict[str, Any], slug: str, title: str) -> str:
+    body = str(page.get("content") or "")
+    lines = [line.strip() for line in body.splitlines() if line.strip() and not line.strip().startswith("#")]
+    excerpt = " ".join(lines[:3])
+    excerpt = re.sub(r"\s+", " ", excerpt).strip()
+    if len(excerpt) > 260:
+        excerpt = excerpt[:257].rstrip() + "..."
+    return f"Agentwiki ({slug or title}): {excerpt}" if excerpt else f"Agentwiki ({slug or title}) raw markdown page"
+
+
+def _normalize_query(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _tokenize(text: str) -> List[str]:
+    return _TOKEN_RE.findall((text or "").lower())
+
+
+def _find_line_value(lines: Iterable[str], prefix: str) -> str:
+    prefix_lower = prefix.lower()
+    for line in lines:
+        if line.lower().startswith(prefix_lower):
+            return line.split(":", 1)[-1].strip()
+    return ""
+
+
+def _strip_quote_prefix(value: str) -> str:
+    return value.lstrip("> ").strip()
+
+
+def _split_scope_phrases(text: str) -> List[str]:
+    raw_parts = re.split(r"[;,]", (text or ""))
+    parts: List[str] = []
+    for raw in raw_parts:
+        cleaned = raw.strip().lower()
+        if not cleaned:
+            continue
+        if cleaned.startswith("and "):
+            cleaned = cleaned[4:]
+        parts.append(cleaned)
+    return parts
+
+
+def _extract_date(text: Optional[str]) -> Optional[date]:
+    if not text:
+        return None
+    match = _DATE_RE.search(text)
+    if not match:
+        return None
+    raw = match.group(1)
+    try:
+        if len(raw) == 10:
+            return datetime.strptime(raw, "%Y-%m-%d").date()
+        if len(raw) == 7:
+            return datetime.strptime(raw + "-01", "%Y-%m-%d").date()
+        if len(raw) == 4:
+            return datetime.strptime(raw + "-01-01", "%Y-%m-%d").date()
+    except ValueError:
+        return None
+    return None
+
+
+def _absolute_url(base_url: str, path: str) -> str:
+    if not path:
+        return ""
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    origin_match = re.match(r"^(https?://[^/]+)", base_url)
+    origin = origin_match.group(1) if origin_match else base_url
+    return urljoin(origin.rstrip("/") + "/", path.lstrip("/"))

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -97,6 +97,7 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
+from tools.agentwiki_routing import maybe_agentwiki_route_search
 from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
 import sys
 
@@ -672,6 +673,19 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
+        web_config = _load_web_config()
+        agentwiki_result = maybe_agentwiki_route_search(query, web_config, limit=limit)
+        decision_record = agentwiki_result.decision.log_record(query)
+        if agentwiki_result.response_data is not None:
+            response_data = agentwiki_result.response_data
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            debug_call_data["agentwiki_decision"] = decision_record
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         # Dispatch through the web search registry. All 7 providers
         # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
         # now live as plugins; the dispatcher is just a registry lookup +
@@ -722,9 +736,19 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             )
             response_data = provider.search(query, limit)
 
+        response_data.setdefault("source_routing", {
+            "selected_source": "web_search",
+            "selected_wiki_slug": agentwiki_result.decision.selected_wiki_slug,
+            "selection_reason": agentwiki_result.decision.reason,
+            "current_as_used": agentwiki_result.decision.current_as_used,
+            "pages_fetched_count": agentwiki_result.decision.pages_fetched_count,
+            "fallback_occurred": bool(agentwiki_result.decision.fallback_occurred or agentwiki_result.decision.reason != "disabled"),
+        })
+
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
+        debug_call_data["agentwiki_decision"] = decision_record
         _debug.log_call("web_search_tool", debug_call_data)
         _debug.save()
         return result_json


### PR DESCRIPTION
## What does this PR do?

Routes covered `web_search` queries through a configured Agent Wiki first (respecting each wiki's freshness date), failing open to normal web search otherwise. Gives authoritative, curated answers for covered tools/platforms while never blocking on the wiki. **Off by default** — inert unless enabled via the `web.agentwikis` config in #63604.

## Related Issue

Pairs with #63604 (config defaults, `enabled: False`).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/agentwiki_routing.py` (new) — routing decision logic, wiki fetch, freshness check, fail-open.
- `tools/web_tools.py` — `web_search_tool` consults `maybe_agentwiki_route_search` before provider dispatch and records a `source_routing` block. **Purely additive; `web_extract_tool` and all other functions are byte-identical to `main`** (rebased onto current upstream; no unrelated changes).
- `tests/tools/test_agentwiki_routing.py` (new) + one additive assertion in `tests/tools/test_web_tools_config.py`.

## How to Test

1. `pytest tests/tools/test_agentwiki_routing.py tests/tools/test_web_tools_config.py tests/tools/test_web_tools_dict_urls.py -q` — 74 pass.
2. With the default `web.agentwikis.enabled: false`, `web_search` behaves exactly as before (fail-open path).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(web):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (rebased onto current `main`; no unrelated reversions)
- [x] I've run the relevant tests and all pass (74 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] Config keys live in the paired #63604 — N/A here
- [x] Cross-platform: no platform-bound primitives — N/A
