### PR TITLE
fix(agent): infer OpenCode transport on runtime switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1787,7 +1787,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── Determine api_mode if not provided ──
     if not api_mode:
-        api_mode = determine_api_mode(new_provider, base_url)
+        if new_provider in {"opencode-zen", "opencode-go"}:
+            from hermes_cli.models import opencode_model_api_mode
+
+            api_mode = opencode_model_api_mode(new_provider, new_model)
+        else:
+            api_mode = determine_api_mode(new_provider, base_url)
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to

--- a/tests/hermes_cli/test_model_switch_opencode_anthropic.py
+++ b/tests/hermes_cli/test_model_switch_opencode_anthropic.py
@@ -251,6 +251,47 @@ class TestAgentSwitchModelDefenseInDepth:
             "to build_anthropic_client"
         )
 
+    @pytest.mark.parametrize("model", ["qwen3.7-plus", "opencode-go/qwen3.7-max"])
+    def test_agent_switch_model_infers_messages_api_for_go_qwen(self, model):
+        """Direct runtime callers must infer OpenCode's model-specific transport."""
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.model = "glm-5"
+        agent.provider = "opencode-go"
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.api_key = "sk-opencode-fake"
+        agent.api_mode = "chat_completions"
+        agent._client_kwargs = {}
+
+        captured = {}
+
+        class _Sentinel(Exception):
+            pass
+
+        def _raise_after_capture(api_key, base_url, **kwargs):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+            raise _Sentinel("transport verified")
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            side_effect=_raise_after_capture,
+        ), patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=""), patch(
+            "agent.anthropic_adapter._is_oauth_token", return_value=False
+        ):
+            with pytest.raises(_Sentinel, match="transport verified"):
+                agent.switch_model(
+                    new_model=model,
+                    new_provider="opencode-go",
+                    api_key="sk-opencode-fake",
+                    base_url="https://opencode.ai/zen/go/v1",
+                )
+
+        assert captured == {
+            "api_key": "sk-opencode-fake",
+            "base_url": "https://opencode.ai/zen/go",
+        }
 
 
 class TestStaleConfigDefaultDoesNotWedgeResolver:


### PR DESCRIPTION
## What does this PR do?

Uses OpenCode's model-aware transport resolver during direct runtime model switches. Qwen models on OpenCode Go now select Anthropic Messages instead of inheriting the provider-only Chat Completions fallback.

## Related Issue

Fixes #63506

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route OpenCode Zen/Go runtime switches through `opencode_model_api_mode()`.
- Preserve the existing provider-only resolver for every other provider.
- Cover prefixed and unprefixed OpenCode Go Qwen model IDs.

## How to Test

1. Run `uv run --with pytest pytest tests/hermes_cli/test_model_switch_opencode_anthropic.py -q`.
2. Switch directly to an OpenCode Go Qwen model without passing `api_mode`.
3. Confirm the Anthropic Messages client receives the base URL without trailing `/v1`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Affected test file: 14 passed. Ruff, compileall, and `git diff --check` pass.
