### PR TITLE
fix(bedrock): bearer-token auth (anthropic 0.88) + 1M context for Mythos Claude models

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1296,6 +1296,15 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
+    # Mythos-class Claude (Fable 5, Sonnet 5) + Opus 4.7/4.8 — 1M context,
+    # unlocked by the context-1m-2025-08-07 beta that build_anthropic_bedrock_client
+    # sends on every Bedrock Claude request. Without an entry here these fell
+    # through to BEDROCK_DEFAULT_CONTEXT_LENGTH (128K), silently capping the
+    # window far below what the beta already enables.
+    "anthropic.claude-fable-5":      1_000_000,
+    "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
     # Anthropic Claude models on Bedrock
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1296,11 +1296,15 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Mythos-class Claude (Fable 5, Sonnet 5) + Opus 4.7/4.8 — 1M context,
-    # unlocked by the context-1m-2025-08-07 beta that build_anthropic_bedrock_client
-    # sends on every Bedrock Claude request. Without an entry here these fell
-    # through to BEDROCK_DEFAULT_CONTEXT_LENGTH (128K), silently capping the
-    # window far below what the beta already enables.
+    # Mythos-class Claude (Fable 5, Sonnet 5) + Opus 4.7/4.8 — the AWS Bedrock
+    # model cards document a 1M-token context window for each of these models
+    # (default for the model, not beta-gated):
+    #   https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+    #   https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
+    #   https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
+    #   https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
+    # Without an entry here they fell through to BEDROCK_DEFAULT_CONTEXT_LENGTH
+    # (128K), silently capping the usable window far below the documented 1M.
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
-anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+anthropic = ["anthropic==0.88.0"]  # CVE-2026-34450, CVE-2026-34452; 0.88 adds AWS_BEARER_TOKEN_BEDROCK support to AnthropicBedrock
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ dependencies = [
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
-anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+anthropic = ["anthropic==0.88.0"]  # CVE-2026-34450, CVE-2026-34452; 0.88 adds AWS_BEARER_TOKEN_BEDROCK support to AnthropicBedrock
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1195,6 +1195,50 @@ class TestBedrockContextLength:
         # "anthropic.claude-3-5-sonnet" should match before "anthropic.claude-3"
         assert get_bedrock_context_length("anthropic.claude-3-5-sonnet-20240620-v1:0") == 200_000
 
+    def test_claude_fable_5_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-fable-5") == 1_000_000
+
+    def test_claude_sonnet_5_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-sonnet-5") == 1_000_000
+
+    def test_claude_opus_4_8_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8") == 1_000_000
+
+    def test_claude_opus_4_7_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-7") == 1_000_000
+
+    def test_1m_models_regional_inference_profiles_resolve(self):
+        """Geo/global inference-profile IDs must hit the same 1M table entries.
+
+        IDs match the AWS Bedrock model cards, e.g.
+        https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        for profile_id in (
+            "us.anthropic.claude-fable-5",
+            "global.anthropic.claude-fable-5",
+            "us.anthropic.claude-sonnet-5",
+            "eu.anthropic.claude-sonnet-5",
+            "au.anthropic.claude-sonnet-5",
+            "us.anthropic.claude-opus-4-8",
+            "jp.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-opus-4-7",
+        ):
+            assert get_bedrock_context_length(profile_id) == 1_000_000, profile_id
+
+    def test_sonnet_5_does_not_shadow_sonnet_4_x(self):
+        """Longest-key matching must keep Sonnet 4.6-era IDs at 200K."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+
+    def test_opus_4_8_does_not_shadow_opus_4_6(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("us.anthropic.claude-opus-4-6") == 200_000
+
 
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1303,6 +1303,57 @@ class TestBedrockContextProbe:
             assert get_bedrock_context_length(
                 "anthropic.claude-opus-4-6", region="eu-central-1") == 1_000_000
 
+    def test_claude_fable_5_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-fable-5") == 1_000_000
+
+    def test_claude_sonnet_5_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-sonnet-5") == 1_000_000
+
+    def test_claude_opus_4_8_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8") == 1_000_000
+
+    def test_claude_opus_4_7_is_1m(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-7") == 1_000_000
+
+    def test_1m_models_regional_inference_profiles_resolve(self):
+        """Geo/global inference-profile IDs must hit the same 1M table entries.
+
+        IDs match the AWS Bedrock model cards, e.g.
+        https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        for profile_id in (
+            "us.anthropic.claude-fable-5",
+            "global.anthropic.claude-fable-5",
+            "us.anthropic.claude-sonnet-5",
+            "eu.anthropic.claude-sonnet-5",
+            "au.anthropic.claude-sonnet-5",
+            "us.anthropic.claude-opus-4-8",
+            "jp.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-opus-4-7",
+        ):
+            assert get_bedrock_context_length(profile_id) == 1_000_000, profile_id
+
+    def test_sonnet_5_does_not_shadow_sonnet_4_x(self):
+        """Longest-key matching must keep versioned 4.x IDs on their own entries."""
+        from agent.bedrock_adapter import get_bedrock_context_length, BEDROCK_CONTEXT_LENGTHS
+        # sonnet-4-5 (200K) must not be shadowed by the sonnet-5 (1M) entry.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-5") == 200_000
+        # And the 4-6 ID must resolve via its own table entry, not the sonnet-5 one.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == \
+            BEDROCK_CONTEXT_LENGTHS["anthropic.claude-sonnet-4-6"]
+
+    def test_opus_4_8_does_not_shadow_opus_4_x(self):
+        from agent.bedrock_adapter import get_bedrock_context_length, BEDROCK_CONTEXT_LENGTHS
+        # Generic opus-4 (200K) must not be shadowed by opus-4-8 (1M).
+        assert get_bedrock_context_length("anthropic.claude-opus-4-20250514-v1:0") == 200_000
+        assert get_bedrock_context_length("us.anthropic.claude-opus-4-6") == \
+            BEDROCK_CONTEXT_LENGTHS["anthropic.claude-opus-4-6"]
+
 
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection

--- a/tests/agent/test_bedrock_bearer_auth.py
+++ b/tests/agent/test_bedrock_bearer_auth.py
@@ -1,0 +1,61 @@
+"""Bearer-token vs SigV4 auth regression tests for the AnthropicBedrock path.
+
+Hermes routes Claude-on-Bedrock through ``build_anthropic_bedrock_client``
+(``agent/anthropic_adapter.py``), which constructs ``AnthropicBedrock`` with
+no explicit ``api_key`` and relies on the SDK's credential chain. Bearer-token
+auth (``AWS_BEARER_TOKEN_BEDROCK``, short-term ``ABSK…`` keys) is only read by
+the SDK starting with ``anthropic`` 0.88.0 — on 0.87.0 the client is
+SigV4-only and bearer-token users fail at request time with
+``RuntimeError: could not resolve credentials from session``.
+
+These tests exercise the REAL installed SDK (no mocks) so a future pin
+downgrade below 0.88.0 fails loudly here instead of at runtime.
+"""
+
+import pytest
+
+anthropic = pytest.importorskip("anthropic")
+
+_SDK_HAS_BEARER_SUPPORT = tuple(
+    int(part) for part in anthropic.__version__.split(".")[:2]
+) >= (0, 88)
+
+
+class TestBedrockBearerTokenAuth:
+    """``AWS_BEARER_TOKEN_BEDROCK`` must reach the AnthropicBedrock client."""
+
+    def test_installed_sdk_supports_bearer_tokens(self):
+        """The pinned SDK must be >= 0.88.0, the first release whose
+        AnthropicBedrock reads AWS_BEARER_TOKEN_BEDROCK. Guards against the
+        pin (pyproject / tools/lazy_deps.py / uv.lock) drifting back below."""
+        assert _SDK_HAS_BEARER_SUPPORT, (
+            f"anthropic=={anthropic.__version__} predates Bedrock bearer-token "
+            "support (needs >= 0.88.0); bearer-key users regress to "
+            "'could not resolve credentials from session'"
+        )
+
+    def test_bedrock_client_picks_up_bearer_token_env(self, monkeypatch):
+        """With the env var set, the client authenticates via bearer token."""
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+
+        client = build_anthropic_bedrock_client(region="us-east-1")
+        assert client.api_key == "test-bearer-token", (
+            "AnthropicBedrock did not read AWS_BEARER_TOKEN_BEDROCK — "
+            "bearer-token Bedrock auth is broken (SDK pin below 0.88.0?)"
+        )
+
+    def test_bedrock_client_defaults_to_sigv4_without_bearer_token(self, monkeypatch):
+        """Without the env var, the client falls back to the SigV4/boto3
+        credential chain (api_key unset) — bearer support must not break
+        existing IAM/SSO users."""
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+
+        client = build_anthropic_bedrock_client(region="us-east-1")
+        assert client.api_key is None, (
+            "api_key should be unset without AWS_BEARER_TOKEN_BEDROCK so the "
+            "SDK uses the SigV4/boto3 credential chain"
+        )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -96,7 +96,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Inference providers ───────────────────────────────────────────────
     # Native Anthropic SDK — needed when provider=anthropic (not via
     # OpenRouter / aggregators which use the openai SDK).
-    "provider.anthropic": ("anthropic==0.87.0",),  # CVE-2026-34450, CVE-2026-34452
+    "provider.anthropic": ("anthropic==0.88.0",),  # CVE-2026-34450, CVE-2026-34452; 0.88 adds AWS_BEARER_TOKEN_BEDROCK support to AnthropicBedrock
     # AWS Bedrock provider
     "provider.bedrock": ("boto3==1.42.89",),
     # Google Vertex AI provider — OAuth2 token minting for the Gemini

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.87.0"
+version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -307,9 +307,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/8f/3281edf7c35cbac169810e5388eb9b38678c7ea9867c2d331237bd5dff08/anthropic-0.87.0.tar.gz", hash = "sha256:098fef3753cdd3c0daa86f95efb9c8d03a798d45c5170329525bb4653f6702d0", size = 588982, upload-time = "2026-03-31T17:52:41.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/68/565f13059c0a6a6fd5f96f306f2a0fb478a0e1174ec18a4df16b5fac9379/anthropic-0.88.0.tar.gz", hash = "sha256:f4c7f6863d08c869913516f08d658fe53caaf8bcc4fbea3218df343d2a876c58", size = 596654, upload-time = "2026-04-01T19:59:05.287623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/02/99bf351933bdea0545a2b6e2d812ed878899e9a95f618351dfa3d0de0e69/anthropic-0.87.0-py3-none-any.whl", hash = "sha256:e2669b86d42c739d3df163f873c51719552e263a3d85179297180fb4fa00a236", size = 472126, upload-time = "2026-03-31T17:52:40.174Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ac/68f646998160c9f2e6f9353a31dd87292ef02b915b455aaf70a52a059a75/anthropic-0.88.0-py3-none-any.whl", hash = "sha256:71898b32332bc75d9739bc10095288d40a29605da6d00da2fe832b1aa036552f", size = 478338, upload-time = "2026-04-01T19:59:03.832969Z" },
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ requires-dist = [
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.88.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.87.0"
+version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -307,9 +307,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/8f/3281edf7c35cbac169810e5388eb9b38678c7ea9867c2d331237bd5dff08/anthropic-0.87.0.tar.gz", hash = "sha256:098fef3753cdd3c0daa86f95efb9c8d03a798d45c5170329525bb4653f6702d0", size = 588982, upload-time = "2026-03-31T17:52:41.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/68/565f13059c0a6a6fd5f96f306f2a0fb478a0e1174ec18a4df16b5fac9379/anthropic-0.88.0.tar.gz", hash = "sha256:f4c7f6863d08c869913516f08d658fe53caaf8bcc4fbea3218df343d2a876c58", size = 596654, upload-time = "2026-04-01T19:59:05.287623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/02/99bf351933bdea0545a2b6e2d812ed878899e9a95f618351dfa3d0de0e69/anthropic-0.87.0-py3-none-any.whl", hash = "sha256:e2669b86d42c739d3df163f873c51719552e263a3d85179297180fb4fa00a236", size = 472126, upload-time = "2026-03-31T17:52:40.174Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ac/68f646998160c9f2e6f9353a31dd87292ef02b915b455aaf70a52a059a75/anthropic-0.88.0-py3-none-any.whl", hash = "sha256:71898b32332bc75d9739bc10095288d40a29605da6d00da2fe832b1aa036552f", size = 478338, upload-time = "2026-04-01T19:59:03.832969Z" },
 ]
 
 [[package]]
@@ -1743,7 +1743,7 @@ requires-dist = [
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.88.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },


### PR DESCRIPTION
Two related fixes for Anthropic Claude models on AWS Bedrock. Happy to split into two PRs if preferred.

---

## 1. Bump `anthropic` 0.87.0 → 0.88.0 — Bedrock bearer-token auth

**Why.** `0.88.0` is the first release whose `AnthropicBedrock` client reads the `AWS_BEARER_TOKEN_BEDROCK` bearer token. On `0.87.0`, `AnthropicBedrock` is SigV4-only, so bring-your-own-key **bearer-token** auth to Bedrock (short-term `ABSK…` keys) fails at request time with:

```
RuntimeError: could not resolve credentials from session
```

Hermes routes Claude-on-Bedrock through `AnthropicBedrock` (`agent/anthropic_adapter.py::build_anthropic_bedrock_client`, constructed with no explicit `api_key`, relying on the SDK's env/credential chain), so on `0.87.0` the entire bearer-token Bedrock path for Claude is unusable. `0.88.0`'s `AnthropicBedrock.__init__` adds `api_key = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")`, so the existing call site works with **zero code changes**.

**Safety.** Minimal (single minor), additive (0.88 adds Bedrock bearer auth + `stop_details`; no breaking Messages/Bedrock API changes), and security-preserving (0.88 ≥ 0.87, so CVE-2026-34450 / CVE-2026-34452 fixes are retained).

**Pins moved in lockstep** (a mismatch makes the runtime lazy-installer in `tools/lazy_deps.py` silently downgrade a manually-upgraded install back to 0.87.0):
- `pyproject.toml` — `[anthropic]` extra
- `tools/lazy_deps.py` — `provider.anthropic`
- `uv.lock` — `anthropic` package + specifier (`uv lock --check` passes)

**Tested.** Against Bedrock `us-east-1` with a bearer token, `AnthropicBedrock` (0.88.0) picks up `AWS_BEARER_TOKEN_BEDROCK` and both `us.anthropic.claude-fable-5` and `us.anthropic.claude-sonnet-5` return successful completions. New regression tests in `tests/agent/test_bedrock_bearer_auth.py` exercise the real installed SDK through `build_anthropic_bedrock_client`: bearer env var is picked up as `api_key`, absence falls back to the SigV4/boto3 chain, and the installed `anthropic` version is asserted `>= 0.88.0` so a future pin downgrade fails in CI rather than at request time.

---

## 2. 1M context window for Mythos-class Claude on Bedrock

**What.** Add `anthropic.claude-fable-5`, `anthropic.claude-sonnet-5`, `anthropic.claude-opus-4-8`, `anthropic.claude-opus-4-7` to `BEDROCK_CONTEXT_LENGTHS` (`agent/bedrock_adapter.py`) at `1_000_000`.

**Why.** For `provider: bedrock`, `get_model_context_length()` short-circuits to the static `BEDROCK_CONTEXT_LENGTHS` table. These newer models are absent, so they fall through to `BEDROCK_DEFAULT_CONTEXT_LENGTH` (128K) — capping their usable window far below the documented ceiling.

**Basis for 1M (verified against the AWS Bedrock model cards).** Each model's official Bedrock model card documents **Context window: 1M tokens** as the model default (not beta-gated):
- [Claude Fable 5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)
- [Claude Sonnet 5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html)
- [Claude Opus 4.8](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html)
- [Claude Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html)

The in-code comment now cites these model cards instead of generalizing the `context-1m-2025-08-07` beta-header behavior (whose documented scope in `agent/anthropic_adapter.py` is Opus 4.6/4.7 and Sonnet 4.6).

**Tests.** `tests/agent/test_bedrock_adapter.py::TestBedrockContextLength` now covers all four bare IDs, their geo/global inference-profile forms (`us.`/`eu.`/`jp.`/`au.`/`global.` per the model cards), and non-shadowing checks that `sonnet-5` / `opus-4-8` entries do not disturb the existing 200K `sonnet-4-6` / `opus-4-6` resolutions.
