### PR TITLE
fix(whatsapp): tolerate localized Windows netstat and taskkill output

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -90,6 +90,7 @@ def _kill_port_process(port: int) -> None:
                 ["netstat", "-ano", "-p", "TCP"],
                 capture_output=True, text=True, timeout=5,
                 creationflags=windows_hide_flags(),
+                errors="replace",
             )
             for line in result.stdout.splitlines():
                 parts = line.split()
@@ -224,6 +225,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 cmd,
                 capture_output=True,
                 text=True,
+                errors="replace",
                 timeout=10,
             )
         except FileNotFoundError:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -490,10 +490,15 @@ class TestKillPortProcess:
              patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run:
             _kill_port_process(3000)
 
-        # netstat called
-        assert any(
-            call.args[0][0] == "netstat" for call in mock_run.call_args_list
+        netstat_call = next(
+            call for call in mock_run.call_args_list
+            if call.args[0][0] == "netstat"
         )
+        assert netstat_call.args[0] == ["netstat", "-ano", "-p", "TCP"]
+        assert netstat_call.kwargs["capture_output"] is True
+        assert netstat_call.kwargs["text"] is True
+        assert netstat_call.kwargs["errors"] == "replace"
+        assert netstat_call.kwargs["timeout"] == 5
         # taskkill called with correct PID
         assert any(
             call.args[0] == ["taskkill", "/PID", "12345", "/F"]
@@ -591,6 +596,7 @@ class TestHttpSessionLifecycle:
             ["taskkill", "/PID", "12345", "/T"],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
         mock_proc.terminate.assert_not_called()


### PR DESCRIPTION
## What & why

On Windows, `netstat` and `taskkill` can emit localized text using the active code page. With `text=True` and a UTF-8-forced process environment, Python may raise `UnicodeDecodeError` before the WhatsApp bridge cleanup output is parsed. The outer cleanup guard can then silently leave a stale bridge process or port behind.

## Change

- Add `errors="replace"` to the Windows `netstat` call in `_kill_port_process()`.
- Add the same decoding policy to the text-mode `taskkill` call in `_terminate_bridge_process()`.
- Assert the exact decoding kwargs in the Windows mock coverage.

Replacing undecodable status text is safe here: the parser only consumes ASCII port/state/PID tokens, and taskkill output is diagnostic.

## Validation

- Focused Windows netstat/taskkill and POSIX listener tests: 6 passed.
- `ruff` and `git diff --check` pass.

Related #63223 work is complementary rather than duplicate.