### PR TITLE
feat(gateway): add staged-write approval controls

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from gateway.write_approval_interactions import merge_response_delivery_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -6015,7 +6016,9 @@ class BasePlatformAdapter(ABC):
                     chat_id=event.source.chat_id,
                     content=_text,
                     reply_to=_reply_anchor_for_event(event),
-                    metadata=_mark_notify_metadata(thread_meta),
+                    metadata=_mark_notify_metadata(
+                        merge_response_delivery_metadata(thread_meta, response)
+                    ),
                 )
                 if _eph_ttl > 0 and _r.success and _r.message_id:
                     self._schedule_ephemeral_delete(
@@ -6143,7 +6146,11 @@ class BasePlatformAdapter(ABC):
                             chat_id=event.source.chat_id,
                             content=_text,
                             reply_to=_reply_anchor_for_event(event),
-                            metadata=_mark_notify_metadata(_thread_meta),
+                            metadata=_mark_notify_metadata(
+                                merge_response_delivery_metadata(
+                                    _thread_meta, response
+                                )
+                            ),
                         )
                         if _eph_ttl > 0 and _r.success and _r.message_id:
                             self._schedule_ephemeral_delete(
@@ -6196,7 +6203,11 @@ class BasePlatformAdapter(ABC):
                                 chat_id=event.source.chat_id,
                                 content=_text,
                                 reply_to=_reply_anchor_for_event(event),
-                                metadata=_mark_notify_metadata(_thread_meta),
+                                metadata=_mark_notify_metadata(
+                                    merge_response_delivery_metadata(
+                                        _thread_meta, response
+                                    )
+                                ),
                             )
                             if _eph_ttl > 0 and _r.success and _r.message_id:
                                 self._schedule_ephemeral_delete(
@@ -6339,6 +6350,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            structured_response = response
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -6454,7 +6466,11 @@ class BasePlatformAdapter(ABC):
                 # the existing notify=True marker. Clone once so typing/status
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
-                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _final_thread_metadata = _mark_notify_metadata(
+                    merge_response_delivery_metadata(
+                        _thread_metadata, structured_response
+                    )
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from gateway.write_approval_interactions import merge_response_delivery_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -5524,7 +5525,9 @@ class BasePlatformAdapter(ABC):
                     chat_id=event.source.chat_id,
                     content=_text,
                     reply_to=_reply_anchor_for_event(event),
-                    metadata=_mark_notify_metadata(thread_meta),
+                    metadata=_mark_notify_metadata(
+                        merge_response_delivery_metadata(thread_meta, response)
+                    ),
                 )
                 if _eph_ttl > 0 and _r.success and _r.message_id:
                     self._schedule_ephemeral_delete(
@@ -5640,7 +5643,11 @@ class BasePlatformAdapter(ABC):
                             chat_id=event.source.chat_id,
                             content=_text,
                             reply_to=_reply_anchor_for_event(event),
-                            metadata=_mark_notify_metadata(_thread_meta),
+                            metadata=_mark_notify_metadata(
+                                merge_response_delivery_metadata(
+                                    _thread_meta, response
+                                )
+                            ),
                         )
                         if _eph_ttl > 0 and _r.success and _r.message_id:
                             self._schedule_ephemeral_delete(
@@ -5693,7 +5700,11 @@ class BasePlatformAdapter(ABC):
                                 chat_id=event.source.chat_id,
                                 content=_text,
                                 reply_to=_reply_anchor_for_event(event),
-                                metadata=_mark_notify_metadata(_thread_meta),
+                                metadata=_mark_notify_metadata(
+                                    merge_response_delivery_metadata(
+                                        _thread_meta, response
+                                    )
+                                ),
                             )
                             if _eph_ttl > 0 and _r.success and _r.message_id:
                                 self._schedule_ephemeral_delete(
@@ -5836,6 +5847,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            structured_response = response
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -5947,7 +5959,11 @@ class BasePlatformAdapter(ABC):
                 # the existing notify=True marker. Clone once so typing/status
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
-                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _final_thread_metadata = _mark_notify_metadata(
+                    merge_response_delivery_metadata(
+                        _thread_metadata, structured_response
+                    )
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21501,6 +21501,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         (already_sent). The delivered reply is stashed on the event so
         those hooks still see it.
         """
+        if isinstance(agent_result, WriteApprovalReply):
+            return ""
         text = ""
         if isinstance(agent_result, dict):
             text = str(agent_result.get("final_response") or "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2585,6 +2585,11 @@ from gateway.shutdown_watchdog import (
     resolve_shutdown_watchdog_delay,
     start_loop_liveness_watchdog,
 )
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_METADATA_KEY,
+    WriteApprovalReply,
+    build_pending_surface,
+)
 from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
@@ -5782,12 +5787,27 @@ class TurnRunner:
         def _deliver_bg_review_message(message: str) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():
                 return
-            safe_schedule_threadsafe(
-                ctx._status_adapter.send(
+
+            async def _deliver() -> None:
+                metadata = _non_conversational_metadata(
+                    ctx._status_thread_metadata,
+                    platform=ctx.source.platform,
+                )
+                surface = await asyncio.to_thread(
+                    build_pending_surface,
+                    ("memory", "skills"),
+                )
+                if surface:
+                    metadata = dict(metadata or {})
+                    metadata[WRITE_APPROVAL_METADATA_KEY] = surface
+                await ctx._status_adapter.send(
                     ctx._status_chat_id,
                     message,
-                    metadata=_interim_metadata(_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform)),
-                ),
+                    metadata=_interim_metadata(metadata),
+                )
+
+            safe_schedule_threadsafe(
+                _deliver(),
                 ctx._loop_for_step,
                 logger=logger,
                 log_message="background_review_callback scheduling error",
@@ -18088,6 +18108,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text,
                     audio_paths,
                 )
+                if (
+                    event.message_type == MessageType.VOICE
+                    and len(_successful_transcripts) == 1
+                    and not (event.text or "").strip()
+                ):
+                    _handled, _approval_response = (
+                        await self._dispatch_write_approval_reply_intent(
+                            event,
+                            _successful_transcripts[0],
+                        )
+                    )
+                    if _handled:
+                        return _approval_response or WriteApprovalReply(
+                            "Write-approval action produced no response."
+                        )
                 # Echo each successful transcript back to the user immediately
                 # when configured. Lets users verify STT quality in real-time,
                 # while allowing quiet STT for users who only want the agent to
@@ -19939,6 +19974,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if message_text is None:
             return
+        if isinstance(message_text, WriteApprovalReply):
+            return message_text
 
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2396,6 +2396,11 @@ from gateway.shutdown_watchdog import (
     resolve_shutdown_watchdog_delay,
     start_loop_liveness_watchdog,
 )
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_METADATA_KEY,
+    WriteApprovalReply,
+    build_pending_surface,
+)
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -4921,12 +4926,27 @@ class TurnRunner:
         def _deliver_bg_review_message(message: str) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():
                 return
-            safe_schedule_threadsafe(
-                ctx._status_adapter.send(
+
+            async def _deliver() -> None:
+                metadata = _non_conversational_metadata(
+                    ctx._status_thread_metadata,
+                    platform=ctx.source.platform,
+                )
+                surface = await asyncio.to_thread(
+                    build_pending_surface,
+                    ("memory", "skills"),
+                )
+                if surface:
+                    metadata = dict(metadata or {})
+                    metadata[WRITE_APPROVAL_METADATA_KEY] = surface
+                await ctx._status_adapter.send(
                     ctx._status_chat_id,
                     message,
-                    metadata=_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform),
-                ),
+                    metadata=metadata,
+                )
+
+            safe_schedule_threadsafe(
+                _deliver(),
                 ctx._loop_for_step,
                 logger=logger,
                 log_message="background_review_callback scheduling error",
@@ -15697,7 +15717,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
-                if isinstance(_agent_result, dict):
+                if isinstance(_agent_result, WriteApprovalReply):
+                    _final_text = ""
+                elif isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
@@ -15928,6 +15950,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text,
                     audio_paths,
                 )
+                if (
+                    event.message_type == MessageType.VOICE
+                    and len(_successful_transcripts) == 1
+                    and not (event.text or "").strip()
+                ):
+                    _handled, _approval_response = (
+                        await self._dispatch_write_approval_reply_intent(
+                            event,
+                            _successful_transcripts[0],
+                        )
+                    )
+                    if _handled:
+                        return _approval_response or WriteApprovalReply(
+                            "Write-approval action produced no response."
+                        )
                 # Echo each successful transcript back to the user immediately
                 # when configured. Lets users verify STT quality in real-time,
                 # while allowing quiet STT for users who only want the agent to
@@ -17473,6 +17510,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if message_text is None:
             return
+        if isinstance(message_text, WriteApprovalReply):
+            return message_text
 
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -40,6 +40,12 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_REPLY_KEY,
+    WriteApprovalReply,
+    build_pending_surface,
+    command_for_reply_intent,
+)
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
     atomic_json_write,
@@ -3814,7 +3820,7 @@ class GatewaySlashCommandsMixin:
         if out is None:
             out = ("Unknown /memory subcommand. Use: pending, approve <id>, "
                    "reject <id>, approval <on|off>.")
-        return out
+        return WriteApprovalReply(out, build_pending_surface((wa.MEMORY,)))
 
     async def _handle_skills_command(self, event: MessageEvent) -> str:
         """Handle /skills on the gateway — pending skill-write review only.
@@ -3875,7 +3881,35 @@ class GatewaySlashCommandsMixin:
             out = (out[:3000]
                    + "\n… (truncated — full diff in "
                      f"~/.hermes/pending/skills/{pending_id}.json)")
-        return out
+        return WriteApprovalReply(out, build_pending_surface((wa.SKILLS,)))
+
+    async def _dispatch_write_approval_reply_intent(
+        self,
+        event: MessageEvent,
+        intent_text: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Route a scoped text/voice intent through the existing slash handler."""
+        surface = (getattr(event, "metadata", None) or {}).get(
+            WRITE_APPROVAL_REPLY_KEY
+        )
+        command_text = command_for_reply_intent(intent_text, surface)
+        if command_text is None:
+            return False, None
+
+        command_event = dataclasses.replace(
+            event,
+            text=command_text,
+            message_type=MessageType.COMMAND,
+        )
+        canonical = command_text.split(None, 1)[0].lstrip("/")
+        denied = self._check_slash_access(command_event.source, canonical)
+        if denied is not None:
+            return True, WriteApprovalReply(denied)
+        if canonical == "memory":
+            return True, await self._handle_memory_command(command_event)
+        if canonical == "skills":
+            return True, await self._handle_skills_command(command_event)
+        return False, None
 
     async def _handle_fast_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -40,6 +40,12 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_REPLY_KEY,
+    WriteApprovalReply,
+    build_pending_surface,
+    command_for_reply_intent,
+)
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
     atomic_json_write,
@@ -3613,7 +3619,7 @@ class GatewaySlashCommandsMixin:
         if out is None:
             out = ("Unknown /memory subcommand. Use: pending, approve <id>, "
                    "reject <id>, approval <on|off>.")
-        return out
+        return WriteApprovalReply(out, build_pending_surface((wa.MEMORY,)))
 
     async def _handle_skills_command(self, event: MessageEvent) -> str:
         """Handle /skills on the gateway — pending skill-write review only.
@@ -3674,7 +3680,35 @@ class GatewaySlashCommandsMixin:
             out = (out[:3000]
                    + "\n… (truncated — full diff in "
                      f"~/.hermes/pending/skills/{pending_id}.json)")
-        return out
+        return WriteApprovalReply(out, build_pending_surface((wa.SKILLS,)))
+
+    async def _dispatch_write_approval_reply_intent(
+        self,
+        event: MessageEvent,
+        intent_text: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Route a scoped text/voice intent through the existing slash handler."""
+        surface = (getattr(event, "metadata", None) or {}).get(
+            WRITE_APPROVAL_REPLY_KEY
+        )
+        command_text = command_for_reply_intent(intent_text, surface)
+        if command_text is None:
+            return False, None
+
+        command_event = dataclasses.replace(
+            event,
+            text=command_text,
+            message_type=MessageType.COMMAND,
+        )
+        canonical = command_text.split(None, 1)[0].lstrip("/")
+        denied = self._check_slash_access(command_event.source, canonical)
+        if denied is not None:
+            return True, WriteApprovalReply(denied)
+        if canonical == "memory":
+            return True, await self._handle_memory_command(command_event)
+        if canonical == "skills":
+            return True, await self._handle_skills_command(command_event)
+        return False, None
 
     async def _handle_fast_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats.

--- a/gateway/write_approval_interactions.py
+++ b/gateway/write_approval_interactions.py
@@ -109,15 +109,6 @@ def _single_subsystem(surface: dict) -> Optional[str]:
     return subsystems[0] if len(subsystems) == 1 else None
 
 
-def _explicit_subsystem(token: str) -> Optional[str]:
-    token = token.casefold()
-    if token in {"memory", "память", "памяти"}:
-        return "memory"
-    if token in {"skills", "skill", "навыки", "навыков"}:
-        return "skills"
-    return None
-
-
 def command_for_reply_intent(text: str, raw_surface: Any) -> Optional[str]:
     """Map an exact intent to an existing slash command.
 
@@ -134,26 +125,13 @@ def command_for_reply_intent(text: str, raw_surface: Any) -> Optional[str]:
         return None
 
     single = _single_subsystem(surface)
-    all_words = {"all", "всё", "все"}
     approve_words = {"approve", "одобри", "одобрить"}
     reject_words = {"reject", "deny", "отклони", "отклонить"}
     parts = intent.split()
 
-    if len(parts) == 2 and parts[0] in approve_words and parts[1] in all_words:
-        return f"/{single} approve all" if single else None
-    if len(parts) == 2 and parts[0] in reject_words and parts[1] in all_words:
-        return f"/{single} reject all" if single else None
-
-    if len(parts) in {2, 3} and parts[0] in approve_words | reject_words:
+    if len(parts) == 2 and parts[0] in approve_words | reject_words:
         action = "approve" if parts[0] in approve_words else "reject"
-        target_token = parts[-1]
-        if len(parts) == 3 and parts[1] not in all_words:
-            return None
-        subsystem = _explicit_subsystem(target_token)
-        if subsystem:
-            if subsystem not in surface["subsystems"]:
-                return None
-            return f"/{subsystem} {action} all"
+        target_token = parts[1]
         if _PENDING_ID_RE.fullmatch(target_token):
             owners = [
                 name for name, ids in surface["items"].items() if target_token in ids
@@ -194,6 +172,8 @@ def command_for_callback_data(data: str) -> Optional[str]:
         if subsystem != "skills" or target == "all":
             return None
         return f"/skills diff {target}"
+    if target == "all":
+        return None
     action = "approve" if action_code == "a" else "reject"
     return f"/{subsystem} {action} {target}"
 

--- a/gateway/write_approval_interactions.py
+++ b/gateway/write_approval_interactions.py
@@ -1,0 +1,210 @@
+"""Structured delivery and conservative reply intents for staged writes."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping, Optional
+
+
+WRITE_APPROVAL_METADATA_KEY = "write_approval"
+WRITE_APPROVAL_REPLY_KEY = "write_approval_reply"
+_SUBSYSTEMS = ("memory", "skills")
+_PENDING_ID_RE = re.compile(r"^[0-9a-f]{8}$", re.IGNORECASE)
+
+
+def normalize_surface(surface: Any) -> Optional[dict]:
+    """Return a payload-safe surface containing subsystem names and IDs only."""
+    if not isinstance(surface, Mapping):
+        return None
+    raw_items = surface.get("items")
+    if not isinstance(raw_items, Mapping):
+        return None
+
+    requested = surface.get("subsystems")
+    if isinstance(requested, str):
+        requested = [requested]
+    if not isinstance(requested, (list, tuple)):
+        requested = list(raw_items)
+
+    subsystems: list[str] = []
+    items: dict[str, list[str]] = {}
+    for raw_subsystem in requested:
+        subsystem = str(raw_subsystem or "").strip().lower()
+        if subsystem not in _SUBSYSTEMS or subsystem in subsystems:
+            continue
+        raw_ids = raw_items.get(subsystem)
+        if not isinstance(raw_ids, (list, tuple)):
+            continue
+        pending_ids = [
+            str(value).lower()
+            for value in raw_ids
+            if _PENDING_ID_RE.fullmatch(str(value or "").strip())
+        ]
+        if not pending_ids:
+            continue
+        subsystems.append(subsystem)
+        items[subsystem] = list(dict.fromkeys(pending_ids))
+
+    if not subsystems:
+        return None
+    return {"subsystems": subsystems, "items": items}
+
+
+def build_pending_surface(subsystems: Iterable[str]) -> Optional[dict]:
+    """Snapshot pending IDs without exposing summaries or staged payloads."""
+    from tools import write_approval as wa
+
+    items: dict[str, list[str]] = {}
+    ordered: list[str] = []
+    for raw_subsystem in subsystems:
+        subsystem = str(raw_subsystem or "").strip().lower()
+        if subsystem not in _SUBSYSTEMS or subsystem in ordered:
+            continue
+        ids = [
+            str(record.get("id") or "").lower()
+            for record in wa.list_pending(subsystem)
+            if isinstance(record, dict)
+            and _PENDING_ID_RE.fullmatch(str(record.get("id") or "").strip())
+        ]
+        if ids:
+            ordered.append(subsystem)
+            items[subsystem] = list(dict.fromkeys(ids))
+    return normalize_surface({"subsystems": ordered, "items": items})
+
+
+class WriteApprovalReply(str):
+    """Text response carrying internal platform-delivery metadata."""
+
+    delivery_metadata: dict
+
+    def __new__(cls, text: str, surface: Any = None):
+        instance = super().__new__(cls, text)
+        normalized = normalize_surface(surface)
+        instance.delivery_metadata = (
+            {WRITE_APPROVAL_METADATA_KEY: normalized} if normalized else {}
+        )
+        return instance
+
+
+def merge_response_delivery_metadata(
+    metadata: Optional[Mapping[str, Any]], response: Any
+) -> Optional[dict]:
+    """Merge trusted metadata carried by a structured gateway reply."""
+    merged = dict(metadata or {})
+    extra = getattr(response, "delivery_metadata", None)
+    if isinstance(extra, Mapping):
+        for key, value in extra.items():
+            if isinstance(key, str):
+                merged[key] = value
+    return merged or None
+
+
+def _normalize_intent(text: str) -> str:
+    normalized = " ".join(str(text or "").strip().casefold().split())
+    return normalized.rstrip(".!?。！？")
+
+
+def _single_subsystem(surface: dict) -> Optional[str]:
+    subsystems = surface["subsystems"]
+    return subsystems[0] if len(subsystems) == 1 else None
+
+
+def _explicit_subsystem(token: str) -> Optional[str]:
+    token = token.casefold()
+    if token in {"memory", "память", "памяти"}:
+        return "memory"
+    if token in {"skills", "skill", "навыки", "навыков"}:
+        return "skills"
+    return None
+
+
+def command_for_reply_intent(text: str, raw_surface: Any) -> Optional[str]:
+    """Map an exact intent to an existing slash command.
+
+    The caller must supply a surface recorded from a Hermes-owned outbound
+    approval message. Ambiguous or conversational language fails open to the
+    normal agent path; this function never infers intent from message text
+    alone.
+    """
+    surface = normalize_surface(raw_surface)
+    if surface is None:
+        return None
+    intent = _normalize_intent(text)
+    if not intent:
+        return None
+
+    single = _single_subsystem(surface)
+    all_words = {"all", "всё", "все"}
+    approve_words = {"approve", "одобри", "одобрить"}
+    reject_words = {"reject", "deny", "отклони", "отклонить"}
+    parts = intent.split()
+
+    if len(parts) == 2 and parts[0] in approve_words and parts[1] in all_words:
+        return f"/{single} approve all" if single else None
+    if len(parts) == 2 and parts[0] in reject_words and parts[1] in all_words:
+        return f"/{single} reject all" if single else None
+
+    if len(parts) in {2, 3} and parts[0] in approve_words | reject_words:
+        action = "approve" if parts[0] in approve_words else "reject"
+        target_token = parts[-1]
+        if len(parts) == 3 and parts[1] not in all_words:
+            return None
+        subsystem = _explicit_subsystem(target_token)
+        if subsystem:
+            if subsystem not in surface["subsystems"]:
+                return None
+            return f"/{subsystem} {action} all"
+        if _PENDING_ID_RE.fullmatch(target_token):
+            owners = [
+                name for name, ids in surface["items"].items() if target_token in ids
+            ]
+            if len(owners) == 1:
+                return f"/{owners[0]} {action} {target_token}"
+        return None
+
+    if intent in {"show pending", "покажи pending", "покажи ожидающие"}:
+        return f"/{single} pending" if single else None
+    if intent in {
+        "show diff",
+        "show skill diff",
+        "покажи diff",
+        "покажи разницу",
+    }:
+        skill_ids = surface["items"].get("skills", [])
+        if len(skill_ids) == 1:
+            return f"/skills diff {skill_ids[0]}"
+    return None
+
+
+def command_for_callback_data(data: str) -> Optional[str]:
+    """Decode a compact Telegram ``wa:*`` callback into a slash command."""
+    match = re.fullmatch(
+        r"wa:(m|s):(a|r|p|d):(all|[0-9a-f]{8})",
+        str(data or ""),
+        re.IGNORECASE,
+    )
+    if match is None:
+        return None
+    subsystem = "memory" if match.group(1).lower() == "m" else "skills"
+    action_code = match.group(2).lower()
+    target = match.group(3).lower()
+    if action_code == "p":
+        return f"/{subsystem} pending"
+    if action_code == "d":
+        if subsystem != "skills" or target == "all":
+            return None
+        return f"/skills diff {target}"
+    action = "approve" if action_code == "a" else "reject"
+    return f"/{subsystem} {action} {target}"
+
+
+__all__ = [
+    "WRITE_APPROVAL_METADATA_KEY",
+    "WRITE_APPROVAL_REPLY_KEY",
+    "WriteApprovalReply",
+    "build_pending_surface",
+    "command_for_callback_data",
+    "command_for_reply_intent",
+    "merge_response_delivery_metadata",
+    "normalize_surface",
+]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1223,14 +1223,6 @@ class TelegramAdapter(BasePlatformAdapter):
         for subsystem in surface["subsystems"]:
             code = "m" if subsystem == "memory" else "s"
             ids = surface["items"][subsystem]
-            rows.append([
-                InlineKeyboardButton(
-                    f"Approve all {subsystem}", callback_data=f"wa:{code}:a:all"
-                ),
-                InlineKeyboardButton(
-                    f"Reject all {subsystem}", callback_data=f"wa:{code}:r:all"
-                ),
-            ])
             for pending_id in ids[:8]:
                 item_row = [
                     InlineKeyboardButton(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,7 @@ import html as _html
 import re
 import threading
 import time
+from collections import OrderedDict
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -297,7 +298,16 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
+    _thread_metadata_for_source,
     utf16_len,
+)
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_METADATA_KEY,
+    WRITE_APPROVAL_REPLY_KEY,
+    command_for_callback_data,
+    command_for_reply_intent,
+    merge_response_delivery_metadata,
+    normalize_surface,
 )
 from plugins.platforms.telegram.telegram_ids import (
     normalize_telegram_chat_id,
@@ -893,6 +903,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Only replies to message IDs recorded here may become natural-language
+        # write-approval actions. Text matching alone is never sufficient.
+        self._write_approval_surfaces: OrderedDict[tuple[str, str], dict] = OrderedDict()
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -1172,6 +1185,116 @@ class TelegramAdapter(BasePlatformAdapter):
             return {}
         return {"disable_notification": True}
 
+    @staticmethod
+    def _callback_source(
+        user_id: str,
+        *,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+    ):
+        from gateway.session import SessionSource
+
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(chat_id or user_id),
+            chat_type=normalized_chat_type,
+            user_id=str(user_id),
+            user_name=str(user_name).strip() if user_name else None,
+            thread_id=str(thread_id) if thread_id is not None else None,
+        )
+
+    def _write_approval_keyboard(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> tuple[Optional[dict], Optional[Any]]:
+        surface = normalize_surface(
+            (metadata or {}).get(WRITE_APPROVAL_METADATA_KEY)
+        )
+        if surface is None:
+            return None, None
+
+        rows = []
+        for subsystem in surface["subsystems"]:
+            code = "m" if subsystem == "memory" else "s"
+            ids = surface["items"][subsystem]
+            rows.append([
+                InlineKeyboardButton(
+                    f"Approve all {subsystem}", callback_data=f"wa:{code}:a:all"
+                ),
+                InlineKeyboardButton(
+                    f"Reject all {subsystem}", callback_data=f"wa:{code}:r:all"
+                ),
+            ])
+            for pending_id in ids[:8]:
+                item_row = [
+                    InlineKeyboardButton(
+                        f"Approve {pending_id}",
+                        callback_data=f"wa:{code}:a:{pending_id}",
+                    ),
+                    InlineKeyboardButton(
+                        f"Reject {pending_id}",
+                        callback_data=f"wa:{code}:r:{pending_id}",
+                    ),
+                ]
+                if subsystem == "skills":
+                    item_row.append(
+                        InlineKeyboardButton(
+                            f"Diff {pending_id}",
+                            callback_data=f"wa:s:d:{pending_id}",
+                        )
+                    )
+                rows.append(item_row)
+            rows.append([
+                InlineKeyboardButton(
+                    f"Show pending {subsystem}", callback_data=f"wa:{code}:p:all"
+                )
+            ])
+        return surface, InlineKeyboardMarkup(rows)
+
+    def _remember_write_approval_surface(
+        self, chat_id: str, message_id: str, surface: dict
+    ) -> None:
+        store = getattr(self, "_write_approval_surfaces", None)
+        if not isinstance(store, OrderedDict):
+            store = OrderedDict()
+            self._write_approval_surfaces = store
+        key = (str(chat_id), str(message_id))
+        store[key] = dict(surface)
+        store.move_to_end(key)
+        while len(store) > 256:
+            store.popitem(last=False)
+
+    def _lookup_write_approval_surface(
+        self, chat_id: str, message_id: str
+    ) -> Optional[dict]:
+        store = getattr(self, "_write_approval_surfaces", None)
+        if not isinstance(store, OrderedDict):
+            return None
+        key = (str(chat_id), str(message_id))
+        surface = store.get(key)
+        if surface is not None:
+            store.move_to_end(key)
+            return dict(surface)
+        return None
+
+    @staticmethod
+    def _rewrite_write_approval_reply(event: MessageEvent) -> bool:
+        surface = (getattr(event, "metadata", None) or {}).get(
+            WRITE_APPROVAL_REPLY_KEY
+        )
+        command = command_for_reply_intent(event.text, surface)
+        if command is None:
+            return False
+        event.text = command
+        event.message_type = MessageType.COMMAND
+        return True
+
     def _is_callback_user_authorized(
         self,
         user_id: str,
@@ -1190,21 +1313,12 @@ class TelegramAdapter(BasePlatformAdapter):
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
-
-                source = SessionSource(
-                    platform=Platform.TELEGRAM,
-                    chat_id=str(chat_id or normalized_user_id),
-                    chat_type=normalized_chat_type,
-                    user_id=normalized_user_id,
-                    user_name=str(user_name).strip() if user_name else None,
+                source = self._callback_source(
+                    normalized_user_id,
+                    chat_id=str(chat_id) if chat_id is not None else None,
+                    chat_type=chat_type,
                     thread_id=str(thread_id) if thread_id is not None else None,
+                    user_name=user_name,
                 )
                 return bool(auth_fn(source))
             except Exception:
@@ -5150,12 +5264,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            approval_surface, approval_markup = self._write_approval_keyboard(
+                metadata
+            )
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if approval_markup is None and self._should_attempt_rich(
+                content, metadata=metadata
+            ):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -5250,6 +5369,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_kwargs = dict(thread_kwargs)
                     thread_kwargs["message_thread_id"] = None
                 effective_thread_id = thread_kwargs.get("message_thread_id")
+                interactive_kwargs = (
+                    {"reply_markup": approval_markup}
+                    if i == 0 and approval_markup is not None
+                    else {}
+                )
 
                 msg = None
                 for _send_attempt in range(3):
@@ -5262,6 +5386,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
+                                **interactive_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
@@ -5276,6 +5401,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     **thread_kwargs,
+                                    **interactive_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
                                 )
@@ -5400,7 +5526,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 await asyncio.sleep(wait)
                                 continue
                         raise
-                message_ids.append(str(msg.message_id))
+                message_id = str(msg.message_id)
+                message_ids.append(message_id)
+                if i == 0 and approval_surface is not None:
+                    self._remember_write_approval_surface(
+                        str(chat_id), message_id, approval_surface
+                    )
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -7022,6 +7153,97 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    async def _handle_write_approval_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch a write-approval button through the normal command rail."""
+        command_text = command_for_callback_data(data)
+        if command_text is None:
+            await query.answer(text="Invalid write-approval action.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=(
+                str(query_chat_type) if query_chat_type is not None else None
+            ),
+            thread_id=(
+                str(query_thread_id) if query_thread_id is not None else None
+            ),
+            user_name=query_user_name,
+        ):
+            await query.answer(
+                text="⛔ You are not authorized to review staged writes."
+            )
+            return
+        if not callable(getattr(self, "_message_handler", None)):
+            await query.answer(text="Gateway command handler is unavailable.")
+            return
+
+        source = self._callback_source(
+            caller_id,
+            chat_id=str(query_chat_id or caller_id),
+            chat_type=(
+                str(query_chat_type) if query_chat_type is not None else None
+            ),
+            thread_id=(
+                str(query_thread_id) if query_thread_id is not None else None
+            ),
+            user_name=query_user_name,
+        )
+        prompt_message_id = getattr(query.message, "message_id", None)
+        source.message_id = (
+            str(prompt_message_id) if prompt_message_id is not None else None
+        )
+        event = MessageEvent(
+            text=command_text,
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=query.message,
+            message_id=source.message_id,
+            reply_to_message_id=source.message_id,
+        )
+
+        await query.answer(text="Processing write-approval action…")
+        try:
+            response = await self._message_handler(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] write-approval callback dispatch failed: %s",
+                self.name,
+                exc,
+                exc_info=True,
+            )
+            return
+        if not response or query_chat_id is None:
+            return
+
+        metadata = _thread_metadata_for_source(source, source.message_id)
+        metadata = merge_response_delivery_metadata(metadata, response)
+        metadata = dict(metadata or {})
+        metadata["notify"] = True
+        await self.send(
+            str(query_chat_id),
+            str(response),
+            reply_to=source.message_id,
+            metadata=metadata,
+        )
+
+        if data.split(":", 3)[2].lower() in {"a", "r"}:
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -7036,6 +7258,18 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Staged memory/skill write callbacks (wa:subsystem:action:target) ---
+        if data.startswith("wa:"):
+            await self._handle_write_approval_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
@@ -9538,6 +9772,9 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
+        if self._rewrite_write_approval_reply(event):
+            await self.handle_message(event)
+            return
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
 
@@ -10500,6 +10737,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        event_metadata: Dict[str, Any] = {}
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
             quote = getattr(message, "quote", None)
@@ -10525,6 +10763,11 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
                     except Exception:
                         reply_to_text = None
+            approval_surface = self._lookup_write_approval_surface(
+                str(chat.id), reply_to_id
+            )
+            if approval_surface is not None:
+                event_metadata[WRITE_APPROVAL_REPLY_KEY] = approval_surface
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
@@ -10544,6 +10787,7 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            metadata=event_metadata,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,7 @@ import html as _html
 import re
 import threading
 import time
+from collections import OrderedDict
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -295,7 +296,16 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
+    _thread_metadata_for_source,
     utf16_len,
+)
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_METADATA_KEY,
+    WRITE_APPROVAL_REPLY_KEY,
+    command_for_callback_data,
+    command_for_reply_intent,
+    merge_response_delivery_metadata,
+    normalize_surface,
 )
 from plugins.platforms.telegram.telegram_ids import (
     normalize_telegram_chat_id,
@@ -860,6 +870,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Only replies to message IDs recorded here may become natural-language
+        # write-approval actions. Text matching alone is never sufficient.
+        self._write_approval_surfaces: OrderedDict[tuple[str, str], dict] = OrderedDict()
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -923,6 +936,116 @@ class TelegramAdapter(BasePlatformAdapter):
             return {}
         return {"disable_notification": True}
 
+    @staticmethod
+    def _callback_source(
+        user_id: str,
+        *,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+    ):
+        from gateway.session import SessionSource
+
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(chat_id or user_id),
+            chat_type=normalized_chat_type,
+            user_id=str(user_id),
+            user_name=str(user_name).strip() if user_name else None,
+            thread_id=str(thread_id) if thread_id is not None else None,
+        )
+
+    def _write_approval_keyboard(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> tuple[Optional[dict], Optional[Any]]:
+        surface = normalize_surface(
+            (metadata or {}).get(WRITE_APPROVAL_METADATA_KEY)
+        )
+        if surface is None:
+            return None, None
+
+        rows = []
+        for subsystem in surface["subsystems"]:
+            code = "m" if subsystem == "memory" else "s"
+            ids = surface["items"][subsystem]
+            rows.append([
+                InlineKeyboardButton(
+                    f"Approve all {subsystem}", callback_data=f"wa:{code}:a:all"
+                ),
+                InlineKeyboardButton(
+                    f"Reject all {subsystem}", callback_data=f"wa:{code}:r:all"
+                ),
+            ])
+            for pending_id in ids[:8]:
+                item_row = [
+                    InlineKeyboardButton(
+                        f"Approve {pending_id}",
+                        callback_data=f"wa:{code}:a:{pending_id}",
+                    ),
+                    InlineKeyboardButton(
+                        f"Reject {pending_id}",
+                        callback_data=f"wa:{code}:r:{pending_id}",
+                    ),
+                ]
+                if subsystem == "skills":
+                    item_row.append(
+                        InlineKeyboardButton(
+                            f"Diff {pending_id}",
+                            callback_data=f"wa:s:d:{pending_id}",
+                        )
+                    )
+                rows.append(item_row)
+            rows.append([
+                InlineKeyboardButton(
+                    f"Show pending {subsystem}", callback_data=f"wa:{code}:p:all"
+                )
+            ])
+        return surface, InlineKeyboardMarkup(rows)
+
+    def _remember_write_approval_surface(
+        self, chat_id: str, message_id: str, surface: dict
+    ) -> None:
+        store = getattr(self, "_write_approval_surfaces", None)
+        if not isinstance(store, OrderedDict):
+            store = OrderedDict()
+            self._write_approval_surfaces = store
+        key = (str(chat_id), str(message_id))
+        store[key] = dict(surface)
+        store.move_to_end(key)
+        while len(store) > 256:
+            store.popitem(last=False)
+
+    def _lookup_write_approval_surface(
+        self, chat_id: str, message_id: str
+    ) -> Optional[dict]:
+        store = getattr(self, "_write_approval_surfaces", None)
+        if not isinstance(store, OrderedDict):
+            return None
+        key = (str(chat_id), str(message_id))
+        surface = store.get(key)
+        if surface is not None:
+            store.move_to_end(key)
+            return dict(surface)
+        return None
+
+    @staticmethod
+    def _rewrite_write_approval_reply(event: MessageEvent) -> bool:
+        surface = (getattr(event, "metadata", None) or {}).get(
+            WRITE_APPROVAL_REPLY_KEY
+        )
+        command = command_for_reply_intent(event.text, surface)
+        if command is None:
+            return False
+        event.text = command
+        event.message_type = MessageType.COMMAND
+        return True
+
     def _is_callback_user_authorized(
         self,
         user_id: str,
@@ -941,21 +1064,12 @@ class TelegramAdapter(BasePlatformAdapter):
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
-
-                source = SessionSource(
-                    platform=Platform.TELEGRAM,
-                    chat_id=str(chat_id or normalized_user_id),
-                    chat_type=normalized_chat_type,
-                    user_id=normalized_user_id,
-                    user_name=str(user_name).strip() if user_name else None,
+                source = self._callback_source(
+                    normalized_user_id,
+                    chat_id=str(chat_id) if chat_id is not None else None,
+                    chat_type=chat_type,
                     thread_id=str(thread_id) if thread_id is not None else None,
+                    user_name=user_name,
                 )
                 return bool(auth_fn(source))
             except Exception:
@@ -4449,12 +4563,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            approval_surface, approval_markup = self._write_approval_keyboard(
+                metadata
+            )
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if approval_markup is None and self._should_attempt_rich(
+                content, metadata=metadata
+            ):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -4549,6 +4668,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_kwargs = dict(thread_kwargs)
                     thread_kwargs["message_thread_id"] = None
                 effective_thread_id = thread_kwargs.get("message_thread_id")
+                interactive_kwargs = (
+                    {"reply_markup": approval_markup}
+                    if i == 0 and approval_markup is not None
+                    else {}
+                )
 
                 msg = None
                 for _send_attempt in range(3):
@@ -4561,6 +4685,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
+                                **interactive_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
@@ -4575,6 +4700,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     **thread_kwargs,
+                                    **interactive_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
                                 )
@@ -4699,7 +4825,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 await asyncio.sleep(wait)
                                 continue
                         raise
-                message_ids.append(str(msg.message_id))
+                message_id = str(msg.message_id)
+                message_ids.append(message_id)
+                if i == 0 and approval_surface is not None:
+                    self._remember_write_approval_surface(
+                        str(chat_id), message_id, approval_surface
+                    )
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -6307,6 +6438,97 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    async def _handle_write_approval_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch a write-approval button through the normal command rail."""
+        command_text = command_for_callback_data(data)
+        if command_text is None:
+            await query.answer(text="Invalid write-approval action.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=(
+                str(query_chat_type) if query_chat_type is not None else None
+            ),
+            thread_id=(
+                str(query_thread_id) if query_thread_id is not None else None
+            ),
+            user_name=query_user_name,
+        ):
+            await query.answer(
+                text="⛔ You are not authorized to review staged writes."
+            )
+            return
+        if not callable(getattr(self, "_message_handler", None)):
+            await query.answer(text="Gateway command handler is unavailable.")
+            return
+
+        source = self._callback_source(
+            caller_id,
+            chat_id=str(query_chat_id or caller_id),
+            chat_type=(
+                str(query_chat_type) if query_chat_type is not None else None
+            ),
+            thread_id=(
+                str(query_thread_id) if query_thread_id is not None else None
+            ),
+            user_name=query_user_name,
+        )
+        prompt_message_id = getattr(query.message, "message_id", None)
+        source.message_id = (
+            str(prompt_message_id) if prompt_message_id is not None else None
+        )
+        event = MessageEvent(
+            text=command_text,
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=query.message,
+            message_id=source.message_id,
+            reply_to_message_id=source.message_id,
+        )
+
+        await query.answer(text="Processing write-approval action…")
+        try:
+            response = await self._message_handler(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] write-approval callback dispatch failed: %s",
+                self.name,
+                exc,
+                exc_info=True,
+            )
+            return
+        if not response or query_chat_id is None:
+            return
+
+        metadata = _thread_metadata_for_source(source, source.message_id)
+        metadata = merge_response_delivery_metadata(metadata, response)
+        metadata = dict(metadata or {})
+        metadata["notify"] = True
+        await self.send(
+            str(query_chat_id),
+            str(response),
+            reply_to=source.message_id,
+            metadata=metadata,
+        )
+
+        if data.split(":", 3)[2].lower() in {"a", "r"}:
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -6321,6 +6543,18 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Staged memory/skill write callbacks (wa:subsystem:action:target) ---
+        if data.startswith("wa:"):
+            await self._handle_write_approval_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
@@ -8810,6 +9044,9 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
+        if self._rewrite_write_approval_reply(event):
+            await self.handle_message(event)
+            return
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
 
@@ -9749,6 +9986,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        event_metadata: Dict[str, Any] = {}
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
             quote = getattr(message, "quote", None)
@@ -9774,6 +10012,11 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
                     except Exception:
                         reply_to_text = None
+            approval_surface = self._lookup_write_approval_surface(
+                str(chat.id), reply_to_id
+            )
+            if approval_surface is not None:
+                event_metadata[WRITE_APPROVAL_REPLY_KEY] = approval_surface
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
@@ -9793,6 +10036,7 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            metadata=event_metadata,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -974,14 +974,6 @@ class TelegramAdapter(BasePlatformAdapter):
         for subsystem in surface["subsystems"]:
             code = "m" if subsystem == "memory" else "s"
             ids = surface["items"][subsystem]
-            rows.append([
-                InlineKeyboardButton(
-                    f"Approve all {subsystem}", callback_data=f"wa:{code}:a:all"
-                ),
-                InlineKeyboardButton(
-                    f"Reject all {subsystem}", callback_data=f"wa:{code}:r:all"
-                ),
-            ])
             for pending_id in ids[:8]:
                 item_row = [
                     InlineKeyboardButton(

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -10,6 +10,7 @@ import pytest
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, ProcessingOutcome, SendResult
 from gateway.session import SessionSource, build_session_key
+from gateway.write_approval_interactions import WriteApprovalReply
 
 
 class DummyTelegramAdapter(BasePlatformAdapter):
@@ -135,6 +136,40 @@ class TestBasePlatformTopicSessions:
             ("complete", "1", ProcessingOutcome.SUCCESS),
         ]
 
+    @pytest.mark.asyncio
+    async def test_process_message_background_forwards_reply_delivery_metadata(self):
+        adapter = DummyTelegramAdapter()
+
+        async def handler(_event):
+            return WriteApprovalReply(
+                "Pending memory writes (1)",
+                {
+                    "subsystems": ["memory"],
+                    "items": {"memory": ["abc12345"]},
+                },
+            )
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+
+        assert adapter.sent[0]["metadata"] == {
+            "thread_id": "17585",
+            "notify": True,
+            "write_approval": {
+                "subsystems": ["memory"],
+                "items": {"memory": ["abc12345"]},
+            },
+        }
+
 
 class TestTelegramAutoTtsCaptionDelivery:
     @staticmethod
@@ -198,4 +233,3 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
-

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1383,6 +1383,14 @@ async def test_run_agent_sends_normalized_failure_before_queued_followup(
 
 @pytest.mark.asyncio
 async def test_run_agent_defers_background_review_notification_until_release(monkeypatch, tmp_path):
+    approval_surface = {
+        "subsystems": ["skills"],
+        "items": {"skills": ["abc12345"]},
+    }
+    monkeypatch.setattr(
+        "gateway.run.build_pending_surface",
+        lambda _subsystems: approval_surface,
+    )
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
@@ -1393,6 +1401,28 @@ async def test_run_agent_defers_background_review_notification_until_release(mon
 
     assert result["final_response"] == "done"
     assert adapter.sent == []
+
+    session_key = "agent:main:telegram:group:-1001:17585"
+    entry = adapter._post_delivery_callbacks[session_key]
+    release = entry[1] if isinstance(entry, tuple) else entry
+    release()
+    for _ in range(20):
+        if adapter.sent:
+            break
+        await asyncio.sleep(0.01)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "-1001",
+            "content": "💾 Skill 'prospect-scanner' created.",
+            "reply_to": None,
+            "metadata": {
+                "_interim_send": True,
+                "thread_id": "17585",
+                "write_approval": approval_surface,
+            },
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_write_approval_interactions.py
+++ b/tests/gateway/test_telegram_write_approval_interactions.py
@@ -1,0 +1,308 @@
+"""Telegram interaction regressions for staged memory and skill writes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.write_approval_interactions import (
+    WRITE_APPROVAL_REPLY_KEY,
+    WriteApprovalReply,
+    build_pending_surface,
+    command_for_reply_intent,
+)
+from plugins.platforms.telegram import adapter as telegram_module
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+MEMORY_SURFACE = {
+    "subsystems": ["memory"],
+    "items": {"memory": ["abc12345"]},
+}
+SKILL_SURFACE = {
+    "subsystems": ["skills"],
+    "items": {"skills": ["def67890"]},
+}
+
+
+class _Button:
+    def __init__(self, text, callback_data=None, **_kwargs):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class _Markup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _make_adapter(monkeypatch) -> TelegramAdapter:
+    monkeypatch.setattr(telegram_module, "InlineKeyboardButton", _Button)
+    monkeypatch.setattr(telegram_module, "InlineKeyboardMarkup", _Markup)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=77))
+    return adapter
+
+
+def _event(text: str, surface=None, *, message_type=MessageType.TEXT) -> MessageEvent:
+    metadata = {}
+    if surface is not None:
+        metadata[WRITE_APPROVAL_REPLY_KEY] = surface
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="42",
+        ),
+        reply_to_message_id="77" if surface is not None else None,
+        metadata=metadata,
+    )
+
+
+def test_reply_intents_are_exact_and_scoped():
+    assert (
+        command_for_reply_intent("approve all", MEMORY_SURFACE) == "/memory approve all"
+    )
+    assert (
+        command_for_reply_intent("одобри всё", MEMORY_SURFACE) == "/memory approve all"
+    )
+    assert (
+        command_for_reply_intent("reject skills", SKILL_SURFACE) == "/skills reject all"
+    )
+    assert (
+        command_for_reply_intent("покажи diff", SKILL_SURFACE)
+        == "/skills diff def67890"
+    )
+
+    assert command_for_reply_intent("approve all", None) is None
+    assert (
+        command_for_reply_intent("can you approve all of this?", MEMORY_SURFACE) is None
+    )
+    assert (
+        command_for_reply_intent(
+            "approve all",
+            {
+                "subsystems": ["memory", "skills"],
+                "items": {"memory": ["abc12345"], "skills": ["def67890"]},
+            },
+        )
+        is None
+    )
+
+
+def test_pending_surface_contains_ids_only(monkeypatch):
+    monkeypatch.setattr(
+        "tools.write_approval.list_pending",
+        lambda subsystem: (
+            [
+                {
+                    "id": "abc12345",
+                    "summary": "private content must not enter delivery metadata",
+                    "payload": {"content": "secret"},
+                }
+            ]
+            if subsystem == "memory"
+            else []
+        ),
+    )
+
+    assert build_pending_surface(("memory", "skills")) == MEMORY_SURFACE
+
+
+@pytest.mark.asyncio
+async def test_telegram_pending_reply_adds_buttons_and_records_owned_surface(
+    monkeypatch,
+):
+    adapter = _make_adapter(monkeypatch)
+
+    result = await adapter.send(
+        "12345",
+        "Pending memory writes (1): abc12345",
+        metadata={"write_approval": MEMORY_SURFACE},
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args.kwargs
+    callbacks = [
+        button.callback_data
+        for row in kwargs["reply_markup"].inline_keyboard
+        for button in row
+    ]
+    assert "wa:m:a:all" in callbacks
+    assert "wa:m:r:all" in callbacks
+    assert "wa:m:a:abc12345" in callbacks
+    assert "wa:m:r:abc12345" in callbacks
+    assert adapter._lookup_write_approval_surface("12345", "77") == MEMORY_SURFACE
+
+
+def test_only_known_approval_replies_are_rewritten(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+
+    scoped = _event("approve all", MEMORY_SURFACE)
+    assert adapter._rewrite_write_approval_reply(scoped) is True
+    assert scoped.text == "/memory approve all"
+    assert scoped.message_type == MessageType.COMMAND
+
+    unrelated = _event("can you approve this design?", MEMORY_SURFACE)
+    assert adapter._rewrite_write_approval_reply(unrelated) is False
+    assert unrelated.text == "can you approve this design?"
+
+    unscoped = _event("approve all")
+    assert adapter._rewrite_write_approval_reply(unscoped) is False
+
+
+class _IntentRunner(GatewaySlashCommandsMixin):
+    def __init__(self, denied=None):
+        self.denied = denied
+        self.events = []
+
+    def _check_slash_access(self, _source, _command):
+        return self.denied
+
+    async def _handle_memory_command(self, event):
+        self.events.append(event)
+        return WriteApprovalReply("Approved memory", MEMORY_SURFACE)
+
+    async def _handle_skills_command(self, event):
+        self.events.append(event)
+        return WriteApprovalReply("Approved skills", SKILL_SURFACE)
+
+
+@pytest.mark.asyncio
+async def test_voice_intent_dispatch_reuses_slash_handler_and_access_gate():
+    runner = _IntentRunner()
+    handled, response = await runner._dispatch_write_approval_reply_intent(
+        _event("", MEMORY_SURFACE, message_type=MessageType.VOICE),
+        "одобри всё",
+    )
+    assert handled is True
+    assert response == "Approved memory"
+    assert runner.events[0].text == "/memory approve all"
+    assert runner.events[0].message_type == MessageType.COMMAND
+
+    denied_runner = _IntentRunner(denied="admin only")
+    handled, response = await denied_runner._dispatch_write_approval_reply_intent(
+        _event("", MEMORY_SURFACE, message_type=MessageType.VOICE),
+        "approve all",
+    )
+    assert handled is True
+    assert response == "admin only"
+    assert denied_runner.events == []
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_is_intercepted_at_the_stt_boundary(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._check_slash_access = lambda _source, _command: None
+    runner._handle_memory_command = AsyncMock(
+        return_value=WriteApprovalReply("Approved memory", MEMORY_SURFACE)
+    )
+
+    event = _event("", MEMORY_SURFACE, message_type=MessageType.VOICE)
+    event.media_urls = ["/tmp/approval-reply.ogg"]
+    event.media_types = ["audio/ogg"]
+    monkeypatch.setattr(
+        runner,
+        "_enrich_message_with_transcription",
+        AsyncMock(return_value=("transcribed", ["approve all"])),
+    )
+
+    response = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert isinstance(response, WriteApprovalReply)
+    assert response == "Approved memory"
+    runner._handle_memory_command.assert_awaited_once()
+    command_event = runner._handle_memory_command.call_args.args[0]
+    assert command_event.text == "/memory approve all"
+    assert command_event.message_type == MessageType.COMMAND
+
+
+class _CallbackRunner:
+    def __init__(self, authorized=True):
+        self.authorized = authorized
+        self.events = []
+
+    def _is_user_authorized(self, _source):
+        return self.authorized
+
+    async def _handle_message(self, event):
+        self.events.append(event)
+        return WriteApprovalReply("Approved 1 memory write(s).", MEMORY_SURFACE)
+
+
+@pytest.mark.asyncio
+async def test_callback_routes_through_runner_command_path(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    runner = _CallbackRunner()
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="78"))
+    query = SimpleNamespace(
+        data="wa:m:a:abc12345",
+        from_user=SimpleNamespace(id=42, first_name="Joe"),
+        message=SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=77,
+        ),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert runner.events[0].text == "/memory approve abc12345"
+    assert runner.events[0].message_type == MessageType.COMMAND
+    adapter.send.assert_awaited_once()
+    assert adapter.send.call_args.args[1] == "Approved 1 memory write(s)."
+    assert adapter.send.call_args.kwargs["metadata"]["write_approval"] == MEMORY_SURFACE
+
+
+@pytest.mark.asyncio
+async def test_callback_fails_closed_for_unauthorized_user(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    runner = _CallbackRunner(authorized=False)
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock()
+    query = SimpleNamespace(
+        data="wa:m:r:all",
+        from_user=SimpleNamespace(id=99, first_name="Mallory"),
+        message=SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=77,
+        ),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert runner.events == []
+    adapter.send.assert_not_awaited()
+    assert "not authorized" in query.answer.call_args.kwargs["text"].lower()

--- a/tests/gateway/test_telegram_write_approval_interactions.py
+++ b/tests/gateway/test_telegram_write_approval_interactions.py
@@ -69,19 +69,21 @@ def _event(text: str, surface=None, *, message_type=MessageType.TEXT) -> Message
 
 def test_reply_intents_are_exact_and_scoped():
     assert (
-        command_for_reply_intent("approve all", MEMORY_SURFACE) == "/memory approve all"
+        command_for_reply_intent("approve abc12345", MEMORY_SURFACE)
+        == "/memory approve abc12345"
     )
     assert (
-        command_for_reply_intent("одобри всё", MEMORY_SURFACE) == "/memory approve all"
-    )
-    assert (
-        command_for_reply_intent("reject skills", SKILL_SURFACE) == "/skills reject all"
+        command_for_reply_intent("одобри abc12345", MEMORY_SURFACE)
+        == "/memory approve abc12345"
     )
     assert (
         command_for_reply_intent("покажи diff", SKILL_SURFACE)
         == "/skills diff def67890"
     )
 
+    assert command_for_reply_intent("approve all", MEMORY_SURFACE) is None
+    assert command_for_reply_intent("одобри всё", MEMORY_SURFACE) is None
+    assert command_for_reply_intent("reject skills", SKILL_SURFACE) is None
     assert command_for_reply_intent("approve all", None) is None
     assert (
         command_for_reply_intent("can you approve all of this?", MEMORY_SURFACE) is None
@@ -136,8 +138,8 @@ async def test_telegram_pending_reply_adds_buttons_and_records_owned_surface(
         for row in kwargs["reply_markup"].inline_keyboard
         for button in row
     ]
-    assert "wa:m:a:all" in callbacks
-    assert "wa:m:r:all" in callbacks
+    assert "wa:m:a:all" not in callbacks
+    assert "wa:m:r:all" not in callbacks
     assert "wa:m:a:abc12345" in callbacks
     assert "wa:m:r:abc12345" in callbacks
     assert adapter._lookup_write_approval_surface("12345", "77") == MEMORY_SURFACE
@@ -146,9 +148,9 @@ async def test_telegram_pending_reply_adds_buttons_and_records_owned_surface(
 def test_only_known_approval_replies_are_rewritten(monkeypatch):
     adapter = _make_adapter(monkeypatch)
 
-    scoped = _event("approve all", MEMORY_SURFACE)
+    scoped = _event("approve abc12345", MEMORY_SURFACE)
     assert adapter._rewrite_write_approval_reply(scoped) is True
-    assert scoped.text == "/memory approve all"
+    assert scoped.text == "/memory approve abc12345"
     assert scoped.message_type == MessageType.COMMAND
 
     unrelated = _event("can you approve this design?", MEMORY_SURFACE)
@@ -181,17 +183,17 @@ async def test_voice_intent_dispatch_reuses_slash_handler_and_access_gate():
     runner = _IntentRunner()
     handled, response = await runner._dispatch_write_approval_reply_intent(
         _event("", MEMORY_SURFACE, message_type=MessageType.VOICE),
-        "одобри всё",
+        "одобри abc12345",
     )
     assert handled is True
     assert response == "Approved memory"
-    assert runner.events[0].text == "/memory approve all"
+    assert runner.events[0].text == "/memory approve abc12345"
     assert runner.events[0].message_type == MessageType.COMMAND
 
     denied_runner = _IntentRunner(denied="admin only")
     handled, response = await denied_runner._dispatch_write_approval_reply_intent(
         _event("", MEMORY_SURFACE, message_type=MessageType.VOICE),
-        "approve all",
+        "approve abc12345",
     )
     assert handled is True
     assert response == "admin only"
@@ -219,7 +221,7 @@ async def test_voice_reply_is_intercepted_at_the_stt_boundary(monkeypatch):
     monkeypatch.setattr(
         runner,
         "_enrich_message_with_transcription",
-        AsyncMock(return_value=("transcribed", ["approve all"])),
+        AsyncMock(return_value=("transcribed", ["approve abc12345"])),
     )
 
     response = await runner._prepare_inbound_message_text(
@@ -233,7 +235,7 @@ async def test_voice_reply_is_intercepted_at_the_stt_boundary(monkeypatch):
     assert response == "Approved memory"
     runner._handle_memory_command.assert_awaited_once()
     command_event = runner._handle_memory_command.call_args.args[0]
-    assert command_event.text == "/memory approve all"
+    assert command_event.text == "/memory approve abc12345"
     assert command_event.message_type == MessageType.COMMAND
 
 
@@ -287,7 +289,7 @@ async def test_callback_fails_closed_for_unauthorized_user(monkeypatch):
     adapter.set_message_handler(runner._handle_message)
     adapter.send = AsyncMock()
     query = SimpleNamespace(
-        data="wa:m:r:all",
+        data="wa:m:r:abc12345",
         from_user=SimpleNamespace(id=99, first_name="Mallory"),
         message=SimpleNamespace(
             chat_id=12345,
@@ -306,3 +308,43 @@ async def test_callback_fails_closed_for_unauthorized_user(monkeypatch):
     assert runner.events == []
     adapter.send.assert_not_awaited()
     assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_stale_bulk_callback_cannot_touch_later_pending_record(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    pending_ids = {"abc12345", "feed6789"}
+
+    class PendingRunner(_CallbackRunner):
+        async def _handle_message(self, event):
+            self.events.append(event)
+            if event.text.endswith(" all"):
+                pending_ids.clear()
+            else:
+                pending_ids.discard(event.text.rsplit(" ", 1)[-1])
+            return WriteApprovalReply("updated", MEMORY_SURFACE)
+
+    runner = PendingRunner()
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock()
+    query = SimpleNamespace(
+        data="wa:m:a:all",
+        from_user=SimpleNamespace(id=42, first_name="Joe"),
+        message=SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=77,
+        ),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert pending_ids == {"abc12345", "feed6789"}
+    assert runner.events == []
+    adapter.send.assert_not_awaited()
+    assert "invalid" in query.answer.call_args.kwargs["text"].lower()

--- a/tests/gateway/test_telegram_write_approval_interactions.py
+++ b/tests/gateway/test_telegram_write_approval_interactions.py
@@ -313,7 +313,18 @@ async def test_callback_fails_closed_for_unauthorized_user(monkeypatch):
 @pytest.mark.asyncio
 async def test_stale_bulk_callback_cannot_touch_later_pending_record(monkeypatch):
     adapter = _make_adapter(monkeypatch)
-    pending_ids = {"abc12345", "feed6789"}
+    pending_ids = {"abc12345"}
+
+    rendered = await adapter.send(
+        "12345",
+        "Pending memory writes (1): abc12345",
+        metadata={"write_approval": MEMORY_SURFACE},
+    )
+    assert rendered.success is True
+    assert adapter._lookup_write_approval_surface("12345", "77") == MEMORY_SURFACE
+
+    # This record did not exist when message 77's controls were rendered.
+    pending_ids.add("feed6789")
 
     class PendingRunner(_CallbackRunner):
         async def _handle_message(self, event):

--- a/tests/gateway/test_telegram_write_approval_interactions.py
+++ b/tests/gateway/test_telegram_write_approval_interactions.py
@@ -239,6 +239,35 @@ async def test_voice_reply_is_intercepted_at_the_stt_boundary(monkeypatch):
     assert command_event.message_type == MessageType.COMMAND
 
 
+@pytest.mark.asyncio
+async def test_write_approval_reply_does_not_drive_goal_continuation():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    session_entry = object()
+    runner.session_store = object()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=session_entry),
+    )
+    runner._post_turn_goal_continuation = AsyncMock()
+    runner._post_turn_loop_completion = AsyncMock()
+    source = _event("approve abc12345", MEMORY_SURFACE).source
+
+    await runner._run_post_turn_hooks(
+        agent_result=WriteApprovalReply("Approved memory", MEMORY_SURFACE),
+        source=source,
+        is_internal=False,
+    )
+
+    runner._post_turn_goal_continuation.assert_not_awaited()
+    runner._post_turn_loop_completion.assert_awaited_once_with(
+        session_entry=session_entry,
+        source=source,
+        final_response="",
+    )
+
+
 class _CallbackRunner:
     def __init__(self, authorized=True):
         self.authorized = authorized


### PR DESCRIPTION
## Summary

- add Telegram inline controls for pending memory and skill writes
- route button clicks through the existing gateway slash-command path
- support conservative English/Russian text and voice reply intents
- attach approval controls to `/memory`, `/skills`, and background-review notifications

Closes #63651.

## Security and routing

- delivery metadata contains only subsystem names and validated 8-character pending IDs; staged summaries and payloads are excluded
- natural-language intents are exact-match and require a reply to a Hermes-owned pending-write message recorded by chat ID and bot message ID
- ambiguous multi-subsystem replies fall through to normal conversation
- callbacks recheck platform authorization, synthesize a command event, and reuse slash-access checks, command hooks, and memory/skills handlers
- voice replies use the same scoped parser immediately after STT and return before model execution
- complete follow-up messages are sent after callbacks, so the interaction does not depend on an edit-only UI for screen readers

## Sibling-path audit

Structured reply metadata is preserved across normal delivery, active-session command delivery, and clarify-intercept delivery. Telegram rich-message delivery is skipped only when an approval keyboard is present so the keyboard is not dropped. Existing slash commands, ordinary Telegram sends, topic routing, text batching, unrelated reply text, and unscoped voice transcripts retain their previous paths.

The current-main conflict added an interim-send marker to background-review notices so they cannot seal a live streamed answer. The resolution composes that marker with staged-write controls in one metadata object, with a regression that releases the real deferred callback and proves both survive.

The open write-gate PRs found in preflight concern CLI store fallback, write staging, fail-closed mutation, sync sanitization, review cadence, or group-review suppression. The open Telegram callback PRs concern dangerous-command approvals or clarify cards. None implements staged memory/skill controls or scoped reply intents. Related issue #58834 requests proactive notification timing rather than these approval affordances.

## Validation

- focused interaction, delivery, topic, async-session, and turn-lease suites: 55 passed
- broader Telegram, callback, slash-access, and write-approval matrix: 607 passed across 62 files
- Ruff on every changed Python module and regression: passed
- `git diff --check`: passed
- existing-PR publish gate, public identity/privacy checks, and gitleaks: passed

All tests use fake Telegram objects and temporary or mocked state; no live Hermes profile, provider, credential, or messaging account was used.

Current head: `7b751fb0d9b95d626918db4b99612f35c7a8181d`
