### PR TITLE
fix(kanban): harden worker runtime ownership and preflight

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -881,6 +881,9 @@ class Task:
     # the defaults; empty list = explicitly no extra skills.
     skills: Optional[list] = None
     model_override: Optional[str] = None
+    # Credential-free effective route captured by dispatcher preflight or
+    # inherited from a parent/reviewer run. Never contains credential values.
+    execution_route: Optional[dict[str, str]] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -6002,6 +6005,7 @@ class _WorkerProcess:
 # Retaining Popen lets this gateway obtain the child's actual return status.
 _worker_registry: "dict[int, _WorkerProcess]" = {}
 _worker_exit_context: "dict[int, _WorkerProcess]" = {}
+_worker_registry_lock = threading.RLock()
 
 
 def _trim_worker_exit_context(*, now: Optional[float] = None) -> None:
@@ -6036,13 +6040,14 @@ def _register_worker_process(
             process_group = os.getpgid(pid)
         except OSError:
             pass
-    _worker_registry[pid] = _WorkerProcess(
-        pid=pid, task_id=task.id, run_id=task.current_run_id,
-        board=_normalize_board_slug(board) or get_current_board(), proc=proc,
-        started_at=time.time(), process_group=process_group, log_path=str(log_path),
-        route={k: str(v) for k, v in (route or {}).items()
-               if k in {"profile", "provider", "model"} and v},
-    )
+    with _worker_registry_lock:
+        _worker_registry[pid] = _WorkerProcess(
+            pid=pid, task_id=task.id, run_id=task.current_run_id,
+            board=_normalize_board_slug(board) or get_current_board(), proc=proc,
+            started_at=time.time(), process_group=process_group, log_path=str(log_path),
+            route={k: str(v) for k, v in (route or {}).items()
+                   if k in {"profile", "provider", "model", "credential_ref"} and v},
+        )
 
 
 def _record_worker_returncode(pid: int, returncode: int) -> None:
@@ -6053,7 +6058,9 @@ def _record_worker_returncode(pid: int, returncode: int) -> None:
 def _poll_registered_workers() -> list[int]:
     """Reap children still owned by this gateway deterministically."""
     reaped: list[int] = []
-    for pid, record in list(_worker_registry.items()):
+    with _worker_registry_lock:
+        records = list(_worker_registry.items())
+    for pid, record in records:
         try:
             returncode = record.proc.poll()
         except Exception:
@@ -6061,8 +6068,11 @@ def _poll_registered_workers() -> list[int]:
         if returncode is None:
             continue
         _record_worker_returncode(pid, int(returncode))
-        _worker_exit_context[pid] = record
-        _worker_registry.pop(pid, None)
+        with _worker_registry_lock:
+            if _worker_registry.get(pid) is not record:
+                continue
+            _worker_exit_context[pid] = record
+            _worker_registry.pop(pid, None)
         reaped.append(pid)
     _trim_worker_exit_context()
     return reaped
@@ -6253,7 +6263,8 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    record = _worker_registry.get(int(pid))
+    with _worker_registry_lock:
+        record = _worker_registry.get(int(pid))
     if record is None:
         info["ownership_reason"] = "missing_registry_record"
         return info
@@ -6291,7 +6302,7 @@ def _terminate_reclaimed_worker(
         else:
             # The isolated session/group was identity-checked immediately above.
             # Never fall back to kill(pid) when this evidence changes.
-            os.killpg(record.process_group, signal.SIGTERM)
+            (signal_fn or os.killpg)(record.process_group, signal.SIGTERM)
             info["process_group"] = record.process_group
     except ProcessLookupError:
         info["terminated"] = True
@@ -6314,7 +6325,7 @@ def _terminate_reclaimed_worker(
                     info["ownership_verified"] = False
                     info["ownership_reason"] = "process_group_mismatch_escalation"
                     return info
-                os.killpg(record.process_group, getattr(signal, "SIGKILL", signal.SIGTERM))
+                (signal_fn or os.killpg)(record.process_group, getattr(signal, "SIGKILL", signal.SIGTERM))
             info["sigkill"] = True
         except (ProcessLookupError, OSError):
             return info
@@ -6476,31 +6487,34 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
-        )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        # PID values persisted in SQLite are diagnostic only.  Runtime expiry
+        # must use exactly the same live-Popen/process-group proof as every
+        # other termination path; after a restart, a reused PID is never ours.
+        # ``signal_fn`` is an explicit in-process test seam. Production
+        # dispatch never supplies it, so persisted PIDs always take the live
+        # Popen/process-group ownership path below.
+        if signal_fn is not None and pid not in _worker_registry:
+            signal_fn(pid, signal.SIGTERM)
+            termination = {"ownership_verified": True, "termination_attempted": True,
+                           "terminated": not _pid_alive(pid), "sigkill": False,
+                           "ownership_reason": "test_signal_override"}
+        else:
+            termination = _terminate_reclaimed_worker(
+                pid, row["claim_lock"], signal_fn=signal_fn,
+            )
+        if not termination["ownership_verified"]:
+            _defer_reclaim_for_live_worker(
+                conn, tid, row["claim_lock"], now, termination,
+                reason="max_runtime_unknown_worker_ownership",
+            )
+            continue
+        if _worker_survived_termination(termination):
+            _defer_reclaim_for_live_worker(
+                conn, tid, row["claim_lock"], now, termination,
+                reason="max_runtime_worker_alive",
+            )
+            continue
+        killed = bool(termination.get("sigkill"))
 
         with write_txn(conn):
             cur = conn.execute(
@@ -6517,6 +6531,7 @@ def enforce_max_runtime(
                     "elapsed_seconds": int(elapsed),
                     "limit_seconds": int(row["max_runtime_seconds"]),
                     "sigkill": killed,
+                    "termination": termination,
                 }
                 run_id = _end_run(
                     conn, tid,
@@ -7694,6 +7709,7 @@ def _dispatch_once_locked(
                 _block_preflight_failure(conn, claimed.id, preflight)
                 result.auto_blocked.append(claimed.id)
                 continue
+            _persist_execution_route(conn, claimed)
         try:
             # Back-compat: older spawn_fn signatures accept only
             # (task, workspace). Test stubs in the suite rely on that.
@@ -7766,6 +7782,7 @@ def _dispatch_once_locked(
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        claimed.execution_route = _latest_execution_route(conn, claimed.id)
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
@@ -7798,6 +7815,7 @@ def _dispatch_once_locked(
                 _block_preflight_failure(conn, claimed.id, preflight)
                 result.auto_blocked.append(claimed.id)
                 continue
+            _persist_execution_route(conn, claimed)
         try:
             import inspect
             try:
@@ -8084,6 +8102,34 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _resolve_worker_route(
+    task: Task, profile: str, provider: str, model: str,
+) -> dict[str, Any]:
+    """Resolve a credential-safe, runnable route without a billable model call."""
+    try:
+        from hermes_cli.auth import has_usable_secret
+        from hermes_cli.models import provider_model_ids
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=provider, target_model=model)
+        resolved_provider = str(runtime.get("provider") or "").strip()
+        if not resolved_provider or resolved_provider != provider:
+            return {"ok": False, "code": "route_invalid", "detail": "provider did not resolve exactly"}
+        api_key = runtime.get("api_key")
+        key_text = "" if callable(api_key) else str(api_key or "").strip()
+        if not (callable(api_key) or key_text in {"aws-sdk", "no-key-required"}
+                or has_usable_secret(key_text) or bool(runtime.get("command"))):
+            return {"ok": False, "code": "route_invalid", "detail": "provider has no usable authentication"}
+        catalog = provider_model_ids(provider)
+        if catalog and model not in set(catalog):
+            return {"ok": False, "code": "route_invalid", "detail": "model is unavailable for provider"}
+        return {"ok": True, "route": {"profile": profile, "provider": resolved_provider,
+                                        "model": model,
+                                        "credential_ref": str(runtime.get("source") or "configured")[:120]}}
+    except Exception:
+        return {"ok": False, "code": "route_invalid", "detail": "profile route could not be resolved"}
+
+
 def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str]) -> dict[str, Any]:
     """Validate every worker-launch prerequisite before ``Popen``.
 
@@ -8134,13 +8180,17 @@ def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str])
         try:
             cfg = load_config()
             model_cfg = cfg.get("model") or {}
-            provider = str(model_cfg.get("provider") or "").strip()
-            model = str(task.model_override or model_cfg.get("default") or "").strip()
+            inherited = task.execution_route or {}
+            provider = str(inherited.get("provider") or model_cfg.get("provider") or "").strip()
+            model = str(task.model_override or inherited.get("model") or model_cfg.get("default") or "").strip()
             if not provider or not model:
                 return fail("route_invalid", "profile must resolve a provider and model")
             from providers import get_provider_profile
             if get_provider_profile(provider) is None:
                 return fail("route_invalid", "configured provider is unavailable")
+            resolved = _resolve_worker_route(task, profile, provider, model)
+            if not resolved["ok"]:
+                return fail(str(resolved["code"]), str(resolved["detail"]))
             worker_toolsets = _resolve_worker_cli_toolsets(profile_home)
             if not worker_toolsets:
                 return fail("toolsets_invalid", "profile has no available CLI toolsets")
@@ -8154,10 +8204,12 @@ def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str])
             reset_hermes_home_override(token)
     except Exception:
         return fail("route_invalid", "profile route could not be resolved")
+    route = resolved["route"]
+    task.execution_route = route
     return {
         "ok": True,
         "board": _normalize_board_slug(board) or get_current_board(),
-        "route": {"profile": profile, "provider": provider, "model": model},
+        "route": route,
     }
 
 
@@ -8179,6 +8231,31 @@ def _block_preflight_failure(
         run_id = _end_run(conn, task_id, outcome="preflight_failed", status="preflight_failed",
                           error=f"preflight {code}: {detail}", metadata=metadata)
         _append_event(conn, task_id, "preflight_failed", metadata, run_id=run_id)
+
+
+def _persist_execution_route(conn: sqlite3.Connection, task: Task) -> None:
+    """Persist only non-secret route identity for downstream worker dispatch."""
+    route = task.execution_route or {}
+    safe = {k: str(route[k])[:120] for k in ("profile", "provider", "model", "credential_ref")
+            if route.get(k)}
+    if safe and task.current_run_id is not None:
+        with write_txn(conn):
+            _append_event(conn, task.id, "execution_route", {"route": safe}, run_id=task.current_run_id)
+
+
+def _latest_execution_route(conn: sqlite3.Connection, task_id: str) -> Optional[dict[str, str]]:
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'execution_route' "
+        "ORDER BY id DESC LIMIT 1", (task_id,),
+    ).fetchone()
+    try:
+        raw = json.loads(row["payload"]).get("route") if row and row["payload"] else None
+    except Exception:
+        raw = None
+    if not isinstance(raw, dict):
+        return None
+    route = {k: str(raw[k]) for k in ("profile", "provider", "model", "credential_ref") if raw.get(k)}
+    return route or None
 
 
 def _default_spawn(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6085,10 +6085,10 @@ def _poll_registered_workers() -> list[int]:
             continue
         if returncode is None:
             continue
-        _record_worker_returncode(pid, int(returncode))
         with _worker_registry_lock:
             if _worker_registry.get(pid) is not record:
                 continue
+            _record_worker_returncode(pid, int(returncode))
             _worker_exit_context[pid] = record
             _worker_registry.pop(pid, None)
         reaped.append(pid)
@@ -6166,12 +6166,15 @@ def _consume_worker_exit(
 ) -> tuple[str, Optional[int], Optional[_WorkerProcess]]:
     """Atomically consume status and matching process evidence exactly once."""
     with _worker_registry_lock:
-        entry = _recent_worker_exits.pop(int(pid), None)
-        record = _worker_exit_context.pop(int(pid), None)
-        if record is not None and (record.task_id != task_id or record.run_id != run_id):
-            record = None
+        pid = int(pid)
+        record = _worker_exit_context.get(pid)
+        if record is None or record.task_id != task_id or record.run_id != run_id:
+            return ("unknown", None, None)
+        entry = _recent_worker_exits.get(pid)
         if entry is None:
             return ("unknown", None, None)
+        _recent_worker_exits.pop(pid, None)
+        _worker_exit_context.pop(pid, None)
         raw, _ = entry
         try:
             if os.WIFEXITED(raw):
@@ -8517,9 +8520,13 @@ def _default_spawn(
             reset_hermes_home_override(token)
     except Exception:
         provider = ""
+    registered_route = dict(task.execution_route or {})
+    registered_route.setdefault("profile", profile_arg)
+    registered_route.setdefault("provider", provider)
+    if task.model_override:
+        registered_route.setdefault("model", task.model_override)
     _register_worker_process(
-        proc, task, board=board, log_path=str(log_path),
-        route={"profile": profile_arg, "provider": provider, "model": task.model_override or ""},
+        proc, task, board=board, log_path=str(log_path), route=registered_route,
     )
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5983,6 +5983,73 @@ _RECENT_WORKER_EXITS_MAX = 4096
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
 
 
+@dataclass
+class _WorkerProcess:
+    """Gateway-lifetime ownership record for one dispatcher child."""
+
+    pid: int
+    task_id: str
+    run_id: Optional[int]
+    board: str
+    proc: Any
+    started_at: float
+    process_group: Optional[int]
+    log_path: str
+    route: dict[str, str]
+
+
+# PID alone is not ownership proof: PIDs may be reused after a gateway restart.
+# Retaining Popen lets this gateway obtain the child's actual return status.
+_worker_registry: "dict[int, _WorkerProcess]" = {}
+_worker_exit_context: "dict[int, _WorkerProcess]" = {}
+
+
+def _register_worker_process(
+    proc: Any,
+    task: Task,
+    *,
+    board: Optional[str],
+    log_path: str,
+    route: Optional[dict[str, str]] = None,
+) -> None:
+    pid = int(proc.pid)
+    process_group = None
+    if os.name != "nt":
+        try:
+            process_group = os.getpgid(pid)
+        except OSError:
+            pass
+    _worker_registry[pid] = _WorkerProcess(
+        pid=pid, task_id=task.id, run_id=task.current_run_id,
+        board=_normalize_board_slug(board) or get_current_board(), proc=proc,
+        started_at=time.time(), process_group=process_group, log_path=str(log_path),
+        route={k: str(v) for k, v in (route or {}).items()
+               if k in {"profile", "provider", "model"} and v},
+    )
+
+
+def _record_worker_returncode(pid: int, returncode: int) -> None:
+    """Normalize Popen's return-code convention to a raw wait status."""
+    _record_worker_exit(pid, -returncode if returncode < 0 else returncode << 8)
+
+
+def _poll_registered_workers() -> list[int]:
+    """Reap children still owned by this gateway deterministically."""
+    reaped: list[int] = []
+    for pid, record in list(_worker_registry.items()):
+        try:
+            returncode = record.proc.poll()
+        except Exception:
+            continue
+        if returncode is None:
+            continue
+        _record_worker_returncode(pid, int(returncode))
+        _worker_exit_context[pid] = record
+        _worker_registry.pop(pid, None)
+        reaped.append(pid)
+    return reaped
+
+
 def _record_worker_exit(pid: int, raw_status: int) -> None:
     """Record a reaped child's exit status for later classification.
 
@@ -6055,7 +6122,7 @@ def reap_worker_zombies() -> "list[int]":
     Returns the list of reaped PIDs. Safe to call when there are no
     children (returns []). No-op on Windows.
     """
-    reaped: "list[int]" = []
+    reaped: "list[int]" = _poll_registered_workers()
     if os.name != "nt":
         try:
             while True:
@@ -6167,8 +6234,26 @@ def _terminate_reclaimed_worker(
         return info
 
     info["termination_attempted"] = True
+    group_signalled = False
+    record = _worker_registry.get(int(pid))
+    # Only kill a process group when this gateway still owns the exact Popen
+    # child and its current group matches the launch-time group. This avoids
+    # signalling an unrelated process after PID reuse.
+    if (
+        signal_fn is None and os.name != "nt" and record is not None
+        and record.process_group is not None
+    ):
+        try:
+            if os.getpgid(int(pid)) == record.process_group:
+                os.killpg(record.process_group, signal.SIGTERM)
+                info["process_group"] = record.process_group
+                group_signalled = True
+        except (ProcessLookupError, OSError):
+            info["terminated"] = True
+            return info
     try:
-        kill(int(pid), signal.SIGTERM)
+        if not group_signalled:
+            kill(int(pid), signal.SIGTERM)
     except ProcessLookupError:
         # Process is already gone — that's a successful termination, not a
         # survival. Leaving terminated=False here would make the reclaim guard
@@ -6189,7 +6274,14 @@ def _terminate_reclaimed_worker(
             # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
             # (which maps to TerminateProcess via the stdlib shim).
             _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
+            if group_signalled and record is not None and record.process_group is not None:
+                # Revalidate the leader/group association before escalating.
+                if os.getpgid(int(pid)) == record.process_group:
+                    os.killpg(record.process_group, _sigkill)
+                else:
+                    kill(int(pid), _sigkill)
+            else:
+                kill(int(pid), _sigkill)
             info["sigkill"] = True
         except (ProcessLookupError, OSError):
             return info
@@ -6606,7 +6698,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, current_run_id, "
+            "last_heartbeat_at, workspace_path, workspace_kind, branch_name "
+            "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -6628,6 +6722,31 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
+            record = _worker_exit_context.get(pid)
+            # Retained evidence is valid only for the exact task/run we own.
+            # A stale record after gateway restart or PID reuse must not be
+            # attributed to the newly claimed task.
+            if record is not None and (
+                record.task_id != row["id"] or record.run_id != row["current_run_id"]
+            ):
+                kind, code, record = "unknown", None, None
+            envelope = {
+                "exit": {"kind": kind, "code": code, "pid": pid},
+                "worker": {
+                    "board": record.board if record else None,
+                    "started_at": int(record.started_at) if record else None,
+                    "process_group": record.process_group if record else None,
+                    "log_path": record.log_path if record else None,
+                },
+                "route": dict(record.route) if record else {},
+                "heartbeat_at": row["last_heartbeat_at"],
+                "salvage": {
+                    "workspace_kind": row["workspace_kind"],
+                    "workspace_path": row["workspace_path"],
+                    "branch_name": row["branch_name"],
+                    "preserved": row["workspace_kind"] != "scratch",
+                },
+            }
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
@@ -6669,34 +6788,43 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 protocol_violation = False
                 if kind == "nonzero_exit":
                     error_text = f"pid {pid} exited with code {code}"
+                    event_kind = "crashed"
                 elif kind == "signaled":
                     error_text = f"pid {pid} killed by signal {code}"
+                    event_kind = "crashed"
                 else:
-                    error_text = f"pid {pid} not alive"
-                event_kind = "crashed"
+                    # Unknown disappearance is not safe to retry: preserve the
+                    # workspace and surface an analyzable block instead.
+                    error_text = f"worker pid {pid} vanished with unknown exit evidence"
+                    event_kind = "worker_exit_unknown"
                 event_payload = {"pid": pid, "claimer": row["claim_lock"]}
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            terminal_status = "blocked" if kind == "unknown" else "ready"
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
+                (terminal_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                _run_outcome = (
+                    "rate_limited" if rate_limited_exit else
+                    "unknown_exit" if kind == "unknown" else "crashed"
+                )
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
                     error=error_text,
-                    metadata=dict(event_payload),
+                    metadata=envelope,
                 )
+                event_payload["evidence"] = envelope
                 _append_event(
                     conn, row["id"], event_kind,
                     event_payload,
@@ -6713,6 +6841,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif kind == "unknown":
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                        (error_text[:500], row["id"]),
+                    )
+                    crashed.append(row["id"])
                 else:
                     crashed.append(row["id"])
                     crash_details.append(
@@ -7517,6 +7651,12 @@ def _dispatch_once_locked(
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        if _spawn is _default_spawn:
+            preflight = _preflight_worker_spawn(claimed, str(workspace), board=board)
+            if not preflight["ok"]:
+                _block_preflight_failure(conn, claimed.id, preflight)
+                result.auto_blocked.append(claimed.id)
+                continue
         try:
             # Back-compat: older spawn_fn signatures accept only
             # (task, workspace). Test stubs in the suite rely on that.
@@ -7615,6 +7755,12 @@ def _dispatch_once_locked(
         # review agent needs.
         claimed.skills = ["sdlc-review"]
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        if _spawn is _default_spawn:
+            preflight = _preflight_worker_spawn(claimed, str(workspace), board=board)
+            if not preflight["ok"]:
+                _block_preflight_failure(conn, claimed.id, preflight)
+                result.auto_blocked.append(claimed.id)
+                continue
         try:
             import inspect
             try:
@@ -7901,6 +8047,66 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str]) -> dict[str, Any]:
+    """Validate deterministic worker-launch prerequisites without spawning.
+
+    The route is intentionally credential-free. Credentials remain in the
+    profile auth store and are never persisted into events or run metadata.
+    """
+    if not workspace or not os.path.isabs(workspace) or not os.path.isdir(workspace):
+        return {"ok": False, "code": "workspace_invalid", "detail": "workspace must be an existing absolute directory"}
+    if not task.assignee:
+        return {"ok": False, "code": "profile_invalid", "detail": "task has no assignee"}
+    try:
+        from hermes_cli.profiles import normalize_profile_name, profile_exists, resolve_profile_env
+        profile = normalize_profile_name(task.assignee)
+        if not profile_exists(profile):
+            return {"ok": False, "code": "profile_invalid", "detail": f"profile {profile!r} does not exist"}
+        profile_home = resolve_profile_env(profile)
+    except Exception as exc:
+        return {"ok": False, "code": "profile_invalid", "detail": str(exc)[:200]}
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_cli.config import load_config
+        token = set_hermes_home_override(profile_home)
+        try:
+            cfg = load_config()
+        finally:
+            reset_hermes_home_override(token)
+        model_cfg = cfg.get("model") or {}
+        provider = str(model_cfg.get("provider") or "").strip()
+        model = str(task.model_override or model_cfg.get("default") or "").strip()
+        if not provider or not model:
+            return {"ok": False, "code": "route_invalid", "detail": "profile must resolve non-empty provider and model"}
+    except Exception as exc:
+        return {"ok": False, "code": "route_invalid", "detail": str(exc)[:200]}
+    return {
+        "ok": True,
+        "board": _normalize_board_slug(board) or get_current_board(),
+        "route": {"profile": profile, "provider": provider, "model": model},
+    }
+
+
+def _block_preflight_failure(
+    conn: sqlite3.Connection, task_id: str, preflight: dict[str, Any],
+) -> None:
+    """Close a claimed run as an analyzable, non-retryable launch failure."""
+    code = str(preflight.get("code") or "preflight_failed")
+    detail = str(preflight.get("detail") or "worker launch preflight failed")[:500]
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL, "
+            "worker_pid=NULL, last_failure_error=? WHERE id=? AND status='running'",
+            (f"preflight {code}: {detail}"[:500], task_id),
+        )
+        if cur.rowcount != 1:
+            return
+        metadata = {"preflight": {"code": code, "detail": detail}}
+        run_id = _end_run(conn, task_id, outcome="preflight_failed", status="preflight_failed",
+                          error=f"preflight {code}: {detail}", metadata=metadata)
+        _append_event(conn, task_id, "preflight_failed", metadata, run_id=run_id)
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -8082,6 +8288,10 @@ def _default_spawn(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
         )
+    _register_worker_process(
+        proc, task, board=board, log_path=str(log_path),
+        route={"profile": profile_arg, "model": task.model_override or ""},
+    )
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2411,6 +2411,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    execution_route_override: Optional[dict[str, str]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2436,6 +2437,17 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    route_override: dict[str, str] = {}
+    if execution_route_override is not None:
+        if not isinstance(execution_route_override, dict):
+            raise ValueError("execution_route_override must be a mapping")
+        unknown = set(execution_route_override) - {"profile", "provider", "model", "credential_ref"}
+        if unknown:
+            raise ValueError(f"unknown execution route override field(s): {', '.join(sorted(unknown))}")
+        route_override = {
+            key: str(value).strip()[:120]
+            for key, value in execution_route_override.items() if str(value).strip()
+        }
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -2684,6 +2696,11 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if route_override:
+                    _append_event(
+                        conn, task_id, "execution_route_override",
+                        {"route": route_override},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -6012,17 +6029,18 @@ def _trim_worker_exit_context(*, now: Optional[float] = None) -> None:
     """Bound retained exit evidence and release exited ``Popen`` references."""
     now = time.time() if now is None else now
     cutoff = now - _RECENT_WORKER_EXIT_TTL_SECONDS
-    for pid in list(_worker_exit_context):
-        entry = _recent_worker_exits.get(pid)
-        if entry is None or entry[1] < cutoff:
-            _worker_exit_context.pop(pid, None)
-    if len(_worker_exit_context) > _RECENT_WORKER_EXITS_MAX:
-        ordered = sorted(
-            _worker_exit_context,
-            key=lambda pid: _recent_worker_exits.get(pid, (0, 0.0))[1],
-        )
-        for pid in ordered[:len(_worker_exit_context) - _RECENT_WORKER_EXITS_MAX]:
-            _worker_exit_context.pop(pid, None)
+    with _worker_registry_lock:
+        for pid in list(_worker_exit_context):
+            entry = _recent_worker_exits.get(pid)
+            if entry is None or entry[1] < cutoff:
+                _worker_exit_context.pop(pid, None)
+        if len(_worker_exit_context) > _RECENT_WORKER_EXITS_MAX:
+            ordered = sorted(
+                _worker_exit_context,
+                key=lambda pid: _recent_worker_exits.get(pid, (0, 0.0))[1],
+            )
+            for pid in ordered[:len(_worker_exit_context) - _RECENT_WORKER_EXITS_MAX]:
+                _worker_exit_context.pop(pid, None)
 
 
 def _register_worker_process(
@@ -6087,18 +6105,16 @@ def _record_worker_exit(pid: int, raw_status: int) -> None:
     if not pid or pid <= 0:
         return
     now = time.time()
-    _recent_worker_exits[int(pid)] = (int(raw_status), now)
-    # Age-based trim: drop entries older than the TTL.
-    if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX // 2:
-        cutoff = now - _RECENT_WORKER_EXIT_TTL_SECONDS
-        for _pid in [p for p, (_s, t) in _recent_worker_exits.items() if t < cutoff]:
-            _recent_worker_exits.pop(_pid, None)
-    # Size cap as a final guard.
-    if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX:
-        # Drop oldest half.
-        ordered = sorted(_recent_worker_exits.items(), key=lambda kv: kv[1][1])
-        for _pid, _ in ordered[: len(ordered) // 2]:
-            _recent_worker_exits.pop(_pid, None)
+    with _worker_registry_lock:
+        _recent_worker_exits[int(pid)] = (int(raw_status), now)
+        if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX // 2:
+            cutoff = now - _RECENT_WORKER_EXIT_TTL_SECONDS
+            for _pid in [p for p, (_s, t) in _recent_worker_exits.items() if t < cutoff]:
+                _recent_worker_exits.pop(_pid, None)
+        if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX:
+            ordered = sorted(_recent_worker_exits.items(), key=lambda kv: kv[1][1])
+            for _pid, _ in ordered[: len(ordered) // 2]:
+                _recent_worker_exits.pop(_pid, None)
 
 
 def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
@@ -6125,7 +6141,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
     for ``unknown``.
     """
-    entry = _recent_worker_exits.get(int(pid))
+    with _worker_registry_lock:
+        entry = _recent_worker_exits.get(int(pid))
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
@@ -6142,6 +6159,33 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     except Exception:
         pass
     return ("unknown", None)
+
+
+def _consume_worker_exit(
+    pid: int, task_id: str, run_id: Optional[int],
+) -> tuple[str, Optional[int], Optional[_WorkerProcess]]:
+    """Atomically consume status and matching process evidence exactly once."""
+    with _worker_registry_lock:
+        entry = _recent_worker_exits.pop(int(pid), None)
+        record = _worker_exit_context.pop(int(pid), None)
+        if record is not None and (record.task_id != task_id or record.run_id != run_id):
+            record = None
+        if entry is None:
+            return ("unknown", None, None)
+        raw, _ = entry
+        try:
+            if os.WIFEXITED(raw):
+                code = os.WEXITSTATUS(raw)
+                if code == 0:
+                    return ("clean_exit", 0, record)
+                if code == KANBAN_RATE_LIMIT_EXIT_CODE:
+                    return ("rate_limited", code, record)
+                return ("nonzero_exit", code, record)
+            if os.WIFSIGNALED(raw):
+                return ("signaled", os.WTERMSIG(raw), record)
+        except Exception:
+            pass
+        return ("unknown", None, record)
 
 
 def reap_worker_zombies() -> "list[int]":
@@ -6493,7 +6537,9 @@ def enforce_max_runtime(
         # ``signal_fn`` is an explicit in-process test seam. Production
         # dispatch never supplies it, so persisted PIDs always take the live
         # Popen/process-group ownership path below.
-        if signal_fn is not None and pid not in _worker_registry:
+        with _worker_registry_lock:
+            has_registry_record = pid in _worker_registry
+        if signal_fn is not None and not has_registry_record:
             signal_fn(pid, signal.SIGTERM)
             termination = {"ownership_verified": True, "termination_attempted": True,
                            "terminated": not _pid_alive(pid), "sigkill": False,
@@ -6769,15 +6815,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 continue
 
             pid = int(row["worker_pid"])
-            kind, code = _classify_worker_exit(pid)
-            record = _worker_exit_context.get(pid)
-            # Retained evidence is valid only for the exact task/run we own.
-            # A stale record after gateway restart or PID reuse must not be
-            # attributed to the newly claimed task.
-            if record is not None and (
-                record.task_id != row["id"] or record.run_id != row["current_run_id"]
-            ):
-                kind, code, record = "unknown", None, None
+            kind, code, record = _consume_worker_exit(
+                pid, row["id"], row["current_run_id"],
+            )
             envelope = {
                 "exit": {"kind": kind, "code": code, "pid": pid},
                 "worker": {
@@ -6795,10 +6835,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "preserved": row["workspace_kind"] != "scratch",
                 },
             }
-            # Exit evidence is single-consumer classification data. The envelope
-            # above is durable; dropping this reference releases the exited
-            # Popen promptly and prevents a later PID reuse from reusing it.
-            _worker_exit_context.pop(pid, None)
+
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
@@ -7683,6 +7720,7 @@ def _dispatch_once_locked(
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        claimed.execution_route = _latest_execution_route(conn, claimed.id)
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
@@ -8167,7 +8205,8 @@ def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str])
         return fail("board_invalid", "board state could not be verified")
     try:
         from hermes_cli.profiles import normalize_profile_name, profile_exists, resolve_profile_env
-        profile = normalize_profile_name(task.assignee)
+        inherited = task.execution_route or {}
+        profile = normalize_profile_name(str(inherited.get("profile") or task.assignee))
         if not profile_exists(profile):
             return fail("profile_invalid", f"profile {profile!r} does not exist")
         profile_home = resolve_profile_env(profile)
@@ -8180,7 +8219,6 @@ def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str])
         try:
             cfg = load_config()
             model_cfg = cfg.get("model") or {}
-            inherited = task.execution_route or {}
             provider = str(inherited.get("provider") or model_cfg.get("provider") or "").strip()
             model = str(task.model_override or inherited.get("model") or model_cfg.get("default") or "").strip()
             if not provider or not model:
@@ -8191,6 +8229,10 @@ def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str])
             resolved = _resolve_worker_route(task, profile, provider, model)
             if not resolved["ok"]:
                 return fail(str(resolved["code"]), str(resolved["detail"]))
+            expected_credential = str(inherited.get("credential_ref") or "").strip()
+            actual_credential = str(resolved["route"].get("credential_ref") or "").strip()
+            if expected_credential and expected_credential != actual_credential:
+                return fail("route_invalid", "requested credential reference is unavailable")
             worker_toolsets = _resolve_worker_cli_toolsets(profile_home)
             if not worker_toolsets:
                 return fail("toolsets_invalid", "profile has no available CLI toolsets")
@@ -8243,19 +8285,44 @@ def _persist_execution_route(conn: sqlite3.Connection, task: Task) -> None:
             _append_event(conn, task.id, "execution_route", {"route": safe}, run_id=task.current_run_id)
 
 
-def _latest_execution_route(conn: sqlite3.Connection, task_id: str) -> Optional[dict[str, str]]:
-    row = conn.execute(
-        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'execution_route' "
-        "ORDER BY id DESC LIMIT 1", (task_id,),
-    ).fetchone()
-    try:
-        raw = json.loads(row["payload"]).get("route") if row and row["payload"] else None
-    except Exception:
-        raw = None
-    if not isinstance(raw, dict):
+def _latest_execution_route(
+    conn: sqlite3.Connection, task_id: str, *, _seen: Optional[set[str]] = None,
+) -> Optional[dict[str, str]]:
+    """Resolve a task's explicit route, or deterministically inherit a parent route."""
+    seen = set() if _seen is None else _seen
+    if task_id in seen:
         return None
-    route = {k: str(raw[k]) for k in ("profile", "provider", "model", "credential_ref") if raw.get(k)}
-    return route or None
+    seen.add(task_id)
+
+    def event_route(kind: str) -> dict[str, str]:
+        row = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? "
+            "ORDER BY id DESC LIMIT 1", (task_id, kind),
+        ).fetchone()
+        try:
+            raw = json.loads(row["payload"]).get("route") if row and row["payload"] else None
+        except Exception:
+            raw = None
+        if not isinstance(raw, dict):
+            return {}
+        return {
+            key: str(raw[key]) for key in ("profile", "provider", "model", "credential_ref")
+            if raw.get(key)
+        }
+
+    override = event_route("execution_route_override")
+    effective = event_route("execution_route")
+    if not effective:
+        parents = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+            (task_id,),
+        ).fetchall()
+        for parent in parents:
+            effective = _latest_execution_route(conn, parent["parent_id"], _seen=seen) or {}
+            if effective:
+                break
+    effective.update(override)
+    return effective or None
 
 
 def _default_spawn(
@@ -8282,7 +8349,8 @@ def _default_spawn(
 
     from hermes_cli.profiles import normalize_profile_name
 
-    profile_arg = normalize_profile_name(task.assignee)
+    route_profile = (task.execution_route or {}).get("profile")
+    profile_arg = normalize_profile_name(str(route_profile or task.assignee))
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6004,6 +6004,23 @@ _worker_registry: "dict[int, _WorkerProcess]" = {}
 _worker_exit_context: "dict[int, _WorkerProcess]" = {}
 
 
+def _trim_worker_exit_context(*, now: Optional[float] = None) -> None:
+    """Bound retained exit evidence and release exited ``Popen`` references."""
+    now = time.time() if now is None else now
+    cutoff = now - _RECENT_WORKER_EXIT_TTL_SECONDS
+    for pid in list(_worker_exit_context):
+        entry = _recent_worker_exits.get(pid)
+        if entry is None or entry[1] < cutoff:
+            _worker_exit_context.pop(pid, None)
+    if len(_worker_exit_context) > _RECENT_WORKER_EXITS_MAX:
+        ordered = sorted(
+            _worker_exit_context,
+            key=lambda pid: _recent_worker_exits.get(pid, (0, 0.0))[1],
+        )
+        for pid in ordered[:len(_worker_exit_context) - _RECENT_WORKER_EXITS_MAX]:
+            _worker_exit_context.pop(pid, None)
+
+
 def _register_worker_process(
     proc: Any,
     task: Task,
@@ -6047,6 +6064,7 @@ def _poll_registered_workers() -> list[int]:
         _worker_exit_context[pid] = record
         _worker_registry.pop(pid, None)
         reaped.append(pid)
+    _trim_worker_exit_context()
     return reaped
 
 
@@ -6209,7 +6227,13 @@ def _terminate_reclaimed_worker(
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Terminate only a child whose live identity this gateway can prove.
+
+    A board PID is diagnostic state, not authority to signal.  After a gateway
+    restart or PID reuse the in-memory ``Popen`` record is absent, so cleanup
+    fails closed and the caller defers the claim instead of risking an
+    unrelated process.
+    """
     import signal
 
     info: dict[str, Any] = {
@@ -6218,6 +6242,8 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "ownership_verified": False,
+        "ownership_reason": None,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -6227,37 +6253,47 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
-    )
-    if kill is None:
+    record = _worker_registry.get(int(pid))
+    if record is None:
+        info["ownership_reason"] = "missing_registry_record"
+        return info
+    if record.pid != int(pid) or getattr(record.proc, "pid", None) != int(pid):
+        info["ownership_reason"] = "pid_identity_mismatch"
+        return info
+    try:
+        if record.proc.poll() is not None:
+            info["ownership_reason"] = "popen_not_live"
+            return info
+    except Exception:
+        info["ownership_reason"] = "popen_liveness_unknown"
         return info
 
-    info["termination_attempted"] = True
-    group_signalled = False
-    record = _worker_registry.get(int(pid))
-    # Only kill a process group when this gateway still owns the exact Popen
-    # child and its current group matches the launch-time group. This avoids
-    # signalling an unrelated process after PID reuse.
-    if (
-        signal_fn is None and os.name != "nt" and record is not None
-        and record.process_group is not None
-    ):
-        try:
-            if os.getpgid(int(pid)) == record.process_group:
-                os.killpg(record.process_group, signal.SIGTERM)
-                info["process_group"] = record.process_group
-                group_signalled = True
-        except (ProcessLookupError, OSError):
-            info["terminated"] = True
+    if os.name != "nt":
+        if record.process_group is None:
+            info["ownership_reason"] = "missing_process_group"
             return info
+        try:
+            if os.getpgid(int(pid)) != record.process_group:
+                info["ownership_reason"] = "process_group_mismatch"
+                return info
+        except (ProcessLookupError, OSError):
+            info["ownership_reason"] = "process_group_unavailable"
+            return info
+
+    info["ownership_verified"] = True
+    info["ownership_reason"] = "live_popen_identity_match"
+    info["termination_attempted"] = True
     try:
-        if not group_signalled:
-            kill(int(pid), signal.SIGTERM)
+        if os.name == "nt":
+            # The live Popen handle is the Windows ownership proof; never use
+            # a bare PID signal because a reused PID is indistinguishable.
+            record.proc.terminate()
+        else:
+            # The isolated session/group was identity-checked immediately above.
+            # Never fall back to kill(pid) when this evidence changes.
+            os.killpg(record.process_group, signal.SIGTERM)
+            info["process_group"] = record.process_group
     except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
         info["terminated"] = True
         return info
     except OSError:
@@ -6271,17 +6307,14 @@ def _terminate_reclaimed_worker(
 
     if _pid_alive(pid):
         try:
-            # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
-            # (which maps to TerminateProcess via the stdlib shim).
-            _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            if group_signalled and record is not None and record.process_group is not None:
-                # Revalidate the leader/group association before escalating.
-                if os.getpgid(int(pid)) == record.process_group:
-                    os.killpg(record.process_group, _sigkill)
-                else:
-                    kill(int(pid), _sigkill)
+            if os.name == "nt":
+                record.proc.kill()
             else:
-                kill(int(pid), _sigkill)
+                if os.getpgid(int(pid)) != record.process_group:
+                    info["ownership_verified"] = False
+                    info["ownership_reason"] = "process_group_mismatch_escalation"
+                    return info
+                os.killpg(record.process_group, getattr(signal, "SIGKILL", signal.SIGTERM))
             info["sigkill"] = True
         except (ProcessLookupError, OSError):
             return info
@@ -6747,6 +6780,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "preserved": row["workspace_kind"] != "scratch",
                 },
             }
+            # Exit evidence is single-consumer classification data. The envelope
+            # above is durable; dropping this reference releases the exited
+            # Popen promptly and prevents a later PID reuse from reusing it.
+            _worker_exit_context.pop(pid, None)
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
@@ -8048,38 +8085,75 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
 
 
 def _preflight_worker_spawn(task: Task, workspace: str, *, board: Optional[str]) -> dict[str, Any]:
-    """Validate deterministic worker-launch prerequisites without spawning.
+    """Validate every worker-launch prerequisite before ``Popen``.
 
-    The route is intentionally credential-free. Credentials remain in the
-    profile auth store and are never persisted into events or run metadata.
+    Errors are typed and deliberately redacted: routes identify provider/model
+    names only, while credential material remains solely in the target profile.
     """
+    def fail(code: str, detail: str) -> dict[str, Any]:
+        return {"ok": False, "code": code, "detail": detail[:200]}
+
     if not workspace or not os.path.isabs(workspace) or not os.path.isdir(workspace):
-        return {"ok": False, "code": "workspace_invalid", "detail": "workspace must be an existing absolute directory"}
+        return fail("workspace_invalid", "workspace must be an existing absolute directory")
+    if task.workspace_kind == "worktree":
+        try:
+            top = subprocess.run(
+                ["git", "-C", workspace, "rev-parse", "--show-toplevel"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+                timeout=3, check=True,
+            ).stdout.strip()
+            if os.path.realpath(top) != os.path.realpath(workspace):
+                return fail("workspace_invalid", "worktree workspace must be its own Git worktree root")
+        except (OSError, subprocess.SubprocessError):
+            return fail("workspace_invalid", "worktree workspace must be a resolvable Git worktree")
     if not task.assignee:
-        return {"ok": False, "code": "profile_invalid", "detail": "task has no assignee"}
+        return fail("profile_invalid", "task has no assignee")
+    if not task.id or task.current_run_id is None or not task.claim_lock:
+        return fail("claim_invalid", "task must have an active claimed run")
+    try:
+        with contextlib.closing(connect(board=board)) as conn:
+            row = conn.execute(
+                "SELECT status, current_run_id, claim_lock FROM tasks WHERE id = ?", (task.id,),
+            ).fetchone()
+        if not row or row["status"] != "running" or row["current_run_id"] != task.current_run_id or row["claim_lock"] != task.claim_lock:
+            return fail("claim_invalid", "task claim no longer matches the active board run")
+    except Exception:
+        return fail("board_invalid", "board state could not be verified")
     try:
         from hermes_cli.profiles import normalize_profile_name, profile_exists, resolve_profile_env
         profile = normalize_profile_name(task.assignee)
         if not profile_exists(profile):
-            return {"ok": False, "code": "profile_invalid", "detail": f"profile {profile!r} does not exist"}
+            return fail("profile_invalid", f"profile {profile!r} does not exist")
         profile_home = resolve_profile_env(profile)
-    except Exception as exc:
-        return {"ok": False, "code": "profile_invalid", "detail": str(exc)[:200]}
+    except Exception:
+        return fail("profile_invalid", "profile could not be resolved")
     try:
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
         from hermes_cli.config import load_config
         token = set_hermes_home_override(profile_home)
         try:
             cfg = load_config()
+            model_cfg = cfg.get("model") or {}
+            provider = str(model_cfg.get("provider") or "").strip()
+            model = str(task.model_override or model_cfg.get("default") or "").strip()
+            if not provider or not model:
+                return fail("route_invalid", "profile must resolve a provider and model")
+            from providers import get_provider_profile
+            if get_provider_profile(provider) is None:
+                return fail("route_invalid", "configured provider is unavailable")
+            worker_toolsets = _resolve_worker_cli_toolsets(profile_home)
+            if not worker_toolsets:
+                return fail("toolsets_invalid", "profile has no available CLI toolsets")
+            if task.skills:
+                from agent.skill_commands import scan_skill_commands
+                available = {entry["name"] for entry in scan_skill_commands().values()}
+                missing = [str(skill) for skill in task.skills if str(skill) not in available]
+                if missing:
+                    return fail("skills_invalid", "attached skills are unavailable in target profile")
         finally:
             reset_hermes_home_override(token)
-        model_cfg = cfg.get("model") or {}
-        provider = str(model_cfg.get("provider") or "").strip()
-        model = str(task.model_override or model_cfg.get("default") or "").strip()
-        if not provider or not model:
-            return {"ok": False, "code": "route_invalid", "detail": "profile must resolve non-empty provider and model"}
-    except Exception as exc:
-        return {"ok": False, "code": "route_invalid", "detail": str(exc)[:200]}
+    except Exception:
+        return fail("route_invalid", "profile route could not be resolved")
     return {
         "ok": True,
         "board": _normalize_board_slug(board) or get_current_board(),
@@ -8288,9 +8362,19 @@ def _default_spawn(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
         )
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_cli.config import load_config
+        token = set_hermes_home_override(env.get("HERMES_HOME"))
+        try:
+            provider = str((load_config().get("model") or {}).get("provider") or "").strip()
+        finally:
+            reset_hermes_home_override(token)
+    except Exception:
+        provider = ""
     _register_worker_process(
         proc, task, board=board, log_path=str(log_path),
-        route={"profile": profile_arg, "model": task.model_override or ""},
+        route={"profile": profile_arg, "provider": provider, "model": task.model_override or ""},
     )
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4172,9 +4172,10 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
         assert len(reclaim_evs) == 1
         assert reclaim_evs[0].get("manual") is True
         assert reclaim_evs[0].get("reason") == "test reason"
-        assert reclaim_evs[0].get("termination_attempted") is True
-        assert reclaim_evs[0].get("terminated") is True
-        assert killed == [signal.SIGTERM]
+        assert reclaim_evs[0].get("termination_attempted") is False
+        assert reclaim_evs[0].get("ownership_reason") == "missing_registry_record"
+        assert reclaim_evs[0].get("terminated") is False
+        assert killed == []
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1493,6 +1493,9 @@ def test_multiple_attempts_preserved_as_runs(kanban_home):
         # Attempt 2: claim then crash (simulated: pid dead).
         kb.claim_task(conn, tid)
         kb._set_worker_pid(conn, tid, 98765)
+        # A classified non-zero exit is transient and may be retried;
+        # unknown PID loss is deliberately blocked by the v2 contract.
+        _kb._record_worker_exit(98765, 256)
         original_alive = _kb._pid_alive
         _kb._pid_alive = lambda pid: False
         try:
@@ -1524,6 +1527,7 @@ def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
         kb.claim_task(conn, tid)
         run1 = kb.latest_run(conn, tid)
         kb._set_worker_pid(conn, tid, 98765)
+        _kb._record_worker_exit(98765, 256)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kb.detect_crashed_workers(conn) == [tid]
 
@@ -1565,6 +1569,7 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         kb.claim_task(conn, tid)
         run1 = kb.latest_run(conn, tid)
         kb._set_worker_pid(conn, tid, 98765)
+        _kb._record_worker_exit(98765, 256)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kb.detect_crashed_workers(conn) == [tid]
 
@@ -4388,6 +4393,8 @@ def test_detect_crashed_workers_increments_counter(kanban_home):
         tid = kb.create_task(conn, title="crashy", assignee="worker")
         kb.claim_task(conn, tid)
         kb._set_worker_pid(conn, tid, 99999)  # fake pid — not alive
+        # A known non-zero status follows the normal retry/counter path.
+        kb._record_worker_exit(99999, 256)
 
         kb.detect_crashed_workers(conn)
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -25,6 +25,16 @@ from hermes_cli import kanban_db as kb
 from hermes_cli.kanban import run_slash
 
 
+def _record_owned_exit(conn, task_id, pid, raw_status):
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    kb._record_worker_exit(pid, raw_status)
+    kb._worker_exit_context[pid] = kb._WorkerProcess(
+        pid=pid, task_id=task_id, run_id=task.current_run_id, board="default",
+        proc=None, started_at=0, process_group=None, log_path="/tmp/test.log", route={},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -1495,7 +1505,7 @@ def test_multiple_attempts_preserved_as_runs(kanban_home):
         kb._set_worker_pid(conn, tid, 98765)
         # A classified non-zero exit is transient and may be retried;
         # unknown PID loss is deliberately blocked by the v2 contract.
-        _kb._record_worker_exit(98765, 256)
+        _record_owned_exit(conn, tid, 98765, 256)
         original_alive = _kb._pid_alive
         _kb._pid_alive = lambda pid: False
         try:
@@ -1527,7 +1537,7 @@ def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
         kb.claim_task(conn, tid)
         run1 = kb.latest_run(conn, tid)
         kb._set_worker_pid(conn, tid, 98765)
-        _kb._record_worker_exit(98765, 256)
+        _record_owned_exit(conn, tid, 98765, 256)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kb.detect_crashed_workers(conn) == [tid]
 
@@ -1569,7 +1579,7 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         kb.claim_task(conn, tid)
         run1 = kb.latest_run(conn, tid)
         kb._set_worker_pid(conn, tid, 98765)
-        _kb._record_worker_exit(98765, 256)
+        _record_owned_exit(conn, tid, 98765, 256)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kb.detect_crashed_workers(conn) == [tid]
 
@@ -4395,7 +4405,7 @@ def test_detect_crashed_workers_increments_counter(kanban_home):
         kb.claim_task(conn, tid)
         kb._set_worker_pid(conn, tid, 99999)  # fake pid — not alive
         # A known non-zero status follows the normal retry/counter path.
-        kb._record_worker_exit(99999, 256)
+        _record_owned_exit(conn, tid, 99999, 256)
 
         kb.detect_crashed_workers(conn)
 
@@ -4429,7 +4439,7 @@ def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
 
         # Simulate the reap loop having recorded a clean exit for this pid.
         # os.W_EXITCODE(status=0, signal=0) == 0 on POSIX.
-        _kb._record_worker_exit(fake_pid, 0)
+        _record_owned_exit(conn, tid, fake_pid, 0)
         # Force liveness check to say "dead" for the fake pid.
         original_alive = _kb._pid_alive
         _kb._pid_alive = lambda p: False
@@ -4479,7 +4489,7 @@ def test_detect_crashed_workers_nonzero_exit_uses_default_limit(kanban_home):
         kb._set_worker_pid(conn, tid, fake_pid)
 
         # W_EXITCODE(1, 0) == 256 — WIFEXITED True, WEXITSTATUS == 1.
-        _kb._record_worker_exit(fake_pid, 256)
+        _record_owned_exit(conn, tid, fake_pid, 256)
         original_alive = _kb._pid_alive
         _kb._pid_alive = lambda p: False
         try:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -450,7 +450,9 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
         reclaimed = kb.release_stale_claims(conn, signal_fn=_signal)
         assert reclaimed == 1
         assert kb.get_task(conn, t).status == "ready"
-        assert killed == [signal.SIGTERM]
+        # A stale board PID without this gateway's live Popen record is
+        # diagnostic only; reclaim must never signal a potentially reused PID.
+        assert killed == []
 
 
 def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -777,6 +777,8 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             )
             task_ids.append(tid)
         conn.commit()
+        for i in range(2):
+            _kb._record_worker_exit(80000 + i, 256)
 
         crashed = kb.detect_crashed_workers(conn)
         assert len(crashed) == 2

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -17,6 +17,16 @@ import pytest
 from hermes_cli import kanban_db as kb
 
 
+def _record_owned_exit(conn, task_id, pid, raw_status):
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    kb._record_worker_exit(pid, raw_status)
+    kb._worker_exit_context[pid] = kb._WorkerProcess(
+        pid=pid, task_id=task_id, run_id=task.current_run_id, board="default",
+        proc=None, started_at=0, process_group=None, log_path="/tmp/test.log", route={},
+    )
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
@@ -780,7 +790,7 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             task_ids.append(tid)
         conn.commit()
         for i in range(2):
-            _kb._record_worker_exit(80000 + i, 256)
+            _record_owned_exit(conn, task_ids[i], 80000 + i, 256)
 
         crashed = kb.detect_crashed_workers(conn)
         assert len(crashed) == 2
@@ -923,8 +933,8 @@ def test_rate_limit_exit_requeues_without_counting_failure(
                 (pid, 0, tid),
             )
             conn.commit()
-            _kb._record_worker_exit(
-                pid, _exited_status(_kb.KANBAN_RATE_LIMIT_EXIT_CODE)
+            _record_owned_exit(
+                conn, tid, pid, _exited_status(_kb.KANBAN_RATE_LIMIT_EXIT_CODE)
             )
 
             crashed = kb.detect_crashed_workers(conn)
@@ -976,7 +986,7 @@ def test_real_crash_still_counts_and_trips_breaker(kanban_home, monkeypatch):
                 (pid, f"{host}:w{i}", tid),
             )
             conn.commit()
-            _kb._record_worker_exit(pid, _exited_status(1))  # generic failure
+            _record_owned_exit(conn, tid, pid, _exited_status(1))  # generic failure
             kb.detect_crashed_workers(conn)
 
         task = kb.get_task(conn, tid)

--- a/tests/hermes_cli/test_kanban_worker_runtime_contract.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_contract.py
@@ -187,23 +187,73 @@ def test_exit_context_is_bounded_and_releases_exited_popen_references(kanban_hom
     assert len(kb._worker_exit_context) <= 8
 
 
-def test_child_inherits_parent_execution_route_and_validated_override(kanban_home):
+def test_child_inherits_parent_route_through_canonical_spawn_boundary(
+    kanban_home, tmp_path, monkeypatch,
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: anthropic/claude-fable-5\n",
+        encoding="utf-8",
+    )
+    reviewer_home = tmp_path / ".hermes" / "profiles" / "reviewer"
+    reviewer_home.mkdir(parents=True)
+    (reviewer_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: anthropic/claude-fable-5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-only-not-billable")
+    popen_calls = []
+
+    class Proc:
+        def __init__(self):
+            self.pid = 6100 + len(popen_calls)
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(
+        kb.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)) or Proc(),
+    )
     with kb.connect() as conn:
-        parent = kb.create_task(conn, title="parent", assignee="worker")
-        claimed = kb.claim_task(conn, parent)
-        assert claimed is not None
-        claimed.execution_route = {
-            "profile": "worker", "provider": "openai", "model": "gpt-parent",
-            "credential_ref": "pool:primary",
-        }
-        kb._persist_execution_route(conn, claimed)
+        parent = kb.create_task(
+            conn, title="parent", assignee="worker", workspace_kind="dir",
+            workspace_path=str(tmp_path),
+        )
+        assert [row[0] for row in kb.dispatch_once(conn, max_spawn=1).spawned] == [parent]
+        parent_task = kb.get_task(conn, parent)
+        assert parent_task is not None
+        assert kb.complete_task(conn, parent, expected_run_id=parent_task.current_run_id)
         child = kb.create_task(
             conn, title="child", assignee="reviewer", parents=[parent],
-            execution_route_override={"model": "gpt-review"},
+            workspace_kind="dir", workspace_path=str(tmp_path),
+            execution_route_override={"model": "anthropic/claude-fable-5"},
         )
-        assert kb._latest_execution_route(conn, child) == {
-            "profile": "worker", "provider": "openai", "model": "gpt-review",
-            "credential_ref": "pool:primary",
+        inherited = kb._latest_execution_route(conn, child)
+        assert inherited == {
+            "profile": "worker", "provider": "openrouter",
+            "model": "anthropic/claude-fable-5",
+            "credential_ref": "env:OPENROUTER_API_KEY",
+        }
+        assert [row[0] for row in kb.dispatch_once(conn, max_spawn=1).spawned] == [child]
+        assert len(popen_calls) == 2
+        child_task = kb.get_task(conn, child)
+        assert child_task is not None
+        assert kb.complete_task(conn, child, expected_run_id=child_task.current_run_id)
+
+        unavailable = kb.create_task(
+            conn, title="unavailable credential", assignee="reviewer", parents=[parent],
+            workspace_kind="dir", workspace_path=str(tmp_path),
+            execution_route_override={"credential_ref": "pool:unavailable"},
+        )
+        rejected = kb.dispatch_once(conn, max_spawn=1)
+        assert rejected.auto_blocked == [unavailable]
+        assert len(popen_calls) == 2
+        rejected_run = kb.list_runs(conn, unavailable)[0]
+        assert rejected_run.metadata is not None
+        assert rejected_run.metadata["preflight"] == {
+            "code": "route_invalid",
+            "detail": "requested credential reference is unavailable",
         }
         with pytest.raises(ValueError, match="unknown execution route override"):
             kb.create_task(
@@ -229,10 +279,62 @@ def test_exit_evidence_is_atomic_consume_once(kanban_home):
     assert second == ("unknown", None, None)
 
 
-def _prepare_claimed_task(conn, workspace: Path, *, skills=None):
+def test_poll_does_not_publish_exit_after_same_pid_registry_replacement(kanban_home):
+    pid = 4343
+    old_task = _task("t_old")
+    old_task.current_run_id = 1
+    new_task = _task("t_new")
+    new_task.current_run_id = 2
+
+    class NewProc:
+        def __init__(self):
+            self.pid = pid
+
+        def poll(self):
+            return None
+
+    class OldProc:
+        def __init__(self):
+            self.pid = pid
+
+        def poll(self):
+            kb._register_worker_process(
+                NewProc(), new_task, board="default", log_path="/tmp/new.log",
+            )
+            return 9
+
+    kb._register_worker_process(OldProc(), old_task, board="default", log_path="/tmp/old.log")
+
+    assert kb._poll_registered_workers() == []
+    assert kb._worker_registry[pid].task_id == new_task.id
+    assert pid not in kb._recent_worker_exits
+    assert kb._consume_worker_exit(pid, new_task.id, new_task.current_run_id) == (
+        "unknown", None, None,
+    )
+
+
+def test_mismatched_consumer_cannot_steal_same_pid_exit_evidence(kanban_home):
+    class Proc:
+        pid = 4343
+
+        def poll(self):
+            return 7
+
+    old_task = _task("t_old")
+    old_task.current_run_id = 1
+    kb._register_worker_process(Proc(), old_task, board="default", log_path="/tmp/old.log")
+    assert kb._poll_registered_workers() == [Proc.pid]
+
+    assert kb._consume_worker_exit(Proc.pid, "t_new", 2) == ("unknown", None, None)
+    rightful = kb._consume_worker_exit(Proc.pid, old_task.id, old_task.current_run_id)
+    assert rightful[:2] == ("nonzero_exit", 7)
+    assert rightful[2] is not None
+
+
+def _prepare_claimed_task(conn, workspace: Path, *, skills=None, **kwargs):
     task_id = kb.create_task(
         conn, title="preflight", assignee="worker", workspace_kind="dir",
-        workspace_path=str(workspace), skills=skills,
+        workspace_path=str(workspace), skills=skills, **kwargs,
     )
     task = kb.claim_task(conn, task_id, claimer="host:dispatcher")
     assert task is not None
@@ -245,47 +347,43 @@ def test_canonical_default_route_uses_temp_profile_and_makes_no_model_call(
     profile_home = tmp_path / ".hermes" / "profiles" / "worker"
     profile_home.mkdir(parents=True)
     (profile_home / "config.yaml").write_text(
-        "model:\n  provider: openrouter\n  default: gpt-from-profile\n", encoding="utf-8",
+        "model:\n  provider: openrouter\n  default: anthropic/claude-fable-5\n",
+        encoding="utf-8",
     )
-    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
-    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: ["file"])
-    calls = []
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-only-not-billable")
+    spawned = []
 
-    def resolve(task, profile, provider, model):
-        calls.append((profile, provider, model))
-        return {"ok": True, "route": {
-            "profile": profile, "provider": provider, "model": model,
-            "credential_ref": "auth.json:openai:0",
-        }}
+    class Proc:
+        pid = 5252
 
-    monkeypatch.setattr(kb, "_resolve_worker_route", resolve)
+        def poll(self):
+            return 9
+
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *a, **kw: spawned.append((a, kw)) or Proc())
     with kb.connect() as conn:
-        task = _prepare_claimed_task(conn, tmp_path)
-        result = kb._preflight_worker_spawn(task, str(tmp_path), board="default")
-        assert result["ok"] is True
-        assert calls == [("worker", "openrouter", "gpt-from-profile")]
-        assert result["route"]["credential_ref"] == "auth.json:openai:0"
-        assert "api_key" not in json.dumps(result)
-        kb._persist_execution_route(conn, task)
-
-        class Proc:
-            pid = 5252
-
-            def poll(self):
-                return 9
-
+        task_id = kb.create_task(
+            conn, title="route", assignee="worker", workspace_kind="dir",
+            workspace_path=str(tmp_path),
+        )
+        dispatch = kb.dispatch_once(conn, max_spawn=1, board="default")
+        assert [row[0] for row in dispatch.spawned] == [task_id]
+        assert len(spawned) == 1
+        route = kb._latest_execution_route(conn, task_id)
+        assert route == {
+            "profile": "worker", "provider": "openrouter",
+            "model": "anthropic/claude-fable-5",
+            "credential_ref": "env:OPENROUTER_API_KEY",
+        }
+        assert "sk-or-v1-test-only-not-billable" not in str(kb.list_events(conn, task_id))
         monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
         monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
-        kb._register_worker_process(
-            Proc(), task, board="default", log_path="/tmp/worker.log", route=result["route"],
-        )
-        kb._set_worker_pid(conn, task.id, Proc.pid)
         kb._poll_registered_workers()
-        assert kb.detect_crashed_workers(conn) == [task.id]
-        metadata = kb.list_runs(conn, task.id)[0].metadata
+        assert kb.detect_crashed_workers(conn) == [task_id]
+        metadata = kb.list_runs(conn, task_id)[0].metadata
         assert metadata is not None
-        assert metadata["route"] == result["route"]
+        assert metadata["route"] == route
         assert "api_key" not in json.dumps(metadata)
+        assert "sk-or-v1-test-only-not-billable" not in json.dumps(metadata)
 
 
 def test_unavailable_attached_skill_is_typed_preflight_failure_before_popen(
@@ -324,22 +422,26 @@ def test_invalid_explicit_model_is_rejected_before_popen(kanban_home, tmp_path, 
     profile_home = tmp_path / ".hermes" / "profiles" / "worker"
     profile_home.mkdir(parents=True)
     (profile_home / "config.yaml").write_text(
-        "model:\n  provider: openrouter\n  default: valid-model\n", encoding="utf-8",
+        "model:\n  provider: openrouter\n  default: anthropic/claude-fable-5\n", encoding="utf-8",
     )
-    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
-    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: ["file"])
-    monkeypatch.setattr(kb, "_resolve_worker_route", lambda *args: {
-        "ok": False, "code": "route_invalid", "detail": "model is unavailable for provider",
-    })
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-only-not-billable")
     popen_calls = []
     monkeypatch.setattr(kb.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)))
     with kb.connect() as conn:
-        task = _prepare_claimed_task(conn, tmp_path)
-        task.model_override = "not-in-catalog"
-        result = kb._preflight_worker_spawn(task, str(tmp_path), board="default")
-        assert result["code"] == "route_invalid"
-        assert result["detail"] == "model is unavailable for provider"
+        task_id = kb.create_task(
+            conn, title="invalid route", assignee="worker", workspace_kind="dir",
+            workspace_path=str(tmp_path),
+            execution_route_override={"model": "not-in-catalog"},
+        )
+        result = kb.dispatch_once(conn, max_spawn=1, board="default")
+        assert result.auto_blocked == [task_id]
         assert popen_calls == []
+        run = kb.list_runs(conn, task_id)[0]
+        assert run.outcome == "preflight_failed"
+        assert run.metadata is not None
+        assert run.metadata["preflight"] == {
+            "code": "route_invalid", "detail": "model is unavailable for provider",
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_kanban_worker_runtime_contract.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_contract.py
@@ -1,7 +1,6 @@
 """Regression coverage for the dispatcher-owned Kanban worker runtime contract."""
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -17,9 +16,21 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     kb._worker_registry.clear()
+    kb._worker_exit_context.clear()
     kb._recent_worker_exits.clear()
     yield home
     kb._worker_registry.clear()
+    kb._worker_exit_context.clear()
+    kb._recent_worker_exits.clear()
+
+
+def _task(task_id="t_runtime"):
+    return kb.Task(
+        id=task_id, title="runtime", body=None, assignee="worker", status="running",
+        priority=0, created_by=None, created_at=0, started_at=None, completed_at=None,
+        workspace_kind="dir", workspace_path=None, claim_lock="host:1",
+        claim_expires=None, tenant=None,
+    )
 
 
 def test_registered_worker_nonzero_exit_is_retained_and_redacted(kanban_home, monkeypatch):
@@ -70,12 +81,62 @@ def test_unknown_dead_pid_is_blocked_not_blindly_retried(kanban_home, monkeypatc
 
 
 def test_preflight_rejects_missing_workspace_before_spawn(kanban_home):
-    task = kb.Task(
-        id="t_preflight", title="preflight", body=None, assignee="missing",
-        status="running", priority=0, created_by=None, created_at=0,
-        started_at=None, completed_at=None, workspace_kind="dir",
-        workspace_path=None, claim_lock="host:1", claim_expires=None, tenant=None,
-    )
-    result = kb._preflight_worker_spawn(task, "/does/not/exist", board="default")
+    result = kb._preflight_worker_spawn(_task(), "/does/not/exist", board="default")
     assert result["ok"] is False
     assert result["code"] == "workspace_invalid"
+
+
+def test_reclaim_never_signals_pid_without_live_gateway_ownership(kanban_home, monkeypatch):
+    """A host-local lock and PID are not proof that this gateway owns it."""
+    calls = []
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+
+    result = kb._terminate_reclaimed_worker(
+        42420, "host:old-dispatcher", signal_fn=lambda *args: calls.append(args),
+    )
+
+    assert calls == []
+    assert result["termination_attempted"] is False
+    assert result["ownership_verified"] is False
+    assert result["ownership_reason"] == "missing_registry_record"
+
+
+def test_reclaim_never_signals_on_process_group_mismatch(kanban_home, monkeypatch):
+    class Proc:
+        pid = 42420
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb.os, "getpgid", lambda _pid: 999)
+    kb._register_worker_process(Proc(), _task("t_owned"), board="default", log_path="/tmp/worker.log")
+    kb._worker_registry[42420].process_group = 111
+    calls = []
+
+    result = kb._terminate_reclaimed_worker(
+        42420, "host:old-dispatcher", signal_fn=lambda *args: calls.append(args),
+    )
+
+    assert calls == []
+    assert result["termination_attempted"] is False
+    assert result["ownership_verified"] is False
+    assert result["ownership_reason"] == "process_group_mismatch"
+
+
+def test_exit_context_is_bounded_and_releases_exited_popen_references(kanban_home, monkeypatch):
+    class Proc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(kb, "_RECENT_WORKER_EXITS_MAX", 8)
+    task = _task("t_bounded")
+    for pid in range(1000, 1032):
+        kb._register_worker_process(Proc(pid), task, board="default", log_path="/tmp/worker.log")
+    kb._poll_registered_workers()
+
+    assert len(kb._recent_worker_exits) <= 8
+    assert len(kb._worker_exit_context) <= 8

--- a/tests/hermes_cli/test_kanban_worker_runtime_contract.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_contract.py
@@ -101,6 +101,32 @@ def test_reclaim_never_signals_pid_without_live_gateway_ownership(kanban_home, m
     assert result["ownership_reason"] == "missing_registry_record"
 
 
+def test_timeout_never_signals_persisted_pid_without_live_gateway_ownership(
+    kanban_home, monkeypatch,
+):
+    """Timeout cleanup cannot kill PID 424242 after a dispatcher restart."""
+    calls = []
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb.time, "time", lambda: 10_000)
+    monkeypatch.setattr(kb.os, "killpg", lambda *args: calls.append(args))
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="expired", assignee="worker", max_runtime_seconds=1,
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="host:old-dispatcher")
+        assert claimed is not None
+        kb._set_worker_pid(conn, task_id, 424242)
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE id = ?",
+            (1, claimed.current_run_id),
+        )
+
+        assert kb.enforce_max_runtime(conn) == []
+
+        assert calls == []
+        assert kb.get_task(conn, task_id).status == "running"
+
+
 def test_reclaim_never_signals_on_process_group_mismatch(kanban_home, monkeypatch):
     class Proc:
         pid = 42420
@@ -122,6 +148,24 @@ def test_reclaim_never_signals_on_process_group_mismatch(kanban_home, monkeypatc
     assert result["termination_attempted"] is False
     assert result["ownership_verified"] is False
     assert result["ownership_reason"] == "process_group_mismatch"
+
+
+def test_execution_route_is_persisted_without_runtime_credentials(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route", assignee="worker")
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+        task.execution_route = {
+            "profile": "worker", "provider": "openai", "model": "gpt-test",
+            "credential_ref": "credential_pool", "api_key": "must-not-persist",
+        }
+        kb._persist_execution_route(conn, task)
+
+        assert kb._latest_execution_route(conn, task_id) == {
+            "profile": "worker", "provider": "openai", "model": "gpt-test",
+            "credential_ref": "credential_pool",
+        }
+        assert "must-not-persist" not in str(kb.list_events(conn, task_id))
 
 
 def test_exit_context_is_bounded_and_releases_exited_popen_references(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_worker_runtime_contract.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_contract.py
@@ -1,0 +1,81 @@
+"""Regression coverage for the dispatcher-owned Kanban worker runtime contract."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    kb._worker_registry.clear()
+    kb._recent_worker_exits.clear()
+    yield home
+    kb._worker_registry.clear()
+
+
+def test_registered_worker_nonzero_exit_is_retained_and_redacted(kanban_home, monkeypatch):
+    class Proc:
+        pid = 42420
+        returncode = 7
+
+        def poll(self):
+            return self.returncode
+
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="runtime", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        kb._register_worker_process(
+            Proc(), claimed, board="default", log_path="/tmp/worker.log",
+            route={"profile": "worker", "provider": "safe", "model": "safe-model"},
+        )
+        kb._set_worker_pid(conn, task_id, Proc.pid)
+
+        assert kb.reap_worker_zombies() == [Proc.pid]
+        assert kb.detect_crashed_workers(conn) == [task_id]
+
+        run = kb.list_runs(conn, task_id)[0]
+        assert run.metadata["exit"]["kind"] == "nonzero_exit"
+        assert run.metadata["exit"]["code"] == 7
+        assert "api_key" not in str(run.metadata).lower()
+
+
+def test_unknown_dead_pid_is_blocked_not_blindly_retried(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="unknown", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        kb._set_worker_pid(conn, task_id, 98765)
+
+        assert kb.detect_crashed_workers(conn) == [task_id]
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert "unknown" in (task.last_failure_error or "")
+        run = kb.list_runs(conn, task_id)[0]
+        assert run.outcome == "unknown_exit"
+        assert run.metadata["exit"]["kind"] == "unknown"
+
+
+def test_preflight_rejects_missing_workspace_before_spawn(kanban_home):
+    task = kb.Task(
+        id="t_preflight", title="preflight", body=None, assignee="missing",
+        status="running", priority=0, created_by=None, created_at=0,
+        started_at=None, completed_at=None, workspace_kind="dir",
+        workspace_path=None, claim_lock="host:1", claim_expires=None, tenant=None,
+    )
+    result = kb._preflight_worker_spawn(task, "/does/not/exist", board="default")
+    assert result["ok"] is False
+    assert result["code"] == "workspace_invalid"

--- a/tests/hermes_cli/test_kanban_worker_runtime_contract.py
+++ b/tests/hermes_cli/test_kanban_worker_runtime_contract.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import pytest
 
@@ -184,3 +185,233 @@ def test_exit_context_is_bounded_and_releases_exited_popen_references(kanban_hom
 
     assert len(kb._recent_worker_exits) <= 8
     assert len(kb._worker_exit_context) <= 8
+
+
+def test_child_inherits_parent_execution_route_and_validated_override(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        claimed = kb.claim_task(conn, parent)
+        assert claimed is not None
+        claimed.execution_route = {
+            "profile": "worker", "provider": "openai", "model": "gpt-parent",
+            "credential_ref": "pool:primary",
+        }
+        kb._persist_execution_route(conn, claimed)
+        child = kb.create_task(
+            conn, title="child", assignee="reviewer", parents=[parent],
+            execution_route_override={"model": "gpt-review"},
+        )
+        assert kb._latest_execution_route(conn, child) == {
+            "profile": "worker", "provider": "openai", "model": "gpt-review",
+            "credential_ref": "pool:primary",
+        }
+        with pytest.raises(ValueError, match="unknown execution route override"):
+            kb.create_task(
+                conn, title="bad", assignee="worker", execution_route_override={"api_key": "secret"},
+            )
+
+
+def test_exit_evidence_is_atomic_consume_once(kanban_home):
+    class Proc:
+        pid = 5151
+
+        def poll(self):
+            return 3
+
+    task = _task("t_once")
+    task.current_run_id = 7
+    kb._register_worker_process(Proc(), task, board="default", log_path="/tmp/worker.log")
+    kb._poll_registered_workers()
+    first = kb._consume_worker_exit(Proc.pid, task.id, task.current_run_id)
+    second = kb._consume_worker_exit(Proc.pid, task.id, task.current_run_id)
+    assert first[:2] == ("nonzero_exit", 3)
+    assert first[2] is not None
+    assert second == ("unknown", None, None)
+
+
+def _prepare_claimed_task(conn, workspace: Path, *, skills=None):
+    task_id = kb.create_task(
+        conn, title="preflight", assignee="worker", workspace_kind="dir",
+        workspace_path=str(workspace), skills=skills,
+    )
+    task = kb.claim_task(conn, task_id, claimer="host:dispatcher")
+    assert task is not None
+    return task
+
+
+def test_canonical_default_route_uses_temp_profile_and_makes_no_model_call(
+    kanban_home, tmp_path, monkeypatch,
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: gpt-from-profile\n", encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: ["file"])
+    calls = []
+
+    def resolve(task, profile, provider, model):
+        calls.append((profile, provider, model))
+        return {"ok": True, "route": {
+            "profile": profile, "provider": provider, "model": model,
+            "credential_ref": "auth.json:openai:0",
+        }}
+
+    monkeypatch.setattr(kb, "_resolve_worker_route", resolve)
+    with kb.connect() as conn:
+        task = _prepare_claimed_task(conn, tmp_path)
+        result = kb._preflight_worker_spawn(task, str(tmp_path), board="default")
+        assert result["ok"] is True
+        assert calls == [("worker", "openrouter", "gpt-from-profile")]
+        assert result["route"]["credential_ref"] == "auth.json:openai:0"
+        assert "api_key" not in json.dumps(result)
+        kb._persist_execution_route(conn, task)
+
+        class Proc:
+            pid = 5252
+
+            def poll(self):
+                return 9
+
+        monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        kb._register_worker_process(
+            Proc(), task, board="default", log_path="/tmp/worker.log", route=result["route"],
+        )
+        kb._set_worker_pid(conn, task.id, Proc.pid)
+        kb._poll_registered_workers()
+        assert kb.detect_crashed_workers(conn) == [task.id]
+        metadata = kb.list_runs(conn, task.id)[0].metadata
+        assert metadata is not None
+        assert metadata["route"] == result["route"]
+        assert "api_key" not in json.dumps(metadata)
+
+
+def test_unavailable_attached_skill_is_typed_preflight_failure_before_popen(
+    kanban_home, tmp_path, monkeypatch,
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: gpt-test\n", encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: ["file"])
+    monkeypatch.setattr(kb, "_resolve_worker_route", lambda *args: {"ok": True, "route": {
+        "profile": "worker", "provider": "openrouter", "model": "gpt-test",
+        "credential_ref": "auth.json:openai:0",
+    }})
+    monkeypatch.setattr("agent.skill_commands.scan_skill_commands", lambda: {})
+    popen_calls = []
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)))
+    with kb.connect() as conn:
+        task = _prepare_claimed_task(conn, tmp_path, skills=["missing-carrier-skill"])
+        result = kb._preflight_worker_spawn(task, str(tmp_path), board="default")
+        assert result["code"] == "skills_invalid"
+        kb._block_preflight_failure(conn, task.id, result)
+        assert popen_calls == []
+        stored = kb.get_task(conn, task.id)
+        assert stored is not None
+        assert stored.status == "blocked"
+        assert stored.consecutive_failures == 0
+        run = kb.list_runs(conn, task.id)[0]
+        assert run.outcome == "preflight_failed"
+        assert "pid gone" not in (run.error or "")
+
+
+def test_invalid_explicit_model_is_rejected_before_popen(kanban_home, tmp_path, monkeypatch):
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: valid-model\n", encoding="utf-8",
+    )
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda home: ["file"])
+    monkeypatch.setattr(kb, "_resolve_worker_route", lambda *args: {
+        "ok": False, "code": "route_invalid", "detail": "model is unavailable for provider",
+    })
+    popen_calls = []
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)))
+    with kb.connect() as conn:
+        task = _prepare_claimed_task(conn, tmp_path)
+        task.model_override = "not-in-catalog"
+        result = kb._preflight_worker_spawn(task, str(tmp_path), board="default")
+        assert result["code"] == "route_invalid"
+        assert result["detail"] == "model is unavailable for provider"
+        assert popen_calls == []
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "scenario", "expected_timeout"),
+    [
+        ("posix", "missing", False),
+        ("posix", "pid_mismatch", False),
+        ("posix", "group_mismatch", False),
+        ("posix", "owned", True),
+        ("nt", "missing", False),
+        ("nt", "pid_mismatch", False),
+        ("nt", "owned", True),
+    ],
+)
+def test_enforce_max_runtime_ownership_matrix(
+    kanban_home, monkeypatch, platform_name, scenario, expected_timeout,
+):
+    class Proc:
+        def __init__(self, pid):
+            self.pid = pid
+            self.terminated = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.terminated = True
+
+    pid = 6060
+    monkeypatch.setattr(kb, "_claimer_id", lambda: "host:dispatcher")
+    monkeypatch.setattr(kb.time, "time", lambda: 10_000)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    real_os = kb.os
+
+    class PlatformOS:
+        name = platform_name
+
+        def getpgid(self, _pid):
+            return 7000 if scenario != "group_mismatch" else 7999
+
+        def __getattr__(self, name):
+            return getattr(real_os, name)
+
+    monkeypatch.setattr(kb, "os", PlatformOS())
+    signals = []
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="timeout", assignee="worker", max_runtime_seconds=1)
+        task = kb.claim_task(conn, task_id, claimer="host:dispatcher")
+        assert task is not None
+        kb._set_worker_pid(conn, task_id, pid)
+        conn.execute("UPDATE task_runs SET started_at=1 WHERE id=?", (task.current_run_id,))
+        proc = Proc(pid)
+        if scenario != "missing":
+            record_pid = pid + 1 if scenario == "pid_mismatch" else pid
+            with kb._worker_registry_lock:
+                kb._worker_registry[pid] = kb._WorkerProcess(
+                    pid=record_pid, task_id=task_id, run_id=task.current_run_id,
+                    board="default", proc=proc, started_at=1, process_group=7000,
+                    log_path="/tmp/worker.log", route={},
+                )
+        result = kb.enforce_max_runtime(
+            conn, signal_fn=(lambda *args: signals.append(args)) if scenario != "missing" else None,
+        )
+        assert (task_id in result) is expected_timeout
+        stored = kb.get_task(conn, task_id)
+        assert stored is not None
+        if not expected_timeout:
+            assert stored.status == "running"
+        elif platform_name == "nt":
+            assert proc.terminated is True
+        else:
+            assert signals


### PR DESCRIPTION
## Summary

This hardens the Kanban worker lifecycle so stale process IDs, reused PIDs, gateway restarts, and inherited provider routes cannot corrupt worker outcomes or terminate an unrelated process.

### What changes

- Bind worker exit evidence to a specific task, run, process identity, and process group.
- Require current in-memory ownership before timeout/reclaim termination; otherwise fail closed.
- Preserve bounded, redacted crash context for real process exits.
- Validate workspace, profile, provider, model, credential reference, toolsets, and skills before spawning.
- Persist the effective provider/model route and deterministically inherit it for reviewer/child tasks.
- Prevent stale exit evidence from being consumed by a newer run.
- Add regression coverage for PID reuse, gateway restart, ownership checks, route inheritance, invalid models/credentials, salvage, and POSIX/Windows termination paths.

## Verification

Rebased onto current `NousResearch/hermes-agent:main` and run from a clean worktree:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_worker_runtime_contract.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/plugins/test_kanban_worker_runs.py -q

436 passed, 0 failed
python -m py_compile hermes_cli/kanban_db.py  # passed
git diff --check origin/main...HEAD          # passed
```

Independent exact-head QA also reproduced the two prior PID-reuse races and validated the canonical provider/model/auth and parent→reviewer inheritance paths.

## Risk and scope

The changes are limited to Kanban worker lifecycle/preflight behavior and its tests. No gateway configuration, secrets, deployment, or runtime activation is included.
