### PR TITLE
fix(serve): bridge terminal.backend config to TERMINAL_ENV in start_server

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17083,6 +17083,16 @@ def start_server(
             ", ".join(p.name for p in list_providers()),
         )
 
+    # Bridge terminal.backend config into the process environment so the
+    # terminal tool used by the serve process respects docker/ssh config
+    # from config.yaml, not just the default local backend.
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+
+        apply_terminal_config_to_env()
+    except Exception:
+        _log.debug("Failed to apply terminal config bridge for serve process", exc_info=True)
+
     # Record the bound host so host_header_middleware can validate incoming
     # Host headers against it. Defends against DNS rebinding (GHSA-ppp5-vxwm-4cf7).
     app.state.bound_host = host


### PR DESCRIPTION
Fixes #63141

## Summary
The `start_server()` function (used by `hermes serve` and Hermes Desktop's backend) never called `apply_terminal_config_to_env()`, so `terminal.backend: docker` from `config.yaml` was silently ignored — the terminal tool always ran in local mode.

## Change
Added a call to `apply_terminal_config_to_env()` in `start_server()`, right after the auth-check block and before uvicorn starts. This tells the serve process to read `terminal.*` config and set the corresponding `TERMINAL_*` env vars, matching the behavior already present in the TUI and dashboard-PTY launch paths.

Also partially addresses #63383 (docker_volumes ignored in Desktop) — the same config-bridge gap.