### PR TITLE
fix(codex): stop double-counting cached input tokens in app-server usage accounting

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -143,8 +143,16 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
 
-    input_tokens = _coerce_usage_int(usage.get("inputTokens"))
+    input_total = _coerce_usage_int(usage.get("inputTokens"))
     cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
+    # Codex reports ``inputTokens`` INCLUSIVE of ``cachedInputTokens`` (same
+    # contract as the Responses API — see usage_pricing.normalize_usage's
+    # ``codex_responses`` branch). CanonicalUsage.prompt_tokens re-adds
+    # cache_read on top of input_tokens, so the canonical input bucket must be
+    # the UNCACHED remainder or the cached tokens are counted twice. The
+    # app-server transport exposes no cache-write, so subtract cache-read only
+    # (matching cache_write_tokens=0 below).
+    input_tokens = max(0, input_total - cache_read_tokens)
     output_tokens = _coerce_usage_int(usage.get("outputTokens"))
     reasoning_tokens = _coerce_usage_int(usage.get("reasoningOutputTokens"))
     reported_total = _coerce_usage_int(usage.get("totalTokens"))

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -110,27 +110,32 @@ class TestRunConversationCodexPath:
         with patch.object(agent, "_spawn_background_review", return_value=None):
             result = agent.run_conversation("hello")
 
+        # Codex reports inputTokens (80) INCLUSIVE of cachedInputTokens (20).
+        # The canonical uncached-input bucket is therefore 80 - 20 = 60, and
+        # prompt_tokens (uncached + cache_read) is 60 + 20 = 80 — NOT 100, which
+        # would double-count the cached tokens. total_tokens stays the reported
+        # passthrough (130).
         assert result["api_calls"] == 1
-        assert result["prompt_tokens"] == 100
+        assert result["prompt_tokens"] == 80
         assert result["completion_tokens"] == 25
         assert result["total_tokens"] == 130
-        assert result["input_tokens"] == 80
+        assert result["input_tokens"] == 60
         assert result["output_tokens"] == 25
         assert result["cache_read_tokens"] == 20
         assert result["cache_write_tokens"] == 0
         assert result["reasoning_tokens"] == 5
-        assert result["last_prompt_tokens"] == 100
+        assert result["last_prompt_tokens"] == 80
 
         assert agent.session_api_calls == 1
-        assert agent.session_prompt_tokens == 100
+        assert agent.session_prompt_tokens == 80
         assert agent.session_completion_tokens == 25
         assert agent.session_total_tokens == 130
-        assert agent.session_input_tokens == 80
+        assert agent.session_input_tokens == 60
         assert agent.session_output_tokens == 25
         assert agent.session_cache_read_tokens == 20
         assert agent.session_cache_write_tokens == 0
         assert agent.session_reasoning_tokens == 5
-        assert agent.context_compressor.last_prompt_tokens == 100
+        assert agent.context_compressor.last_prompt_tokens == 80
         assert agent.context_compressor.last_completion_tokens == 25
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000


### PR DESCRIPTION
## What does this PR do?

Fixes a token-accounting bug in the Codex **app-server** runtime path. In `agent/codex_runtime.py::_record_codex_app_server_usage`, the raw `inputTokens` value was written straight into the canonical *uncached*-input bucket (`CanonicalUsage.input_tokens`) while `cachedInputTokens` was *also* recorded as `cache_read_tokens`. But Codex reports `inputTokens` **inclusive** of `cachedInputTokens` (the same contract as the Responses API — documented in `agent/usage_pricing.py` and handled there by the `codex_responses` branch of `normalize_usage`). Since `CanonicalUsage.prompt_tokens = input_tokens + cache_read_tokens + cache_write_tokens`, the cached tokens were summed twice.

Consequences on every multi-turn Codex app-server session with a cache hit:
- displayed prompt/token counts and estimated cost are inflated,
- `context_compressor.last_prompt_tokens` is biased high → premature compaction,
- context-retirement thresholds trip early.

The fix recovers the uncached remainder — `input_tokens = max(0, inputTokens - cachedInputTokens)` — mirroring the existing `normalize_usage(api_mode="codex_responses")` precedence: `input_tokens = max(0, input_total - cache_read - cache_write)`. The app-server transport exposes no cache-write, so only cache-read is subtracted (consistent with `cache_write_tokens=0`). Both Codex transports now produce identical accounting for identical usage. `total_tokens` is unchanged — it still passes through the provider-reported `totalTokens`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_runtime.py`: in `_record_codex_app_server_usage`, subtract `cachedInputTokens` from the reported `inputTokens` to derive the uncached-input bucket, so `prompt_tokens` no longer double-counts cached tokens. Added an explanatory comment referencing the mirrored Responses-path behavior.
- `tests/run_agent/test_codex_app_server_integration.py`: updated `test_codex_app_server_token_usage_updates_session_accounting` to assert the corrected uncached/cached split.

## How to Test

For a turn reporting `inputTokens=80`, `cachedInputTokens=20`, `outputTokens=25`, `totalTokens=130`:

1. **Before the fix:** `prompt_tokens == 100`, `input_tokens == 80` (cached 20 counted twice).
2. **After the fix:** `prompt_tokens == 80` (60 uncached + 20 cached), `input_tokens == 60`, `cache_read_tokens == 20`, `total_tokens == 130` (reported passthrough).
3. Run: `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/run_agent/test_codex_app_server_integration.py -q` → 29 passed. The updated assertions fail against the pre-fix code and pass after (verified both directions). Adjacent `tests/agent/test_usage_pricing.py` → 15 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests and they pass (`tests/run_agent/test_codex_app_server_integration.py`, `tests/agent/test_usage_pricing.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A