### PR TITLE
fix(local): remove redundant temp-file read from `LocalEnvironment._update_cwd`

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -179,9 +179,9 @@ class TestUpdateCwdRejectsMissingPaths:
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        with open(env._cwd_file, "w") as f:
-            f.write(str(new_dir))
-
-        env._update_cwd({"output": "", "returncode": 0})
+        # CWD is now parsed from the stdout marker, not from the temp file.
+        marker = env._cwd_marker
+        output = f"\n{marker}{new_dir}{marker}\n"
+        env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(new_dir)

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -165,17 +165,19 @@ class TestUpdateCwdWindowsMsys:
         new_dir = tmp_path / "next"
         new_dir.mkdir()
 
-        with open(env._cwd_file, "w") as f:
-            f.write("/c/whatever/from/bash")
-
-        # Translate the synthetic MSYS string to the real native dir.
+        # CWD is now parsed from the stdout marker, not from the temp file.
+        # Simulate the marker in stdout like the shell bootstrap would emit.
+        marker = env._cwd_marker
+        # _msys_to_windows_path is called inside the override
+        # _extract_cwd_from_output when _IS_WINDOWS is True.
         def fake_translate(p):
             if p == "/c/whatever/from/bash":
                 return str(new_dir)
             return p
 
         with patch.object(local_mod, "_msys_to_windows_path", side_effect=fake_translate):
-            env._update_cwd({"output": "", "returncode": 0})
+            output = f"\n{marker}/c/whatever/from/bash{marker}\n"
+            env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(new_dir)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1144,31 +1144,14 @@ class LocalEnvironment(BaseEnvironment):
                 pass
 
     def _update_cwd(self, result: dict):
-        """Read CWD from temp file (local-only, no round-trip needed).
+        """Extract CWD from the shell marker in stdout.
 
-        Skip the assignment when the path no longer exists as a directory —
-        ``pwd -P`` on a deleted cwd can leave a stale value in the marker
-        file, and propagating it would re-wedge the next ``Popen``.  The
-        ``_run_bash`` recovery path will resolve a safe fallback if needed.
-
-        On Windows, the value written by Git Bash's ``pwd -P`` is in
-        MSYS form (``/c/Users/x``). Translate it to native Windows form
-        before validating with ``os.path.isdir`` and before storing on
-        ``self.cwd``; otherwise the isdir check rejects every valid
-        result and ``_run_bash`` later prints a misleading "cwd is
-        missing" warning on every command.
+        The shell bootstrap emits __HERMES_CWD_{session}__ into both
+        stdout (consumed here) and a temp file.  The base class parser
+        already handles the marker — the redundant temp file read has been
+        removed.  Windows path normalization is handled by the overridden
+        ``_extract_cwd_from_output`` below.
         """
-        try:
-            with open(self._cwd_file, encoding="utf-8") as f:
-                cwd_path = f.read().strip()
-            if _IS_WINDOWS:
-                cwd_path = _msys_to_windows_path(cwd_path)
-            if cwd_path and os.path.isdir(cwd_path):
-                self.cwd = cwd_path
-        except (OSError, FileNotFoundError):
-            pass
-
-        # Still strip the marker from output so it's not visible
         self._extract_cwd_from_output(result)
 
     def _extract_cwd_from_output(self, result: dict):


### PR DESCRIPTION
Fixes #63225

## Summary
Every `terminal()` call opened and re-read the CWD temp file that the shell bootstrap had just written, even though the base class `_extract_cwd_from_output()` already parses the identical value from the stdout marker. This redundant I/O added unnecessary overhead on every command.

## Change
Removed the temp-file read block from `LocalEnvironment._update_cwd()`. The method now delegates entirely to `_extract_cwd_from_output()`, which handles both the stdout marker parsing (base class) and Windows MSYS path normalization (override). The temp file continues to be written by the shell bootstrap and cleaned up on shutdown — only the redundant Python-side read is removed.

Updated two tests that relied on the old temp-file mechanism to instead simulate the stdout marker.