### PR TITLE
feat(desktop): minimize to system tray on close (Windows)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -26,7 +26,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -2265,6 +2266,8 @@ let updateInFlight = false
 // set, window-all-closed calls app.quit() on every platform so the process
 // actually dies and the hand-off script can proceed immediately.
 let isQuittingForHandoff = false
+let isQuitting = false
+let appTray: Tray | null = null
 
 // Resolve the staged updater binary. The Tauri installer copies itself to
 // HERMES_HOME/hermes-setup.exe on a successful install (see
@@ -7226,6 +7229,42 @@ function closePetOverlay() {
   petOverlayWindow = null
 }
 
+function createTray(): Tray | null {
+  let iconPath = getAppIconPath()
+  if (!iconPath || !fs.existsSync(iconPath)) {
+    iconPath = path.join(APP_ROOT, 'assets', 'icon.png')
+  }
+  if (!iconPath || !fs.existsSync(iconPath)) {
+    iconPath = path.join(APP_ROOT, 'assets', 'icon.ico')
+  }
+  const trayIcon = iconPath && fs.existsSync(iconPath)
+    ? nativeImage.createFromPath(iconPath) : null
+  if (!trayIcon) {
+    rememberLog('[tray] no usable icon found')
+    return null
+  }
+  let tray: Tray
+  try { tray = new Tray(trayIcon.resize({ width: 24, height: 24 })) }
+  catch {
+    try { tray = new Tray(trayIcon) }
+    catch { rememberLog('[tray] failed to create tray from icon'); return null }
+  }
+  const contextMenu = Menu.buildFromTemplate([
+    { label: 'Show Hermes', click: () => { if (mainWindow && !mainWindow.isDestroyed()) { mainWindow.show(); mainWindow.focus() } } },
+    { type: 'separator' },
+    { label: 'Quit', click: () => { isQuitting = true; app.quit() } }
+  ])
+  tray.setContextMenu(contextMenu)
+  tray.on('click', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isVisible()) { mainWindow.focus() }
+      else { mainWindow.show(); mainWindow.focus() }
+    }
+  })
+  tray.setToolTip('Hermes Agent')
+  return tray
+}
+
 function createWindow() {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
@@ -7304,6 +7343,16 @@ function createWindow() {
   mainWindow.on('closed', () => closePetOverlay())
 
   wireCommonWindowHandlers(mainWindow)
+
+  if (!IS_MAC && !appTray) {
+    appTray = createTray()
+  }
+  mainWindow.on('close', (event: Event) => {
+    if (!isQuitting && !IS_MAC) {
+      event.preventDefault()
+      mainWindow.hide()
+    }
+  })
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     rememberLog(`[renderer] render-process-gone reason=${details?.reason} exitCode=${details?.exitCode}`)
@@ -9149,6 +9198,13 @@ app.on('before-quit', () => {
 
   stopBackendChild(hermesProcess)
   stopAllPoolBackends()
+
+  // Tray cleanup
+  isQuitting = true
+  if (appTray) {
+    appTray.destroy()
+    appTray = null
+  }
 })
 
 app.on('window-all-closed', () => {
@@ -9158,6 +9214,8 @@ app.on('window-all-closed', () => {
   // the bundle and relaunch — without this the script's PID-wait spins to its
   // full timeout and the user is left with an invisible app (or an uninstall
   // that appears to do nothing).
+  // Tray: if quitting explicitly via tray menu, always quit.
+  if (isQuitting) { app.quit(); return; }
   if (process.platform !== 'darwin' || isQuittingForHandoff) {
     app.quit()
   }


### PR DESCRIPTION
Closes #46566

Adds system tray support to Hermes Desktop on Windows. Clicking the close button (X) hides the window to the system tray instead of quitting the app.

**Changes:**
- Added `Tray` import from electron
- `createTray()` function: locates app icon (getAppIconPath → icon.png → icon.ico), creates 24×24 tray icon with context menu (Show Hermes / Quit) and left-click restore
- In `createWindow()`: creates tray and intercepts close event (hides instead of quitting)
- In `before-quit`: tray cleanup (destroy tooltip, set isQuitting)
- In `window-all-closed`: respects `isQuitting` for explicit quit via tray menu

**Design decisions:**
- macOS is excluded (follows standard macOS dock convention — closing windows doesn't quit the app)
- The tray's "Quit" menu sets `isQuitting = true` before `app.quit()`, allowing the close handler to distinguish between "hide window" (click X) and "quit app" (click Quit in tray menu)
- Icon resolution: getAppIconPath() → assets/icon.png → assets/icon.ico, with null safety and fallback logging