### PR TITLE
fix(oidc): add User-Agent header to JWKS client for Cloudflare/WAF compat

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,6 +601,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "User-Agent": "Hermes-Agent/1.0",
+                    "Accept": "application/json",
+                },
             )
         return self._jwks_client
 


### PR DESCRIPTION
Fixes #63273

## Summary
`SelfHostedOIDCProvider._get_jwks_client()` constructs `jwt.PyJWKClient` without request headers. PyJWT's `PyJWKClient` uses `urllib` under the hood with `urlopen()`, which sends a generic Python/urllib User-Agent. Cloudflare and other WAFs may challenge or block this default fingerprint (HTTP 403).

## Change
Added a standard `User-Agent: Hermes-Agent/1.0` and `Accept: application/json` header to the `PyJWKClient` constructor call so JWKS requests are treated as normal API calls by CDNs and WAFs.