### PR TITLE
feat(gateway): publish Telegram runtime receipt

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2666,25 +2666,43 @@ class BasePlatformAdapter(ABC):
     def set_fatal_error_handler(self, handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None]) -> None:
         self._fatal_error_handler = handler
 
-    def _mark_connected(self) -> None:
+    def _mark_connected(self, *, platform_runtime: Any = None) -> None:
         self._running = True
         self._fatal_error_code = None
         self._fatal_error_message = None
         self._fatal_error_retryable = True
-        self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
+        self._write_runtime_status_safe(
+            "connected",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+            platform_runtime=platform_runtime,
+        )
 
     def _mark_disconnected(self) -> None:
         self._running = False
         if self.has_fatal_error:
             return
-        self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
+        self._write_runtime_status_safe(
+            "disconnected",
+            platform_state="disconnected",
+            error_code=None,
+            error_message=None,
+            platform_runtime=None,
+        )
 
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._running = False
         self._fatal_error_code = code
         self._fatal_error_message = message
         self._fatal_error_retryable = retryable
-        self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
+        self._write_runtime_status_safe(
+            "fatal",
+            platform_state="fatal",
+            error_code=code,
+            error_message=message,
+            platform_runtime=None,
+        )
 
     def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
         """Write runtime status; log first failure per context at warning, rest at debug.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -46,6 +46,67 @@ _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
 
+_PLATFORM_RUNTIME_CREDENTIAL_SOURCES = frozenset(
+    {
+        "managed_env",
+        "bitwarden",
+        "onepassword",
+        "profile_env",
+        "process_env",
+        "missing",
+        "unknown",
+    }
+)
+_PLATFORM_RUNTIME_TRANSPORT_MODES = frozenset({"polling", "webhook"})
+
+
+def _sanitize_platform_runtime(runtime: Any) -> Optional[dict[str, Any]]:
+    """Return the fixed public runtime-receipt shape, or ``None`` if invalid.
+
+    Unknown fields are deliberately dropped.  The allowlist excludes all raw
+    credentials, hashes, URLs, and error details, so future adapter metadata
+    cannot accidentally expand this persisted diagnostics boundary.
+    """
+    if not isinstance(runtime, dict):
+        return None
+
+    credential_source = runtime.get("credential_source")
+    authenticated = runtime.get("authenticated")
+    bot_id = runtime.get("bot_id")
+    bot_username = runtime.get("bot_username")
+    transport_mode = runtime.get("transport_mode")
+    transport_ready = runtime.get("transport_ready")
+    verified_at = runtime.get("verified_at")
+
+    if credential_source not in _PLATFORM_RUNTIME_CREDENTIAL_SOURCES:
+        return None
+    if type(authenticated) is not bool or type(transport_ready) is not bool:
+        return None
+    if not isinstance(bot_id, str):
+        return None
+    if bot_username is not None and not isinstance(bot_username, str):
+        return None
+    if transport_mode not in _PLATFORM_RUNTIME_TRANSPORT_MODES:
+        return None
+    if not isinstance(verified_at, str):
+        return None
+    try:
+        parsed_verified_at = datetime.fromisoformat(verified_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed_verified_at.tzinfo is None:
+        return None
+
+    return {
+        "credential_source": credential_source,
+        "authenticated": authenticated,
+        "bot_id": bot_id,
+        "bot_username": bot_username,
+        "transport_mode": transport_mode,
+        "transport_ready": transport_ready,
+        "verified_at": verified_at,
+    }
+
 
 def _get_process_hermes_home() -> Path:
     """Return the process-level HERMES_HOME, skipping context-local overrides.
@@ -804,12 +865,27 @@ def write_runtime_status(
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    platform_runtime: Any = _UNSET,
     served_profiles: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    payload = _read_json_file(path)
+    if payload is None:
+        payload = _build_runtime_status_record()
+    elif (
+        payload.get("pid") != current_record["pid"]
+        or payload.get("start_time") != current_record["start_time"]
+    ):
+        # A status file belongs to exactly one process incarnation. Never carry
+        # platform authentication/readiness evidence across a PID or start-time
+        # change and then make it appear to have been produced by the new
+        # gateway.
+        desired_state = payload.get("desired_state")
+        payload = _build_runtime_status_record()
+        if desired_state in {"running", "stopped"}:
+            payload["desired_state"] = desired_state
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
@@ -830,6 +906,13 @@ def write_runtime_status(
         # for a single-profile gateway. Lets `hermes status` show per-profile
         # coverage without a second probe.
         payload["served_profiles"] = list(served_profiles or [])
+        if len(payload["served_profiles"]) > 1:
+            # The fixed platforms.<name>.runtime shape identifies one adapter.
+            # A multiplexed gateway can own several adapters for the same
+            # platform, so retaining any one receipt would be ambiguous.
+            for existing_platform in payload["platforms"].values():
+                if isinstance(existing_platform, dict):
+                    existing_platform.pop("runtime", None)
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})
@@ -839,6 +922,14 @@ def write_runtime_status(
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
+        if platform_runtime is not _UNSET:
+            sanitized_runtime = _sanitize_platform_runtime(platform_runtime)
+            served = payload.get("served_profiles")
+            multiplexed = isinstance(served, list) and len(served) > 1
+            if sanitized_runtime is None or multiplexed:
+                platform_payload.pop("runtime", None)
+            else:
+                platform_payload["runtime"] = sanitized_runtime
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -29,6 +29,11 @@ _WARNED_KEYS: set[str] = set()
 # the .env case and they don't know Bitwarden is wired up).
 _SECRET_SOURCES: dict[str, str] = {}
 
+# Runtime provenance is profile-scoped even though the legacy UI lookup above
+# remains process-global.  A composite key retains independent attribution for
+# profiles that use the same conventional environment-variable name.
+_SECRET_SOURCES_BY_HOME: dict[tuple[str, str], str] = {}
+
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
 # several hot modules (cli.py, hermes_cli/main.py, run_agent.py,
@@ -39,17 +44,100 @@ _SECRET_SOURCES: dict[str, str] = {}
 _APPLIED_HOMES: set[str] = set()
 
 
-def get_secret_source(env_var: str) -> str | None:
+def classify_effective_credential_source(
+    *,
+    effective_value: str | None,
+    managed_value: str | None = None,
+    external_source: str | None = None,
+    profile_value: str | None = None,
+) -> str:
+    """Classify an effective credential without returning the credential.
+
+    Inputs are values already resolved by the caller.  Keeping this helper pure
+    makes the precedence contract independently testable while ensuring its
+    only output is a fixed, non-secret source label.
+    """
+    if not effective_value:
+        return "missing"
+    if managed_value is not None and managed_value == effective_value:
+        return "managed_env"
+    if external_source:
+        if external_source in {"bitwarden", "onepassword"}:
+            return external_source
+        return "unknown"
+    if profile_value is not None and profile_value == effective_value:
+        return "profile_env"
+    return "process_env"
+
+
+def get_effective_credential_source(
+    env_var: str,
+    *,
+    effective_value: str | None,
+    hermes_home: str | os.PathLike | None = None,
+) -> str:
+    """Resolve credential-source metadata for the active runtime value.
+
+    The resolver reads only source metadata and compares candidate values in
+    memory.  It never returns, logs, hashes, or persists a credential value.
+    """
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        home_path = get_hermes_home()
+    else:
+        home_path = Path(hermes_home)
+
+    managed_value: str | None = None
+    try:
+        from hermes_cli import managed_scope
+
+        managed_value = managed_scope.load_managed_env().get(env_var)
+    except Exception:  # noqa: BLE001 — diagnostics must never block startup
+        pass
+
+    profile_value: str | None = None
+    try:
+        from dotenv import dotenv_values
+
+        try:
+            parsed = dotenv_values(home_path / ".env", encoding="utf-8")
+        except UnicodeDecodeError:
+            parsed = dotenv_values(home_path / ".env", encoding="latin-1")
+        value = parsed.get(env_var)
+        if isinstance(value, str):
+            profile_value = value
+    except (OSError, UnicodeError, ValueError):
+        pass
+
+    return classify_effective_credential_source(
+        effective_value=effective_value,
+        managed_value=managed_value,
+        external_source=get_secret_source(env_var, hermes_home=home_path),
+        profile_value=profile_value,
+    )
+
+
+def get_secret_source(
+    env_var: str,
+    *,
+    hermes_home: str | os.PathLike | None = None,
+) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
     Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager
     during the current process's ``load_hermes_dotenv()`` call.  Returns
     ``None`` for keys that came from ``.env``, the shell environment, or
-    aren't tracked.  The returned label is metadata only: credential-pool
+    aren't tracked.  When ``hermes_home`` is supplied, provenance from another
+    profile is ignored.  The returned label is metadata only: credential-pool
     persistence may store it to explain the origin of a borrowed secret, but
     must never treat it as authorization to persist the raw value.
     """
-    return _SECRET_SOURCES.get(env_var)
+    source = _SECRET_SOURCES.get(env_var)
+    if hermes_home is None or source is None:
+        return source
+    home_key = str(Path(hermes_home).resolve())
+    return _SECRET_SOURCES_BY_HOME.get((home_key, env_var))
 
 
 def reset_secret_source_cache() -> None:
@@ -330,6 +418,13 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
     _APPLIED_HOMES.add(home_key)
 
+    # A forced refresh rebuilds this home's provenance from the new apply
+    # report.  Clearing first ensures a removed/disabled source cannot leave a
+    # stale runtime attribution behind while preserving other profiles.
+    stale_keys = [key for key in _SECRET_SOURCES_BY_HOME if key[0] == home_key]
+    for key in stale_keys:
+        del _SECRET_SOURCES_BY_HOME[key]
+
     try:
         cfg = _load_secrets_config(home_path)
     except Exception:  # noqa: BLE001 — config errors must not block startup
@@ -358,6 +453,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # no hint the value came from a vault rather than .env.
         for name, applied in report.provenance.items():
             _SECRET_SOURCES[name] = applied.source
+            _SECRET_SOURCES_BY_HOME[(home_key, name)] = applied.source
 
     for src in report.sources:
         if src.applied:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -678,9 +678,56 @@ class TelegramAdapter(BasePlatformAdapter):
         # blow the gateway's connect timeout (#46298).
         self._post_connect_task: Optional[asyncio.Task] = None
 
-    def _mark_connected(self) -> None:
+    def _telegram_runtime_receipt(self, *, transport_ready: bool) -> dict[str, Any]:
+        """Build the fixed, secret-free Telegram runtime receipt."""
+        bot = getattr(self, "_bot", None)
+        raw_bot_id = getattr(bot, "id", None)
+        bot_id = str(raw_bot_id) if isinstance(raw_bot_id, (int, str)) else ""
+        raw_username = getattr(bot, "username", None)
+        bot_username = raw_username if isinstance(raw_username, str) else None
+        try:
+            from hermes_cli.env_loader import get_effective_credential_source
+
+            credential_source = get_effective_credential_source(
+                "TELEGRAM_BOT_TOKEN",
+                effective_value=getattr(self.config, "token", None),
+            )
+        except Exception:  # noqa: BLE001 — receipt metadata must not block connect
+            credential_source = "unknown"
+
+        return {
+            "credential_source": credential_source,
+            "authenticated": bool(bot_id),
+            "bot_id": bot_id,
+            "bot_username": bot_username,
+            "transport_mode": (
+                "webhook" if getattr(self, "_webhook_mode", False) else "polling"
+            ),
+            "transport_ready": bool(transport_ready),
+            "verified_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def _publish_telegram_runtime_receipt(
+        self,
+        *,
+        context: str,
+        transport_ready: bool,
+    ) -> None:
+        """Persist a current readiness transition without exposing secrets."""
+        self._write_runtime_status_safe(
+            context,
+            platform_runtime=self._telegram_runtime_receipt(
+                transport_ready=transport_ready,
+            ),
+        )
+
+    def _mark_telegram_connected(self, *, transport_ready: bool = True) -> None:
         self._drop_delayed_deliveries = False
-        super()._mark_connected()
+        super()._mark_connected(
+            platform_runtime=self._telegram_runtime_receipt(
+                transport_ready=transport_ready,
+            ),
+        )
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -1953,6 +2000,10 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
         self._send_path_degraded = True
+        self._publish_telegram_runtime_receipt(
+            context="polling-degraded",
+            transport_ready=False,
+        )
         logger.warning(
             "[%s] Telegram polling degraded (%s); gateway stays alive and will retry. Error: %s",
             self.name, reason, error,
@@ -2051,6 +2102,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._polling_network_error_count += 1
         self._send_path_degraded = True
+        self._publish_telegram_runtime_receipt(
+            context="polling-network-degraded",
+            transport_ready=False,
+        )
         attempt = self._polling_network_error_count
 
         if attempt > MAX_NETWORK_RETRIES:
@@ -2142,6 +2197,10 @@ class TelegramAdapter(BasePlatformAdapter):
             # (or forever, if the probe is never scheduled), blocking the send
             # path even though the bot has fully recovered. See #35205.
             self._send_path_degraded = False
+            self._publish_telegram_runtime_receipt(
+                context="polling-network-recovered",
+                transport_ready=True,
+            )
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx
@@ -2372,6 +2431,10 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
             self._send_path_degraded = False
+            self._publish_telegram_runtime_receipt(
+                context="polling-probe-ready",
+                transport_ready=True,
+            )
         except Exception as probe_err:
             logger.warning(
                 "[%s] Polling heartbeat probe failed %ds after reconnect: %s",
@@ -2463,6 +2526,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # retry attempt instead of returning silently, and only escalate to
         # fatal after all retries are exhausted.
         self._polling_conflict_count += 1
+        self._publish_telegram_runtime_receipt(
+            context="polling-conflict",
+            transport_ready=False,
+        )
 
         MAX_CONFLICT_RETRIES = 5
         # Delay grows with each attempt: 15s, 25s, 35s, 45s, 55s.
@@ -2533,6 +2600,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, self._polling_conflict_count, MAX_CONFLICT_RETRIES,
                 )
                 self._polling_conflict_count = 0  # reset counter on success
+                self._publish_telegram_runtime_receipt(
+                    context="polling-conflict-recovered",
+                    transport_ready=True,
+                )
                 return
             except Exception as retry_err:
                 logger.warning(
@@ -3266,6 +3337,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
+            self._webhook_mode = False
+            transport_ready = True
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
                 # Telegram pushes updates to our HTTP endpoint.  This
@@ -3358,6 +3431,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     drop_pending_updates=not is_reconnect,
                     error_callback=_polling_error_callback,
                 )
+                transport_ready = bool(polling_started)
                 if not polling_started:
                     logger.warning(
                         "[%s] Connected in degraded Telegram mode: gateway is alive, "
@@ -3365,7 +3439,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self.name,
                     )
             
-            self._mark_connected()
+            self._mark_telegram_connected(transport_ready=transport_ready)
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -460,6 +460,75 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 2000
 
+    def test_write_runtime_status_does_not_rebind_stale_platform_receipt(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 99999,
+                    "start_time": 1000,
+                    "kind": "hermes-gateway",
+                    "gateway_state": "running",
+                    "platforms": {
+                        "telegram": {
+                            "state": "connected",
+                            "runtime": {
+                                "credential_source": "profile_env",
+                                "authenticated": True,
+                                "bot_id": "123456",
+                                "bot_username": "old_bot",
+                                "transport_mode": "polling",
+                                "transport_ready": True,
+                                "verified_at": "2026-07-13T12:34:56+00:00",
+                            },
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="starting")
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["pid"] == os.getpid()
+        assert payload["platforms"] == {}
+
+    def test_process_restart_preserves_valid_durable_desired_state(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 99999,
+                    "start_time": 1000,
+                    "kind": "hermes-gateway",
+                    "desired_state": "running",
+                    "gateway_state": "startup_failed",
+                    "exit_reason": "old failure",
+                    "platforms": {"telegram": {"state": "fatal"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="starting")
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["desired_state"] == "running"
+        assert payload["gateway_state"] == "starting"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"] == {}
+
     def test_runtime_status_running_pid_rejects_stale_record_for_supervisor_pid(self, monkeypatch):
         """Regression: stale profile runtime state must not mark s6 supervisors live.
 
@@ -640,6 +709,94 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["telegram"]["state"] == "fatal"
         assert payload["platforms"]["telegram"]["error_code"] == "telegram_polling_conflict"
         assert payload["platforms"]["telegram"]["error_message"] == "another poller is active"
+
+    def test_write_runtime_status_sanitizes_platform_runtime_receipt(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        verified_at = "2026-07-13T12:34:56+00:00"
+
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime={
+                "credential_source": "onepassword",
+                "authenticated": True,
+                "bot_id": "123456",
+                "bot_username": None,
+                "transport_mode": "polling",
+                "transport_ready": False,
+                "verified_at": verified_at,
+                "token": "must-not-persist",
+                "webhook_url": "https://secret.example/telegram",
+                "raw_error": "must-not-persist",
+                "future_field": "must-not-persist",
+            },
+        )
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["platforms"]["telegram"]["runtime"] == {
+            "credential_source": "onepassword",
+            "authenticated": True,
+            "bot_id": "123456",
+            "bot_username": None,
+            "transport_mode": "polling",
+            "transport_ready": False,
+            "verified_at": verified_at,
+        }
+        serialized = json.dumps(payload)
+        assert "must-not-persist" not in serialized
+        assert payload["pid"] == os.getpid()
+        assert "start_time" in payload
+
+    def test_write_runtime_status_clears_platform_runtime_receipt(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime={
+                "credential_source": "profile_env",
+                "authenticated": True,
+                "bot_id": "123456",
+                "bot_username": "fleet_bot",
+                "transport_mode": "webhook",
+                "transport_ready": True,
+                "verified_at": "2026-07-13T12:34:56+00:00",
+            },
+        )
+
+        status.write_runtime_status(platform="telegram", platform_runtime=None)
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert "runtime" not in payload["platforms"]["telegram"]
+
+    def test_multiplexed_status_never_persists_ambiguous_platform_runtime(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runtime = {
+            "credential_source": "profile_env",
+            "authenticated": True,
+            "bot_id": "123456",
+            "bot_username": "fleet_bot",
+            "transport_mode": "polling",
+            "transport_ready": True,
+            "verified_at": "2026-07-13T12:34:56+00:00",
+        }
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime=runtime,
+        )
+
+        status.write_runtime_status(served_profiles=["default", "coder"])
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime=runtime,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert "runtime" not in payload["platforms"]["telegram"]
 
     def test_write_runtime_status_explicit_none_clears_stale_fields(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/gateway/test_telegram_runtime_receipt.py
+++ b/tests/gateway/test_telegram_runtime_receipt.py
@@ -1,0 +1,141 @@
+"""Telegram runtime receipt contracts."""
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from hermes_cli import env_loader
+from plugins.platforms.telegram import adapter as telegram_module
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def test_mark_connected_publishes_sanitized_degraded_polling_receipt(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
+    adapter._bot = SimpleNamespace(id=123456, username="fleet_bot")
+    status_writer = MagicMock()
+    monkeypatch.setattr(adapter, "_write_runtime_status_safe", status_writer)
+    monkeypatch.setattr(
+        env_loader,
+        "get_effective_credential_source",
+        lambda *args, **kwargs: "onepassword",
+    )
+
+    adapter._mark_telegram_connected(transport_ready=False)
+
+    status_writer.assert_called_once()
+    runtime_call = status_writer.call_args
+    assert runtime_call.args == ("connected",)
+    receipt = runtime_call.kwargs["platform_runtime"]
+    assert receipt == {
+        "credential_source": "onepassword",
+        "authenticated": True,
+        "bot_id": "123456",
+        "bot_username": "fleet_bot",
+        "transport_mode": "polling",
+        "transport_ready": False,
+        "verified_at": receipt["verified_at"],
+    }
+    assert datetime.fromisoformat(receipt["verified_at"]).tzinfo is not None
+    assert "secret-token" not in repr(receipt)
+
+
+def test_mark_disconnected_clears_runtime_receipt(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
+    status_writer = MagicMock()
+    monkeypatch.setattr(adapter, "_write_runtime_status_safe", status_writer)
+
+    adapter._mark_disconnected()
+
+    status_writer.assert_called_once_with(
+        "disconnected",
+        platform_state="disconnected",
+        error_code=None,
+        error_message=None,
+        platform_runtime=None,
+    )
+
+
+def test_connect_records_polling_not_ready_when_bootstrap_degrades(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.bot = SimpleNamespace(id=123456, username="fleet_bot")
+    fake_app.initialize = AsyncMock(return_value=None)
+    fake_app.start = AsyncMock(return_value=None)
+    fake_app.add_handler = MagicMock()
+
+    chainable = MagicMock()
+    chainable.token.return_value = chainable
+    chainable.request.return_value = chainable
+    chainable.get_updates_request.return_value = chainable
+    chainable.build.return_value = fake_app
+    builder_root = MagicMock()
+    builder_root.builder.return_value = chainable
+
+    monkeypatch.setattr(telegram_module, "Application", builder_root)
+    monkeypatch.setattr(telegram_module, "HTTPXRequest", MagicMock)
+    monkeypatch.setattr(
+        telegram_module,
+        "discover_fallback_ips",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(telegram_module, "resolve_proxy_url", lambda *a, **k: None)
+    monkeypatch.setattr(
+        env_loader,
+        "get_effective_credential_source",
+        lambda *args, **kwargs: "profile_env",
+    )
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
+    status_writer = MagicMock()
+    monkeypatch.setattr(adapter, "_write_runtime_status_safe", status_writer)
+    monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *a, **k: True)
+    monkeypatch.setattr(adapter, "_fallback_ips", lambda: [])
+    monkeypatch.setattr(adapter, "_delete_webhook_best_effort", AsyncMock())
+    monkeypatch.setattr(
+        adapter,
+        "_start_polling_resilient",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(adapter, "_polling_heartbeat_loop", AsyncMock())
+    monkeypatch.setattr(adapter, "_start_post_connect_housekeeping", MagicMock())
+
+    assert asyncio.run(adapter.connect()) is True
+
+    runtime_calls = [
+        call
+        for call in status_writer.call_args_list
+        if "platform_runtime" in call.kwargs
+    ]
+    assert runtime_calls[-1].kwargs["platform_runtime"]["transport_ready"] is False
+
+
+def test_polling_network_recovery_updates_runtime_readiness(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
+    adapter._bot = SimpleNamespace(id=123456, username="fleet_bot")
+    adapter._app = SimpleNamespace(
+        bot=adapter._bot,
+        updater=SimpleNamespace(
+            running=False,
+            start_polling=AsyncMock(return_value=None),
+        ),
+    )
+    status_writer = MagicMock()
+    monkeypatch.setattr(adapter, "_write_runtime_status_safe", status_writer)
+    monkeypatch.setattr(adapter, "_drain_polling_connections", AsyncMock())
+    monkeypatch.setattr(adapter, "_verify_polling_after_reconnect", AsyncMock())
+    monkeypatch.setattr(telegram_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        env_loader,
+        "get_effective_credential_source",
+        lambda *args, **kwargs: "profile_env",
+    )
+
+    asyncio.run(adapter._handle_polling_network_error(OSError("network down")))
+
+    readiness = [
+        call.kwargs["platform_runtime"]["transport_ready"]
+        for call in status_writer.call_args_list
+        if "platform_runtime" in call.kwargs
+    ]
+    assert readiness == [False, True]

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -2,7 +2,204 @@ import importlib
 import os
 import sys
 
-from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.env_loader import (
+    classify_effective_credential_source,
+    get_effective_credential_source,
+    load_hermes_dotenv,
+)
+
+
+def test_effective_credential_source_prefers_matching_managed_value():
+    source = classify_effective_credential_source(
+        effective_value="managed-token",
+        managed_value="managed-token",
+        external_source="onepassword",
+        profile_value="managed-token",
+    )
+
+    assert source == "managed_env"
+
+
+def test_effective_credential_source_precedence_and_fallbacks():
+    assert classify_effective_credential_source(
+        effective_value="vault-token",
+        managed_value="different-token",
+        external_source="bitwarden",
+        profile_value="vault-token",
+    ) == "bitwarden"
+    assert classify_effective_credential_source(
+        effective_value="profile-token",
+        profile_value="profile-token",
+    ) == "profile_env"
+    assert classify_effective_credential_source(
+        effective_value="shell-token",
+        profile_value="different-token",
+    ) == "process_env"
+    assert classify_effective_credential_source(
+        effective_value=None,
+        external_source="onepassword",
+    ) == "missing"
+    assert classify_effective_credential_source(
+        effective_value="vault-token",
+        external_source="custom-vault",
+    ) == "unknown"
+
+
+def test_get_effective_credential_source_detects_profile_env(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=profile-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+
+    source = get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="profile-token",
+        hermes_home=home,
+    )
+
+    assert source == "profile_env"
+
+
+def test_get_effective_credential_source_reads_legacy_encoded_profile_env(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_bytes(
+        b"# caf\xe9\nTELEGRAM_BOT_TOKEN=profile-token\n"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+
+    source = get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="profile-token",
+        hermes_home=home,
+    )
+
+    assert source == "profile_env"
+
+
+def test_get_effective_credential_source_honors_context_local_profile(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    primary = tmp_path / "primary"
+    secondary = tmp_path / "secondary"
+    primary.mkdir()
+    secondary.mkdir()
+    (primary / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=primary-token\n",
+        encoding="utf-8",
+    )
+    (secondary / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=secondary-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(primary))
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+
+    token = set_hermes_home_override(secondary)
+    try:
+        source = get_effective_credential_source(
+            "TELEGRAM_BOT_TOKEN",
+            effective_value="secondary-token",
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert source == "profile_env"
+
+
+def test_get_effective_credential_source_does_not_cross_profile_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import env_loader
+
+    primary = tmp_path / "primary"
+    secondary = tmp_path / "secondary"
+    primary.mkdir()
+    secondary.mkdir()
+    (secondary / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=secondary-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCES,
+        "TELEGRAM_BOT_TOKEN",
+        "onepassword",
+    )
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCES_BY_HOME,
+        (str(primary.resolve()), "TELEGRAM_BOT_TOKEN"),
+        "onepassword",
+    )
+
+    source = get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="secondary-token",
+        hermes_home=secondary,
+    )
+
+    assert source == "profile_env"
+
+
+def test_get_effective_credential_source_uses_same_profile_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import env_loader
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=old-profile-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCES,
+        "TELEGRAM_BOT_TOKEN",
+        "onepassword",
+    )
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCES_BY_HOME,
+        (str(home.resolve()), "TELEGRAM_BOT_TOKEN"),
+        "onepassword",
+    )
+
+    source = get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="vault-token",
+        hermes_home=home,
+    )
+
+    assert source == "onepassword"
 
 
 def test_user_env_overrides_stale_shell_values(tmp_path, monkeypatch):

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -24,9 +24,11 @@ from hermes_cli import env_loader  # noqa: E402
 def _reset_sources():
     """Each test starts with a clean source map and applied-home guard."""
     env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     yield
     env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
 
 
@@ -219,6 +221,95 @@ def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monk
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from 1Password)"
     )
+
+
+def test_external_provenance_is_independent_per_home_and_refreshes(
+    tmp_path,
+    monkeypatch,
+):
+    """Real loader path keeps two profiles independent and removes stale data."""
+    bitwarden_home = tmp_path / "bitwarden-profile"
+    onepassword_home = tmp_path / "onepassword-profile"
+    bitwarden_home.mkdir()
+    onepassword_home.mkdir()
+    (bitwarden_home / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+    (onepassword_home / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    env:\n"
+        "      TELEGRAM_BOT_TOKEN: 'op://Private/Telegram/credential'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test-token")
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.managed_scope.load_managed_env",
+        lambda: {},
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+    import agent.secret_sources.onepassword as op_module
+    from agent.secret_sources import registry as reg_module
+
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw_module,
+        "fetch_bitwarden_secrets",
+        lambda **_kw: ({"TELEGRAM_BOT_TOKEN": "bitwarden-token"}, []),
+    )
+    monkeypatch.setattr(op_module, "find_op", lambda *_a, **_kw: Path("/fake/op"))
+    monkeypatch.setattr(
+        op_module,
+        "fetch_onepassword_secrets",
+        lambda **_kw: ({"TELEGRAM_BOT_TOKEN": "onepassword-token"}, []),
+    )
+    reg_module._reset_registry_for_tests()
+
+    env_loader._apply_external_secret_sources(bitwarden_home)
+    env_loader._apply_external_secret_sources(onepassword_home)
+
+    assert env_loader.get_secret_source(
+        "TELEGRAM_BOT_TOKEN",
+        hermes_home=bitwarden_home,
+    ) == "bitwarden"
+    assert env_loader.get_secret_source(
+        "TELEGRAM_BOT_TOKEN",
+        hermes_home=onepassword_home,
+    ) == "onepassword"
+    assert env_loader.get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="bitwarden-token",
+        hermes_home=bitwarden_home,
+    ) == "bitwarden"
+    assert env_loader.get_effective_credential_source(
+        "TELEGRAM_BOT_TOKEN",
+        effective_value="onepassword-token",
+        hermes_home=onepassword_home,
+    ) == "onepassword"
+
+    (bitwarden_home / "config.yaml").write_text(
+        "secrets:\n  bitwarden:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(bitwarden_home)
+
+    assert env_loader.get_secret_source(
+        "TELEGRAM_BOT_TOKEN",
+        hermes_home=bitwarden_home,
+    ) is None
+    assert env_loader.get_secret_source(
+        "TELEGRAM_BOT_TOKEN",
+        hermes_home=onepassword_home,
+    ) == "onepassword"
 
 
 def test_apply_external_secret_sources_survives_non_dict_section(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Publishes a strictly sanitized Telegram runtime receipt in `gateway_state.json` so an external controller can distinguish configuration from authenticated runtime truth without reading or persisting the bot token.

The receipt is bound to the current gateway PID/start time and contains only credential provenance, authenticated bot identity, transport mode/readiness, and verification time. It is cleared on disconnect/fatal transitions and process rollover, suppressed for ambiguous multiplexed same-platform gateways, and updated across polling degradation/recovery. Durable operator `desired_state` survives process rollover while volatile evidence does not.

Credential provenance follows the fixed precedence `managed_env > bitwarden/onepassword > profile_env > process_env > missing`, is isolated by resolved Hermes home, and never returns, logs, hashes, or persists credential values.

## Related Issue

N/A — runtime observability contract for downstream health verification. Existing PRs and issues were searched before implementation; no duplicate was found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py`: add pure effective credential-source classification and profile-scoped external provenance.
- `gateway/status.py`: sanitize and atomically persist the exact `platforms.telegram.runtime` receipt; prevent stale-process rebinding and ambiguous multiplex persistence.
- `gateway/platforms/base.py`: atomically clear runtime metadata with disconnect/fatal lifecycle writes.
- `plugins/platforms/telegram/adapter.py`: publish authenticated bot identity and polling/webhook readiness after bootstrap and recovery transitions.
- `tests/`: cover source precedence/isolation/refresh, receipt redaction/clearing/process binding, lifecycle atomicity, degraded polling bootstrap, and readiness recovery.

## How to Test

1. Run the receipt and compatibility regression surface:
   `scripts/run_tests.sh tests/hermes_cli/test_env_loader.py tests/test_env_loader_secret_sources.py tests/hermes_cli/test_managed_scope_env.py tests/gateway/test_status.py tests/gateway/test_platform_base.py tests/gateway/test_telegram_runtime_receipt.py tests/gateway/test_telegram_init_deadline.py tests/gateway/test_telegram_start_polling_timeout.py tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_error_redaction.py tests/gateway/test_run_progress_topics.py -q`
2. Confirm deterministic result: **12 files, 411 tests passed, 0 failed**.
3. Run `ruff`, `compileall`, `scripts/check-windows-footguns.py`, and compare `ty` diagnostics with `origin/main`; all pass and the type-diagnostic delta is **0 new / 0 fixed**.

Repository-wide proof: `scripts/run_tests.sh -q` completed all 1,984 files with **40,448 passed / 28 failed**. The remaining failures are outside the changed receipt surface and are dominated by host-specific `/tmp` vs `/private/tmp`, unavailable systemd/s6 behavior on macOS, external catalog/keychain state, and timing-sensitive tests. The first full run did expose a change-caused fake-`dotenv` import regression; that was fixed, and its complete regression file now passes **36/36** as part of the 411-test command above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full wrapper completed with 40,448 passed / 28 host/external-state failures documented above; focused changed surface is 411/411 green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; no user configuration added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-footgun scan passed across all eight changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema changed

## Screenshots / Logs

Screenshots are not applicable: this PR changes only server-side credential-source classification and `gateway_state.json` serialization/lifecycle; it introduces no renderable UI or user-visible screen.

Deterministic proof:

```text
Focused receipt + compatibility suite: 12 files, 411 passed, 0 failed
Full repository wrapper: 1,984 files, 40,448 passed, 28 failed
Ruff: passed
Compileall: passed
Windows footgun scan: passed (8 files)
ty diff vs origin/main: 0 new, 0 fixed (108 unchanged baseline diagnostics)
Independent Spec review: CLEAR
Independent Standards review: CLEAR
```
