### PR TITLE
fix(tools): add timeout to proc.wait() after kill in voice playback

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1106,7 +1106,10 @@ def play_audio_file(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    pass  # process survived SIGKILL; move on
                 with _playback_lock:
                     _active_playback = None
             except Exception as e:


### PR DESCRIPTION
## Summary

Add a 10s timeout to `proc.wait()` in the voice playback fallback path (with guard), so killing a hung audio player cannot block indefinitely.

## Problem

In `tools/voice_mode.py`, when a system audio player (afplay/ffplay/aplay) exceeds the 300s timeout, the code calls `proc.kill()` followed by `proc.wait()` with **no timeout**. On macOS, a process stuck in uninterruptible I/O (D state — common with audio device drivers) can survive `SIGKILL`, causing `proc.wait()` to block forever. This defeats the 300s timeout and can freeze the entire agent turn.

## Fix

Changed `proc.wait()` → `proc.wait(timeout=10)` wrapped in its own try/except `TimeoutExpired`. After killing a process that already exceeded 300s, a 10s grace period is sufficient. If the process still hasn't exited (rare SIGKILL-resistant case), we silently move on — clearing `_active_playback` and falling through to the next player.

## Testing
- Syntax check passed (py_compile)
- `TestSubprocessTimeoutKill::test_timeout_kills_process` passed
- Control-flow verified: nested `except TimeoutExpired` prevents unhandled exception propagation