### PR TITLE
fix: detect env-var-configured providers absent from PROVIDER_REGISTRY

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1524,6 +1524,12 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # not by the user explicitly configuring anthropic in Hermes.
     _IMPLICIT_ENV_VARS = {"CLAUDE_CODE_OAUTH_TOKEN"}
     pconfig = PROVIDER_REGISTRY.get(normalized)
+    # Fallback to ProviderDef from models.dev catalog when the provider
+    # isn't in the manually-maintained PROVIDER_REGISTRY (e.g. openrouter).
+    # Both expose .auth_type and .api_key_env_vars with the same shape.
+    if pconfig is None:
+        from hermes_cli.providers import get_provider
+        pconfig = get_provider(normalized)
     if pconfig and pconfig.auth_type == "api_key":
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -171,3 +171,24 @@ def test_env_pool_entry_counts_when_var_still_resolves(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("deepseek") is True
+
+
+def test_provider_not_in_registry_but_in_models_dev(tmp_path, monkeypatch):
+    """Providers absent from PROVIDER_REGISTRY but present in the models.dev
+    catalog (e.g. openrouter) must still be detected via their env vars.
+
+    Regression: is_provider_explicitly_configured() only checked
+    PROVIDER_REGISTRY for env-var names, so providers that exist solely in
+    the models.dev catalog were never recognised as explicitly configured -
+    hiding them from the desktop model picker even when their API key was
+    set in .env.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-key-12345678")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured, PROVIDER_REGISTRY
+    # Sanity: openrouter is not in the manual registry
+    assert "openrouter" not in PROVIDER_REGISTRY
+    assert is_provider_explicitly_configured("openrouter") is True


### PR DESCRIPTION
## Problem

`is_provider_explicitly_configured()` in `hermes_cli/auth.py` only checked `PROVIDER_REGISTRY` (a manually-maintained dict) for env-var names. Providers that exist solely in the models.dev catalog — e.g. **openrouter** — were never recognised as explicitly configured, so they were filtered out of the desktop model picker even when their API key was set in `.env`.

This meant users who added `OPENROUTER_API_KEY` to their `.env` could not see or select OpenRouter in the desktop app's model picker (Settings → Model), even though the key was correctly detected by the CLI (`hermes config` showed it as set).

## Root cause

`PROVIDER_REGISTRY` in `auth.py` explicitly **excludes** openrouter (and a few other aggregator/custom providers) by design — see the skip set in the auto-extend block:

```python
if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
    continue
```

But `is_provider_explicitly_configured()` relied solely on `PROVIDER_REGISTRY` to find env-var names. When `pconfig` was `None`, the entire env-var check was skipped — even though `get_provider('openrouter')` from `providers.py` (backed by the models.dev catalog) correctly returns a `ProviderDef` with `auth_type='api_key'` and `api_key_env_vars=('OPENROUTER_API_KEY',)`.

## Fix

Add a fallback to `get_provider()` when `PROVIDER_REGISTRY.get()` returns `None`. Both `ProviderConfig` and `ProviderDef` expose `.auth_type` and `.api_key_env_vars` with the same shape, so the existing check works without modification.

```python
pconfig = PROVIDER_REGISTRY.get(normalized)
if pconfig is None:
    from hermes_cli.providers import get_provider
    pconfig = get_provider(normalized)
```

## Test

Added a regression test `test_provider_not_in_registry_but_in_models_dev` that:
- Sets `OPENROUTER_API_KEY` in the env
- Asserts openrouter is NOT in `PROVIDER_REGISTRY` (sanity check)
- Asserts `is_provider_explicitly_configured('openrouter')` returns `True`

All 11 tests in `test_auth_provider_gate.py` pass.