### PR TITLE
fix(desktop): re-assert +x on staged node-pty spawn-helper

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -20,6 +21,24 @@ import {
   rmSync
 } from 'node:fs'
 import { isMain } from './utils.mjs'
+
+/**
+ * Copy a native helper, re-asserting +x on the destination.
+ *
+ * cpSync preserves the source mode, and node-pty's published `spawn-helper`
+ * can arrive from npm without its execute bit. node-pty posix_spawnp()s that
+ * binary on darwin, so a stripped mode surfaces only at runtime, as an opaque
+ * "posix_spawnp failed" the first time a terminal is opened. Re-assert the bit
+ * rather than trusting whatever mode the package manager left behind.
+ */
+function copyExecutable(src, dest) {
+  cpSync(src, dest)
+  try {
+    chmodSync(dest, 0o755)
+  } catch {
+    // Best-effort: a failed chmod is still better than an unhandled throw here.
+  }
+}
 
 const here = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(here, '..')
@@ -71,7 +90,11 @@ function copyBuildRelease(srcDir, destDir) {
       cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
       continue
     }
-    if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
+    if (entry.name === 'spawn-helper') {
+      copyExecutable(join(srcDir, entry.name), join(destDir, entry.name))
+      continue
+    }
+    if (/\.(node|dll|exe)$/.test(entry.name)) {
       cpSync(join(srcDir, entry.name), join(destDir, entry.name))
     }
   }
@@ -114,7 +137,7 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        copyExecutable(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
       }
     }
   } else {


### PR DESCRIPTION
## Problem

Opening the embedded terminal in the desktop app fails with:

```
Terminal failed to start: Error invoking remote method 'hermes:terminal:start': Error: posix_spawnp failed.
```

On darwin, node-pty does not exec the shell directly — it `posix_spawnp()`s a native `spawn-helper` binary, which then execs the shell. That binary ships from npm **without its execute bit** (mode `0644`). `cpSync` faithfully preserves the broken mode into `dist/`, and electron-builder then carries it into `app.asar.unpacked`, so the packaged app spawns a helper it isn't allowed to execute. The kernel returns `EACCES` and node-pty surfaces it as the opaque `posix_spawnp failed`.

Nothing in the build output hints at this; it only shows up the first time a user opens a terminal.

## Root cause

`stage-native-deps.mjs` copies `spawn-helper` with a bare `cpSync` at both staging sites (`build/Release` and `prebuilds/<platform>-<arch>`), inheriting whatever mode npm left behind.

The previous `.cjs` version of this script re-asserted `+x` explicitly, with a comment warning that "a stripped mode would be silently broken at runtime". The `.mjs` rewrite dropped that defense — this restores it.

## Fix

Route `spawn-helper` through a `copyExecutable()` helper that `chmod 0755`s the destination after copying, applied at both staging sites.

## Verification

- Ran the staging script end-to-end: it wipes and re-stages `dist/`, and the helper now comes out `-rwxr-xr-x` where the same step previously produced `-rw-r--r--`.
- Spawned `zsh -il` through node-pty against the freshly staged tree: the pty comes up and the shell echoes back.
- Controlled A/B against the app's own node-pty: at `0644` it reproduces `Error: posix_spawnp failed.` verbatim; at `0755` it passes.

## Note for reviewers

This fixes the staging path, which is what the packaged app consumes. The underlying `0644` originates in node-pty's tarball extraction into the root `node_modules/`, so any *other* consumer loading node-pty directly from that tree would still hit the same wall. A root-level postinstall chmod would close that off more broadly if it's worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)