### PR TITLE
fix(desktop): scope messaging sidebar by profile

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -129,6 +129,7 @@ import {
   useRepoWorktreeMap
 } from './projects'
 import {
+  shouldIncludeMessagingSession,
   shouldShowSessionSections,
   SidebarBlankState,
   SidebarPinnedEmptyState,
@@ -860,7 +861,7 @@ export function ChatSidebar({
     const bySource = new Map<string, SessionInfo[]>()
 
     for (const session of messagingSessions) {
-      if (!showAllProfiles && normalizeProfileKey(session.profile) !== profileScope) {
+      if (!shouldIncludeMessagingSession(profileScope, session.profile)) {
         continue
       }
 
@@ -893,7 +894,7 @@ export function ChatSidebar({
         }
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [messagingSessions, messagingPlatformTotals, messagingTruncated, profileScope, showAllProfiles])
+  }, [messagingSessions, messagingPlatformTotals, messagingTruncated, profileScope])
 
   // ALL-profiles view: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -128,7 +128,12 @@ import {
   StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
-import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import {
+  shouldShowSessionSections,
+  SidebarBlankState,
+  SidebarPinnedEmptyState,
+  SidebarSessionSkeletons
+} from './section-states'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -855,6 +860,10 @@ export function ChatSidebar({
     const bySource = new Map<string, SessionInfo[]>()
 
     for (const session of messagingSessions) {
+      if (!showAllProfiles && normalizeProfileKey(session.profile) !== profileScope) {
+        continue
+      }
+
       const sourceId = normalizeSessionSource(session.source)
 
       if (!sourceId) {
@@ -884,7 +893,7 @@ export function ChatSidebar({
         }
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [messagingSessions, messagingPlatformTotals, messagingTruncated])
+  }, [messagingSessions, messagingPlatformTotals, messagingTruncated, profileScope, showAllProfiles])
 
   // ALL-profiles view: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.
@@ -1043,7 +1052,13 @@ export function ChatSidebar({
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  const showSessionSections = shouldShowSessionSections({
+    hasCronJobs: cronJobs.length > 0,
+    hasMessaging: messagingGroups.length > 0,
+    hasProjects: projectModel.length > 0,
+    hasSessions: sortedSessions.length > 0,
+    loadingSessions: showSessionSkeletons
+  })
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowSessionSections } from './section-states'
+
+const emptySidebar = {
+  hasCronJobs: false,
+  hasMessaging: false,
+  hasProjects: false,
+  hasSessions: false,
+  loadingSessions: false
+}
+
+describe('shouldShowSessionSections', () => {
+  it('keeps messaging visible without normal sessions', () => {
+    expect(shouldShowSessionSections({ ...emptySidebar, hasMessaging: true })).toBe(true)
+  })
+
+  it('keeps cron jobs visible without normal sessions', () => {
+    expect(shouldShowSessionSections({ ...emptySidebar, hasCronJobs: true })).toBe(true)
+  })
+
+  it('uses the blank state only when every section is empty', () => {
+    expect(shouldShowSessionSections(emptySidebar)).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldShowSessionSections } from './section-states'
+import { ALL_PROFILES } from '@/store/profile'
+
+import { shouldIncludeMessagingSession, shouldShowSessionSections } from './section-states'
 
 const emptySidebar = {
   hasCronJobs: false,
@@ -21,5 +23,16 @@ describe('shouldShowSessionSections', () => {
 
   it('uses the blank state only when every section is empty', () => {
     expect(shouldShowSessionSections(emptySidebar)).toBe(false)
+  })
+})
+
+describe('shouldIncludeMessagingSession', () => {
+  it('keeps rows when a persisted All Profiles scope falls back to one profile', () => {
+    expect(shouldIncludeMessagingSession(ALL_PROFILES, 'default')).toBe(true)
+  })
+
+  it('filters rows outside a concrete profile scope', () => {
+    expect(shouldIncludeMessagingSession('work', 'default')).toBe(false)
+    expect(shouldIncludeMessagingSession('work', 'work')).toBe(true)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -3,6 +3,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 
 interface SidebarSectionVisibility {
   hasCronJobs: boolean
@@ -20,6 +21,10 @@ export function shouldShowSessionSections({
   loadingSessions
 }: SidebarSectionVisibility): boolean {
   return loadingSessions || hasSessions || hasProjects || hasMessaging || hasCronJobs
+}
+
+export function shouldIncludeMessagingSession(profileScope: string, sessionProfile?: string): boolean {
+  return profileScope === ALL_PROFILES || normalizeProfileKey(sessionProfile) === profileScope
 }
 
 export function SidebarSessionSkeletons() {

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -4,6 +4,24 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
+interface SidebarSectionVisibility {
+  hasCronJobs: boolean
+  hasMessaging: boolean
+  hasProjects: boolean
+  hasSessions: boolean
+  loadingSessions: boolean
+}
+
+export function shouldShowSessionSections({
+  hasCronJobs,
+  hasMessaging,
+  hasProjects,
+  hasSessions,
+  loadingSessions
+}: SidebarSectionVisibility): boolean {
+  return loadingSessions || hasSessions || hasProjects || hasMessaging || hasCronJobs
+}
+
 export function SidebarSessionSkeletons() {
   return (
     <div aria-hidden="true" className="grid gap-px">

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
@@ -2,9 +2,9 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getCronJobs, listAllProfileSessions } from '@/hermes'
+import { getCronJobs, listAllProfileSessions, type PaginatedSessions, type SessionInfo } from '@/hermes'
 import { ALL_PROFILES } from '@/store/profile'
-import { setMessagingSessions } from '@/store/session'
+import { $messagingSessions, setMessagingSessions } from '@/store/session'
 
 import { useSessionListActions } from './use-session-list-actions'
 
@@ -14,12 +14,41 @@ vi.mock('@/hermes', async importOriginal => ({
   listAllProfileSessions: vi.fn()
 }))
 
-const emptyPage = {
+const emptyPage: PaginatedSessions = {
   limit: 50,
   offset: 0,
   profile_totals: {},
   sessions: [],
   total: 0
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function messagingSession(id: string, profile: string): SessionInfo {
+  return {
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile,
+    source: 'telegram',
+    started_at: 1,
+    title: id,
+    tool_call_count: 0
+  }
 }
 
 describe('useSessionListActions messaging scope', () => {
@@ -78,5 +107,44 @@ describe('useSessionListActions messaging scope', () => {
     expect(listAllProfileSessions).toHaveBeenCalledWith(expect.any(Number), 1, 'exclude', 'recent', 'silas', {
       source: 'slack'
     })
+  })
+
+  it('ignores an older profile response that resolves after the active profile', async () => {
+    const first = deferred<typeof emptyPage>()
+    const second = deferred<typeof emptyPage>()
+
+    vi.mocked(listAllProfileSessions)
+      .mockReset()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'nolan' } }
+    )
+
+    let firstRequest!: Promise<void>
+    act(() => {
+      firstRequest = result.current.refreshMessagingSessions()
+    })
+
+    rerender({ profileScope: 'silas' })
+
+    let secondRequest!: Promise<void>
+    act(() => {
+      secondRequest = result.current.refreshMessagingSessions()
+    })
+
+    await act(async () => {
+      second.resolve({ ...emptyPage, sessions: [messagingSession('silas-session', 'silas')], total: 1 })
+      await secondRequest
+    })
+
+    await act(async () => {
+      first.resolve({ ...emptyPage, sessions: [messagingSession('nolan-session', 'nolan')], total: 1 })
+      await firstRequest
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['silas-session'])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getCronJobs, listAllProfileSessions, type PaginatedSessions, type SessionInfo } from '@/hermes'
 import { ALL_PROFILES } from '@/store/profile'
-import { $messagingSessions, setMessagingSessions } from '@/store/session'
+import {
+  $messagingPlatformTotals,
+  $messagingSessions,
+  setMessagingPlatformTotals,
+  setMessagingSessions
+} from '@/store/session'
 
 import { useSessionListActions } from './use-session-list-actions'
 
@@ -54,6 +59,7 @@ function messagingSession(id: string, profile: string): SessionInfo {
 describe('useSessionListActions messaging scope', () => {
   beforeEach(() => {
     setMessagingSessions([])
+    setMessagingPlatformTotals({})
     vi.mocked(getCronJobs).mockResolvedValue([])
     vi.mocked(listAllProfileSessions).mockResolvedValue(emptyPage)
   })
@@ -118,10 +124,9 @@ describe('useSessionListActions messaging scope', () => {
       .mockImplementationOnce(() => first.promise)
       .mockImplementationOnce(() => second.promise)
 
-    const { rerender, result } = renderHook(
-      ({ profileScope }) => useSessionListActions({ profileScope }),
-      { initialProps: { profileScope: 'nolan' } }
-    )
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'nolan' }
+    })
 
     let firstRequest!: Promise<void>
     act(() => {
@@ -146,5 +151,39 @@ describe('useSessionListActions messaging scope', () => {
     })
 
     expect($messagingSessions.get().map(session => session.id)).toEqual(['silas-session'])
+  })
+
+  it('ignores a load-more response after the active profile changes', async () => {
+    const page = deferred<typeof emptyPage>()
+
+    vi.mocked(listAllProfileSessions)
+      .mockReset()
+      .mockImplementationOnce(() => page.promise)
+    setMessagingSessions([messagingSession('nolan-seed', 'nolan')])
+    setMessagingPlatformTotals({ telegram: 1 })
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'nolan' }
+    })
+
+    let loadMoreRequest!: Promise<void>
+    act(() => {
+      loadMoreRequest = result.current.loadMoreMessagingForPlatform('telegram')
+    })
+
+    rerender({ profileScope: 'silas' })
+    setMessagingSessions([messagingSession('silas-session', 'silas')])
+
+    await act(async () => {
+      page.resolve({
+        ...emptyPage,
+        sessions: [messagingSession('nolan-more', 'nolan')],
+        total: 2
+      })
+      await loadMoreRequest
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['silas-session'])
+    expect($messagingPlatformTotals.get()).toEqual({ telegram: 1 })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCronJobs, listAllProfileSessions } from '@/hermes'
+import { ALL_PROFILES } from '@/store/profile'
+import { setMessagingSessions } from '@/store/session'
+
+import { useSessionListActions } from './use-session-list-actions'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobs: vi.fn(),
+  listAllProfileSessions: vi.fn()
+}))
+
+const emptyPage = {
+  limit: 50,
+  offset: 0,
+  profile_totals: {},
+  sessions: [],
+  total: 0
+}
+
+describe('useSessionListActions messaging scope', () => {
+  beforeEach(() => {
+    setMessagingSessions([])
+    vi.mocked(getCronJobs).mockResolvedValue([])
+    vi.mocked(listAllProfileSessions).mockResolvedValue(emptyPage)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('fetches messaging sessions only for the active profile', async () => {
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'nolan' }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'nolan',
+      expect.objectContaining({ excludeSources: expect.any(Array) })
+    )
+  })
+
+  it('keeps messaging global in the explicit all-profiles view', async () => {
+    const { result } = renderHook(() => useSessionListActions({ profileScope: ALL_PROFILES }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'all',
+      expect.any(Object)
+    )
+  })
+
+  it('pages one messaging platform within the active profile', async () => {
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'silas' }))
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('slack')
+    })
+
+    expect(listAllProfileSessions).toHaveBeenCalledWith(expect.any(Number), 1, 'exclude', 'recent', 'silas', {
+      source: 'slack'
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -74,9 +74,12 @@ interface UseSessionListActionsArgs {
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+  const messagingProfileRef = useRef(sessionProfile)
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
-  const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
+  messagingProfileRef.current = sessionProfile
 
   // Cron-job sessions as their own list (latest N). Independent of the recents
   // page so the two never compete for slots. Cheap + bounded. Kept (even though
@@ -111,7 +114,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // sources) — those stay in local recents, not a platform section.
       const rows = result.sessions.filter(s => isMessagingSource(s.source))
 
-      if (refreshMessagingSessionsRequestRef.current === requestId) {
+      if (messagingProfileRef.current === sessionProfile && refreshMessagingSessionsRequestRef.current === requestId) {
         setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
         // Hit the cap → at least one platform may have more on disk than loaded,
         // so platform sections offer their own per-platform "load more".
@@ -138,6 +141,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         sessionProfile,
         { source: platform }
       )
+
+      if (messagingProfileRef.current !== sessionProfile) {
+        return
+      }
 
       const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -75,6 +75,7 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const refreshSessionsRequestRef = useRef(0)
+  const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
   // Cron-job sessions as their own list (latest N). Independent of the recents
   // page so the two never compete for slots. Cheap + bounded. Kept (even though
@@ -98,7 +99,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
 
@@ -113,29 +114,37 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [sessionProfile])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
   // every other platform's rows untouched. Resolves the platform's exact total.
-  const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
-    const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
-    const loaded = $messagingSessions.get().filter(inPlatform).length
+  const loadMoreMessagingForPlatform = useCallback(
+    async (platform: string) => {
+      const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
+      const loaded = $messagingSessions.get().filter(inPlatform).length
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
-      source: platform
-    })
+      const result = await listAllProfileSessions(
+        loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
+        1,
+        'exclude',
+        'recent',
+        sessionProfile,
+        { source: platform }
+      )
 
-    const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
+      const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
 
-    setMessagingSessions(prev => [
-      ...prev.filter(s => !inPlatform(s)),
-      ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
-    ])
+      setMessagingSessions(prev => [
+        ...prev.filter(s => !inPlatform(s)),
+        ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
+      ])
 
-    const total = result.total ?? incoming.length
-    setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+      const total = result.total ?? incoming.length
+      setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
+    },
+    [sessionProfile]
+  )
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right
@@ -170,8 +179,6 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // Scope the fetch to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
-      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
-
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: SIDEBAR_EXCLUDED_SOURCES
       })
@@ -190,7 +197,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     void refreshCronSessions()
     void refreshCronJobs()
     void refreshMessagingSessions()
-  }, [profileScope, refreshCronSessions, refreshCronJobs, refreshMessagingSessions])
+  }, [refreshCronSessions, refreshCronJobs, refreshMessagingSessions, sessionProfile])
 
   const loadMoreSessions = useCallback(async () => {
     bumpSessionsLimit()

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -74,6 +74,7 @@ interface UseSessionListActionsArgs {
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
   const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
@@ -98,6 +99,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // competes with local chats for the recents page budget. One combined fetch
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
+    const requestId = refreshMessagingSessionsRequestRef.current + 1
+    refreshMessagingSessionsRequestRef.current = requestId
+
     try {
       const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
@@ -107,10 +111,12 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // sources) — those stay in local recents, not a platform section.
       const rows = result.sessions.filter(s => isMessagingSource(s.source))
 
-      setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
-      // Hit the cap → at least one platform may have more on disk than loaded,
-      // so platform sections offer their own per-platform "load more".
-      setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
+      if (refreshMessagingSessionsRequestRef.current === requestId) {
+        setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
+        // Hit the cap → at least one platform may have more on disk than loaded,
+        // so platform sections offer their own per-platform "load more".
+        setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
+      }
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }


### PR DESCRIPTION
## Summary
- fetch messaging seed pages and per-platform pagination within the active profile
- keep cross-profile messaging only in the explicit All Profiles view
- keep messaging and cron sections visible when a profile has no normal sessions or projects

## Why
The Desktop sidebar fetched messaging sessions with `profile=all` regardless of the selected profile, then hid every session section when the normal-session/project lists were empty. This could expose another profile’s Slack rows and make the messaging section appear only after creating a local chat.

Fixes #63593

## Testing
- `npm run test:ui --workspace apps/desktop -- src/app/session/hooks/use-session-list-actions.test.ts src/app/chat/sidebar/section-states.test.ts` (6 passed)
- `npm run typecheck --workspace apps/desktop`
- `npm exec --workspace apps/desktop -- eslint src/app/session/hooks/use-session-list-actions.ts src/app/session/hooks/use-session-list-actions.test.ts src/app/chat/sidebar/index.tsx src/app/chat/sidebar/section-states.tsx src/app/chat/sidebar/section-states.test.ts`
- `npm exec --workspace apps/desktop -- prettier --check src/app/session/hooks/use-session-list-actions.ts src/app/session/hooks/use-session-list-actions.test.ts src/app/chat/sidebar/index.tsx src/app/chat/sidebar/section-states.tsx src/app/chat/sidebar/section-states.test.ts`