### PR TITLE
fix(zai): restore request-local prompt policy

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1180,6 +1180,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
+            provider_name=agent.provider,
             ollama_num_ctx=agent._ollama_num_ctx,
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,
@@ -1965,6 +1966,18 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # Same safety net as the main loop: drop thinking-only assistant
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # The summary path hand-builds messages and bypasses
+        # ChatCompletionsTransport.build_kwargs(), so apply the same request-local
+        # Z.AI prompt policy explicitly before dispatch.
+        from agent.zai_prompt_policy import apply_zai_prompt_policy
+
+        api_messages = apply_zai_prompt_policy(
+            api_messages,
+            provider=agent.provider,
+            model=agent.model,
+            base_url=agent.base_url,
+        )
 
         summary_extra_body = {}
         try:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -333,6 +333,18 @@ class ChatCompletionsTransport(ProviderTransport):
         # Gemini targets and stripped for strict non-Gemini providers.
         sanitized = self.convert_messages(messages, model=model)
 
+        # Direct Z.AI endpoints reject some branded system-prompt variants as
+        # provider-side 429/code-1305 failures. Rewrite only the outbound copy;
+        # cached prompts and conversation history remain byte-for-byte intact.
+        from agent.zai_prompt_policy import apply_zai_prompt_policy
+
+        sanitized = apply_zai_prompt_policy(
+            sanitized,
+            provider=params.get("provider_name", ""),
+            model=model,
+            base_url=params.get("base_url", ""),
+        )
+
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")
         if _profile:

--- a/agent/zai_prompt_policy.py
+++ b/agent/zai_prompt_policy.py
@@ -1,0 +1,88 @@
+"""Request-local system-prompt policy for direct Z.AI endpoints."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+
+_ZAI_SYSTEM_PREFIX = (
+    "You are a precise local AI coding and operations assistant. "
+    "Answer the user's task directly. Use the provided tools and conversation "
+    "context when available. Do not mention internal platform branding."
+)
+
+_BRANDING_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    (r"You are Hermes Agent, an intelligent AI assistant created by Nous Research\.\s*", ""),
+    (r"You run on Hermes Agent \(by Nous Research\)\.\s*", ""),
+    (r"Hermes Agent", "the local assistant"),
+    (r"Nous Research", "the platform provider"),
+)
+
+
+def is_zai_request(*, provider: str = "", model: str = "", base_url: str = "") -> bool:
+    """Return whether a request targets the direct Z.AI API endpoint."""
+    provider_lower = str(provider or "").strip().lower()
+    if provider_lower in {"zai", "z-ai", "z.ai", "glm", "zhipu"}:
+        return True
+
+    del model  # Model family alone is not endpoint identity (local GLM is valid).
+    try:
+        hostname = (urlparse(str(base_url or "")).hostname or "").lower()
+    except ValueError:
+        hostname = ""
+    return hostname in {"api.z.ai", "open.bigmodel.cn"}
+
+
+def sanitize_zai_system_prompt(text: str) -> str:
+    """Return a neutralized Z.AI system prompt while preserving instructions."""
+    output = text
+    for pattern, replacement in _BRANDING_REPLACEMENTS:
+        output = re.sub(pattern, replacement, output, flags=re.IGNORECASE)
+    output = re.sub(r"\n{3,}", "\n\n", output).strip()
+    if not output:
+        return _ZAI_SYSTEM_PREFIX
+    if output.startswith(_ZAI_SYSTEM_PREFIX):
+        return output
+    return f"{_ZAI_SYSTEM_PREFIX}\n\n{output}"
+
+
+def _sanitize_content(content: Any) -> Any:
+    if isinstance(content, str):
+        return sanitize_zai_system_prompt(content)
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if isinstance(part.get("text"), str):
+                part["text"] = sanitize_zai_system_prompt(part["text"])
+            elif isinstance(part.get("content"), str):
+                part["content"] = sanitize_zai_system_prompt(part["content"])
+    return content
+
+
+def apply_zai_prompt_policy(
+    messages: list[dict[str, Any]],
+    *,
+    provider: str = "",
+    model: str = "",
+    base_url: str = "",
+) -> list[dict[str, Any]]:
+    """Rewrite only the outbound message copy for direct Z.AI requests."""
+    if not is_zai_request(provider=provider, model=model, base_url=base_url):
+        return messages
+
+    sanitized = list(messages)
+    saw_system = False
+    for index, message in enumerate(messages):
+        if message.get("role") != "system":
+            continue
+        saw_system = True
+        cloned = copy.deepcopy(message)
+        cloned["content"] = _sanitize_content(cloned.get("content"))
+        sanitized[index] = cloned
+    if not saw_system:
+        sanitized.insert(0, {"role": "system", "content": _ZAI_SYSTEM_PREFIX})
+    return sanitized

--- a/tests/agent/test_zai_prompt_policy.py
+++ b/tests/agent/test_zai_prompt_policy.py
@@ -1,0 +1,218 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import handle_max_iterations
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def test_zai_chat_completion_rewrites_branded_system_prompt_without_mutating_input():
+    transport = ChatCompletionsTransport()
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are Hermes Agent, an intelligent AI assistant created by Nous Research.\n"
+                "You run on Hermes Agent (by Nous Research).\n"
+                "Use the provided tools."
+            ),
+        },
+        {"role": "user", "content": "hello"},
+    ]
+
+    kwargs = transport.build_kwargs(
+        model="glm-5.2",
+        messages=messages,
+        provider_name="custom",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+
+    assert kwargs["messages"] is not messages
+    assert messages[0]["content"].startswith("You are Hermes Agent")
+    system = kwargs["messages"][0]["content"]
+    assert system.startswith("You are a precise local AI coding and operations assistant.")
+    assert "Hermes" not in system
+    assert "Nous Research" not in system
+    assert "Use the provided tools." in system
+
+
+def test_zai_chat_completion_inserts_neutral_system_prompt_when_missing():
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-5.2",
+        messages=[{"role": "user", "content": "hello"}],
+        provider_name="custom",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+
+    assert kwargs["messages"][0]["role"] == "system"
+    assert "precise local AI" in kwargs["messages"][0]["content"]
+    assert kwargs["messages"][1] == {"role": "user", "content": "hello"}
+
+
+def test_zai_provider_alias_triggers_policy_without_base_url():
+    messages = [{"role": "system", "content": "Hermes Agent by Nous Research"}]
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-5.2",
+        messages=messages,
+        provider_name="zai",
+        base_url="",
+    )
+
+    assert kwargs["messages"] is not messages
+    assert "Hermes" not in kwargs["messages"][0]["content"]
+    assert "Nous Research" not in kwargs["messages"][0]["content"]
+
+
+def test_zhipu_bigmodel_endpoint_triggers_policy_for_custom_provider():
+    messages = [{"role": "system", "content": "Hermes Agent by Nous Research"}]
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-4.5",
+        messages=messages,
+        provider_name="custom",
+        base_url="https://open.bigmodel.cn/api/paas/v4",
+    )
+
+    assert kwargs["messages"] is not messages
+    assert "Hermes Agent" not in kwargs["messages"][0]["content"]
+    assert "Nous Research" not in kwargs["messages"][0]["content"]
+
+
+def test_non_zai_request_preserves_message_identity_and_content():
+    messages = [{"role": "system", "content": "You are Hermes Agent."}]
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="gpt-4.1",
+        messages=messages,
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+    )
+
+    assert kwargs["messages"] is messages
+    assert kwargs["messages"][0]["content"] == "You are Hermes Agent."
+
+
+def test_locally_hosted_glm_model_does_not_trigger_endpoint_policy():
+    messages = [{"role": "system", "content": "You are Hermes Agent."}]
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-5.2",
+        messages=messages,
+        provider_name="custom",
+        base_url="http://127.0.0.1:8000/v1",
+    )
+
+    assert kwargs["messages"] is messages
+    assert kwargs["messages"][0]["content"] == "You are Hermes Agent."
+
+
+def test_zai_policy_preserves_operational_cli_paths_and_environment_names():
+    operational = (
+        "Run `hermes tools` and `hermes status`. "
+        "Read ~/.hermes/config.yaml and .hermes.md. "
+        "Keep HERMES_HOME unchanged. Active Hermes profile: default."
+    )
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-5.2",
+        messages=[{"role": "system", "content": operational}],
+        provider_name="custom",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+
+    system = kwargs["messages"][0]["content"]
+    for fragment in (
+        "hermes tools",
+        "hermes status",
+        "~/.hermes/config.yaml",
+        ".hermes.md",
+        "HERMES_HOME",
+        "Active Hermes profile",
+    ):
+        assert fragment in system
+
+
+def test_zai_policy_rewrites_multipart_system_text_without_mutating_input():
+    content = [
+        {
+            "type": "text",
+            "text": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Use tools.",
+        }
+    ]
+    messages = [{"role": "system", "content": content}]
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="glm-5.2",
+        messages=messages,
+        provider_name="custom",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+
+    assert messages[0]["content"] is content
+    assert messages[0]["content"][0]["text"].startswith("You are Hermes Agent")
+    rewritten = kwargs["messages"][0]["content"][0]["text"]
+    assert rewritten.startswith("You are a precise local AI coding and operations assistant.")
+    assert "Hermes Agent" not in rewritten
+    assert "Nous Research" not in rewritten
+    assert "Use tools." in rewritten
+
+
+def test_zai_iteration_limit_summary_uses_prompt_policy():
+    captured = {}
+
+    class Completions:
+        @staticmethod
+        def create(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+    class Transport:
+        @staticmethod
+        def normalize_response(_response):
+            return SimpleNamespace(content="done")
+
+    agent = SimpleNamespace(
+        max_iterations=1,
+        _should_sanitize_tool_calls=lambda: False,
+        _copy_reasoning_content_for_api=lambda _source, _target: None,
+        _cached_system_prompt=(
+            "You are Hermes Agent, an intelligent AI assistant created by Nous Research.\n"
+            "You run on Hermes Agent (by Nous Research)."
+        ),
+        ephemeral_system_prompt="",
+        prefill_messages=[],
+        _sanitize_api_messages=lambda messages: messages,
+        _drop_thinking_only_and_merge_users=lambda messages: messages,
+        model="glm-5.2",
+        provider="custom",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        _base_url_lower="https://api.z.ai/api/coding/paas/v4",
+        api_mode="chat_completions",
+        reasoning_config=None,
+        _supports_reasoning_extra_body=lambda: False,
+        max_tokens=64,
+        _max_tokens_param=lambda value: {"max_tokens": value},
+        openrouter_min_coding_score=None,
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        _is_openrouter_url=lambda: False,
+        _ensure_primary_openai_client=lambda **_kwargs: SimpleNamespace(
+            chat=SimpleNamespace(completions=Completions())
+        ),
+        _get_transport=lambda: Transport(),
+    )
+
+    result = handle_max_iterations(
+        agent,
+        [{"role": "user", "content": "original task"}],
+        api_call_count=1,
+    )
+
+    assert result == "done"
+    system = captured["messages"][0]["content"]
+    assert system.startswith("You are a precise local AI coding and operations assistant.")
+    assert "Hermes" not in system
+    assert "Nous Research" not in system

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1832,6 +1832,24 @@ class TestBuildApiKwargs:
         assert kwargs["messages"] is messages
         assert kwargs["timeout"] == 1800.0
 
+    def test_provider_profile_forwards_provider_name(self, agent, monkeypatch):
+        captured = {}
+
+        class CapturingTransport:
+            @staticmethod
+            def build_kwargs(**kwargs):
+                captured.update(kwargs)
+                return kwargs
+
+        agent.provider = "zai"
+        agent.base_url = ""
+        agent._base_url_lower = ""
+        monkeypatch.setattr(agent, "_get_transport", lambda: CapturingTransport())
+
+        agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert captured["provider_name"] == "zai"
+
     def test_public_moonshot_kimi_k2_5_omits_temperature(self, agent):
         """Kimi models should NOT have client-side temperature overrides.
 


### PR DESCRIPTION
## Summary

Restore a request-local prompt compatibility policy for direct Z.AI endpoints on current `main`.

This is a fresh, current-main replacement for the closed #52976 carried patch. The request assembly code has since moved into `ChatCompletionsTransport`, so the old commit no longer applies cleanly.

## Motivation

Direct Z.AI Coding Plan requests have intermittently returned HTTP 429 with provider code `1305` when the full Hermes/Nous identity prompt is sent. The failure is not reliably deterministic—an exact failed payload can succeed later—so this change is deliberately narrow and fail-safe rather than treating every GLM model as affected.

## What changed

- Add a request-local Z.AI prompt policy that:
  - activates only for explicit Z.AI/Zhipu provider identities or the exact `api.z.ai` / `open.bigmodel.cn` hostnames;
  - does **not** activate from the `glm-*` model name alone, preserving locally hosted GLM deployments;
  - strips the known identity sentences and rewrites only the multi-word `Hermes Agent` / `Nous Research` branding phrases;
  - preserves operational identifiers such as `hermes tools`, `~/.hermes/`, `.hermes.md`, `HERMES_HOME`, and `Active Hermes profile`;
  - handles string and multipart system content;
  - inserts a neutral system message if one is absent.
- Apply the policy at the Chat Completions transport boundary.
- Forward the resolved provider name through provider-profile transport calls, so explicit Z.AI identities remain available even without a URL-derived match.
- Apply the same policy to the iteration-limit summary path, which intentionally bypasses the transport builder.
- Keep cached prompts, session history, user messages, and non-Z.AI request identity unchanged.

## Verification

```text
uv run --with pytest python -m pytest tests/agent/test_zai_prompt_policy.py -q -o addopts=
9 passed

uv run --with pytest python -m pytest \
  tests/agent/test_zai_prompt_policy.py \
  tests/providers/test_transport_parity.py \
  tests/providers/test_profile_wiring.py \
  tests/agent/test_model_extra_type_guard.py \
  tests/run_agent/test_run_agent.py \
  -k 'zai_prompt_policy or transport_parity or profile_wiring or model_extra_type_guard or BuildApiKwargs or build_api_kwargs' \
  -q -o addopts=
94 passed, 381 deselected

uv run --with ruff ruff check agent/zai_prompt_policy.py agent/chat_completion_helpers.py agent/transports/chat_completions.py tests/agent/test_zai_prompt_policy.py tests/run_agent/test_run_agent.py
All checks passed!

uv run --with ty ty check agent/zai_prompt_policy.py tests/agent/test_zai_prompt_policy.py
All checks passed!
```

Live checks against the configured `custom:z2` Z.AI endpoint:

```text
hermes --provider custom:z2 -m glm-5.2 -z 'Reply with exactly: OK'
OK
```

A request-local replay of the previously failed 29k-token payload verified that the original messages remained unchanged, the outbound identity block was neutralized, and Z.AI returned HTTP 200 (`finish_reason=tool_calls`). No credentials or request content are included here.

## Safety / scope

- No mutation of cached prompts or persisted conversation history.
- No model-name-only gating.
- Exact hostname parsing for `api.z.ai` and `open.bigmodel.cn` avoids substring-host spoofing.
- Non-target providers return the original message object unchanged.
- Operational Hermes CLI/path/config identifiers are covered by preservation tests.

Supersedes #52976.
