### PR TITLE
fix(installer): preserve user-managed Node commands

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -470,8 +470,8 @@ get_command_link_display_dir() {
 # so global package binaries land in $HERMES_HOME/node/bin — which is NOT on
 # PATH (only the command link dir is) and is wiped on every Node upgrade.
 # Redirecting the prefix to the link dir's parent makes global bins resolve to
-# the command link dir (node/npm/npx live there too, already on PATH) and
-# survive upgrades. Scoped to the managed Node via its prefix-local global
+# the command link dir, which is already on PATH, and survive upgrades. Scoped
+# to the managed Node via its prefix-local global
 # npmrc, so the user's other Node installs and their ~/.npmrc are untouched.
 # Hermes's own global installs pass an explicit --prefix and are unaffected.
 # Idempotent and a no-op when there is no Hermes-managed npm, so calling it on
@@ -482,6 +482,24 @@ configure_managed_node_npm_prefix() {
     link_dir="$(get_command_link_dir)"
     mkdir -p "$HERMES_HOME/node/etc"
     printf 'prefix=%s\n' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+}
+
+# Expose a Hermes-managed Node tool without taking ownership of a user-managed
+# command. Existing regular files and non-Hermes symlinks are always preserved.
+link_managed_node_tool() {
+    local link_dir="$1"
+    local tool="$2"
+    local target="$HERMES_HOME/node/bin/$tool"
+    local destination="$link_dir/$tool"
+
+    if [ -L "$destination" ] && [ "$(readlink "$destination" 2>/dev/null)" = "$target" ]; then
+        return 0
+    fi
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+        log_warn "Leaving existing $destination unchanged; Hermes-managed $tool is at $target"
+        return 0
+    fi
+    ln -s "$target" "$destination"
 }
 
 get_hermes_command_path() {
@@ -795,6 +813,31 @@ node_satisfies_build() {
     return 1
 }
 
+# GUI-launched installers inherit launchd's minimal PATH on macOS. Probe common
+# user-managed Node locations before downloading another copy. This avoids
+# replacing a perfectly usable Homebrew/Volta/fnm/proto/nvm installation just
+# because its shim directory was absent from the GUI environment.
+activate_node_from_known_locations() {
+    local candidate version
+    for candidate in \
+        "$HOME/.volta/bin/node" \
+        "$HOME/.local/share/fnm/aliases/default/bin/node" \
+        "$HOME/.proto/shims/node" \
+        /opt/homebrew/bin/node \
+        /usr/local/bin/node \
+        "$HOME"/.nvm/versions/node/*/bin/node; do
+        [ -x "$candidate" ] || continue
+        version=$("$candidate" --version 2>/dev/null) || continue
+        if node_satisfies_build "$version"; then
+            export PATH="$(dirname "$candidate"):$PATH"
+            log_success "Node.js $version found at $candidate"
+            HAS_NODE=true
+            return 0
+        fi
+    done
+    return 1
+}
+
 check_node() {
     log_info "Checking Node.js (for browser tools)..."
 
@@ -806,6 +849,10 @@ check_node() {
     if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
         log_success "Node.js $(node --version) found"
         HAS_NODE=true
+        return 0
+    fi
+
+    if activate_node_from_known_locations; then
         return 0
     fi
 
@@ -917,7 +964,7 @@ install_node() {
         return 0
     fi
 
-    # Place into ~/.hermes/node/ and symlink binaries into the same bin dir
+    # Place into ~/.hermes/node/ and expose binaries in the same bin dir
     # the hermes command uses (get_command_link_dir): /usr/local/bin for root
     # FHS installs, $PREFIX/bin on Termux, ~/.local/bin otherwise.
     rm -rf "$HERMES_HOME/node"
@@ -928,9 +975,9 @@ install_node() {
     local node_link_dir
     node_link_dir="$(get_command_link_dir)"
     mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+    link_managed_node_tool "$node_link_dir" node
+    link_managed_node_tool "$node_link_dir" npm
+    link_managed_node_tool "$node_link_dir" npx
 
     configure_managed_node_npm_prefix
 

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -70,6 +70,22 @@ _nb_configure_npm_prefix() {
     printf 'prefix=%s\n' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"
 }
 
+_nb_link_managed_tool() {
+    local _link_dir="$1"
+    local _tool="$2"
+    local _target="$HERMES_HOME/node/bin/$_tool"
+    local _destination="$_link_dir/$_tool"
+
+    if [ -L "$_destination" ] && [ "$(readlink "$_destination" 2>/dev/null)" = "$_target" ]; then
+        return 0
+    fi
+    if [ -e "$_destination" ] || [ -L "$_destination" ]; then
+        _nb_warn "Leaving existing $_destination unchanged; Hermes-managed $_tool is at $_target"
+        return 0
+    fi
+    ln -s "$_target" "$_destination"
+}
+
 _nb_node_major() {
     local v
     v=$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)
@@ -79,6 +95,28 @@ _nb_node_major() {
 _nb_have_modern_node() {
     command -v node >/dev/null 2>&1 || return 1
     [ "$(_nb_node_major)" -ge "$HERMES_NODE_MIN_VERSION" ]
+}
+
+# GUI applications often start with a minimal PATH. Respect common existing
+# Node installations before invoking a version manager or installing a bundle.
+_nb_try_known_node() {
+    local _candidate _major
+    for _candidate in \
+        "$HOME/.volta/bin/node" \
+        "$HOME/.local/share/fnm/aliases/default/bin/node" \
+        "$HOME/.proto/shims/node" \
+        /opt/homebrew/bin/node \
+        /usr/local/bin/node \
+        "$HOME"/.nvm/versions/node/*/bin/node; do
+        [ -x "$_candidate" ] || continue
+        _major=$("$_candidate" --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)
+        if [[ "$_major" =~ ^[0-9]+$ ]] && [ "$_major" -ge "$HERMES_NODE_MIN_VERSION" ]; then
+            export PATH="$(dirname "$_candidate"):$PATH"
+            _nb_ok "Node $("$_candidate" --version) found at $_candidate"
+            return 0
+        fi
+    done
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -216,9 +254,9 @@ _nb_install_bundled_node() {
     local _link_dir
     _link_dir="$(_nb_get_link_dir)"
     mkdir -p "$_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$_link_dir/npx"
+    _nb_link_managed_tool "$_link_dir" node
+    _nb_link_managed_tool "$_link_dir" npm
+    _nb_link_managed_tool "$_link_dir" npx
 
     _nb_configure_npm_prefix
 
@@ -285,6 +323,11 @@ ensure_node() {
 
     if _nb_have_modern_node; then
         _nb_ok "Node $(node --version) found"
+        HERMES_NODE_AVAILABLE=true
+        return 0
+    fi
+
+    if _nb_try_known_node; then
         HERMES_NODE_AVAILABLE=true
         return 0
     fi

--- a/tests/test_install_sh_node_global_prefix.py
+++ b/tests/test_install_sh_node_global_prefix.py
@@ -7,10 +7,12 @@ drops the package binary in ``$HERMES_HOME/node/bin`` — which is NOT on PATH
 report "I can ``npm i -g`` but the package isn't usable on the command line".
 
 The fix redirects the bundled Node's global prefix to the command link dir's
-parent (so global bins land in the already-on-PATH link dir alongside
-node/npm/npx), scoped to the bundled Node via its prefix-local global npmrc.
+parent (so global bins land in the already-on-PATH link dir), scoped to the
+bundled Node via its prefix-local global npmrc.
 """
 
+import os
+import subprocess
 from pathlib import Path
 
 
@@ -23,10 +25,12 @@ def test_install_sh_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
     text = INSTALL_SH.read_text()
 
     # The redirect must target the link dir's PARENT so global bins resolve to
-    # <parent>/bin == the command link dir (node/npm/npx live there and it is
-    # guaranteed on PATH by the installer's PATH setup).
+    # <parent>/bin == the command link dir, which the installer puts on PATH.
     assert "configure_managed_node_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert (
+        'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"'
+        in text
+    )
 
 
 def test_install_sh_repairs_existing_managed_node_on_rerun() -> None:
@@ -46,7 +50,10 @@ def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> Non
     text = NODE_BOOTSTRAP.read_text()
 
     assert "_nb_configure_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert (
+        'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"'
+        in text
+    )
 
     # Runs at the top of ensure_node so existing managed installs are repaired
     # even when a modern Node is already present (early return path).
@@ -56,3 +63,92 @@ def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> Non
     assert "heal_managed_node()" in text
     assert "_nb_managed_tool_broken" in text
     assert "for tool in node npm npx" in text
+
+
+def _run_bootstrap_helper(
+    tmp_path: Path, body: str
+) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "HERMES_HOME": str(home / ".hermes")})
+    return subprocess.run(
+        ["bash", "-c", f'source "{NODE_BOOTSTRAP}"\n{body}'],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_node_bootstrap_preserves_unrelated_command_link(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    existing = home / ".local" / "bin" / "node"
+    existing.parent.mkdir(parents=True)
+    user_node = home / ".volta" / "bin" / "node"
+    user_node.parent.mkdir(parents=True)
+    user_node.write_text("user-owned\n")
+    existing.symlink_to(user_node)
+    target = home / ".hermes" / "node" / "bin" / "node"
+    target.parent.mkdir(parents=True)
+    target.write_text("managed\n")
+
+    result = _run_bootstrap_helper(
+        tmp_path,
+        '_nb_link_managed_tool "$HOME/.local/bin" node',
+    )
+
+    assert result.returncode == 0
+    assert existing.is_symlink()
+    assert existing.resolve() == user_node
+    assert "Leaving existing" in result.stderr
+
+
+def test_node_bootstrap_links_missing_command_idempotently(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    link = home / ".local" / "bin" / "node"
+    link.parent.mkdir(parents=True)
+    target = home / ".hermes" / "node" / "bin" / "node"
+    target.parent.mkdir(parents=True)
+    target.write_text("managed\n")
+
+    result = _run_bootstrap_helper(
+        tmp_path,
+        '_nb_link_managed_tool "$HOME/.local/bin" node\n'
+        '_nb_link_managed_tool "$HOME/.local/bin" node',
+    )
+
+    assert result.returncode == 0
+    assert link.is_symlink()
+    assert link.readlink() == target
+
+
+def test_node_bootstrap_finds_volta_node_outside_gui_path(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    node = home / ".volta" / "bin" / "node"
+    node.parent.mkdir(parents=True)
+    node.write_text("#!/bin/sh\necho v22.12.0\n")
+    node.chmod(0o755)
+
+    result = _run_bootstrap_helper(
+        tmp_path,
+        "PATH=/usr/bin:/bin\n"
+        "_nb_try_known_node\n"
+        'printf "resolved=%s\\n" "$(command -v node)"',
+    )
+
+    assert result.returncode == 0
+    assert f"resolved={node}" in result.stdout
+
+
+def test_install_sh_uses_collision_safe_links_and_known_node_probe() -> None:
+    text = INSTALL_SH.read_text()
+    install_node_body = text.split("install_node()", 1)[1].split(
+        "\ncheck_network_prerequisites()", 1
+    )[0]
+    check_node_body = text.split("check_node()", 1)[1].split("\ninstall_node()", 1)[0]
+
+    assert "ln -sf" not in install_node_body
+    assert 'link_managed_node_tool "$node_link_dir" node' in install_node_body
+    assert "activate_node_from_known_locations" in check_node_body
+    assert "Leaving existing $destination unchanged" in text


### PR DESCRIPTION
## Summary
- detect modern Node installations in common Homebrew and version-manager paths when GUI launchers provide a minimal `PATH`
- preserve existing non-Hermes `node`, `npm`, and `npx` commands when installing the Hermes-managed fallback
- cover GUI-path discovery, collision handling, and idempotent managed links with regression tests

## Testing
- `uv run --extra dev pytest -q tests/test_install_sh_*.py tests/hermes_cli/test_uninstall_node_symlinks.py` (44 passed)
- `uv run --extra dev ruff check tests/test_install_sh_node_global_prefix.py`
- `uv run --extra dev ruff format --check tests/test_install_sh_node_global_prefix.py`
- `bash -n scripts/install.sh scripts/lib/node-bootstrap.sh`

Closes #63612