### PR TITLE
fix(skills): gate edits to upstream-managed skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -563,6 +563,127 @@ class TestSkillManageDispatcher:
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
 
+    def test_bundled_patch_stages_even_when_global_approval_is_off(
+        self, tmp_path, monkeypatch
+    ):
+        """A local edit must not silently freeze an upstream-managed package."""
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            (skills_root / ".bundled_manifest").write_text(
+                "test-skill:origin-hash\n", encoding="utf-8"
+            )
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+
+            raw = skill_manage(
+                action="patch",
+                name="test-skill",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the local thing.",
+            )
+
+        result = json.loads(raw)
+        assert result["staged"] is True
+        assert result["provenance"] == "bundled"
+        assert "upstream-managed" in result["message"]
+        assert "freeze future package updates" in result["message"]
+        assert "supporting files" in result["message"]
+        assert (skills_root / "test-skill" / "SKILL.md").read_text() == VALID_SKILL_CONTENT
+
+    @pytest.mark.parametrize(
+        ("action", "kwargs"),
+        [
+            ("edit", {"content": VALID_SKILL_CONTENT_2}),
+            (
+                "patch",
+                {
+                    "old_string": "Step 1: Do the thing.",
+                    "new_string": "Step 1: Do the local thing.",
+                },
+            ),
+            ("write_file", {"file_path": "references/local.md", "content": "local"}),
+            ("remove_file", {"file_path": "references/existing.md"}),
+            ("delete", {}),
+        ],
+    )
+    def test_all_bundled_mutations_stage(self, tmp_path, monkeypatch, action, kwargs):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            _write_file("test-skill", "references/existing.md", "existing")
+            (skills_root / ".bundled_manifest").write_text(
+                "test-skill:origin-hash\n", encoding="utf-8"
+            )
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(skill_manage(action=action, name="test-skill", **kwargs))
+
+        assert result["staged"] is True
+        assert result["provenance"] == "bundled"
+        assert (skills_root / "test-skill" / "SKILL.md").exists()
+
+    def test_hub_skill_patch_stages(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            hub_dir = skills_root / ".hub"
+            hub_dir.mkdir()
+            (hub_dir / "lock.json").write_text(
+                json.dumps(
+                    {
+                        "installed": {
+                            "upstream-name": {"install_path": "test-skill"}
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="test-skill",
+                    old_string="Step 1: Do the thing.",
+                    new_string="Step 1: Do the local thing.",
+                )
+            )
+
+        assert result["staged"] is True
+        assert result["provenance"] == "hub"
+
+    def test_user_owned_patch_remains_autonomous(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="test-skill",
+                    old_string="Step 1: Do the thing.",
+                    new_string="Step 1: Do the local thing.",
+                )
+            )
+
+        assert result["success"] is True
+        assert result.get("staged") is None
+        assert "local thing" in (skills_root / "test-skill" / "SKILL.md").read_text()
+
     def test_create_from_background_review_marks_agent_created(self, tmp_path):
         """Background-review fork creates ARE marked as agent-created."""
         from tools.skill_provenance import set_current_write_origin, BACKGROUND_REVIEW

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -662,6 +662,151 @@ class TestSkillManageDispatcher:
         assert result["staged"] is True
         assert result["provenance"] == "hub"
 
+    def test_same_name_skill_in_other_category_is_not_bundled(
+        self, tmp_path, monkeypatch
+    ):
+        """A user-owned skill sharing a bundled skill's name in another
+        category must not be staged as bundled."""
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        # User-owned skill lives in a category; the bundled origin ships
+        # the same name at the top level.
+        user_skill = skills_root / "othercat" / "test-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        (skills_root / ".bundled_manifest").write_text(
+            "test-skill:origin-hash\n", encoding="utf-8"
+        )
+        bundled_src = tmp_path / "bundled-src"
+        bundled_skill = bundled_src / "test-skill"
+        bundled_skill.mkdir(parents=True)
+        (bundled_skill / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_src))
+        with _skill_dir(skills_root):
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="test-skill",
+                    old_string="Step 1: Do the thing.",
+                    new_string="Step 1: Do the local thing.",
+                )
+            )
+
+        assert result["success"] is True
+        assert result.get("staged") is None
+        assert result.get("provenance") is None
+        assert "local thing" in (user_skill / "SKILL.md").read_text()
+
+    def test_bundled_skill_at_synced_path_still_stages(self, tmp_path, monkeypatch):
+        """Path-awareness must not weaken the original #63482 protection:
+        a skill sitting at the bundled install destination still stages."""
+        skills_root = tmp_path / "skills"
+        (skills_root / "mlops" / "test-skill").mkdir(parents=True)
+        (skills_root / "mlops" / "test-skill" / "SKILL.md").write_text(
+            VALID_SKILL_CONTENT
+        )
+        (skills_root / ".bundled_manifest").write_text(
+            "test-skill:origin-hash\n", encoding="utf-8"
+        )
+        bundled_src = tmp_path / "bundled-src"
+        (bundled_src / "mlops" / "test-skill").mkdir(parents=True)
+        (bundled_src / "mlops" / "test-skill" / "SKILL.md").write_text(
+            VALID_SKILL_CONTENT
+        )
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_src))
+        with _skill_dir(skills_root):
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="patch",
+                    name="test-skill",
+                    old_string="Step 1: Do the thing.",
+                    new_string="Step 1: Do the local thing.",
+                )
+            )
+
+        assert result["staged"] is True
+        assert result["provenance"] == "bundled"
+        assert "freeze future package updates" in result["message"]
+
+    def test_hub_edit_stages_with_overwrite_warning(self, tmp_path, monkeypatch):
+        """Hub mutations beyond patch also stage, and their warning names
+        the hub-specific risk (overwrite on reinstall), not the bundled
+        update-starvation wording."""
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            hub_dir = skills_root / ".hub"
+            hub_dir.mkdir()
+            (hub_dir / "lock.json").write_text(
+                json.dumps(
+                    {
+                        "installed": {
+                            "upstream-name": {"install_path": "test-skill"}
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="edit",
+                    name="test-skill",
+                    content=VALID_SKILL_CONTENT_2,
+                )
+            )
+
+        assert result["staged"] is True
+        assert result["provenance"] == "hub"
+        assert "overwritten" in result["message"]
+        assert "freeze future package updates" not in result["message"]
+
+    def test_hub_write_file_stages(self, tmp_path, monkeypatch):
+        """write_file against a hub-managed skill stages too."""
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        with _skill_dir(skills_root):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            hub_dir = skills_root / ".hub"
+            hub_dir.mkdir()
+            (hub_dir / "lock.json").write_text(
+                json.dumps(
+                    {
+                        "installed": {
+                            "upstream-name": {"install_path": "test-skill"}
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            monkeypatch.setattr(
+                "tools.write_approval.write_approval_enabled",
+                lambda _subsystem: False,
+            )
+            result = json.loads(
+                skill_manage(
+                    action="write_file",
+                    name="test-skill",
+                    file_path="references/local.md",
+                    content="local",
+                )
+            )
+
+        assert result["staged"] is True
+        assert result["provenance"] == "hub"
+
     def test_user_owned_patch_remains_autonomous(self, tmp_path, monkeypatch):
         skills_root = tmp_path / "skills"
         skills_root.mkdir()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1256,6 +1256,59 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 )
 
 
+def _managed_skill_provenance(name: str) -> Optional[str]:
+    """Return upstream provenance for an installed skill, if any.
+
+    Bundled and hub skills are package-managed as a unit. Mutating one file
+    makes their update machinery preserve the whole local directory, including
+    withholding unrelated files added upstream. Keep this lookup local to the
+    skill manager so the write policy follows the exact path it will mutate.
+    """
+    existing = _find_skill(name)
+    if not existing:
+        return None
+
+    skills_root = _skills_dir()
+    try:
+        relative_path = existing["path"].resolve().relative_to(
+            skills_root.resolve()
+        ).as_posix()
+    except (OSError, ValueError):
+        # External skill roots are not represented by the local package
+        # provenance stores.
+        return None
+
+    manifest_path = skills_root / ".bundled_manifest"
+    try:
+        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+            manifest_name = line.partition(":")[0].strip()
+            if manifest_name == name:
+                return "bundled"
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.warning("Could not read bundled skill manifest %s", manifest_path, exc_info=True)
+
+    lock_path = skills_root / ".hub" / "lock.json"
+    try:
+        lock_data = json.loads(lock_path.read_text(encoding="utf-8"))
+        installed = lock_data.get("installed", {}) if isinstance(lock_data, dict) else {}
+        if not isinstance(installed, dict):
+            installed = {}
+        for lock_name, record in installed.items():
+            if not isinstance(record, dict):
+                continue
+            install_path = str(record.get("install_path") or lock_name).strip("/")
+            if install_path == relative_path:
+                return "hub"
+    except FileNotFoundError:
+        pass
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        logger.warning("Could not read hub skill lock %s", lock_path, exc_info=True)
+
+    return None
+
+
 def _apply_skill_write_gate(action, name, **payload_kwargs):
     """Evaluate the skill write gate. Returns a JSON tool-result string when the
     write should NOT proceed (blocked or staged), or None to perform the real
@@ -1271,7 +1324,19 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     except Exception:
         return None  # fail open
 
+    provenance = None if action == "create" else _managed_skill_provenance(name)
     decision = wa.evaluate_gate(wa.SKILLS)
+    if provenance and not decision.blocked:
+        decision = wa.GateDecision(
+            stage=True,
+            message=(
+                f"Staged for approval because '{name}' is an upstream-managed "
+                f"{provenance} skill. Not yet saved: editing it will freeze future "
+                "package updates, including supporting files added upstream. "
+                "Prefer SOUL, project context, or a user-owned overlay skill for "
+                "user-specific guidance. Review with /skills pending."
+            ),
+        )
     if decision.allow:
         return None
     if decision.blocked:
@@ -1290,7 +1355,9 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
     return json.dumps(
         {"success": True, "staged": True, "pending_id": record["id"],
-         "gist": gist, "message": decision.message},
+         "gist": gist, "message": decision.message, **(
+             {"provenance": provenance} if provenance else {}
+         )},
         ensure_ascii=False,
     )
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1256,6 +1256,40 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 )
 
 
+def _bundled_install_relpath(name: str) -> Optional[str]:
+    """Return the install-relative path of bundled skill ``name``.
+
+    Bundled skills sync into the skills root preserving their category
+    structure (e.g. ``bundled/skills/mlops/axolotl`` ->
+    ``~/.hermes/skills/mlops/axolotl``), while the bundled manifest records
+    only the skill name. Comparing names alone lets a user-owned skill that
+    merely shares the name in another category be misread as bundled, so
+    the provenance check must also confirm the on-disk path.
+
+    Returns the posix relative path (e.g. ``"mlops/axolotl"``), or None when
+    the bundled origin cannot be located or does not ship ``name``.
+    """
+    try:
+        from agent.skill_utils import is_excluded_skill_path
+        from hermes_constants import get_bundled_skills_dir
+    except Exception:
+        return None
+    try:
+        bundled_dir = get_bundled_skills_dir(
+            Path(__file__).parent.parent / "skills"
+        )
+        if not bundled_dir.exists():
+            return None
+        for skill_md in bundled_dir.rglob("SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            if skill_md.parent.name == name:
+                return skill_md.parent.relative_to(bundled_dir).as_posix()
+    except (OSError, ValueError):
+        return None
+    return None
+
+
 def _managed_skill_provenance(name: str) -> Optional[str]:
     """Return upstream provenance for an installed skill, if any.
 
@@ -1282,8 +1316,15 @@ def _managed_skill_provenance(name: str) -> Optional[str]:
     try:
         for line in manifest_path.read_text(encoding="utf-8").splitlines():
             manifest_name = line.partition(":")[0].strip()
-            if manifest_name == name:
+            if manifest_name != name:
+                continue
+            # Name-only is not enough: bundled skills keep their category
+            # structure on disk, so a user-owned skill that merely shares
+            # the name in another category must not be treated as bundled.
+            expected = _bundled_install_relpath(name)
+            if expected is None or expected == relative_path:
                 return "bundled"
+            break
     except FileNotFoundError:
         pass
     except OSError:
@@ -1327,12 +1368,26 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     provenance = None if action == "create" else _managed_skill_provenance(name)
     decision = wa.evaluate_gate(wa.SKILLS)
     if provenance and not decision.blocked:
+        if provenance == "hub":
+            # Hub skills reinstall from the stored lock on update, so the
+            # risk is overwrite of local edits — not update starvation.
+            risk = (
+                "hub updates reinstall the skill from the stored lock, "
+                "so local edits will be overwritten and lost"
+            )
+        else:
+            # Bundled skills are package-managed as a unit: mutating one
+            # file makes the updater preserve the whole local directory,
+            # withholding unrelated files added upstream.
+            risk = (
+                "editing it will freeze future package updates, including "
+                "supporting files added upstream"
+            )
         decision = wa.GateDecision(
             stage=True,
             message=(
                 f"Staged for approval because '{name}' is an upstream-managed "
-                f"{provenance} skill. Not yet saved: editing it will freeze future "
-                "package updates, including supporting files added upstream. "
+                f"{provenance} skill. Not yet saved: {risk}. "
                 "Prefer SOUL, project context, or a user-owned overlay skill for "
                 "user-specific guidance. Review with /skills pending."
             ),


### PR DESCRIPTION
## What does this PR do?

Routes mutations to bundled and Hub-installed skills through the existing approval queue, even when global skill approval is disabled. The approval message explains that a local edit freezes package updates for the full skill directory, including supporting files added upstream.

User-owned skills keep their current autonomous behavior.

## Related Issue

Fixes #63482

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Detect bundled provenance from `.bundled_manifest`.
- Detect Hub provenance from `.hub/lock.json` install paths.
- Stage edit, patch, write-file, remove-file, and delete operations for upstream-managed skills.
- Preserve autonomous writes for user-owned skills and existing background-review protections.

## How to Test

Run:

```bash
uv run --with pytest pytest tests/tools/test_skill_manager_tool.py tests/tools/test_write_approval.py -q
```

The focused suites pass with 149 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Ruff, compileall, and `git diff --check` pass.
