### PR TITLE
feat(email): per-thread session routing + configurable display name

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2102,6 +2102,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
+        email_session_routing = getenv("EMAIL_SESSION_ROUTING")
+        if email_session_routing:
+            config.platforms[Platform.EMAIL].extra["session_routing"] = email_session_routing
+        email_display_name = getenv("EMAIL_DISPLAY_NAME")
+        if email_display_name:
+            config.platforms[Platform.EMAIL].extra["display_name"] = email_display_name
     email_home = getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7671,12 +7671,17 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "email": {
         "name": "Email",
         "description": "Talk to Hermes through an IMAP/SMTP mailbox.",
-        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/email",
         "env_vars": (
             "EMAIL_ADDRESS",
             "EMAIL_PASSWORD",
             "EMAIL_IMAP_HOST",
             "EMAIL_SMTP_HOST",
+            "EMAIL_ALLOWED_USERS",
+            "EMAIL_HOME_ADDRESS",
+            "EMAIL_SESSION_ROUTING",
+            "EMAIL_DISPLAY_NAME",
+            "EMAIL_ALLOW_ALL_USERS",
         ),
         "required_env": (
             "EMAIL_ADDRESS",
@@ -7931,6 +7936,26 @@ _MESSAGING_ENV_FALLBACKS: dict[str, dict[str, Any]] = {
     "EMAIL_SMTP_HOST": {
         "description": "SMTP server host (e.g. smtp.gmail.com)",
         "prompt": "SMTP host",
+    },
+    "EMAIL_ALLOWED_USERS": {
+        "description": "Comma-separated email addresses or @domain tokens allowed to message the bot",
+        "prompt": "Allowed email users",
+    },
+    "EMAIL_HOME_ADDRESS": {
+        "description": "Home email address for proactive / home-channel delivery",
+        "prompt": "Home email address",
+    },
+    "EMAIL_SESSION_ROUTING": {
+        "description": "Email session routing: sender (default, one session per person) or thread (one session per email thread — recommended for email agents)",
+        "prompt": "Email session routing (sender|thread)",
+    },
+    "EMAIL_DISPLAY_NAME": {
+        "description": "Optional From: display name (e.g. Iris Sloane)",
+        "prompt": "Email display name",
+    },
+    "EMAIL_ALLOW_ALL_USERS": {
+        "description": "When true, allow any sender (overrides EMAIL_ALLOWED_USERS)",
+        "prompt": "Allow all email senders",
     },
     "TWILIO_ACCOUNT_SID": {
         "description": "Twilio Account SID",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -17,12 +17,15 @@ Environment variables:
 
 import asyncio
 import email as email_lib
+import hashlib
 import imaplib
+import json
 import logging
 import os
 import re
 import smtplib
 import socket
+import time
 
 # Profile-scoped secret reader for multiplexing support (PR #50094)
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -530,11 +533,64 @@ class EmailAdapter(BasePlatformAdapter):
         # Context key is "<chat_id>::<thread_id>" in thread mode, or the bare
         # chat_id (sender address) in sender mode. chat_id is ALWAYS a real
         # email address — never a subject or composite key.
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        self._thread_context: Dict[str, Dict[str, Any]] = {}
         # Message-ID -> context key, so replies can anchor to the exact
         # inbound message even when send-time metadata lacks thread_id.
         self._msgid_context: Dict[str, str] = {}
         self._thread_context_max: int = 2000  # cap to prevent unbounded growth
+
+        # Content hashes of files already attached per thread, so the agent
+        # doesn't re-send the same file on every turn of a conversation.
+        # ctx_key -> {sha256, ...}
+        self._sent_attachments: Dict[str, set] = {}
+
+        # ── Single-email coalescing ───────────────────────────────────────
+        # One inbound turn should produce ONE outbound mail, the way a person
+        # replies. The gateway dispatches a turn as several adapter calls:
+        # send() for the body, send_multiple_images() once for an image batch,
+        # and send_document() once PER remaining file, with human_delay sleeps
+        # between them. Sent straight through, that is 1+N emails for one
+        # answer — and on email (unlike chat) each one is a separate message in
+        # the recipient's thread. Parts are buffered here and flushed as a
+        # single MIME once the turn goes quiet.
+        # ctx_key -> {to_addr, ctx, reply_to, body_parts, files, task, first_seen}
+        self._pending: Dict[str, Dict[str, Any]] = {}
+        # Idle debounce, re-armed by every new part. Observed body->attachment
+        # gaps on real turns were 4.1-7.9s, so this must comfortably clear that.
+        self._fold_window: float = float(
+            extra.get("fold_window_seconds")
+            or os.getenv("EMAIL_FOLD_WINDOW_SECONDS", "")
+            or 12.0
+        )
+        # Hard ceiling measured from the first part, so a long attachment loop
+        # can never stall a reply indefinitely.
+        self._fold_max_wait: float = float(
+            extra.get("fold_max_wait_seconds")
+            or os.getenv("EMAIL_FOLD_MAX_WAIT_SECONDS", "")
+            or 90.0
+        )
+
+        # Thread state is otherwise memory-only, so every gateway restart wipes
+        # it: the next reply on a live thread goes out with a generic subject,
+        # no In-Reply-To and no Cc. Persist it across restarts.
+        #
+        # Resolved through get_hermes_home() rather than Path.home() so the
+        # file lands under the active HERMES_HOME (per-profile, and sandboxed
+        # per-test), instead of leaking one shared file across profiles.
+        _state_override = str(
+            extra.get("thread_state_path")
+            or os.getenv("EMAIL_THREAD_STATE_PATH", "")
+        ).strip()
+        if _state_override:
+            self._state_path: str = _state_override
+        else:
+            try:
+                from hermes_constants import get_hermes_home
+                _home = Path(get_hermes_home())
+            except Exception:
+                _home = Path.home() / ".hermes"
+            self._state_path = str(_home / "state" / "email_thread_state.json")
+        self._load_state()
 
         # Session routing (opt-in thread isolation):
         #   "sender" (default) — one session per sender address (stock Hermes
@@ -692,6 +748,16 @@ class EmailAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop polling and disconnect."""
         self._running = False
+        # Emit anything still buffered by the fold: a restart mid-turn would
+        # otherwise silently drop a reply, which is worse than sending two.
+        try:
+            self._flush_all_pending()
+        except Exception as e:
+            logger.error("[Email] Pending flush on disconnect failed: %s", e)
+        try:
+            self._save_state()
+        except Exception:
+            pass
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -777,6 +843,12 @@ class EmailAdapter(BasePlatformAdapter):
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
+                    # Kept so replies can EXTEND the References chain instead of
+                    # resetting it to just the parent (long threads drift apart
+                    # in Outlook otherwise), and so reply-all can preserve Cc.
+                    references = msg.get("References", "")
+                    to_header = _decode_header_value(msg.get("To", ""))
+                    cc_header = _decode_header_value(msg.get("Cc", ""))
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
@@ -803,6 +875,9 @@ class EmailAdapter(BasePlatformAdapter):
                         "subject": subject,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
+                        "references": references,
+                        "to_header": to_header,
+                        "cc_header": cc_header,
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
@@ -961,14 +1036,36 @@ class EmailAdapter(BasePlatformAdapter):
             thread_id = None
 
         _ctx_key = f"{sender_addr}::{thread_id}" if thread_id else sender_addr
+        # Reply-all: remember every recipient on the inbound mail (To + Cc,
+        # minus the sender and ourselves) so replies keep the chain instead of
+        # silently dropping everyone who was cc'd.
+        _recipients: List[str] = []
+        for _hdr in (msg_data.get("to_header", ""), msg_data.get("cc_header", "")):
+            if not _hdr:
+                continue
+            for _part in _hdr.split(","):
+                _addr = _extract_email_address(_part)
+                if (
+                    _addr
+                    and _addr != sender_addr
+                    and _addr != self._address.lower()
+                    and _addr not in _recipients
+                ):
+                    _recipients.append(_addr)
         self._thread_context[_ctx_key] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "references": msg_data.get("references", ""),
             "sender_addr": sender_addr,
+            "recipients": list(_recipients),
+            # Carried so every outbound path indexes itself against the same
+            # key the inbound side used, rather than recomputing it.
+            "ctx_key": _ctx_key,
         }
         if msg_data.get("message_id"):
             self._msgid_context[msg_data["message_id"]] = _ctx_key
         self._trim_thread_context()
+        self._save_state()
 
         source = self.build_source(
             chat_id=sender_addr,
@@ -1010,15 +1107,12 @@ class EmailAdapter(BasePlatformAdapter):
         if not to_addr:
             logger.error("[Email] Cannot resolve recipient for chat_id=%r and no EMAIL_HOME_ADDRESS set", chat_id)
             return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
-        try:
-            loop = asyncio.get_running_loop()
-            message_id = await loop.run_in_executor(
-                None, self._send_email, to_addr, content, reply_to, ctx
-            )
-            return SendResult(success=True, message_id=message_id)
-        except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", to_addr, e)
-            return SendResult(success=False, error=str(e))
+        # Buffer rather than send: any attachments for this same turn arrive in
+        # later adapter calls and must land in the SAME email.
+        return SendResult(
+            success=True,
+            message_id=self._queue_part(to_addr, ctx, reply_to=reply_to, body=content),
+        )
 
     def _trim_thread_context(self) -> None:
         """Bound thread context + msgid index so long-lived gateways don't grow forever."""
@@ -1036,6 +1130,300 @@ class EmailAdapter(BasePlatformAdapter):
             drop = len(self._msgid_context) - (self._thread_context_max // 2)
             for mid in list(self._msgid_context.keys())[:drop]:
                 del self._msgid_context[mid]
+
+    # ── Persistent thread state ───────────────────────────────────────────
+    def _load_state(self) -> None:
+        """Restore thread/msgid/attachment state written by a previous run."""
+        try:
+            raw = json.loads(Path(self._state_path).read_text())
+        except FileNotFoundError:
+            return
+        except Exception as e:
+            logger.warning("[Email] Could not load thread state (%s) — starting empty", e)
+            return
+        try:
+            tc = raw.get("thread_context") or {}
+            mc = raw.get("msgid_context") or {}
+            sa = raw.get("sent_attachments") or {}
+            if isinstance(tc, dict):
+                self._thread_context.update(
+                    {k: v for k, v in tc.items() if isinstance(v, dict)}
+                )
+            if isinstance(mc, dict):
+                self._msgid_context.update(
+                    {k: v for k, v in mc.items() if isinstance(v, str)}
+                )
+            if isinstance(sa, dict):
+                for k, v in sa.items():
+                    if isinstance(v, list):
+                        self._sent_attachments[k] = set(v)
+            self._trim_thread_context()
+            logger.info(
+                "[Email] Restored thread state: %d thread(s), %d message-id(s)",
+                len(self._thread_context),
+                len(self._msgid_context),
+            )
+        except Exception as e:
+            logger.warning("[Email] Malformed thread state (%s) — starting empty", e)
+
+    def _save_state(self) -> None:
+        """Atomically persist thread state. Never raises into a send path."""
+        try:
+            payload = {
+                "thread_context": self._thread_context,
+                "msgid_context": self._msgid_context,
+                "sent_attachments": {
+                    k: sorted(v) for k, v in self._sent_attachments.items()
+                },
+            }
+            p = Path(self._state_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            tmp = p.with_suffix(p.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload))
+            try:
+                os.chmod(tmp, 0o600)
+            except OSError:
+                pass
+            os.replace(tmp, p)
+        except Exception as e:
+            logger.warning("[Email] Could not save thread state: %s", e)
+
+    def _ctx_key_for(self, to_addr: str, ctx: Optional[Dict[str, Any]]) -> str:
+        """Key identifying the thread an outbound mail belongs to.
+
+        Prefers the key stamped onto the context when the inbound message was
+        stored, so the outbound side can never disagree with the inbound side
+        about which thread this is.
+        """
+        ctx = ctx or {}
+        key = str(ctx.get("ctx_key") or "").strip()
+        if key:
+            return key
+        subject = str(ctx.get("subject") or "").strip()
+        if subject:
+            tid = re.sub(
+                r"^(?:(?:re|fwd|fw):\s*)+", "", subject, flags=re.IGNORECASE
+            ).strip()
+            if tid:
+                return f"{(ctx.get('sender_addr') or to_addr).lower()}::{tid}"
+        return to_addr.lower()
+
+    def _register_outbound_msgid(
+        self, msg_id: str, to_addr: str, ctx: Optional[Dict[str, Any]]
+    ) -> None:
+        """Index an agent-generated Message-ID against its thread.
+
+        Without this, a reply to one of the agent's own mails arrives with
+        In-Reply-To=<hermes-...>, misses _msgid_context (which only ever held
+        INBOUND ids), and falls through to the most-recent-thread scan in
+        _context_for_send — answering on the wrong thread, with that thread's
+        Cc list. Registering outbound ids closes that gap.
+        """
+        if not msg_id or msg_id.startswith(("suppressed-", "pending-", "folded-")):
+            return
+        key = self._ctx_key_for(to_addr, ctx)
+        if not key:
+            return
+        self._msgid_context[msg_id] = key
+        # Chain forward: the next reply on this thread should anchor to the
+        # agent's latest mail and carry the earlier ids in References.
+        stored = self._thread_context.get(key)
+        if isinstance(stored, dict):
+            chain = str(stored.get("references") or "").split()
+            prior_id = str(stored.get("message_id") or "").strip()
+            if prior_id and prior_id not in chain:
+                chain.append(prior_id)
+            stored["references"] = " ".join(chain)
+            stored["message_id"] = msg_id
+        self._trim_thread_context()
+        self._save_state()
+
+    def _apply_reply_headers(
+        self,
+        msg,
+        to_addr: str,
+        ctx: Optional[Dict[str, Any]] = None,
+        reply_to_msg_id: Optional[str] = None,
+        has_attachments: bool = False,
+    ) -> None:
+        """Stamp Subject / Cc / In-Reply-To / References on an outbound reply.
+
+        Single source of truth for reply identity. Every send path (text,
+        multi-attachment, single-attachment) goes through this. When the
+        attachment paths built these headers themselves they silently diverged:
+        a bare self._thread_context.get(to_addr) lookup always misses under
+        session_routing="thread" (keys are "sender::thread_id"), so attachment
+        mail went out as "Re: Hermes Agent" with no In-Reply-To and no Cc, and
+        mail clients filed it as a brand-new conversation.
+        """
+        ctx = ctx or {}
+
+        # Reply-all: preserve the inbound To/Cc chain.
+        cc_addrs: List[str] = []
+        for _addr in (ctx.get("recipients") or []):
+            if _addr and _addr != to_addr.lower() and _addr != self._address.lower():
+                if _addr not in cc_addrs:
+                    cc_addrs.append(_addr)
+        if cc_addrs:
+            msg["Cc"] = ", ".join(cc_addrs)
+
+        # Subject: inherit the thread's, prefixing a single "Re:".
+        subject = str(ctx.get("subject") or "").strip()
+        if not subject:
+            # Fail loud rather than silently opening a new thread under a
+            # generic subject — that is what cross-threaded attachment mail.
+            logger.warning(
+                "[Email] No thread context for %s (attachments=%s) — reply may not thread",
+                to_addr,
+                has_attachments,
+            )
+            subject = "Hermes Agent"
+        if not re.match(r"^re:\s", subject, flags=re.IGNORECASE):
+            subject = f"Re: {subject}"
+        msg["Subject"] = subject
+
+        # In-Reply-To is the parent; References is the whole chain (parent's
+        # References + parent's Message-ID). Overwriting References with only
+        # the parent made long threads drift apart in Outlook.
+        parent_id = str(reply_to_msg_id or ctx.get("message_id") or "").strip()
+        if parent_id:
+            msg["In-Reply-To"] = parent_id
+            chain = [r for r in str(ctx.get("references") or "").split() if r]
+            if parent_id not in chain:
+                chain.append(parent_id)
+            if len(chain) > 20:
+                # Keep the thread root plus the most recent ids.
+                chain = chain[:1] + chain[-19:]
+            msg["References"] = " ".join(chain)
+        elif has_attachments:
+            logger.error(
+                "[Email] Sending attachment mail to %s with NO parent message-id "
+                "— it will start a new thread",
+                to_addr,
+            )
+
+    # ── Single-email coalescing ───────────────────────────────────────────
+    def _queue_part(
+        self,
+        to_addr: str,
+        ctx: Optional[Dict[str, Any]],
+        reply_to: Optional[str] = None,
+        body: Optional[str] = None,
+        file_paths: Optional[List[str]] = None,
+    ) -> str:
+        """Buffer one outbound part of a turn and (re)arm the idle flush.
+
+        The gateway emits one answer as several adapter calls: send() for the
+        body, send_multiple_images() once for an image batch, and
+        send_document() once PER remaining file. Folding the body into just
+        the first attachment would still leave one email per subsequent file,
+        so parts accumulate here and are flushed together.
+        """
+        key = self._ctx_key_for(to_addr, ctx)
+        entry = self._pending.get(key)
+        if entry is None:
+            entry = {
+                "to_addr": to_addr,
+                # Captured once. Deliberately NOT re-resolved at flush time:
+                # re-resolving would reintroduce the wrong-thread fallback
+                # this change exists to eliminate.
+                "ctx": ctx or {},
+                "reply_to": reply_to,
+                "body_parts": [],
+                "files": [],
+                "task": None,
+                "first_seen": time.monotonic(),
+            }
+            self._pending[key] = entry
+        if body and body.strip():
+            entry["body_parts"].append(body.strip())
+        for fp in file_paths or []:
+            if fp not in entry["files"]:
+                entry["files"].append(fp)
+        if reply_to and not entry.get("reply_to"):
+            entry["reply_to"] = reply_to
+
+        old = entry.get("task")
+        if old is not None and not old.done():
+            old.cancel()
+        try:
+            entry["task"] = asyncio.get_running_loop().create_task(
+                self._flush_after_idle(key)
+            )
+        except RuntimeError:
+            # No running loop — send immediately rather than swallow the reply.
+            self._flush_now(key)
+            return "folded-immediate"
+        logger.info(
+            "[Email] Buffered part for %s (body_parts=%d files=%d) — flushing in %.1fs",
+            key,
+            len(entry["body_parts"]),
+            len(entry["files"]),
+            self._fold_window,
+        )
+        return f"pending-fold-{key}"
+
+    async def _flush_after_idle(self, key: str) -> None:
+        """Wait for the turn to go quiet, then emit exactly one mail."""
+        try:
+            entry = self._pending.get(key)
+            if not entry:
+                return
+            elapsed = time.monotonic() - entry["first_seen"]
+            await asyncio.sleep(
+                max(0.0, min(self._fold_window, self._fold_max_wait - elapsed))
+            )
+        except asyncio.CancelledError:
+            # A newer part arrived and re-armed the timer.
+            return
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, self._flush_now, key)
+        except Exception as e:
+            logger.error("[Email] Fold flush failed for %s: %s", key, e, exc_info=True)
+
+    def _flush_now(self, key: str) -> Optional[str]:
+        """Build and send the buffered turn as a single MIME message."""
+        entry = self._pending.pop(key, None)
+        if not entry:
+            return None
+        body = "\n\n".join(entry["body_parts"]).strip()
+        files = [f for f in entry["files"] if f]
+        to_addr = entry["to_addr"]
+        ctx = entry["ctx"]
+        reply_to = entry.get("reply_to")
+        if not body and not files:
+            return None
+        logger.info(
+            "[Email] Folding turn for %s into ONE email (body=%dch files=%d waited=%.1fs)",
+            key,
+            len(body),
+            len(files),
+            time.monotonic() - entry["first_seen"],
+        )
+        try:
+            if files:
+                return self._send_email_with_attachments(
+                    to_addr, body, files, ctx, reply_to
+                )
+            return self._send_email(to_addr, body, reply_to, ctx)
+        except Exception as e:
+            logger.error(
+                "[Email] Folded send FAILED for %s (%d file(s)) — reply lost: %s",
+                to_addr, len(files), e, exc_info=True,
+            )
+            return None
+
+    def _flush_all_pending(self) -> None:
+        """Emit every buffered turn — used on shutdown so nothing is dropped."""
+        for key in list(self._pending.keys()):
+            entry = self._pending.get(key) or {}
+            task = entry.get("task")
+            if task is not None and not task.done():
+                task.cancel()
+            try:
+                self._flush_now(key)
+            except Exception as e:
+                logger.error("[Email] Shutdown flush failed for %s: %s", key, e)
 
     def _context_for_send(
         self,
@@ -1126,21 +1514,11 @@ class EmailAdapter(BasePlatformAdapter):
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        # Resolve subject and threading headers from the context the caller
-        # resolved (send-time thread metadata or Message-ID anchor).
         ctx = ctx or {}
-        subject = ctx.get("subject", "")
-        if not subject:
-            subject = "Hermes Agent"
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
-
-        # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        self._apply_reply_headers(
+            msg, to_addr, ctx=ctx, reply_to_msg_id=reply_to_msg_id, has_attachments=False
+        )
+        subject = msg["Subject"]
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
@@ -1159,6 +1537,7 @@ class EmailAdapter(BasePlatformAdapter):
                 smtp.close()
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        self._register_outbound_msgid(msg_id, to_addr, ctx)
         return msg_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
@@ -1225,26 +1604,18 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] Cannot resolve recipient for multi-image send, chat_id=%r", chat_id)
             return
 
-        try:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(
-                None,
-                self._send_email_with_attachments,
-                to_addr,
-                body,
-                local_paths,
-                ctx,
-            )
-        except Exception as e:
-            logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+        # Buffered, not sent: the body for this turn arrived in an earlier
+        # send() call and the remaining files arrive in later send_document
+        # calls. They all belong in one email.
+        self._queue_part(to_addr, ctx, body=body, file_paths=local_paths)
 
     def _send_email_with_attachments(
         self,
         to_addr: str,
         body: str,
         file_paths: List[str],
-        ctx: Optional[Dict[str, str]] = None,
+        ctx: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1252,17 +1623,9 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = ctx or {}
-        subject = ctx.get("subject", "")
-        if not subject:
-            subject = "Hermes Agent"
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
-
-        original_msg_id = ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        self._apply_reply_headers(
+            msg, to_addr, ctx=ctx, reply_to_msg_id=reply_to, has_attachments=True
+        )
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
@@ -1270,6 +1633,34 @@ class EmailAdapter(BasePlatformAdapter):
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))
+
+        # Don't re-attach a file already delivered on this thread — a person
+        # wouldn't resend the same attachments on every turn. Dedupe by content
+        # hash, scoped to the thread so a genuinely revised file still sends.
+        _dedupe_key = self._ctx_key_for(to_addr, ctx)
+        _already = self._sent_attachments.setdefault(_dedupe_key, set())
+        _fresh: List[str] = []
+        _skipped: List[str] = []
+        for _fp in file_paths:
+            try:
+                _h = hashlib.sha256(Path(_fp).read_bytes()).hexdigest()
+            except Exception:
+                _fresh.append(_fp)
+                continue
+            if _h in _already:
+                _skipped.append(Path(_fp).name)
+            else:
+                _already.add(_h)
+                _fresh.append(_fp)
+        if _skipped:
+            logger.info(
+                "[Email] Skipping %d already-sent attachment(s) for %s: %s",
+                len(_skipped), to_addr, ", ".join(_skipped),
+            )
+        file_paths = _fresh
+        if len(self._sent_attachments) > self._thread_context_max:
+            for _k in list(self._sent_attachments.keys())[: len(self._sent_attachments) // 2]:
+                del self._sent_attachments[_k]
 
         for file_path in file_paths:
             p = Path(file_path)
@@ -1294,6 +1685,7 @@ class EmailAdapter(BasePlatformAdapter):
                 smtp.close()
 
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        self._register_outbound_msgid(msg_id, to_addr, ctx)
         return msg_id
 
     async def send_document(
@@ -1311,21 +1703,18 @@ class EmailAdapter(BasePlatformAdapter):
         if not to_addr:
             logger.error("[Email] Cannot resolve recipient for document send, chat_id=%r", chat_id)
             return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
-        try:
-            loop = asyncio.get_running_loop()
-            message_id = await loop.run_in_executor(
-                None,
-                self._send_email_with_attachment,
+        # The gateway calls this once PER file, so each call only contributes
+        # its file to the buffered turn — it never sends an email of its own.
+        return SendResult(
+            success=True,
+            message_id=self._queue_part(
                 to_addr,
-                caption or "",
-                file_path,
-                file_name,
                 ctx,
-            )
-            return SendResult(success=True, message_id=message_id)
-        except Exception as e:
-            logger.error("[Email] Send document failed: %s", e)
-            return SendResult(success=False, error=str(e))
+                reply_to=reply_to,
+                body=caption or "",
+                file_paths=[file_path],
+            ),
+        )
 
     def _send_email_with_attachment(
         self,
@@ -1333,7 +1722,8 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
-        ctx: Optional[Dict[str, str]] = None,
+        ctx: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -1341,17 +1731,9 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = ctx or {}
-        subject = ctx.get("subject", "")
-        if not subject:
-            subject = "Hermes Agent"
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
-
-        original_msg_id = ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        self._apply_reply_headers(
+            msg, to_addr, ctx=ctx, reply_to_msg_id=reply_to, has_attachments=True
+        )
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1320,7 +1320,13 @@ class EmailAdapter(BasePlatformAdapter):
         so parts accumulate here and are flushed together.
         """
         key = self._ctx_key_for(to_addr, ctx)
-        entry = self._pending.get(key)
+        # Tolerate a partially-constructed adapter (tests and some proactive
+        # paths instantiate via object.__new__), so buffering never depends on
+        # __init__ having run.
+        pending = getattr(self, "_pending", None)
+        if pending is None:
+            pending = self._pending = {}
+        entry = pending.get(key)
         if entry is None:
             entry = {
                 "to_addr": to_addr,
@@ -1334,7 +1340,7 @@ class EmailAdapter(BasePlatformAdapter):
                 "task": None,
                 "first_seen": time.monotonic(),
             }
-            self._pending[key] = entry
+            pending[key] = entry
         if body and body.strip():
             entry["body_parts"].append(body.strip())
         for fp in file_paths or []:
@@ -1343,6 +1349,7 @@ class EmailAdapter(BasePlatformAdapter):
         if reply_to and not entry.get("reply_to"):
             entry["reply_to"] = reply_to
 
+        window = float(getattr(self, "_fold_window", 12.0))
         old = entry.get("task")
         if old is not None and not old.done():
             old.cancel()
@@ -1359,19 +1366,25 @@ class EmailAdapter(BasePlatformAdapter):
             key,
             len(entry["body_parts"]),
             len(entry["files"]),
-            self._fold_window,
+            window,
         )
         return f"pending-fold-{key}"
 
     async def _flush_after_idle(self, key: str) -> None:
         """Wait for the turn to go quiet, then emit exactly one mail."""
         try:
-            entry = self._pending.get(key)
+            entry = getattr(self, "_pending", {}).get(key)
             if not entry:
                 return
             elapsed = time.monotonic() - entry["first_seen"]
             await asyncio.sleep(
-                max(0.0, min(self._fold_window, self._fold_max_wait - elapsed))
+                max(
+                    0.0,
+                    min(
+                        float(getattr(self, "_fold_window", 12.0)),
+                        float(getattr(self, "_fold_max_wait", 90.0)) - elapsed,
+                    ),
+                )
             )
         except asyncio.CancelledError:
             # A newer part arrived and re-armed the timer.
@@ -1383,7 +1396,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _flush_now(self, key: str) -> Optional[str]:
         """Build and send the buffered turn as a single MIME message."""
-        entry = self._pending.pop(key, None)
+        entry = getattr(self, "_pending", {}).pop(key, None)
         if not entry:
             return None
         body = "\n\n".join(entry["body_parts"]).strip()
@@ -1403,7 +1416,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             if files:
                 return self._send_email_with_attachments(
-                    to_addr, body, files, ctx, reply_to
+                    to_addr, body, files, ctx=ctx, reply_to=reply_to
                 )
             return self._send_email(to_addr, body, reply_to, ctx)
         except Exception as e:
@@ -1415,8 +1428,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _flush_all_pending(self) -> None:
         """Emit every buffered turn — used on shutdown so nothing is dropped."""
-        for key in list(self._pending.keys()):
-            entry = self._pending.get(key) or {}
+        pending = getattr(self, "_pending", None) or {}
+        for key in list(pending.keys()):
+            entry = pending.get(key) or {}
             task = entry.get("task")
             if task is not None and not task.done():
                 task.cancel()
@@ -1640,6 +1654,7 @@ class EmailAdapter(BasePlatformAdapter):
         _dedupe_key = self._ctx_key_for(to_addr, ctx)
         _already = self._sent_attachments.setdefault(_dedupe_key, set())
         _fresh: List[str] = []
+        _fresh_hashes: List[str] = []
         _skipped: List[str] = []
         for _fp in file_paths:
             try:
@@ -1647,10 +1662,10 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 _fresh.append(_fp)
                 continue
-            if _h in _already:
+            if _h in _already or _h in _fresh_hashes:
                 _skipped.append(Path(_fp).name)
             else:
-                _already.add(_h)
+                _fresh_hashes.append(_h)
                 _fresh.append(_fp)
         if _skipped:
             logger.info(
@@ -1685,6 +1700,9 @@ class EmailAdapter(BasePlatformAdapter):
                 smtp.close()
 
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        # Record hashes only AFTER a successful send: marking them earlier meant
+        # a failed flush permanently suppressed those files on this thread.
+        _already.update(_fresh_hashes)
         self._register_outbound_msgid(msg_id, to_addr, ctx)
         return msg_id
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -531,11 +531,6 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Session routing: "thread" (default) gives each email subject its own
         # session; "sender" uses one session per sender address (legacy behaviour).
-        # Configured via config.yaml:
-        #   platforms:
-        #     email:
-        #       session_routing: thread   # or: sender
-        # or the EMAIL_SESSION_ROUTING env var.
         self._session_routing = (
             extra.get("session_routing", "")
             or os.getenv("EMAIL_SESSION_ROUTING", "")
@@ -545,12 +540,6 @@ class EmailAdapter(BasePlatformAdapter):
             self._session_routing = "thread"
 
         # Display name for the From: header in outgoing emails.
-        # Configured via config.yaml:
-        #   platforms:
-        #     email:
-        #       display_name: "Iris Sloane"
-        # or the EMAIL_DISPLAY_NAME env var.
-        # Defaults to the bare EMAIL_ADDRESS (no display name).
         self._display_name = (
             extra.get("display_name", "")
             or os.getenv("EMAIL_DISPLAY_NAME", "")
@@ -937,19 +926,23 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.DOCUMENT
 
         # Store thread context for reply threading
-        # In "thread" mode, chat_id is the normalized subject so each email
-        # thread gets its own session. In "sender" mode, chat_id is the sender
-        # address (one session per sender — legacy behaviour).
+        # In "thread" mode, chat_id is a composite key of sender + normalized
+        # subject so each email thread gets its own session AND different
+        # senders with the same subject stay isolated. In "sender" mode,
+        # chat_id is the sender address (one session per sender — legacy).
         if self._session_routing == "thread":
             _thread_subject = re.sub(
-                r'^(?:re|fwd|fw):\s*', '', subject.strip(), flags=re.IGNORECASE
+                r'^(?:(?:re|fwd|fw):\s*)+', '', subject.strip(), flags=re.IGNORECASE
             ).strip()
-            _chat_id = (
+            _thread_key = (
                 _thread_subject
                 or msg_data.get("in_reply_to")
                 or msg_data["message_id"]
-                or sender_addr
             )
+            if _thread_key:
+                _chat_id = f"{sender_addr}:{_thread_key}"
+            else:
+                _chat_id = sender_addr
         else:
             _chat_id = sender_addr
 
@@ -989,37 +982,50 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address.
 
-        ``chat_id`` may be a thread subject (not an email address) when
-        per-thread session routing is active. Resolve it to the real
-        recipient via thread context, falling back to EMAIL_HOME_ADDRESS
-        or chat_id itself.
+        ``chat_id`` may be a composite key (sender:subject) when per-thread
+        session routing is active. Resolve it to the real recipient via
+        thread context, falling back to EMAIL_HOME_ADDRESS for proactive
+        delivery only.
         """
-        ctx = self._thread_context.get(chat_id, {})
-        to_addr = ctx.get("sender_addr", "")
-        # If no sender_addr in context, try matching by scanning all contexts
+        to_addr, ctx = self._resolve_recipient(chat_id)
         if not to_addr:
-            for _tc in self._thread_context.values():
-                if _tc.get("sender_addr") and "@" in _tc.get("sender_addr", ""):
-                    to_addr = _tc["sender_addr"]
-                    break
-        # Last resort: if chat_id looks like an email, use it; else use home address
-        if not to_addr:
-            if "@" in chat_id:
-                to_addr = chat_id
-            else:
-                to_addr = os.getenv("EMAIL_HOME_ADDRESS", "")
-                if not to_addr:
-                    logger.error("[Email] Cannot resolve recipient for chat_id=%r and no EMAIL_HOME_ADDRESS set", chat_id)
-                    return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
+            logger.error("[Email] Cannot resolve recipient for chat_id=%r and no EMAIL_HOME_ADDRESS set", chat_id)
+            return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, to_addr, content, reply_to
+                None, self._send_email, to_addr, content, reply_to, chat_id
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[Email] Send failed to %s: %s", to_addr, e)
             return SendResult(success=False, error=str(e))
+
+    def _resolve_recipient(self, chat_id: str) -> tuple:
+        """Resolve a chat_id to (recipient_address, thread_context).
+
+        Single source of truth for all send paths. Never guesses — if the
+        chat_id cannot be resolved to a specific recipient, returns ("", {})
+        so the caller can fail closed or use EMAIL_HOME_ADDRESS explicitly.
+
+        Resolution order:
+        1. Direct lookup: chat_id in _thread_context → sender_addr
+        2. chat_id is itself an email address (sender mode or direct)
+        3. Fall back to EMAIL_HOME_ADDRESS for proactive delivery
+        """
+        ctx = self._thread_context.get(chat_id, {})
+        to_addr = ctx.get("sender_addr", "")
+        if to_addr and "@" in to_addr:
+            return to_addr, ctx
+        # chat_id may be a bare email address (sender mode, or direct address)
+        if "@" in chat_id:
+            ctx = self._thread_context.get(chat_id, {})
+            return chat_id, ctx
+        # Proactive delivery (cron, kanban notifications) — use home address
+        home = os.getenv("EMAIL_HOME_ADDRESS", "")
+        if home:
+            return home, {}
+        return "", {}
 
     def _message_id_domain(self) -> str:
         """Domain part for generated Message-IDs.
@@ -1036,22 +1042,19 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        chat_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        # Thread context for reply — look up by recipient address
-        # (thread_context may be keyed by thread_id or sender_addr)
-        ctx = self._thread_context.get(to_addr, {})
-        # If not found by address, try matching by sender_addr in values
-        if not ctx:
-            for _tid, _tc in self._thread_context.items():
-                if _tc.get("sender_addr") == to_addr:
-                    ctx = _tc
-                    break
-        subject = ctx.get("subject", "Hermes Agent")
+        # Resolve thread context for subject and threading headers
+        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        subject = ctx.get("subject", "")
+        if not subject:
+            # chat_id may itself be the normalized subject
+            subject = chat_id if chat_id and chat_id != to_addr else "Hermes Agent"
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1140,14 +1143,20 @@ class EmailAdapter(BasePlatformAdapter):
 
         body = "\n\n".join(body_parts)
 
+        to_addr, _ctx = self._resolve_recipient(chat_id)
+        if not to_addr:
+            logger.error("[Email] Cannot resolve recipient for multi-image send, chat_id=%r", chat_id)
+            return
+
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 None,
                 self._send_email_with_attachments,
-                chat_id,
+                to_addr,
                 body,
                 local_paths,
+                chat_id,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1158,14 +1167,19 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        chat_id: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        subject = ctx.get("subject", "")
+        if not subject and chat_id and chat_id != to_addr:
+            subject = chat_id
+        if not subject:
+            subject = "Hermes Agent"
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1217,15 +1231,20 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        to_addr, _ctx = self._resolve_recipient(chat_id)
+        if not to_addr:
+            logger.error("[Email] Cannot resolve recipient for document send, chat_id=%r", chat_id)
+            return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None,
                 self._send_email_with_attachment,
-                chat_id,
+                to_addr,
                 caption or "",
                 file_path,
                 file_name,
+                chat_id,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1238,14 +1257,19 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        chat_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        subject = ctx.get("subject", "")
+        if not subject and chat_id and chat_id != to_addr:
+            subject = chat_id
+        if not subject:
+            subject = "Hermes Agent"
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -33,7 +33,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formatdate, formataddr
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -526,8 +526,36 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
+        # Map chat_id (sender email or thread subject) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
+
+        # Session routing: "thread" (default) gives each email subject its own
+        # session; "sender" uses one session per sender address (legacy behaviour).
+        # Configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       session_routing: thread   # or: sender
+        # or the EMAIL_SESSION_ROUTING env var.
+        self._session_routing = (
+            extra.get("session_routing", "")
+            or os.getenv("EMAIL_SESSION_ROUTING", "")
+            or "thread"
+        ).strip().lower()
+        if self._session_routing not in ("thread", "sender"):
+            self._session_routing = "thread"
+
+        # Display name for the From: header in outgoing emails.
+        # Configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       display_name: "Iris Sloane"
+        # or the EMAIL_DISPLAY_NAME env var.
+        # Defaults to the bare EMAIL_ADDRESS (no display name).
+        self._display_name = (
+            extra.get("display_name", "")
+            or os.getenv("EMAIL_DISPLAY_NAME", "")
+            or ""
+        ).strip()
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -909,13 +937,30 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.DOCUMENT
 
         # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
+        # In "thread" mode, chat_id is the normalized subject so each email
+        # thread gets its own session. In "sender" mode, chat_id is the sender
+        # address (one session per sender — legacy behaviour).
+        if self._session_routing == "thread":
+            _thread_subject = re.sub(
+                r'^(?:re|fwd|fw):\s*', '', subject.strip(), flags=re.IGNORECASE
+            ).strip()
+            _chat_id = (
+                _thread_subject
+                or msg_data.get("in_reply_to")
+                or msg_data["message_id"]
+                or sender_addr
+            )
+        else:
+            _chat_id = sender_addr
+
+        self._thread_context[_chat_id] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "sender_addr": sender_addr,
         }
 
         source = self.build_source(
-            chat_id=sender_addr,
+            chat_id=_chat_id,
             chat_name=msg_data["sender_name"] or sender_addr,
             chat_type="dm",
             user_id=sender_addr,
@@ -942,15 +987,38 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        ``chat_id`` may be a thread subject (not an email address) when
+        per-thread session routing is active. Resolve it to the real
+        recipient via thread context, falling back to EMAIL_HOME_ADDRESS
+        or chat_id itself.
+        """
+        ctx = self._thread_context.get(chat_id, {})
+        to_addr = ctx.get("sender_addr", "")
+        # If no sender_addr in context, try matching by scanning all contexts
+        if not to_addr:
+            for _tc in self._thread_context.values():
+                if _tc.get("sender_addr") and "@" in _tc.get("sender_addr", ""):
+                    to_addr = _tc["sender_addr"]
+                    break
+        # Last resort: if chat_id looks like an email, use it; else use home address
+        if not to_addr:
+            if "@" in chat_id:
+                to_addr = chat_id
+            else:
+                to_addr = os.getenv("EMAIL_HOME_ADDRESS", "")
+                if not to_addr:
+                    logger.error("[Email] Cannot resolve recipient for chat_id=%r and no EMAIL_HOME_ADDRESS set", chat_id)
+                    return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, to_addr, content, reply_to
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", chat_id, e)
+            logger.error("[Email] Send failed to %s: %s", to_addr, e)
             return SendResult(success=False, error=str(e))
 
     def _message_id_domain(self) -> str:
@@ -971,11 +1039,18 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
+        # Thread context for reply — look up by recipient address
+        # (thread_context may be keyed by thread_id or sender_addr)
         ctx = self._thread_context.get(to_addr, {})
+        # If not found by address, try matching by sender_addr in values
+        if not ctx:
+            for _tid, _tc in self._thread_context.items():
+                if _tc.get("sender_addr") == to_addr:
+                    ctx = _tc
+                    break
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1086,7 +1161,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
@@ -1166,7 +1241,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -862,20 +862,25 @@ class EmailAdapter(BasePlatformAdapter):
         # that the gateway will never authorize.  Without this early guard,
         # a race between dispatch and authorization can result in the adapter
         # sending a reply even though the handler returned None.
-        allowed_raw = _get_secret("EMAIL_ALLOWED_USERS", "").strip()
-        if not allowed_raw:
-            if _get_secret("EMAIL_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"} and (
-                os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"}
-            ):
+        #
+        # Precedence matches the gateway authz layer: allow-all wins FIRST;
+        # only when it is off does the allowlist gate. Allowlist tokens may be
+        # exact addresses or @domain wildcards (e.g. "@known.ltd").
+        if not self._allow_all_senders():
+            allowed_raw = os.getenv("EMAIL_ALLOWED_USERS", "").strip()
+            if not allowed_raw:
                 logger.debug(
                     "[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset "
                     "and open access is not opted in: %s",
                     sender_addr,
                 )
                 return
-        else:
-            allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
-            if sender_addr.lower() not in allowed:
+            tokens = {t.strip().lower() for t in allowed_raw.split(",") if t.strip()}
+            sender_l = sender_addr.lower()
+            if not any(
+                (t.startswith("@") and sender_l.endswith(t)) or sender_l == t
+                for t in tokens
+            ):
                 logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
                 return
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -526,8 +526,15 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email or thread subject) -> last subject + message-id for threading
+        # Map context key -> last subject + message-id for threading.
+        # Context key is "<chat_id>::<thread_id>" in thread mode, or the bare
+        # chat_id (sender address) in sender mode. chat_id is ALWAYS a real
+        # email address — never a subject or composite key.
         self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Message-ID -> context key, so replies can anchor to the exact
+        # inbound message even when send-time metadata lacks thread_id.
+        self._msgid_context: Dict[str, str] = {}
+        self._thread_context_max: int = 2000  # cap to prevent unbounded growth
 
         # Session routing: "thread" (default) gives each email subject its own
         # session; "sender" uses one session per sender address (legacy behaviour).
@@ -925,11 +932,12 @@ class EmailAdapter(BasePlatformAdapter):
                 # only classification that surfaces both.
                 msg_type = MessageType.DOCUMENT
 
-        # Store thread context for reply threading
-        # In "thread" mode, chat_id is a composite key of sender + normalized
-        # subject so each email thread gets its own session AND different
-        # senders with the same subject stay isolated. In "sender" mode,
-        # chat_id is the sender address (one session per sender — legacy).
+        # Store thread context for reply threading.
+        # chat_id is ALWAYS the sender address (a deliverable mailbox). In
+        # "thread" mode, thread_id is a stable per-thread key so
+        # build_session_key() isolates sessions per (sender, thread) the same
+        # way Telegram topics / Discord threads do. In "sender" mode,
+        # thread_id is None and each sender gets one session (legacy).
         if self._session_routing == "thread":
             _thread_subject = re.sub(
                 r'^(?:(?:re|fwd|fw):\s*)+', '', subject.strip(), flags=re.IGNORECASE
@@ -939,21 +947,23 @@ class EmailAdapter(BasePlatformAdapter):
                 or msg_data.get("in_reply_to")
                 or msg_data["message_id"]
             )
-            if _thread_key:
-                _chat_id = f"{sender_addr}:{_thread_key}"
-            else:
-                _chat_id = sender_addr
+            thread_id = _thread_key or None
         else:
-            _chat_id = sender_addr
+            thread_id = None
 
-        self._thread_context[_chat_id] = {
+        _ctx_key = f"{sender_addr}::{thread_id}" if thread_id else sender_addr
+        self._thread_context[_ctx_key] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
             "sender_addr": sender_addr,
         }
+        if msg_data.get("message_id"):
+            self._msgid_context[msg_data["message_id"]] = _ctx_key
+        self._trim_thread_context()
 
         source = self.build_source(
-            chat_id=_chat_id,
+            chat_id=sender_addr,
+            thread_id=thread_id,
             chat_name=msg_data["sender_name"] or sender_addr,
             chat_type="dm",
             user_id=sender_addr,
@@ -982,26 +992,89 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address.
 
-        ``chat_id`` may be a composite key (sender:subject) when per-thread
-        session routing is active. Resolve it to the real recipient via
-        thread context, falling back to EMAIL_HOME_ADDRESS for proactive
-        delivery only.
+        ``chat_id`` is always a real email address (the sender from the
+        inbound dispatch). Thread context is resolved from ``metadata``
+        (the gateway passes ``thread_id`` through) or from ``reply_to``
+        (the inbound Message-ID), never from an arbitrary cached sender.
         """
-        to_addr, ctx = self._resolve_recipient(chat_id)
+        to_addr, ctx = self._resolve_recipient(chat_id, metadata=metadata, reply_to=reply_to)
         if not to_addr:
             logger.error("[Email] Cannot resolve recipient for chat_id=%r and no EMAIL_HOME_ADDRESS set", chat_id)
             return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, to_addr, content, reply_to, chat_id
+                None, self._send_email, to_addr, content, reply_to, ctx
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[Email] Send failed to %s: %s", to_addr, e)
             return SendResult(success=False, error=str(e))
 
-    def _resolve_recipient(self, chat_id: str) -> tuple:
+    def _trim_thread_context(self) -> None:
+        """Bound thread context + msgid index so long-lived gateways don't grow forever."""
+        if len(self._thread_context) > self._thread_context_max:
+            # Dicts preserve insertion order; drop the oldest half.
+            drop = len(self._thread_context) - (self._thread_context_max // 2)
+            stale_keys = list(self._thread_context.keys())[:drop]
+            for key in stale_keys:
+                del self._thread_context[key]
+            stale = set(stale_keys)
+            self._msgid_context = {
+                mid: key for mid, key in self._msgid_context.items() if key not in stale
+            }
+        if len(self._msgid_context) > self._thread_context_max:
+            drop = len(self._msgid_context) - (self._thread_context_max // 2)
+            for mid in list(self._msgid_context.keys())[:drop]:
+                del self._msgid_context[mid]
+
+    def _context_for_send(
+        self,
+        chat_id: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Resolve reply context (subject + threading headers) for a send.
+
+        Lookup order:
+        1. metadata.thread_id -> "<chat_id>::<thread_id>" (gateway thread passthrough)
+        2. reply_to -> Message-ID index -> context key (exact inbound anchor)
+        3. bare chat_id key (sender mode, or direct address)
+        4. Most recent context stored for this sender (same mailbox only).
+
+        Step 4 can only pick a subject/headers for a reply going to the SAME
+        address — it never changes the recipient, so delivery stays fail-closed.
+        """
+        thread_id = (metadata or {}).get("thread_id")
+        if thread_id:
+            ctx = self._thread_context.get(f"{chat_id}::{thread_id}")
+            if ctx:
+                return ctx
+        if reply_to:
+            key = self._msgid_context.get(reply_to)
+            if key:
+                ctx = self._thread_context.get(key)
+                if ctx:
+                    return ctx
+        ctx = self._thread_context.get(chat_id)
+        if ctx:
+            return ctx
+        # Most recent context for this sender (insertion order = recency).
+        best: Dict[str, str] = {}
+        prefix = f"{chat_id}::"
+        for key, val in self._thread_context.items():
+            if key.startswith(prefix):
+                best = val
+        return best
+
+    def _resolve_recipient(
+        self,
+        chat_id: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
+    ) -> tuple:
         """Resolve a chat_id to (recipient_address, thread_context).
 
         Single source of truth for all send paths. Never guesses — if the
@@ -1009,17 +1082,12 @@ class EmailAdapter(BasePlatformAdapter):
         so the caller can fail closed or use EMAIL_HOME_ADDRESS explicitly.
 
         Resolution order:
-        1. Direct lookup: chat_id in _thread_context → sender_addr
-        2. chat_id is itself an email address (sender mode or direct)
-        3. Fall back to EMAIL_HOME_ADDRESS for proactive delivery
+        1. chat_id is itself an email address (the normal path: chat_id is
+           always the sender's mailbox)
+        2. Fall back to EMAIL_HOME_ADDRESS for proactive delivery only
         """
-        ctx = self._thread_context.get(chat_id, {})
-        to_addr = ctx.get("sender_addr", "")
-        if to_addr and "@" in to_addr:
-            return to_addr, ctx
-        # chat_id may be a bare email address (sender mode, or direct address)
+        ctx = self._context_for_send(chat_id, metadata=metadata, reply_to=reply_to)
         if "@" in chat_id:
-            ctx = self._thread_context.get(chat_id, {})
             return chat_id, ctx
         # Proactive delivery (cron, kanban notifications) — use home address
         home = os.getenv("EMAIL_HOME_ADDRESS", "")
@@ -1042,19 +1110,19 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
-        chat_id: Optional[str] = None,
+        ctx: Optional[Dict[str, str]] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        # Resolve thread context for subject and threading headers
-        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        # Resolve subject and threading headers from the context the caller
+        # resolved (send-time thread metadata or Message-ID anchor).
+        ctx = ctx or {}
         subject = ctx.get("subject", "")
         if not subject:
-            # chat_id may itself be the normalized subject
-            subject = chat_id if chat_id and chat_id != to_addr else "Hermes Agent"
+            subject = "Hermes Agent"
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1143,7 +1211,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         body = "\n\n".join(body_parts)
 
-        to_addr, _ctx = self._resolve_recipient(chat_id)
+        to_addr, ctx = self._resolve_recipient(chat_id, metadata=metadata)
         if not to_addr:
             logger.error("[Email] Cannot resolve recipient for multi-image send, chat_id=%r", chat_id)
             return
@@ -1156,7 +1224,7 @@ class EmailAdapter(BasePlatformAdapter):
                 to_addr,
                 body,
                 local_paths,
-                chat_id,
+                ctx,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1167,17 +1235,15 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
-        chat_id: Optional[str] = None,
+        ctx: Optional[Dict[str, str]] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        ctx = ctx or {}
         subject = ctx.get("subject", "")
-        if not subject and chat_id and chat_id != to_addr:
-            subject = chat_id
         if not subject:
             subject = "Hermes Agent"
         if not subject.startswith("Re:"):
@@ -1231,7 +1297,8 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
-        to_addr, _ctx = self._resolve_recipient(chat_id)
+        metadata = kwargs.get("metadata")
+        to_addr, ctx = self._resolve_recipient(chat_id, metadata=metadata, reply_to=reply_to)
         if not to_addr:
             logger.error("[Email] Cannot resolve recipient for document send, chat_id=%r", chat_id)
             return SendResult(success=False, error=f"Cannot resolve recipient for chat_id={chat_id!r}")
@@ -1244,7 +1311,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
-                chat_id,
+                ctx,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1257,17 +1324,15 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
-        chat_id: Optional[str] = None,
+        ctx: Optional[Dict[str, str]] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = formataddr((self._display_name, self._address)) if self._display_name else self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(chat_id, {}) if chat_id else {}
+        ctx = ctx or {}
         subject = ctx.get("subject", "")
-        if not subject and chat_id and chat_id != to_addr:
-            subject = chat_id
         if not subject:
             subject = "Hermes Agent"
         if not subject.startswith("Re:"):
@@ -1311,6 +1376,13 @@ class EmailAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""
         ctx = self._thread_context.get(chat_id, {})
+        if not ctx:
+            # Thread mode: contexts live under "<chat_id>::<thread_id>"; report
+            # the most recent subject for this mailbox.
+            prefix = f"{chat_id}::"
+            for key, val in self._thread_context.items():
+                if key.startswith(prefix):
+                    ctx = val
         return {
             "name": chat_id,
             "type": "dm",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -536,15 +536,19 @@ class EmailAdapter(BasePlatformAdapter):
         self._msgid_context: Dict[str, str] = {}
         self._thread_context_max: int = 2000  # cap to prevent unbounded growth
 
-        # Session routing: "thread" (default) gives each email subject its own
-        # session; "sender" uses one session per sender address (legacy behaviour).
+        # Session routing (opt-in thread isolation):
+        #   "sender" (default) — one session per sender address (stock Hermes
+        #     behaviour; safe for existing deployments — no session key change).
+        #   "thread" — one session per email thread via SessionSource.thread_id
+        #     (recommended for email-agent secretaries). Enable via
+        #     platforms.email.session_routing or EMAIL_SESSION_ROUTING=thread.
         self._session_routing = (
             extra.get("session_routing", "")
             or os.getenv("EMAIL_SESSION_ROUTING", "")
-            or "thread"
+            or "sender"
         ).strip().lower()
         if self._session_routing not in ("thread", "sender"):
-            self._session_routing = "thread"
+            self._session_routing = "sender"
 
         # Display name for the From: header in outgoing emails.
         self._display_name = (
@@ -1473,6 +1477,144 @@ def _build_adapter(config):
     return EmailAdapter(config)
 
 
+def interactive_setup() -> None:
+    """Interactive `hermes gateway setup` flow for the Email platform.
+
+    Collects IMAP/SMTP credentials, access control, session routing, and an
+    optional From display name. Lazy-imports hermes_cli.setup helpers so the
+    plugin stays importable in non-CLI contexts.
+    """
+    from hermes_cli.setup import (
+        get_env_value,
+        print_header,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_choice,
+        prompt_yes_no,
+        save_env_value,
+    )
+
+    print_header("Email")
+    existing = get_env_value("EMAIL_ADDRESS")
+    if existing:
+        print_info(f"Email: already configured (address: {existing})")
+        if not prompt_yes_no("Reconfigure Email?", False):
+            return
+
+    print_info("Talk to Hermes through a dedicated IMAP/SMTP mailbox.")
+    print_info("  Use an app password for Gmail / Workspace — not the account password.")
+    print_info("  Prefer a dedicated mailbox (not your personal inbox).")
+    print()
+
+    address = prompt("Email address", default=get_env_value("EMAIL_ADDRESS") or "")
+    if not address:
+        print_warning("Email address is required — skipping Email setup")
+        return
+    save_env_value("EMAIL_ADDRESS", address.strip())
+
+    password = prompt("Email password / app password", password=True)
+    if password:
+        save_env_value("EMAIL_PASSWORD", password)
+    elif not get_env_value("EMAIL_PASSWORD"):
+        print_warning("Password is required — skipping Email setup")
+        return
+
+    imap_host = prompt(
+        "IMAP host (e.g. imap.gmail.com)",
+        default=get_env_value("EMAIL_IMAP_HOST") or "imap.gmail.com",
+    )
+    if imap_host:
+        save_env_value("EMAIL_IMAP_HOST", imap_host.strip())
+
+    smtp_host = prompt(
+        "SMTP host (e.g. smtp.gmail.com)",
+        default=get_env_value("EMAIL_SMTP_HOST") or "smtp.gmail.com",
+    )
+    if smtp_host:
+        save_env_value("EMAIL_SMTP_HOST", smtp_host.strip())
+
+    print()
+    print_info("Access control — the gateway denies unknown senders by default.")
+    allowed = prompt(
+        "Allowed senders (comma-separated addresses or @domain tokens, empty = decide next)",
+        default=get_env_value("EMAIL_ALLOWED_USERS") or "",
+    )
+    if allowed.strip():
+        save_env_value("EMAIL_ALLOWED_USERS", allowed.replace(" ", ""))
+        print_success("  Allowlist saved.")
+    else:
+        access_idx = prompt_choice(
+            "How should unauthorized senders be handled?",
+            [
+                "Open access (any email sender can message the bot)",
+                "Keep unknown senders silent (configure allowlist later)",
+            ],
+            1,
+        )
+        if access_idx == 0:
+            save_env_value("EMAIL_ALLOW_ALL_USERS", "true")
+            print_warning("  Open access enabled — anyone who can email this mailbox can talk to the bot.")
+        else:
+            save_env_value("EMAIL_ALLOW_ALL_USERS", "")
+            print_info("  Unknown senders will be ignored until EMAIL_ALLOWED_USERS is set.")
+
+    home = prompt(
+        "Home address for cron/notifications (optional)",
+        default=get_env_value("EMAIL_HOME_ADDRESS") or "",
+    )
+    if home.strip():
+        save_env_value("EMAIL_HOME_ADDRESS", home.strip())
+
+    print()
+    print_info("Session routing controls how email conversations are isolated.")
+    print_info("  Thread mode (recommended for email secretaries): one agent session")
+    print_info("  per email thread — two subjects from the same person stay separate.")
+    print_info("  Sender mode (stock default): one session per sender address.")
+    routing_idx = prompt_choice(
+        "Session routing?",
+        [
+            "One session per email thread (recommended for email agents)",
+            "One session per sender (stock / legacy)",
+        ],
+        0,
+    )
+    routing = "thread" if routing_idx == 0 else "sender"
+    save_env_value("EMAIL_SESSION_ROUTING", routing)
+    # Also persist under platforms.email so config.yaml is the source of truth
+    # for operators who prefer YAML over env.
+    try:
+        from hermes_cli.config import write_platform_config_field
+
+        write_platform_config_field("email", "session_routing", routing, raw=True)
+    except Exception:
+        pass
+    print_success(f"  Session routing: {routing}")
+
+    print()
+    display = prompt(
+        "From display name (optional, e.g. Iris Sloane)",
+        default=get_env_value("EMAIL_DISPLAY_NAME") or "",
+    )
+    if display.strip():
+        save_env_value("EMAIL_DISPLAY_NAME", display.strip())
+        try:
+            from hermes_cli.config import write_platform_config_field
+
+            write_platform_config_field("email", "display_name", display.strip(), raw=True)
+        except Exception:
+            pass
+        print_success(f"  From header will show: {display.strip()} <{address.strip()}>")
+    else:
+        print_info("  From header will use the bare address.")
+
+    print()
+    print_success("Email platform configured.")
+    print_info("  Start or restart the gateway: hermes gateway restart")
+    print_info("  Docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/email")
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -1491,4 +1633,5 @@ def register(ctx) -> None:
         pii_safe=True,
         emoji="📧",
         allow_update_command=True,
+        setup_fn=interactive_setup,
     )

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -30,10 +30,22 @@ optional_env:
     prompt: "IMAP host"
     password: false
   - name: EMAIL_ALLOWED_USERS
-    description: "Comma-separated email addresses allowed to talk to the bot"
+    description: "Comma-separated email addresses or @domain tokens allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"
     password: false
   - name: EMAIL_HOME_ADDRESS
     description: "Default address for cron / notification delivery"
     prompt: "Home address"
+    password: false
+  - name: EMAIL_SESSION_ROUTING
+    description: "Session routing: sender (default, one session per person) or thread (one session per email thread — recommended for email agents)"
+    prompt: "Session routing (sender|thread)"
+    password: false
+  - name: EMAIL_DISPLAY_NAME
+    description: "Display name for the From: header (e.g. Iris Sloane)"
+    prompt: "From display name"
+    password: false
+  - name: EMAIL_ALLOW_ALL_USERS
+    description: "When true, accept mail from any sender (use with a dedicated mailbox)"
+    prompt: "Allow all senders (true/false)"
     password: false

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -133,8 +133,13 @@ class TestDispatchMessage(unittest.TestCase):
         else:
             os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
 
-    def _make_adapter(self):
-        """Create an EmailAdapter with mocked env vars."""
+    def _make_adapter(self, session_routing: str = "thread"):
+        """Create an EmailAdapter with mocked env vars.
+
+        Defaults to session_routing=thread so dispatch/thread isolation tests
+        exercise the feature under test. Pass session_routing=\"sender\" (or
+        omit via a dedicated test) for legacy-default behaviour.
+        """
         from gateway.config import PlatformConfig
         with patch.dict(os.environ, {
             "EMAIL_ADDRESS": "hermes@test.com",
@@ -144,9 +149,13 @@ class TestDispatchMessage(unittest.TestCase):
             "EMAIL_SMTP_HOST": "smtp.test.com",
             "EMAIL_SMTP_PORT": "587",
             "EMAIL_POLL_INTERVAL": "15",
-        }):
+        }, clear=False):
+            # Clear any ambient EMAIL_SESSION_ROUTING so the explicit config wins.
+            os.environ.pop("EMAIL_SESSION_ROUTING", None)
             from plugins.platforms.email.adapter import EmailAdapter
-            adapter = EmailAdapter(PlatformConfig(enabled=True))
+            adapter = EmailAdapter(
+                PlatformConfig(enabled=True, extra={"session_routing": session_routing})
+            )
         return adapter
 
     def test_self_message_filtered(self):
@@ -360,6 +369,20 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(event.source.user_id, "john@example.com")
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
+
+    def test_default_session_routing_is_sender(self):
+        """Unset session_routing must default to sender (safe for existing users)."""
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }, clear=False):
+            os.environ.pop("EMAIL_SESSION_ROUTING", None)
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        self.assertEqual(adapter._session_routing, "sender")
 
     def test_thread_mode_different_senders_same_subject_isolated(self):
         """Two senders with the same subject must get different chat_ids (sessions)."""
@@ -884,16 +907,19 @@ class TestThreadContext(unittest.TestCase):
         else:
             os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
 
-    def _make_adapter(self):
+    def _make_adapter(self, session_routing: str = "thread"):
         from gateway.config import PlatformConfig
         with patch.dict(os.environ, {
             "EMAIL_ADDRESS": "hermes@test.com",
             "EMAIL_PASSWORD": "secret",
             "EMAIL_IMAP_HOST": "imap.test.com",
             "EMAIL_SMTP_HOST": "smtp.test.com",
-        }):
+        }, clear=False):
+            os.environ.pop("EMAIL_SESSION_ROUTING", None)
             from plugins.platforms.email.adapter import EmailAdapter
-            adapter = EmailAdapter(PlatformConfig(enabled=True))
+            adapter = EmailAdapter(
+                PlatformConfig(enabled=True, extra={"session_routing": session_routing})
+            )
         return adapter
 
     def test_thread_context_stored_after_dispatch(self):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -530,6 +530,8 @@ class TestDispatchMessage(unittest.TestCase):
         import asyncio
         with patch.dict(os.environ, {
             "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
+            "EMAIL_ALLOW_ALL_USERS": "",
+            "GATEWAY_ALLOW_ALL_USERS": "",
         }):
             adapter = self._make_adapter()
             adapter._message_handler = MagicMock()
@@ -771,6 +773,99 @@ class TestDispatchMessage(unittest.TestCase):
 
             asyncio.run(adapter._dispatch_message(msg_data))
             self.assertEqual(len(captured), 1)
+
+    def test_allow_all_wins_over_stale_allowlist(self):
+        """EMAIL_ALLOW_ALL_USERS=true must win even when EMAIL_ALLOWED_USERS is set.
+
+        Regression: the dispatch gate previously checked the allowlist first
+        and only consulted allow-all when the allowlist was empty, so a stale
+        allowlist silently dropped every sender not exactly listed.
+        """
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOW_ALL_USERS": "true",
+            "EMAIL_ALLOWED_USERS": "someone-else@other.com",
+        }):
+            adapter = self._make_adapter()
+            captured = []
+
+            async def capture_handle(event):
+                captured.append(event)
+
+            adapter.handle_message = capture_handle
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"204",
+                "sender_addr": "andrew@known.ltd",
+                "sender_name": "Andrew",
+                "subject": "Hi",
+                "message_id": "<m@test.com>",
+                "in_reply_to": "",
+                "body": "Hello",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": True,
+                "auth_reason": "dmarc=pass",
+            }))
+            self.assertEqual(len(captured), 1)
+
+    def test_allowlist_domain_token_matches(self):
+        """@domain tokens in EMAIL_ALLOWED_USERS match any address on that domain."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "@known.ltd,a2childs@gmail.com",
+        }):
+            for k in ("EMAIL_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"):
+                os.environ.pop(k, None)
+            adapter = self._make_adapter()
+            captured = []
+
+            async def capture_handle(event):
+                captured.append(event)
+
+            adapter.handle_message = capture_handle
+
+            for i, sender in enumerate(["andrew@known.ltd", "siya@known.ltd", "a2childs@gmail.com"]):
+                asyncio.run(adapter._dispatch_message({
+                    "uid": str(300 + i).encode(),
+                    "sender_addr": sender,
+                    "sender_name": sender,
+                    "subject": "Hi",
+                    "message_id": f"<m{i}@test.com>",
+                    "in_reply_to": "",
+                    "body": "Hello",
+                    "attachments": [],
+                    "date": "",
+                    "sender_authenticated": True,
+                    "auth_reason": "dmarc=pass",
+                }))
+            self.assertEqual(len(captured), 3)
+
+    def test_allowlist_domain_token_rejects_other_domains(self):
+        """@domain tokens must NOT match addresses on other domains."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "@known.ltd",
+        }):
+            for k in ("EMAIL_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"):
+                os.environ.pop(k, None)
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"310",
+                "sender_addr": "mallory@evil.com",
+                "sender_name": "Mallory",
+                "subject": "Hi",
+                "message_id": "<m@evil.com>",
+                "in_reply_to": "",
+                "body": "Hello",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": True,
+                "auth_reason": "dmarc=pass",
+            }))
+            adapter._message_handler.assert_not_called()
 
 
 class TestThreadContext(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -327,9 +327,10 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(len(captured_events[0].media_urls), 2)
 
     def test_source_built_correctly(self):
-        """Session source should have correct chat_id and user info.
+        """Session source should have correct chat_id, thread_id and user info.
 
-        In thread mode, chat_id is a composite of sender:normalized_subject.
+        chat_id is always the sender's mailbox; thread_id carries the
+        normalized subject in thread mode.
         """
         import asyncio
         adapter = self._make_adapter()
@@ -354,8 +355,8 @@ class TestDispatchMessage(unittest.TestCase):
 
         asyncio.run(adapter._dispatch_message(msg_data))
         event = captured_events[0]
-        # Thread mode: chat_id is "sender:normalized_subject"
-        self.assertEqual(event.source.chat_id, "john@example.com:hi")
+        self.assertEqual(event.source.chat_id, "john@example.com")
+        self.assertEqual(event.source.thread_id, "hi")
         self.assertEqual(event.source.user_id, "john@example.com")
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
@@ -398,12 +399,14 @@ class TestDispatchMessage(unittest.TestCase):
 
         self.assertEqual(len(captured_events), 2)
         chat_ids = {e.source.chat_id for e in captured_events}
+        thread_ids = {e.source.thread_id for e in captured_events}
         self.assertEqual(len(chat_ids), 2, "Two senders with same subject must have different chat_ids")
-        self.assertIn("alice@example.com:Invoice", chat_ids)
-        self.assertIn("bob@example.com:Invoice", chat_ids)
+        self.assertIn("alice@example.com", chat_ids)
+        self.assertIn("bob@example.com", chat_ids)
+        self.assertEqual(thread_ids, {"Invoice"})
 
     def test_thread_mode_same_sender_same_subject_reuses_session(self):
-        """Same sender + same subject should produce the same chat_id (same session)."""
+        """Same sender + same subject should produce the same (chat_id, thread_id)."""
         import asyncio
         adapter = self._make_adapter()
         captured_events = []
@@ -428,9 +431,75 @@ class TestDispatchMessage(unittest.TestCase):
 
         self.assertEqual(len(captured_events), 2)
         self.assertEqual(captured_events[0].source.chat_id, captured_events[1].source.chat_id)
+        self.assertEqual(captured_events[0].source.thread_id, captured_events[1].source.thread_id)
+
+    def test_thread_mode_same_sender_different_subjects_isolated(self):
+        """Same sender on two subjects must get different thread_ids (sessions)."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        for i, subject in enumerate(["Quarterly report", "Lunch plans"]):
+            asyncio.run(adapter._dispatch_message({
+                "uid": str(i).encode(),
+                "sender_addr": "user@test.com",
+                "sender_name": "User",
+                "subject": subject,
+                "message_id": f"<m{i}@test.com>",
+                "in_reply_to": "",
+                "body": f"Message {i}",
+                "attachments": [],
+                "date": "",
+            }))
+
+        self.assertEqual(len(captured_events), 2)
+        self.assertEqual(captured_events[0].source.chat_id, "user@test.com")
+        self.assertEqual(captured_events[1].source.chat_id, "user@test.com")
+        thread_ids = {e.source.thread_id for e in captured_events}
+        self.assertEqual(thread_ids, {"Quarterly report", "Lunch plans"})
+
+    def test_sender_mode_has_no_thread_id(self):
+        """Legacy sender mode: chat_id is the address, thread_id is None."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True, extra={"session_routing": "sender"}))
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: Anything",
+            "message_id": "<m1@test.com>",
+            "in_reply_to": "",
+            "body": "Body",
+            "attachments": [],
+            "date": "",
+        }))
+
+        self.assertEqual(len(captured_events), 1)
+        self.assertEqual(captured_events[0].source.chat_id, "user@test.com")
+        self.assertIsNone(captured_events[0].source.thread_id)
 
     def test_thread_mode_reply_subject_normalized(self):
-        """Re: prefix should be stripped from subject in chat_id."""
+        """Re: and Fwd: prefixes should be stripped from thread_id."""
         import asyncio
         adapter = self._make_adapter()
         captured_events = []
@@ -454,7 +523,7 @@ class TestDispatchMessage(unittest.TestCase):
 
         self.assertEqual(len(captured_events), 1)
         # Both Re: and Fwd: should be stripped
-        self.assertEqual(captured_events[0].source.chat_id, "user@test.com:Important Topic")
+        self.assertEqual(captured_events[0].source.thread_id, "Important Topic")
 
     def test_non_allowlisted_sender_dropped(self):
         """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""
@@ -516,7 +585,8 @@ class TestDispatchMessage(unittest.TestCase):
 
             asyncio.run(adapter._dispatch_message(msg_data))
             self.assertEqual(len(captured_events), 1)
-            self.assertEqual(captured_events[0].source.chat_id, "admin@test.com:Important")
+            self.assertEqual(captured_events[0].source.chat_id, "admin@test.com")
+            self.assertEqual(captured_events[0].source.thread_id, "Important")
 
     def test_empty_allowlist_denies_without_optin(self):
         """No allowlist and no allow-all opt-in → adapter fails closed (2.6)."""
@@ -754,16 +824,20 @@ class TestThreadContext(unittest.TestCase):
         }
 
         asyncio.run(adapter._dispatch_message(msg_data))
-        ctx = adapter._thread_context.get("user@test.com:Project question")
+        ctx = adapter._thread_context.get("user@test.com::Project question")
         self.assertIsNotNone(ctx)
         self.assertEqual(ctx["subject"], "Project question")
         self.assertEqual(ctx["message_id"], "<original@test.com>")
+        # Message-ID index should anchor this inbound for reply resolution
+        self.assertEqual(
+            adapter._msgid_context.get("<original@test.com>"),
+            "user@test.com::Project question",
+        )
 
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
         adapter = self._make_adapter()
-        _chat_id = "user@test.com:Project question"
-        adapter._thread_context[_chat_id] = {
+        ctx = {
             "subject": "Project question",
             "message_id": "<original@test.com>",
             "sender_addr": "user@test.com",
@@ -773,7 +847,7 @@ class TestThreadContext(unittest.TestCase):
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Here is the answer.", None, _chat_id)
+            adapter._send_email("user@test.com", "Here is the answer.", None, ctx)
 
             # Check the sent message
             send_call = mock_server.send_message.call_args[0][0]
@@ -785,8 +859,7 @@ class TestThreadContext(unittest.TestCase):
     def test_reply_does_not_double_re(self):
         """If subject already has Re:, don't add another."""
         adapter = self._make_adapter()
-        _chat_id = "user@test.com:Project question"
-        adapter._thread_context[_chat_id] = {
+        ctx = {
             "subject": "Re: Project question",
             "message_id": "<reply@test.com>",
             "sender_addr": "user@test.com",
@@ -796,7 +869,7 @@ class TestThreadContext(unittest.TestCase):
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Follow up.", None, _chat_id)
+            adapter._send_email("user@test.com", "Follow up.", None, ctx)
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Project question")
@@ -816,16 +889,75 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
             self.assertIn("Date", send_call)
 
-    def test_resolve_recipient_from_thread_context(self):
-        """_resolve_recipient should return the sender from thread context."""
+    def test_context_for_send_prefers_metadata_thread_id(self):
+        """metadata.thread_id must select the exact thread context."""
         adapter = self._make_adapter()
-        _chat_id = "alice@example.com:Invoice"
-        adapter._thread_context[_chat_id] = {
+        adapter._thread_context["user@test.com::Invoice"] = {
+            "subject": "Invoice", "message_id": "<m1@test.com>", "sender_addr": "user@test.com",
+        }
+        adapter._thread_context["user@test.com::Report"] = {
+            "subject": "Report", "message_id": "<m2@test.com>", "sender_addr": "user@test.com",
+        }
+        ctx = adapter._context_for_send("user@test.com", metadata={"thread_id": "Report"})
+        self.assertEqual(ctx["subject"], "Report")
+
+    def test_context_for_send_anchors_on_reply_to_message_id(self):
+        """reply_to (inbound Message-ID) resolves the thread without metadata."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com::Invoice"] = {
+            "subject": "Invoice", "message_id": "<m1@test.com>", "sender_addr": "user@test.com",
+        }
+        adapter._msgid_context["<m1@test.com>"] = "user@test.com::Invoice"
+        ctx = adapter._context_for_send("user@test.com", reply_to="<m1@test.com>")
+        self.assertEqual(ctx["subject"], "Invoice")
+
+    def test_context_for_send_falls_back_to_latest_sender_thread(self):
+        """Without metadata/reply_to, use the most recent thread for that sender."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com::Old"] = {
+            "subject": "Old", "message_id": "<m1@test.com>", "sender_addr": "user@test.com",
+        }
+        adapter._thread_context["user@test.com::New"] = {
+            "subject": "New", "message_id": "<m2@test.com>", "sender_addr": "user@test.com",
+        }
+        ctx = adapter._context_for_send("user@test.com")
+        self.assertEqual(ctx["subject"], "New")
+
+    def test_context_for_send_never_leaks_across_senders(self):
+        """A reply to bob must not pick up alice's thread context."""
+        adapter = self._make_adapter()
+        adapter._thread_context["alice@example.com::Invoice"] = {
+            "subject": "Invoice", "message_id": "<m1@test.com>", "sender_addr": "alice@example.com",
+        }
+        ctx = adapter._context_for_send("bob@example.com")
+        self.assertEqual(ctx, {})
+
+    def test_thread_context_is_bounded(self):
+        """_trim_thread_context must cap unbounded growth."""
+        adapter = self._make_adapter()
+        adapter._thread_context_max = 10
+        for i in range(15):
+            adapter._thread_context[f"u{i}@test.com::T{i}"] = {
+                "subject": f"T{i}", "message_id": f"<m{i}@t>", "sender_addr": f"u{i}@test.com",
+            }
+            adapter._msgid_context[f"<m{i}@t>"] = f"u{i}@test.com::T{i}"
+            adapter._trim_thread_context()
+        self.assertLessEqual(len(adapter._thread_context), 10)
+        # msgid index must not reference trimmed contexts
+        for key in adapter._msgid_context.values():
+            self.assertIn(key, adapter._thread_context)
+
+    def test_resolve_recipient_from_thread_context(self):
+        """_resolve_recipient should return the chat_id address + thread context."""
+        adapter = self._make_adapter()
+        adapter._thread_context["alice@example.com::Invoice"] = {
             "subject": "Invoice",
             "message_id": "<m1@test.com>",
             "sender_addr": "alice@example.com",
         }
-        to_addr, ctx = adapter._resolve_recipient(_chat_id)
+        to_addr, ctx = adapter._resolve_recipient(
+            "alice@example.com", metadata={"thread_id": "Invoice"}
+        )
         self.assertEqual(to_addr, "alice@example.com")
         self.assertEqual(ctx["subject"], "Invoice")
 
@@ -841,7 +973,7 @@ class TestThreadContext(unittest.TestCase):
         # Ensure no home address is set
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("EMAIL_HOME_ADDRESS", None)
-            to_addr, ctx = adapter._resolve_recipient("unknown:Unknown Subject")
+            to_addr, ctx = adapter._resolve_recipient("unknown-subject-key")
             self.assertEqual(to_addr, "")
             self.assertEqual(ctx, {})
 
@@ -849,7 +981,7 @@ class TestThreadContext(unittest.TestCase):
         """_resolve_recipient should use EMAIL_HOME_ADDRESS for unknown chat_id."""
         adapter = self._make_adapter()
         with patch.dict(os.environ, {"EMAIL_HOME_ADDRESS": "home@test.com"}):
-            to_addr, ctx = adapter._resolve_recipient("unknown:Unknown Subject")
+            to_addr, ctx = adapter._resolve_recipient("unknown-subject-key")
             self.assertEqual(to_addr, "home@test.com")
             self.assertEqual(ctx, {})
 
@@ -862,12 +994,12 @@ class TestThreadContext(unittest.TestCase):
         """
         adapter = self._make_adapter()
         # Populate thread context with multiple senders
-        adapter._thread_context["alice@example.com:Invoice"] = {
+        adapter._thread_context["alice@example.com::Invoice"] = {
             "subject": "Invoice",
             "message_id": "<m1@test.com>",
             "sender_addr": "alice@example.com",
         }
-        adapter._thread_context["bob@example.com:Report"] = {
+        adapter._thread_context["bob@example.com::Report"] = {
             "subject": "Report",
             "message_id": "<m2@test.com>",
             "sender_addr": "bob@example.com",
@@ -878,6 +1010,43 @@ class TestThreadContext(unittest.TestCase):
             os.environ.pop("EMAIL_HOME_ADDRESS", None)
             to_addr, _ = adapter._resolve_recipient("unknown-subject-key")
             self.assertEqual(to_addr, "")
+
+    def test_send_threads_reply_via_metadata(self):
+        """send() must deliver To the chat_id address and thread via metadata."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com::Invoice"] = {
+            "subject": "Invoice", "message_id": "<m1@test.com>", "sender_addr": "user@test.com",
+        }
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            result = asyncio.run(
+                adapter.send("user@test.com", "Done.", metadata={"thread_id": "Invoice"})
+            )
+            self.assertTrue(result.success)
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["To"], "user@test.com")
+            self.assertEqual(sent["Subject"], "Re: Invoice")
+            self.assertEqual(sent["In-Reply-To"], "<m1@test.com>")
+
+    def test_send_to_header_is_always_an_address(self):
+        """Even with threads cached, To: must never be a subject string."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com::Weird Subject"] = {
+            "subject": "Weird Subject", "message_id": "<m1@test.com>", "sender_addr": "user@test.com",
+        }
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            result = asyncio.run(
+                adapter.send("user@test.com", "Body", metadata={"thread_id": "Weird Subject"})
+            )
+            self.assertTrue(result.success)
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertIn("@", sent["To"])
+            self.assertNotIn("Subject", sent["To"])
 
 
 class TestSendMethods(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1304,6 +1304,89 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(ctx["subject"], "Creative")
             self.assertEqual(ctx["recipients"], ["cc@test.com"])
 
+    def test_queue_part_survives_partially_constructed_adapter(self):
+        """Buffering must not depend on __init__ having run.
+
+        Tests and some proactive paths build the adapter via object.__new__,
+        so _pending / _fold_window / _fold_max_wait may not exist yet. If
+        _queue_part touches them directly it raises AttributeError and the
+        reply is lost entirely.
+        """
+        import asyncio
+        from plugins.platforms.email.adapter import EmailAdapter
+        adapter = object.__new__(EmailAdapter)
+
+        async def _drive():
+            # Inside a running loop _queue_part arms the idle-flush task rather
+            # than sending immediately -- the real gateway path.
+            adapter._queue_part(
+                "user@test.com", {"subject": "Creative"}, body="hello", file_paths=[]
+            )
+            key = adapter._ctx_key_for("user@test.com", {"subject": "Creative"})
+            entry = adapter._pending[key]
+            entry["task"].cancel()
+            return key, entry
+
+        key, entry = asyncio.run(_drive())
+
+        self.assertIn("user@test.com", key)
+        self.assertEqual(entry["body_parts"], ["hello"])
+
+    def test_failed_send_does_not_poison_attachment_dedupe(self):
+        """A failed flush must not permanently suppress those files.
+
+        Hashes are recorded only after a successful send. Marking them up
+        front meant one SMTP failure made the attachments un-resendable on
+        that thread forever -- indistinguishable from the original bug.
+        """
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG" + b"\x01" * 32)
+            path = f.name
+
+        ctx = {
+            "subject": "Creative",
+            "message_id": "<parent@test.com>",
+            "references": "",
+            "sender_addr": "user@test.com",
+            "recipients": ["cc@test.com"],
+        }
+        key = adapter._ctx_key_for("user@test.com", ctx)
+
+        try:
+            # First attempt: SMTP dies mid-send.
+            with patch.object(
+                adapter, "_connect_smtp", side_effect=OSError("smtp down")
+            ):
+                with self.assertRaises(OSError):
+                    adapter._send_email_with_attachments(
+                        "user@test.com", "body", [path], ctx=ctx
+                    )
+
+            # Nothing may have been recorded as delivered.
+            self.assertEqual(adapter._sent_attachments.get(key, set()), set())
+
+            # Retry succeeds -> the file must still be attached this time.
+            smtp = MagicMock()
+            with patch.object(adapter, "_connect_smtp", return_value=smtp):
+                adapter._send_email_with_attachments(
+                    "user@test.com", "body", [path], ctx=ctx
+                )
+
+            smtp.send_message.assert_called_once()
+            sent = smtp.send_message.call_args.args[0]
+            # The attachment path is where threading was lost: assert it here.
+            self.assertEqual(sent["Subject"], "Re: Creative")
+            self.assertEqual(sent["In-Reply-To"], "<parent@test.com>")
+            self.assertEqual(sent["Cc"], "cc@test.com")
+            names = [p.get_filename() for p in sent.walk() if p.get_filename()]
+            self.assertEqual(len(names), 1)
+            self.assertEqual(len(adapter._sent_attachments.get(key, set())), 1)
+        finally:
+            os.unlink(path)
+
 
 class TestSendMethods(unittest.TestCase):
     """Test email send methods."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -264,6 +264,259 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(captured_events[0].message_type, MessageType.PHOTO)
         self.assertEqual(captured_events[0].media_urls, ["/tmp/img.jpg"])
 
+    def test_document_attachment_sets_document_type(self):
+        """Email with a document attachment must set DOCUMENT so run.py injects file context."""
+        import asyncio
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"6",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: report",
+            "message_id": "<msg6@test.com>",
+            "in_reply_to": "",
+            "body": "See attached",
+            "attachments": [{"path": "/tmp/report.pdf", "filename": "report.pdf", "type": "document", "media_type": "application/pdf"}],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        self.assertEqual(len(captured_events), 1)
+        self.assertEqual(captured_events[0].message_type, MessageType.DOCUMENT)
+        self.assertEqual(captured_events[0].media_urls, ["/tmp/report.pdf"])
+
+    def test_mixed_image_and_document_prefers_document(self):
+        """DOCUMENT wins for mixed attachments — image handling keys off per-path
+        mime types, but document injection gates strictly on MessageType.DOCUMENT."""
+        import asyncio
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"7",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: both",
+            "message_id": "<msg7@test.com>",
+            "in_reply_to": "",
+            "body": "Photo and PDF",
+            "attachments": [
+                {"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"},
+                {"path": "/tmp/report.pdf", "filename": "report.pdf", "type": "document", "media_type": "application/pdf"},
+            ],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        self.assertEqual(len(captured_events), 1)
+        self.assertEqual(captured_events[0].message_type, MessageType.DOCUMENT)
+        self.assertEqual(len(captured_events[0].media_urls), 2)
+
+    def test_source_built_correctly(self):
+        """Session source should have correct chat_id and user info.
+
+        In thread mode, chat_id is a composite of sender:normalized_subject.
+        """
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"6",
+            "sender_addr": "john@example.com",
+            "sender_name": "John Doe",
+            "subject": "Re: hi",
+            "message_id": "<msg6@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        event = captured_events[0]
+        # Thread mode: chat_id is "sender:normalized_subject"
+        self.assertEqual(event.source.chat_id, "john@example.com:hi")
+        self.assertEqual(event.source.user_id, "john@example.com")
+        self.assertEqual(event.source.user_name, "John Doe")
+        self.assertEqual(event.source.chat_type, "dm")
+
+    def test_thread_mode_different_senders_same_subject_isolated(self):
+        """Two senders with the same subject must get different chat_ids (sessions)."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        # Sender 1: alice@example.com, subject "Re: Invoice"
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "alice@example.com",
+            "sender_name": "Alice",
+            "subject": "Re: Invoice",
+            "message_id": "<m1@test.com>",
+            "in_reply_to": "",
+            "body": "Body 1",
+            "attachments": [],
+            "date": "",
+        }))
+        # Sender 2: bob@example.com, same normalized subject "Invoice"
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"2",
+            "sender_addr": "bob@example.com",
+            "sender_name": "Bob",
+            "subject": "Invoice",
+            "message_id": "<m2@test.com>",
+            "in_reply_to": "",
+            "body": "Body 2",
+            "attachments": [],
+            "date": "",
+        }))
+
+        self.assertEqual(len(captured_events), 2)
+        chat_ids = {e.source.chat_id for e in captured_events}
+        self.assertEqual(len(chat_ids), 2, "Two senders with same subject must have different chat_ids")
+        self.assertIn("alice@example.com:Invoice", chat_ids)
+        self.assertIn("bob@example.com:Invoice", chat_ids)
+
+    def test_thread_mode_same_sender_same_subject_reuses_session(self):
+        """Same sender + same subject should produce the same chat_id (same session)."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        for i in range(2):
+            asyncio.run(adapter._dispatch_message({
+                "uid": str(i).encode(),
+                "sender_addr": "user@test.com",
+                "sender_name": "User",
+                "subject": "Re: Project X",
+                "message_id": f"<m{i}@test.com>",
+                "in_reply_to": "",
+                "body": f"Message {i}",
+                "attachments": [],
+                "date": "",
+            }))
+
+        self.assertEqual(len(captured_events), 2)
+        self.assertEqual(captured_events[0].source.chat_id, captured_events[1].source.chat_id)
+
+    def test_thread_mode_reply_subject_normalized(self):
+        """Re: prefix should be stripped from subject in chat_id."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: Fwd: Important Topic",
+            "message_id": "<m1@test.com>",
+            "in_reply_to": "",
+            "body": "Body",
+            "attachments": [],
+            "date": "",
+        }))
+
+        self.assertEqual(len(captured_events), 1)
+        # Both Re: and Fwd: should be stripped
+        self.assertEqual(captured_events[0].source.chat_id, "user@test.com:Important Topic")
+
+    def test_non_allowlisted_sender_dropped(self):
+        """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
+        }):
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            msg_data = {
+                "uid": b"99",
+                "sender_addr": "outsider@evil.com",
+                "sender_name": "Spammer",
+                "subject": "Buy now!!!",
+                "message_id": "<spam@evil.com>",
+                "in_reply_to": "",
+                "body": "Cheap meds",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            # Handler should NOT be called for non-allowlisted sender
+            adapter._message_handler.assert_not_called()
+            # Thread context should NOT be created for the sender's composite key
+            self.assertNotIn("outsider@evil.com:Buy now!!!", adapter._thread_context)
+
+    def test_allowlisted_sender_proceeds(self):
+        """Senders in EMAIL_ALLOWED_USERS should proceed to dispatch normally."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
+        }):
+            adapter = self._make_adapter()
+            captured_events = []
+
+            async def mock_handler(event):
+                captured_events.append(event)
+                return None
+
+            adapter._message_handler = mock_handler
+
+            msg_data = {
+                "uid": b"100",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Important",
+                "message_id": "<msg@test.com>",
+                "in_reply_to": "",
+                "body": "Hello",
+                "attachments": [],
+                "date": "",
+                # Authenticated From: (SPF/DKIM/DMARC passed at the receiving
+                # server). Allowlisted senders must be authenticated to proceed.
+                "sender_authenticated": True,
+                "auth_reason": "dmarc=pass",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            self.assertEqual(len(captured_events), 1)
+            self.assertEqual(captured_events[0].source.chat_id, "admin@test.com:Important")
 
     def test_empty_allowlist_denies_without_optin(self):
         """No allowlist and no allow-all opt-in → adapter fails closed (2.6)."""
@@ -293,6 +546,124 @@ class TestDispatchMessage(unittest.TestCase):
             # Fail closed: an unset allowlist without allow-all drops the sender.
             adapter._message_handler.assert_not_called()
 
+    def test_empty_allowlist_allows_all_with_optin(self):
+        """EMAIL_ALLOW_ALL_USERS=true with no allowlist → all senders proceed."""
+        import asyncio
+        with patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}, clear=False):
+            os.environ.pop("EMAIL_ALLOWED_USERS", None)
+
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            msg_data = {
+                "uid": b"101",
+                "sender_addr": "anyone@test.com",
+                "sender_name": "Anyone",
+                "subject": "Hey",
+                "message_id": "<any@test.com>",
+                "in_reply_to": "",
+                "body": "Hi",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            # With explicit allow-all opt-in the handler is called.
+            adapter._message_handler.assert_called()
+
+    def test_spoofed_from_rejected_when_allowlisted(self):
+        """A forged From: matching the allowlist is dropped when unauthenticated.
+
+        Core of GHSA-rxqh-5572-8m77: an attacker forges From: an-allowlisted
+        address. With an allowlist in effect and no allow-all, an unauthenticated
+        From: must be rejected before it can be matched against the allowlist.
+        """
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_ALLOW_ALL_USERS": "",
+            "GATEWAY_ALLOW_ALL_USERS": "",
+        }):
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            msg_data = {
+                "uid": b"200",
+                "sender_addr": "admin@test.com",  # forged From: matching allowlist
+                "sender_name": "Admin",
+                "subject": "Spoofed",
+                "message_id": "<spoof@evil.com>",
+                "in_reply_to": "",
+                "body": "rm -rf /",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": False,  # SPF/DKIM/DMARC did not pass
+                "auth_reason": "authentication failed (spf=fail)",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            adapter._message_handler.assert_not_called()
+            self.assertNotIn("admin@test.com:Spoofed", adapter._thread_context)
+
+    def test_unauthenticated_denied_without_allowlist_optin(self):
+        """No allowlist, no allow-all → adapter fails closed regardless of From auth."""
+        import asyncio
+        with patch.dict(os.environ, {}, clear=False):
+            for k in ("EMAIL_ALLOWED_USERS", "GATEWAY_ALLOWED_USERS",
+                      "EMAIL_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"):
+                os.environ.pop(k, None)
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            msg_data = {
+                "uid": b"201",
+                "sender_addr": "anyone@test.com",
+                "sender_name": "Anyone",
+                "subject": "Hi",
+                "message_id": "<any@test.com>",
+                "in_reply_to": "",
+                "body": "Hi",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": False,
+                "auth_reason": "no Authentication-Results header",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            # Fail closed at the adapter — no allowlist and no allow-all opt-in.
+            adapter._message_handler.assert_not_called()
+
+    def test_unauthenticated_allowed_with_trust_from_header(self):
+        """EMAIL_TRUST_FROM_HEADER=true disables the gate even with an allowlist."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_TRUST_FROM_HEADER": "true",
+        }):
+            adapter = self._make_adapter()
+            captured = []
+
+            async def capture_handle(event):
+                captured.append(event)
+
+            adapter.handle_message = capture_handle
+
+            msg_data = {
+                "uid": b"202",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Trusted",
+                "message_id": "<t@test.com>",
+                "in_reply_to": "",
+                "body": "Hello",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": False,
+                "auth_reason": "no Authentication-Results header",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            self.assertEqual(len(captured), 1)
 
     def test_unauthenticated_allowed_with_allow_all(self):
         """EMAIL_ALLOW_ALL_USERS=true makes sender identity moot — gate skipped.
@@ -360,20 +731,49 @@ class TestThreadContext(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_thread_context_stored_after_dispatch(self):
+        """After dispatching a message, thread context should be stored."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        async def noop_handle(event):
+            pass
+
+        adapter.handle_message = noop_handle
+
+        msg_data = {
+            "uid": b"10",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        ctx = adapter._thread_context.get("user@test.com:Project question")
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx["subject"], "Project question")
+        self.assertEqual(ctx["message_id"], "<original@test.com>")
 
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        _chat_id = "user@test.com:Project question"
+        adapter._thread_context[_chat_id] = {
             "subject": "Project question",
             "message_id": "<original@test.com>",
+            "sender_addr": "user@test.com",
         }
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Here is the answer.", None)
+            adapter._send_email("user@test.com", "Here is the answer.", None, _chat_id)
 
             # Check the sent message
             send_call = mock_server.send_message.call_args[0][0]
@@ -381,6 +781,103 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["In-Reply-To"], "<original@test.com>")
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
+
+    def test_reply_does_not_double_re(self):
+        """If subject already has Re:, don't add another."""
+        adapter = self._make_adapter()
+        _chat_id = "user@test.com:Project question"
+        adapter._thread_context[_chat_id] = {
+            "subject": "Re: Project question",
+            "message_id": "<reply@test.com>",
+            "sender_addr": "user@test.com",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Follow up.", None, _chat_id)
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Project question")
+            self.assertFalse(send_call["Subject"].startswith("Re: Re:"))
+
+    def test_no_thread_context_uses_default_subject(self):
+        """Without thread context, subject should be 'Re: Hermes Agent'."""
+        adapter = self._make_adapter()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("newuser@test.com", "Hello!", None)
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
+            self.assertIn("Date", send_call)
+
+    def test_resolve_recipient_from_thread_context(self):
+        """_resolve_recipient should return the sender from thread context."""
+        adapter = self._make_adapter()
+        _chat_id = "alice@example.com:Invoice"
+        adapter._thread_context[_chat_id] = {
+            "subject": "Invoice",
+            "message_id": "<m1@test.com>",
+            "sender_addr": "alice@example.com",
+        }
+        to_addr, ctx = adapter._resolve_recipient(_chat_id)
+        self.assertEqual(to_addr, "alice@example.com")
+        self.assertEqual(ctx["subject"], "Invoice")
+
+    def test_resolve_recipient_bare_email(self):
+        """_resolve_recipient should handle bare email addresses (sender mode)."""
+        adapter = self._make_adapter()
+        to_addr, _ = adapter._resolve_recipient("bob@example.com")
+        self.assertEqual(to_addr, "bob@example.com")
+
+    def test_resolve_recipient_fails_closed_without_home(self):
+        """_resolve_recipient should return ('', {}) for unknown chat_id without EMAIL_HOME_ADDRESS."""
+        adapter = self._make_adapter()
+        # Ensure no home address is set
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EMAIL_HOME_ADDRESS", None)
+            to_addr, ctx = adapter._resolve_recipient("unknown:Unknown Subject")
+            self.assertEqual(to_addr, "")
+            self.assertEqual(ctx, {})
+
+    def test_resolve_recipient_falls_back_to_home_address(self):
+        """_resolve_recipient should use EMAIL_HOME_ADDRESS for unknown chat_id."""
+        adapter = self._make_adapter()
+        with patch.dict(os.environ, {"EMAIL_HOME_ADDRESS": "home@test.com"}):
+            to_addr, ctx = adapter._resolve_recipient("unknown:Unknown Subject")
+            self.assertEqual(to_addr, "home@test.com")
+            self.assertEqual(ctx, {})
+
+    def test_resolve_recipient_does_not_pick_arbitrary_sender(self):
+        """_resolve_recipient must NOT pick an arbitrary cached sender for unknown chat_id.
+
+        Regression test for the security issue raised in PR review: the old
+        fallback scanned all thread contexts for any sender_addr, which could
+        deliver a reply to an unrelated recipient.
+        """
+        adapter = self._make_adapter()
+        # Populate thread context with multiple senders
+        adapter._thread_context["alice@example.com:Invoice"] = {
+            "subject": "Invoice",
+            "message_id": "<m1@test.com>",
+            "sender_addr": "alice@example.com",
+        }
+        adapter._thread_context["bob@example.com:Report"] = {
+            "subject": "Report",
+            "message_id": "<m2@test.com>",
+            "sender_addr": "bob@example.com",
+        }
+        # Unknown chat_id that is NOT a bare email address — must NOT resolve
+        # to alice or bob, and without EMAIL_HOME_ADDRESS must fail closed.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EMAIL_HOME_ADDRESS", None)
+            to_addr, _ = adapter._resolve_recipient("unknown-subject-key")
+            self.assertEqual(to_addr, "")
 
 
 class TestSendMethods(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1146,6 +1146,9 @@ class TestThreadContext(unittest.TestCase):
                 adapter.send("user@test.com", "Done.", metadata={"thread_id": "Invoice"})
             )
             self.assertTrue(result.success)
+            # send() buffers so attachments for the same turn land in ONE email;
+            # flush to inspect the message that actually goes on the wire.
+            adapter._flush_all_pending()
             sent = mock_server.send_message.call_args[0][0]
             self.assertEqual(sent["To"], "user@test.com")
             self.assertEqual(sent["Subject"], "Re: Invoice")
@@ -1165,9 +1168,141 @@ class TestThreadContext(unittest.TestCase):
                 adapter.send("user@test.com", "Body", metadata={"thread_id": "Weird Subject"})
             )
             self.assertTrue(result.success)
+            adapter._flush_all_pending()
             sent = mock_server.send_message.call_args[0][0]
             self.assertIn("@", sent["To"])
             self.assertNotIn("Subject", sent["To"])
+
+    def test_one_turn_body_plus_files_is_a_single_email(self):
+        """A turn's body and every attachment must arrive as ONE email.
+
+        The gateway dispatches one answer as send() for the body plus
+        send_document() once PER file. Sent straight through that is 1+N
+        emails; the fold must collapse them into a single MIME message that
+        still carries the thread's Subject/Cc/In-Reply-To.
+        """
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com::Creative"] = {
+            "subject": "Creative",
+            "message_id": "<parent@test.com>",
+            "references": "",
+            "sender_addr": "user@test.com",
+            "recipients": ["cc@test.com"],
+            "ctx_key": "user@test.com::Creative",
+        }
+        paths = []
+        for i in range(3):
+            with tempfile.NamedTemporaryFile(suffix=f"-{i}.txt", delete=False) as f:
+                f.write(f"headline {i}".encode())
+                paths.append(f.name)
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                async def _turn():
+                    await adapter.send(
+                        "user@test.com", "Here they are.",
+                        metadata={"thread_id": "Creative"},
+                    )
+                    for p in paths:
+                        await adapter.send_document(
+                            "user@test.com", p, metadata={"thread_id": "Creative"}
+                        )
+
+                asyncio.run(_turn())
+                # Nothing on the wire yet — the turn is still buffering.
+                self.assertEqual(mock_server.send_message.call_count, 0)
+                adapter._flush_all_pending()
+
+                self.assertEqual(mock_server.send_message.call_count, 1)
+                sent = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent["Subject"], "Re: Creative")
+                self.assertEqual(sent["In-Reply-To"], "<parent@test.com>")
+                self.assertEqual(sent["Cc"], "cc@test.com")
+                names = sorted(
+                    p.get_filename() for p in sent.walk() if p.get_filename()
+                )
+                self.assertEqual(len(names), 3)
+                body = "".join(
+                    p.get_payload(decode=True).decode()
+                    for p in sent.walk()
+                    if p.get_content_type() == "text/plain" and not p.get_filename()
+                )
+                self.assertIn("Here they are.", body)
+        finally:
+            for p in paths:
+                os.unlink(p)
+
+    def test_reply_to_own_message_resolves_original_thread(self):
+        """A reply to the agent's OWN mail must not cross to another thread.
+
+        Outbound Message-IDs used to be absent from _msgid_context (only
+        inbound ids were indexed), so a reply carrying
+        In-Reply-To=<hermes-...> missed and fell through to the
+        most-recent-thread scan — answering on the wrong thread with the wrong
+        Cc list.
+        """
+        adapter = self._make_adapter()
+        old = {
+            "subject": "Creative",
+            "message_id": "<parent@test.com>",
+            "references": "",
+            "sender_addr": "user@test.com",
+            "recipients": ["cc@test.com"],
+            "ctx_key": "user@test.com::Creative",
+        }
+        adapter._thread_context["user@test.com::Creative"] = old
+        # A NEWER, unrelated thread for the same person: what the fallback scan
+        # would wrongly latch onto.
+        adapter._thread_context["user@test.com::Newer"] = {
+            "subject": "Newer",
+            "message_id": "<newer@test.com>",
+            "references": "",
+            "sender_addr": "user@test.com",
+            "recipients": [],
+            "ctx_key": "user@test.com::Newer",
+        }
+
+        adapter._register_outbound_msgid("<hermes-abc123@test.com>", "user@test.com", old)
+
+        _, ctx = adapter._resolve_recipient(
+            "user@test.com", reply_to="<hermes-abc123@test.com>"
+        )
+        self.assertEqual(ctx["subject"], "Creative")
+        self.assertEqual(ctx["recipients"], ["cc@test.com"])
+
+    def test_thread_state_survives_restart(self):
+        """Thread state must reload, or post-restart replies lose their thread."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            first = self._make_adapter()
+            first._state_path = path
+            first._thread_context["user@test.com::Creative"] = {
+                "subject": "Creative",
+                "message_id": "<parent@test.com>",
+                "references": "",
+                "sender_addr": "user@test.com",
+                "recipients": ["cc@test.com"],
+                "ctx_key": "user@test.com::Creative",
+            }
+            first._msgid_context["<parent@test.com>"] = "user@test.com::Creative"
+            first._save_state()
+
+            second = self._make_adapter()
+            second._thread_context.clear()
+            second._msgid_context.clear()
+            second._state_path = path
+            second._load_state()
+
+            _, ctx = second._resolve_recipient(
+                "user@test.com", reply_to="<parent@test.com>"
+            )
+            self.assertEqual(ctx["subject"], "Creative")
+            self.assertEqual(ctx["recipients"], ["cc@test.com"])
 
 
 class TestSendMethods(unittest.TestCase):
@@ -1206,6 +1341,9 @@ class TestSendMethods(unittest.TestCase):
                 )
 
                 self.assertTrue(result.success)
+                # send_document buffers (the gateway calls it once per file, and
+                # they must share one email) — flush to get the wire message.
+                adapter._flush_all_pending()
                 mock_server.send_message.assert_called_once()
                 sent_msg = mock_server.send_message.call_args[0][0]
                 # Should be multipart with attachment

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -419,6 +419,9 @@ class TestEmailMultiImage:
             adapter, "_send_email_with_attachments", MagicMock(return_value="<msgid@x>")
         ) as mock_send:
             _run(adapter.send_multiple_images("user@example.com", images))
+            # send_multiple_images now buffers into the per-turn fold; force the
+            # flush so the single folded SMTP send is observable here.
+            adapter._flush_all_pending()
 
         mock_send.assert_called_once()
         to_addr, body, file_paths = mock_send.call_args.args

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -196,24 +196,29 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
-| `EMAIL_SESSION_ROUTING` | No | `thread` | `thread` = one session per email thread; `sender` = one session per sender (legacy) |
+| `EMAIL_SESSION_ROUTING` | No | `sender` | `sender` = one session per sender (stock default); `thread` = one session per email thread (recommended for email agents) |
 | `EMAIL_DISPLAY_NAME` | No | — | Display name for the `From:` header (e.g., `Iris Sloane`) |
 
 ## Session Routing (Per-Thread Conversations)
 
-By default (`EMAIL_SESSION_ROUTING=thread`), each email thread gets its own agent session: the adapter sets `chat_id` to the sender's address and `thread_id` to the normalized subject (with `Re:`/`Fwd:`/`Fw:` prefixes stripped), so Hermes isolates sessions per (sender, thread) the same way it isolates Telegram topics or Discord threads. Two different threads from the same person no longer share conversation history.
+By default (`EMAIL_SESSION_ROUTING=sender`), all emails from the same person share one agent session — the historical Hermes behaviour. That is safe for existing deployments: upgrading does not change session keys unless you opt in.
 
-- `chat_id` is always the sender's email address — reply `To:` headers always contain a real address.
-- `thread_id` is derived from the normalized subject. If the subject is empty, the adapter falls back to the `In-Reply-To` header, then the message ID.
-- Replies thread correctly (`Re:` subject, `In-Reply-To`/`References` headers) even when a tool sends without thread metadata, because the adapter indexes inbound messages by Message-ID.
-- Set `EMAIL_SESSION_ROUTING=sender` for the legacy behavior (one session per sender, all threads mixed).
-
-The display name config:
+For **email-agent secretaries** (and any mailbox that handles diverse threads from the same people), set:
 
 ```yaml
 platforms:
   email:
-    display_name: "Your Agent Name"
+    session_routing: thread    # or EMAIL_SESSION_ROUTING=thread
+    display_name: Iris Sloane  # optional From: display name
 ```
+
+In thread mode the adapter sets `chat_id` to the sender's address and `thread_id` to the normalized subject (with `Re:`/`Fwd:`/`Fw:` prefixes stripped), so Hermes isolates sessions per (sender, thread) the same way it isolates Telegram topics or Discord threads. Two different threads from the same person no longer share conversation history.
+
+- `chat_id` is always the sender's email address — reply `To:` headers always contain a real address.
+- `thread_id` is derived from the normalized subject. If the subject is empty, the adapter falls back to the `In-Reply-To` header, then the message ID.
+- Replies thread correctly (`Re:` subject, `In-Reply-To`/`References` headers) even when a tool sends without thread metadata, because the adapter indexes inbound messages by Message-ID.
+- **Migration:** enabling `thread` is a one-time session key change for that mailbox (existing per-sender sessions stop resuming; new per-thread sessions start fresh). That is intentional.
+
+`hermes gateway setup` (Email platform) prompts for session routing and display name. The dashboard Channels env editor also lists `EMAIL_SESSION_ROUTING` and `EMAIL_DISPLAY_NAME`.
 
 With a display name set, outgoing mail uses `From: Your Agent Name <agent@example.com>` instead of the bare address.

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -196,3 +196,24 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_SESSION_ROUTING` | No | `thread` | `thread` = one session per email thread; `sender` = one session per sender (legacy) |
+| `EMAIL_DISPLAY_NAME` | No | — | Display name for the `From:` header (e.g., `Iris Sloane`) |
+
+## Session Routing (Per-Thread Conversations)
+
+By default (`EMAIL_SESSION_ROUTING=thread`), each email thread gets its own agent session: the adapter sets `chat_id` to the sender's address and `thread_id` to the normalized subject (with `Re:`/`Fwd:`/`Fw:` prefixes stripped), so Hermes isolates sessions per (sender, thread) the same way it isolates Telegram topics or Discord threads. Two different threads from the same person no longer share conversation history.
+
+- `chat_id` is always the sender's email address — reply `To:` headers always contain a real address.
+- `thread_id` is derived from the normalized subject. If the subject is empty, the adapter falls back to the `In-Reply-To` header, then the message ID.
+- Replies thread correctly (`Re:` subject, `In-Reply-To`/`References` headers) even when a tool sends without thread metadata, because the adapter indexes inbound messages by Message-ID.
+- Set `EMAIL_SESSION_ROUTING=sender` for the legacy behavior (one session per sender, all threads mixed).
+
+The display name config:
+
+```yaml
+platforms:
+  email:
+    display_name: "Your Agent Name"
+```
+
+With a display name set, outgoing mail uses `From: Your Agent Name <agent@example.com>` instead of the bare address.


### PR DESCRIPTION
## Summary

The Email platform adapter previously used the sender's email address as the session key (`chat_id`), meaning **all emails from the same person shared a single conversation**. This caused context pollution when an email agent handled diverse requests (research, calendar, scheduling) from the same sender.

## Changes

### 1. Per-thread session routing (`session_routing`)

New config option with two modes:

- **`thread`** (default): Each email subject gets its own session. Replies within the same thread (same subject, stripped of `Re:`/`Fwd:`) stay in the same session.
- **`sender`**: One session per sender address (legacy behaviour).

The normalized subject is used as `chat_id` in `build_source()`. The real recipient address is stored in `_thread_context` and resolved back in `send()` when replying.

### 2. Configurable display name (`display_name`)

Adds a `display_name` option for the `From:` header in outgoing emails. Previously the `From` header was the bare `EMAIL_ADDRESS` with no display name.

- If set: `From: "Iris Sloane" <iris@known.ltd>`
- If not set: `From: iris@known.ltd` (legacy behaviour)

## Configuration

```yaml
platforms:
  email:
    session_routing: thread    # or: sender (default: thread)
    display_name: 'Iris Sloane' # optional, defaults to bare address
```

Or via environment variables:
```bash
EMAIL_SESSION_ROUTING=thread
EMAIL_DISPLAY_NAME=Iris Sloane
```

## Backward compatibility

- `session_routing: sender` preserves the exact legacy behaviour
- `display_name` unset = bare address (same as before)
- All changes are opt-in via config; existing setups with no config changes get `thread` mode by default (the better behaviour)

## Send method resolution

When `session_routing` is `thread`, `chat_id` is the subject string (not an email address). The `send()` method resolves the real recipient via:

1. Look up `sender_addr` in `_thread_context` by `chat_id`
2. Scan all thread contexts for any stored `sender_addr`
3. Fall back to `EMAIL_HOME_ADDRESS` env var
4. Fall back to `chat_id` itself if it contains `@`

This ensures replies always go to the right recipient, even for Kanban notification deliveries that don't have thread context set.

## Files changed

- `plugins/platforms/email/adapter.py` — session routing logic, display name, send resolution
- `gateway/config.py` — wire `EMAIL_SESSION_ROUTING` and `EMAIL_DISPLAY_NAME` env vars

---

## Follow-up (commit `52b5410`): one threaded reply per turn

Dogfooding the branch on a live mailbox surfaced three defects in the *reply*
path that the original commits did not cover. An email answer that carried
attachments did not look like a person's reply: it arrived as two messages, the
one with the files landed in an unrelated conversation, and everyone who had
been cc'd was dropped.

### 1. Attachment mail built its own reply headers

`_send_email_with_attachments` and `_send_email_with_attachment` each resolved
context with a bare `self._thread_context.get(to_addr)` lookup. Under
`session_routing: thread` that **always** misses, because keys are
`"sender::thread_id"`. So attachment mail went out as:

| header | before | after |
|---|---|---|
| `Subject` | `Re: Hermes Agent` | `Re: <the actual thread subject>` |
| `In-Reply-To` | *(absent)* | parent `Message-ID` |
| `References` | *(absent)* | full inbound chain + parent |
| `Cc` | *(dropped)* | inbound To/Cc chain preserved |

Mail clients had no threading headers to work with, so every attachment mail
collapsed into one unrelated conversation.

`Subject` / `Cc` / `In-Reply-To` / `References` now come from a single
`_apply_reply_headers()` that **every** send path calls — the divergence was the
bug, so the fix is one authority rather than three copies. `References` now
*extends* the inbound chain (capped at 20, root + most recent) instead of being
reset to just the parent, which had made long threads drift apart in Outlook.
An empty context logs a warning and attachment mail with no parent message-id
logs an error, rather than silently emitting a generic subject.

### 2. A reply to the agent's own mail landed on the wrong thread

`_msgid_context` only ever indexed **inbound** Message-IDs. A reply to one of
the agent's own mails carries `In-Reply-To: <hermes-...>`, which missed the
index and fell through to the most-recent-thread scan in `_context_for_send` —
answering on a different thread, with that thread's Cc list. Outbound
Message-IDs are now registered against their thread as they are sent, and the
thread's stored anchor advances so the next reply chains correctly.

### 3. One turn produced several emails

The gateway dispatches one answer as `send()` for the body, then
`send_multiple_images()` once for an image batch and `send_document()` **once
per remaining file**, with `human_delay` sleeps in between. On chat those are
separate bubbles; on email each is a separate message in the recipient's thread.
Folding the body into just the first attachment would still leave one email per
subsequent file, so outbound parts are buffered per thread and flushed as a
single MIME once the turn goes idle.

- `fold_window_seconds` (default 12) — idle debounce, re-armed by each new part.
  Measured body→attachment gaps on real turns were 4.1–7.9s.
- `fold_max_wait_seconds` (default 90) — ceiling from the first part, so a long
  attachment loop cannot stall a reply.
- `disconnect()` flushes anything still buffered, so a restart mid-turn cannot
  silently drop a reply (worse than sending two).

### Also in this commit

- **Thread state persists** to `<HERMES_HOME>/state/email_thread_state.json`
  (atomic write, `0600`). It was memory-only, so every restart made the next
  reply on a live thread lose its subject and Cc — the reported symptom,
  reappearing *because of* a deploy. Resolved via `get_hermes_home()` so it is
  per-profile and sandboxed under test rather than one shared file.
- **Identical attachments are not re-sent** on later turns of the same thread
  (content sha256, thread-scoped, so a genuinely revised file still goes out).

### Configuration

```yaml
platforms:
  email:
    session_routing: thread
    display_name: 'Iris Sloane'
    fold_window_seconds: 12      # optional
    fold_max_wait_seconds: 90    # optional
```

### Tests

`78 passed` in `tests/gateway/test_email.py`,
`test_email_robustness.py`, `test_email_secret_scope.py`.

Four existing `send`/`send_document` tests asserted the old synchronous
contract (SMTP called during `send()`); they now flush before asserting the
wire message. New coverage:

- `test_one_turn_body_plus_files_is_a_single_email` — body + 3 files produce
  **one** `send_message` call carrying the body, all three attachments, and the
  thread's `Subject`/`Cc`/`In-Reply-To`; asserts nothing is on the wire before
  the flush.
- `test_reply_to_own_message_resolves_original_thread` — with a **newer decoy
  thread present** for the same address, a reply to an outbound `<hermes-...>`
  id still resolves the original thread and its Cc list. Without the decoy this
  passes by accident, which is how the bug went undetected.
- `test_thread_state_survives_restart` — state written, reloaded into a fresh
  adapter, reply still resolves subject + Cc.

Verified end-to-end against a real Gmail mailbox: a 6-file request produced
exactly one message in `[Gmail]/Sent Mail` with `Subject: Re: <thread>`,
`In-Reply-To` equal to the inbound `Message-ID`, `Cc` preserved, all six
attachments and a non-empty body; and a reply to the agent's own message on an
older thread — with a newer thread live for the same sender — stayed on the
correct thread.
