### PR TITLE
fix(kanban): enforce terminal lifecycle and delivery gates

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sqlite3
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -23,6 +25,26 @@ from agent.i18n import t
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+def _format_completed_message(title: str, summary: str = "") -> str:
+    """Render one short completion line without internal task/commit ids."""
+    clean_title = re.sub(
+        r"\b(?:t_[0-9a-f]{8,}|[0-9a-f]{7,40})\b", "", title,
+        flags=re.IGNORECASE,
+    )
+    clean_title = re.sub(r"\s+", " ", clean_title).strip(" -–—:,.\t\r\n") or "Aufgabe"
+    first = f"{clean_title[:120].rstrip()} fertig."
+    pr = re.search(r"PR\s*#(\d+)", summary, re.IGNORECASE)
+    merged = bool(re.search(r"\b(?:gemerged|merged)\b", summary, re.IGNORECASE))
+    production = bool(re.search(r"\bproduction\b", summary, re.IGNORECASE))
+    checked = bool(re.search(r"\b(?:geprüft|verified|ready|success)\b", summary, re.IGNORECASE))
+    details = []
+    if pr and merged:
+        details.append(f"PR #{pr.group(1)} gemerged")
+    if production and checked:
+        details.append("Production geprüft")
+    return first + (" " + ", ".join(details) + "." if details else "")
 
 
 def _resolve_auto_decompose_settings(
@@ -336,34 +358,34 @@ class GatewayKanbanWatchersMixin:
                         continue
                     title = (task.title if task else sub["task_id"])[:120]
                     board_tag = f"[{board_slug}] " if board_slug else ""
+                    receipt_id = None
+                    receipt_event_id = None
+                    completion_finalized = False
                     for ev in d["events"]:
                         kind = ev.kind
+                        if kind == "completed":
+                            existing_receipt = await asyncio.to_thread(
+                                self._kanban_completion_receipt,
+                                sub,
+                                ev.id,
+                                board_slug,
+                            )
+                            if existing_receipt:
+                                receipt_id, receipt_event_id = existing_receipt, ev.id
+                                completion_finalized = True
+                                continue
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
+                            msg = _format_completed_message(
+                                title,
+                                payload_summary or (task.result if task else "") or "",
                             )
                         elif kind == "blocked":
                             reason = ""
@@ -405,7 +427,13 @@ class GatewayKanbanWatchersMixin:
                             # internal transition. They are also excluded from
                             # _WAKE_KINDS below, so they never wake the creator.
                             continue
-                        metadata: dict[str, Any] = {}
+                        metadata: dict[str, Any] = {
+                            "client_msg_id": str(uuid.uuid5(
+                                uuid.NAMESPACE_URL,
+                                f"hermes-kanban:{board_slug}:{sub['task_id']}:{ev.id}:"
+                                f"{sub['platform']}:{sub['chat_id']}:{sub.get('thread_id') or ''}",
+                            )),
+                        }
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         sub_key = (
@@ -413,9 +441,35 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            if getattr(send_result, "success", True) is False:
+                                raise RuntimeError(
+                                    getattr(send_result, "error", None)
+                                    or "notification send failed"
+                                )
+                            message_id = getattr(send_result, "message_id", None)
+                            if platform_str == "slack" and kind == "completed" and not message_id:
+                                raise RuntimeError("Slack completion send returned no message receipt")
+                            if message_id:
+                                receipt_id, receipt_event_id = str(message_id), ev.id
+                            if (
+                                kind == "completed"
+                                and ev.payload
+                                and ev.payload.get("pending_notification_ack")
+                            ):
+                                if not message_id:
+                                    raise RuntimeError("coding completion send returned no message receipt")
+                                completion_finalized = await asyncio.to_thread(
+                                    self._kanban_ack_completion,
+                                    sub,
+                                    ev.id,
+                                    str(message_id),
+                                    board_slug,
+                                )
+                                if not completion_finalized:
+                                    raise RuntimeError("coding completion receipt was not acknowledged")
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
@@ -454,32 +508,23 @@ class GatewayKanbanWatchersMixin:
                                 sub["task_id"], platform_str, fails,
                                 MAX_SEND_FAILURES, exc,
                             )
-                            if fails >= MAX_SEND_FAILURES:
-                                logger.warning(
-                                    "kanban notifier: dropping subscription "
-                                    "%s on %s after %d consecutive send failures",
-                                    sub["task_id"], platform_str, fails,
-                                )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
-                                sub_fail_counts.pop(sub_key, None)
-                            else:
-                                await asyncio.to_thread(
-                                    self._kanban_rewind,
-                                    sub,
-                                    d["cursor"],
-                                    d.get("old_cursor", 0),
-                                    board_slug,
-                                )
-                            # Rewind the pre-send claim on transient failure so
-                            # a later tick can retry. After too many failures,
-                            # dropping the subscription is the terminal action.
+                            await asyncio.to_thread(
+                                self._kanban_rewind,
+                                sub,
+                                d["cursor"],
+                                d.get("old_cursor", 0),
+                                board_slug,
+                            )
+                            # Never delete the only durable delivery route after
+                            # an adapter failure. The event-scoped client_msg_id
+                            # makes repeated sends idempotent.
                             break
                     else:
-                        # All events delivered; advance cursor. The cursor
-                        # is the dedup mechanism — it prevents re-delivery
-                        # of the same event on subsequent ticks.
+                        # All events delivered; acknowledge the lease and retain
+                        # the real platform receipt before terminal unsubscribe.
                         await asyncio.to_thread(
                             self._kanban_advance, sub, d["cursor"], board_slug,
+                            receipt_id, receipt_event_id,
                         )
                         # Unsubscribe only when the task has reached a truly
                         # final status (done / archived). For blocked /
@@ -488,7 +533,9 @@ class GatewayKanbanWatchersMixin:
                         # dispatcher respawns the task and it cycles into the
                         # same state. See the longer comment on TERMINAL_KINDS
                         # above for the failure mode this prevents.
-                        task_terminal = task and task.status in {"done", "archived"}
+                        task_terminal = completion_finalized or (
+                            task and task.status in {"done", "cancelled", "archived"}
+                        )
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         if _wake_kinds:
@@ -575,6 +622,8 @@ class GatewayKanbanWatchersMixin:
 
     def _kanban_advance(
         self, sub: dict, cursor: int, board: Optional[str] = None,
+        message_id: Optional[str] = None,
+        message_event_id: Optional[int] = None,
     ) -> None:
         """Sync helper: advance a subscription's cursor. Runs in to_thread.
 
@@ -591,6 +640,42 @@ class GatewayKanbanWatchersMixin:
                 chat_id=sub["chat_id"],
                 thread_id=sub.get("thread_id") or "",
                 new_cursor=cursor,
+                message_id=message_id,
+                message_event_id=message_event_id,
+            )
+        finally:
+            conn.close()
+
+    def _kanban_completion_receipt(
+        self,
+        sub: dict,
+        event_id: int,
+        board: Optional[str] = None,
+    ) -> Optional[str]:
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            return _kb.completion_receipt_for_event(conn, sub["task_id"], event_id)
+        finally:
+            conn.close()
+
+    def _kanban_ack_completion(
+        self,
+        sub: dict,
+        event_id: int,
+        message_id: str,
+        board: Optional[str] = None,
+    ) -> bool:
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            return _kb.ack_completion_notification(
+                conn,
+                sub["task_id"],
+                event_id=event_id,
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                message_id=message_id,
             )
         finally:
             conn.close()

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -441,6 +441,31 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
+                            if (
+                                kind == "completed"
+                                and platform_str == "slack"
+                                and int(sub.get("pending_event_id") or 0) == ev.id
+                                and hasattr(adapter, "find_message_by_client_msg_id")
+                            ):
+                                recovered = await adapter.find_message_by_client_msg_id(
+                                    sub["chat_id"],
+                                    metadata["client_msg_id"],
+                                    thread_ts=sub.get("thread_id") or None,
+                                )
+                                if recovered:
+                                    completion_finalized = await asyncio.to_thread(
+                                        self._kanban_ack_completion,
+                                        sub,
+                                        ev.id,
+                                        recovered,
+                                        board_slug,
+                                    )
+                                    if not completion_finalized:
+                                        raise RuntimeError(
+                                            "recovered completion receipt was not acknowledged"
+                                        )
+                                    receipt_id, receipt_event_id = recovered, ev.id
+                                    continue
                             send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -676,6 +676,8 @@ class GatewayKanbanWatchersMixin:
                 platform=sub["platform"],
                 chat_id=sub["chat_id"],
                 message_id=message_id,
+                thread_id=sub.get("thread_id") or "",
+                notifier_profile=sub.get("notifier_profile") or None,
             )
         finally:
             conn.close()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -313,6 +313,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--workspace", default="scratch",
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
+    p_create.add_argument(
+        "--delivery-required", action="store_true",
+        help="Require review, merge, production, E2E, and Slack receipt gates before Done",
+    )
     p_create.add_argument("--branch", default=None,
                           help="Branch name for worktree tasks, e.g. wt/t6-wire")
     p_create.add_argument("--project", default=None,
@@ -1359,6 +1363,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            delivery_required=bool(getattr(args, "delivery_required", False)),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -533,6 +533,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
 
+    p_cancel = sub.add_parser("cancel", help="Terminate a task without marking it successful")
+    p_cancel.add_argument("task_id")
+    p_cancel.add_argument("reason", nargs="+", help="Auditable cancellation reason")
+
+    p_reopen = sub.add_parser("reopen", help="Explicitly reopen a done/cancelled task")
+    p_reopen.add_argument("task_id")
+    p_reopen.add_argument("reason", nargs="+", help="Reason for the new handoff generation")
+    p_reopen.add_argument("--actor", default=None,
+                          help="Actor authorizing the reopen (default: active profile)")
+
     p_edit = sub.add_parser(
         "edit",
         help="Edit recovery fields on an already-completed task",
@@ -952,6 +962,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "claim":    _cmd_claim,
             "comment":  _cmd_comment,
             "complete": _cmd_complete,
+            "cancel":   _cmd_cancel,
+            "reopen":   _cmd_reopen,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
@@ -1894,18 +1906,52 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if not kb.complete_task(
-                conn, tid,
-                result=args.result,
-                summary=summary,
-                metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.complete_task(
+                    conn, tid,
+                    result=args.result,
+                    summary=summary,
+                    metadata=metadata,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.CompletionGateError as exc:
+                failed.append(tid)
+                print(str(exc), file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_cancel(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip()
+    with kb.connect_closing() as conn:
+        ok = kb.cancel_task(
+            conn,
+            args.task_id,
+            reason=reason,
+            expected_run_id=_worker_run_id_for(args.task_id),
+        )
+    if not ok:
+        print(f"cannot cancel {args.task_id} (unknown id or terminal state)", file=sys.stderr)
+        return 1
+    print(f"Cancelled {args.task_id}")
+    return 0
+
+
+def _cmd_reopen(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip()
+    actor = args.actor or _profile_author()
+    with kb.connect_closing() as conn:
+        ok = kb.reopen_task(conn, args.task_id, actor=actor, reason=reason)
+    if not ok:
+        print(f"cannot reopen {args.task_id} (not done/cancelled)", file=sys.stderr)
+        return 1
+    print(f"Reopened {args.task_id}")
+    return 0
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -317,6 +317,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--delivery-required", action="store_true",
         help="Require review, merge, production, E2E, and Slack receipt gates before Done",
     )
+    p_create.add_argument("--task-kind", choices=("coding", "general"), default=None)
     p_create.add_argument("--branch", default=None,
                           help="Branch name for worktree tasks, e.g. wt/t6-wire")
     p_create.add_argument("--project", default=None,
@@ -1364,6 +1365,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
             delivery_required=bool(getattr(args, "delivery_required", False)),
+            task_kind=(getattr(args, "task_kind", None) or ("coding" if args.assignee == "developer" else "general")),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,7 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "cancelled", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -915,6 +915,8 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    handoff_version: int = 1
+    pending_completion_event_id: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -999,6 +1001,16 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            handoff_version=(
+                int(row["handoff_version"])
+                if "handoff_version" in keys and row["handoff_version"] is not None
+                else 1
+            ),
+            pending_completion_event_id=(
+                int(row["pending_completion_event_id"])
+                if "pending_completion_event_id" in keys and row["pending_completion_event_id"] is not None
+                else None
+            ),
         )
 
 
@@ -1029,6 +1041,7 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    handoff_version: int = 1
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1053,6 +1066,11 @@ class Run:
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
+            handoff_version=(
+                int(row["handoff_version"])
+                if "handoff_version" in row.keys() and row["handoff_version"] is not None
+                else 1
+            ),
         )
 
 
@@ -1176,7 +1194,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    handoff_version      INTEGER NOT NULL DEFAULT 1,
+    pending_completion_event_id INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1228,7 +1248,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    handoff_version     INTEGER NOT NULL DEFAULT 1
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -1261,6 +1282,11 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     notifier_profile TEXT,
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
+    pending_event_id INTEGER,
+    pending_previous_event_id INTEGER,
+    pending_claimed_at INTEGER,
+    last_message_id TEXT,
+    last_message_event_id INTEGER,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
@@ -1987,6 +2013,26 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "handoff_version" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "handoff_version",
+            "handoff_version INTEGER NOT NULL DEFAULT 1",
+        )
+    if "pending_completion_event_id" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "pending_completion_event_id",
+            "pending_completion_event_id INTEGER",
+        )
+
+    run_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+    }
+    if run_cols and "handoff_version" not in run_cols:
+        _add_column_if_missing(
+            conn, "task_runs", "handoff_version",
+            "handoff_version INTEGER NOT NULL DEFAULT 1",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2026,6 +2072,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if "notifier_profile" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
+            )
+        for column in (
+            "pending_event_id",
+            "pending_previous_event_id",
+            "pending_claimed_at",
+            "last_message_event_id",
+        ):
+            if column not in notify_cols:
+                _add_column_if_missing(
+                    conn, "kanban_notify_subs", column, f"{column} INTEGER"
+                )
+        if "last_message_id" not in notify_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_subs", "last_message_id", "last_message_id TEXT"
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -2140,7 +2200,7 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, handoff_version INTEGER NOT NULL DEFAULT 1)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
@@ -2152,6 +2212,9 @@ _REBUILD_SPECS = {
         " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
         " notifier_profile TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
+        " pending_event_id INTEGER, pending_previous_event_id INTEGER,"
+        " pending_claimed_at INTEGER, last_message_id TEXT,"
+        " last_message_event_id INTEGER,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
     ),
@@ -3212,7 +3275,7 @@ def _synthesize_ended_run(
     """
     now = int(time.time())
     trow = conn.execute(
-        "SELECT assignee, current_step_key FROM tasks WHERE id = ?",
+        "SELECT assignee, current_step_key, handoff_version FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     profile = trow["assignee"] if trow else None
@@ -3223,8 +3286,8 @@ def _synthesize_ended_run(
             task_id, profile, step_key,
             status, outcome,
             summary, error, metadata,
-            started_at, ended_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            started_at, ended_at, handoff_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             task_id, profile, step_key,
@@ -3232,6 +3295,7 @@ def _synthesize_ended_run(
             summary, error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now, now,
+            int(trow["handoff_version"] or 1) if trow else 1,
         ),
     )
     return int(cur.lastrowid or 0)
@@ -3377,7 +3441,7 @@ def claim_task(
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
 ) -> Optional[Task]:
-    """Atomically transition ``ready -> running``.
+    """Atomically claim a ready task or explicitly reopened running task.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
@@ -3403,7 +3467,7 @@ def claim_task(
         if undone:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
-                "WHERE id = ? AND status = 'ready'",
+                "WHERE id = ? AND status IN ('ready', 'running')",
                 (task_id,),
             )
             _append_event(
@@ -3416,7 +3480,8 @@ def claim_task(
         # it when the CAS resets the pointer below. No-op when the invariant
         # holds (the common case).
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'ready'",
+            "SELECT current_run_id FROM tasks "
+            "WHERE id = ? AND status IN ('ready', 'running') AND claim_lock IS NULL",
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -3439,7 +3504,7 @@ def claim_task(
                    claim_expires = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
-               AND status = 'ready'
+               AND status IN ('ready', 'running')
                AND claim_lock IS NULL
             """,
             (lock, expires, now, task_id),
@@ -3447,9 +3512,9 @@ def claim_task(
         if cur.rowcount != 1:
             return None
         # Look up the current task row so we can populate the run with
-        # its assignee / step / runtime cap.
+        # its assignee / step / runtime cap and handoff generation.
         trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key "
+            "SELECT assignee, max_runtime_seconds, current_step_key, handoff_version "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -3458,8 +3523,8 @@ def claim_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                started_at, handoff_version
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -3469,6 +3534,7 @@ def claim_task(
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
+                int(trow["handoff_version"] or 1) if trow else 1,
             ),
         )
         run_id = run_cur.lastrowid
@@ -3980,6 +4046,249 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class CompletionGateError(ValueError):
+    """A coding task tried to finish without objective delivery evidence."""
+
+    def __init__(self, missing: Iterable[str]):
+        self.missing = list(missing)
+        super().__init__(f"coding completion blocked; missing gates: {', '.join(self.missing)}")
+
+
+def _missing_delivery_gates(metadata: Optional[dict]) -> list[str]:
+    raw_delivery = metadata.get("delivery") if isinstance(metadata, dict) else None
+    delivery: dict = raw_delivery if isinstance(raw_delivery, dict) else {}
+    missing: list[str] = []
+    review = delivery.get("review") if isinstance(delivery.get("review"), dict) else {}
+    if str(review.get("verdict", "")).upper() != "PASS" or not review.get("head"):
+        missing.append("review")
+    merge = delivery.get("merge") if isinstance(delivery.get("merge"), dict) else {}
+    if not merge.get("commit"):
+        missing.append("merge")
+    production = delivery.get("production") if isinstance(delivery.get("production"), dict) else {}
+    if production.get("deployed") is not True or not production.get("evidence"):
+        missing.append("production")
+    migration = delivery.get("migration") if isinstance(delivery.get("migration"), dict) else {}
+    if migration.get("required") is not False and not (
+        migration.get("required") is True
+        and migration.get("applied") is True
+        and migration.get("evidence")
+    ):
+        missing.append("migration")
+    e2e = delivery.get("e2e") if isinstance(delivery.get("e2e"), dict) else {}
+    if e2e.get("passed") is not True or not e2e.get("evidence"):
+        missing.append("e2e")
+    return missing
+
+
+def cancel_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Terminate a task as cancelled without emitting a success event."""
+    now = int(time.time())
+    with write_txn(conn):
+        params: list[Any] = [now, task_id]
+        sql = (
+            "UPDATE tasks SET status = 'cancelled', completed_at = ?, result = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "pending_completion_event_id = NULL "
+            "WHERE id = ? AND status IN ('running', 'ready', 'blocked', 'review')"
+        )
+        if expected_run_id is not None:
+            sql += " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(sql, params)
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id, outcome="cancelled", status="cancelled", summary=reason,
+        )
+        if run_id is None:
+            run_id = _synthesize_ended_run(
+                conn, task_id, outcome="cancelled", summary=reason,
+            )
+        _append_event(conn, task_id, "cancelled", {"reason": reason}, run_id=run_id)
+    return True
+
+
+def reopen_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    reason: str,
+) -> bool:
+    """Explicitly reopen a terminal task as a new handoff generation."""
+    with write_txn(conn):
+        previous = conn.execute(
+            "SELECT status, handoff_version FROM tasks "
+            "WHERE id = ? AND status IN ('done', 'cancelled')",
+            (task_id,),
+        ).fetchone()
+        if previous is None:
+            return False
+        version = int(previous["handoff_version"] or 1) + 1
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'running', completed_at = NULL, result = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "current_run_id = NULL, pending_completion_event_id = NULL, "
+            "handoff_version = ? WHERE id = ? AND status = ?",
+            (version, task_id, previous["status"]),
+        )
+        if cur.rowcount != 1:
+            return False
+        conn.execute(
+            "UPDATE tasks SET status = 'todo' WHERE status = 'ready' AND id IN "
+            "(SELECT child_id FROM task_links WHERE parent_id = ?)",
+            (task_id,),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "reopened",
+            {
+                "actor": actor,
+                "reason": reason,
+                "previous_status": previous["status"],
+                "handoff_version": version,
+            },
+        )
+    return True
+
+
+def _prepare_coding_completion(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    result: Optional[str],
+    summary: Optional[str],
+    metadata: Optional[dict],
+    expected_run_id: Optional[int],
+) -> bool:
+    """Persist a completion event while keeping Done closed until receipt ack."""
+    missing = _missing_delivery_gates(metadata)
+    if missing:
+        with write_txn(conn):
+            _append_event(conn, task_id, "completion_blocked_gates", {"missing": missing})
+        raise CompletionGateError(missing)
+
+    with write_txn(conn):
+        params: list[Any] = [result, task_id]
+        sql = (
+            "UPDATE tasks SET status = 'review', result = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND status IN ('running', 'ready', 'blocked')"
+        )
+        if expected_run_id is not None:
+            sql += " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(sql, params)
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn,
+            task_id,
+            outcome="completion_pending",
+            status="review",
+            summary=summary if summary is not None else result,
+            metadata=metadata,
+        )
+        if run_id is None:
+            run_id = _synthesize_ended_run(
+                conn,
+                task_id,
+                outcome="completion_pending",
+                summary=summary if summary is not None else result,
+                metadata=metadata,
+            )
+        ev_summary = ((summary if summary is not None else result) or "").strip()
+        task = get_task(conn, task_id)
+        _append_event(
+            conn,
+            task_id,
+            "completed",
+            {
+                "summary": ev_summary.splitlines()[0][:400] if ev_summary else None,
+                "pending_notification_ack": True,
+                "handoff_version": task.handoff_version if task else 1,
+            },
+            run_id=run_id,
+        )
+        event_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+        conn.execute(
+            "UPDATE tasks SET pending_completion_event_id = ? WHERE id = ?",
+            (event_id, task_id),
+        )
+    return True
+
+
+def ack_completion_notification(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    event_id: int,
+    platform: str,
+    chat_id: str,
+    message_id: str,
+) -> bool:
+    """Finalize a pending coding completion exactly once after real receipt."""
+    if not message_id:
+        return False
+    now = int(time.time())
+    run_id: Optional[int] = None
+    with write_txn(conn):
+        event = conn.execute(
+            "SELECT run_id FROM task_events WHERE id = ? AND task_id = ? "
+            "AND kind = 'completed'",
+            (int(event_id), task_id),
+        ).fetchone()
+        if event is None:
+            return False
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'done', completed_at = ?, "
+            "pending_completion_event_id = NULL, block_kind = NULL, "
+            "block_recurrences = 0 WHERE id = ? AND status = 'review' "
+            "AND pending_completion_event_id = ?",
+            (now, task_id, int(event_id)),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = int(event["run_id"]) if event["run_id"] is not None else None
+        if run_id is not None:
+            conn.execute(
+                "UPDATE task_runs SET status = 'done', outcome = 'completed' WHERE id = ?",
+                (run_id,),
+            )
+        _append_event(
+            conn,
+            task_id,
+            "completion_acknowledged",
+            {
+                "completed_event_id": int(event_id),
+                "platform": platform,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
+            run_id=run_id,
+        )
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    done = get_task(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_completed",
+        task_id,
+        board=get_current_board(),
+        assignee=done.assignee if done else None,
+        run_id=run_id,
+        summary=done.result if done else None,
+    )
+    return True
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4046,6 +4355,17 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    task = get_task(conn, task_id)
+    if task and task.workspace_kind == "worktree":
+        return _prepare_coding_completion(
+            conn,
+            task_id,
+            result=result,
+            summary=summary,
+            metadata=metadata,
+            expected_run_id=expected_run_id,
+        )
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
@@ -4126,6 +4446,7 @@ def complete_task(
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
+            "handoff_version": task.handoff_version if task else 1,
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
@@ -7319,13 +7640,13 @@ def _dispatch_once_locked(
     if max_spawn is not None:
         running_count = int(
             conn.execute(
-                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running' AND claim_lock IS NOT NULL"
             ).fetchone()[0]
         )
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
+        "WHERE status IN ('ready', 'running') AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
@@ -7334,7 +7655,7 @@ def _dispatch_once_locked(
     # pile up and time out.
     if max_in_progress is not None and ready_rows:
         in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running' AND claim_lock IS NOT NULL"
         ).fetchone()[0]
         if in_progress >= max_in_progress:
             return result
@@ -7359,7 +7680,7 @@ def _dispatch_once_locked(
     if _per_profile_cap is not None:
         for prow in conn.execute(
             "SELECT assignee, COUNT(*) AS n FROM tasks "
-            "WHERE status = 'running' AND assignee IS NOT NULL "
+            "WHERE status = 'running' AND claim_lock IS NOT NULL AND assignee IS NOT NULL "
             "GROUP BY assignee"
         ):
             _per_profile_running[prow["assignee"]] = int(prow["n"])
@@ -8296,7 +8617,10 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             pt = get_task(conn, pid)
             if not pt or pt.status != "done":
                 continue
-            runs = [r for r in list_runs(conn, pid) if r.outcome == "completed"]
+            runs = [
+                r for r in list_runs(conn, pid)
+                if r.outcome == "completed" and r.handoff_version == pt.handoff_version
+            ]
             runs.sort(key=lambda r: r.started_at, reverse=True)
             run = runs[0] if runs else None
 
@@ -8319,7 +8643,11 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             elif pt.completed_at:
                 done_ts = pt.completed_at
             age = _relative_age(done_ts, _now)
-            lines.append(f"### {pid}" + (f" (completed {age})" if age else ""))
+            version = f"handoff v{pt.handoff_version}"
+            lines.append(
+                f"### {pid} ({version}"
+                + (f", completed {age})" if age else ")")
+            )
 
             body_lines: list[str] = []
             if run is not None and run.summary and run.summary.strip():
@@ -8353,6 +8681,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             "ORDER BY r.ended_at DESC LIMIT 5",
             (task.assignee, task_id),
         ).fetchall()
+        # Parents are rendered above with generation filtering. Repeating their
+        # older runs here would re-inject superseded truth after a reopen.
+        role_rows = [row for row in role_rows if row["id"] not in parent_ids]
         if role_rows:
             lines.append(f"## Recent work by @{task.assignee}")
             for row in role_rows:
@@ -8605,6 +8936,28 @@ def unseen_events_for_sub(
     return max_id, out
 
 
+def completion_receipt_for_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    event_id: int,
+) -> Optional[str]:
+    """Return the durable platform receipt for an already-acked completion."""
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'completion_acknowledged' ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if int(payload.get("completed_event_id") or 0) == int(event_id):
+            message_id = payload.get("message_id")
+            return str(message_id) if message_id else None
+    return None
+
+
 def claim_unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,
@@ -8630,13 +8983,32 @@ def claim_unseen_events_for_sub(
     """
     with write_txn(conn):
         row = conn.execute(
-            "SELECT last_event_id FROM kanban_notify_subs "
+            "SELECT last_event_id, pending_event_id, pending_previous_event_id, pending_claimed_at "
+            "FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
             (task_id, platform, chat_id, thread_id or ""),
         ).fetchone()
         if row is None:
             return 0, 0, []
         old_cursor = int(row["last_event_id"])
+        pending_cursor = row["pending_event_id"]
+        if pending_cursor is not None:
+            claimed_at = int(row["pending_claimed_at"] or 0)
+            if int(time.time()) - claimed_at < 60:
+                return old_cursor, old_cursor, []
+            previous = int(row["pending_previous_event_id"] or 0)
+            allowed = set(kinds or ())
+            events = [
+                event for event in list_events(conn, task_id)
+                if previous < event.id <= int(pending_cursor)
+                and (not allowed or event.kind in allowed)
+            ]
+            conn.execute(
+                "UPDATE kanban_notify_subs SET pending_claimed_at = ? "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+                (int(time.time()), task_id, platform, chat_id, thread_id or ""),
+            )
+            return previous, int(pending_cursor), events
         new_cursor, events = unseen_events_for_sub(
             conn,
             task_id=task_id,
@@ -8648,10 +9020,14 @@ def claim_unseen_events_for_sub(
         if not events:
             return old_cursor, old_cursor, []
         conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = ?, pending_previous_event_id = ?, pending_claimed_at = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
-            "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            "AND last_event_id = ? AND pending_event_id IS NULL",
+            (
+                int(new_cursor), int(new_cursor), int(old_cursor), int(time.time()),
+                task_id, platform, chat_id, thread_id or "", int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -8664,12 +9040,21 @@ def advance_notify_cursor(
     chat_id: str,
     thread_id: Optional[str] = None,
     new_cursor: int,
+    message_id: Optional[str] = None,
+    message_event_id: Optional[int] = None,
 ) -> None:
     with write_txn(conn):
         conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = NULL, pending_previous_event_id = NULL, pending_claimed_at = NULL, "
+            "last_message_id = COALESCE(?, last_message_id), "
+            "last_message_event_id = COALESCE(?, last_message_event_id) "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND (pending_event_id IS NULL OR pending_event_id = ?)",
+            (
+                int(new_cursor), message_id, message_event_id,
+                task_id, platform, chat_id, thread_id or "", int(new_cursor),
+            ),
         )
 
 
@@ -8691,12 +9076,13 @@ def rewind_notify_cursor(
     """
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE kanban_notify_subs SET last_event_id = ? "
+            "UPDATE kanban_notify_subs SET last_event_id = ?, "
+            "pending_event_id = NULL, pending_previous_event_id = NULL, pending_claimed_at = NULL "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
-            "AND last_event_id = ?",
+            "AND last_event_id = ? AND pending_event_id = ?",
             (
                 int(old_cursor), task_id, platform, chat_id, thread_id or "",
-                int(claimed_cursor),
+                int(claimed_cursor), int(claimed_cursor),
             ),
         )
     return cur.rowcount > 0
@@ -8710,14 +9096,14 @@ def gc_events(
     conn: sqlite3.Connection, *, older_than_seconds: int = 30 * 24 * 3600,
 ) -> int:
     """Delete task_events rows older than ``older_than_seconds`` for tasks
-    in a terminal state (``done`` or ``archived``). Returns the number of
+    in a terminal state (``done``, ``cancelled`` or ``archived``). Returns the number of
     rows deleted. Running / ready / blocked tasks keep their full event
     history."""
     cutoff = int(time.time()) - int(older_than_seconds)
     with write_txn(conn):
         cur = conn.execute(
             "DELETE FROM task_events WHERE created_at < ? AND task_id IN "
-            "(SELECT id FROM tasks WHERE status IN ('done', 'archived'))",
+            "(SELECT id FROM tasks WHERE status IN ('done', 'cancelled', 'archived'))",
             (cutoff,),
         )
     return int(cur.rowcount or 0)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -918,6 +918,7 @@ class Task:
     handoff_version: int = 1
     pending_completion_event_id: Optional[int] = None
     delivery_required: bool = False
+    task_kind: str = "general"
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1016,6 +1017,7 @@ class Task:
                 bool(row["delivery_required"])
                 if "delivery_required" in keys else False
             ),
+            task_kind=row["task_kind"] if "task_kind" in keys else "legacy",
         )
 
 
@@ -1202,7 +1204,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     block_recurrences    INTEGER NOT NULL DEFAULT 0,
     handoff_version      INTEGER NOT NULL DEFAULT 1,
     pending_completion_event_id INTEGER,
-    delivery_required    INTEGER NOT NULL DEFAULT 0
+    delivery_required    INTEGER NOT NULL DEFAULT 0,
+    task_kind            TEXT NOT NULL DEFAULT 'general'
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1294,6 +1297,33 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     last_message_id TEXT,
     last_message_event_id INTEGER,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+
+CREATE TABLE IF NOT EXISTS task_delivery_attestations (
+    task_id TEXT NOT NULL,
+    handoff_version INTEGER NOT NULL,
+    repo TEXT NOT NULL,
+    gate TEXT NOT NULL,
+    head TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    evidence TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (task_id, handoff_version, repo, gate)
+);
+
+CREATE TABLE IF NOT EXISTS completion_deliveries (
+    event_id INTEGER PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    handoff_version INTEGER NOT NULL,
+    platform TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    notifier_profile TEXT,
+    state TEXT NOT NULL DEFAULT 'pending',
+    receipt_id TEXT,
+    created_at INTEGER NOT NULL,
+    acknowledged_at INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
@@ -2030,14 +2060,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "pending_completion_event_id INTEGER",
         )
     if "delivery_required" not in cols:
-        added = _add_column_if_missing(
+        _add_column_if_missing(
             conn, "tasks", "delivery_required",
             "delivery_required INTEGER NOT NULL DEFAULT 0",
         )
-        if added:
-            conn.execute(
-                "UPDATE tasks SET delivery_required = 1 WHERE workspace_kind = 'worktree'"
-            )
+    if "task_kind" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "task_kind", "task_kind TEXT NOT NULL DEFAULT 'legacy'",
+        )
+        conn.execute("UPDATE tasks SET task_kind = 'coding' WHERE delivery_required = 1")
 
     run_cols = {
         row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
@@ -2487,6 +2518,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     delivery_required: bool = False,
+    task_kind: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2512,6 +2544,10 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    if task_kind is None:
+        task_kind = "coding" if delivery_required else "general"
+    if task_kind not in {"coding", "general", "legacy"}:
+        raise ValueError("task_kind must be coding, general, or legacy")
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -2716,8 +2752,8 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, goal_mode, goal_max_turns, session_id,
-                        delivery_required
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        delivery_required, task_kind
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2740,7 +2776,8 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
-                        1 if delivery_required else 0,
+                        1 if task_kind == "coding" else 0,
+                        task_kind,
                     ),
                 )
                 for pid in parents:
@@ -2761,6 +2798,7 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
                         "delivery_required": bool(delivery_required) or None,
+                        "task_kind": task_kind,
                     },
                 )
             return task_id
@@ -4073,76 +4111,83 @@ class CompletionGateError(ValueError):
         super().__init__(f"coding completion blocked; missing gates: {', '.join(self.missing)}")
 
 
+_DELIVERY_GATES = {"review", "merge", "production", "migration", "e2e"}
+_GIT_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def record_delivery_attestation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    repo: str,
+    gate: str,
+    head: str,
+    subject: str,
+    actor: str,
+    evidence: str,
+) -> None:
+    """Persist immutable proof emitted by a trusted delivery integration."""
+    task = get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"unknown task: {task_id}")
+    values = (repo, gate, head, subject, actor, evidence)
+    if gate not in _DELIVERY_GATES or any(not str(value).strip() for value in values):
+        raise ValueError("complete delivery attestation fields are required")
+    if gate in {"review", "merge"} and not _GIT_SHA_RE.fullmatch(head):
+        raise ValueError("review/merge head must be a full git SHA")
+    if gate == "review" and (subject != head or actor.casefold() == str(task.assignee or "").casefold()):
+        raise ValueError("review must pass the attested head under an independent actor")
+    if gate == "merge" and not _GIT_SHA_RE.fullmatch(subject):
+        raise ValueError("merge subject must be a full git SHA")
+    row = (task_id, task.handoff_version, repo, gate, head, subject, actor, evidence, int(time.time()))
+    with write_txn(conn):
+        existing = conn.execute(
+            "SELECT head, subject, actor, evidence FROM task_delivery_attestations "
+            "WHERE task_id = ? AND handoff_version = ? AND repo = ? AND gate = ?",
+            row[:4],
+        ).fetchone()
+        if existing:
+            if tuple(existing) != row[4:8]:
+                raise ValueError("delivery attestation is immutable for this generation")
+            return
+        conn.execute(
+            "INSERT INTO task_delivery_attestations "
+            "(task_id, handoff_version, repo, gate, head, subject, actor, evidence, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            row,
+        )
+
+
 def _missing_delivery_gates(
     conn: sqlite3.Connection,
     task: Task,
     metadata: Optional[dict],
 ) -> list[str]:
-    raw = metadata.get("delivery") if isinstance(metadata, dict) else None
-    delivery: dict[str, Any] = dict(raw) if isinstance(raw, dict) else {}
+    del metadata  # Worker handoff text is never authoritative delivery proof.
+    rows = conn.execute(
+        "SELECT repo, gate, head, subject FROM task_delivery_attestations "
+        "WHERE task_id = ? AND handoff_version = ?",
+        (task.id, task.handoff_version),
+    ).fetchall()
+    by_repo: dict[str, dict[str, sqlite3.Row]] = {}
+    for row in rows:
+        by_repo.setdefault(row["repo"], {})[row["gate"]] = row
+    if not by_repo:
+        return ["review", "merge", "production", "migration", "e2e"]
     missing: list[str] = []
-    final_head = str(delivery.get("final_head") or "")
-    valid_head = bool(re.fullmatch(r"[0-9a-fA-F]{40}", final_head))
-
-    def evidence(value: Any) -> bool:
-        return isinstance(value, str) and bool(re.fullmatch(r"https?://\S+", value.strip()))
-
-    review_raw = delivery.get("review")
-    review: dict[str, Any] = dict(review_raw) if isinstance(review_raw, dict) else {}
-    reviewer = str(review.get("reviewer") or "").strip()
-    if not (
-        valid_head
-        and str(review.get("verdict") or "").upper() == "PASS"
-        and review.get("head") == final_head
-        and reviewer
-        and reviewer.casefold() != str(task.assignee or "").casefold()
-        and evidence(review.get("evidence"))
-    ):
-        missing.append("review")
-
-    merge_raw = delivery.get("merge")
-    merge: dict[str, Any] = dict(merge_raw) if isinstance(merge_raw, dict) else {}
-    merge_commit = str(merge.get("commit") or "")
-    valid_merge = bool(
-        valid_head
-        and merge.get("head") == final_head
-        and re.fullmatch(r"[0-9a-fA-F]{40}", merge_commit)
-        and evidence(merge.get("evidence"))
-    )
-    if not valid_merge:
-        missing.append("merge")
-
-    production_raw = delivery.get("production")
-    production: dict[str, Any] = dict(production_raw) if isinstance(production_raw, dict) else {}
-    if not (
-        valid_merge
-        and production.get("deployed") is True
-        and production.get("commit") == merge_commit
-        and evidence(production.get("evidence"))
-    ):
-        missing.append("production")
-
-    migration_raw = delivery.get("migration")
-    migration: dict[str, Any] = dict(migration_raw) if isinstance(migration_raw, dict) else {}
-    if migration.get("required") is not False and not (
-        migration.get("required") is True
-        and migration.get("applied") is True
-        and migration.get("commit") == merge_commit
-        and evidence(migration.get("evidence"))
-    ):
-        missing.append("migration")
-
-    e2e_raw = delivery.get("e2e")
-    e2e: dict[str, Any] = dict(e2e_raw) if isinstance(e2e_raw, dict) else {}
-    if not (
-        valid_merge
-        and e2e.get("passed") is True
-        and e2e.get("commit") == merge_commit
-        and evidence(e2e.get("evidence"))
-    ):
-        missing.append("e2e")
-
-    return missing
+    for attestations in by_repo.values():
+        review = attestations.get("review")
+        merge = attestations.get("merge")
+        if review is None:
+            missing.append("review")
+        if merge is None or review is None or merge["head"] != review["subject"]:
+            missing.append("merge")
+            merge = None
+        for gate in ("production", "migration", "e2e"):
+            attestation = attestations.get(gate)
+            if merge is None or attestation is None or attestation["head"] != merge["subject"]:
+                missing.append(gate)
+    return list(dict.fromkeys(missing))
 
 
 def cancel_task(
@@ -4154,16 +4199,26 @@ def cancel_task(
 ) -> bool:
     """Terminate a task as cancelled without emitting a success event."""
     now = int(time.time())
-    worker = conn.execute(
-        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?", (task_id,),
-    ).fetchone()
-    termination = _terminate_reclaimed_worker(
-        worker["worker_pid"] if worker else None,
-        worker["claim_lock"] if worker else None,
-    )
-    if _worker_survived_termination(termination):
-        return False
     with write_txn(conn):
+        worker = conn.execute(
+            "SELECT status, current_run_id, worker_pid, claim_lock FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if worker is None or worker["status"] not in {
+            "triage", "todo", "scheduled", "running", "ready", "blocked", "review",
+        }:
+            return False
+        if expected_run_id is not None and worker["current_run_id"] != int(expected_run_id):
+            return False
+
+        termination = _terminate_reclaimed_worker(
+            worker["worker_pid"], worker["claim_lock"],
+        )
+        if worker["worker_pid"] and (
+            not termination.get("host_local") or _worker_survived_termination(termination)
+        ):
+            return False
+
         params: list[Any] = [now, task_id]
         sql = (
             "UPDATE tasks SET status = 'cancelled', completed_at = ?, "
@@ -4177,6 +4232,12 @@ def cancel_task(
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
+        conn.execute(
+            "UPDATE completion_deliveries SET state = 'cancelled' "
+            "WHERE task_id = ? AND state = 'pending'",
+            (task_id,),
+        )
+        conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         run_id = _end_run(
             conn, task_id, outcome="cancelled", status="cancelled", summary=reason,
         )
@@ -4207,6 +4268,17 @@ def reopen_task(
         ).fetchone()
         if previous is None:
             return False
+        historical_run = conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id = ? AND handoff_version = ? LIMIT 1",
+            (task_id, int(previous["handoff_version"] or 1)),
+        ).fetchone()
+        if historical_run is None and previous["result"]:
+            _synthesize_ended_run(
+                conn,
+                task_id,
+                outcome=("completed" if previous["status"] == "done" else "cancelled"),
+                summary=previous["result"],
+            )
         version = int(previous["handoff_version"] or 1) + 1
         cur = conn.execute(
             "UPDATE tasks SET status = 'running', completed_at = NULL, "
@@ -4309,6 +4381,11 @@ def _prepare_coding_completion(
             "UPDATE tasks SET pending_completion_event_id = ? WHERE id = ?",
             (event_id, task_id),
         )
+        conn.execute(
+            "INSERT INTO completion_deliveries "
+            "(event_id, task_id, handoff_version, created_at) VALUES (?, ?, ?, ?)",
+            (event_id, task_id, task.handoff_version, int(time.time())),
+        )
     return True
 
 
@@ -4337,11 +4414,12 @@ def ack_completion_notification(
         if event is None:
             return False
         route = conn.execute(
-            "SELECT notifier_profile FROM kanban_notify_subs WHERE task_id = ? "
-            "AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            "SELECT 1 FROM completion_deliveries WHERE event_id = ? AND task_id = ? "
+            "AND state = 'pending' AND platform = ? AND chat_id = ? "
+            "AND thread_id = ? AND notifier_profile = ?",
+            (int(event_id), task_id, platform, chat_id, thread_id or "", notifier_profile or ""),
         ).fetchone()
-        if route is None or str(route["notifier_profile"] or "") != str(notifier_profile or ""):
+        if route is None:
             return False
         cur = conn.execute(
             "UPDATE tasks SET status = 'done', completed_at = ?, "
@@ -4352,6 +4430,11 @@ def ack_completion_notification(
         )
         if cur.rowcount != 1:
             return False
+        conn.execute(
+            "UPDATE completion_deliveries SET state = 'acknowledged', receipt_id = ?, "
+            "acknowledged_at = ? WHERE event_id = ? AND state = 'pending'",
+            (message_id, now, int(event_id)),
+        )
         run_id = int(event["run_id"]) if event["run_id"] is not None else None
         if run_id is not None:
             conn.execute(
@@ -4453,7 +4536,7 @@ def complete_task(
         verified_cards = []
 
     task = get_task(conn, task_id)
-    if task and task.delivery_required:
+    if task and task.task_kind == "coding":
         return _prepare_coding_completion(
             conn,
             task_id,
@@ -8876,14 +8959,40 @@ def add_notify_sub(
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
     now = int(time.time())
+    thread = thread_id or ""
+    profile = notifier_profile or ""
     with write_txn(conn):
+        pending = conn.execute(
+            "SELECT pending_completion_event_id FROM tasks WHERE id = ? "
+            "AND status = 'review' AND pending_completion_event_id IS NOT NULL",
+            (task_id,),
+        ).fetchone()
+        if pending:
+            event_id = int(pending["pending_completion_event_id"])
+            route = conn.execute(
+                "SELECT platform, chat_id, thread_id, notifier_profile "
+                "FROM completion_deliveries WHERE event_id = ? AND state = 'pending'",
+                (event_id,),
+            ).fetchone()
+            requested = (platform, chat_id, thread, profile)
+            if route and route["platform"] is not None:
+                if tuple(route) != requested:
+                    raise ValueError("pending completion delivery is already bound to another route")
+            else:
+                updated = conn.execute(
+                    "UPDATE completion_deliveries SET platform = ?, chat_id = ?, thread_id = ?, "
+                    "notifier_profile = ? WHERE event_id = ? AND state = 'pending' AND platform IS NULL",
+                    (*requested, event_id),
+                )
+                if updated.rowcount != 1:
+                    raise ValueError("pending completion delivery is already bound to another route")
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
                 (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (task_id, platform, chat_id, thread, user_id, notifier_profile, now),
         )
         if notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -917,6 +917,7 @@ class Task:
     block_recurrences: int = 0
     handoff_version: int = 1
     pending_completion_event_id: Optional[int] = None
+    delivery_required: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1010,6 +1011,10 @@ class Task:
                 int(row["pending_completion_event_id"])
                 if "pending_completion_event_id" in keys and row["pending_completion_event_id"] is not None
                 else None
+            ),
+            delivery_required=(
+                bool(row["delivery_required"])
+                if "delivery_required" in keys else False
             ),
         )
 
@@ -1196,7 +1201,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- the amnesia that let the loop run unbounded).
     block_recurrences    INTEGER NOT NULL DEFAULT 0,
     handoff_version      INTEGER NOT NULL DEFAULT 1,
-    pending_completion_event_id INTEGER
+    pending_completion_event_id INTEGER,
+    delivery_required    INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2023,6 +2029,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "pending_completion_event_id",
             "pending_completion_event_id INTEGER",
         )
+    if "delivery_required" not in cols:
+        added = _add_column_if_missing(
+            conn, "tasks", "delivery_required",
+            "delivery_required INTEGER NOT NULL DEFAULT 0",
+        )
+        if added:
+            conn.execute(
+                "UPDATE tasks SET delivery_required = 1 WHERE workspace_kind = 'worktree'"
+            )
 
     run_cols = {
         row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
@@ -2471,6 +2486,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    delivery_required: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2699,8 +2715,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        delivery_required
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2723,6 +2740,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        1 if delivery_required else 0,
                     ),
                 )
                 for pid in parents:
@@ -2742,6 +2760,7 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "delivery_required": bool(delivery_required) or None,
                     },
                 )
             return task_id
@@ -4054,29 +4073,80 @@ class CompletionGateError(ValueError):
         super().__init__(f"coding completion blocked; missing gates: {', '.join(self.missing)}")
 
 
-def _missing_delivery_gates(metadata: Optional[dict]) -> list[str]:
-    raw_delivery = metadata.get("delivery") if isinstance(metadata, dict) else None
-    delivery: dict = raw_delivery if isinstance(raw_delivery, dict) else {}
+def _missing_delivery_gates(
+    conn: sqlite3.Connection,
+    task: Task,
+    metadata: Optional[dict],
+) -> list[str]:
+    raw = metadata.get("delivery") if isinstance(metadata, dict) else None
+    delivery: dict[str, Any] = dict(raw) if isinstance(raw, dict) else {}
     missing: list[str] = []
-    review = delivery.get("review") if isinstance(delivery.get("review"), dict) else {}
-    if str(review.get("verdict", "")).upper() != "PASS" or not review.get("head"):
+    final_head = str(delivery.get("final_head") or "")
+    valid_head = bool(re.fullmatch(r"[0-9a-fA-F]{40}", final_head))
+
+    def evidence(value: Any) -> bool:
+        return isinstance(value, str) and bool(re.fullmatch(r"https?://\S+", value.strip()))
+
+    review_raw = delivery.get("review")
+    review: dict[str, Any] = dict(review_raw) if isinstance(review_raw, dict) else {}
+    reviewer = str(review.get("reviewer") or "").strip()
+    if not (
+        valid_head
+        and str(review.get("verdict") or "").upper() == "PASS"
+        and review.get("head") == final_head
+        and reviewer
+        and reviewer.casefold() != str(task.assignee or "").casefold()
+        and evidence(review.get("evidence"))
+    ):
         missing.append("review")
-    merge = delivery.get("merge") if isinstance(delivery.get("merge"), dict) else {}
-    if not merge.get("commit"):
+
+    merge_raw = delivery.get("merge")
+    merge: dict[str, Any] = dict(merge_raw) if isinstance(merge_raw, dict) else {}
+    merge_commit = str(merge.get("commit") or "")
+    valid_merge = bool(
+        valid_head
+        and merge.get("head") == final_head
+        and re.fullmatch(r"[0-9a-fA-F]{40}", merge_commit)
+        and evidence(merge.get("evidence"))
+    )
+    if not valid_merge:
         missing.append("merge")
-    production = delivery.get("production") if isinstance(delivery.get("production"), dict) else {}
-    if production.get("deployed") is not True or not production.get("evidence"):
+
+    production_raw = delivery.get("production")
+    production: dict[str, Any] = dict(production_raw) if isinstance(production_raw, dict) else {}
+    if not (
+        valid_merge
+        and production.get("deployed") is True
+        and production.get("commit") == merge_commit
+        and evidence(production.get("evidence"))
+    ):
         missing.append("production")
-    migration = delivery.get("migration") if isinstance(delivery.get("migration"), dict) else {}
+
+    migration_raw = delivery.get("migration")
+    migration: dict[str, Any] = dict(migration_raw) if isinstance(migration_raw, dict) else {}
     if migration.get("required") is not False and not (
         migration.get("required") is True
         and migration.get("applied") is True
-        and migration.get("evidence")
+        and migration.get("commit") == merge_commit
+        and evidence(migration.get("evidence"))
     ):
         missing.append("migration")
-    e2e = delivery.get("e2e") if isinstance(delivery.get("e2e"), dict) else {}
-    if e2e.get("passed") is not True or not e2e.get("evidence"):
+
+    e2e_raw = delivery.get("e2e")
+    e2e: dict[str, Any] = dict(e2e_raw) if isinstance(e2e_raw, dict) else {}
+    if not (
+        valid_merge
+        and e2e.get("passed") is True
+        and e2e.get("commit") == merge_commit
+        and evidence(e2e.get("evidence"))
+    ):
         missing.append("e2e")
+
+    route_count = conn.execute(
+        "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (task.id,)
+    ).fetchone()[0]
+    if int(route_count) != 1:
+        missing.append("notification")
     return missing
 
 
@@ -4089,13 +4159,22 @@ def cancel_task(
 ) -> bool:
     """Terminate a task as cancelled without emitting a success event."""
     now = int(time.time())
+    worker = conn.execute(
+        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    termination = _terminate_reclaimed_worker(
+        worker["worker_pid"] if worker else None,
+        worker["claim_lock"] if worker else None,
+    )
+    if _worker_survived_termination(termination):
+        return False
     with write_txn(conn):
         params: list[Any] = [now, task_id]
         sql = (
-            "UPDATE tasks SET status = 'cancelled', completed_at = ?, result = NULL, "
+            "UPDATE tasks SET status = 'cancelled', completed_at = ?, "
             "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
             "pending_completion_event_id = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked', 'review')"
+            "WHERE id = ? AND status IN ('triage', 'todo', 'scheduled', 'running', 'ready', 'blocked', 'review')"
         )
         if expected_run_id is not None:
             sql += " AND current_run_id = ?"
@@ -4110,7 +4189,10 @@ def cancel_task(
             run_id = _synthesize_ended_run(
                 conn, task_id, outcome="cancelled", summary=reason,
             )
-        _append_event(conn, task_id, "cancelled", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn, task_id, "cancelled",
+            {"reason": reason, "termination": termination}, run_id=run_id,
+        )
     return True
 
 
@@ -4124,7 +4206,7 @@ def reopen_task(
     """Explicitly reopen a terminal task as a new handoff generation."""
     with write_txn(conn):
         previous = conn.execute(
-            "SELECT status, handoff_version FROM tasks "
+            "SELECT status, handoff_version, result FROM tasks "
             "WHERE id = ? AND status IN ('done', 'cancelled')",
             (task_id,),
         ).fetchone()
@@ -4132,7 +4214,7 @@ def reopen_task(
             return False
         version = int(previous["handoff_version"] or 1) + 1
         cur = conn.execute(
-            "UPDATE tasks SET status = 'running', completed_at = NULL, result = NULL, "
+            "UPDATE tasks SET status = 'running', completed_at = NULL, "
             "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
             "current_run_id = NULL, pending_completion_event_id = NULL, "
             "handoff_version = ? WHERE id = ? AND status = ?",
@@ -4140,11 +4222,16 @@ def reopen_task(
         )
         if cur.rowcount != 1:
             return False
-        conn.execute(
-            "UPDATE tasks SET status = 'todo' WHERE status = 'ready' AND id IN "
-            "(SELECT child_id FROM task_links WHERE parent_id = ?)",
-            (task_id,),
-        )
+        demoted = conn.execute(
+            "SELECT id FROM tasks WHERE status = 'ready' AND id IN "
+            "(SELECT child_id FROM task_links WHERE parent_id = ?)", (task_id,),
+        ).fetchall()
+        for child in demoted:
+            conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child["id"],))
+            _append_event(
+                conn, child["id"], "status",
+                {"status": "todo", "reason": "parent_reopened", "parent_id": task_id},
+            )
         _append_event(
             conn,
             task_id,
@@ -4169,7 +4256,10 @@ def _prepare_coding_completion(
     expected_run_id: Optional[int],
 ) -> bool:
     """Persist a completion event while keeping Done closed until receipt ack."""
-    missing = _missing_delivery_gates(metadata)
+    task = get_task(conn, task_id)
+    if task is None:
+        return False
+    missing = _missing_delivery_gates(conn, task, metadata)
     if missing:
         with write_txn(conn):
             _append_event(conn, task_id, "completion_blocked_gates", {"missing": missing})
@@ -4205,7 +4295,6 @@ def _prepare_coding_completion(
                 metadata=metadata,
             )
         ev_summary = ((summary if summary is not None else result) or "").strip()
-        task = get_task(conn, task_id)
         _append_event(
             conn,
             task_id,
@@ -4233,9 +4322,11 @@ def ack_completion_notification(
     platform: str,
     chat_id: str,
     message_id: str,
+    thread_id: str = "",
+    notifier_profile: Optional[str] = None,
 ) -> bool:
     """Finalize a pending coding completion exactly once after real receipt."""
-    if not message_id:
+    if platform != "slack" or not message_id:
         return False
     now = int(time.time())
     run_id: Optional[int] = None
@@ -4246,6 +4337,13 @@ def ack_completion_notification(
             (int(event_id), task_id),
         ).fetchone()
         if event is None:
+            return False
+        route = conn.execute(
+            "SELECT notifier_profile FROM kanban_notify_subs WHERE task_id = ? "
+            "AND platform = ? AND chat_id = ? AND thread_id = ?",
+            (task_id, platform, chat_id, thread_id or ""),
+        ).fetchone()
+        if route is None or str(route["notifier_profile"] or "") != str(notifier_profile or ""):
             return False
         cur = conn.execute(
             "UPDATE tasks SET status = 'done', completed_at = ?, "
@@ -4357,7 +4455,7 @@ def complete_task(
         verified_cards = []
 
     task = get_task(conn, task_id)
-    if task and task.workspace_kind == "worktree":
+    if task and task.delivery_required:
         return _prepare_coding_completion(
             conn,
             task_id,
@@ -5024,63 +5122,8 @@ def edit_completed_task_result(
     summary: Optional[str] = None,
     metadata: Optional[dict] = None,
 ) -> bool:
-    """Backfill the user-visible result for an already completed task."""
-    handoff_summary = summary if summary is not None else result
-    with write_txn(conn):
-        row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (task_id,),
-        ).fetchone()
-        if not row or row["status"] != "done":
-            return False
-        conn.execute(
-            "UPDATE tasks SET result = ? WHERE id = ?",
-            (result, task_id),
-        )
-        run = conn.execute(
-            """
-            SELECT id FROM task_runs
-             WHERE task_id = ?
-               AND outcome = 'completed'
-             ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
-             LIMIT 1
-            """,
-            (task_id,),
-        ).fetchone()
-        run_id = int(run["id"]) if run else None
-        if run_id is None:
-            run_id = _synthesize_ended_run(
-                conn, task_id,
-                outcome="completed",
-                summary=handoff_summary,
-                metadata=metadata,
-            )
-        else:
-            conn.execute(
-                "UPDATE task_runs SET summary = ? WHERE id = ?",
-                (handoff_summary, run_id),
-            )
-            if metadata is not None:
-                conn.execute(
-                    "UPDATE task_runs SET metadata = ? WHERE id = ?",
-                    (json.dumps(metadata, ensure_ascii=False), run_id),
-                )
-        ev_summary = (
-            handoff_summary.strip().splitlines()[0][:400]
-            if handoff_summary else ""
-        )
-        _append_event(
-            conn, task_id, "edited",
-            {
-                "fields": (
-                    ["result", "summary"]
-                    + (["metadata"] if metadata is not None else [])
-                ),
-                "result_len": len(result) if result else 0,
-                "summary": ev_summary or None,
-            },
-            run_id=run_id,
-        )
-    return True
+    """Completed handoffs are immutable; reopen or create a follow-up instead."""
+    return False
 
 
 def block_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4142,11 +4142,6 @@ def _missing_delivery_gates(
     ):
         missing.append("e2e")
 
-    route_count = conn.execute(
-        "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (task.id,)
-    ).fetchone()[0]
-    if int(route_count) != 1:
-        missing.append("notification")
     return missing
 
 
@@ -4294,6 +4289,9 @@ def _prepare_coding_completion(
                 summary=summary if summary is not None else result,
                 metadata=metadata,
             )
+        # Replace creator/progress subscriptions with the single route that
+        # the durable projection outbox installs after observing this event.
+        conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         ev_summary = ((summary if summary is not None else result) or "").strip()
         _append_event(
             conn,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -475,7 +475,11 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
+            # Cancellation is terminal but not successful; keep the visible
+            # workflow stable while preserving the raw status for its badge.
+            col = "done" if t.status == "cancelled" else (
+                t.status if t.status in columns else "todo"
+            )
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks
@@ -811,6 +815,7 @@ class UpdateTaskBody(BaseModel):
     body: Optional[str] = None
     result: Optional[str] = None
     block_reason: Optional[str] = None
+    actor: Optional[str] = None
     # Structured handoff fields — forwarded to complete_task when status
     # transitions to 'done'. Dashboard parity with ``hermes kanban
     # complete --summary ... --metadata ...``.
@@ -843,11 +848,27 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                except kanban_db.CompletionGateError as exc:
+                    raise HTTPException(status_code=409, detail=str(exc)) from exc
+            elif s == "cancelled":
+                if not payload.block_reason:
+                    raise HTTPException(status_code=400, detail="cancelled requires block_reason")
+                ok = kanban_db.cancel_task(conn, task_id, reason=payload.block_reason)
+            elif s == "reopen":
+                if not payload.block_reason:
+                    raise HTTPException(status_code=400, detail="reopen requires block_reason")
+                ok = kanban_db.reopen_task(
+                    conn,
+                    task_id,
+                    actor=payload.actor or "dashboard",
+                    reason=payload.block_reason,
                 )
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
@@ -999,6 +1020,11 @@ def _set_status_direct(
         if prev is None:
             return False
 
+        if prev["status"] in {"done", "cancelled", "archived"}:
+            # Terminal history is immutable through drag/drop; the explicit
+            # reopen verb records actor, reason and a new handoff generation.
+            return False
+
         # Guard: don't allow promoting to 'ready' unless all parents are done.
         # Prevents the dispatcher from spawning a child whose upstream work
         # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
@@ -1015,10 +1041,6 @@ def _set_status_direct(
                 return False
 
         was_running = prev["status"] == "running"
-        reopening_satisfied_parent = (
-            prev["status"] in {"done", "archived"}
-            and new_status not in {"done", "archived"}
-        )
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
@@ -1042,38 +1064,7 @@ def _set_status_direct(
             "VALUES (?, ?, 'status', ?, ?)",
             (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
         )
-        if reopening_satisfied_parent:
-            # A parent leaving done/archived invalidates any direct child that
-            # was sitting in ready solely because that parent used to satisfy
-            # the dependency gate. Demote those children immediately so the
-            # dashboard does not keep advertising stale-ready work.
-            for row in conn.execute(
-                "SELECT child_id FROM task_links WHERE parent_id = ? ORDER BY child_id",
-                (task_id,),
-            ).fetchall():
-                child_id = row["child_id"]
-                demoted = conn.execute(
-                    "UPDATE tasks SET status = 'todo' "
-                    "WHERE id = ? AND status = 'ready'",
-                    (child_id,),
-                )
-                if demoted.rowcount == 1:
-                    conn.execute(
-                        "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                        "VALUES (?, 'status', ?, ?)",
-                        (
-                            child_id,
-                            json.dumps(
-                                {
-                                    "status": "todo",
-                                    "reason": "parent_reopened",
-                                    "parent": task_id,
-                                }
-                            ),
-                            int(time.time()),
-                        ),
-                    )
-    # If we re-opened something, children may have gone stale.
+    # Moving a task to a dependency-satisfying state may unlock children.
     if new_status in {"done", "ready"}:
         kanban_db.recompute_ready(conn)
     return True

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -596,6 +596,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    task_kind: Optional[str] = None
 
 
 @router.post("/tasks")
@@ -620,6 +621,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            task_kind=(payload.task_kind or ("coding" if payload.assignee == "developer" else "general")),
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -475,11 +475,11 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            # Cancellation is terminal but not successful; keep the visible
-            # workflow stable while preserving the raw status for its badge.
-            col = "done" if t.status == "cancelled" else (
-                t.status if t.status in columns else "todo"
-            )
+            # Cancellation is terminal but not successful. It remains
+            # available through task detail/list APIs, never in Done.
+            if t.status == "cancelled":
+                continue
+            col = t.status if t.status in columns else "todo"
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1399,6 +1399,8 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": chunk,
                     "mrkdwn": True,
                 }
+                if i == 0 and metadata and metadata.get("client_msg_id"):
+                    kwargs["client_msg_id"] = str(metadata["client_msg_id"])
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
                 if thread_ts:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1438,6 +1438,29 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def find_message_by_client_msg_id(
+        self,
+        chat_id: str,
+        client_msg_id: str,
+        *,
+        thread_ts: Optional[str] = None,
+    ) -> Optional[str]:
+        """Recover Slack's receipt after a send-response crash window."""
+        try:
+            client = self._get_client(chat_id)
+            response = await (
+                client.conversations_replies(channel=chat_id, ts=thread_ts, limit=100)
+                if thread_ts
+                else client.conversations_history(channel=chat_id, limit=100)
+            )
+            for message in response.get("messages", []):
+                if str(message.get("client_msg_id") or "") == client_msg_id:
+                    receipt = message.get("ts")
+                    return str(receipt) if receipt else None
+        except Exception as exc:
+            logger.warning("[Slack] Failed to recover client_msg_id receipt: %s", exc)
+        return None
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -120,11 +120,11 @@ def test_coding_completion_reaches_done_only_after_receipt(tmp_path, monkeypatch
             workspace_path=str(tmp_path / "worktree"),
             delivery_required=True,
         )
+        assert kb.complete_task(conn, tid, summary="merged production verified", metadata=metadata)
         kb.add_notify_sub(
             conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
             notifier_profile="developer",
         )
-        assert kb.complete_task(conn, tid, summary="merged production verified", metadata=metadata)
         pending = kb.get_task(conn, tid)
         assert pending is not None and pending.status == "review"
 
@@ -153,11 +153,11 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
             workspace_path=str(tmp_path / "worktree"),
             delivery_required=True,
         )
+        assert kb.complete_task(conn, tid, summary="verified", metadata=metadata)
         kb.add_notify_sub(
             conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
             notifier_profile="developer",
         )
-        assert kb.complete_task(conn, tid, summary="verified", metadata=metadata)
         _, _, events = kb.claim_unseen_events_for_sub(
             conn,
             task_id=tid,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 
 from gateway.config import Platform
@@ -13,6 +14,7 @@ class RecordingAdapter:
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        return SimpleNamespace(success=True, message_id=f"receipt-{len(self.sent)}")
 
 
 class DisconnectedAdapters(dict):
@@ -84,8 +86,100 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
-    assert "Kanban" in adapter.sent[0]["text"]
-    assert tid in adapter.sent[0]["text"]
+    assert adapter.sent[0]["text"] == "notify once fertig."
+    assert tid not in adapter.sent[0]["text"]
+
+
+def test_coding_completion_reaches_done_only_after_receipt(tmp_path, monkeypatch):
+    db_path = tmp_path / "coding-receipt.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    metadata = {
+        "delivery": {
+            "review": {"verdict": "PASS", "head": "abc123"},
+            "merge": {"commit": "merge123"},
+            "production": {"deployed": True, "evidence": "release"},
+            "migration": {"required": False},
+            "e2e": {"passed": True, "evidence": "smoke"},
+        }
+    }
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ship coding task",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "worktree"),
+        )
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        assert kb.complete_task(conn, tid, summary="merged production verified", metadata=metadata)
+        pending = kb.get_task(conn, tid)
+        assert pending is not None and pending.status == "review"
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert task is not None and task.status == "done"
+    assert len(adapter.sent) == 1
+    assert [e.kind for e in events].count("completion_acknowledged") == 1
+
+
+def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypatch):
+    db_path = tmp_path / "post-send-crash.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    metadata = {
+        "delivery": {
+            "review": {"verdict": "PASS", "head": "abc123"},
+            "merge": {"commit": "merge123"},
+            "production": {"deployed": True, "evidence": "release"},
+            "migration": {"required": False},
+            "e2e": {"passed": True, "evidence": "smoke"},
+        }
+    }
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="crash-safe completion",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "worktree"),
+        )
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        assert kb.complete_task(conn, tid, summary="verified", metadata=metadata)
+        _, _, events = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed"],
+        )
+        assert len(events) == 1
+        assert kb.ack_completion_notification(
+            conn,
+            tid,
+            event_id=events[0].id,
+            platform="telegram",
+            chat_id="chat-1",
+            message_id="receipt-before-crash",
+        )
+        conn.execute(
+            "UPDATE kanban_notify_subs SET pending_claimed_at = 0 "
+            "WHERE task_id = ?",
+            (tid,),
+        )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    with kb.connect() as conn:
+        assert kb.list_notify_subs(conn) == []
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status == "done"
+    assert adapter.sent == []
 
 
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,12 @@ class RecordingAdapter:
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
         return SimpleNamespace(success=True, message_id=f"receipt-{len(self.sent)}")
+
+    async def find_message_by_client_msg_id(self, chat_id, client_msg_id, *, thread_ts=None):
+        for index, sent in enumerate(self.sent, 1):
+            if sent["chat_id"] == chat_id and sent["metadata"].get("client_msg_id") == client_msg_id:
+                return f"receipt-{index}"
+        return None
 
 
 class DisconnectedAdapters(dict):
@@ -87,6 +94,16 @@ def _delivery_gates():
     }
 
 
+def _record_delivery_gates(conn, task_id):
+    head = "a" * 40
+    merge = "b" * 40
+    kb.record_delivery_attestation(conn, task_id, repo="example/repo", gate="review", head=head, subject=head, actor="reviewer", evidence="review-1")
+    kb.record_delivery_attestation(conn, task_id, repo="example/repo", gate="merge", head=head, subject=merge, actor="github-app", evidence="merge-1")
+    for gate in ("production", "e2e"):
+        kb.record_delivery_attestation(conn, task_id, repo="example/repo", gate=gate, head=merge, subject=f"{gate}-1", actor="delivery-runner", evidence=f"{gate}-1")
+    kb.record_delivery_attestation(conn, task_id, repo="example/repo", gate="migration", head=merge, subject="not-required", actor="delivery-runner", evidence="migration-inventory-1")
+
+
 def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):
     db_path = tmp_path / "shared-kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
@@ -120,6 +137,7 @@ def test_coding_completion_reaches_done_only_after_receipt(tmp_path, monkeypatch
             workspace_path=str(tmp_path / "worktree"),
             delivery_required=True,
         )
+        _record_delivery_gates(conn, tid)
         assert kb.complete_task(conn, tid, summary="merged production verified", metadata=metadata)
         kb.add_notify_sub(
             conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
@@ -144,6 +162,7 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
     metadata = _delivery_gates()
+    adapter = RecordingAdapter()
     with kb.connect() as conn:
         tid = kb.create_task(
             conn,
@@ -153,6 +172,7 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
             workspace_path=str(tmp_path / "worktree"),
             delivery_required=True,
         )
+        _record_delivery_gates(conn, tid)
         assert kb.complete_task(conn, tid, summary="verified", metadata=metadata)
         kb.add_notify_sub(
             conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
@@ -166,29 +186,29 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
             kinds=["completed"],
         )
         assert len(events) == 1
-        assert kb.ack_completion_notification(
-            conn,
-            tid,
-            event_id=events[0].id,
-            platform="slack",
-            chat_id="C0BGA1TAYRY",
-            message_id="receipt-before-crash",
-            notifier_profile="developer",
-        )
+        client_msg_id = str(uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"hermes-kanban:default:{tid}:{events[0].id}:slack:C0BGA1TAYRY:",
+        ))
+        asyncio.run(adapter.send(
+            "C0BGA1TAYRY",
+            "delivered before crash",
+            metadata={"client_msg_id": client_msg_id},
+        ))
         conn.execute(
-            "UPDATE kanban_notify_subs SET pending_claimed_at = 0 "
-            "WHERE task_id = ?",
+            "UPDATE kanban_notify_subs SET pending_claimed_at = 0 WHERE task_id = ?",
             (tid,),
         )
 
-    adapter = RecordingAdapter()
     asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
 
     with kb.connect() as conn:
         assert kb.list_notify_subs(conn) == []
         task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
         assert task is not None and task.status == "done"
-    assert adapter.sent == []
+    assert len(adapter.sent) == 1
+    assert [event.kind for event in events].count("completion_acknowledged") == 1
 
 
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -40,7 +40,8 @@ async def _run_one_notifier_tick(monkeypatch, runner):
 def _make_runner(adapter):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {Platform.TELEGRAM: adapter, Platform.SLACK: adapter}
+    runner._profile_adapters = {"developer": {Platform.SLACK: adapter}}
     runner._kanban_sub_fail_counts = {}
     return runner
 
@@ -71,6 +72,21 @@ def _unseen_terminal_events(tid):
         conn.close()
 
 
+def _delivery_gates():
+    head = "a" * 40
+    merge = "b" * 40
+    return {
+        "delivery": {
+            "final_head": head,
+            "review": {"verdict": "PASS", "head": head, "reviewer": "reviewer", "evidence": "https://example.test/review"},
+            "merge": {"head": head, "commit": merge, "evidence": "https://example.test/merge"},
+            "production": {"deployed": True, "commit": merge, "evidence": "https://example.test/deploy"},
+            "migration": {"required": False},
+            "e2e": {"passed": True, "commit": merge, "evidence": "https://example.test/e2e"},
+        }
+    }
+
+
 def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):
     db_path = tmp_path / "shared-kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
@@ -94,15 +110,7 @@ def test_coding_completion_reaches_done_only_after_receipt(tmp_path, monkeypatch
     db_path = tmp_path / "coding-receipt.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
-    metadata = {
-        "delivery": {
-            "review": {"verdict": "PASS", "head": "abc123"},
-            "merge": {"commit": "merge123"},
-            "production": {"deployed": True, "evidence": "release"},
-            "migration": {"required": False},
-            "e2e": {"passed": True, "evidence": "smoke"},
-        }
-    }
+    metadata = _delivery_gates()
     with kb.connect() as conn:
         tid = kb.create_task(
             conn,
@@ -110,8 +118,12 @@ def test_coding_completion_reaches_done_only_after_receipt(tmp_path, monkeypatch
             assignee="worker",
             workspace_kind="worktree",
             workspace_path=str(tmp_path / "worktree"),
+            delivery_required=True,
         )
-        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
+            notifier_profile="developer",
+        )
         assert kb.complete_task(conn, tid, summary="merged production verified", metadata=metadata)
         pending = kb.get_task(conn, tid)
         assert pending is not None and pending.status == "review"
@@ -131,15 +143,7 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
     db_path = tmp_path / "post-send-crash.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
-    metadata = {
-        "delivery": {
-            "review": {"verdict": "PASS", "head": "abc123"},
-            "merge": {"commit": "merge123"},
-            "production": {"deployed": True, "evidence": "release"},
-            "migration": {"required": False},
-            "e2e": {"passed": True, "evidence": "smoke"},
-        }
-    }
+    metadata = _delivery_gates()
     with kb.connect() as conn:
         tid = kb.create_task(
             conn,
@@ -147,14 +151,18 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
             assignee="worker",
             workspace_kind="worktree",
             workspace_path=str(tmp_path / "worktree"),
+            delivery_required=True,
         )
-        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="slack", chat_id="C0BGA1TAYRY",
+            notifier_profile="developer",
+        )
         assert kb.complete_task(conn, tid, summary="verified", metadata=metadata)
         _, _, events = kb.claim_unseen_events_for_sub(
             conn,
             task_id=tid,
-            platform="telegram",
-            chat_id="chat-1",
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
             kinds=["completed"],
         )
         assert len(events) == 1
@@ -162,9 +170,10 @@ def test_notifier_recovers_post_send_crash_without_duplicate(tmp_path, monkeypat
             conn,
             tid,
             event_id=events[0].id,
-            platform="telegram",
-            chat_id="chat-1",
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
             message_id="receipt-before-crash",
+            notifier_profile="developer",
         )
         conn.execute(
             "UPDATE kanban_notify_subs SET pending_claimed_at = 0 "

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3242,6 +3242,13 @@ class TestMessageSplitting:
         assert adapter._app.client.chat_postMessage.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_send_forwards_event_scoped_client_message_id(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        await adapter.send("C123", "done", metadata={"client_msg_id": "stable-event-id"})
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["client_msg_id"] == "stable-event-id"
+
+    @pytest.mark.asyncio
     async def test_send_preserves_blockquote_formatting(self, adapter):
         """Blockquote '>' markers must survive format → chunk → send pipeline."""
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -494,6 +494,24 @@ def test_run_slash_specify_help_is_reachable(kanban_home):
     assert not out.startswith("⚠")
 
 
+def test_run_slash_cancel_and_reopen_are_explicit(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stop me", assignee="developer")
+
+    assert "Cancelled" in kc.run_slash(f"cancel {tid} no longer needed")
+    with kb.connect() as conn:
+        cancelled = kb.get_task(conn, tid)
+        assert cancelled is not None and cancelled.status == "cancelled"
+
+    assert "Reopened" in kc.run_slash(
+        f"reopen {tid} requirements changed --actor mika"
+    )
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status == "running"
+        assert task.handoff_version == 2
+
+
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_terminal_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_terminal_lifecycle.py
@@ -16,13 +16,16 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 def _delivery_gates():
+    head = "a" * 40
+    merge = "b" * 40
     return {
         "delivery": {
-            "review": {"verdict": "PASS", "head": "final-head"},
-            "merge": {"commit": "merge-commit"},
-            "production": {"deployed": True, "evidence": "deployment-url"},
+            "final_head": head,
+            "review": {"verdict": "PASS", "head": head, "reviewer": "reviewer", "evidence": "https://example.test/review"},
+            "merge": {"head": head, "commit": merge, "evidence": "https://example.test/merge"},
+            "production": {"deployed": True, "commit": merge, "evidence": "https://example.test/deploy"},
             "migration": {"required": False},
-            "e2e": {"passed": True, "evidence": "production-smoke"},
+            "e2e": {"passed": True, "commit": merge, "evidence": "https://example.test/e2e"},
         }
     }
 
@@ -55,6 +58,30 @@ def test_done_task_cannot_run_again_without_explicit_reopen(kanban_home):
         assert kb.claim_task(conn, task_id, claimer="allowed") is not None
 
 
+def test_reopen_preserves_handoff_and_audits_child_demotion(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="developer")
+        child = kb.create_task(conn, title="child", assignee="developer", parents=[parent])
+        assert kb.complete_task(conn, parent, result="historical", summary="historical")
+        assert kb.reopen_task(conn, parent, actor="mika", reason="new work")
+
+        assert kb.get_task(conn, parent).result == "historical"
+        assert kb.get_task(conn, child).status == "todo"
+        assert any(
+            event.kind == "status" and event.payload.get("status") == "todo"
+            for event in kb.list_events(conn, child)
+        )
+
+
+def test_done_handoff_cannot_be_edited_in_place(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="done", assignee="developer")
+        assert kb.complete_task(conn, task_id, result="original", summary="original")
+        assert not kb.edit_completed_task_result(conn, task_id, result="rewritten")
+        assert kb.get_task(conn, task_id).result == "original"
+        assert kb.latest_summary(conn, task_id) == "original"
+
+
 def test_child_reads_only_current_handoff_after_reopen(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="developer")
@@ -77,6 +104,11 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             title="ship code",
             assignee="developer",
             workspace_kind="worktree",
+            delivery_required=True,
+        )
+        kb.add_notify_sub(
+            conn, task_id=task_id, platform="slack", chat_id="C0BGA1TAYRY",
+            notifier_profile="developer",
         )
         claimed = kb.claim_task(conn, task_id, claimer="coder")
         assert claimed is not None
@@ -86,13 +118,7 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
                 conn,
                 task_id,
                 summary="not shipped",
-                metadata={
-                    "delivery": {
-                        "review": {"verdict": "PASS", "head": "final-head"},
-                        "merge": {"commit": "merge-commit"},
-                        "migration": {"required": False},
-                    }
-                },
+                metadata={"delivery": {"migration": {"required": False}}},
                 expected_run_id=claimed.current_run_id,
             )
         assert kb.get_task(conn, task_id).status == "running"
@@ -125,6 +151,7 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             platform="slack",
             chat_id="C0BGA1TAYRY",
             message_id="123.456",
+            notifier_profile="developer",
         )
         done = kb.get_task(conn, task_id)
         assert done.status == "done"
@@ -136,5 +163,6 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             platform="slack",
             chat_id="C0BGA1TAYRY",
             message_id="duplicate",
+            notifier_profile="developer",
         )
         assert [event.kind for event in kb.list_events(conn, task_id)].count("completion_acknowledged") == 1

--- a/tests/hermes_cli/test_kanban_terminal_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_terminal_lifecycle.py
@@ -106,10 +106,6 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             workspace_kind="worktree",
             delivery_required=True,
         )
-        kb.add_notify_sub(
-            conn, task_id=task_id, platform="slack", chat_id="C0BGA1TAYRY",
-            notifier_profile="developer",
-        )
         claimed = kb.claim_task(conn, task_id, claimer="coder")
         assert claimed is not None
 
@@ -133,6 +129,10 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
         pending = kb.get_task(conn, task_id)
         assert pending.status == "review"
         assert pending.pending_completion_event_id is not None
+        kb.add_notify_sub(
+            conn, task_id=task_id, platform="slack", chat_id="C0BGA1TAYRY",
+            notifier_profile="developer",
+        )
 
         assert not kb.ack_completion_notification(
             conn,

--- a/tests/hermes_cli/test_kanban_terminal_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_terminal_lifecycle.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _delivery_gates():
+    return {
+        "delivery": {
+            "review": {"verdict": "PASS", "head": "final-head"},
+            "merge": {"commit": "merge-commit"},
+            "production": {"deployed": True, "evidence": "deployment-url"},
+            "migration": {"required": False},
+            "e2e": {"passed": True, "evidence": "production-smoke"},
+        }
+    }
+
+
+def test_cancelled_task_requires_explicit_reopen_before_new_run(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="cancel me", assignee="developer")
+        first = kb.claim_task(conn, task_id, claimer="first")
+        assert first is not None
+        assert kb.cancel_task(conn, task_id, reason="user stopped", expected_run_id=first.current_run_id)
+
+        assert kb.get_task(conn, task_id).status == "cancelled"
+        assert kb.claim_task(conn, task_id, claimer="forbidden") is None
+
+        assert kb.reopen_task(conn, task_id, actor="mika", reason="resume explicitly")
+        second = kb.claim_task(conn, task_id, claimer="second")
+
+        assert second is not None
+        assert second.current_run_id != first.current_run_id
+        assert [run.outcome for run in kb.list_runs(conn, task_id)] == ["cancelled", None]
+
+
+def test_done_task_cannot_run_again_without_explicit_reopen(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="done", assignee="developer")
+        assert kb.complete_task(conn, task_id, summary="finished")
+
+        assert kb.claim_task(conn, task_id, claimer="forbidden") is None
+        assert kb.reopen_task(conn, task_id, actor="mika", reason="new acceptance")
+        assert kb.claim_task(conn, task_id, claimer="allowed") is not None
+
+
+def test_child_reads_only_current_handoff_after_reopen(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="developer")
+        child = kb.create_task(conn, title="child", assignee="developer", parents=[parent])
+        assert kb.complete_task(conn, parent, summary="old handoff")
+        assert kb.reopen_task(conn, parent, actor="mika", reason="correct old result")
+        assert kb.complete_task(conn, parent, summary="current handoff")
+
+        context = kb.build_worker_context(conn, child)
+
+    assert "current handoff" in context
+    assert "old handoff" not in context
+    assert "handoff v2" in context
+
+
+def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="ship code",
+            assignee="developer",
+            workspace_kind="worktree",
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="coder")
+        assert claimed is not None
+
+        with pytest.raises(kb.CompletionGateError, match="production, e2e"):
+            kb.complete_task(
+                conn,
+                task_id,
+                summary="not shipped",
+                metadata={
+                    "delivery": {
+                        "review": {"verdict": "PASS", "head": "final-head"},
+                        "merge": {"commit": "merge-commit"},
+                        "migration": {"required": False},
+                    }
+                },
+                expected_run_id=claimed.current_run_id,
+            )
+        assert kb.get_task(conn, task_id).status == "running"
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="shipped",
+            metadata=_delivery_gates(),
+            expected_run_id=claimed.current_run_id,
+        )
+        pending = kb.get_task(conn, task_id)
+        assert pending.status == "review"
+        assert pending.pending_completion_event_id is not None
+
+        assert not kb.ack_completion_notification(
+            conn,
+            task_id,
+            event_id=pending.pending_completion_event_id + 1,
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
+            message_id="wrong",
+        )
+        assert kb.get_task(conn, task_id).status == "review"
+
+        assert kb.ack_completion_notification(
+            conn,
+            task_id,
+            event_id=pending.pending_completion_event_id,
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
+            message_id="123.456",
+        )
+        done = kb.get_task(conn, task_id)
+        assert done.status == "done"
+        assert done.pending_completion_event_id is None
+        assert not kb.ack_completion_notification(
+            conn,
+            task_id,
+            event_id=pending.pending_completion_event_id,
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
+            message_id="duplicate",
+        )
+        assert [event.kind for event in kb.list_events(conn, task_id)].count("completion_acknowledged") == 1

--- a/tests/hermes_cli/test_kanban_terminal_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_terminal_lifecycle.py
@@ -30,6 +30,16 @@ def _delivery_gates():
     }
 
 
+def _record_delivery_gates(conn, task_id, *, repo="example/repo"):
+    head = "a" * 40
+    merge = "b" * 40
+    kb.record_delivery_attestation(conn, task_id, repo=repo, gate="review", head=head, subject=head, actor="reviewer", evidence="review-1")
+    kb.record_delivery_attestation(conn, task_id, repo=repo, gate="merge", head=head, subject=merge, actor="github-app", evidence="merge-1")
+    for gate in ("production", "e2e"):
+        kb.record_delivery_attestation(conn, task_id, repo=repo, gate=gate, head=merge, subject=f"{gate}-1", actor="delivery-runner", evidence=f"{gate}-1")
+    kb.record_delivery_attestation(conn, task_id, repo=repo, gate="migration", head=merge, subject="not-required", actor="delivery-runner", evidence="migration-inventory-1")
+
+
 def test_cancelled_task_requires_explicit_reopen_before_new_run(kanban_home):
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="cancel me", assignee="developer")
@@ -46,6 +56,49 @@ def test_cancelled_task_requires_explicit_reopen_before_new_run(kanban_home):
         assert second is not None
         assert second.current_run_id != first.current_run_id
         assert [run.outcome for run in kb.list_runs(conn, task_id)] == ["cancelled", None]
+
+
+def test_cancel_with_stale_run_does_not_signal_current_worker(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="stale cancel", assignee="developer")
+        claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        calls = []
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *args, **kwargs: calls.append(args) or {"terminated": True},
+        )
+
+        assert not kb.cancel_task(
+            conn,
+            task_id,
+            reason="stale request",
+            expected_run_id=claimed.current_run_id + 1,
+        )
+        assert calls == []
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "running"
+
+
+def test_cancel_refuses_to_release_remote_worker_claim(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="remote worker", assignee="developer")
+        claimed = kb.claim_task(conn, task_id, claimer="remote-host:123")
+        assert claimed is not None
+        conn.execute("UPDATE tasks SET worker_pid = 999999 WHERE id = ?", (task_id,))
+
+        assert not kb.cancel_task(
+            conn,
+            task_id,
+            reason="cannot stop remotely",
+            expected_run_id=claimed.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock == "remote-host:123"
 
 
 def test_done_task_cannot_run_again_without_explicit_reopen(kanban_home):
@@ -71,6 +124,21 @@ def test_reopen_preserves_handoff_and_audits_child_demotion(kanban_home):
             event.kind == "status" and event.payload.get("status") == "todo"
             for event in kb.list_events(conn, child)
         )
+
+
+def test_reopen_snapshots_legacy_result_before_next_completion(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy", assignee="developer")
+        assert kb.complete_task(conn, task_id, result="historical")
+        conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+
+        assert kb.reopen_task(conn, task_id, actor="mika", reason="new generation")
+        assert kb.complete_task(conn, task_id, result="current")
+
+        assert [run.summary for run in kb.list_runs(conn, task_id)] == [
+            "historical",
+            "current",
+        ]
 
 
 def test_done_handoff_cannot_be_edited_in_place(kanban_home):
@@ -109,7 +177,7 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
         claimed = kb.claim_task(conn, task_id, claimer="coder")
         assert claimed is not None
 
-        with pytest.raises(kb.CompletionGateError, match="production, e2e"):
+        with pytest.raises(kb.CompletionGateError, match="review, merge, production, migration, e2e"):
             kb.complete_task(
                 conn,
                 task_id,
@@ -119,6 +187,7 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             )
         assert kb.get_task(conn, task_id).status == "running"
 
+        _record_delivery_gates(conn, task_id)
         assert kb.complete_task(
             conn,
             task_id,
@@ -166,3 +235,67 @@ def test_coding_done_waits_for_delivery_gates_and_notification_ack(kanban_home):
             notifier_profile="developer",
         )
         assert [event.kind for event in kb.list_events(conn, task_id)].count("completion_acknowledged") == 1
+
+
+@pytest.mark.parametrize("workspace_kind", ["scratch", "dir", "worktree"])
+def test_developer_tasks_cannot_bypass_delivery_gates_by_workspace(kanban_home, workspace_kind):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="coding", assignee="developer", workspace_kind=workspace_kind, task_kind="coding")
+        with pytest.raises(kb.CompletionGateError):
+            kb.complete_task(conn, task_id, summary="forged", metadata=_delivery_gates())
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_general_worktree_is_not_coding_gated(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="research", assignee="researcher", workspace_kind="worktree", task_kind="general")
+        assert kb.complete_task(conn, task_id, summary="done")
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_pending_completion_route_is_bound_once(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route", assignee="developer", task_kind="coding")
+        _record_delivery_gates(conn, task_id)
+        assert kb.complete_task(conn, task_id, summary="ready")
+        kb.add_notify_sub(conn, task_id=task_id, platform="slack", chat_id="CORCH", notifier_profile="developer")
+        kb.add_notify_sub(conn, task_id=task_id, platform="slack", chat_id="CORCH", notifier_profile="developer")
+        with pytest.raises(ValueError, match="already bound"):
+            kb.add_notify_sub(conn, task_id=task_id, platform="slack", chat_id="CWRONG", notifier_profile="developer")
+        _, _, events = kb.claim_unseen_events_for_sub(conn, task_id=task_id, platform="slack", chat_id="CORCH", kinds=["completed"])
+        assert len(events) == 1
+
+
+def test_cancelled_pending_completion_cannot_be_claimed_for_delivery(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="withdraw completion",
+            assignee="developer",
+            delivery_required=True,
+        )
+        _record_delivery_gates(conn, task_id)
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="must not send",
+            metadata=_delivery_gates(),
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
+            notifier_profile="developer",
+        )
+        assert kb.cancel_task(conn, task_id, reason="withdrawn")
+
+        _, _, events = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            platform="slack",
+            chat_id="C0BGA1TAYRY",
+            kinds=["completed"],
+        )
+
+        assert events == []

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -71,7 +71,7 @@ def test_board_empty(client):
     data = r.json()
     # All canonical columns present (triage + the rest), each empty.
     names = [c["name"] for c in data["columns"]]
-    assert set(names) == kb.VALID_STATUSES - {"archived"}
+    assert set(names) == kb.VALID_STATUSES - {"archived", "cancelled"}
     for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
         assert expected in names, f"missing column {expected}: {names}"
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
@@ -524,14 +524,22 @@ def test_reopening_parent_demotes_ready_child(client):
 
     r = client.patch(
         f"/api/plugins/kanban/tasks/{parent['id']}",
-        json={"status": "todo"},
+        json={
+            "status": "reopen",
+            "block_reason": "acceptance changed",
+            "actor": "operator",
+        },
     )
     assert r.status_code == 200
 
     child_after_reopen = client.get(
         f"/api/plugins/kanban/tasks/{child['id']}"
     ).json()["task"]
+    parent_after_reopen = client.get(
+        f"/api/plugins/kanban/tasks/{parent['id']}"
+    ).json()["task"]
     assert child_after_reopen["status"] == "todo"
+    assert parent_after_reopen["status"] == "running"
 
 
 def test_patch_reassign(client):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -115,6 +115,26 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_cancelled_task_is_not_projected_as_done(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "cancelled", "assignee": "developer"},
+    ).json()["task"]
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "cancelled", "block_reason": "stopped"},
+    )
+    assert response.status_code == 200
+
+    board = client.get("/api/plugins/kanban/board").json()
+    done_ids = {
+        task["id"]
+        for column in board["columns"] if column["name"] == "done"
+        for task in column["tasks"]
+    }
+    assert created["id"] not in done_ids
+
+
 def test_board_list_recommends_persistent_workspace_for_configured_workdir(
     client, tmp_path
 ):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -662,7 +662,15 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            task = kb.get_task(conn, tid)
+            return _ok(
+                task_id=tid,
+                run_id=run.id if run else None,
+                status=task.status if task else None,
+                notification_ack_pending=bool(
+                    task and task.pending_completion_event_id is not None
+                ),
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -827,6 +835,16 @@ def _handle_comment(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            task = kb.get_task(conn, tid)
+            if (
+                tid == os.environ.get("HERMES_KANBAN_TASK")
+                and task
+                and task.status in {"done", "cancelled", "archived"}
+            ):
+                return tool_error(
+                    f"kanban_comment: {tid} is terminal ({task.status}); "
+                    "reopen it explicitly before continuing work"
+                )
             cid = kb.add_comment(conn, tid, author=author, body=str(body))
             return _ok(task_id=tid, comment_id=cid)
         finally:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -898,6 +898,9 @@ def _handle_create(args: dict, **kw) -> str:
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    task_kind = args.get("task_kind") or (
+        "coding" if str(assignee).casefold() == "developer" else "general"
+    )
     delivery_required, delivery_bool_error = _parse_bool_arg(args, "delivery_required")
     if delivery_bool_error:
         return tool_error(delivery_bool_error)
@@ -962,6 +965,7 @@ def _handle_create(args: dict, **kw) -> str:
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
                 delivery_required=delivery_required,
+                task_kind=str(task_kind),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1543,6 +1547,11 @@ KANBAN_CREATE_SCHEMA = {
                     "(when applicable), E2E, and one Slack receipt before Done. "
                     "Use for coding deliveries."
                 ),
+            },
+            "task_kind": {
+                "type": "string",
+                "enum": ["coding", "general"],
+                "description": "Semantic task class; coding fails closed on delivery gates.",
             },
             "skills": {
                 "type": "array",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -898,6 +898,9 @@ def _handle_create(args: dict, **kw) -> str:
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    delivery_required, delivery_bool_error = _parse_bool_arg(args, "delivery_required")
+    if delivery_bool_error:
+        return tool_error(delivery_bool_error)
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -958,6 +961,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                delivery_required=delivery_required,
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1530,6 +1534,14 @@ KANBAN_CREATE_SCHEMA = {
                     "require immediate human ops (R3 gate) to skip the "
                     "brief running-to-blocked transition. Defaults to "
                     "'running', which preserves the usual dispatch path."
+                ),
+            },
+            "delivery_required": {
+                "type": "boolean",
+                "description": (
+                    "Require independent review, merge, production, migration "
+                    "(when applicable), E2E, and one Slack receipt before Done. "
+                    "Use for coding deliveries."
                 ),
             },
             "skills": {


### PR DESCRIPTION
## Summary
- add explicit cancelled and reopen lifecycle with versioned handoffs
- keep coding tasks out of Done until review/merge/deploy/migration/E2E evidence and a durable notification receipt exist
- make completion delivery crash-safe and event-idempotent, including Slack client_msg_id forwarding
- prevent terminal worker continuation and preserve cancelled state in dashboard APIs

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_terminal_lifecycle.py tests/hermes_cli/test_kanban_cli.py tests/gateway/test_kanban_notifier.py tests/gateway/test_slack.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py -q`
- 708 passed