### PR TITLE
fix(agent): reinforce WeChat, WeCom, and QQ platform identity

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -477,6 +477,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    # Repeat platform identity in the high-salience volatile tier for compact
+    # models that may overlook the longer formatting/capability hint above.
+    # Keep this deliberately free of chat/user identifiers.
+    _prominent_platform_names = {
+        "wecom": "WeCom",
+        "qqbot": "QQ",
+    }
+    _platform_name = _prominent_platform_names.get(platform_key)
+    if _platform_name:
+        volatile_parts.append(
+            f"Platform identity: {_platform_name} ({platform_key}). "
+            "This value is authoritative; do not guess or ask the user which "
+            "messaging platform this conversation uses."
+        )
+
     from hermes_time import now as _hermes_now
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -481,8 +481,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # models that may overlook the longer formatting/capability hint above.
     # Keep this deliberately free of chat/user identifiers.
     _prominent_platform_names = {
-        "wecom": "WeCom",
         "qqbot": "QQ",
+        "wecom": "WeCom",
+        "wecom_callback": "WeCom",
+        "weixin": "Weixin/WeChat",
     }
     _platform_name = _prominent_platform_names.get(platform_key)
     if _platform_name:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -45,6 +45,25 @@ def _captured_context_cwd(agent):
     return captured["cwd"]
 
 
+class TestPlatformIdentity:
+    def test_wecom_identity_is_prominent_in_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="wecom"))
+
+        assert "Platform identity: WeCom (wecom)" in parts["volatile"]
+        assert "do not guess or ask the user" in parts["volatile"]
+
+    def test_qqbot_identity_is_prominent_in_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="qqbot"))
+
+        assert "Platform identity: QQ (qqbot)" in parts["volatile"]
+        assert "do not guess or ask the user" in parts["volatile"]
+
+    def test_other_platforms_keep_existing_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="telegram"))
+
+        assert "Platform identity:" not in parts["volatile"]
+
+
 class TestContextFileCwd:
     def test_none_when_terminal_cwd_unset(self, monkeypatch):
         # Unset → None, so discovery falls back to the launch dir inside

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -46,16 +46,28 @@ def _captured_context_cwd(agent):
 
 
 class TestPlatformIdentity:
+    def test_qqbot_identity_is_prominent_in_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="qqbot"))
+
+        assert "Platform identity: QQ (qqbot)" in parts["volatile"]
+        assert "do not guess or ask the user" in parts["volatile"]
+
     def test_wecom_identity_is_prominent_in_volatile_prompt(self):
         parts = build_system_prompt_parts(_make_agent(platform="wecom"))
 
         assert "Platform identity: WeCom (wecom)" in parts["volatile"]
         assert "do not guess or ask the user" in parts["volatile"]
 
-    def test_qqbot_identity_is_prominent_in_volatile_prompt(self):
-        parts = build_system_prompt_parts(_make_agent(platform="qqbot"))
+    def test_wecom_callback_identity_is_prominent_in_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="wecom_callback"))
 
-        assert "Platform identity: QQ (qqbot)" in parts["volatile"]
+        assert "Platform identity: WeCom (wecom_callback)" in parts["volatile"]
+        assert "do not guess or ask the user" in parts["volatile"]
+
+    def test_weixin_identity_is_prominent_in_volatile_prompt(self):
+        parts = build_system_prompt_parts(_make_agent(platform="weixin"))
+
+        assert "Platform identity: Weixin/WeChat (weixin)" in parts["volatile"]
         assert "do not guess or ask the user" in parts["volatile"]
 
     def test_other_platforms_keep_existing_volatile_prompt(self):


### PR DESCRIPTION
## What does this PR do?

Makes personal WeChat, WeCom, and QQ platform identity prominent in the volatile prompt tier. The existing detailed hints remain unchanged, while compact models get a short authoritative identity near other high-salience runtime context.

## Related Issue

Fixes #63602

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add authoritative volatile-tier identity lines for personal WeChat (`weixin`), QQ Bot (`qqbot`), WeCom (`wecom`), and its callback adapter (`wecom_callback`).
- Keep the identity line free of chat IDs and user identifiers.
- Add focused regression coverage for every affected platform key and unchanged behavior on other platforms.

## How to Test

1. Run `uv run --with pytest pytest tests/agent/test_system_prompt.py tests/agent/test_platform_hint_overrides.py tests/agent/test_prompt_builder.py -q`.
2. Confirm personal WeChat, WeCom, and QQ Bot prompts include their authoritative platform identity.
3. Confirm Telegram retains the existing volatile prompt without the new line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused prompt suites: 186 passed, 1 skipped. Ruff, compileall, and `git diff --check` pass. All required CI checks are green.
