### PR TITLE
fix(telegram): fail fast when user images cannot be accessed (rebase for moved file)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2056,7 +2056,11 @@ def _build_media_placeholder(event) -> str:
             parts.append(f"[User sent a video: {url}]")
         else:
             parts.append(f"[User sent a file: {url}]")
-    return "\n".join(parts)
+    if parts:
+        return "\n".join(parts)
+    # Safeguard: if there's nothing to placehold (no media_urls at all),
+    # return a neutral fallback so the agent doesn't receive empty input.
+    return "[User sent a message with media that couldn't be accessed]"
 
 
 def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
@@ -15155,6 +15159,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         enriched_parts = []
+        all_failed = True
         for path in image_paths:
             try:
                 logger.debug("Auto-analyzing user image: %s", path)
@@ -15166,6 +15171,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if result.get("success"):
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
+                    all_failed = False
                     enriched_parts.append(
                         f"[The user sent an image~ Here's what I can see:\n{description}]\n"
                         f"[If you need a closer look, use vision_analyze with "
@@ -15187,6 +15193,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Combine: vision descriptions first, then the user's original text
         if enriched_parts:
+            # If ALL images failed to analyze AND the user didn't
+            # provide a caption, give a clear fail-fast message
+            # so the agent doesn't keep retrying for 30+ minutes.
+            if all_failed and not user_text.strip():
+                return (
+                    "[The user sent an image but I'm unable to see it — "
+                    "the vision analysis is not available right now. "
+                    "Ask the user to describe what the image contains.]"
+                )
             prefix = "\n\n".join(enriched_parts)
             if user_text:
                 return f"{prefix}\n\n{user_text}"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7823,7 +7823,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Save to local cache (for vision tool access)
                 cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
                 event.media_urls = [cached_path]
-                event.media_types = [f"image/{ext.lstrip('.')}" ]
+                # Normalize MIME: "image/jpg" → "image/jpeg" (standard MIME)
+                raw_ext = ext.lstrip('.')
+                mime_ext = "jpeg" if raw_ext == "jpg" else raw_ext
+                event.media_types = [f"image/{mime_ext}"]
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
                 media_group_id = getattr(msg, "media_group_id", None)
                 if media_group_id:

--- a/tests/gateway/test_vision_memory_leak.py
+++ b/tests/gateway/test_vision_memory_leak.py
@@ -78,3 +78,45 @@ class TestEnrichMessageWithVision:
         assert "photograph of a dog" in out
         assert "fenced leak" not in out
         assert "<memory-context>" not in out
+
+    # ─── 22413: all-failed / fail-fast ───────────────────────────────────
+
+    def test_all_failed_no_caption_returns_failfast(self, gateway_runner):
+        """When ALL images fail AND the user has no caption, return the
+        fail-fast message instead of enriched parts."""
+        fake_result = json.dumps({"success": False, "analysis": ""})
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=fake_result)):
+            out = _run(gateway_runner._enrich_message_with_vision("", ["/tmp/img1.jpg", "/tmp/img2.jpg"]))
+        assert "unable to see it" in out
+        assert "not available right now" in out
+
+    def test_all_failed_with_caption_returns_original(self, gateway_runner):
+        """When ALL images fail but user provided a caption, return the
+        original user text (no enriched parts)."""
+        fake_result = json.dumps({"success": False, "analysis": ""})
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=fake_result)):
+            out = _run(gateway_runner._enrich_message_with_vision("my caption", ["/tmp/img.jpg"]))
+        assert "my caption" in out
+        assert "unable to see it" not in out
+
+    def test_all_exception_no_caption_returns_failfast(self, gateway_runner):
+        """When ALL images raise exceptions and no caption, fail-fast."""
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(side_effect=ValueError("API error"))):
+            out = _run(gateway_runner._enrich_message_with_vision("", ["/tmp/img.jpg"]))
+        assert "unable to see it" in out
+
+    def test_mixed_success_failure_includes_user_text(self, gateway_runner):
+        """When some images succeed and some fail, still return the mixed
+        enriched results with user caption."""
+        def side_effect(*a, **kw):
+            path = kw.get("image_url") or a[0]
+            if "good" in path:
+                return json.dumps({"success": True, "analysis": "A beautiful landscape."})
+            return json.dumps({"success": False, "analysis": ""})
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(side_effect=side_effect)):
+            out = _run(gateway_runner._enrich_message_with_vision(
+                "here are two pics",
+                ["/tmp/good.jpg", "/tmp/bad.jpg"],
+            ))
+        assert "beautiful landscape" in out
+        assert "here are two pics" in out


### PR DESCRIPTION
## Summary

Rebase of PR #22413 onto current main, resolving the file-move conflict.

The original PR modified `gateway/platforms/telegram.py` which no longer exists on main — the Telegram adapter was moved to `plugins/platforms/telegram/adapter.py`. This PR transplants the MIME fix to the new location.

## Changes

| File | Change |
|------|--------|
| `plugins/platforms/telegram/adapter.py` | Normalize MIME type `image/jpg` → `image/jpeg` using standard MIME types (transplanted from old `gateway/platforms/telegram.py`) |
| `gateway/run.py` — `_build_media_placeholder` | Return neutral fallback when no `media_urls` exist, preventing empty user input |
| `gateway/run.py` — `_enrich_message_with_vision` | Track `all_failed` across all images. When ALL analyses fail AND the user provided no caption, return a clear fail-fast message |
| `tests/gateway/test_vision_memory_leak.py` | Add 4 tests: all-failed/no-caption, all-failed/with-caption, exception/no-caption, mixed success/failure |

## Addresses Review Feedback

Per @teknium1's review on PR #22413:
- ✅ MIME fix transplanted to `plugins/platforms/telegram/adapter.py`
- ✅ 4 new regression tests added in `test_vision_memory_leak.py`

Fixes #22385
Closes #22413 (replaced by this rebased version)