### PR TITLE
fix(desktop): reconcile stale subagent rows

### DIFF
--- a/apps/desktop/src/app/agents/use-subagent-liveness.test.tsx
+++ b/apps/desktop/src/app/agents/use-subagent-liveness.test.tsx
@@ -1,0 +1,125 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+
+import { useSubagentLiveness } from './use-subagent-liveness'
+
+type Request = (method: string, params?: Record<string, unknown>) => Promise<unknown>
+
+const entry = (profile: string, request: Request) => ({ gateway: { request }, profile })
+
+const registry =
+  (...entries: ReturnType<typeof entry>[]) =>
+  () =>
+    entries
+
+const resolves = (value: unknown) =>
+  vi.fn((_method: string, _params?: Record<string, unknown>) => Promise.resolve(value))
+
+const rejects = () =>
+  vi.fn((_method: string, _params?: Record<string, unknown>) => Promise.reject(new Error('offline')))
+
+const spawn = (sid: string, id: string, profile = 'default') =>
+  upsertSubagent(
+    sid,
+    {
+      goal: id,
+      status: 'running',
+      subagent_id: id,
+      task_index: 0
+    },
+    true,
+    undefined,
+    profile
+  )
+
+describe('useSubagentLiveness', () => {
+  beforeEach(() => {
+    $subagentsBySession.set({})
+    vi.spyOn(Date, 'now').mockReturnValue(1_000)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('drops stale rows after an authoritative empty snapshot', async () => {
+    spawn('s1', 'stale')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    const request = resolves({ active: [] })
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', request))))
+
+    await waitFor(() => expect(request).toHaveBeenCalledWith('delegation.status', {}))
+    await waitFor(() => expect($subagentsBySession.get()).toEqual({}))
+  })
+
+  it('keeps rows returned by the backend registry', async () => {
+    spawn('s1', 'live')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    const request = resolves({ active: [{ subagent_id: 'live' }] })
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', request))))
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    expect($subagentsBySession.get().s1?.map(item => item.id)).toEqual(['live'])
+  })
+
+  it('unions live ids across foreground and background profiles', async () => {
+    spawn('s1', 'background', 'background')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    const foreground = resolves({ active: [] })
+    const background = resolves({ active: [{ subagent_id: 'background' }] })
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', foreground), entry('background', background))))
+
+    await waitFor(() => expect(background).toHaveBeenCalledTimes(1))
+    expect($subagentsBySession.get().s1?.map(item => item.id)).toEqual(['background'])
+  })
+
+  it('reconciles a healthy profile while preserving an unavailable profile', async () => {
+    spawn('local', 'local')
+    spawn('remote', 'remote', 'remote')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    const local = resolves({ active: [] })
+    const remote = rejects()
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', local), entry('remote', remote))))
+
+    await waitFor(() => expect(remote).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect($subagentsBySession.get().local).toBeUndefined())
+    expect($subagentsBySession.get().remote).toHaveLength(1)
+  })
+
+  it('does not prune when every backend response is unusable', async () => {
+    spawn('s1', 'unknown')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    const malformed = resolves({ active: [{}] })
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', malformed))))
+    await waitFor(() => expect(malformed).toHaveBeenCalledTimes(1))
+
+    expect($subagentsBySession.get().s1).toHaveLength(1)
+  })
+
+  it('does not prune a row that starts after the snapshot request', async () => {
+    spawn('old', 'old')
+    vi.mocked(Date.now).mockReturnValue(60_000)
+    let finish!: (value: unknown) => void
+
+    const request = vi.fn(
+      (_method: string, _params?: Record<string, unknown>) => new Promise<unknown>(resolve => (finish = resolve))
+    )
+
+    renderHook(() => useSubagentLiveness(registry(entry('default', request))))
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    vi.mocked(Date.now).mockReturnValue(120_000)
+    act(() => spawn('new', 'new'))
+    vi.mocked(Date.now).mockReturnValue(200_000)
+    await act(async () => finish({ active: [] }))
+
+    await waitFor(() => expect(Object.keys($subagentsBySession.get())).toEqual(['new']))
+  })
+})

--- a/apps/desktop/src/app/agents/use-subagent-liveness.ts
+++ b/apps/desktop/src/app/agents/use-subagent-liveness.ts
@@ -1,0 +1,118 @@
+import { useStore } from '@nanostores/react'
+import { useEffect } from 'react'
+
+import { gatewayRegistrySnapshot } from '@/store/gateway'
+import { reconcileActiveSubagents } from '@/store/subagent-liveness'
+import { $subagentsBySession } from '@/store/subagents'
+
+export const SUBAGENT_LIVENESS_POLL_MS = 15_000
+
+interface GatewayLike {
+  request: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+}
+
+interface GatewayEntry {
+  gateway: GatewayLike
+  profile: string
+}
+
+type GatewaySnapshot = () => readonly GatewayEntry[]
+
+function activeIdsFromStatus(value: unknown): null | string[] {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const active = (value as { active?: unknown }).active
+
+  if (!Array.isArray(active)) {
+    return null
+  }
+
+  const activeIds: string[] = []
+
+  for (const item of active) {
+    if (!item || typeof item !== 'object') {
+      return null
+    }
+
+    const id = (item as { subagent_id?: unknown }).subagent_id
+
+    if (typeof id !== 'string' || !id) {
+      return null
+    }
+
+    activeIds.push(id)
+  }
+
+  return activeIds
+}
+
+/** Poll every live profile gateway while event-derived rows look active.
+ * Missing terminal events are thereby bounded instead of pinning the Desktop
+ * Agents indicator forever. Failed or malformed profiles remain untouched,
+ * while valid profile snapshots reconcile independently. */
+export function useSubagentLiveness(getGateways: GatewaySnapshot = gatewayRegistrySnapshot): void {
+  const bySession = useStore($subagentsBySession)
+
+  const hasActive = Object.values(bySession).some(list =>
+    list.some(item => item.status === 'queued' || item.status === 'running')
+  )
+
+  useEffect(() => {
+    if (!hasActive || typeof window === 'undefined') {
+      return
+    }
+
+    let disposed = false
+    let inFlight = false
+
+    const refresh = async () => {
+      if (inFlight) {
+        return
+      }
+
+      const gateways = getGateways()
+
+      if (gateways.length === 0) {
+        return
+      }
+
+      inFlight = true
+
+      try {
+        // Reconcile against the instant this snapshot was requested. Events that
+        // arrive while a slow RPC is in flight are newer than the snapshot and
+        // must not be pruned by its stale view.
+        const requestedAt = Date.now()
+        const settled = await Promise.allSettled(gateways.map(entry => entry.gateway.request('delegation.status', {})))
+
+        const snapshots = settled.flatMap((result, index) => {
+          if (result.status !== 'fulfilled') {
+            return []
+          }
+
+          const activeIds = activeIdsFromStatus(result.value)
+
+          return activeIds ? [{ activeIds, profile: gateways[index]!.profile }] : []
+        })
+
+        const allAuthoritative = snapshots.length === gateways.length
+
+        if (!disposed && snapshots.length > 0) {
+          reconcileActiveSubagents(snapshots, requestedAt, allAuthoritative)
+        }
+      } finally {
+        inFlight = false
+      }
+    }
+
+    void refresh()
+    const interval = window.setInterval(() => void refresh(), SUBAGENT_LIVENESS_POLL_MS)
+
+    return () => {
+      disposed = true
+      window.clearInterval(interval)
+    }
+  }, [getGateways, hasActive])
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -59,6 +59,7 @@ import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/t
 import { isSecondaryWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
+import { useSubagentLiveness } from '../agents/use-subagent-liveness'
 import { requestComposerInsert } from '../chat/composer/focus'
 import { useComposerActions } from '../chat/hooks/use-composer-actions'
 import { CommandPalette } from '../command-palette'
@@ -608,6 +609,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshHermesConfig,
     refreshSessions
   })
+
+  useSubagentLiveness()
 
   // Only the open messaging transcript needs its own poll — local chats are
   // live over the websocket already.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,9 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
 
 import { useGatewayBoot } from './use-gateway-boot'
 
@@ -28,6 +30,7 @@ class FakeWebSocket {
   // errors (a dead remote). Mirrors a VPS going away after the first connect.
   static mode: 'open' | 'fail' = 'open'
   static instances: FakeWebSocket[] = []
+  static eventOnOpen: RpcEvent | null = null
 
   readyState = 0
   private listeners: Record<string, Set<Listener>> = {}
@@ -41,6 +44,10 @@ class FakeWebSocket {
       if (willOpen) {
         this.readyState = FakeWebSocket.OPEN
         this.emit('open', {})
+
+        if (FakeWebSocket.eventOnOpen) {
+          this.gatewayEvent(FakeWebSocket.eventOnOpen)
+        }
       } else {
         this.readyState = FakeWebSocket.CLOSED
         this.emit('error', {})
@@ -65,6 +72,12 @@ class FakeWebSocket {
   drop() {
     this.readyState = FakeWebSocket.CLOSED
     this.emit('close', {})
+  }
+
+  gatewayEvent(event: RpcEvent) {
+    this.emit('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params: event })
+    })
   }
 
   private emit(type: string, ev: unknown) {
@@ -105,9 +118,9 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({ handleGatewayEvent = () => undefined }: { handleGatewayEvent?: (event: RpcEvent) => void }) {
   useGatewayBoot({
-    handleGatewayEvent: () => undefined,
+    handleGatewayEvent,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig: async () => undefined,
@@ -123,8 +136,10 @@ beforeEach(() => {
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
+  FakeWebSocket.eventOnOpen = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
+  $activeGatewayProfile.set('default')
   $gatewayState.set('idle')
   $desktopBoot.set({
     error: null,
@@ -162,6 +177,48 @@ async function advanceBackoff() {
 }
 
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
+  it('attributes an event received immediately on open to a non-default primary profile', async () => {
+    const desktop = fakeDesktop()
+    const events: RpcEvent[] = []
+
+    desktop.profile.get = vi.fn(async () => ({ profile: 'work' }))
+    FakeWebSocket.eventOnOpen = {
+      type: 'subagent.progress',
+      session_id: 'parent-session',
+      payload: { subagent_id: 'child-1', status: 'running' }
+    }
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness handleGatewayEvent={event => events.push(event)} />)
+    await flushAsync()
+
+    expect(events).toHaveLength(1)
+    expect(events[0].profile).toBe('work')
+  })
+
+  it('keeps primary event attribution stable when the foreground profile changes', async () => {
+    const desktop = fakeDesktop()
+    const events: RpcEvent[] = []
+
+    desktop.profile.get = vi.fn(async () => ({ profile: 'work' }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness handleGatewayEvent={event => events.push(event)} />)
+    await flushAsync()
+
+    act(() => {
+      $activeGatewayProfile.set('default')
+      FakeWebSocket.instances[0].gatewayEvent({
+        type: 'subagent.progress',
+        session_id: 'parent-session',
+        payload: { subagent_id: 'child-2', status: 'running' }
+      })
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0].profile).toBe('work')
+  })
+
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
     // startHermes()'s remote branch awaits waitForHermes() for 45s before it

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -227,6 +227,12 @@ export function useGatewayBoot({
       }
     }
 
+    // Events can arrive synchronously with the socket opening, before connect()
+    // resumes. Keep the primary's source tag separate from the foreground atom
+    // and update it before dialing so those first events are attributed to the
+    // backend that emitted them (even when the foreground later switches).
+    let sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
+
     // Adopt the profile the primary (window) backend booted as, so same-profile
     // resumes are no-op swaps and reconnects target the right backend.
     // Best-effort: a missing preference means "default". Shared by boot + soft
@@ -234,12 +240,15 @@ export function useGatewayBoot({
     async function adoptPrimaryProfile() {
       try {
         const pref = await desktop.profile?.get?.()
-        const profileKey = (pref?.profile ?? '').trim() || 'default'
-        $activeGatewayProfile.set(profileKey)
-        setPrimaryGateway(gateway, profileKey)
-        void ensureGatewayForProfile(profileKey)
+        sourceProfile = normalizeProfileKey(pref?.profile)
+        $activeGatewayProfile.set(sourceProfile)
+        setPrimaryGateway(gateway, sourceProfile)
+        void ensureGatewayForProfile(sourceProfile)
       } catch {
-        $activeGatewayProfile.set('default')
+        sourceProfile = 'default'
+        $activeGatewayProfile.set(sourceProfile)
+        setPrimaryGateway(gateway, sourceProfile)
+        void ensureGatewayForProfile(sourceProfile)
       }
     }
 
@@ -280,6 +289,12 @@ export function useGatewayBoot({
         }
 
         publish(conn)
+        await adoptPrimaryProfile()
+
+        if (cancelled) {
+          return
+        }
+
         const wsUrl = await resolveGatewayWsUrl(desktop, conn)
         await gateway.connect(wsUrl)
 
@@ -287,7 +302,6 @@ export function useGatewayBoot({
           return
         }
 
-        await adoptPrimaryProfile()
         await seedDefaultCwd()
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
@@ -332,7 +346,7 @@ export function useGatewayBoot({
 
     const gateway = new HermesGateway()
     callbacksRef.current.onGatewayReady(gateway)
-    setPrimaryGateway(gateway, normalizeProfileKey($activeGatewayProfile.get()))
+    setPrimaryGateway(gateway, sourceProfile)
     // Secondary (background-profile) sockets funnel into the same handler.
     configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
 
@@ -362,7 +376,6 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
     const offEvent = gateway.onEvent(event =>
       callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
     )
@@ -459,6 +472,12 @@ export function useGatewayBoot({
           progress: 95
         })
         publish(conn)
+        await adoptPrimaryProfile()
+
+        if (cancelled) {
+          return
+        }
+
         // Mint a fresh WS URL right before connecting. For OAuth gateways the
         // ticket is single-use with a short TTL, so the ticket baked into
         // conn.wsUrl is stale; resolveGatewayWsUrl() re-mints it and, on
@@ -470,8 +489,6 @@ export function useGatewayBoot({
         if (cancelled) {
           return
         }
-
-        await adoptPrimaryProfile()
 
         setDesktopBootStep({
           phase: 'renderer.config',

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -40,6 +40,7 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { resetTileRuntimeBindings } from '@/store/session-states'
+import { $subagentsBySession } from '@/store/subagents'
 import type { RpcEvent } from '@/types/hermes'
 
 // After this many consecutive failed reconnects (≈45s with the 1→15s backoff)
@@ -403,11 +404,20 @@ export function useGatewayBoot({
         }
       }
 
+      for (const list of Object.values($subagentsBySession.get())) {
+        for (const item of list) {
+          if (item.profile && (item.status === 'queued' || item.status === 'running')) {
+            keep.add(normalizeProfileKey(item.profile))
+          }
+        }
+      }
+
       pruneSecondaryGateways(keep)
     }
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
+    const offSubagents = $subagentsBySession.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
@@ -503,6 +513,7 @@ export function useGatewayBoot({
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()
+      offSubagents()
       offActiveProfile()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -476,7 +476,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             sessionId,
             payload as Record<string, unknown>,
             event.type === 'subagent.spawn_requested' || event.type === 'subagent.start',
-            event.type
+            event.type,
+            event.profile
           )
         }
       } else if (event.type === 'clarify.request') {

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -15,6 +15,7 @@ import {
   setSessionsLoading,
   setSessionsTotal
 } from '@/store/session'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
 
@@ -32,6 +33,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setSessionsLoading(false)
     setFreshDraftReady(false)
     $sessionsLimit.set(SIDEBAR_SESSIONS_PAGE_SIZE * 3)
+    upsertSubagent('s1', { goal: 'old worker', status: 'running', subagent_id: 'worker-1', task_index: 0 })
   })
 
   afterEach(() => {
@@ -39,6 +41,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setSessions([])
     setCronSessions([])
     setMessagingSessions([])
+    $subagentsBySession.set({})
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
   })
@@ -53,5 +56,6 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+    expect($subagentsBySession.get()).toEqual({})
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -19,6 +19,7 @@ import {
   setUnreadFinishedSessionIds,
   setWorkingSessionIds
 } from '@/store/session'
+import { clearAllSubagents } from '@/store/subagent-liveness'
 
 // True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
 // boot hook suppress the backend-exit toast and keeps the cold-boot CONNECTING
@@ -48,6 +49,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setWorkingSessionIds([])
   setAttentionSessionIds([])
   setUnreadFinishedSessionIds([])
+  clearAllSubagents()
   setSessionsLoading(true)
   resetSessionsLimit()
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -74,6 +74,28 @@ export function activeGateway(): HermesGateway | null {
   return secondaries.get(activeKey)?.gateway ?? primaryGateway
 }
 
+export interface GatewayRegistryEntry {
+  gateway: HermesGateway
+  profile: string
+}
+
+/** Snapshot every backend socket that can still emit session events. Consumers
+ * that reconcile global UI state must query this whole set, not only $gateway:
+ * background-profile sessions keep streaming after the foreground switches. */
+export function gatewayRegistrySnapshot(): GatewayRegistryEntry[] {
+  const gateways: GatewayRegistryEntry[] = []
+
+  if (primaryGateway) {
+    gateways.push({ gateway: primaryGateway, profile: primaryProfile })
+  }
+
+  for (const entry of secondaries.values()) {
+    gateways.push({ gateway: entry.gateway, profile: entry.profile })
+  }
+
+  return gateways
+}
+
 // Mirror a backend's connection state into the global composer state, but only
 // when that backend is the one the user is currently looking at. Lets the
 // composer reflect the active profile's socket without a background reconnect

--- a/apps/desktop/src/store/subagent-liveness.ts
+++ b/apps/desktop/src/store/subagent-liveness.ts
@@ -34,10 +34,17 @@ export function reconcileActiveSubagents(
 ): void {
   const current = $subagentsBySession.get()
   const itemsByProfile = new Map<string, Map<string, SubagentProgress>>()
+  const legacyItemsById = new Map<string, SubagentProgress>()
   const authoritativeProfiles = new Set<string>()
   const keepIdsByProfile = new Map<string, Set<string>>()
 
   for (const item of Object.values(current).flat()) {
+    if (!item.profile?.trim()) {
+      legacyItemsById.set(item.id, item)
+
+      continue
+    }
+
     const profile = normProfile(item.profile)
     const byId = itemsByProfile.get(profile) ?? new Map<string, SubagentProgress>()
 
@@ -62,22 +69,50 @@ export function reconcileActiveSubagents(
 
   // Preserve missing parents while an authoritative descendant is still live,
   // otherwise nested children would jump to the tree root during reconciliation.
+  // Legacy rows without a profile are a fail-open fallback, but rows assigned
+  // to a different explicit profile must never participate in this traversal.
+  const keepLegacyIds = new Set<string>()
+
   for (const [profile, keepIds] of keepIdsByProfile) {
     const byId = itemsByProfile.get(profile)
 
-    for (const activeId of keepIds) {
-      let parentId = byId?.get(activeId)?.parentId ?? null
-      const seen = new Set<string>()
+    for (const activeId of [...keepIds]) {
+      const pending = [byId?.get(activeId), legacyItemsById.get(activeId)].filter(
+        (item): item is SubagentProgress => item !== undefined
+      )
 
-      while (parentId && !seen.has(parentId)) {
-        seen.add(parentId)
-        keepIds.add(parentId)
-        parentId = byId?.get(parentId)?.parentId ?? null
+      const seen = new Set<SubagentProgress>()
+
+      while (pending.length > 0) {
+        const item = pending.pop()!
+
+        if (seen.has(item)) {
+          continue
+        }
+
+        seen.add(item)
+
+        if (!item.parentId) {
+          continue
+        }
+
+        const scopedParent = byId?.get(item.parentId)
+        const legacyParent = legacyItemsById.get(item.parentId)
+
+        if (scopedParent) {
+          keepIds.add(scopedParent.id)
+          pending.push(scopedParent)
+        }
+
+        if (legacyParent) {
+          keepLegacyIds.add(legacyParent.id)
+          pending.push(legacyParent)
+        }
       }
     }
   }
 
-  const keepIdsAnywhere = new Set<string>()
+  const keepIdsAnywhere = new Set(keepLegacyIds)
 
   for (const keepIds of keepIdsByProfile.values()) {
     keepIds.forEach(id => keepIdsAnywhere.add(id))

--- a/apps/desktop/src/store/subagent-liveness.ts
+++ b/apps/desktop/src/store/subagent-liveness.ts
@@ -33,22 +33,54 @@ export function reconcileActiveSubagents(
   allProfilesAuthoritative = true
 ): void {
   const current = $subagentsBySession.get()
-  const items = Object.values(current).flat()
-  const byId = new Map(items.map(item => [item.id, item]))
-  const authoritativeProfiles = new Set(snapshots.map(item => normProfile(item.profile)))
-  const keepIds = new Set(snapshots.flatMap(item => item.activeIds).filter(Boolean))
+  const itemsByProfile = new Map<string, Map<string, SubagentProgress>>()
+  const authoritativeProfiles = new Set<string>()
+  const keepIdsByProfile = new Map<string, Set<string>>()
+
+  for (const item of Object.values(current).flat()) {
+    const profile = normProfile(item.profile)
+    const byId = itemsByProfile.get(profile) ?? new Map<string, SubagentProgress>()
+
+    byId.set(item.id, item)
+    itemsByProfile.set(profile, byId)
+  }
+
+  for (const snapshot of snapshots) {
+    const profile = normProfile(snapshot.profile)
+    const keepIds = keepIdsByProfile.get(profile) ?? new Set<string>()
+
+    authoritativeProfiles.add(profile)
+
+    for (const id of snapshot.activeIds) {
+      if (id) {
+        keepIds.add(id)
+      }
+    }
+
+    keepIdsByProfile.set(profile, keepIds)
+  }
 
   // Preserve missing parents while an authoritative descendant is still live,
   // otherwise nested children would jump to the tree root during reconciliation.
-  for (const activeId of keepIds) {
-    let parentId = byId.get(activeId)?.parentId ?? null
-    const seen = new Set<string>()
+  for (const [profile, keepIds] of keepIdsByProfile) {
+    const byId = itemsByProfile.get(profile)
 
-    while (parentId && !seen.has(parentId)) {
-      seen.add(parentId)
-      keepIds.add(parentId)
-      parentId = byId.get(parentId)?.parentId ?? null
+    for (const activeId of keepIds) {
+      let parentId = byId?.get(activeId)?.parentId ?? null
+      const seen = new Set<string>()
+
+      while (parentId && !seen.has(parentId)) {
+        seen.add(parentId)
+        keepIds.add(parentId)
+        parentId = byId?.get(parentId)?.parentId ?? null
+      }
     }
+  }
+
+  const keepIdsAnywhere = new Set<string>()
+
+  for (const keepIds of keepIdsByProfile.values()) {
+    keepIds.forEach(id => keepIdsAnywhere.add(id))
   }
 
   let changed = false
@@ -56,7 +88,9 @@ export function reconcileActiveSubagents(
 
   for (const [sid, list] of Object.entries(current)) {
     const retained = list.filter(item => {
-      if (isTerminal(item) || keepIds.has(item.id)) {
+      const keepIds = keepIdsByProfile.get(normProfile(item.profile))
+
+      if (isTerminal(item) || (item.profile ? keepIds?.has(item.id) : keepIdsAnywhere.has(item.id))) {
         return true
       }
 

--- a/apps/desktop/src/store/subagent-liveness.ts
+++ b/apps/desktop/src/store/subagent-liveness.ts
@@ -1,0 +1,86 @@
+import { $subagentsBySession, type SubagentProgress } from './subagents'
+
+export const SUBAGENT_LIVENESS_GRACE_MS = 30_000
+export const SUBAGENT_ORPHAN_GRACE_MS = 60 * 60 * 1_000
+
+export interface ActiveSubagentSnapshot {
+  activeIds: readonly string[]
+  profile: string
+}
+
+const normProfile = (profile: string | undefined) => profile?.trim() || 'default'
+
+const isTerminal = (item: SubagentProgress) =>
+  item.status === 'completed' || item.status === 'failed' || item.status === 'interrupted'
+
+const usesStartupGrace = (item: SubagentProgress) => item.status === 'queued' || item.id.startsWith('delegate-tool:')
+
+export function clearAllSubagents(): void {
+  if (Object.keys($subagentsBySession.get()).length > 0) {
+    $subagentsBySession.set({})
+  }
+}
+
+/** Reconcile event-derived rows with per-profile gateway registries.
+ *
+ * Successful profile snapshots are authoritative after a short race grace.
+ * Unavailable profiles remain untouched (fail-open). Queued rows and synthetic
+ * fallback rows receive a longer grace after an authoritative snapshot because
+ * they can precede backend registration. */
+export function reconcileActiveSubagents(
+  snapshots: readonly ActiveSubagentSnapshot[],
+  now = Date.now(),
+  allProfilesAuthoritative = true
+): void {
+  const current = $subagentsBySession.get()
+  const items = Object.values(current).flat()
+  const byId = new Map(items.map(item => [item.id, item]))
+  const authoritativeProfiles = new Set(snapshots.map(item => normProfile(item.profile)))
+  const keepIds = new Set(snapshots.flatMap(item => item.activeIds).filter(Boolean))
+
+  // Preserve missing parents while an authoritative descendant is still live,
+  // otherwise nested children would jump to the tree root during reconciliation.
+  for (const activeId of keepIds) {
+    let parentId = byId.get(activeId)?.parentId ?? null
+    const seen = new Set<string>()
+
+    while (parentId && !seen.has(parentId)) {
+      seen.add(parentId)
+      keepIds.add(parentId)
+      parentId = byId.get(parentId)?.parentId ?? null
+    }
+  }
+
+  let changed = false
+  const next: Record<string, SubagentProgress[]> = {}
+
+  for (const [sid, list] of Object.entries(current)) {
+    const retained = list.filter(item => {
+      if (isTerminal(item) || keepIds.has(item.id)) {
+        return true
+      }
+
+      const profileAuthoritative = item.profile
+        ? authoritativeProfiles.has(normProfile(item.profile))
+        : allProfilesAuthoritative
+
+      if (!profileAuthoritative) {
+        return true
+      }
+
+      const grace = usesStartupGrace(item) ? SUBAGENT_ORPHAN_GRACE_MS : SUBAGENT_LIVENESS_GRACE_MS
+
+      return now - item.updatedAt <= grace
+    })
+
+    if (retained.length > 0) {
+      next[sid] = retained
+    }
+
+    changed ||= retained.length !== list.length
+  }
+
+  if (changed) {
+    $subagentsBySession.set(next)
+  }
+}

--- a/apps/desktop/src/store/subagents-liveness.test.ts
+++ b/apps/desktop/src/store/subagents-liveness.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { reconcileActiveSubagents, SUBAGENT_LIVENESS_GRACE_MS, SUBAGENT_ORPHAN_GRACE_MS } from './subagent-liveness'
+import { $subagentsBySession, type SubagentStatus, upsertSubagent } from './subagents'
+
+const idsFor = (sid: string) => ($subagentsBySession.get()[sid] ?? []).map(item => item.id)
+const snapshot = (activeIds: string[] = [], profile = 'default') => ({ activeIds, profile })
+
+const spawn = (sid: string, id: string, status: SubagentStatus = 'running', profile = 'default', parentId?: string) =>
+  upsertSubagent(
+    sid,
+    {
+      goal: id,
+      parent_id: parentId,
+      status,
+      subagent_id: id,
+      task_index: 0
+    },
+    true,
+    undefined,
+    profile
+  )
+
+describe('subagent liveness reconciliation', () => {
+  beforeEach(() => $subagentsBySession.set({}))
+
+  it('removes stale running rows missing from an authoritative profile snapshot', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('s1', 'stale')
+    spawn('s2', 'orphan')
+    nowSpy.mockReturnValue(2_000)
+    spawn('s1', 'live')
+    nowSpy.mockReturnValue(3_000)
+    spawn('s1', 'done', 'completed')
+
+    reconcileActiveSubagents([snapshot(['live'])], 1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1)
+    nowSpy.mockRestore()
+
+    expect(idsFor('s1')).toEqual(['live', 'done'])
+    expect($subagentsBySession.get().s2).toBeUndefined()
+  })
+
+  it('keeps recent rows while gateway events and the registry race', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('s1', 'starting')
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_LIVENESS_GRACE_MS - 1)
+    expect(idsFor('s1')).toEqual(['starting'])
+
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1)
+    nowSpy.mockRestore()
+    expect($subagentsBySession.get().s1).toBeUndefined()
+  })
+
+  it('gives queued and fallback rows a longer grace without keeping them forever', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('s1', 'queued', 'queued')
+    spawn('s1', 'delegate-tool:call:0')
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1)
+    expect(idsFor('s1')).toEqual(['queued', 'delegate-tool:call:0'])
+
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_ORPHAN_GRACE_MS + 1)
+    nowSpy.mockRestore()
+    expect($subagentsBySession.get().s1).toBeUndefined()
+  })
+
+  it('keeps a missing parent while an authoritative child is active', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('s1', 'parent')
+    spawn('s1', 'child', 'running', 'default', 'parent')
+    reconcileActiveSubagents([snapshot(['child'])], 1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1)
+    nowSpy.mockRestore()
+
+    expect(idsFor('s1')).toEqual(['parent', 'child'])
+  })
+
+  it('reconciles healthy profiles without trusting an unavailable profile', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('local', 'local', 'running', 'default')
+    spawn('remote', 'remote', 'running', 'remote')
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1, false)
+    nowSpy.mockRestore()
+
+    expect($subagentsBySession.get().local).toBeUndefined()
+    expect(idsFor('remote')).toEqual(['remote'])
+    reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_ORPHAN_GRACE_MS * 2, false)
+    expect(idsFor('remote')).toEqual(['remote'])
+  })
+})

--- a/apps/desktop/src/store/subagents-liveness.test.ts
+++ b/apps/desktop/src/store/subagents-liveness.test.ts
@@ -90,4 +90,19 @@ describe('subagent liveness reconciliation', () => {
     reconcileActiveSubagents([snapshot()], 1_000 + SUBAGENT_ORPHAN_GRACE_MS * 2, false)
     expect(idsFor('remote')).toEqual(['remote'])
   })
+
+  it('does not let an active id in one profile retain a stale row in another', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    spawn('local', 'shared-id', 'running', 'default')
+    spawn('remote', 'shared-id', 'running', 'remote')
+    reconcileActiveSubagents(
+      [snapshot([], 'default'), snapshot(['shared-id'], 'remote')],
+      1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1
+    )
+    nowSpy.mockRestore()
+
+    expect($subagentsBySession.get().local).toBeUndefined()
+    expect(idsFor('remote')).toEqual(['shared-id'])
+  })
 })

--- a/apps/desktop/src/store/subagents-liveness.test.ts
+++ b/apps/desktop/src/store/subagents-liveness.test.ts
@@ -105,4 +105,33 @@ describe('subagent liveness reconciliation', () => {
     expect($subagentsBySession.get().local).toBeUndefined()
     expect(idsFor('remote')).toEqual(['shared-id'])
   })
+
+  it('keeps unprofiled legacy ancestors without consulting another explicit profile', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    upsertSubagent('legacy', { goal: 'grandparent', status: 'running', subagent_id: 'grandparent', task_index: 0 })
+    upsertSubagent('legacy', {
+      goal: 'parent',
+      parent_id: 'grandparent',
+      status: 'running',
+      subagent_id: 'parent',
+      task_index: 0
+    })
+    upsertSubagent('legacy', {
+      goal: 'child',
+      parent_id: 'parent',
+      status: 'running',
+      subagent_id: 'child',
+      task_index: 0
+    })
+    spawn('other', 'parent', 'running', 'other')
+    reconcileActiveSubagents(
+      [snapshot(['child'], 'remote'), snapshot([], 'other')],
+      1_000 + SUBAGENT_LIVENESS_GRACE_MS + 1
+    )
+    nowSpy.mockRestore()
+
+    expect(idsFor('legacy')).toEqual(['grandparent', 'parent', 'child'])
+    expect($subagentsBySession.get().other).toBeUndefined()
+  })
 })

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -26,6 +26,18 @@ describe('subagent store', () => {
     expect(item?.summary).toBe('done')
   })
 
+  it('records the renderer-side source profile separately from the backend payload', () => {
+    upsertSubagent(
+      's1',
+      { goal: 'scan files', status: 'running', subagent_id: 'a1', task_index: 0 },
+      true,
+      undefined,
+      'review'
+    )
+
+    expect(listFor('s1')[0]?.profile).toBe('review')
+  })
+
   it('builds parent/child trees', () => {
     upsertSubagent('s1', { goal: 'parent', status: 'running', subagent_id: 'p', task_index: 0 })
     upsertSubagent('s1', { goal: 'child', parent_id: 'p', status: 'queued', subagent_id: 'c', task_index: 1 })

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -19,6 +19,7 @@ export interface SubagentProgress {
   /** The child's own stored session id — lets UIs open its session window. */
   sessionId?: string
   model?: string
+  profile?: string
   status: SubagentStatus
   taskCount: number
   taskIndex: number
@@ -146,7 +147,12 @@ function streamFromPayload(
   return out
 }
 
-function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined, eventType = ''): SubagentProgress {
+function toProgress(
+  payload: SubagentPayload,
+  prev: SubagentProgress | undefined,
+  eventType = '',
+  sourceProfile?: string
+): SubagentProgress {
   const at = Date.now()
   const status = asStatus(payload.status)
   const tool = str(payload.tool_name)
@@ -160,6 +166,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
     goal: str(payload.goal) || prev?.goal || 'Subagent',
     sessionId: str(payload.child_session_id) || prev?.sessionId,
     model: str(payload.model) || prev?.model,
+    profile: sourceProfile || prev?.profile,
     status,
     taskCount: num(payload.task_count) ?? prev?.taskCount ?? 1,
     taskIndex: num(payload.task_index) ?? prev?.taskIndex ?? 0,
@@ -206,7 +213,13 @@ export function pruneDelegateFallbackSubagents(sid: string) {
   $subagentsBySession.set({ ...map, [sid]: next })
 }
 
-export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMissing = true, eventType?: string) {
+export function upsertSubagent(
+  sid: string,
+  payload: SubagentPayload,
+  createIfMissing = true,
+  eventType?: string,
+  sourceProfile?: string
+) {
   const map = $subagentsBySession.get()
   const list = map[sid] ?? []
   const id = idOf(payload)
@@ -222,7 +235,7 @@ export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMi
     return
   }
 
-  const next = toProgress(payload, prev, eventType)
+  const next = toProgress(payload, prev, eventType, sourceProfile)
   const nextList = idx >= 0 ? list.map(item => (item.id === id ? next : item)) : [...list, next]
 
   $subagentsBySession.set({ ...map, [sid]: nextList })


### PR DESCRIPTION
## Summary

Fixes Hermes Desktop subagent rows that can remain `running` indefinitely when a terminal `subagent.complete` event is lost or the renderer changes gateway context.

This revision is rebased onto the current contribution-shell architecture: the liveness hook now mounts from `ContribWiring` beside `useGatewayBoot()`, while the retired `desktop-controller.tsx` remains deleted.

## Root cause

`$subagentsBySession` is populated from `subagent.*` gateway events and had no authoritative reconciliation path. If the terminal event was missed, the renderer retained a non-terminal row forever even after the backend registry was empty.

## What changed

- Mount `useSubagentLiveness()` from the live `apps/desktop/src/app/contrib/wiring.tsx` composition root.
- Poll `delegation.status` every 15 seconds only while the renderer has queued/running rows.
- Query every tracked profile gateway, not only the foreground one.
- Consume the renderer registry's top-level `event.profile` source tag and reconcile each valid profile snapshot independently.
- Adopt the primary backend profile before opening its WebSocket, so events arriving synchronously with `open` receive the correct non-default profile.
- Keep the primary socket's source tag separate from the foreground profile atom, so switching the visible profile cannot reattribute primary events.
- Scope active IDs and ancestor preservation by profile so identical IDs across gateways cannot retain stale rows.
- Preserve profileless legacy ancestor chains through a fail-open fallback without consulting another explicit profile.
- Keep failed or malformed profile snapshots fail-open; they never delete UI state.
- Use the snapshot request timestamp so events arriving during a slow RPC cannot be removed by that older snapshot.
- Apply a 30-second event/registry race grace and a one-hour grace to queued/synthetic fallback rows.
- Preserve terminal rows and active ancestors; this only repairs renderer state and never interrupts backend work.
- Keep secondary profile gateways alive while their profile has active-looking subagent rows, allowing reconciliation to complete.
- Clear renderer subagent state during an explicit gateway settings switch, alongside the current unread/session-state cleanup.

## Tests

Added regression coverage for:

- stale running-row cleanup from an authoritative empty registry;
- active-row and parent preservation;
- event/registry race grace;
- delayed snapshot responses versus newer events;
- queued/synthetic fallback grace;
- multi-profile aggregation and partial profile failure;
- cross-profile identical-ID isolation;
- recursive profileless legacy ancestor preservation without explicit-profile leakage;
- malformed snapshot fail-open behavior;
- gateway-switch state reset;
- interaction with the upstream profile-aware event path;
- an event delivered immediately when a non-default primary WebSocket opens;
- stable primary event attribution after the foreground profile changes.

Fresh verification on the final head:

```text
npm run test:ui -- \
  src/app/agents/use-subagent-liveness.test.tsx \
  src/store/subagents-liveness.test.ts \
  src/store/subagents.test.ts \
  src/store/gateway-switch.test.ts \
  src/app/gateway/hooks/use-gateway-boot.test.tsx \
  src/app/session/hooks/use-message-stream/approval-mode-event.test.tsx
npm run typecheck
npx eslint <all changed Desktop source/test files>
npx prettier --check <all changed Desktop source/test files>
npm run build
git diff --check
```

Result:

- 31/31 targeted tests passed.
- Renderer + Electron TypeScript checks passed.
- Changed-file ESLint completed with 0 errors and 0 warnings.
- Changed-file Prettier check passed.
- Production build and `assert-dist-built` passed from a clean committed head.
- Diff check passed.

## Broader-suite baseline

A full `npm run test` on the final head completed with **1,715 passed, 21 failed, 1 skipped**. None of the PR-changed test files failed.

This Windows full-suite run is load-sensitive: an earlier run in the same worktree completed with **1,727 passed, 7 failed, 1 skipped**. The Electron POSIX-path failures and messaging/skills failure classes reproduce on an isolated detached `origin/main` worktree using the same lockfile-resolved dependencies; the isolated `model-settings` rerun passed 10/10. The additional final-run failures are in untouched git-worktree/settings/streaming tests and include timeouts or shared-DOM leakage under full parallel load.

## Related work

#51358 addresses async-delegation session working flags and status-bar presentation. This PR is complementary: it reconciles stale event-derived subagent rows against the backend registry and does not change session working semantics.
