### PR TITLE
fix(gateway): skip goal continuation on failed agent turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10286,14 +10286,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
+                _is_failed = False
                 if isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
+                    _is_failed = bool(_agent_result.get("failed", False))
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                if _final_text.strip() and not _is_failed:
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:


### PR DESCRIPTION
Fixes #63180

## Summary
When a gateway session has an active standing goal and the agent's provider call fails, the error is normalized into a non-empty `final_response` text. The goal continuation check only tested whether `_final_text.strip()` was truthy, so it treated the error response as a successful turn, ran the goal judge, and enqueued another continuation. Repeated failures created a self-sustaining loop that appended duplicate `[Continuing toward your standing goal]` blocks.

## Change
Added a check for the `failed` flag from the agent result dict. When `failed` is `True` (indicating a provider error, compression exhaustion, or other failure), the goal continuation is skipped regardless of whether the final response text is non-empty. Empty/interrupted responses were already skipped by the existing `strip()` check.