### PR TITLE
fix(image-gen): classify unsupported Codex image accounts

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -48,14 +48,22 @@ _IMAGE_GENERATION_UNAVAILABLE_MESSAGE = (
     "Image generation is not enabled for the current Codex account. "
     "Switch the image provider to OpenAI API key, FAL, or xAI."
 )
+_IMAGE_GENERATION_UNSUPPORTED_ERROR = (
+    "Tool choice 'image_generation' not found in 'tools' parameter."
+)
 
 
 def _is_image_generation_unsupported_error(status_code: int, body: str) -> bool:
     """Match only Codex's account-capability rejection for the image tool."""
     if status_code != 400:
         return False
-    normalized = " ".join((body or "").lower().split())
-    return "tool choice 'image_generation' not found in 'tools' parameter" in normalized
+    try:
+        payload = json.loads(body)
+        error = payload.get("error") if isinstance(payload, dict) else None
+        message = error.get("message") if isinstance(error, dict) else None
+    except (TypeError, ValueError):
+        message = body
+    return isinstance(message, str) and message.strip() == _IMAGE_GENERATION_UNSUPPORTED_ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -411,12 +419,13 @@ def _collect_image_b64(
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
                 exc.response.read()
-                body = exc.response.text[:500]
+                full_body = exc.response.text
                 if _is_image_generation_unsupported_error(
                     exc.response.status_code,
-                    body,
+                    full_body,
                 ):
-                    raise CodexImageGenerationUnsupportedError(body) from exc
+                    raise CodexImageGenerationUnsupportedError(full_body) from exc
+                body = full_body[:500]
                 raise RuntimeError(
                     f"Codex Responses API returned HTTP {exc.response.status_code}: {body}"
                 ) from exc

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -40,6 +40,24 @@ from agent.image_gen_provider import (
 logger = logging.getLogger(__name__)
 
 
+class CodexImageGenerationUnsupportedError(RuntimeError):
+    """The active Codex account cannot use the hosted image tool."""
+
+
+_IMAGE_GENERATION_UNAVAILABLE_MESSAGE = (
+    "Image generation is not enabled for the current Codex account. "
+    "Switch the image provider to OpenAI API key, FAL, or xAI."
+)
+
+
+def _is_image_generation_unsupported_error(status_code: int, body: str) -> bool:
+    """Match only Codex's account-capability rejection for the image tool."""
+    if status_code != 400:
+        return False
+    normalized = " ".join((body or "").lower().split())
+    return "tool choice 'image_generation' not found in 'tools' parameter" in normalized
+
+
 # ---------------------------------------------------------------------------
 # Model catalog — mirrors the ``openai`` plugin so the picker UX is identical.
 # ---------------------------------------------------------------------------
@@ -394,6 +412,11 @@ def _collect_image_b64(
             except httpx.HTTPStatusError as exc:
                 exc.response.read()
                 body = exc.response.text[:500]
+                if _is_image_generation_unsupported_error(
+                    exc.response.status_code,
+                    body,
+                ):
+                    raise CodexImageGenerationUnsupportedError(body) from exc
                 raise RuntimeError(
                     f"Codex Responses API returned HTTP {exc.response.status_code}: {body}"
                 ) from exc
@@ -541,6 +564,19 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 size=size,
                 quality=meta["quality"],
                 input_images=input_images or None,
+            )
+        except CodexImageGenerationUnsupportedError:
+            logger.debug(
+                "Codex account does not expose image generation",
+                exc_info=True,
+            )
+            return error_response(
+                error=_IMAGE_GENERATION_UNAVAILABLE_MESSAGE,
+                error_type="capability_unsupported",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -9,6 +9,7 @@ endpoint.
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 
 import pytest
@@ -347,6 +348,50 @@ class TestCapabilityErrorDetection:
     )
     def test_does_not_misclassify_other_failures(self, status_code, body):
         assert codex_plugin._is_image_generation_unsupported_error(status_code, body) is False
+
+    def test_does_not_match_error_message_with_extra_text(self):
+        body = json.dumps({
+            "error": {
+                "message": (
+                    "Tool choice 'image_generation' not found in 'tools' parameter "
+                    "because the request is malformed."
+                )
+            }
+        })
+
+        assert codex_plugin._is_image_generation_unsupported_error(400, body) is False
+
+    def test_collect_classifies_exact_http_error_after_large_metadata(self, monkeypatch):
+        import httpx
+
+        body = json.dumps({
+            "metadata": "x" * 600,
+            "error": {
+                "message": "Tool choice 'image_generation' not found in 'tools' parameter."
+            },
+        })
+
+        def _handler(request):
+            return httpx.Response(400, text=body, request=request)
+
+        real_client = httpx.Client
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            lambda *args, **kwargs: real_client(
+                transport=httpx.MockTransport(_handler),
+                headers=kwargs.get("headers"),
+                timeout=kwargs.get("timeout"),
+            ),
+        )
+
+        with pytest.raises(codex_plugin.CodexImageGenerationUnsupportedError):
+            codex_plugin._collect_image_b64(
+                "codex-token",
+                prompt="a cat",
+                size="1024x1024",
+                quality="low",
+            )
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -307,6 +307,47 @@ class TestGenerate:
         assert result["error_type"] == "api_error"
         assert "cloudflare 403" in result["error"]
 
+    def test_unsupported_image_tool_returns_capability_error(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        def _unsupported(*args, **kwargs):
+            raise codex_plugin.CodexImageGenerationUnsupportedError(
+                "Tool choice 'image_generation' not found in 'tools' parameter."
+            )
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _unsupported)
+
+        result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "capability_unsupported"
+        assert "current Codex account" in result["error"]
+        assert "OpenAI API key, FAL, or xAI" in result["error"]
+
+
+class TestCapabilityErrorDetection:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Tool choice 'image_generation' not found in 'tools' parameter.",
+            '{"error":{"message":"Tool choice \'image_generation\' not found in \'tools\' parameter."}}',
+        ],
+    )
+    def test_detects_exact_codex_image_tool_rejection(self, body):
+        assert codex_plugin._is_image_generation_unsupported_error(400, body) is True
+
+    @pytest.mark.parametrize(
+        ("status_code", "body"),
+        [
+            (401, "Tool choice 'image_generation' not found in 'tools' parameter."),
+            (400, "Tool choice 'web_search' not found in 'tools' parameter."),
+            (400, "The image_generation request was rejected by moderation."),
+            (500, "Tool choice 'image_generation' not found in 'tools' parameter."),
+        ],
+    )
+    def test_does_not_misclassify_other_failures(self, status_code, body):
+        assert codex_plugin._is_image_generation_unsupported_error(status_code, body) is False
+
 
 # ── Plugin entry point ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Kanban completion now preserves user-facing scratch deliverables before cleanup, so Done tasks cannot point at files Hermes has already deleted.

Built on Kevin Yin's contribution in #39777 and widened into one complete artifact handoff across storage, dashboard visibility, strict-mode delivery, legacy summary paths, and retry behavior.

## Changes
- Copies declared scratch artifacts into existing per-task attachment storage before deleting the workspace.
- Records preserved files as real attachment rows and rewrites run/event paths to the durable copies.
- Preserves existing scratch deliverable paths named by legacy workers in completion summaries/results.
- Keeps tasks in flight when a declared scratch artifact is missing, oversized, or cannot be copied; the worker receives retry guidance.
- Keeps scratch ephemeral: undeclared working files are still cleaned up.
- Allows durable Kanban attachment roots through strict gateway media validation without trusting neighboring scratch directories.
- Shares the 25 MiB attachment cap between dashboard uploads and worker-produced deliverables.
- Updates English and Chinese Kanban documentation.

Closes #39747.
Closes #36046.

## Attribution
- Kevin Yin (@yinkev): original managed-scratch copy and board-aware attachment-root implementation from #39777.
- Christopher Schulze (@Christopher-Schulze): strict preservation, attachment-row, retry, and strict-mode delivery ideas from #62036 informed the hardening follow-up.
- @alexwill87: durable archive direction from #55903 informed the storage review.
- @ahmadashfq: project-bound worktree direction from #60850 was handled separately by #63123 and #63249.

## Validation
| Check | Result |
|---|---|
| Targeted Kanban/gateway/plugin tests | 531 passed |
| Real tool → DB → cleanup → notifier E2E | Durable file uploaded after scratch removal |
| Missing declared artifact | Task remained in flight with retry error |
| Legacy summary path | File preserved without explicit `artifacts` field |
| Strict media mode | Durable attachment allowed; neighboring scratch rejected |

## Infographic

![Durable Kanban deliverables](https://v3b.fal.media/files/b/0aa20c90/H7SYqdx-EB8zwWkCOUuFc_1d8utmjM.png)
