### PR TITLE
fix(whatsapp): skip unavailable retry payloads

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -38,6 +38,7 @@ import {
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  createRetryMessageLookup,
   extractBridgeEvent,
   inferMediaType,
   mediaPayloadForFile,
@@ -398,13 +399,10 @@ async function startSocket() {
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
     markOnlineOnConnect: false,
-    // Required for Baileys 7.x: without this, incoming messages that need
-    // E2EE session re-establishment are silently dropped (msg.message === null)
-    getMessage: async (key) => {
-      // We don't maintain a message store, so return a placeholder.
-      // This is enough for Baileys to complete the retry handshake.
-      return { conversation: '' };
-    },
+    // Retry only payloads that are still available in the bounded store.
+    // Returning a fabricated `{ conversation: '' }` is truthy, so Baileys
+    // relays it as a visible blank message when a device requests a retry.
+    getMessage: createRetryMessageLookup(messageStore),
   });
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -16,12 +16,34 @@ import {
   buildPollPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  createRetryMessageLookup,
   appendMediaFailureNote,
   extractBridgeEvent,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- missing-message retry safety -----------------------------------------
+{
+  const store = createBoundedMessageStore(2);
+  store.remember({
+    key: { id: 'outbound-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: true },
+    message: { conversation: 'real payload' },
+  });
+
+  const getMessage = createRetryMessageLookup(store);
+  assert.deepEqual(
+    await getMessage({ id: 'outbound-1' }),
+    { conversation: 'real payload' },
+  );
+  assert.equal(
+    await getMessage({ id: 'missing-id' }),
+    undefined,
+    'a missing retry payload must not become a truthy empty conversation',
+  );
+  console.log('  ✓ retries use stored payloads and decline missing messages');
+}
 
 // -- quoted outbound text -------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -65,6 +65,10 @@ export function createBoundedMessageStore(limit = 512) {
   return { remember, get };
 }
 
+export function createRetryMessageLookup(messageStore) {
+  return async (key) => messageStore?.get(key?.id)?.message;
+}
+
 export function pollCreationMessageSecret(pollCreation) {
   return pollCreation?.message?.messageContextInfo?.messageSecret
     || pollCreation?.messageContextInfo?.messageSecret


### PR DESCRIPTION
## Summary

- replace the WhatsApp bridge's fabricated `{ conversation: '' }` retry payload with lookup from its existing bounded message store
- return `undefined` when the original message is unavailable, allowing Baileys to skip `relayMessage()`
- add regression coverage for both stored and missing retry payloads

## Root cause

Baileys treats any truthy value returned by `getMessage` as retryable and relays it using the original message ID. The bridge returned `{ conversation: '' }` for every missing ID, so retry/session churn could emit visible blank messages without a gateway-level send.

## Test plan

- [x] Confirmed the regression test failed before implementation
- [x] All WhatsApp bridge `*.test.mjs` files pass
- [x] `node --check bridge.js`
- [x] `node --check bridge_helpers.js`
- [x] `git diff --check`
- [x] `uv run --extra dev --extra messaging pytest tests/gateway/test_whatsapp_*.py -q -o addopts=''` — 281 passed

Fixes #63647
