### PR TITLE
fix(whatsapp): never fabricate empty getMessage payloads

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -38,6 +38,7 @@ import {
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  resolveGetMessagePayload,
   extractBridgeEvent,
   inferMediaType,
   mediaPayloadForFile,
@@ -401,9 +402,10 @@ async function startSocket() {
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)
     getMessage: async (key) => {
-      // We don't maintain a message store, so return a placeholder.
-      // This is enough for Baileys to complete the retry handshake.
-      return { conversation: '' };
+      // Never fabricate empty conversation payloads — during E2EE session
+      // churn WhatsApp retries can turn those placeholders into 1000s of
+      // blank user-visible bubbles (#63647). Serve stored payloads only.
+      return resolveGetMessagePayload(messageStore, key);
     },
   });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -40,6 +40,7 @@ import {
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  resolveGetMessagePayload,
   extractBridgeEvent,
   inboundReadReceiptKeys,
   inferMediaType,
@@ -413,9 +414,10 @@ async function startSocket() {
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)
     getMessage: async (key) => {
-      // We don't maintain a message store, so return a placeholder.
-      // This is enough for Baileys to complete the retry handshake.
-      return { conversation: '' };
+      // Never fabricate empty conversation payloads — during E2EE session
+      // churn WhatsApp retries can turn those placeholders into 1000s of
+      // blank user-visible bubbles (#63647). Serve stored payloads only.
+      return resolveGetMessagePayload(messageStore, key);
     },
   });
 

--- a/scripts/whatsapp-bridge/bridge_getmessage.test.mjs
+++ b/scripts/whatsapp-bridge/bridge_getmessage.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createBoundedMessageStore,
+  resolveGetMessagePayload,
+} from './bridge_helpers.js';
+
+test('missing key returns undefined (never empty conversation)', () => {
+  const store = createBoundedMessageStore(8);
+  const payload = resolveGetMessagePayload(store, { id: 'nope' });
+  assert.equal(payload, undefined);
+});
+
+test('null/absent store returns undefined', () => {
+  assert.equal(resolveGetMessagePayload(null, { id: 'x' }), undefined);
+  assert.equal(resolveGetMessagePayload(undefined, { id: 'x' }), undefined);
+  assert.equal(resolveGetMessagePayload(createBoundedMessageStore(), null), undefined);
+  assert.equal(resolveGetMessagePayload(createBoundedMessageStore(), {}), undefined);
+});
+
+test('serves stored message content for retry', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember({
+    key: { id: 'm1' },
+    message: { conversation: 'hello world' },
+  });
+  const payload = resolveGetMessagePayload(store, { id: 'm1' });
+  assert.deepEqual(payload, { conversation: 'hello world' });
+});
+
+test('does not invent empty conversation from empty stored message', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember({
+    key: { id: 'm2' },
+    message: { conversation: '' },
+  });
+  // Real stored empty text is technically present; still return stored object
+  // (not undefined) — the bug was fabricating empty when key was missing.
+  const payload = resolveGetMessagePayload(store, { id: 'm2' });
+  assert.deepEqual(payload, { conversation: '' });
+});
+
+test('retry storm for unknown keys never returns empty conversation', () => {
+  const store = createBoundedMessageStore(8);
+  for (let i = 0; i < 1000; i += 1) {
+    const payload = resolveGetMessagePayload(store, { id: `retry-${i}` });
+    assert.equal(payload, undefined);
+    assert.notDeepEqual(payload, { conversation: '' });
+  }
+});

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -65,6 +65,37 @@ export function createBoundedMessageStore(limit = 512) {
   return { remember, get };
 }
 
+/**
+ * Baileys ``getMessage`` resolution for E2EE / linked-device retries.
+ *
+ * Returning ``{ conversation: '' }`` for missing keys fabricates user-visible
+ * blank bubbles during session churn (#63647). Prefer the real payload from
+ * the bounded message store when available; otherwise return ``undefined``
+ * so Baileys fails the retry handshake without emitting empty content.
+ */
+export function resolveGetMessagePayload(messageStore, key) {
+  const id = key?.id;
+  if (!id || !messageStore || typeof messageStore.get !== 'function') {
+    return undefined;
+  }
+  const stored = messageStore.get(id);
+  if (!stored) {
+    return undefined;
+  }
+  // Prefer the full WebMessageInfo.message when present; avoid inventing text.
+  if (stored.message && typeof stored.message === 'object') {
+    return stored.message;
+  }
+  // Some remember() paths store a synthetic ``message`` field separately.
+  if (stored && typeof stored === 'object' && stored.conversation !== undefined) {
+    const text = stored.conversation;
+    if (typeof text === 'string' && text.length > 0) {
+      return { conversation: text };
+    }
+  }
+  return undefined;
+}
+
 export function pollCreationMessageSecret(pollCreation) {
   return pollCreation?.message?.messageContextInfo?.messageSecret
     || pollCreation?.messageContextInfo?.messageSecret


### PR DESCRIPTION
## Summary

- Baileys getMessage no longer returns empty conversation placeholders
- Missing keys resolve from the bounded messageStore, else undefined (no blank bubbles)

## Motivation

Closes #63647.

During E2EE / linked-device session churn WhatsApp issues many message retries. bridge.js always answered getMessage with { conversation: '' }, which completed the handshake but could emit 1000+ user-visible blank WhatsApp bubbles with no matching gateway outbound log.

## Verification

- node --test scripts/whatsapp-bridge/bridge_getmessage.test.mjs — 5 passed
- Missing-key retry storm (1000x) never returns empty conversation
- Did NOT change: send queue, allowlist, outbound echo tracking, or protocol reconnect path

