### PR TITLE
fix(web): guard config setNestedValue/getNestedValue against prototype pollution

### DIFF
--- a/web/src/lib/nested.test.ts
+++ b/web/src/lib/nested.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { getNestedValue, setNestedValue } from "./nested";
+
+describe("setNestedValue prototype-pollution hardening", () => {
+  it("does not pollute Object.prototype via a __proto__ path", () => {
+    expect(() => setNestedValue({}, "__proto__.polluted", true)).toThrow();
+    // The global prototype must stay clean regardless of how the call is handled.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("rejects a constructor.prototype path too", () => {
+    expect(() => setNestedValue({}, "constructor.prototype.x", 1)).toThrow();
+    expect(({} as Record<string, unknown>).x).toBeUndefined();
+  });
+
+  it("rejects a dangerous leaf segment", () => {
+    expect(() => setNestedValue({}, "__proto__", 1)).toThrow();
+    expect(() => setNestedValue({}, "a.constructor", 1)).toThrow();
+  });
+});
+
+describe("setNestedValue / getNestedValue happy path", () => {
+  it("sets a nested value without mutating the input", () => {
+    const input = { a: {} as Record<string, unknown> };
+    const result = setNestedValue(input, "a.b", 1);
+    expect(result).toEqual({ a: { b: 1 } });
+    // structuredClone semantics: original is untouched.
+    expect(input).toEqual({ a: {} });
+  });
+
+  it("creates intermediate objects for a fresh path", () => {
+    expect(setNestedValue({}, "a.b.c", "x")).toEqual({ a: { b: { c: "x" } } });
+  });
+
+  it("reads a nested value", () => {
+    expect(getNestedValue({ a: { b: 2 } }, "a.b")).toBe(2);
+  });
+
+  it("returns undefined for a missing path", () => {
+    expect(getNestedValue({ a: {} }, "a.b")).toBeUndefined();
+    expect(getNestedValue({}, "x.y")).toBeUndefined();
+  });
+});

--- a/web/src/lib/nested.ts
+++ b/web/src/lib/nested.ts
@@ -1,23 +1,61 @@
-export function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+// Path segments that would let a crafted config key walk into the prototype
+// chain (e.g. "__proto__.polluted") and mutate the global Object.prototype for
+// the whole SPA session. Mirrors the hardening already shipped in the desktop
+// twin of this helper (apps/desktop/src/app/settings/helpers.ts).
+const POLLUTING_PATH_PARTS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isSafePart(part: string): boolean {
+  return part.length > 0 && !POLLUTING_PATH_PARTS.has(part);
+}
+
+function safePathParts(path: string): string[] {
   const parts = path.split(".");
+
+  if (!parts.every(isSafePart)) {
+    throw new Error(`Unsafe config path: ${path}`);
+  }
+
+  return parts;
+}
+
+// Assign via an own-property definition rather than bracket assignment so a
+// "constructor"/"prototype" leaf can never reach the prototype chain even if a
+// future caller bypasses safePathParts.
+function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (!isSafePart(key)) {
+    throw new Error(`Unsafe config key: ${key}`);
+  }
+
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+export function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   let cur: unknown = obj;
-  for (const p of parts) {
+  for (const part of safePathParts(path)) {
     if (cur == null || typeof cur !== "object") return undefined;
-    cur = (cur as Record<string, unknown>)[p];
+    if (!Object.prototype.hasOwnProperty.call(cur, part)) return undefined;
+    cur = (cur as Record<string, unknown>)[part];
   }
   return cur;
 }
 
 export function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): Record<string, unknown> {
   const clone = structuredClone(obj);
-  const parts = path.split(".");
+  const parts = safePathParts(path);
   let cur: Record<string, unknown> = clone;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (cur[parts[i]] == null || typeof cur[parts[i]] !== "object") {
-      cur[parts[i]] = {};
+    const part = parts[i];
+    const existing = Object.prototype.hasOwnProperty.call(cur, part) ? cur[part] : undefined;
+    if (existing == null || typeof existing !== "object") {
+      safeSet(cur, part, {});
     }
-    cur = cur[parts[i]] as Record<string, unknown>;
+    cur = cur[part] as Record<string, unknown>;
   }
-  cur[parts[parts.length - 1]] = value;
+  safeSet(cur, parts[parts.length - 1], value);
   return clone;
 }


### PR DESCRIPTION
## This is a sibling follow-up to #20059 (commit 51c68d4)

- **What the parent covered:** #20059 added `apps/desktop/src/app/settings/helpers.ts` with a deliberate prototype-pollution guard — `POLLUTING_PATH_PARTS = {__proto__, constructor, prototype}`, per-segment validity checks, an own-property `safeSet`, and `hasOwnProperty` reads in `getNested`/`setNested`.
- **What the parent did NOT touch:** the web dashboard's own copy of the same helper, `web/src/lib/nested.ts` (`getNestedValue`/`setNestedValue`), which predates the desktop app (introduced in #8756) and never received the guard.
- **What this adds:** ports the exact desktop guard idiom to the web helper so both config-editing surfaces are hardened identically.

## What does this PR do?

`web/src/lib/nested.ts::setNestedValue` walks a dotted config path and materializes intermediate objects without rejecting dangerous key segments:

```ts
for (let i = 0; i < parts.length - 1; i++) {
  if (cur[parts[i]] == null || typeof cur[parts[i]] !== "object") {
    cur[parts[i]] = {};
  }
  cur = cur[parts[i]] as Record<string, unknown>;   // parts[i] === "__proto__" -> cur becomes Object.prototype
}
cur[parts[parts.length - 1]] = value;               // writes onto Object.prototype
```

For a path whose segment is `__proto__`, `cur["__proto__"]` reads back `Object.prototype` (an object, so the `typeof !== "object"` reset never fires), `cur` is reassigned to `Object.prototype`, and the leaf write pollutes the **global** prototype for the whole SPA session.

Reproduction: `setNestedValue({}, "__proto__.polluted", "X")` then `({}).polluted === "X"` → `true`.

This helper backs **every** dashboard config write — `web/src/pages/ConfigPage.tsx` calls `setNestedValue`/`getNestedValue` at the reset (`:322`) and edit (`:416`) paths. The desktop twin (`apps/desktop/src/app/settings/helpers.ts`) was already hardened against exactly this in #20059; the web copy was missed.

The fix ports the desktop guard: reject `__proto__`/`constructor`/`prototype`/empty path segments (throw a clear `Error`, matching desktop `safeSet`), assign leaves via `Object.defineProperty` own-property writes instead of bracket assignment, and add a defense-in-depth `hasOwnProperty` guard to `getNestedValue`. The happy path is unchanged: `setNestedValue({a:{}}, "a.b", 1)` → `{a:{b:1}}`, `getNestedValue({a:{b:2}}, "a.b")` → `2`.

## Related Issue

Fixes #

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/nested.ts`: add `POLLUTING_PATH_PARTS` guard, `isSafePart`/`safePathParts` validation, and own-property `safeSet`; harden both `setNestedValue` and `getNestedValue`. Mirrors `apps/desktop/src/app/settings/helpers.ts`.
- `web/src/lib/nested.test.ts`: new vitest suite proving a `__proto__`/`constructor.prototype` path no longer pollutes `Object.prototype` (throws + prototype stays clean) and that normal nested set/get still work.

## How to Test

1. **Before the fix:** `setNestedValue({}, "__proto__.polluted", true)` silently pollutes `Object.prototype`, so `({}).polluted === true` afterward.
2. **After the fix:** the same call throws `Unsafe config path`, and `Object.prototype` is untouched.
3. Run: `cd web && npx vitest run src/lib/nested.test.ts` → 7 passed. The three hardening assertions fail against the pre-fix code and pass after (verified both directions). `npx tsc -p . --noEmit` and `npx eslint src/lib/nested.ts src/lib/nested.test.ts` are clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests and they pass (`web/src/lib/nested.test.ts` via vitest; tsc + eslint clean)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A