### PR TITLE
fix(kanban): redact durable worker logs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7454,6 +7454,21 @@ def _rotated_log_path(log_path: Path, generation: int) -> Path:
     return log_path.with_suffix(log_path.suffix + f".{generation}")
 
 
+def _harden_worker_log_permissions(log_path: Path) -> None:
+    """Restrict an existing worker log to its owner on POSIX platforms."""
+    try:
+        os.chmod(log_path, 0o600)
+    except OSError:
+        pass
+
+
+def _open_worker_log(log_path: Path):
+    """Open a worker log for append without creating a world-readable file."""
+    fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    _harden_worker_log_permissions(log_path)
+    return os.fdopen(fd, "ab")
+
+
 def _rotate_worker_log(
     log_path: Path,
     max_bytes: int,
@@ -7466,15 +7481,24 @@ def _rotate_worker_log(
     Higher values shift older generations up to ``backup_count``.
     """
     try:
-        if not log_path.exists():
-            return
-        if log_path.stat().st_size <= max_bytes:
-            return
         backup_count = _positive_int(
             backup_count,
             DEFAULT_LOG_BACKUP_COUNT,
             minimum=0,
         )
+        for candidate in (
+            log_path,
+            *(
+                _rotated_log_path(log_path, generation)
+                for generation in range(1, backup_count + 1)
+            ),
+        ):
+            if candidate.exists():
+                _harden_worker_log_permissions(candidate)
+        if not log_path.exists():
+            return
+        if log_path.stat().st_size <= max_bytes:
+            return
         if backup_count == 0:
             log_path.unlink()
             return
@@ -7493,6 +7517,10 @@ def _rotate_worker_log(
             except OSError:
                 pass
         log_path.rename(_rotated_log_path(log_path, 1))
+        for generation in range(1, backup_count + 1):
+            rotated = _rotated_log_path(log_path, generation)
+            if rotated.exists():
+                _harden_worker_log_permissions(rotated)
     except OSError:
         pass
 
@@ -7833,7 +7861,7 @@ def _default_spawn(
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
-    log_f = open(log_path, "ab")
+    log_f = _open_worker_log(log_path)
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -577,6 +577,17 @@ try:
 except Exception:
     pass  # best-effort — redaction stays at default (enabled) on config errors
 
+# Dispatcher-spawned Kanban workers write stdout/stderr to durable per-task
+# logs. Install the redacting streams before logging handlers capture stderr so
+# every Python-level worker message crosses the same secret-scrubbing boundary.
+if os.environ.get("HERMES_KANBAN_TASK"):
+    try:
+        from hermes_cli.worker_log import install_worker_log_redaction
+
+        install_worker_log_redaction()
+    except Exception:
+        pass  # best-effort; the dispatcher still restricts log file permissions
+
 # Initialize centralized file logging early — all `hermes` subcommands
 # (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
 # Dashboard entrypoints bootstrap with GUI mode so gui.log is always present

--- a/hermes_cli/worker_log.py
+++ b/hermes_cli/worker_log.py
@@ -1,0 +1,128 @@
+"""Redacting text streams for durable Kanban worker logs."""
+
+from __future__ import annotations
+
+import atexit
+import sys
+import threading
+from typing import Callable, TextIO
+
+from agent.redact import redact_sensitive_text
+
+
+def _redact_worker_text(text: str) -> str:
+    # Worker logs are durable security boundaries, like debug captures and
+    # session exports. Never persist a reusable secret even if display
+    # redaction was disabled for the interactive UI.
+    return redact_sensitive_text(text, force=True)
+
+
+class RedactingTextStream:
+    """Line-buffered stream that redacts secrets before writing them.
+
+    Buffering complete lines keeps credentials split across adjacent
+    ``write()`` calls from escaping detection. Private-key blocks are held
+    until their closing marker so the shared multiline redactor sees the
+    complete value.
+    """
+
+    def __init__(
+        self,
+        stream: TextIO,
+        *,
+        redact: Callable[[str], str] = _redact_worker_text,
+    ) -> None:
+        self._stream = stream
+        self._redact = redact
+        self._pending = ""
+        self._private_key = ""
+        self._lock = threading.RLock()
+        self._finalized = False
+
+    @staticmethod
+    def _starts_private_key(text: str) -> bool:
+        return "-----BEGIN" in text and "PRIVATE KEY-----" in text
+
+    @staticmethod
+    def _ends_private_key(text: str) -> bool:
+        return "-----END" in text and "PRIVATE KEY-----" in text
+
+    def _emit_line(self, line: str) -> None:
+        if self._private_key:
+            self._private_key += line
+            if self._ends_private_key(line):
+                self._stream.write(self._redact(self._private_key))
+                self._private_key = ""
+            return
+
+        if self._starts_private_key(line):
+            self._private_key = line
+            if self._ends_private_key(line):
+                self._stream.write(self._redact(self._private_key))
+                self._private_key = ""
+            return
+
+        self._stream.write(self._redact(line))
+
+    def write(self, text: str) -> int:
+        if not isinstance(text, str):
+            text = str(text)
+        with self._lock:
+            self._pending += text
+            while "\n" in self._pending:
+                line, self._pending = self._pending.split("\n", 1)
+                self._emit_line(line + "\n")
+        return len(text)
+
+    def flush(self) -> None:
+        # Keep an incomplete line buffered: it may be the first half of a
+        # credential split across writes. ``finalize`` drains it at shutdown.
+        with self._lock:
+            self._stream.flush()
+
+    def finalize(self) -> None:
+        with self._lock:
+            if self._finalized:
+                return
+            self._finalized = True
+            if self._private_key:
+                # An unterminated key is still secret. Do not depend on the
+                # complete-block regex matching malformed/truncated output.
+                self._stream.write("[REDACTED INCOMPLETE PRIVATE KEY]\n")
+                self._private_key = ""
+                self._pending = ""
+            elif self._pending:
+                self._stream.write(self._redact(self._pending))
+                self._pending = ""
+            self._stream.flush()
+
+    def isatty(self) -> bool:
+        return self._stream.isatty()
+
+    def fileno(self) -> int:
+        return self._stream.fileno()
+
+    @property
+    def encoding(self):
+        return getattr(self._stream, "encoding", None)
+
+    @property
+    def errors(self):
+        return getattr(self._stream, "errors", None)
+
+    @property
+    def closed(self) -> bool:
+        return self._stream.closed
+
+    def __getattr__(self, name: str):
+        return getattr(self._stream, name)
+
+
+def install_worker_log_redaction() -> None:
+    """Wrap process output once for a dispatcher-spawned Kanban worker."""
+    if not isinstance(sys.stdout, RedactingTextStream):
+        sys.stdout = RedactingTextStream(sys.stdout)
+        atexit.register(sys.stdout.finalize)
+    if not isinstance(sys.stderr, RedactingTextStream):
+        sys.stderr = RedactingTextStream(sys.stderr)
+        atexit.register(sys.stderr.finalize)

--- a/tests/hermes_cli/test_kanban_worker_log_redaction.py
+++ b/tests/hermes_cli/test_kanban_worker_log_redaction.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import io
+import os
+import stat
+import subprocess
+import sys
+
+from hermes_cli.worker_log import RedactingTextStream
+
+
+def test_redacting_stream_handles_split_tokens_and_multiline_private_keys():
+    output = io.StringIO()
+    stream = RedactingTextStream(output)
+    secret = "ghp_" + "A" * 40
+    private_key = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "sensitive-key-material\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    )
+
+    stream.write("ordinary output\ncredential: ghp_")
+    stream.write("A" * 40 + "\n")
+    for line in private_key.splitlines(keepends=True):
+        stream.write(line)
+    stream.finalize()
+
+    stored = output.getvalue()
+    assert "ordinary output" in stored
+    assert secret not in stored
+    assert "sensitive-key-material" not in stored
+    assert "[REDACTED PRIVATE KEY]" in stored
+
+
+def test_redacting_stream_drops_unterminated_private_key_material():
+    output = io.StringIO()
+    stream = RedactingTextStream(output)
+
+    stream.write("-----BEGIN OPENSSH PRIVATE KEY-----\nraw-key-data")
+    stream.finalize()
+
+    assert output.getvalue() == "[REDACTED INCOMPLETE PRIVATE KEY]\n"
+
+
+def test_main_startup_installs_redaction_for_kanban_worker(tmp_path):
+    secret = "ghp_" + "B" * 40
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path / ".hermes")
+    env["HERMES_KANBAN_TASK"] = "t_worker"
+
+    result = subprocess.run(  # noqa: S603 -- interpreter and inline code are fixed
+        [sys.executable, "-c", f'import hermes_cli.main; print("{secret}")'],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    assert secret not in result.stdout
+
+
+def _make_task(kb):
+    return kb.Task(
+        id="t_private_log",
+        title="private log",
+        body=None,
+        assignee="worker",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=1,
+    )
+
+
+def test_default_spawn_creates_owner_only_worker_log(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles
+
+    log_dir = tmp_path / "logs"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: log_dir)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: None)
+    monkeypatch.setattr(profiles, "resolve_profile_env", lambda profile: str(tmp_path))
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4321
+
+    def fake_popen(cmd, *args, **kwargs):
+        log_file = kwargs["stdout"]
+        captured["mode"] = stat.S_IMODE(os.fstat(log_file.fileno()).st_mode)
+        log_file.close()
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    assert kb._default_spawn(_make_task(kb), str(workspace)) == 4321
+    assert captured["mode"] == 0o600
+
+
+def test_rotation_hardens_existing_worker_log_and_backups(tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    log_path = tmp_path / "worker.log"
+    log_path.write_text("secret")
+    os.chmod(log_path, 0o644)
+
+    kb._rotate_worker_log(log_path, max_bytes=1, backup_count=1)
+
+    rotated = tmp_path / "worker.log.1"
+    assert stat.S_IMODE(rotated.stat().st_mode) == 0o600
+
+
+def test_rotation_hardens_backup_without_rotating_current_log(tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    log_path = tmp_path / "worker.log"
+    backup_path = tmp_path / "worker.log.1"
+    log_path.write_text("current")
+    backup_path.write_text("historic secret")
+    os.chmod(log_path, 0o644)
+    os.chmod(backup_path, 0o644)
+
+    kb._rotate_worker_log(log_path, max_bytes=1024, backup_count=1)
+
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(backup_path.stat().st_mode) == 0o600


### PR DESCRIPTION
## Summary
- redact dispatcher-spawned Kanban worker stdout/stderr before it reaches durable per-task logs
- buffer split writes and multiline private-key blocks so credentials cannot escape at write boundaries
- create and harden active and rotated worker logs with owner-only `0600` permissions

## Why
Kanban workers currently inherit a direct file descriptor for stdout/stderr, bypassing the existing secret-redaction boundary and leaving logs readable according to the process umask. This keeps the fire-and-forget worker lifecycle intact while moving redaction into the worker process itself.

Fixes #63594

## Testing
- `uv run --extra dev pytest -q tests/hermes_cli/test_kanban_worker_log_redaction.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/hermes_cli/test_kanban_core_functionality.py -k "worker_log or default_spawn or rotation"` (20 passed)
- `uv run --extra dev pytest -q tests/agent/test_redact.py tests/tools/test_kanban_redaction.py tests/hermes_cli/test_kanban_boards.py -k "redact or spawn or rotation or log"` (160 passed)
- `uv run --extra dev ruff check hermes_cli/worker_log.py hermes_cli/main.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worker_log_redaction.py`