### PR TITLE
fix(compress): allow manual /compress when auto-compaction is disabled

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1895,7 +1895,10 @@ class HermesACPAgent(acp.Agent):
                 lines.append(f"Compression threshold: ~{threshold_tokens:,} tokens")
 
         if getattr(agent, "compression_enabled", True) is False:
-            lines.append("Compression is disabled for this agent.")
+            lines.append(
+                "Auto-compaction is disabled (compression.enabled: false); "
+                "/compact still compresses manually."
+            )
         else:
             lines.append("Tip: run /compact to compress manually before the threshold.")
 
@@ -1911,8 +1914,9 @@ class HermesACPAgent(acp.Agent):
             return "Nothing to compress — conversation is empty."
         try:
             agent = state.agent
-            if not getattr(agent, "compression_enabled", True):
-                return "Context compression is disabled for this agent."
+            # No compression_enabled gate: the flag disables *automatic*
+            # compaction only; manual /compact must keep working (matches
+            # the CLI /compress and gateway handlers).
             if not hasattr(agent, "_compress_context"):
                 return "Context compression not available for this agent."
 
@@ -1937,6 +1941,7 @@ class HermesACPAgent(acp.Agent):
                     getattr(agent, "_cached_system_prompt", "") or "",
                     approx_tokens=approx_tokens,
                     task_id=state.session_id,
+                    force=True,
                 )
             finally:
                 agent._session_db = original_session_db

--- a/cli.py
+++ b/cli.py
@@ -9464,9 +9464,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             print("(._.) No active agent -- send a message first.")
             return
 
-        if not self.agent.compression_enabled:
-            print("(._.) Compression is disabled in config.")
-            return
+        # No compression_enabled gate here: the config flag disables
+        # *automatic* compaction only. Manual /compress is an explicit user
+        # action — the context-overflow error path (conversation_loop.py)
+        # directs users here when auto-compaction is off, and the gateway's
+        # /compress handler has never gated on the flag.
 
         from hermes_cli.partial_compress import (
             extract_compress_flags,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1560,12 +1560,13 @@ class TestSlashCommands:
         original_session_db = object()
         state.agent._session_db = original_session_db
 
-        def _compress_context(messages, system_prompt, *, approx_tokens, task_id):
+        def _compress_context(messages, system_prompt, *, approx_tokens, task_id, force):
             assert state.agent._session_db is None
             assert messages == state.history
             assert system_prompt == "system"
             assert approx_tokens == 40
             assert task_id == state.session_id
+            assert force is True
             return [{"role": "user", "content": "summary"}], "new-system"
 
         state.agent._compress_context = MagicMock(side_effect=_compress_context)
@@ -1593,8 +1594,42 @@ class TestSlashCommands:
             "system",
             approx_tokens=40,
             task_id=state.session_id,
+            force=True,
         )
         mock_save.assert_called_once_with(state.session_id)
+
+    def test_compact_works_when_auto_compaction_disabled(self, agent, mock_manager):
+        """compression.enabled: false disables *automatic* compaction only —
+        manual /compact must still compress (matches CLI /compress and the
+        gateway handler)."""
+        state = self._make_state(mock_manager)
+        state.history = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ]
+        state.agent.compression_enabled = False
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = None
+        state.agent._session_db = None
+        state.agent._compress_context = MagicMock(
+            return_value=([{"role": "user", "content": "summary"}], "new-system")
+        )
+
+        with (
+            patch.object(agent.session_manager, "save_session"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                side_effect=[40, 12],
+            ),
+        ):
+            result = agent._handle_slash_command("/compact", state)
+
+        assert "disabled" not in result.lower()
+        assert "Context compressed: 4 -> 1 messages" in result
+        state.agent._compress_context.assert_called_once()
+        assert state.agent._compress_context.call_args.kwargs.get("force") is True
 
     def test_unknown_command_returns_none(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -162,6 +162,40 @@ def test_manual_compress_does_not_flush_full_history_when_session_id_unchanged()
     shell.agent._flush_messages_to_session_db.assert_not_called()
 
 
+def test_manual_compress_runs_when_auto_compaction_disabled(capsys):
+    """compression.enabled: false disables *automatic* compaction only.
+
+    Manual /compress must still work: the context-overflow error path
+    (agent/conversation_loop.py) explicitly directs users to /compress when
+    auto-compaction is off, and the gateway's /compress handler has never
+    gated on the flag. Regression for the CLI refusing with "Compression is
+    disabled in config."
+    """
+    shell = _make_cli()
+    history = _make_history()
+    compressed = [
+        {"role": "user", "content": "[summary]"},
+        history[-1],
+    ]
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = False
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+    shell.agent._compress_context.return_value = (compressed, "")
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression is disabled" not in output
+    shell.agent._compress_context.assert_called_once()
+    # Manual compression bypasses the summary-failure cooldown.
+    assert shell.agent._compress_context.call_args.kwargs.get("force") is True
+    assert shell.conversation_history == compressed
+
+
 def test_manual_compress_no_sync_when_session_id_unchanged():
     """If compression is a no-op (agent.session_id didn't change), the CLI
     must NOT clear _pending_title or otherwise disturb session state.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4042,6 +4042,34 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     assert ("session.info", "sid", {"model": "?"}) in emits
 
 
+def test_compress_session_history_passes_force():
+    """_compress_session_history is manual-only (session.compress RPC, slash
+    compress/compact, slash-worker mirror) — it must bypass the
+    summary-failure cooldown via force=True, matching the CLI and gateway
+    manual-compress handlers."""
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    agent.context_compressor = None  # keep _get_usage on the simple path
+    compressed = [{"role": "user", "content": "summary"}]
+    agent._compress_context.return_value = (compressed, "")
+    session = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+    )
+
+    removed, _usage = server._compress_session_history(session)
+
+    assert removed == 3
+    assert session["history"] == compressed
+    assert agent._compress_context.call_args.kwargs.get("force") is True
+
+
 def test_session_compress_uses_compress_helper(monkeypatch):
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3081,11 +3081,17 @@ def _compress_session_history(
     # cached prompt (which already contains the agent identity block)
     # makes the rebuild append the identity a second time. Mirrors the
     # CLI's _manual_compress fix for issue #15281.
+    # force=True: every caller of this helper is a manual /compress path
+    # (session.compress RPC, slash compress/compact, slash-worker mirror) —
+    # auto-compaction runs inside the agent loop, not here. Manual
+    # compaction bypasses the summary-failure cooldown, matching the CLI
+    # and gateway handlers.
     compressed, _ = agent._compress_context(
         history,
         None,
         approx_tokens=approx_tokens,
         focus_topic=focus_topic or None,
+        force=True,
     )
     with session["history_lock"]:
         if int(session.get("history_version", 0)) != history_version:


### PR DESCRIPTION
## What does this PR do?

Makes manual context compaction work on every surface when `compression.enabled: false`. That flag is documented (overflow path in `agent/conversation_loop.py`) as disabling *automatic* compaction only — the context-overflow terminal error explicitly tells users to "Run /compress to compact manually" — but two surfaces contradicted it: the classic CLI (`_manual_compress`) and the ACP adapter (`/compact`) refused with "Compression is disabled", leaving users at a full context window with no manual escape hatch. The gateway handler has never had this gate.

This removes the stale gates (they predate the overflow-path design; the CLI gate is boilerplate from the original /compress commit 30efc263f) and unifies `force=True` (bypass the summary-failure cooldown) across all manual-compaction call sites, matching the CLI and gateway behavior.

## Related Issue

Fixes #64438. (Searched open/closed PRs and issues; no duplicate fix found.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — remove the `compression_enabled` gate from `_manual_compress`.
- `acp_adapter/server.py` — remove the gate from `_cmd_compact`; pass `force=True`; reword the `/context` status line so disabled auto-compaction no longer implies `/compact` is unavailable.
- `tui_gateway/server.py` — `_compress_session_history` (manual-only helper: session.compress RPC, slash compress/compact, slash-worker mirror) now passes `force=True`.
- `scripts/release.py` — AUTHOR_MAP entry for contributor-check.
- Regression tests: `tests/cli/test_manual_compress.py`, `tests/acp/test_server.py`, `tests/test_tui_gateway_server.py`.

No change to automatic compaction: the preflight check, post-response `should_compress` gate, and the overflow guard all still honor `compression.enabled: false`.

## How to Test

1. Set `compression.enabled: false` in `~/.hermes/config.yaml` and start a conversation (≥4 messages).
2. Classic CLI: run `/compress` → it now compacts (previously: `(._.) Compression is disabled in config.`).
3. ACP adapter: run `/compact` → same (previously: `Context compression is disabled for this agent.`).
4. `scripts/run_tests.sh tests/cli/test_manual_compress.py tests/acp/test_server.py tests/test_tui_gateway_server.py` → 405 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(compress): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass (via `scripts/run_tests.sh`, the CI-parity wrapper)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 / Darwin 25.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing doc described the old blocked behavior; swept docs/, website/docs/, skills/)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure control-flow change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/cli/test_manual_compress.py tests/acp/test_server.py tests/test_tui_gateway_server.py
=== Summary: 3 files, 405 tests passed, 0 failed (100% complete) in 9.7s (20 workers) ===

scripts/run_tests.sh tests/cli/test_compress_flags.py tests/cli/test_compress_focus.py tests/cli/test_compress_here.py tests/cli/test_partial_compress.py tests/gateway/test_compress_command.py tests/gateway/test_compress_preview.py tests/gateway/test_compress_focus.py tests/run_agent/test_compression_feasibility.py
=== Summary: 8 files, 81 tests passed, 0 failed (100% complete) in 2.7s (20 workers) ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

