### PR TITLE
fix(config): preserve config set YAML comments

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8150,29 +8150,17 @@ def set_config_value(key: str, value: str):
         print(f"✓ Set {key} in {get_env_path()}")
         return
     
-    # Otherwise it goes to config.yaml
-    # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
+    # Otherwise it goes to config.yaml. Preserve user comments, ordering, and
+    # quotes while updating the requested path.
     config_path = get_config_path()
     require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
-    
-    # Handle nested keys (e.g., "tts.provider") including numeric list
-    # indices (e.g., "custom_providers.0.api_key").  Delegates to
-    # _set_nested which preserves list-typed nodes; before #17876 the
-    # inline navigation here silently overwrote lists with dicts.
 
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
+    is_string_config = isinstance(_default_value_for_key(key), str)
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    if not is_string_config:
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:
@@ -8183,20 +8171,25 @@ def set_config_value(key: str, value: str):
             coerced_value = float(value)
 
     value = coerced_value
-    _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
-    # so a fresh `hermes config set model.api_base ...` lands on the canonical
-    # key the runtime resolver actually reads, instead of being silently
-    # ignored. Mirrors the load-time migration in _normalize_root_model_keys.
+    # so `hermes config set model.api_base ...` lands on the canonical key the
+    # runtime resolver actually reads instead of being silently ignored.
     _alias_norm = key.strip().lower()
     if _alias_norm in ("model.api_base", "api_base"):
-        user_config = _normalize_root_model_keys(user_config)
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    from utils import atomic_roundtrip_yaml_update
+
+    if is_string_config:
+        # ruamel follows YAML 1.2, but config consumers such as PyYAML still
+        # interpret bare ``off``/``yes`` as YAML 1.1 booleans. Keep declared
+        # string settings unambiguous across both parsers.
+        from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+        value = DoubleQuotedScalarString(value)
+    atomic_roundtrip_yaml_update(config_path, key, value)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -124,6 +124,27 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_preserves_comments_and_formatting(self, _isolated_hermes_home):
+        """Config set must retain user-authored YAML comments and whitespace."""
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(
+            "# My custom auxiliary setup\n"
+            "\n"
+            "auxiliary:\n"
+            "  # Keep this model note\n"
+            "  model: gpt-4o-mini  # Inline note\n",
+            encoding="utf-8",
+        )
+
+        set_config_value("auxiliary.model", "gpt-4o")
+
+        config = _read_config(_isolated_hermes_home)
+        assert "# My custom auxiliary setup" in config
+        assert "\n\nauxiliary:" in config
+        assert "# Keep this model note" in config
+        assert "# Inline note" in config
+        assert "model: gpt-4o" in config
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277

--- a/utils.py
+++ b/utils.py
@@ -306,7 +306,7 @@ def atomic_roundtrip_yaml_update(
     file + fsync + atomic replace pattern.
     """
     from ruamel.yaml import YAML
-    from ruamel.yaml.comments import CommentedMap
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -329,12 +329,34 @@ def atomic_roundtrip_yaml_update(
     current = config
     keys = key_path.split(".")
     for key in keys[:-1]:
-        next_value = current.get(key)
-        if not isinstance(next_value, CommentedMap):
-            next_value = CommentedMap()
-            current[key] = next_value
-        current = next_value
-    current[keys[-1]] = value
+        if isinstance(current, CommentedSeq):
+            try:
+                current = current[int(key)]
+            except (TypeError, ValueError) as exc:
+                raise TypeError(
+                    f"Cannot navigate into list at key {key_path!r}: "
+                    f"segment {key!r} is not a numeric index"
+                ) from exc
+        elif isinstance(current, CommentedMap):
+            next_value = current.get(key)
+            if not isinstance(next_value, (CommentedMap, CommentedSeq)):
+                next_value = CommentedMap()
+                current[key] = next_value
+            current = next_value
+        else:
+            raise TypeError(
+                f"Cannot navigate into {type(current).__name__} at key {key_path!r}"
+            )
+
+    last_key = keys[-1]
+    if isinstance(current, CommentedSeq):
+        current[int(last_key)] = value
+    elif isinstance(current, CommentedMap):
+        current[last_key] = value
+    else:
+        raise TypeError(
+            f"Cannot navigate into {type(current).__name__} at key {key_path!r}"
+        )
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)


### PR DESCRIPTION
## What does this PR do?

Makes `hermes config set` preserve user-authored YAML comments, blank lines, ordering, and quotes instead of rewriting the whole file with PyYAML. The shared atomic round-trip updater now also supports the numeric list paths that `config set` already accepts.

## Related Issue

Fixes #63039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: route config-file writes from `config set` through the atomic round-trip YAML updater and keep declared string settings unambiguous for PyYAML consumers.
- `utils.py`: support numeric list segments in the shared round-trip YAML updater.
- `tests/hermes_cli/test_set_config_value.py`: cover preservation of comments and blank lines during `config set`.

## How to Test

1. Create a config file containing comments and blank lines around `auxiliary.model`.
2. Run `hermes config set auxiliary.model gpt-4o`.
3. Confirm the new value is written and the surrounding comments and blank line remain.
4. Run `source $VIRTUAL_ENV/bin/activate && /opt/homebrew/bin/timeout -k 30 480 pytest tests/ -q -x --timeout=60`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-299fa027 kind=pr-open -->