### PR TITLE
fix(web): probe loopback endpoints directly, never via env proxy

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -470,6 +470,38 @@ describe('saveOnboardingLocalEndpoint', () => {
     expect(calls).not.toContain('/api/model/set')
   })
 
+  it('surfaces the probe detail when a reachable endpoint answers with an error', async () => {
+    const calls: string[] = []
+    installApiMock(async ({ path }: { path: string }) => {
+      calls.push(path)
+
+      if (path === '/api/providers/validate') {
+        // What the backend reports when something answers /v1/models with a
+        // non-2xx status — an intercepting proxy, or a gateway with no model
+        // loaded. Reachable, but not empty-handed for the same reason.
+        return {
+          ok: true,
+          reachable: true,
+          message: 'http://127.0.0.1:8000/v1/models answered HTTP 502.',
+          models: []
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const result = await saveOnboardingLocalEndpoint('http://127.0.0.1:8000/v1', '', {
+      requestGateway: readyGateway()
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('answered HTTP 502')
+    // The status is the whole point: flattening it into "advertised no models"
+    // is what sent people hunting for a model that was never the problem.
+    expect(result.message).not.toContain('advertised no models')
+    expect(calls).not.toContain('/api/model/set')
+  })
+
   it('auto-discovers the model and persists provider=custom + base_url, then finishes', async () => {
     const calls: { body?: unknown; path: string }[] = []
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -821,6 +821,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   // the endpoint is up; an unreachable probe hard-blocks because we can't
   // resolve a model to route to.
   let model = ''
+  let probeMessage = ''
 
   try {
     const probe = await validateProviderCredential('OPENAI_BASE_URL', url, key)
@@ -834,14 +835,20 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
     }
 
     model = (probe.models?.[0] ?? '').trim()
+    probeMessage = (probe.message ?? '').trim()
   } catch {
     return { ok: false, message: `Could not reach ${url}.` }
   }
 
   if (!model) {
+    // The probe distinguishes "endpoint answered but errored" (message set,
+    // e.g. a proxy or gateway answered HTTP 502 at /v1/models) from a healthy
+    // endpoint that genuinely serves no models.
     return {
       ok: false,
-      message: `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
+      message: probeMessage
+        ? `Connected to ${url}, but ${probeMessage}`
+        : `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
     }
   }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -25,6 +25,7 @@ import hashlib
 import hmac
 import inspect
 import importlib.util
+import ipaddress
 import json
 import logging
 import math
@@ -7104,6 +7105,30 @@ _CREDENTIAL_PROBES: dict[str, tuple[str, str]] = {
 }
 
 
+def _probe_ignores_env_proxy(url: str) -> bool:
+    """Whether a ``/v1/models`` probe to ``url`` should bypass env proxies.
+
+    A loopback endpoint (llama.cpp, vLLM, Ollama on the same box) is never
+    meaningfully reachable *through* an HTTP(S) proxy: the proxy either fails
+    to connect back or answers with its own error page, which downstream
+    parses as "the endpoint advertised no models" even though hitting the URL
+    directly works. GUI-spawned backends inherit ``HTTP(S)_PROXY`` from the
+    login environment while an interactive CLI shell may not, and httpx (unlike
+    the CLI's urllib path on Windows) has no <local> proxy-bypass — so the
+    bypass must be explicit.
+    """
+    try:
+        host = urllib.parse.urlsplit(url).hostname or ""
+    except ValueError:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def _parse_model_ids(resp: "Any") -> List[str]:
     """Extract model ids from an OpenAI-compatible ``/v1/models`` response.
 
@@ -7501,9 +7526,19 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         api_key = (body.api_key or "").strip()
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(8.0),
+                trust_env=not _probe_ignores_env_proxy(url),
+            ) as client:
                 resp = await client.get(url, headers=headers)
-            return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
+            models = _parse_model_ids(resp)
+            message = ""
+            if not models and not resp.is_success:
+                # Distinguish "endpoint answered but errored" from "endpoint
+                # advertises no models" so the GUI doesn't tell the user to
+                # start a model on an endpoint that returned 404/502/….
+                message = f"{url} answered HTTP {resp.status_code}."
+            return {"ok": True, "reachable": True, "message": message, "models": models}
         except Exception:
             return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3988,7 +3988,11 @@ class TestValidateProviderCredential:
     def test_loopback_probe_ignores_proxy_env_end_to_end(self, monkeypatch):
         """Real localhost server + HTTP(S)_PROXY pointing at a dead port: the
         probe must still enumerate the models. Fails before the fix (httpx
-        routes the loopback request into the dead proxy)."""
+        routes the loopback request into the dead proxy).
+
+        Every bypass spelling is cleared first: an inherited `no_proxy` would
+        route the unfixed client straight to the server and let this pass on a
+        build that still trusts the environment."""
         import http.server
         import threading
 
@@ -4011,9 +4015,11 @@ class TestValidateProviderCredential:
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         try:
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                        "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+                monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
             monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9")
-            monkeypatch.delenv("NO_PROXY", raising=False)
             base_url = f"http://127.0.0.1:{server.server_port}/v1"
             data = self._post("OPENAI_BASE_URL", base_url).json()
         finally:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3943,6 +3943,117 @@ class TestValidateProviderCredential:
             },
         }
 
+    @pytest.mark.parametrize(
+        ("base_url", "expected_trust_env"),
+        [
+            ("http://127.0.0.1:8080/v1", False),
+            ("http://localhost:11434/v1", False),
+            ("http://[::1]:8080/v1", False),
+            ("https://text.example.com/v1", True),
+        ],
+    )
+    def test_loopback_probe_bypasses_env_proxy(self, monkeypatch, base_url, expected_trust_env):
+        """Loopback endpoints must be probed directly, never through an
+        env-configured HTTP(S) proxy: the proxy's error page parses as "no
+        models" even though the endpoint answers fine when hit directly
+        (#63472). Non-loopback endpoints keep honoring env proxies."""
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+            def json(self):
+                return {"data": [{"id": "some-model"}]}
+
+        class _Client:
+            def __init__(self, *a, trust_env=True, **k):
+                captured["trust_env"] = trust_env
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url, *a, **k):
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        data = self._post("OPENAI_BASE_URL", base_url).json()
+        assert data["models"] == ["some-model"]
+        assert captured["trust_env"] is expected_trust_env
+
+    def test_loopback_probe_ignores_proxy_env_end_to_end(self, monkeypatch):
+        """Real localhost server + HTTP(S)_PROXY pointing at a dead port: the
+        probe must still enumerate the models. Fails before the fix (httpx
+        routes the loopback request into the dead proxy)."""
+        import http.server
+        import threading
+
+        payload = json.dumps(
+            {"object": "list", "data": [{"id": "qwen-local", "object": "model"}]}
+        ).encode()
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *a):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+            monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+            monkeypatch.delenv("NO_PROXY", raising=False)
+            base_url = f"http://127.0.0.1:{server.server_port}/v1"
+            data = self._post("OPENAI_BASE_URL", base_url).json()
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+        assert data["ok"] is True and data["reachable"] is True
+        assert data["models"] == ["qwen-local"]
+
+    def test_local_endpoint_error_status_surfaces_in_message(self, monkeypatch):
+        """An endpoint (or intercepting proxy) answering non-2xx must not read
+        as "advertised no models" — the HTTP status is surfaced instead."""
+
+        class _Resp:
+            status_code = 502
+            is_success = False
+
+            def json(self):
+                raise ValueError("not json")
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url, *a, **k):
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        data = self._post("OPENAI_BASE_URL", "http://127.0.0.1:8080/v1").json()
+        assert data["ok"] is True and data["reachable"] is True
+        assert data["models"] == []
+        assert "HTTP 502" in data["message"]
+
 
 class TestDesktopCronTicker:
     """The dashboard backend fires cron jobs itself only when desktop-spawned."""


### PR DESCRIPTION
## What does this PR do?

`POST /api/providers/validate` (the local/custom endpoint probe used by
Desktop onboarding) creates its `httpx.Client` with default `trust_env`,
so an `HTTP(S)_PROXY` inherited from the environment hijacks even
`127.0.0.1` probes. A proxy that answers with its own error page (Clash,
corporate proxies, …) parses as `models=[]`, and the GUI reports
*"Connected …, but it advertised no models at /v1/models"* — although the
endpoint serves a model and the **CLI sees it fine** (the CLI probe goes
through `urllib`, which on Windows honors the `<local>` proxy-bypass;
httpx only reads `*_PROXY` env vars and has no such bypass).

The mismatch is sharpest on Windows Desktop: the GUI-spawned backend
inherits the login environment block (where user-scoped proxy vars live),
while an interactive CLI shell may not — same machine, CLI works, Desktop
fails, exactly as reported in #63472.

Changes:
- loopback hosts (`127.0.0.0/8`, `::1`, `localhost`) are probed with
  `trust_env=False` — a loopback endpoint is never meaningfully reachable
  *through* an HTTP proxy, so this cannot break a legitimate setup;
  non-loopback custom endpoints keep honoring env proxies (corporate
  setups stay intact)
- when a reachable endpoint answers non-2xx, the probe now surfaces
  `"… answered HTTP <status>."` instead of silently returning no models,
  and Desktop onboarding prefers that message over the misleading
  *"start a model on that endpoint"* copy

## Related Issue

Fixes #63472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — new `_probe_ignores_env_proxy()` helper
  (loopback detection via `ipaddress`); the `OPENAI_BASE_URL` probe branch
  passes `trust_env=not _probe_ignores_env_proxy(url)` and reports the HTTP
  status when a reachable endpoint answers non-2xx with no parseable models
- `apps/desktop/src/store/onboarding.ts` — `saveOnboardingLocalEndpoint`
  prefers the probe's error message over the generic no-models copy
- `tests/hermes_cli/test_web_server.py` — 6 new tests: parametrized
  loopback-vs-public `trust_env` matrix, an end-to-end repro (real
  localhost HTTP server + `HTTP(S)_PROXY` pointing at a dead port; fails
  on `main`, passes with the fix), and the non-2xx message contract

## How to Test

1. Start any OpenAI-compatible local server (llama.cpp `llama-server`,
   vLLM, Ollama) on `http://127.0.0.1:8080/v1`.
2. In the environment of the backend process, set
   `HTTP_PROXY=http://127.0.0.1:9` and `HTTPS_PROXY=http://127.0.0.1:9`
   (any dead or error-answering proxy), leave `NO_PROXY` unset.
3. Desktop onboarding → Local / custom endpoint →
   `http://127.0.0.1:8080/v1` → Connect.
   Before: *"…advertised no models at /v1/models"*. After: the model is
   auto-detected (or, if the endpoint itself errors, the real HTTP status
   is shown).
4. `pytest tests/hermes_cli/test_web_server.py -q` — the new
   `test_loopback_probe_ignores_proxy_env_end_to_end` fails on `main`,
   passes here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite: `tests/hermes_cli/test_web_server.py` — 361 passed, 19 skipped
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config/API change; error-message copy only)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: the fix is platform-neutral; the trigger is Windows-Desktop-specific (GUI env inheritance); `scripts/check-windows-footguns.py --diff main` is clean
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Deterministic repro on Windows 11 (fake llama.cpp serving the reporter's
exact JSON on `127.0.0.1:18080`, fake proxy answering 502 on `:18081`),
running the exact probe code path:

```
--- 1. broken-but-alive proxy in env (502), trust_env default
    {'ok': True, 'reachable': True, 'status': 502, 'models': []}
    => GUI message: 'Connected ... but it advertised no models at /v1/models'  <== SYMPTOM #63472
--- 2. dead proxy in env (conn refused), trust_env default
    {'ok': False, 'reachable': False, 'error': 'ConnectError: [WinError 10061] ...'}
    => GUI message: 'Could not reach ...' (reachable=False)
--- 3. control: same env, trust_env=False
    {'ok': True, 'reachable': True, 'status': 200, 'models': ['A:\\AIULYSSES\\models\\Qwen3.6-35B-A3B-Q5_K_M.gguf']}
    => GUI would auto-pick model: 'A:\\AIULYSSES\\models\\Qwen3.6-35B-A3B-Q5_K_M.gguf'
```