### PR TITLE
feat(goal): add opt-in natural-language goal control

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2282,6 +2282,10 @@ DEFAULT_CONFIG = {
         # negatives (goal actually done but judge says continue) and
         # unbounded model spend on fuzzy / unachievable goals.
         "max_turns": 20,
+        # Expose goal_control to the model so explicit natural-language requests
+        # can start the same durable loop as /goal. Opt-in keeps normal tool
+        # schemas small; the slash command remains available when this is false.
+        "model_tool_enabled": False,
     },
 
     # Mixture of Agents — named presets used by /moa. A preset is an execution

--- a/tests/tools/test_goal_control_tool.py
+++ b/tests/tools/test_goal_control_tool.py
@@ -1,0 +1,136 @@
+import json
+
+from hermes_cli.goals import GoalContract, GoalState
+from tools.goal_control_tool import GOAL_CONTROL_SCHEMA, _available, goal_control
+
+
+class _Manager:
+    state = None
+
+    def __init__(self, session_id, default_max_turns=20):
+        self.session_id = session_id
+        self.default_max_turns = default_max_turns
+
+    def is_active(self):
+        return self.state is not None and self.state.status == "active"
+
+    def has_goal(self):
+        return self.state is not None and self.state.status in {"active", "paused"}
+
+    def status_line(self):
+        return "active" if self.has_goal() else "empty"
+
+    def render_contract(self):
+        if self.state is None:
+            return "(no goal)"
+        return self.state.contract.render_block() or "(no completion contract)"
+
+    def set(self, objective, max_turns=None, contract=None):
+        type(self).state = GoalState(
+            goal=objective,
+            max_turns=max_turns or self.default_max_turns,
+            contract=contract or GoalContract(),
+        )
+        return type(self).state
+
+
+def _setup(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-1")
+    monkeypatch.setattr("hermes_cli.goals.GoalManager", _Manager)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"goals": {"max_turns": 120, "model_tool_enabled": True}},
+    )
+    _Manager.state = None
+
+
+def test_model_tool_is_opt_in(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-1")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"goals": {}})
+    assert _available() is False
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"goals": {"model_tool_enabled": True}},
+    )
+    assert _available() is True
+
+
+def test_start_persists_one_goal(monkeypatch):
+    _setup(monkeypatch)
+
+    first = json.loads(goal_control({"action": "start", "objective": "perfect the project"}))
+    second = json.loads(goal_control({"action": "start", "objective": "replace it"}))
+
+    assert first["started"] is True
+    assert first["max_turns"] == 120
+    assert second["started"] is False
+    assert _Manager.state.goal == "perfect the project"
+
+
+def test_start_persists_completion_contract_and_preserves_it(monkeypatch):
+    _setup(monkeypatch)
+    contract = {
+        "outcome": "Project is production-ready",
+        "verification": "Focused tests and build pass",
+        "constraints": "Keep the public API stable",
+        "boundaries": "Only edit this repository",
+        "stop_when": "A paid service or account approval is required",
+    }
+
+    first = json.loads(
+        goal_control({"action": "start", "objective": "perfect the project", "contract": contract})
+    )
+    second = json.loads(
+        goal_control(
+            {
+                "action": "start",
+                "objective": "replace it",
+                "contract": {"outcome": "different"},
+            }
+        )
+    )
+
+    assert first["started"] is True
+    assert first["contract_attached"] is True
+    assert "Focused tests and build pass" in first["contract"]
+    assert second["started"] is False
+    assert _Manager.state.goal == "perfect the project"
+    assert _Manager.state.contract.to_dict() == contract
+
+
+def test_start_without_contract_keeps_legacy_behavior_and_status_is_read_only(monkeypatch):
+    _setup(monkeypatch)
+
+    started = json.loads(goal_control({"action": "start", "objective": "finish it"}))
+    before = _Manager.state
+    status = json.loads(goal_control({"action": "status"}))
+
+    assert started["contract_attached"] is False
+    assert _Manager.state.contract.is_empty()
+    assert status["active"] is True
+    assert status["contract"] == "(no completion contract)"
+    assert _Manager.state is before
+
+
+def test_contract_schema_rejects_unknown_fields():
+    parameters = GOAL_CONTROL_SCHEMA["parameters"]
+    contract = parameters["properties"]["contract"]
+
+    assert parameters["additionalProperties"] is False
+    assert contract["additionalProperties"] is False
+    assert set(contract["properties"]) == {
+        "outcome",
+        "verification",
+        "constraints",
+        "boundaries",
+        "stop_when",
+    }
+
+
+def test_start_requires_session_and_objective(monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    assert "error" in json.loads(goal_control({"action": "start", "objective": "x"}))
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-1")
+    assert "error" in json.loads(goal_control({"action": "start"}))

--- a/tools/goal_control_tool.py
+++ b/tools/goal_control_tool.py
@@ -1,0 +1,131 @@
+"""Opt-in model control for Hermes' persistent Ralph goal loop.
+
+The slash command remains the default human entry point. This service-gated
+tool lets the model activate the same controller when natural language
+explicitly requests durable autonomous continuation.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error, tool_result
+
+
+def _available() -> bool:
+    if not os.environ.get("HERMES_SESSION_ID", "").strip():
+        return False
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        goals = config.get("goals") if isinstance(config.get("goals"), dict) else {}
+        return bool((goals or {}).get("model_tool_enabled", False))
+    except Exception:
+        return False
+
+
+def goal_control(args: Dict[str, Any], **_: Any) -> str:
+    session_id = os.environ.get("HERMES_SESSION_ID", "").strip()
+    if not session_id:
+        return tool_error("persistent goal control requires an active Hermes session")
+
+    action = str(args.get("action", "status") or "status").strip().lower()
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.goals import GoalContract, GoalManager
+
+        config = load_config() or {}
+        goals = config.get("goals") if isinstance(config.get("goals"), dict) else {}
+        max_turns = int((goals or {}).get("max_turns", 20) or 20)
+        manager = GoalManager(session_id=session_id, default_max_turns=max_turns)
+
+        if action == "status":
+            return tool_result(
+                success=True,
+                active=manager.is_active(),
+                status=manager.status_line(),
+                contract=manager.render_contract(),
+            )
+
+        if action != "start":
+            return tool_error("action must be start or status")
+
+        objective = str(args.get("objective", "") or "").strip()
+        if not objective:
+            return tool_error("objective is required when action is start")
+
+        if manager.has_goal():
+            return tool_result(
+                success=True,
+                started=False,
+                reason="an active or paused goal already exists; preserve it unless the user explicitly replaces it",
+                status=manager.status_line(),
+            )
+
+        contract = GoalContract.from_dict(args.get("contract"))
+        state = manager.set(objective, max_turns=max_turns, contract=contract)
+        return tool_result(
+            success=True,
+            started=True,
+            status=manager.status_line(),
+            max_turns=state.max_turns,
+            contract_attached=not contract.is_empty(),
+            contract=manager.render_contract(),
+            resume="/goal resume",
+            pause="/goal pause",
+            clear="/goal clear",
+        )
+    except Exception as exc:
+        return tool_error(f"goal control failed: {exc}")
+
+
+GOAL_CONTROL_SCHEMA = {
+    "name": "goal_control",
+    "description": (
+        "Activate or inspect Hermes' persistent autonomous goal loop. Use start exactly once when the user explicitly "
+        "asks to keep working until done, perfect/improve something autonomously, or continue for hours or days. "
+        "Do not use for ordinary one-turn tasks, and never replace an existing goal without explicit user intent. "
+        "Preserve the user's intent in objective. For start, add a completion contract whenever the request defines "
+        "evidence, constraints, boundaries, or user/account/legal/cost gates; the contract is the authoritative "
+        "definition of done."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["start", "status"]},
+            "objective": {
+                "type": "string",
+                "description": "The user's exact durable objective. Required for start; omit for status.",
+            },
+            "contract": {
+                "type": "object",
+                "description": (
+                    "Optional structured definition of done. Keep factual acceptance evidence in verification, "
+                    "scope limits in constraints/boundaries, and human/account/legal/cost gates in stop_when."
+                ),
+                "properties": {
+                    "outcome": {"type": "string"},
+                    "verification": {"type": "string"},
+                    "constraints": {"type": "string"},
+                    "boundaries": {"type": "string"},
+                    "stop_when": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "required": ["action"],
+        "additionalProperties": False,
+    },
+}
+
+
+registry.register(
+    name="goal_control",
+    toolset="goal",
+    schema=GOAL_CONTROL_SCHEMA,
+    handler=goal_control,
+    check_fn=_available,
+    emoji="🎯",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -51,7 +51,7 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "memory", "goal_control",
     # NOTE: the desktop Project tools (project_list/create/switch) are
     # deliberately NOT here. They only make sense where a GUI can follow the
     # move, so they live in the `project` toolset and are enabled solely by the
@@ -205,6 +205,12 @@ TOOLSETS = {
         "tools": ["todo"],
         "includes": []
     },
+
+    "goal": {
+        "description": "Opt-in persistent autonomous goal-loop control",
+        "tools": ["goal_control"],
+        "includes": []
+    },
     
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
@@ -355,7 +361,7 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
-            "todo", "memory",
+            "todo", "memory", "goal_control",
             "session_search", "clarify",
             "execute_code", "delegate_task",
         ],
@@ -387,7 +393,7 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
-            "todo", "memory",
+            "todo", "memory", "goal_control",
             "session_search",
             "execute_code", "delegate_task",
         ],

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -846,9 +846,10 @@ When a standing goal is active, Hermes judges whether each assistant response sa
 ```yaml
 goals:
   max_turns: 20   # Max continuation turns before Hermes auto-pauses the goal (default: 20)
+  model_tool_enabled: false  # Let explicit natural-language requests start a goal (opt-in)
 ```
 
-`max_turns` caps how many continuation turns a goal can drive before Hermes auto-pauses it and asks the user to `/goal resume`. It protects against judge false negatives (goal actually done but judge says continue) and unbounded model spend on fuzzy or unachievable goals. See [Goals](/user-guide/features/goals) for the full feature.
+`max_turns` caps how many continuation turns a goal can drive before Hermes auto-pauses it and asks the user to `/goal resume`. `model_tool_enabled` exposes the service-gated `goal_control` tool so requests such as “keep improving this until the tests pass” can create the same persistent goal and completion contract without requiring slash-command syntax. It is disabled by default to keep ordinary tool schemas small. See [Goals](/user-guide/features/goals) for the full feature.
 
 ### API Timeouts
 

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -51,6 +51,8 @@ What you'll see:
 
 Works identically on the CLI and every gateway platform (Telegram, Discord, Slack, Matrix, Signal, WhatsApp, SMS, iMessage, Webhook, API server, and the web dashboard).
 
+If `goals.model_tool_enabled` is enabled, an explicit natural-language request for durable autonomous work can start the same goal loop through the `goal_control` tool. Ordinary one-turn requests still stay one turn, and an existing active or paused goal is preserved rather than silently replaced.
+
 ## Completion contracts
 
 A bare `/goal <text>` works fine, but a *vague* goal makes for vague judging — the judge can only check what you told it to want. Codex's `/goal` guidance makes the same point: a durable objective works best when it names **what done means, how to prove it, what not to break, what's in scope, and when to stop**. Hermes adapts this as an optional **completion contract** layered on top of the existing goal loop.
@@ -181,6 +183,9 @@ goals:
   # /goal resume. Default 20. Lower this if you want tighter loops;
   # raise it for long-running refactors.
   max_turns: 20
+  # Optional: expose goal_control so the model can translate explicit
+  # natural-language autonomy requests into a persistent completion contract.
+  model_tool_enabled: false
 ```
 
 ### Choosing the judge model


### PR DESCRIPTION
## What

Adds an opt-in, service-gated `goal_control` model tool that lets explicit natural-language autonomy requests start Hermes' existing persistent goal loop.

The tool reuses `GoalManager` and `GoalContract` rather than adding a second loop. It preserves:

- the user's objective;
- outcome and verification criteria;
- constraints and scope boundaries;
- human/account/legal/cost stop conditions;
- existing active or paused goals (never silently replaces them).

It is disabled by default through `goals.model_tool_enabled: false`, so normal tool schemas remain unchanged unless a user opts in. Slash commands remain the default interface.

## Why

Hermes already has durable goals and structured completion contracts, but a user must know the `/goal` syntax. This closes the natural-language routing gap for requests such as “keep improving this until the tests pass,” while retaining the same persistence, judge, budget, pause, and resume behavior.

The schema follows current tool-design guidance: detailed use/non-use semantics, a closed JSON object, and explicit definitions of done and stop gates.

## Verification

- `6 passed` — `tests/tools/test_goal_control_tool.py`
- `101 passed` — `tests/hermes_cli/test_goals.py`
- `git diff --check`
- staged secret-pattern scan: 0 hits

## Notes

The implementation is intentionally opt-in to match Hermes' tool-footprint ladder. A future lifecycle change could model user-gated pauses as an explicit resumable `input_required` state; that is outside this PR.