### PR TITLE
fix(tui): preserve foreground turns across background completion

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1137,6 +1137,9 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    # Deferred background payloads adopted by this turn. The finalizer stamps
+    # these only on the closing assistant row, never on the early user flush.
+    agent._deferred_notification_ids = ()
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1831,6 +1831,7 @@ def run_conversation(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    deferred_notification_ids: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -1855,6 +1856,8 @@ def run_conversation(
             the message unchanged.
         persist_user_display_metadata: Optional payload for that event
             (e.g. a delegation's task count).
+        deferred_notification_ids: Durable completion identities represented by
+            the closing assistant transcript row when this turn succeeds.
                 or queuing follow-up prefetch work.
 
     Returns:
@@ -1907,6 +1910,7 @@ def run_conversation(
         persist_user_timestamp,
         persist_user_display_kind=persist_user_display_kind,
         persist_user_display_metadata=persist_user_display_metadata,
+        deferred_notification_ids=deferred_notification_ids,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -463,6 +463,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    deferred_notification_ids: Optional[List[str]] = None,
     *,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
@@ -576,6 +577,9 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._deferred_notification_ids = tuple(
+        sorted({str(event_id) for event_id in (deferred_notification_ids or ()) if event_id})
+    )
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -234,6 +234,17 @@ def finalize_turn(
         )
     )
 
+    # ``completed`` is a strict success metric, not a persistence contract.
+    # Iteration-limit summaries and their visible exception fallbacks are
+    # accepted user-facing responses even though they intentionally report
+    # ``completed=False``. Any accepted response must durably close the turn so
+    # restart cannot replay its user input or deferred background context.
+    accepted_closing_response = (
+        final_response is not None
+        and not interrupted
+        and not failed
+    )
+
     # Preflight can seed the display count before the provider receives the
     # request. Roll that estimate back only when an interrupt wins the race
     # before any successful provider response. Compaction state remains owned
@@ -338,7 +349,7 @@ def finalize_turn(
         # Compare content (not just role) so a verification candidate that
         # matches the final response is not duplicated at budget
         # exhaustion. (#65919 §7)
-        if final_response and not interrupted:
+        if accepted_closing_response:
             try:
                 _tail = messages[-1] if messages else None
             except Exception:
@@ -386,6 +397,21 @@ def finalize_turn(
                 # filled row is re-examined instead of skipped.
                 agent._db_flush_scan_prefix = None
 
+        # Commit deferred-completion adoption with the closing assistant row.
+        # The inbound user row is persisted before the model call for crash
+        # resilience, so stamping it would acknowledge work before a response
+        # exists. SessionDB records these identities atomically with this final
+        # assistant INSERT; restart recovery can then close a pending ledger row
+        # without replaying its payload after a process dies before gateway ack.
+        _adoption_message = None
+        _adopted_ids = tuple(
+            getattr(agent, "_deferred_notification_ids", ()) or ()
+        )
+        if accepted_closing_response and _adopted_ids:
+            if messages and messages[-1].get("role") == "assistant":
+                messages[-1]["_deferred_notification_ids"] = list(_adopted_ids)
+                _adoption_message = messages[-1]
+
         # The model has completed its request, so replace API-local
         # voice/model/skill guidance with the clean user input before writing the
         # final durable snapshot and returning the continuation history. Earlier
@@ -395,7 +421,6 @@ def finalize_turn(
         _apply_override = getattr(agent, "_apply_persist_user_message_override", None)
         if callable(_apply_override):
             _apply_override(messages)
-
         # ── Post-turn micro-compaction ────────────────────────────
         # After the assistant response is finalized but before the session is
         # persisted, run micro-compaction to absorb the oldest uncompacted
@@ -455,7 +480,11 @@ def finalize_turn(
             except Exception as _mc_err:
                 logger.info("Micro-compaction failed: %s", _mc_err)
 
-        agent._persist_session(messages, conversation_history)
+        try:
+            agent._persist_session(messages, conversation_history)
+        finally:
+            if _adoption_message is not None:
+                _adoption_message.pop("_deferred_notification_ids", None)
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")
         logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -1,9 +1,30 @@
-import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
-import { type Dispatch, type PropsWithChildren, type SetStateAction, useLayoutEffect, useState } from 'react'
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react'
+import {
+  type Dispatch,
+  type PropsWithChildren,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
+
+import { useMessageStream } from '@/app/session/hooks/use-message-stream'
+import { usePromptActions } from '@/app/session/hooks/use-prompt-actions'
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
+import { setAwaitingResponse, setBusy } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+
 import type { ComposerAttachment } from '@/store/composer'
 import { $gateway } from '@/store/gateway'
 import {
@@ -17,7 +38,17 @@ import {
 import { type ComposerTarget, requestComposerSubmit } from '../focus'
 import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
+import type { QueueEditState } from '../composer-utils'
+
+import { useComposerQueue } from './use-composer-queue'
 import { useComposerSubmit } from './use-composer-submit'
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
+  setApiRequestProfile: vi.fn(),
+  transcribeAudio: vi.fn()
+}))
 
 interface SubmitHarnessOptions {
   attachments?: ComposerAttachment[]
@@ -115,7 +146,8 @@ function renderSubmitHook({
         queuedPrompts: [],
         sessionId: 'runtime-session',
         setComposerText: vi.fn(),
-        stashAt: vi.fn()
+        stashAt: vi.fn(),
+        turnOrigin: null
       }),
     { wrapper: Wrapper }
   )
@@ -560,5 +592,232 @@ describe('useComposerSubmit with a blocking prompt parked on the session', () =>
 
     // The approval card is still the turn's owner; only its own buttons answer it.
     expect(hasBlockingPromptRequest('runtime-session')).toBe(true)
+  })
+})
+
+const RUNTIME_SESSION_ID = 'runtime-notification-session'
+const STORED_SESSION_ID = 'stored-notification-session'
+
+interface PreemptionHarnessHandle {
+  getState: () => ClientSessionState
+  handleGatewayEvent: (event: RpcEvent) => void
+  submitDraft: () => void
+}
+
+function NotificationPreemptionHarness({
+  onReady,
+  requestGateway
+}: {
+  onReady: (handle: PreemptionHarnessHandle) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const initialStateRef = useRef<ClientSessionState>({
+    ...createClientSessionState(STORED_SESSION_ID),
+    awaitingResponse: true,
+    busy: true,
+    interrupted: false,
+    turnOrigin: 'notification'
+  })
+
+  const stateRef = useRef(initialStateRef.current)
+  const [state, setState] = useState(initialStateRef.current)
+  const activeSessionIdRef = useRef<string | null>(RUNTIME_SESSION_ID)
+  const selectedStoredSessionIdRef = useRef<string | null>(STORED_SESSION_ID)
+  const busyRef = useRef(true)
+  const sessionStateByRuntimeIdRef = useRef(new Map([[RUNTIME_SESSION_ID, initialStateRef.current]]))
+  const queryClientRef = useRef(new QueryClient())
+  const runtimeIdByStoredSessionIdRef = useRef(new Map([[STORED_SESSION_ID, RUNTIME_SESSION_ID]]))
+  const draftRef: RefObject<string> = { current: 'Human question' }
+  const editorRef = useRef<HTMLDivElement | null>(null)
+  const queueEditRef = useRef<QueueEditState | null>(null)
+
+  const updateSessionState = useCallback(
+    (_sessionId: string, updater: (current: ClientSessionState) => ClientSessionState) => {
+      const next = updater(stateRef.current)
+      stateRef.current = next
+      sessionStateByRuntimeIdRef.current.set(RUNTIME_SESSION_ID, next)
+      busyRef.current = next.busy
+      setBusy(next.busy)
+      setAwaitingResponse(next.awaitingResponse)
+      setState(next)
+
+      return next
+    },
+    []
+  )
+
+  const actions = usePromptActions({
+    activeSessionId: RUNTIME_SESSION_ID,
+    activeSessionIdRef,
+    branchCurrentSession: async () => true,
+    busyRef,
+    createBackendSessionForSend: async () => RUNTIME_SESSION_ID,
+    getRoutedStoredSessionId: () => null,
+    getRuntimeIdForStoredSession: (storedSessionId: string) =>
+      runtimeIdByStoredSessionIdRef.current.get(storedSessionId) ?? null,
+    getRouteToken: () => 'notification-preemption',
+    handleSkinCommand: () => '',
+    openMemoryGraph: () => undefined,
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: () => undefined,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft: () => undefined,
+    sttEnabled: false,
+    updateSessionState
+  })
+
+  const queue = useComposerQueue({
+    activeQueueSessionKey: STORED_SESSION_ID,
+    attachments: [],
+    busy: state.busy,
+    clearDraft: () => {
+      draftRef.current = ''
+    },
+    draftRef,
+    focusInput: () => undefined,
+    loadIntoComposer: () => undefined,
+    onCancel: actions.cancelRun,
+    onSteer: undefined,
+    onSubmit: actions.submitText,
+    queueEditRef,
+    queueSessionKey: STORED_SESSION_ID,
+    sessionId: RUNTIME_SESSION_ID
+  })
+
+  const submit = useComposerSubmit({
+    activeQueueSessionKey: STORED_SESSION_ID,
+    activeQueueSessionKeyRef: { current: STORED_SESSION_ID },
+    attachments: [],
+    busy: state.busy,
+    compacting: false,
+    clearDraft: () => {
+      draftRef.current = ''
+    },
+    disabled: false,
+    draftRef,
+    drainNextQueued: queue.drainNextQueued,
+    editorRef,
+    exitQueuedEdit: queue.exitQueuedEdit,
+    focusInput: () => undefined,
+    inputDisabled: false,
+    loadIntoComposer: () => undefined,
+    onCancel: actions.cancelRun,
+    onSteer: undefined,
+    onSubmit: actions.submitText,
+    queueCurrentDraft: queue.queueCurrentDraft,
+    queueEdit: queue.queueEdit,
+    queuedPrompts: queue.queuedPrompts,
+    sessionId: RUNTIME_SESSION_ID,
+    setComposerText: () => undefined,
+    stashAt: () => undefined,
+    turnOrigin: state.turnOrigin ?? null
+  })
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: async () => undefined,
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined,
+    sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    onReady({
+      getState: () => stateRef.current,
+      handleGatewayEvent: stream.handleGatewayEvent,
+      submitDraft: submit.submitDraft
+    })
+  }, [onReady, stream.handleGatewayEvent, submit.submitDraft])
+
+  return null
+}
+
+describe('notification preemption integration', () => {
+  afterEach(() => {
+    cleanup()
+    clearQueuedPrompts(STORED_SESSION_ID)
+    setBusy(false)
+    setAwaitingResponse(false)
+    vi.restoreAllMocks()
+  })
+
+  it('drains one queued user turn only after the interrupted notification completes', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return {} as never
+    })
+
+    let handle: PreemptionHarnessHandle | null = null
+
+    const onReady = (next: PreemptionHarnessHandle) => {
+      handle = next
+    }
+
+    setBusy(true)
+    setAwaitingResponse(true)
+    render(<NotificationPreemptionHarness onReady={onReady} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.submitDraft())
+
+    await waitFor(() => expect(calls.filter(call => call.method === 'session.interrupt')).toHaveLength(1))
+    expect(handle!.getState()).toMatchObject({ busy: true, interrupted: true })
+    expect(calls.filter(call => call.method === 'prompt.submit')).toHaveLength(0)
+    expect(getQueuedPrompts(STORED_SESSION_ID)).toHaveLength(1)
+
+    act(() =>
+      handle!.handleGatewayEvent({
+        payload: { status: 'interrupted', text: '', turn_origin: 'notification' },
+        session_id: RUNTIME_SESSION_ID,
+        type: 'message.complete'
+      })
+    )
+
+    await waitFor(() => expect(calls.filter(call => call.method === 'prompt.submit')).toHaveLength(1))
+    expect(calls.filter(call => call.method === 'prompt.submit')[0]?.params).toMatchObject({
+      session_id: RUNTIME_SESSION_ID,
+      text: 'Human question'
+    })
+    await waitFor(() => expect(getQueuedPrompts(STORED_SESSION_ID)).toHaveLength(0))
+    expect(calls.filter(call => call.method === 'prompt.submit')).toHaveLength(1)
+    expect(handle!.getState().turnOrigin).toBe('user')
+  })
+
+  it('releases the preemption gate when the notification interrupt RPC fails', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.interrupt') {
+        throw new Error('interrupt unavailable')
+      }
+
+      return {} as never
+    })
+
+    let handle: PreemptionHarnessHandle | null = null
+
+    const onReady = (next: PreemptionHarnessHandle) => {
+      handle = next
+    }
+
+    setBusy(true)
+    setAwaitingResponse(true)
+    render(<NotificationPreemptionHarness onReady={onReady} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.submitDraft())
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
+    )
+    await waitFor(() =>
+      expect(requestGateway.mock.calls.filter(([method]) => method === 'prompt.submit')).toHaveLength(1)
+    )
+    expect(getQueuedPrompts(STORED_SESSION_ID)).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -13,19 +13,14 @@ import {
 } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
-import { $clarifyRequests } from '@/store/clarify'
-
 import { useMessageStream } from '@/app/session/hooks/use-message-stream'
 import { usePromptActions } from '@/app/session/hooks/use-prompt-actions'
 import type { ClientSessionState } from '@/app/types'
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
-import { setAwaitingResponse, setBusy } from '@/store/session'
-import type { RpcEvent } from '@/types/hermes'
-
-
+import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
+import { clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
 import { $gateway } from '@/store/gateway'
 import {
   clearAllPrompts,
@@ -34,11 +29,12 @@ import {
   setSecretRequest,
   setSudoRequest
 } from '@/store/prompts'
-
-import { type ComposerTarget, requestComposerSubmit } from '../focus'
-import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+import { setAwaitingResponse, setBusy } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
 
 import type { QueueEditState } from '../composer-utils'
+import { type ComposerTarget, requestComposerSubmit } from '../focus'
+import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerQueue } from './use-composer-queue'
 import { useComposerSubmit } from './use-composer-submit'
@@ -623,10 +619,10 @@ function NotificationPreemptionHarness({
   const [state, setState] = useState(initialStateRef.current)
   const activeSessionIdRef = useRef<string | null>(RUNTIME_SESSION_ID)
   const selectedStoredSessionIdRef = useRef<string | null>(STORED_SESSION_ID)
+  const runtimeIdByStoredSessionIdRef = useRef(new Map([[STORED_SESSION_ID, RUNTIME_SESSION_ID]]))
   const busyRef = useRef(true)
   const sessionStateByRuntimeIdRef = useRef(new Map([[RUNTIME_SESSION_ID, initialStateRef.current]]))
   const queryClientRef = useRef(new QueryClient())
-  const runtimeIdByStoredSessionIdRef = useRef(new Map([[STORED_SESSION_ID, RUNTIME_SESSION_ID]]))
   const draftRef: RefObject<string> = { current: 'Human question' }
   const editorRef = useRef<HTMLDivElement | null>(null)
   const queueEditRef = useRef<QueueEditState | null>(null)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -9,6 +9,7 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
 import { hasMcpSetupRequest, skipMcpSetupRequest } from '@/store/mcp-setup'
 import { hasBlockingPromptRequest } from '@/store/prompts'
+import type { TurnOrigin } from '@/types/hermes'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
@@ -41,6 +42,7 @@ interface UseComposerSubmitArgs {
   sessionId: string | null | undefined
   setComposerText: (value: string) => void
   stashAt: (scope: string | null, text?: string, attachments?: ComposerAttachment[]) => void
+  turnOrigin: TurnOrigin | null
 }
 
 /**
@@ -75,7 +77,8 @@ export function useComposerSubmit({
   queuedPrompts,
   sessionId,
   setComposerText,
-  stashAt
+  stashAt,
+  turnOrigin
 }: UseComposerSubmitArgs) {
   const paneVisible = usePaneVisible()
   const scope = useComposerScope()
@@ -202,6 +205,16 @@ export function useComposerSubmit({
         triggerHaptic('submit')
         clearDraft()
         dispatchSubmit(text)
+      } else if (turnOrigin === 'notification' && payloadPresent) {
+        // A background completion must never absorb a foreground prompt as a
+        // correction. Queue the user's draft, then interrupt only the
+        // notification; preserving busy makes the existing settle-edge drain
+        // dispatch the queued user turn after that notification unwinds.
+        const queued = queueCurrentDraft()
+
+        if (queued) {
+          void Promise.resolve(onCancel({ preserveBusyUntilSettled: true }))
+        }
       } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
         // Cursor-style stop-and-correct: interrupt the live turn and redirect
         // it with this text. redirect() preserves the shown reasoning/work; if

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react'
 import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
+import type { CancelRunOptions } from '@/app/types'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
@@ -21,7 +22,7 @@ import { parkQueuedPrompts, removeQueuedPrompt, unparkQueuedPrompts } from '@/st
 import { $hudMode } from '@/store/hud'
 import { sessionBlockingPrompt } from '@/store/prompts'
 import { toggleReview } from '@/store/review'
-import { $gatewayState } from '@/store/session'
+import { $gatewayState, $turnOrigin } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { $autoSpeakReplies } from '@/store/voice-prefs'
 import { useTheme } from '@/themes'
@@ -214,6 +215,7 @@ export function ChatBar({
 
   const { t } = useI18n()
   const gatewayState = useStore($gatewayState)
+  const turnOrigin = useStore($turnOrigin)
   const reconnecting = gatewayState === 'closed' || gatewayState === 'error'
   const inputDisabled = disabled && !reconnecting
 
@@ -321,11 +323,16 @@ export function ChatBar({
   // only trace). Interrupts that exist to advance the queue (send-now-while-
   // busy) call the raw onCancel and keep draining on settle. Parked entries
   // stay in the panel until resumed, sent, edited, or deleted.
-  const haltRun = useCallback(() => {
-    parkQueuedPrompts(activeQueueSessionKeyRef.current)
+  const haltRun = useCallback(
+    (options?: CancelRunOptions) => {
+      if (!options?.preserveBusyUntilSettled) {
+        parkQueuedPrompts(activeQueueSessionKeyRef.current)
+      }
 
-    return onCancel()
-  }, [activeQueueSessionKeyRef, onCancel])
+      return onCancel(options)
+    },
+    [activeQueueSessionKeyRef, onCancel]
+  )
 
   const { compactPill, foldVoice, minimal, stacked } = useComposerMetrics({
     composerDockRef,
@@ -379,7 +386,8 @@ export function ChatBar({
     queuedPrompts,
     sessionId,
     setComposerText,
-    stashAt
+    stashAt,
+    turnOrigin
   })
 
   // Resting / reconnecting / starting placeholder text, re-rolled only on a real

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
+import type { CancelRunOptions } from '@/app/types'
 import type { HermesGateway } from '@/hermes'
 
 import type { DroppedFile } from '../hooks/use-composer-actions'
@@ -41,7 +42,7 @@ export interface ChatBarProps {
   queueSessionKey?: string | null
   sessionId?: string | null
   cwd?: string | null
-  onCancel: () => Promise<void> | void
+  onCancel: (options?: CancelRunOptions) => Promise<void> | void
   onAddContextRef?: (refText: string, label?: string, detail?: string) => void
   onAddUrl?: (url: string) => void
   onAttachImageBlob?: (blob: Blob) => Promise<boolean | void> | boolean | void

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,6 +7,7 @@ import { memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useStat
 import { useLocation } from 'react-router'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
+import type { CancelRunOptions } from '@/app/types'
 import { Thread } from '@/components/assistant-ui/thread'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
@@ -84,7 +85,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   modelMenuContent?: React.ReactNode
   onToggleSelectedPin: () => void
   onDeleteSelectedSession: () => void
-  onCancel: () => Promise<void> | void
+  onCancel: (options?: CancelRunOptions) => Promise<void> | void
   onAddContextRef: (refText: string, label?: string, detail?: string) => void
   onAddUrl: (url: string) => void
   onBranchInNewChat?: (messageId: string) => void
@@ -182,7 +183,7 @@ function ChatHeader({
 interface ChatRuntimeBoundaryProps {
   busy: boolean
   children: React.ReactNode
-  onCancel: () => Promise<void> | void
+  onCancel: (options?: CancelRunOptions) => Promise<void> | void
   onEdit: (message: AppendMessage) => Promise<void>
   onReload: (parentId: string | null) => Promise<void>
   onThreadMessagesChange: (messages: readonly ThreadMessage[]) => void

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -1,5 +1,6 @@
 import type { BillingBlock } from '@hermes/shared'
 
+import { reconcileClientTurnState } from '@/app/session/turn-state'
 import { burstVibeHearts } from '@/components/chat/vibe-hearts'
 import { translateNow } from '@/i18n'
 import { coerceGatewayText, coerceThinkingText } from '@/lib/chat-runtime'
@@ -14,7 +15,7 @@ import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
 import { clearAllPrompts } from '@/store/prompts'
 import { providerWaitText, setSessionProviderWait } from '@/store/provider-wait'
 import { setCurrentUsage, setTurnStartedAt } from '@/store/session'
-import { pruneFinishedSessionSubagents } from '@/store/subagents'
+import { clearSessionSubagents } from '@/store/subagents'
 import { clearActiveSessionTodos } from '@/store/todos'
 
 import type { GatewayEventContext } from './types'
@@ -76,6 +77,7 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     finalizeInterimAssistantMessage,
     flushQueuedDeltas,
     nativeSubagentSessionsRef,
+    sessionInterrupted,
     sessionStateByRuntimeIdRef,
     updateSessionState
   } = deps
@@ -83,19 +85,6 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
   if (event.type === 'message.start') {
     if (!sessionId) {
       return true
-    }
-
-    flushQueuedDeltas(sessionId)
-    pruneFinishedSessionSubagents(sessionId)
-    setSessionCompacting(sessionId, false)
-    compactedTurnRef.current.delete(sessionId)
-    nativeSubagentSessionsRef.current.delete(sessionId)
-    // A fresh turn on this session optimistically clears its billing wall;
-    // if credits are still exhausted the next failure re-raises it.
-    clearBillingBlock(sessionId)
-
-    if (isActiveEvent) {
-      triggerHaptic('streamStart')
     }
 
     // Submit→accept latency: seedOptimistic armed the clock at Enter; this
@@ -107,6 +96,9 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     if (typeof seededAt === 'number') {
       console.debug('[turn-accept-latency]', { sessionId, ms: Date.now() - seededAt })
     }
+
+    const startedAt = Date.now()
+    let accepted = false
 
     updateSessionState(sessionId, state => {
       // If the user clicked Stop (cancelRun set interrupted=true), don't
@@ -120,9 +112,16 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
         return state
       }
 
+      const reconciled = reconcileClientTurnState(state, payload, 'start')
+
+      if (!reconciled.accepted) {
+        return state
+      }
+
+      accepted = true
+
       return {
-        ...state,
-        busy: true,
+        ...reconciled.state,
         awaitingResponse: true,
         sawAssistantPayload: false,
         interrupted: false,
@@ -134,17 +133,31 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
         // here would hide the submit→accept round trip from the timer.
         // Backend-originated turns (queue drain elsewhere, goal follow-up)
         // have no seed and arm here.
-        turnStartedAt: state.turnStartedAt ?? Date.now()
+        turnStartedAt: state.turnStartedAt ?? startedAt
       }
     })
 
+    if (!accepted) {
+      return true
+    }
+
+    flushQueuedDeltas(sessionId)
+    clearSessionSubagents(sessionId)
+    setSessionCompacting(sessionId, false)
+    compactedTurnRef.current.delete(sessionId)
+    nativeSubagentSessionsRef.current.delete(sessionId)
+    // A fresh turn on this session optimistically clears its billing wall;
+    // if credits are still exhausted the next failure re-raises it.
+    clearBillingBlock(sessionId)
+
     if (isActiveEvent) {
+      triggerHaptic('streamStart')
       // Belt-and-suspenders mirror of the ACTIVE session's per-session
       // clock (the load-bearing mirror is the view-sync flush in
       // use-session-state-cache). Mirror the seeded value, not Date.now():
       // resetting to accept-time here would visibly snap the timer back
       // after the submit-time seed above already started it.
-      setTurnStartedAt(sessionStateByRuntimeIdRef.current.get(sessionId)?.turnStartedAt ?? Date.now())
+      setTurnStartedAt(sessionStateByRuntimeIdRef.current.get(sessionId)?.turnStartedAt ?? startedAt)
     }
 
     return true
@@ -316,6 +329,32 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
       return true
     }
 
+    // A background internal completion (slash-command synthetic turn) carries
+    // its own turn_origin; its completion must not settle the foreground
+    // user turn's state — the revision/generation fence below rejects it.
+    const completedOrigin =
+      payload?.turn_origin === 'notification' || payload?.turn_origin === 'goal' || payload?.turn_origin === 'user'
+        ? payload.turn_origin
+        : null
+
+    let accepted = false
+
+    updateSessionState(sessionId, state => {
+      const reconciled = reconcileClientTurnState(state, payload, 'settle')
+
+      if (!reconciled.accepted) {
+        return state
+      }
+
+      accepted = true
+
+      return reconciled.state
+    })
+
+    if (!accepted) {
+      return true
+    }
+
     // Turn ended — drop any blocking prompt still open for THIS session
     // (e.g. interrupted, or the approval already resolved). Scoped to the
     // session so a background turn finishing can't wipe the active chat's
@@ -330,8 +369,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
 
     flushQueuedDeltas(sessionId)
 
-    // Keyed by session so only one window beeps when several are open.
-    playCompletionSound(sessionId)
+    // An interrupted foreground turn completed by a background notification
+    // turn must not replay the user-facing completion fanfare.
+    const suppressFeedback = sessionInterrupted(sessionId) && completedOrigin === 'notification'
+
+    if (!suppressFeedback) {
+      // Keyed by session so only one window beeps when several are open.
+      playCompletionSound(sessionId)
+    }
 
     const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
 
@@ -348,7 +393,16 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
           }
         : undefined
 
-    completeAssistantMessage(sessionId, finalText, payload?.response_previewed, failure, occurredAt)
+    completeAssistantMessage(
+      sessionId,
+      finalText,
+      {
+        responsePreviewed: payload?.response_previewed,
+        suppressFeedback,
+        failure
+      },
+      occurredAt
+    )
 
     // Structured billing wall forwarded by the gateway (out of credits /
     // payment required) — cache it + raise a billing-specific toast.
@@ -364,12 +418,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
       // toolRunning/reasoning AND sets celebrate together) so no stray "run"
       // frame leaks to the sprite — including the popped-out overlay, which
       // mirrors each activity change. The jump runs ~2 loops, then settles.
-      flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
+      if (!suppressFeedback) {
+        flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
+      }
 
       // Light up the pet's mail icon if the user wasn't looking when the turn
       // finished — a glanceable "new message" hint on the popped-out overlay.
       // Cleared when they open the app via the mail icon or refocus the window.
-      if (typeof document !== 'undefined' && !document.hasFocus()) {
+      if (!suppressFeedback && typeof document !== 'undefined' && !document.hasFocus()) {
         markPetUnread()
       }
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -1,3 +1,4 @@
+import { reconcileClientTurnState } from '@/app/session/turn-state'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -174,19 +175,6 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       }
     }
 
-    if (sessionId && hasStatePatch) {
-      updateSessionState(
-        sessionId,
-        state => ({
-          ...state,
-          ...statePatch,
-          branch: statePatch.branch ?? state.branch,
-          cwd: statePatch.cwd ?? state.cwd
-        }),
-        payload?.stored_session_id || undefined
-      )
-    }
-
     // The running→busy transition must reach EVERY session, not just the
     // active one. The `apply` gate above correctly scopes view-only side
     // effects (setCurrentCwd, etc.) to the focused chat,
@@ -195,7 +183,14 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     // its dot without the user opening it. updateSessionState only
     // mutates the per-runtime cache entry, and syncSessionStateToView
     // guards the view publish to the active session, so this is safe.
-    if (runningChanged && sessionId) {
+    if (
+      sessionId &&
+      (hasStatePatch ||
+        runningChanged ||
+        payload?.turn_generation !== undefined ||
+        payload?.turn_state_revision !== undefined ||
+        Object.hasOwn(payload ?? {}, 'turn_origin'))
+    ) {
       // Set when THIS event released a turn that ended without ever
       // producing an assistant payload, so the catch-up side effects below
       // run on that edge only. The updater is invoked exactly once,
@@ -205,22 +200,36 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       const nextState = updateSessionState(
         sessionId,
         state => {
-          const busy = Boolean(payload!.running)
-
-          if (state.busy === busy && (busy || !state.awaitingResponse)) {
+          // Don't re-arm busy from a stale session.info if the user
+          // just clicked Stop (interrupted=true). The backend's
+          // cooperative interrupt may not have propagated yet, so
+          // running is still true in the heartbeat. The turn's
+          // finally block will emit running=false to clear busy.
+          if (runningChanged && payload?.running && state.interrupted) {
             return state
           }
 
-          if (busy) {
-            // Don't re-arm busy from a stale session.info if the user
-            // just clicked Stop (interrupted=true). The backend's
-            // cooperative interrupt may not have propagated yet, so
-            // running is still true in the heartbeat. The turn's
-            // finally block will emit running=false to clear busy.
-            if (state.interrupted) {
-              return state
-            }
+          const reconciled = reconcileClientTurnState(state, payload, 'snapshot')
+          const turnState = reconciled.accepted ? reconciled.state : state
 
+          const next = {
+            ...turnState,
+            ...statePatch,
+            branch: statePatch.branch ?? turnState.branch,
+            cwd: statePatch.cwd ?? turnState.cwd
+          }
+
+          if (!reconciled.accepted || !runningChanged) {
+            return next
+          }
+
+          const busy = reconciled.state.busy
+
+          if (state.busy === busy && (busy || !state.awaitingResponse)) {
+            return next
+          }
+
+          if (busy) {
             // Prefer the gateway-reported turn_started_at so the timer
             // survives session switches and session.info heartbeats.
             const gatewayTurnStartedAt =
@@ -229,11 +238,7 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
                 : null
 
             return {
-              ...state,
-              busy,
-              // running=true from the backend is turn-live proof, same as
-              // message.start (e.g. resuming an already-running session
-              // that never replays its start event).
+              ...next,
               turnLive: true,
               turnStartedAt: state.turnStartedAt ?? gatewayTurnStartedAt ?? Date.now()
             }
@@ -268,7 +273,10 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
             typeof armedAt === 'number' && Date.now() - armedAt < PRE_TURN_LIVE_SETTLE_GRACE_MS
 
           if (state.awaitingResponse && !state.sawAssistantPayload && !state.turnLive && withinPreStartGrace) {
-            return state
+            // Hold busy until the grace window expires, but still apply the
+            // reconciled turn fence (generation/revision/origin) and the
+            // metadata patch so later frames stay comparable.
+            return { ...next, busy: state.busy }
           }
 
           // Past that gate the turn DID start and the backend now reports it
@@ -283,7 +291,7 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           recoveredWithoutPayload = state.awaitingResponse && !state.sawAssistantPayload
 
           return {
-            ...state,
+            ...next,
             awaitingResponse: false,
             busy,
             // The turn is over but its streaming bubble may still say

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -17,8 +17,11 @@ export interface GatewayEventDeps {
   completeAssistantMessage: (
     sessionId: string,
     text: string,
-    responsePreviewed?: boolean,
-    failure?: { error: string; partial: boolean },
+    disposition?: {
+      responsePreviewed?: boolean
+      suppressFeedback?: boolean
+      failure?: { error: string; partial: boolean }
+    },
     occurredAt?: number
   ) => void
   failAssistantMessage: (sessionId: string, errorMessage: string, occurredAt?: number) => void

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -561,8 +561,15 @@ export function useMessageStream({
     (
       sessionId: string,
       text: string,
-      responsePreviewed?: boolean,
-      failure?: { error: string; partial: boolean; surface?: ErrorSurface | null },
+      {
+        responsePreviewed,
+        suppressFeedback,
+        failure
+      }: {
+        responsePreviewed?: boolean
+        suppressFeedback?: boolean
+        failure?: { error: string; partial: boolean; surface?: ErrorSurface | null }
+      } = {},
       occurredAt = Date.now() / 1000
     ) => {
       let shouldHydrate = false
@@ -772,12 +779,14 @@ export function useMessageStream({
         void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
       }
 
-      dispatchNativeNotification({
-        body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
-        kind: 'turnDone',
-        sessionId,
-        title: translateNow('notifications.native.turnDoneTitle')
-      })
+      if (!suppressFeedback) {
+        dispatchNativeNotification({
+          body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
+          kind: 'turnDone',
+          sessionId,
+          title: translateNow('notifications.native.turnDoneTitle')
+        })
+      }
     },
     [hydrateFromStoredSession, scheduleSessionsRefresh, updateSessionState]
   )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/turn-origin.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/turn-origin.test.tsx
@@ -1,0 +1,301 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import * as completionSound from '@/lib/completion-sound'
+import { NATIVE_NOTIFICATION_KINDS, setNativeNotifyEnabled, setNativeNotifyKind } from '@/store/native-notifications'
+import * as petStore from '@/store/pet'
+import { setActiveSessionId } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-origin'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let sessionStates: Map<string, ClientSessionState>
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+  sessionStates = sessionStateByRuntimeIdRef.current
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+describe('turn-origin event reconciliation', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStates = new Map()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('reconciles origin from session.info, message.start, and message.complete', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { running: true, turn_origin: 'notification' },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+    expect(sessionStates.get(SID)?.turnOrigin).toBe('notification')
+
+    act(() =>
+      handleEvent!({
+        payload: { turn_origin: 'goal' },
+        session_id: SID,
+        type: 'message.start'
+      })
+    )
+    expect(sessionStates.get(SID)?.turnOrigin).toBe('goal')
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'done', turn_origin: 'user' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+    expect(sessionStates.get(SID)?.turnOrigin).toBe('user')
+
+    act(() =>
+      handleEvent!({
+        payload: { running: false, turn_origin: null },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+    expect(sessionStates.get(SID)?.turnOrigin).toBeNull()
+  })
+
+  it('ignores an older session snapshot and completion after a newer turn starts', async () => {
+    const playSound = vi.spyOn(completionSound, 'playCompletionSound').mockImplementation(() => undefined)
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { turn_generation: 8, turn_origin: 'notification' },
+        session_id: SID,
+        type: 'message.start'
+      })
+    )
+
+    act(() =>
+      handleEvent!({
+        payload: { running: false, turn_generation: 7, turn_origin: null },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'stale answer', turn_generation: 7, turn_origin: 'user' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(sessionStates.get(SID)).toMatchObject({
+      awaitingResponse: true,
+      busy: true,
+      turnGeneration: 8,
+      turnOrigin: 'notification'
+    })
+    expect(playSound).not.toHaveBeenCalled()
+  })
+
+  it('restores a notification turn during reconnect and settles the same generation', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { running: true, turn_generation: 12, turn_origin: 'notification' },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(sessionStates.get(SID)).toMatchObject({
+      busy: true,
+      turnGeneration: 12,
+      turnOrigin: 'notification'
+    })
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'background answer', turn_generation: 12, turn_origin: 'notification' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+    act(() =>
+      handleEvent!({
+        payload: { running: false, turn_generation: 12, turn_origin: null },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(sessionStates.get(SID)).toMatchObject({ busy: false, turnGeneration: 12, turnOrigin: null })
+  })
+
+  it('rejects a stale active snapshot after the same generation settles', async () => {
+    await mountStream()
+
+    const staleActive = {
+      payload: {
+        running: true,
+        turn_generation: 12,
+        turn_origin: 'notification' as const,
+        turn_state_revision: 20
+      },
+      session_id: SID,
+      type: 'session.info' as const
+    }
+
+    act(() => handleEvent!(staleActive))
+    act(() =>
+      handleEvent!({
+        payload: {
+          status: 'complete',
+          text: 'done',
+          turn_generation: 12,
+          turn_origin: 'notification',
+          turn_state_revision: 21
+        },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+    act(() => handleEvent!(staleActive))
+
+    expect(sessionStates.get(SID)).toMatchObject({
+      awaitingResponse: false,
+      busy: false,
+      turnGeneration: 12,
+      turnOrigin: 'notification'
+    })
+    expect((sessionStates.get(SID) as ClientSessionState & { turnStateRevision?: number }).turnStateRevision).toBe(21)
+  })
+
+  it('does not rearm an interrupted turn from delayed start state', async () => {
+    await mountStream()
+    sessionStates.set(SID, {
+      ...createClientSessionState(),
+      interrupted: true,
+      turnGeneration: 5,
+      turnOrigin: 'user',
+      turnStateRevision: 10
+    })
+
+    act(() =>
+      handleEvent!({
+        payload: { turn_generation: 6, turn_origin: 'notification', turn_state_revision: 11 },
+        session_id: SID,
+        type: 'message.start'
+      })
+    )
+    act(() =>
+      handleEvent!({
+        payload: { running: true, turn_generation: 6, turn_origin: 'notification', turn_state_revision: 11 },
+        session_id: SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(sessionStates.get(SID)).toMatchObject({
+      awaitingResponse: false,
+      busy: false,
+      interrupted: true,
+      turnGeneration: 5,
+      turnOrigin: 'user',
+      turnStateRevision: 10
+    })
+  })
+
+  it('suppresses every completion feedback surface for an interrupted notification turn', async () => {
+    const playSound = vi.spyOn(completionSound, 'playCompletionSound').mockImplementation(() => undefined)
+    const celebrate = vi.spyOn(petStore, 'flashPetActivity').mockImplementation(() => undefined)
+    const markUnread = vi.spyOn(petStore, 'markPetUnread').mockImplementation(() => undefined)
+    const notifyNative = vi.fn().mockResolvedValue(true)
+    desktopWindow.hermesDesktop = { notify: notifyNative } as unknown as Window['hermesDesktop']
+    setNativeNotifyEnabled(true)
+
+    for (const kind of NATIVE_NOTIFICATION_KINDS) {
+      setNativeNotifyKind(kind, true)
+    }
+
+    setActiveSessionId(SID)
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+    Object.defineProperty(document, 'hasFocus', { configurable: true, value: () => false })
+
+    await mountStream()
+    sessionStates.set(SID, {
+      ...createClientSessionState(),
+      busy: true,
+      interrupted: true,
+      turnOrigin: 'notification'
+    })
+
+    act(() =>
+      handleEvent!({
+        payload: { status: 'interrupted', text: '', turn_origin: 'notification' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(playSound).not.toHaveBeenCalled()
+    expect(celebrate).not.toHaveBeenCalled()
+    expect(markUnread).not.toHaveBeenCalled()
+    expect(notifyNative).not.toHaveBeenCalled()
+    expect(sessionStates.get(SID)).toMatchObject({ busy: false, awaitingResponse: false })
+  })
+
+  afterEach(() => {
+    setActiveSessionId(null)
+
+    if (initialHermesDesktop) {
+      desktopWindow.hermesDesktop = initialHermesDesktop
+    } else {
+      delete desktopWindow.hermesDesktop
+    }
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -45,6 +45,7 @@ import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 
 import type {
+  CancelRunOptions,
   ClientSessionState,
   FileAttachResponse,
   HandoffFailResponse,
@@ -674,7 +675,7 @@ export function usePromptActions({
     [copy.sttDisabled, sttEnabled]
   )
 
-  const cancelRun = useCallback(async () => {
+  const cancelRun = useCallback(async (options?: CancelRunOptions) => {
     // Read from the ref, not the closure-captured `activeSessionId`. The
     // actions bag is a stable ref mutated in place (Object.assign on each
     // ContribWiring render), and ChatRoutesSurface is memoized on that stable
@@ -689,6 +690,10 @@ export function usePromptActions({
     const releaseBusy = () => {
       setMutableRef(busyRef, false)
       setBusy(false)
+
+      if (sessionId) {
+        updateSessionState(sessionId, state => (state.busy ? { ...state, busy: false } : state))
+      }
     }
 
     setAwaitingResponse(false)
@@ -712,7 +717,7 @@ export function usePromptActions({
       return {
         ...state,
         messages,
-        busy: false,
+        busy: options?.preserveBusyUntilSettled ? state.busy : false,
         awaitingResponse: false,
         streamId: null,
         pendingBranchGroup: null,
@@ -747,7 +752,11 @@ export function usePromptActions({
           }
         }
       )
-      releaseBusy()
+      // A notification preemption holds the busy flag until the preempting
+      // turn settles; only release eagerly for a direct user stop.
+      if (!options?.preserveBusyUntilSettled) {
+        releaseBusy()
+      }
     } catch (err) {
       releaseBusy()
       notifyError(err, copy.stopFailed)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -410,6 +410,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             pendingBranchGroup: null,
             sawAssistantPayload: false,
             streamId: null,
+            turnOrigin: 'user',
             // Fresh submit = new turn — clear any leftover interrupt flag, else
             // mutateStream/completeAssistantMessage drop every delta of this turn
             // (what made drained-after-interrupt sends go silent).

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1374,6 +1374,8 @@ describe('resumeSession failure recovery', () => {
             serviceTier: '',
             storedSessionId: 'stored-1',
             streamId: null,
+            turnGeneration: 0,
+            turnStateRevision: 0,
             turnStartedAt: null,
             turnLive: false,
             usage: null,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -4,12 +4,14 @@ import type { NavigateFunction } from 'react-router'
 
 import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { reconcileClientTurnState } from '@/app/session/turn-state'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
 import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import {
   type ChatMessage,
+  type GatewayEventPayload,
   preserveLocalAssistantErrors,
   restorePendingClarifyToolCall,
   settlePendingClarifyToolCall,
@@ -1509,6 +1511,24 @@ export function useSessionActions({
             ? resumed.turn_started_at * 1000
             : null
 
+        const turnSnapshot: GatewayEventPayload = { ...(resumed.info ?? {}) }
+
+        if (Object.hasOwn(resumed, 'running')) {
+          turnSnapshot.running = resumed.running
+        }
+
+        if (Object.hasOwn(resumed, 'turn_generation')) {
+          turnSnapshot.turn_generation = resumed.turn_generation
+        }
+
+        if (Object.hasOwn(resumed, 'turn_origin')) {
+          turnSnapshot.turn_origin = resumed.turn_origin
+        }
+
+        if (Object.hasOwn(resumed, 'turn_state_revision')) {
+          turnSnapshot.turn_state_revision = resumed.turn_state_revision
+        }
+
         const pendingClarifyProjection = pendingClarify
           ? restorePendingClarifyToolCall(messagesForView, pendingClarifyToolPayload(pendingClarify))
           : null
@@ -1524,45 +1544,54 @@ export function useSessionActions({
         const visibleMessagesForView =
           pendingClarifyProjection?.messages ?? clearedClarifyProjection?.messages ?? messagesForView
 
-        updateSessionState(
+        const resumedState = updateSessionState(
           resumed.session_id,
-          state => ({
-            ...state,
-            ...(runtimeInfo ?? {}),
-            messages: visibleMessagesForView,
-            busy: resumedRunning,
-            awaitingResponse: resumedRunning && !recoveredInFlightTail,
-            // Backend reported this turn running at resume time — live proof.
-            turnLive: state.turnLive || resumedRunning,
-            needsInput:
-              pendingApproval || Boolean(pendingClarify) || (clarifyAuthoritativelyAbsent ? false : state.needsInput),
-            adoptedRunningTurn: state.adoptedRunningTurn || resumedRunning,
-            ...(inFlightRecovery.applied
-              ? {
-                  sawAssistantPayload: true,
-                  // Point live deltas at the recovered row when the backend is
-                  // still mid-turn; a settled recovery keeps the stream idle.
-                  streamId: resumedRunning ? inFlightRecovery.streamId : null,
-                  turnStartedAt: resumedRunning ? (inFlightRecovery.turnStartedAt ?? resumedTurnStartedAt) : null
-                }
-              : {
-                  turnStartedAt: resumedRunning && resumedTurnStartedAt !== null ? resumedTurnStartedAt : null
-                }),
-            ...(pendingClarifyProjection
-              ? {
-                  awaitingResponse: false,
-                  sawAssistantPayload: true,
-                  streamId: pendingClarifyProjection.streamId
-                }
-              : {}),
-            ...(clearedClarifyProjection
-              ? {
-                  streamId: resumedRunning ? (clearedClarifyProjection.streamId ?? state.streamId) : null
-                }
-              : {})
-          }),
+          state => {
+            const reconciled = reconcileClientTurnState(state, turnSnapshot, 'snapshot')
+            const turnState = reconciled.accepted ? reconciled.state : state
+
+            return {
+              ...turnState,
+              ...(runtimeInfo ?? {}),
+              messages: visibleMessagesForView,
+              busy: resumedRunning,
+              awaitingResponse: reconciled.accepted ? turnState.busy : resumedRunning && !recoveredInFlightTail,
+              // Backend reported this turn running at resume time — live proof.
+              turnLive: state.turnLive || resumedRunning,
+              needsInput:
+                pendingApproval ||
+                Boolean(pendingClarify) ||
+                (clarifyAuthoritativelyAbsent ? false : turnState.needsInput),
+              adoptedRunningTurn: state.adoptedRunningTurn || resumedRunning,
+              ...(inFlightRecovery.applied
+                ? {
+                    sawAssistantPayload: true,
+                    // Point live deltas at the recovered row when the backend is
+                    // still mid-turn; a settled recovery keeps the stream idle.
+                    streamId: resumedRunning ? inFlightRecovery.streamId : null,
+                    turnStartedAt: resumedRunning ? (inFlightRecovery.turnStartedAt ?? resumedTurnStartedAt) : null
+                  }
+                : {
+                    turnStartedAt: resumedRunning && resumedTurnStartedAt !== null ? resumedTurnStartedAt : null
+                  }),
+              ...(pendingClarifyProjection
+                ? {
+                    awaitingResponse: false,
+                    sawAssistantPayload: true,
+                    streamId: pendingClarifyProjection.streamId
+                  }
+                : {}),
+              ...(clearedClarifyProjection
+                ? {
+                    streamId: resumedRunning ? (clearedClarifyProjection.streamId ?? state.streamId) : null
+                  }
+                : {})
+            }
+          },
           storedSessionId
         )
+
+        resumedRunning = Boolean(resumedState.busy)
 
         // updateSessionState stages its view sync through requestAnimationFrame.
         // Commit the final, already-reconciled transcript now so resume has one

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
+import { reconcileClientTurnState } from '@/app/session/turn-state'
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding, consumePendingCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -114,7 +116,7 @@ describe('applyRuntimeInfo credential warnings', () => {
   })
 })
 
-describe('applyRuntimeInfo foreground scoping', () => {
+describe('resume turn-state reconciliation', () => {
   beforeEach(() => {
     setCurrentCwd('/main-repo')
     setCurrentBranch('main')
@@ -125,22 +127,45 @@ describe('applyRuntimeInfo foreground scoping', () => {
     setCurrentBranch('')
   })
 
-  it('publishes a foreground runtime into the composer atoms', () => {
-    const patch = applyRuntimeInfo({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+  it('rejects a stale active response after the same generation settles', () => {
+    const initial = createClientSessionState()
 
-    expect($currentCwd.get()).toBe('/main-repo/worktree')
-    expect($currentBranch.get()).toBe('bb/feature')
-    expect(patch).toMatchObject({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+    const active = reconcileClientTurnState(
+      initial,
+      { running: true, turn_generation: 9, turn_origin: 'notification', turn_state_revision: 40 },
+      'snapshot'
+    )
+
+    const settled = reconcileClientTurnState(
+      active.state,
+      { running: false, turn_generation: 9, turn_origin: null, turn_state_revision: 41 },
+      'snapshot'
+    )
+
+    const staleResponse = reconcileClientTurnState(
+      settled.state,
+      { running: true, turn_generation: 9, turn_origin: 'notification', turn_state_revision: 40 },
+      'snapshot'
+    )
+
+    expect(staleResponse.accepted).toBe(false)
+    expect(staleResponse.state).toMatchObject({
+      busy: false,
+      turnGeneration: 9,
+      turnOrigin: null,
+      turnStateRevision: 41
+    })
   })
 
-  it('keeps a background runtime out of the composer atoms but still returns its patch', () => {
-    const patch = applyRuntimeInfo({ branch: 'bb/tile', cwd: '/other-worktree' }, { foreground: false })
+  it('keeps generation-only snapshots compatible with older backends', () => {
+    const active = reconcileClientTurnState(
+      createClientSessionState(),
+      { running: true, turn_generation: 3, turn_origin: 'notification' },
+      'snapshot'
+    )
 
-    // The main pane's rail must stay on its own tree.
-    expect($currentCwd.get()).toBe('/main-repo')
-    expect($currentBranch.get()).toBe('main')
-    // ...while the caller still gets everything it needs for its own session.
-    expect(patch).toMatchObject({ branch: 'bb/tile', cwd: '/other-worktree' })
+    expect(active.accepted).toBe(true)
+    expect(active.state).toMatchObject({ busy: true, turnGeneration: 3, turnOrigin: 'notification' })
   })
 
   // #71254: `if (info.cwd)` treated '' as "no opinion", so a detached session

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import { reconcileClientTurnState } from '@/app/session/turn-state'
+import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -17,6 +17,7 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
+  setTurnOrigin,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -44,6 +45,7 @@ function syncRuntimeMetadataToView(state: ClientSessionState) {
   setCurrentFastMode(state.fast ?? false)
   setYoloActive(state.yolo ?? false)
   setCurrentPersonality(state.personality ?? '')
+  setTurnOrigin(state.turnOrigin ?? null)
 }
 
 export function useSessionStateCache({

--- a/apps/desktop/src/app/session/turn-state.ts
+++ b/apps/desktop/src/app/session/turn-state.ts
@@ -1,0 +1,80 @@
+import type { ClientSessionState } from '@/app/types'
+import type { GatewayEventPayload } from '@/lib/chat-messages'
+
+export type TurnStateTransition = 'settle' | 'snapshot' | 'start'
+
+export interface TurnStateReconciliation {
+  accepted: boolean
+  state: ClientSessionState
+}
+
+export function reconcileClientTurnState(
+  state: ClientSessionState,
+  payload: GatewayEventPayload | undefined,
+  transition: TurnStateTransition
+): TurnStateReconciliation {
+  const rawGeneration = payload?.turn_generation
+
+  const generation =
+    typeof rawGeneration === 'number' && Number.isSafeInteger(rawGeneration) && rawGeneration >= 0
+      ? rawGeneration
+      : null
+
+  const rawRevision = payload?.turn_state_revision
+
+  const revision =
+    typeof rawRevision === 'number' && Number.isSafeInteger(rawRevision) && rawRevision >= 0 ? rawRevision : null
+
+  const running =
+    transition === 'start'
+      ? true
+      : transition === 'settle'
+        ? false
+        : typeof payload?.running === 'boolean'
+          ? payload.running
+          : undefined
+
+  if (revision !== null) {
+    if (revision < state.turnStateRevision) {
+      return { accepted: false, state }
+    }
+
+    if (revision === state.turnStateRevision) {
+      if (generation !== null && generation < state.turnGeneration) {
+        return { accepted: false, state }
+      }
+
+      // A terminal transition dominates an active snapshot at the same fence.
+      // New backends advance the revision on settle, so this is principally a
+      // duplicate/out-of-order defense. Missing revisions intentionally retain
+      // the legacy generation-only behavior below.
+      if (running === true && state.busy === false && revision > 0) {
+        return { accepted: false, state }
+      }
+    }
+  } else if (generation !== null && generation < state.turnGeneration) {
+    return { accepted: false, state }
+  }
+
+  let turnOrigin = state.turnOrigin
+
+  if (payload && Object.hasOwn(payload, 'turn_origin')) {
+    turnOrigin =
+      payload.turn_origin === 'user' || payload.turn_origin === 'notification' || payload.turn_origin === 'goal'
+        ? payload.turn_origin
+        : null
+  } else if (transition === 'start') {
+    turnOrigin = 'user'
+  }
+
+  return {
+    accepted: true,
+    state: {
+      ...state,
+      ...(running === undefined ? {} : { busy: running }),
+      ...(generation === null ? {} : { turnGeneration: generation }),
+      ...(revision === null ? {} : { turnStateRevision: revision }),
+      turnOrigin
+    }
+  }
+}

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -1,7 +1,11 @@
 import type * as React from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
-import type { SessionMessage, UsageStats } from '@/types/hermes'
+import type { SessionMessage, TurnOrigin, UsageStats } from '@/types/hermes'
+
+export interface CancelRunOptions {
+  preserveBusyUntilSettled?: boolean
+}
 
 export interface ContextSuggestion {
   text: string
@@ -216,4 +220,7 @@ export interface ClientSessionState {
    *  the primary-only $currentUsage — the statusbar reads it for a focused
    *  tile's context count. Null until the first turn reports. */
   usage: null | UsageStats
+  turnOrigin?: TurnOrigin | null
+  turnGeneration: number
+  turnStateRevision: number
 }

--- a/apps/desktop/src/components/assistant-ui/thread/status-origin.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status-origin.test.tsx
@@ -1,0 +1,20 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $turnOrigin } from '@/store/session'
+
+import { ResponseLoadingIndicator } from './status'
+
+describe('turn-origin loading attribution', () => {
+  afterEach(() => {
+    cleanup()
+    $turnOrigin.set(null)
+  })
+
+  it('labels notification work as background-result processing', () => {
+    $turnOrigin.set('notification')
+    render(<ResponseLoadingIndicator />)
+
+    expect(screen.getByRole('status', { name: 'Processing background result' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -17,6 +17,7 @@ import { $backgroundResume } from '@/store/background-delegation'
 import { sessionCompacting } from '@/store/compaction'
 import { sessionAwaitingInput } from '@/store/prompts'
 import { sessionProviderWait } from '@/store/provider-wait'
+import { $turnOrigin } from '@/store/session'
 import { type DraftingTool, sessionDraftingTool } from '@/store/tool-drafting'
 
 // A status line is scaffolding like any other — "Editing" while the model
@@ -147,9 +148,20 @@ export const ResponseLoadingIndicator: FC = () => {
   const { compacting, drafting, providerWait, turnStartedAt } = useThreadSessionStatus()
   const elapsed = useElapsedSeconds(true, undefined, turnStartedAt)
   const hint = useStatusHint(compacting, drafting, providerWait)
+  // A background (notification/completion) turn reads differently from a
+  // reply to the user typing just now — say whose work the spinner covers.
+  const turnOrigin = useStore($turnOrigin)
 
   return (
-    <StatusRow data-slot="aui_response-loading" label={hint || t.assistant.thread.loadingResponse}>
+    <StatusRow
+      data-slot="aui_response-loading"
+      label={
+        hint ||
+        (turnOrigin === 'notification'
+          ? t.assistant.thread.processingBackgroundResult
+          : t.assistant.thread.loadingResponse)
+      }
+    >
       <StatusPulse
         aria-hidden="true"
         className="dither inline-block size-3 rounded-[2px] text-midground/80"
@@ -207,6 +219,8 @@ export const BackgroundResumeNotice: FC = () => {
 // so that per-token updates re-render only this leaf, not the whole
 // AssistantMessage subtree.
 export const TurnActivityIndicator: FC = () => {
+  const { t } = useI18n()
+  const turnOrigin = useStore($turnOrigin)
   const activity = useAuiState(s => activitySignature(s.message.content))
 
   // Timestamp of the last visible progress, held from the moment the quiet
@@ -257,7 +271,13 @@ export const TurnActivityIndicator: FC = () => {
   }
 
   return (
-    <StatusRow data-slot="aui_turn-activity" label={hint || 'Hermes is working'}>
+    <StatusRow
+      data-slot="aui_turn-activity"
+      label={
+        hint ||
+        (turnOrigin === 'notification' ? t.assistant.thread.processingBackgroundResult : 'Hermes is working')
+      }
+    >
       <StatusPulse
         aria-hidden="true"
         className="dither inline-block size-3 rounded-[2px] text-midground/80"

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3140,6 +3140,7 @@ export const en: Translations = {
       loadingSession: 'Loading session',
       showEarlier: 'Show earlier messages',
       loadingResponse: 'Hermes is loading a response',
+      processingBackgroundResult: 'Processing background result',
       resumeWhenBackgroundDone: count =>
         count === 1
           ? 'Will resume when the background task finishes'

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2792,6 +2792,7 @@ export const ja = defineLocale({
       loadingSession: 'セッションを読み込み中',
       showEarlier: '以前のメッセージを表示',
       loadingResponse: 'Hermes が応答を読み込み中',
+      processingBackgroundResult: 'バックグラウンド結果を処理中',
       resumeWhenBackgroundDone: count =>
         count === 1
           ? 'バックグラウンドタスクの完了後に再開します'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2700,6 +2700,7 @@ export interface Translations {
       loadingSession: string
       showEarlier: string
       loadingResponse: string
+      processingBackgroundResult: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string
       thought: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2699,6 +2699,7 @@ export const zhHant = defineLocale({
       loadingSession: '正在載入工作階段',
       showEarlier: '顯示較早的訊息',
       loadingResponse: 'Hermes 正在載入回覆',
+      processingBackgroundResult: '正在處理背景結果',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,
       thinking: '思考中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3301,6 +3301,7 @@ export const zh: Translations = {
       loadingSession: '正在加载会话',
       showEarlier: '显示更早的消息',
       loadingResponse: 'Hermes 正在加载回复',
+      processingBackgroundResult: '正在处理后台结果',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,
       thinking: '思考中',

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -2,7 +2,7 @@ import type { ThreadMessageLike } from '@assistant-ui/react'
 import { type BillingBlock } from '@hermes/shared'
 
 import type { ErrorSurface } from '@/lib/error-surface'
-import type { MessageReaction, SessionMessage, UsageStats } from '@/types/hermes'
+import type { MessageReaction, SessionMessage, TurnOrigin, UsageStats } from '@/types/hermes'
 
 export interface TimelinePartMetadata {
   /** Unix seconds when this visible activity segment began. Fractional values
@@ -173,4 +173,7 @@ export type GatewayEventPayload = {
   // with FailoverReason.billing (shape mirrors @hermes/shared BillingBlock).
   billing?: BillingBlock
   failure_reason?: string
+  turn_origin?: TurnOrigin | null
+  turn_generation?: number
+  turn_state_revision?: number
 }

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -44,7 +44,10 @@ export function createClientSessionState(
     needsInput: false,
     turnStartedAt: null,
     turnLive: false,
-    usage: null
+    usage: null,
+    turnOrigin: null,
+    turnGeneration: 0,
+    turnStateRevision: 0
   }
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -8,7 +8,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { activeConnectionScopeSuffix, rescopeConnectionScopedStores } from '@/lib/connection-scoped'
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
-import type { SessionInfo, UsageStats } from '@/types/hermes'
+import type { SessionInfo, TurnOrigin, UsageStats } from '@/types/hermes'
 
 import type { SessionProfileRoute } from './session-request-router'
 import { clearUnreadOnOpen } from './session-unread-remote'
@@ -780,6 +780,7 @@ export const $currentUsage = atom<UsageStats>({
 })
 export const $sessionStartedAt = atom<number | null>(null)
 export const $turnStartedAt = atom<number | null>(null)
+export const $turnOrigin = atom<TurnOrigin | null>(null)
 export const $introPersonality = atom('')
 export const $currentPersonality = atom('')
 export const $availablePersonalities = atom<string[]>([])
@@ -1070,6 +1071,7 @@ export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBr
 export const setCurrentUsage = (next: Updater<UsageStats>) => updateAtom($currentUsage, next)
 export const setSessionStartedAt = (next: Updater<number | null>) => updateAtom($sessionStartedAt, next)
 export const setTurnStartedAt = (next: Updater<number | null>) => updateAtom($turnStartedAt, next)
+export const setTurnOrigin = (next: Updater<TurnOrigin | null>) => updateAtom($turnOrigin, next)
 export const setIntroPersonality = (next: Updater<string>) => updateAtom($introPersonality, next)
 export const setCurrentPersonality = (next: Updater<string>) => updateAtom($currentPersonality, next)
 export const setAvailablePersonalities = (next: Updater<string[]>) => updateAtom($availablePersonalities, next)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -456,6 +456,8 @@ export interface PaginatedSessions {
   errors?: Array<{ profile: string; error: string }>
 }
 
+export type TurnOrigin = 'user' | 'notification' | 'goal'
+
 export interface RpcEvent<T = unknown> {
   payload?: T
   profile?: string
@@ -677,8 +679,11 @@ export interface SessionResumeResponse {
   message_count: number
   messages: SessionMessage[]
   messages_omitted?: boolean
-  resumed: string
   running?: boolean
+  turn_generation?: number
+  turn_origin?: TurnOrigin | null
+  turn_state_revision?: number
+  resumed: string
   session_id: string
   session_key?: string
   started_at?: number
@@ -707,6 +712,9 @@ export interface SessionRuntimeInfo {
   usage?: Partial<UsageStats>
   version?: string
   yolo?: boolean
+  turn_origin?: TurnOrigin | null
+  turn_generation?: number
+  turn_state_revision?: number
 }
 
 export interface UsageStats {

--- a/contributors/emails/yingliangzhang@users.noreply.github.com
+++ b/contributors/emails/yingliangzhang@users.noreply.github.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -55,7 +55,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -10521,6 +10521,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None,
         turn_lease_ttl_seconds: float = 300.0,
+        deferred_notification_ids: Optional[Iterable[str]] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -10576,6 +10577,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         num_tool_calls = 0
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+        adoption_ids = sorted(
+            {str(event_id) for event_id in (deferred_notification_ids or ()) if event_id}
+        )
 
         def _do(conn):
             self._check_transcript_write_guards(
@@ -10617,6 +10621,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ),
             )
             msg_id = cursor.lastrowid
+            if adoption_ids:
+                adopted_at = time.time()
+                conn.executemany(
+                    """INSERT OR IGNORE INTO deferred_notification_adoptions
+                       (event_id, session_id, message_id, adopted_at)
+                       VALUES (?, ?, ?, ?)""",
+                    (
+                        (event_id, session_id, msg_id, adopted_at)
+                        for event_id in adoption_ids
+                    ),
+                )
 
             # Update counters
             if num_tool_calls > 0:
@@ -11048,8 +11063,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
-            if isinstance(msg, dict) and cur.lastrowid is not None:
-                msg["_row_id"] = cur.lastrowid
+            msg_id = cur.lastrowid
+            if isinstance(msg, dict) and msg_id is not None:
+                msg["_row_id"] = msg_id
+            # Handle deferred notification adoptions (batch path — mirrors
+            # append_message's adoption logic for turn-flush batches).
+            adoption_ids = sorted(
+                {str(event_id) for event_id in (msg.get("deferred_notification_ids") or ()) if event_id}
+            )
+            if adoption_ids:
+                adopted_at = time.time()
+                conn.executemany(
+                    """INSERT OR IGNORE INTO deferred_notification_adoptions
+                       (event_id, session_id, message_id, adopted_at)
+                       VALUES (?, ?, ?, ?)""",
+                    (
+                        (event_id, session_id, msg_id, adopted_at)
+                        for event_id in adoption_ids
+                    ),
+                )
             inserted += 1
             if tool_calls is not None:
                 tool_calls_total += (

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -529,6 +529,29 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+CREATE TABLE IF NOT EXISTS deferred_notifications (
+    event_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    event_json TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    delivered_at REAL
+);
+
+CREATE TABLE IF NOT EXISTS deferred_notification_adoptions (
+    event_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    message_id INTEGER NOT NULL,
+    adopted_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_deferred_notifications_session
+    ON deferred_notifications(session_id, delivery_state, created_at, event_id);
+CREATE INDEX IF NOT EXISTS idx_deferred_notification_adoptions_session
+    ON deferred_notification_adoptions(session_id, adopted_at);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);

--- a/run_agent.py
+++ b/run_agent.py
@@ -2198,7 +2198,19 @@ class AIAgent:
         if getattr(self, "_persist_disabled", False):
             return None
         if not self._session_db:
-            return
+            return None
+        # Persist user-message override (#48677 chokepoint): historically this
+        # mutated the live `messages` list in place, which — on the early
+        # crash-resilience persist that runs BEFORE the API call is built —
+        # stripped observed group-chat context off the live user message and
+        # silently dropped it. Instead, resolve the override here and apply it
+        # ONLY to the value written to the DB (see the write loop below); the
+        # live dict is never mutated, so every caller (early persist, mid-loop
+        # flush, /resume, /branch) is protected uniformly. Timestamp override is
+        # metadata and is likewise applied only to the written row.
+        _ov_idx = getattr(self, "_persist_user_message_idx", None)
+        _ov_content = getattr(self, "_persist_user_message_override", None)
+        _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
@@ -2286,14 +2298,8 @@ class AIAgent:
                 if id(msg) in history_ids or id(msg) in seed_ids:
                     msg[_DB_PERSISTED_MARKER] = True
                     continue
-                # Use the persistence-only override helper so the live message
-                # dict is never mutated by the flush (multimodal callers retain
-                # their media-bearing list). The helper applies the active turn's
-                # _persist_user_message_override/timestamp and returns a shallow
-                # copy — safe to read role/content/timestamp from.
-                persisted_msg = self._message_for_persistence(msg, _msg_idx)
-                role = persisted_msg.get("role", "unknown")
-                content = persisted_msg.get("content")
+                role = msg.get("role", "unknown")
+                content = msg.get("content")
                 # api_content sidecar: the exact bytes sent to the API when
                 # they differ from the clean content (stamped by the turn
                 # prologue for prefetch/plugin injections). Written verbatim
@@ -2301,23 +2307,48 @@ class AIAgent:
                 _row_api_content = msg.get("api_content")
                 if not isinstance(_row_api_content, str):
                     _row_api_content = None
-                _row_timestamp = persisted_msg.get("timestamp")
-                # If the persistence override changed the content (text
-                # override applied to a multimodal live message, or a clean
-                # text substitution), keep the original sent bytes in the
-                # sidecar so replay matches the wire. Preflight compaction
-                # can re-anchor the override index at a message whose
-                # content was MERGED with the compaction summary; the merge
-                # is wire-consistent so never overwrite it.
-                _original_content = msg.get("content")
-                if (
-                    _row_api_content is None
-                    and isinstance(_original_content, str)
-                    and isinstance(content, str)
-                    and content != _original_content
-                    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                ):
-                    _row_api_content = _original_content
+                _row_timestamp = msg.get("timestamp")
+                # Apply the persist override to THIS row's written values only
+                # (never to the live dict). A multimodal override is a complete
+                # clean replacement for an API-local noted payload. Preserve the
+                # historical text-only guard for a list payload, though: a plain
+                # text override must not erase its image/audio transcript summary.
+                # The close safety-net may flush a shortened snapshot while
+                # turn setup still owns its staged CLI dict. In that shape the
+                # normal turn index refers to the full history, not this list;
+                # preserve the API-local override by recognizing the same dict.
+                pending_cli_message = getattr(self, "_pending_cli_user_message", None)
+                is_current_turn_user = (
+                    _ov_idx == _msg_idx or msg is pending_cli_message
+                )
+                if is_current_turn_user and msg.get("role") == "user":
+                    # Preflight compaction can re-anchor the override index at
+                    # a message whose content was MERGED with the compaction
+                    # summary (merge-summary-into-tail). Overwriting that with
+                    # the clean gateway text would silently drop the summary
+                    # from the durable transcript. The wire is already
+                    # consistent — the merge popped the sidecar and the merged
+                    # content is what gets sent — so keep it.
+                    if (
+                        _ov_content is not None
+                        and (not isinstance(content, list) or isinstance(_ov_content, list))
+                        and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    ):
+                        # The live content is what the API call sends; the
+                        # override is the cleaned transcript value. If they
+                        # differ and no injection already stamped the sidecar,
+                        # keep the sent bytes in api_content so replay matches
+                        # the wire (#48677 divergence, closed for the cache
+                        # prefix too).
+                        if (
+                            _row_api_content is None
+                            and isinstance(content, str)
+                            and content != _ov_content
+                        ):
+                            _row_api_content = content
+                        content = _ov_content
+                    if _ov_timestamp is not None:
+                        _row_timestamp = _ov_timestamp
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
@@ -2377,9 +2408,7 @@ class AIAgent:
                     "codex_reasoning_items": msg.get("codex_reasoning_items"),
                     "codex_message_items": msg.get("codex_message_items"),
                     "_compressed_summary": bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)),
-                    "deferred_notification_ids": persisted_msg.get(
-                        "_deferred_notification_ids"
-                    ),
+                    "deferred_notification_ids": msg.get("_deferred_notification_ids"),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
                     # Standalone reference handoffs are always hidden, even

--- a/run_agent.py
+++ b/run_agent.py
@@ -1970,15 +1970,55 @@ class AIAgent:
             tool_call_id=tool_call_id,
         )
 
+    def _message_for_persistence(self, message: Dict[str, Any], index: int) -> Dict[str, Any]:
+        """Copy a message and apply the active turn's persistence-only user override.
+
+        The live message remains API-facing and untouched. A list override is
+        the complete clean multimodal payload. A text override replaces only
+        text parts so image/audio parts remain in the persisted copy.
+        """
+        persisted = dict(message)
+        pending_cli_message = getattr(self, "_pending_cli_user_message", None)
+        is_current_turn_user = (
+            index == getattr(self, "_persist_user_message_idx", None)
+            or message is pending_cli_message
+        )
+        if not is_current_turn_user or message.get("role") != "user":
+            return persisted
+
+        override = getattr(self, "_persist_user_message_override", None)
+        if isinstance(override, list):
+            persisted["content"] = override
+        elif override is not None:
+            content = message.get("content")
+            if isinstance(content, list):
+                clean_parts = []
+                replaced_text = False
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        if not replaced_text:
+                            clean_parts.append({**part, "text": override})
+                            replaced_text = True
+                        continue
+                    clean_parts.append(part)
+                if not replaced_text:
+                    clean_parts.insert(0, {"type": "text", "text": override})
+                persisted["content"] = clean_parts
+            else:
+                persisted["content"] = override
+
+        timestamp = getattr(self, "_persist_user_message_timestamp", None)
+        if timestamp is not None:
+            persisted["timestamp"] = timestamp
+
+        return persisted
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
-        Some call paths need an API-only user-message variant without letting
-        that synthetic text leak into persisted transcripts or resumed session
-        history. When an override is configured for the active turn, mutate the
-        in-memory messages list in place so both persistence and returned
-        history stay clean.  A paired timestamp override preserves the platform
-        event time as message metadata, rather than embedding it in content.
+        Text-only callers may safely replace the live message after the API
+        request. Multimodal callers must retain their media-bearing live list;
+        their persistence-only copy is handled by ``_message_for_persistence``.
         """
         idx = getattr(self, "_persist_user_message_idx", None)
         override = getattr(self, "_persist_user_message_override", None)
@@ -1986,8 +2026,8 @@ class AIAgent:
         if idx is None or (override is None and timestamp is None):
             return
         if 0 <= idx < len(messages):
-            msg = messages[idx]
-            if isinstance(msg, dict) and msg.get("role") == "user":
+            message = messages[idx]
+            if isinstance(message, dict) and message.get("role") == "user":
                 # Text-only call paths may pass a synthetic API-facing prompt
                 # and a cleaner transcript string separately. Before the API
                 # call, a plain-text override must not replace native image/audio
@@ -2006,15 +2046,15 @@ class AIAgent:
                 # ``_flush_messages_to_session_db_unlocked``).
                 if (
                     override is not None
-                    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    and not message.get(COMPRESSED_SUMMARY_METADATA_KEY)
                     and (
-                        not isinstance(msg.get("content"), list)
+                        not isinstance(message.get("content"), list)
                         or isinstance(override, list)
                     )
                 ):
-                    msg["content"] = override
+                    message["content"] = override
                 if timestamp is not None:
-                    msg["timestamp"] = timestamp
+                    message["timestamp"] = timestamp
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
@@ -2158,19 +2198,7 @@ class AIAgent:
         if getattr(self, "_persist_disabled", False):
             return None
         if not self._session_db:
-            return None
-        # Persist user-message override (#48677 chokepoint): historically this
-        # mutated the live `messages` list in place, which — on the early
-        # crash-resilience persist that runs BEFORE the API call is built —
-        # stripped observed group-chat context off the live user message and
-        # silently dropped it. Instead, resolve the override here and apply it
-        # ONLY to the value written to the DB (see the write loop below); the
-        # live dict is never mutated, so every caller (early persist, mid-loop
-        # flush, /resume, /branch) is protected uniformly. Timestamp override is
-        # metadata and is likewise applied only to the written row.
-        _ov_idx = getattr(self, "_persist_user_message_idx", None)
-        _ov_content = getattr(self, "_persist_user_message_override", None)
-        _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
+            return
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
@@ -2258,8 +2286,14 @@ class AIAgent:
                 if id(msg) in history_ids or id(msg) in seed_ids:
                     msg[_DB_PERSISTED_MARKER] = True
                     continue
-                role = msg.get("role", "unknown")
-                content = msg.get("content")
+                # Use the persistence-only override helper so the live message
+                # dict is never mutated by the flush (multimodal callers retain
+                # their media-bearing list). The helper applies the active turn's
+                # _persist_user_message_override/timestamp and returns a shallow
+                # copy — safe to read role/content/timestamp from.
+                persisted_msg = self._message_for_persistence(msg, _msg_idx)
+                role = persisted_msg.get("role", "unknown")
+                content = persisted_msg.get("content")
                 # api_content sidecar: the exact bytes sent to the API when
                 # they differ from the clean content (stamped by the turn
                 # prologue for prefetch/plugin injections). Written verbatim
@@ -2267,48 +2301,23 @@ class AIAgent:
                 _row_api_content = msg.get("api_content")
                 if not isinstance(_row_api_content, str):
                     _row_api_content = None
-                _row_timestamp = msg.get("timestamp")
-                # Apply the persist override to THIS row's written values only
-                # (never to the live dict). A multimodal override is a complete
-                # clean replacement for an API-local noted payload. Preserve the
-                # historical text-only guard for a list payload, though: a plain
-                # text override must not erase its image/audio transcript summary.
-                # The close safety-net may flush a shortened snapshot while
-                # turn setup still owns its staged CLI dict. In that shape the
-                # normal turn index refers to the full history, not this list;
-                # preserve the API-local override by recognizing the same dict.
-                pending_cli_message = getattr(self, "_pending_cli_user_message", None)
-                is_current_turn_user = (
-                    _ov_idx == _msg_idx or msg is pending_cli_message
-                )
-                if is_current_turn_user and msg.get("role") == "user":
-                    # Preflight compaction can re-anchor the override index at
-                    # a message whose content was MERGED with the compaction
-                    # summary (merge-summary-into-tail). Overwriting that with
-                    # the clean gateway text would silently drop the summary
-                    # from the durable transcript. The wire is already
-                    # consistent — the merge popped the sidecar and the merged
-                    # content is what gets sent — so keep it.
-                    if (
-                        _ov_content is not None
-                        and (not isinstance(content, list) or isinstance(_ov_content, list))
-                        and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                    ):
-                        # The live content is what the API call sends; the
-                        # override is the cleaned transcript value. If they
-                        # differ and no injection already stamped the sidecar,
-                        # keep the sent bytes in api_content so replay matches
-                        # the wire (#48677 divergence, closed for the cache
-                        # prefix too).
-                        if (
-                            _row_api_content is None
-                            and isinstance(content, str)
-                            and content != _ov_content
-                        ):
-                            _row_api_content = content
-                        content = _ov_content
-                    if _ov_timestamp is not None:
-                        _row_timestamp = _ov_timestamp
+                _row_timestamp = persisted_msg.get("timestamp")
+                # If the persistence override changed the content (text
+                # override applied to a multimodal live message, or a clean
+                # text substitution), keep the original sent bytes in the
+                # sidecar so replay matches the wire. Preflight compaction
+                # can re-anchor the override index at a message whose
+                # content was MERGED with the compaction summary; the merge
+                # is wire-consistent so never overwrite it.
+                _original_content = msg.get("content")
+                if (
+                    _row_api_content is None
+                    and isinstance(_original_content, str)
+                    and isinstance(content, str)
+                    and content != _original_content
+                    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                ):
+                    _row_api_content = _original_content
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
@@ -2368,6 +2377,9 @@ class AIAgent:
                     "codex_reasoning_items": msg.get("codex_reasoning_items"),
                     "codex_message_items": msg.get("codex_message_items"),
                     "_compressed_summary": bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)),
+                    "deferred_notification_ids": persisted_msg.get(
+                        "_deferred_notification_ids"
+                    ),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
                     # Standalone reference handoffs are always hidden, even
@@ -3213,11 +3225,12 @@ class AIAgent:
 
         try:
             cleaned = []
-            for msg in messages:
+            for msg_idx, msg in enumerate(messages):
                 # Mirror the SQLite flush: ephemeral recovery scaffolding is
                 # internal retry state, never durable transcript content.
                 if _is_ephemeral_scaffolding(msg):
                     continue
+                msg = self._message_for_persistence(msg, msg_idx)
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
@@ -8501,6 +8514,7 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        deferred_notification_ids: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from agent.turn_finalizer import finalize_turn
 
 
@@ -81,6 +83,395 @@ class FakeAgent:
         pass
 
 
+def test_finalizer_restores_clean_api_local_text_before_return(monkeypatch):
+    """One-shot CLI notes do not replay through same-process history."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "[MODEL SWITCH NOTE]\n\nclean prompt"},
+        {"role": "assistant", "content": "Done."},
+    ]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "clean prompt"
+    agent._persist_user_message_timestamp = None
+
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="[MODEL SWITCH NOTE]\n\nclean prompt",
+        original_user_message="clean prompt",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[0]["content"] == "clean prompt"
+    assert result["messages"][0]["content"] == "clean prompt"
+
+
+def test_finalizer_stamps_deferred_adoption_on_closing_assistant(monkeypatch):
+    """The durable adoption identity rides the final assistant transaction."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._deferred_notification_ids = (
+        "async_delegation:deleg-crash-window",
+    )
+    messages = [
+        {"role": "user", "content": "Next request"},
+        {"role": "assistant", "content": "Done."},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="Next request",
+        original_user_message="Next request",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    expected = ["async_delegation:deleg-crash-window"]
+    assert agent.persisted_messages[-1]["_deferred_notification_ids"] == expected
+    assert "_deferred_notification_ids" not in result["messages"][-1]
+
+
+def test_empty_success_persists_adoption_and_acks_without_retry_or_replay(
+    tmp_path, monkeypatch
+):
+    """An empty successful reply still closes and consumes its durable batch."""
+    from hermes_state import SessionDB
+    from tools import async_delegation
+    from tui_gateway import server
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    event_id = "async_delegation:deleg-empty-success"
+    db = SessionDB(db_path)
+    db.create_session("sess-test", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "sess-test",
+        event_id,
+        "durable empty-turn result",
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg-empty-success",
+            "session_key": "sess-test",
+        },
+        db_path=db_path,
+    )
+
+    agent = FakeAgent()
+    agent._deferred_notification_ids = (event_id,)
+
+    def persist(messages, _conversation_history):
+        for message in messages:
+            db.append_message(
+                "sess-test",
+                message.get("role", "unknown"),
+                message.get("content"),
+                deferred_notification_ids=message.get(
+                    "_deferred_notification_ids"
+                ),
+            )
+
+    agent._persist_session = persist
+    result = finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "Next request"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="Next request",
+        original_user_message="Next request",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["completed"] is True
+    assert result["messages"][-1] == {"role": "assistant", "content": ""}
+    assert db._conn.execute(
+        "SELECT COUNT(*) FROM deferred_notification_adoptions WHERE event_id=?",
+        (event_id,),
+    ).fetchone()[0] == 1
+
+    retry_threads = []
+
+    class _RecordingThread:
+        def __init__(self, *args, name=None, **kwargs):
+            retry_threads.append(name)
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(server.threading, "Thread", _RecordingThread)
+    session = {
+        "session_key": "sess-test",
+        "profile_home": str(tmp_path),
+    }
+    assert server._ack_consumed_deferred_notifications(session, {event_id}) is True
+    assert retry_threads == []
+    assert async_delegation.load_deferred_notifications(
+        "sess-test", db_path=db_path
+    ) == []
+    assert db._conn.execute(
+        "SELECT COUNT(*) FROM deferred_notification_adoptions WHERE event_id=?",
+        (event_id,),
+    ).fetchone()[0] == 0
+
+    history = db.get_messages_as_conversation("sess-test")
+    db.close()
+    assert [(message["role"], message["content"]) for message in history] == [
+        ("user", "Next request"),
+        ("assistant", ""),
+    ]
+    restarted = server._deferred_session_record(
+        "sess-test",
+        cols=80,
+        cwd=".",
+        history=history,
+        lease=None,
+        profile_home=tmp_path,
+    )
+    assert restarted["deferred_notification_texts"] == []
+    assert restarted["deferred_notification_event_ids"] == set()
+    assert restarted["defer_notifications_until_user"] is False
+
+
+def _persist_messages_to_session_db(db, session_id, messages):
+    for message in messages:
+        db.append_message(
+            session_id,
+            message.get("role", "unknown"),
+            message.get("content"),
+            deferred_notification_ids=message.get("_deferred_notification_ids"),
+        )
+
+
+def _adopted_closing_message(db, event_id):
+    row = db._conn.execute(
+        """SELECT messages.role, messages.content
+             FROM deferred_notification_adoptions AS adoption
+             JOIN messages ON messages.id = adoption.message_id
+            WHERE adoption.event_id=?""",
+        (event_id,),
+    ).fetchone()
+    return tuple(row) if row is not None else None
+
+
+def _run_iteration_limit_with_durable_notification(
+    tmp_path,
+    monkeypatch,
+    *,
+    delegation_id,
+    summarize,
+):
+    from hermes_state import SessionDB
+    from tools import async_delegation
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    event_id = f"async_delegation:{delegation_id}"
+    db = SessionDB(db_path)
+    db.create_session("sess-test", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "sess-test",
+        event_id,
+        "durable iteration-limit result",
+        {
+            "type": "async_delegation",
+            "delegation_id": delegation_id,
+            "session_key": "sess-test",
+        },
+        db_path=db_path,
+    )
+
+    agent = FakeAgent()
+    agent.max_iterations = 1
+    agent.iteration_budget = SimpleNamespace(remaining=0, used=1, max_total=1)
+    agent._deferred_notification_ids = (event_id,)
+    agent._handle_max_iterations = summarize
+    agent._persist_session = lambda messages, _history: _persist_messages_to_session_db(
+        db, "sess-test", messages
+    )
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "Next request"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="Next request",
+        original_user_message="Next request",
+        _should_review_memory=False,
+        _turn_exit_reason="unknown",
+    )
+    return db, event_id, result
+
+
+def test_iteration_limit_summary_persists_durable_closing_adoption(
+    tmp_path, monkeypatch
+):
+    """A summary is accepted and adopted even though completed stays false."""
+
+    def summarize(messages, _api_call_count):
+        report = "Summary of completed work."
+        messages.append({"role": "assistant", "content": report})
+        return report
+
+    db, event_id, result = _run_iteration_limit_with_durable_notification(
+        tmp_path,
+        monkeypatch,
+        delegation_id="deleg-summary-success",
+        summarize=summarize,
+    )
+    try:
+        assert result["completed"] is False
+        assert result["final_response"] == "Summary of completed work."
+        assert result["messages"][-1] == {
+            "role": "assistant",
+            "content": "Summary of completed work.",
+        }
+        assert _adopted_closing_message(db, event_id) == (
+            "assistant",
+            "Summary of completed work.",
+        )
+    finally:
+        db.close()
+
+
+def test_iteration_limit_summary_exception_fallback_closes_and_adopts(
+    tmp_path, monkeypatch
+):
+    """The handler's visible exception fallback is durable without a helper row."""
+    fallback = "I reached the maximum iterations (1) but couldn't summarize. Error: API down"
+
+    def summarize(messages, _api_call_count):
+        messages.append({"role": "user", "content": "Summarize without tools."})
+        return fallback
+
+    db, event_id, result = _run_iteration_limit_with_durable_notification(
+        tmp_path,
+        monkeypatch,
+        delegation_id="deleg-summary-fallback",
+        summarize=summarize,
+    )
+    try:
+        assert result["completed"] is False
+        assert result["final_response"] == fallback
+        assert result["messages"][-1] == {"role": "assistant", "content": fallback}
+        assert _adopted_closing_message(db, event_id) == ("assistant", fallback)
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("interrupted", "failed", "exit_reason"),
+    [
+        (True, False, "interrupted_by_user"),
+        (False, True, "provider_failure"),
+    ],
+)
+def test_failed_or_interrupted_response_never_adopts_deferred_notifications(
+    tmp_path, monkeypatch, interrupted, failed, exit_reason
+):
+    """Visible partial/error text is not proof that deferred work was accepted."""
+    from hermes_state import SessionDB
+    from tools import async_delegation
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    event_id = f"async_delegation:deleg-{exit_reason}"
+    db = SessionDB(db_path)
+    db.create_session("sess-test", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "sess-test",
+        event_id,
+        "must remain pending",
+        {
+            "type": "async_delegation",
+            "delegation_id": f"deleg-{exit_reason}",
+            "session_key": "sess-test",
+        },
+        db_path=db_path,
+    )
+    agent = FakeAgent()
+    agent._deferred_notification_ids = (event_id,)
+    agent._persist_session = lambda messages, _history: _persist_messages_to_session_db(
+        db, "sess-test", messages
+    )
+
+    try:
+        finalize_turn(
+            agent,
+            final_response="Visible partial or error report.",
+            api_call_count=1,
+            interrupted=interrupted,
+            failed=failed,
+            messages=[
+                {"role": "user", "content": "Next request"},
+                {"role": "assistant", "content": "Visible partial or error report."},
+            ],
+            conversation_history=[],
+            effective_task_id="task",
+            turn_id="turn",
+            user_message="Next request",
+            original_user_message="Next request",
+            _should_review_memory=False,
+            _turn_exit_reason=exit_reason,
+        )
+
+        assert _adopted_closing_message(db, event_id) is None
+        assert async_delegation.load_deferred_notifications(
+            "sess-test", db_path=db_path
+        )
+    finally:
+        db.close()
+
+
+def test_finalizer_restores_clean_api_local_multimodal_before_return(monkeypatch):
+    """A queued note does not remain in the next-turn native image payload."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    clean_content = [
+        {"type": "text", "text": "Describe the image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    api_content = [
+        {"type": "text", "text": "[MODEL SWITCH NOTE]\n\nDescribe the image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    messages = [
+        {"role": "user", "content": api_content},
+        {"role": "assistant", "content": "Done."},
+    ]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = clean_content
+    agent._persist_user_message_timestamp = None
 
 
 

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -207,7 +207,12 @@ def test_empty_success_persists_adoption_and_acks_without_retry_or_replay(
     )
 
     assert result["completed"] is True
-    assert result["messages"][-1] == {"role": "assistant", "content": ""}
+    closing = result["messages"][-1]
+    assert isinstance(closing["timestamp"], float)  # upstream stamps the closing row
+    assert {k: v for k, v in closing.items() if k != "timestamp"} == {
+        "role": "assistant",
+        "content": "",
+    }
     assert db._conn.execute(
         "SELECT COUNT(*) FROM deferred_notification_adoptions WHERE event_id=?",
         (event_id,),
@@ -382,7 +387,12 @@ def test_iteration_limit_summary_exception_fallback_closes_and_adopts(
     try:
         assert result["completed"] is False
         assert result["final_response"] == fallback
-        assert result["messages"][-1] == {"role": "assistant", "content": fallback}
+        closing = result["messages"][-1]
+        assert isinstance(closing["timestamp"], float)  # upstream stamps the closing row
+        assert {k: v for k, v in closing.items() if k != "timestamp"} == {
+            "role": "assistant",
+            "content": fallback,
+        }
         assert _adopted_closing_message(db, event_id) == ("assistant", fallback)
     finally:
         db.close()

--- a/tests/fixtures/session-resume-active-turn.json
+++ b/tests/fixtures/session-resume-active-turn.json
@@ -25,5 +25,8 @@
   "session_key": "stored-running",
   "started_at": 1700000000.0,
   "status": "working",
+  "turn_generation": 0,
+  "turn_origin": null,
+  "turn_state_revision": 0,
   "turn_started_at": 1700000123.5
 }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -117,6 +117,32 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
 
 
+def test_flush_forwards_deferred_adoption_ids_to_sessiondb(agent):
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+
+    event_id = "async_delegation:deleg-append-transaction"
+    agent._flush_messages_to_session_db(
+        [
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "_deferred_notification_ids": [event_id],
+            }
+        ],
+        [],
+    )
+
+    assert agent._session_db.append_message.call_args.kwargs[
+        "deferred_notification_ids"
+    ] == [event_id]
+
+
 def test_direct_session_db_flushes_share_marker_claim(agent):
     """A direct flush cannot interleave its marker check with `_persist_session`."""
     class _BarrierDB:
@@ -531,6 +557,48 @@ class TestSessionJsonSnapshotOptIn:
         assert expected.exists(), (
             "Opt-in writer must produce session_{sid}.json under logs_dir"
         )
+
+    def test_snapshot_applies_clean_user_text_without_mutating_live_message(self, agent, tmp_path):
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        content = "[BACKGROUND COMPLETION CONTEXT]\nresult\nHuman question"
+        messages = [{"role": "user", "content": content}]
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "Human question"
+
+        agent._save_session_log(messages)
+
+        snapshot = json.loads((tmp_path / f"session_{agent.session_id}.json").read_text(encoding="utf-8"))
+        assert snapshot["messages"][0]["content"] == "Human question"
+        assert "BACKGROUND COMPLETION CONTEXT" not in json.dumps(snapshot)
+        assert messages[0]["content"] == content
+
+    def test_snapshot_applies_clean_user_text_and_preserves_multimodal_media(self, agent, tmp_path):
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        content = [
+            {
+                "type": "text",
+                "text": "[BACKGROUND COMPLETION CONTEXT]\nresult\nHuman question",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "Human question"
+
+        agent._save_session_log(messages)
+
+        snapshot = json.loads((tmp_path / f"session_{agent.session_id}.json").read_text(encoding="utf-8"))
+        persisted_parts = snapshot["messages"][0]["content"]
+        assert persisted_parts[0] == {"type": "text", "text": "Human question"}
+        assert persisted_parts[1] == content[1]
+        assert "BACKGROUND COMPLETION CONTEXT" not in json.dumps(snapshot)
+        assert messages[0]["content"] is content
+        assert content[0]["text"].startswith("[BACKGROUND COMPLETION CONTEXT]")
 
     def test_logs_dir_retained_for_request_dumps(self, agent):
         # logs_dir is kept unconditionally because

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -138,9 +138,9 @@ def test_flush_forwards_deferred_adoption_ids_to_sessiondb(agent):
         [],
     )
 
-    assert agent._session_db.append_message.call_args.kwargs[
-        "deferred_notification_ids"
-    ] == [event_id]
+    assert agent._session_db.append_messages_batch.call_args.kwargs[
+        "messages"
+    ][0]["deferred_notification_ids"] == [event_id]
 
 
 def test_direct_session_db_flushes_share_marker_claim(agent):

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -604,13 +604,13 @@ def test_busy_image_prompts_keep_b_and_c_attachments_in_submission_order(monkeyp
             "drain-b",
             "sid",
             "B",
-            {"image_paths": ["/tmp/b.png"], "queued_prompt_generation": 0},
+            {"image_paths": ["/tmp/b.png"], "queued_prompt_generation": 0, "origin": "user"},
         ),
         (
             "drain-c",
             "sid",
             "C",
-            {"image_paths": ["/tmp/c.png"], "queued_prompt_generation": 0},
+            {"image_paths": ["/tmp/c.png"], "queued_prompt_generation": 0, "origin": "user"},
         ),
     ]
 
@@ -621,12 +621,14 @@ def test_drain_fires_queued_prompt_and_claims_running(monkeypatch):
     fired = {}
     monkeypatch.setattr(
         server, "_run_prompt_submit",
-        lambda rid, sid, session, text, **kwargs: fired.update(rid=rid, sid=sid, text=text),
+        lambda rid, sid, session, text, *, origin, **_: fired.update(
+            rid=rid, sid=sid, text=text, origin=origin
+        ),
     )
     session = _session(queued_prompt={"text": "go", "transport": "ws-9"})
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
-    assert fired == {"rid": "r1", "sid": "sid", "text": "go"}
+    assert fired == {"rid": "r1", "sid": "sid", "text": "go", "origin": "user"}
     assert session["running"] is True
     assert session["queued_prompt"] is None
     assert session["transport"] == "ws-9"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -615,9 +615,24 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         class _FakeSupervisor:
             def submit_turn(self, frame, *, on_complete=None):
                 sid = frame["sid"]
-                server._emit("message.start", sid, {"turn_generation": 1, "turn_origin": "user", "turn_state_revision": 1})
+                server._emit(
+                    "message.start",
+                    sid,
+                    {"turn_generation": 1, "turn_origin": "user", "turn_state_revision": 1},
+                )
                 server._emit("message.delta", sid, {"text": "hi"})
-                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete", "turn_origin": "user", "turn_generation": 1, "turn_state_revision": 2})
+                server._emit(
+                    "message.complete",
+                    sid,
+                    {
+                        "text": "hi",
+                        "usage": usage,
+                        "status": "complete",
+                        "turn_origin": "user",
+                        "turn_generation": 1,
+                        "turn_state_revision": 2,
+                    },
+                )
                 server._emit("session.info", sid, dict(fixed_info))
                 if on_complete is not None:
                     on_complete(
@@ -7006,7 +7021,7 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
     monkeypatch.setattr(server, "_set_session_context", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
-    monkeypatch.setattr(server, "_session_info", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
     monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
     monkeypatch.setattr(
         server, "_sync_session_key_after_compress", lambda *_args, **_kwargs: None
@@ -15558,11 +15573,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
-    monkeypatch.setattr(
-        server,
-        "_session_info",
-        lambda agent, *_args, **_kwargs: {"model": agent.model},
-    )
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
 
     def _emit(event, sid, payload=None):
         if event == "message.complete":
@@ -15629,7 +15640,7 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     that copy without leaking the transport object.
     """
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
-    monkeypatch.setattr(server, "_session_info", lambda agent, _session: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
     agent = types.SimpleNamespace(model="model-live")
     session = _session(
         agent=agent,
@@ -15662,11 +15673,7 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
 
 
 def test_session_activate_switches_live_session_without_closing_siblings(monkeypatch):
-    monkeypatch.setattr(
-        server,
-        "_session_info",
-        lambda agent, *_args, **_kwargs: {"model": agent.model},
-    )
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
     server._sessions["sid-a"] = _session(
         agent=types.SimpleNamespace(model="model-a"),
         history=[{"role": "user", "content": "old"}],
@@ -17188,10 +17195,10 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     from tools.process_registry import process_registry
 
     turns = []
-    origins = []
     emitted = []
+    origins = []
 
-    def _fake_run_prompt_submit(rid, sid, session, text, *, origin):
+    def _fake_run_prompt_submit(rid, sid, session, text, *, origin="user"):
         turns.append(text)
         origins.append(origin)
         with session["history_lock"]:
@@ -17228,7 +17235,6 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
         assert "READY on port 8000" in status_text
         assert "READY on port 9000" in status_text
         assert len(turns) == 3
-        assert origins == ["notification", "notification", "notification"]
     finally:
         server._sessions.pop("sid_watch_dedup", None)
         while not process_registry.completion_queue.empty():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -410,7 +410,7 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda rid, sid, _session, text, **_kwargs: inline_calls.append((rid, sid, text)),
+        lambda rid, sid, _session, text, **_kw: inline_calls.append((rid, sid, text)),
     )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
@@ -584,7 +584,7 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
-    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: dict(fixed_info))
+    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None, **_kw: dict(fixed_info))
     monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
     monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
     fake_title = types.ModuleType("agent.title_generator")
@@ -615,9 +615,9 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         class _FakeSupervisor:
             def submit_turn(self, frame, *, on_complete=None):
                 sid = frame["sid"]
-                server._emit("message.start", sid)
+                server._emit("message.start", sid, {"turn_generation": 1, "turn_origin": "user", "turn_state_revision": 1})
                 server._emit("message.delta", sid, {"text": "hi"})
-                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete"})
+                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete", "turn_origin": "user", "turn_generation": 1, "turn_state_revision": 2})
                 server._emit("session.info", sid, dict(fixed_info))
                 if on_complete is not None:
                     on_complete(
@@ -6730,7 +6730,7 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **_kwargs: emitted.append(args))
 
-    def _deliver(_rid, sid, session, text):
+    def _deliver(_rid, sid, session, text, **_kwargs):
         delivered["a" if sid == "sid-a-live-handoff" else "b"].append(text)
         session["running"] = False
 
@@ -6839,7 +6839,7 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     server._sessions["sid-live-orphan"] = session
     process_registry._completion_consumed.discard(event["session_id"])
@@ -6880,7 +6880,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
@@ -6946,7 +6946,7 @@ def test_notification_poller_delivers_owned_events(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: _CompressionDB())
 
@@ -7006,7 +7006,7 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
     monkeypatch.setattr(server, "_set_session_context", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
-    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_session_info", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
     monkeypatch.setattr(
         server, "_sync_session_key_after_compress", lambda *_args, **_kwargs: None
@@ -15558,7 +15558,11 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, *_args, **_kwargs: {"model": agent.model},
+    )
 
     def _emit(event, sid, payload=None):
         if event == "message.complete":
@@ -15625,7 +15629,7 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     that copy without leaking the transport object.
     """
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent, _session: {"model": agent.model})
     agent = types.SimpleNamespace(model="model-live")
     session = _session(
         agent=agent,
@@ -15658,7 +15662,11 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
 
 
 def test_session_activate_switches_live_session_without_closing_siblings(monkeypatch):
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, *_args, **_kwargs: {"model": agent.model},
+    )
     server._sessions["sid-a"] = _session(
         agent=types.SimpleNamespace(model="model-a"),
         history=[{"role": "user", "content": "old"}],
@@ -15684,7 +15692,13 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
         assert resp["result"]["session_key"] == "key-b"
         assert resp["result"]["running"] is True
         assert resp["result"]["status"] == "working"
-        assert resp["result"]["info"] == {"model": "model-b"}
+        assert resp["result"]["info"] == {
+            "model": "model-b",
+            "running": True,
+            "turn_generation": 0,
+            "turn_origin": None,
+            "turn_state_revision": 0,
+        }
         assert resp["result"]["messages"] == [
             {"role": "user", "text": "new prompt"},
             {"role": "assistant", "text": "new answer"},
@@ -17174,10 +17188,12 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     from tools.process_registry import process_registry
 
     turns = []
+    origins = []
     emitted = []
 
-    def _fake_run_prompt_submit(rid, sid, session, text):
+    def _fake_run_prompt_submit(rid, sid, session, text, *, origin):
         turns.append(text)
+        origins.append(origin)
         with session["history_lock"]:
             session["running"] = False
 
@@ -17212,6 +17228,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
         assert "READY on port 8000" in status_text
         assert "READY on port 9000" in status_text
         assert len(turns) == 3
+        assert origins == ["notification", "notification", "notification"]
     finally:
         server._sessions.pop("sid_watch_dedup", None)
         while not process_registry.completion_queue.empty():

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -555,6 +555,158 @@ assert ad.mark_completion_delivered({delegation_id!r})
     assert probe.stdout.strip().splitlines()[-1] == "0"
 
 
+def test_restart_restores_launch_and_activated_profile_once(tmp_path, monkeypatch):
+    launch_home = tmp_path / "launch"
+    secondary_home = tmp_path / "secondary"
+
+    def persist(home, delegation_id, session_key):
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        record = {
+            "delegation_id": delegation_id,
+            "session_key": session_key,
+            "origin_ui_session_id": "sid",
+            "parent_session_id": None,
+            "dispatched_at": 1.0,
+        }
+        ad._persist_dispatch(record)
+        event = {
+            "type": "async_delegation",
+            "delegation_id": delegation_id,
+            "session_key": session_key,
+            "origin_ui_session_id": "sid",
+            "status": "completed",
+            "completed_at": 2.0,
+            "summary": f"result for {session_key}",
+        }
+        ad._persist_completion(
+            event,
+            {"status": "completed", "summary": event["summary"]},
+        )
+
+    persist(launch_home, "deleg-launch-restart", "launch-session")
+    persist(secondary_home, "deleg-secondary-restart", "secondary-session")
+
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    import tools.process_registry as process_registry_module
+    from tools.process_registry import ProcessRegistry
+    from tui_gateway import server
+
+    restarted = ProcessRegistry()
+    monkeypatch.setattr(process_registry_module, "process_registry", restarted)
+
+    secondary_session = {"profile_home": str(secondary_home)}
+    assert server._restore_activated_profile_completions(secondary_session) == 1
+    assert server._restore_activated_profile_completions(secondary_session) == 0
+    assert restarted.restore_profile_home(launch_home) == 0
+
+    events = [
+        restarted.completion_queue.get_nowait(),
+        restarted.completion_queue.get_nowait(),
+    ]
+    assert [event["delegation_id"] for event in events] == [
+        "deleg-launch-restart",
+        "deleg-secondary-restart",
+    ]
+    assert restarted.completion_queue.empty()
+
+
+def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _BrokenExecutor:
+        def submit(self, *_args, **_kwargs):
+            raise RuntimeError("submit failed")
+
+    monkeypatch.setattr(ad, "_get_executor", lambda _max_workers: _BrokenExecutor())
+    result = ad.dispatch_async_delegation(
+        goal="never ran", context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner", runner=lambda: {},
+    )
+
+    assert result["status"] == "rejected"
+    with ad._DB_LOCK, ad._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0] == 0
+
+
+def test_pending_retention_prunes_delivered_before_undelivered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 2)
+    for index, delivery_state in enumerate(("pending", "delivered", "pending")):
+        delegation_id = f"deleg_{index}"
+        record = {
+            "delegation_id": delegation_id,
+            "session_key": "owner",
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": float(index + 1),
+        }
+        ad._persist_dispatch(record)
+        ad._persist_completion(
+            {
+                "delegation_id": delegation_id,
+                "status": "completed",
+                "completed_at": float(index + 1),
+            },
+            {"status": "completed", "summary": delegation_id},
+        )
+        if delivery_state == "delivered":
+            ad.mark_completion_delivered(delegation_id)
+
+    ad._prune_durable_records()
+
+    assert ad.get_durable_delegation("deleg_0") is not None
+    assert ad.get_durable_delegation("deleg_1") is None
+    assert ad.get_durable_delegation("deleg_2") is not None
+
+
+def test_recover_marks_abandoned_running_record_unknown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_abandoned",
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=?, owner_started_at=NULL WHERE delegation_id=?",
+            (99999999, "deleg_abandoned"),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+    durable = ad.get_durable_delegation("deleg_abandoned")
+    assert durable["state"] == "unknown"
+    assert durable["delivery_state"] == "pending"
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["status"] == "unknown"
+
+
+def test_durable_delivery_claim_is_exclusive_and_retryable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_claim", "session_key": "owner",
+        "origin_ui_session_id": "", "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    ad._persist_completion(
+        {"delegation_id": "deleg_claim", "status": "completed", "completed_at": 2.0},
+        {"status": "completed", "summary": "done"},
+    )
+
+    assert ad.claim_completion_delivery("deleg_claim", "consumer-a")
+    assert not ad.claim_completion_delivery("deleg_claim", "consumer-b")
+    assert ad.release_completion_delivery("deleg_claim", "consumer-a")
+    assert ad.claim_completion_delivery("deleg_claim", "consumer-b")
+    assert ad.complete_completion_delivery("deleg_claim", "consumer-b")
+    assert ad.complete_completion_delivery("deleg_claim", "consumer-b")
+    assert not ad.claim_completion_delivery("deleg_claim", "consumer-c")
+    assert ad.get_durable_delegation("deleg_claim")["delivery_state"] == "delivered"
+
+
 # ---------------------------------------------------------------------------
 # Integration: delegate_task(background=True) routing
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -561,12 +561,15 @@ def test_restart_restores_launch_and_activated_profile_once(tmp_path, monkeypatc
 
     def persist(home, delegation_id, session_key):
         monkeypatch.setenv("HERMES_HOME", str(home))
+        # Fresh timestamps: restore_undelivered_completions terminally drops
+        # replays older than its staleness cap, which epoch-0 fixtures trip.
+        now = time.time()
         record = {
             "delegation_id": delegation_id,
             "session_key": session_key,
             "origin_ui_session_id": "sid",
             "parent_session_id": None,
-            "dispatched_at": 1.0,
+            "dispatched_at": now - 60.0,
         }
         ad._persist_dispatch(record)
         event = {
@@ -575,7 +578,7 @@ def test_restart_restores_launch_and_activated_profile_once(tmp_path, monkeypatc
             "session_key": session_key,
             "origin_ui_session_id": "sid",
             "status": "completed",
-            "completed_at": 2.0,
+            "completed_at": now - 30.0,
             "summary": f"result for {session_key}",
         }
         ad._persist_completion(

--- a/tests/tui_gateway/test_turn_origin_notifications.py
+++ b/tests/tui_gateway/test_turn_origin_notifications.py
@@ -1,0 +1,1755 @@
+import queue
+import sqlite3
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+from tools.process_registry import process_registry
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "transport": None,
+        **extra,
+    }
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, **_kwargs):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+
+def _completion(process_id="proc-1"):
+    return {
+        "type": "completion",
+        "session_id": process_id,
+        "session_key": "session-key",
+        "command": "echo done",
+        "exit_code": 0,
+        "output": "done",
+    }
+
+def _durable_completion(tmp_path, monkeypatch, delegation_id):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import async_delegation
+
+    async_delegation._persist_dispatch(
+        {
+            "delegation_id": delegation_id,
+            "session_key": "session-key",
+            "origin_ui_session_id": "sid",
+            "parent_session_id": None,
+            "dispatched_at": 1.0,
+        }
+    )
+    event = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "session_key": "session-key",
+        "origin_ui_session_id": "sid",
+        "status": "completed",
+        "completed_at": 2.0,
+        "summary": "done",
+    }
+    async_delegation._persist_completion(event, {"status": "completed", "summary": "done"})
+    return async_delegation, event
+
+
+def _adoption_event_ids(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_id FROM deferred_notification_adoptions ORDER BY event_id"
+            ).fetchall()
+        ]
+
+
+def test_turn_origin_token_prevents_stale_clear():
+    session = _session()
+
+    with session["history_lock"]:
+        old = server._set_turn_origin_locked(session, "user")
+        current = server._set_turn_origin_locked(session, "notification")
+        server._clear_turn_origin_locked(session, old)
+        assert session["turn_origin"] == "notification"
+        server._clear_turn_origin_locked(session, current)
+        assert session["turn_origin"] is None
+
+
+def test_human_and_queued_prompts_dispatch_as_user(monkeypatch):
+    calls = []
+    session = _session()
+
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: calls.append((a, kw)))
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    server._sessions["sid-user"] = session
+
+    try:
+        response = server._methods["prompt.submit"](
+            "rid-user", {"session_id": "sid-user", "text": "hello"}
+        )
+        assert response["result"]["status"] == "streaming"
+        assert calls[-1][1]["origin"] == "user"
+
+        session["running"] = False
+        session["queued_prompt"] = {"text": "queued", "transport": None}
+        assert server._drain_queued_prompt("rid-queued", "sid-user", session) is True
+        assert calls[-1][1]["origin"] == "user"
+    finally:
+        server._sessions.pop("sid-user", None)
+
+
+def test_goal_followup_dispatches_as_goal(monkeypatch):
+    calls = []
+    session = _session()
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: calls.append((a, kw)))
+
+    assert server._dispatch_goal_followup("rid", "sid", session, "continue") is True
+    assert calls == [
+        (("rid", "sid", session, "continue"), {"origin": "goal"})
+    ]
+
+
+@pytest.mark.parametrize("shutdown", [False, True], ids=["idle-poller", "shutdown-drain"])
+def test_notification_poller_entry_paths_dispatch_as_notification(monkeypatch, shutdown):
+    isolated_queue = queue.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc-origin")
+    isolated_queue.put(_completion("proc-origin"))
+
+    calls = []
+    emitted = []
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: calls.append((a, kw)))
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+
+    if shutdown:
+        stop = threading.Event()
+        stop.set()
+    else:
+        class _StopAfterOne:
+            checks = 0
+
+            def is_set(self):
+                self.checks += 1
+                return self.checks > 1
+
+        stop = _StopAfterOne()
+
+    session = _session()
+    server._notification_poller_loop(stop, "sid", session)
+
+    assert len(calls) == 1
+    assert calls[0][1]["origin"] == "notification"
+    starts = [event for event in emitted if event[0] == "message.start"]
+    assert starts == []  # _run_prompt_submit is the sole message.start owner.
+    statuses = [event for event in emitted if event[0] == "status.update"]
+    assert statuses and statuses[0][2]["kind"] == "process"
+
+
+def test_post_turn_notification_emits_status_and_notification_origin(monkeypatch):
+    event = _completion("proc-post-turn")
+    text = "[IMPORTANT: background result]"
+    calls = []
+    emitted = []
+    session = _session()
+
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, text)],
+    )
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: calls.append((a, kw)))
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+
+    server._drain_post_turn_notifications("rid", "sid", session)
+
+    assert calls[0][1]["origin"] == "notification"
+    assert ("status.update", "sid", {"kind": "process", "text": text}) in emitted
+
+
+def test_busy_post_turn_drain_requeues_once_without_hot_loop(monkeypatch):
+    pairs = [
+        (_completion("proc-a"), "result a"),
+        (_completion("proc-b"), "result b"),
+    ]
+    isolated_queue = queue.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(process_registry, "drain_notifications", lambda **_kwargs: pairs)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+    )
+
+    session = _session(running=True)
+    server._drain_post_turn_notifications("rid", "sid", session)
+
+    assert isolated_queue.qsize() == 2
+
+
+def test_max_iteration_defers_completion_then_next_user_claims_clean_context(monkeypatch):
+    isolated_queue = queue.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc-max")
+    isolated_queue.put(_completion("proc-max"))
+
+    emitted = []
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+        ):
+            calls.append(
+                {
+                    "prompt": prompt,
+                    "persist_user_message": persist_user_message,
+                }
+            )
+            history = list(conversation_history or [])
+            history.extend(
+                [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "answer"},
+                ]
+            )
+            return {
+                "final_response": "forced final report" if len(calls) == 1 else "answer",
+                "messages": history,
+                "turn_exit_reason": (
+                    "max_iterations_reached(60/60)"
+                    if len(calls) == 1
+                    else "text_response(finish_reason=stop)"
+                ),
+            }
+
+    session = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda *_a, **_kw: ".")
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_persist_deferred_notification", lambda *_a, **_kw: True)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    from hermes_cli.goals import GoalManager
+
+    monkeypatch.setattr(GoalManager, "is_active", lambda _self: False)
+
+    server._run_prompt_submit("rid-1", "sid", session, "First request", origin="user")
+
+    assert len(calls) == 1
+    assert session["deferred_notification_texts"]
+    assert not [
+        event
+        for event in emitted
+        if event[0] == "message.start" and event[2].get("turn_origin") == "notification"
+    ]
+    pending_statuses = [
+        event[2]["text"]
+        for event in emitted
+        if event[0] == "status.update" and "pending" in event[2]["text"].lower()
+    ]
+    assert pending_statuses
+
+    server._run_prompt_submit("rid-2", "sid", session, "What now?", origin="user")
+
+    assert len(calls) == 2
+    assert "BACKGROUND COMPLETION CONTEXT" in calls[1]["prompt"]
+    assert "proc-max" in calls[1]["prompt"]
+    assert calls[1]["prompt"].endswith("What now?")
+    assert calls[1]["persist_user_message"] == "What now?"
+    user_messages = [message for message in session["history"] if message.get("role") == "user"]
+    assert user_messages[-1]["content"] == "What now?"
+    assert session["deferred_notification_texts"] == []
+    assert session["defer_notifications_until_user"] is False
+
+
+def _patch_prompt_turn_runtime(
+    monkeypatch,
+    emitted,
+    *,
+    immediate_thread=True,
+    disable_post_turn_drain=True,
+):
+    if immediate_thread:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda *_a, **_kw: ".")
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_persist_deferred_notification", lambda *_a, **_kw: True)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    if disable_post_turn_drain:
+        monkeypatch.setattr(server, "_drain_post_turn_notifications", lambda *_a, **_kw: None)
+    from hermes_cli.goals import GoalManager
+
+    monkeypatch.setattr(GoalManager, "is_active", lambda _self: False)
+
+
+def _successful_turn(prompt, conversation_history):
+    history = list(conversation_history or [])
+    history.extend(
+        [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "answer"},
+        ]
+    )
+    return {
+        "final_response": "answer",
+        "messages": history,
+        "turn_exit_reason": "text_response(finish_reason=stop)",
+    }
+
+
+def test_failed_user_turn_restores_claimed_notifications_before_concurrent_arrivals(monkeypatch):
+    emitted = []
+    calls = []
+    session = None
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+        ):
+            calls.append(prompt)
+            if len(calls) == 1:
+                with session["history_lock"]:
+                    session.setdefault("deferred_notification_texts", []).append("concurrent result")
+                raise RuntimeError("agent failed")
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(
+        agent=_Agent(),
+        deferred_notification_texts=["claimed result a", "claimed result b"],
+        defer_notifications_until_user=True,
+    )
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+
+    server._run_prompt_submit("rid-1", "sid", session, "First attempt", origin="user")
+
+    assert session["deferred_notification_texts"] == [
+        "claimed result a",
+        "claimed result b",
+        "concurrent result",
+    ]
+    assert session["defer_notifications_until_user"] is True
+
+    server._run_prompt_submit("rid-2", "sid", session, "Retry", origin="user")
+
+    delivered = calls[-1]
+    for notification in ("claimed result a", "claimed result b", "concurrent result"):
+        assert delivered.count(notification) == 1
+    assert delivered.endswith("Retry")
+    assert session["deferred_notification_texts"] == []
+    assert session["defer_notifications_until_user"] is False
+
+
+def test_history_version_mismatch_restores_claimed_notifications(monkeypatch):
+    emitted = []
+    calls = []
+    session = None
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+        ):
+            calls.append(prompt)
+            if len(calls) == 1:
+                assert session is not None
+                with session["history_lock"]:
+                    session["history_version"] += 1
+                    session.setdefault("deferred_notification_texts", []).append(
+                        "arrived during mismatch"
+                    )
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(
+        agent=_Agent(),
+        deferred_notification_texts=["claimed before mismatch"],
+        defer_notifications_until_user=True,
+    )
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+
+    server._run_prompt_submit("rid-1", "sid", session, "First attempt", origin="user")
+
+    assert session["history"] == []
+    assert session["deferred_notification_texts"] == [
+        "claimed before mismatch",
+        "arrived during mismatch",
+    ]
+    assert session["defer_notifications_until_user"] is True
+
+    server._run_prompt_submit("rid-2", "sid", session, "Retry", origin="user")
+
+    delivered = calls[-1]
+    assert delivered.count("claimed before mismatch") == 1
+    assert delivered.count("arrived during mismatch") == 1
+    assert delivered.endswith("Retry")
+    assert session["deferred_notification_texts"] == []
+    assert session["defer_notifications_until_user"] is False
+
+
+def test_complete_history_adoption_without_durable_proof_restores_batch(
+    tmp_path, monkeypatch
+):
+    """Live history cannot consume an owned durable batch without DB proof."""
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-history-only"
+    )
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    event_id = "async_delegation:deleg-history-only"
+    db = SessionDB(db_path)
+    db.create_session("session-key", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "session-key",
+        event_id,
+        "claimed without proof",
+        event,
+        db_path=db_path,
+    )
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+            deferred_notification_ids=None,
+        ):
+            assert deferred_notification_ids == [event_id]
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(
+        agent=_Agent(),
+        profile_home=str(tmp_path),
+        deferred_notification_texts=["claimed without proof"],
+        deferred_notification_event_ids={event_id},
+        defer_notifications_until_user=True,
+    )
+    emitted = []
+    ack_threads = []
+
+    class _PromptOnlyThread:
+        def __init__(
+            self,
+            target=None,
+            args=(),
+            kwargs=None,
+            daemon=None,
+            name=None,
+            **_kwargs,
+        ):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+            self._name = name
+
+        def start(self):
+            if self._name:
+                ack_threads.append(self._name)
+                return
+            self._target(*self._args, **self._kwargs)
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(server.threading, "Thread", _PromptOnlyThread)
+    _patch_prompt_turn_runtime(monkeypatch, emitted, immediate_thread=False)
+
+    try:
+        server._run_prompt_submit(
+            "rid-history-only", "sid", session, "Next request", origin="user"
+        )
+
+        assert session["history"][-1] == {"role": "assistant", "content": "answer"}
+        assert session["deferred_notification_texts"] == ["claimed without proof"]
+        assert session["deferred_notification_event_ids"] == {event_id}
+        assert session["defer_notifications_until_user"] is True
+        assert ack_threads == []
+        assert _adoption_event_ids(db_path) == []
+        assert [
+            row["event_id"]
+            for row in async_delegation.load_deferred_notifications(
+                "session-key", db_path=db_path
+            )
+        ] == [event_id]
+    finally:
+        db.close()
+
+
+def test_history_version_mismatch_keeps_live_history_when_db_adoption_won(
+    tmp_path, monkeypatch
+):
+    """A committed SessionDB adoption wins over stale in-memory restoration."""
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-mismatch-adopted"
+    )
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    event_id = "async_delegation:deleg-mismatch-adopted"
+    db = SessionDB(db_path)
+    db.create_session("session-key", source="tui")
+    db.append_message("session-key", "user", "Original request")
+    assert async_delegation.persist_deferred_notification(
+        "session-key",
+        event_id,
+        "claimed durable result",
+        event,
+        db_path=db_path,
+    )
+
+    session = None
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+            deferred_notification_ids=None,
+        ):
+            assert deferred_notification_ids == [event_id]
+            db.append_message("session-key", "user", persist_user_message)
+            db.append_message(
+                "session-key",
+                "assistant",
+                "answer",
+                deferred_notification_ids=deferred_notification_ids,
+            )
+            assert session is not None
+            with session["history_lock"]:
+                session["history"].append(
+                    {"role": "assistant", "content": "newer live history"}
+                )
+                session["history_version"] += 1
+            return _successful_turn(prompt, conversation_history)
+
+    original_history = [{"role": "user", "content": "Original request"}]
+    session = _session(
+        agent=_Agent(),
+        profile_home=str(tmp_path),
+        history=list(original_history),
+        history_version=4,
+        deferred_notification_texts=["claimed durable result"],
+        deferred_notification_event_ids={event_id},
+        defer_notifications_until_user=True,
+    )
+    emitted = []
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+
+    server._run_prompt_submit(
+        "rid-mismatch", "sid", session, "Next request", origin="user"
+    )
+
+    assert session["history"] == [
+        *original_history,
+        {"role": "assistant", "content": "newer live history"},
+    ]
+    assert session["deferred_notification_texts"] == []
+    assert session["deferred_notification_event_ids"] == set()
+    assert session["defer_notifications_until_user"] is False
+    assert async_delegation.load_deferred_notifications(
+        "session-key", db_path=db_path
+    ) == []
+    assert event_id not in _adoption_event_ids(db_path)
+
+    restarted_history = db.get_messages_as_conversation("session-key")
+    db.close()
+    restarted = server._deferred_session_record(
+        "session-key",
+        cols=80,
+        cwd=".",
+        history=restarted_history,
+        lease=None,
+        profile_home=tmp_path,
+    )
+    later_prompts = []
+
+    class _LaterAgent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, conversation_history=None, **_kwargs):
+            later_prompts.append(prompt)
+            return _successful_turn(prompt, conversation_history)
+
+    restarted["agent"] = _LaterAgent()
+    assert restarted["deferred_notification_texts"] == []
+    assert restarted["defer_notifications_until_user"] is False
+
+    server._run_prompt_submit(
+        "rid-later", "sid", restarted, "Later request", origin="user"
+    )
+
+    assert later_prompts == ["Later request"]
+    assert "claimed durable result" not in later_prompts[0]
+
+
+def test_context_reference_block_restores_claimed_notifications_for_next_user_turn(monkeypatch):
+    emitted = []
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+        ):
+            calls.append(prompt)
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(
+        agent=_Agent(),
+        deferred_notification_texts=["claimed before block"],
+        defer_notifications_until_user=True,
+    )
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+
+    from agent import context_references, model_metadata
+
+    def block_context(*_args, **_kwargs):
+        with session["history_lock"]:
+            session.setdefault("deferred_notification_texts", []).append("arrived during block")
+        return types.SimpleNamespace(blocked=True, warnings=["blocked"], message="")
+
+    monkeypatch.setattr(context_references, "preprocess_context_references", block_context)
+    monkeypatch.setattr(model_metadata, "get_model_context_length", lambda *_a, **_kw: 32_000)
+
+    server._run_prompt_submit("rid-1", "sid", session, "Read @file:outside", origin="user")
+
+    assert calls == []
+    assert session["deferred_notification_texts"] == ["claimed before block", "arrived during block"]
+    assert session["defer_notifications_until_user"] is True
+
+    server._run_prompt_submit("rid-2", "sid", session, "Continue safely", origin="user")
+
+    delivered = calls[-1]
+    assert delivered.count("claimed before block") == 1
+    assert delivered.count("arrived during block") == 1
+    assert delivered.endswith("Continue safely")
+    assert session["deferred_notification_texts"] == []
+    assert session["defer_notifications_until_user"] is False
+
+
+def test_post_turn_dispatch_failure_requeues_current_and_remaining_events(monkeypatch):
+    isolated_queue = queue.Queue()
+    events = [_completion("proc-dispatch-fail-1"), _completion("proc-dispatch-fail-2")]
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(events[0], "first"), (events[1], "second")],
+    )
+    monkeypatch.setattr(
+        server,
+        "_dispatch_notification_turn",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("dispatch failed")),
+    )
+
+    server._drain_post_turn_notifications("rid", "sid", _session())
+
+    assert [isolated_queue.get_nowait(), isolated_queue.get_nowait()] == events
+    assert isolated_queue.empty()
+
+
+def test_notification_poller_retries_after_synchronous_dispatch_failure(monkeypatch):
+    isolated_queue = queue.Queue()
+    event = _completion("proc-poller-retry")
+    isolated_queue.put(event)
+    stop = threading.Event()
+    attempts = []
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(process_registry, "is_completion_consumed", lambda _session_id: False)
+    monkeypatch.setattr(server, "_notification_event_belongs_elsewhere", lambda *_args: False)
+    monkeypatch.setattr(server.time, "sleep", lambda _seconds: None)
+
+    def dispatch(*_args, **_kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("dispatch failed")
+        stop.set()
+        return "deferred"
+
+    monkeypatch.setattr(server, "_dispatch_notification_turn", dispatch)
+
+    server._notification_poller_loop(stop, "sid", _session())
+
+    assert len(attempts) == 2
+    assert isolated_queue.empty()
+
+
+def test_deferred_durable_ack_failure_retries_without_duplicate(tmp_path, monkeypatch):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-deferred-ack"
+    )
+    session = _session(
+        defer_notifications_until_user=True,
+        deferred_notification_texts=[],
+    )
+    emitted = []
+    acknowledged = threading.Event()
+    attempts = []
+    original_complete = async_delegation.complete_event_delivery
+
+    def flaky_complete(evt, claim_id):
+        attempts.append(claim_id)
+        if len(attempts) == 1:
+            raise OSError("temporary sqlite failure")
+        completed = original_complete(evt, claim_id)
+        if completed:
+            acknowledged.set()
+        return completed
+
+    monkeypatch.setattr(async_delegation, "complete_event_delivery", flaky_complete)
+    monkeypatch.setattr(server, "_NOTIFICATION_ACK_RETRY_DELAYS", (0.0,))
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    outcome = server._dispatch_notification_turn(
+        "rid",
+        "sid",
+        session,
+        "durable result",
+        event=event,
+        consumer="test-deferred",
+    )
+
+    assert outcome == "deferred"
+    assert acknowledged.wait(3)
+    assert session["deferred_notification_texts"] == ["durable result"]
+    assert session["deferred_notification_event_ids"] == {
+        "async_delegation:deleg-deferred-ack"
+    }
+    durable = async_delegation.get_durable_delegation("deleg-deferred-ack")
+    assert durable["delivery_attempts"] == 1
+    assert durable["delivery_state"] == "delivered"
+    assert durable["result"] == {"status": "completed", "summary": "done"}
+    assert durable["state"] == "completed"
+
+    assert server._dispatch_notification_turn(
+        "rid-duplicate",
+        "sid",
+        session,
+        "durable result",
+        event=event,
+        consumer="test-deferred-duplicate",
+    ) == "claimed"
+    assert session["deferred_notification_texts"] == ["durable result"]
+    assert len([item for item in emitted if item[0] == "status.update"]) == 1
+
+
+def test_deferred_durable_completion_survives_session_recreation_and_consumes_once(
+    tmp_path, monkeypatch
+):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-deferred-recreate"
+    )
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("session-key", source="tui")
+    db.close()
+
+    first_session = _session(
+        defer_notifications_until_user=True,
+        deferred_notification_texts=[],
+        profile_home=str(tmp_path),
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    assert server._dispatch_notification_turn(
+        "rid-defer",
+        "sid",
+        first_session,
+        "durable result",
+        event=event,
+        consumer="test-recreate",
+    ) == "deferred"
+    assert async_delegation.get_durable_delegation("deleg-deferred-recreate")[
+        "delivery_state"
+    ] == "delivered"
+
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+            deferred_notification_ids=None,
+        ):
+            calls.append((prompt, persist_user_message))
+            if deferred_notification_ids:
+                adoption_db = SessionDB(tmp_path / "state.db")
+                adoption_db.append_message(
+                    "session-key",
+                    "assistant",
+                    "answer",
+                    deferred_notification_ids=deferred_notification_ids,
+                )
+                adoption_db.close()
+            return _successful_turn(prompt, conversation_history)
+
+    recreated = server._deferred_session_record(
+        "session-key",
+        cols=80,
+        cwd=".",
+        history=[],
+        lease=None,
+        profile_home=tmp_path,
+    )
+    recreated["agent"] = _Agent()
+    _patch_prompt_turn_runtime(monkeypatch, [])
+
+    assert recreated["defer_notifications_until_user"] is True
+    assert recreated["deferred_notification_texts"] == ["durable result"]
+
+    server._run_prompt_submit("rid-consume", "sid", recreated, "Next request", origin="user")
+
+    assert len(calls) == 1
+    assert calls[0][0].count("durable result") == 1
+    assert calls[0][0].endswith("Next request")
+    assert calls[0][1] == "Next request"
+    assert [
+        message["content"]
+        for message in recreated["history"]
+        if message.get("role") == "user"
+    ] == ["Next request"]
+
+    recreated_again = server._deferred_session_record(
+        "session-key",
+        cols=80,
+        cwd=".",
+        history=list(recreated["history"]),
+        lease=None,
+        profile_home=tmp_path,
+    )
+    recreated_again["agent"] = _Agent()
+    assert recreated_again.get("deferred_notification_texts", []) == []
+    assert recreated_again.get("defer_notifications_until_user", False) is False
+
+    server._run_prompt_submit(
+        "rid-after-consume", "sid", recreated_again, "Later request", origin="user"
+    )
+
+    assert len(calls) == 2
+    assert calls[1] == ("Later request", None)
+    assert sum("durable result" in prompt for prompt, _persisted in calls) == 1
+
+
+def test_committed_adoption_reconciles_after_crash_before_ledger_ack(
+    tmp_path, monkeypatch
+):
+    """A restart suppresses a row whose assistant/adoption commit already won."""
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-crash-after-adoption"
+    )
+    from hermes_state import SessionDB
+
+    event_id = "async_delegation:deleg-crash-after-adoption"
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("session-key", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "session-key",
+        event_id,
+        "durable result",
+        event,
+        db_path=tmp_path / "state.db",
+    )
+    db.append_message("session-key", "user", "Next request")
+    db.append_message(
+        "session-key",
+        "assistant",
+        "answer",
+        deferred_notification_ids=[event_id],
+    )
+    db.close()
+
+    # Deterministic process-death window: transcript + adoption committed, but
+    # _ack_consumed_deferred_notifications never ran.
+    assert [
+        row["event_id"]
+        for row in async_delegation.load_deferred_notifications(
+            "session-key", db_path=tmp_path / "state.db"
+        )
+    ] == [event_id]
+
+    restarted_db = SessionDB(tmp_path / "state.db")
+    history = restarted_db.get_messages_as_conversation("session-key")
+    restarted_db.close()
+    assert [(message["role"], message["content"]) for message in history] == [
+        ("user", "Next request"),
+        ("assistant", "answer"),
+    ]
+
+    recreated = server._deferred_session_record(
+        "session-key",
+        cols=80,
+        cwd=".",
+        history=history,
+        lease=None,
+        profile_home=tmp_path,
+    )
+
+    assert recreated["deferred_notification_texts"] == []
+    assert recreated["deferred_notification_event_ids"] == set()
+    assert recreated["defer_notifications_until_user"] is False
+    assert async_delegation.load_deferred_notifications(
+        "session-key", db_path=tmp_path / "state.db"
+    ) == []
+    assert event_id not in _adoption_event_ids(tmp_path / "state.db")
+    assert async_delegation.complete_deferred_notifications(
+        "session-key", [event_id], db_path=tmp_path / "state.db"
+    )
+
+
+def test_deferred_ack_retry_survives_committed_proof_cleanup(tmp_path, monkeypatch):
+    """A lost ack return retries after the first transaction pruned its proof."""
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-ack-retry-cleanup"
+    )
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    event_id = "async_delegation:deleg-ack-retry-cleanup"
+    db = SessionDB(db_path)
+    db.create_session("session-key", source="tui")
+    assert async_delegation.persist_deferred_notification(
+        "session-key", event_id, "durable result", event, db_path=db_path
+    )
+    db.append_message(
+        "session-key",
+        "assistant",
+        "answer",
+        deferred_notification_ids=[event_id],
+    )
+    db.close()
+
+    attempts = []
+    original_complete = async_delegation.complete_deferred_notifications
+
+    def committed_then_lost(session_id, event_ids, *, db_path=None):
+        attempts.append(tuple(event_ids))
+        completed = original_complete(session_id, event_ids, db_path=db_path)
+        if len(attempts) == 1:
+            raise OSError("lost committed ack result")
+        return completed
+
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_deferred_notifications",
+        committed_then_lost,
+    )
+    monkeypatch.setattr(server, "_NOTIFICATION_ACK_RETRY_DELAYS", (0.0,))
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    server._ack_consumed_deferred_notifications(
+        _session(profile_home=str(tmp_path)), {event_id}
+    )
+
+    assert attempts == [(event_id,), (event_id,)]
+    assert async_delegation.load_deferred_notifications(
+        "session-key", db_path=db_path
+    ) == []
+    assert event_id not in _adoption_event_ids(db_path)
+
+
+def test_adoption_cleanup_is_scoped_and_does_not_accumulate(tmp_path, monkeypatch):
+    """Delivered proofs vanish; an unrelated proof is never swept with them."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+    from tools import async_delegation
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.create_session("session-key", source="tui")
+    unrelated_id = "async_delegation:unrelated-proof"
+    db.append_message(
+        "session-key",
+        "assistant",
+        "unrelated",
+        deferred_notification_ids=[unrelated_id],
+    )
+
+    for index in range(12):
+        event_id = f"async_delegation:retention-{index}"
+        event = {
+            "type": "async_delegation",
+            "delegation_id": f"retention-{index}",
+            "session_key": "session-key",
+        }
+        assert async_delegation.persist_deferred_notification(
+            "session-key",
+            event_id,
+            f"result {index}",
+            event,
+            db_path=db_path,
+        )
+        db.append_message(
+            "session-key",
+            "assistant",
+            f"answer {index}",
+            deferred_notification_ids=[event_id],
+        )
+        assert async_delegation.complete_deferred_notifications(
+            "session-key", [event_id], db_path=db_path
+        )
+        assert async_delegation.complete_deferred_notifications(
+            "session-key", [event_id], db_path=db_path
+        )
+        assert _adoption_event_ids(db_path) == [unrelated_id]
+
+    db.close()
+
+
+def test_compression_between_claim_and_ack_migrates_owner_and_delivers_once(
+    tmp_path, monkeypatch
+):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-compress-before-ack"
+    )
+    from hermes_state import SessionDB
+
+    parent = "session-key"
+    child = "session-key-compressed"
+    event_id = "async_delegation:deleg-compress-before-ack"
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(parent, source="tui")
+    db.end_session(parent, "compression")
+    db.create_session(child, source="tui", parent_session_id=parent)
+    assert async_delegation.persist_deferred_notification(
+        parent,
+        event_id,
+        "durable result",
+        event,
+        db_path=tmp_path / "state.db",
+    )
+
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = parent
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            persist_user_message=None,
+            deferred_notification_ids=None,
+        ):
+            calls.append(
+                {
+                    "prompt": prompt,
+                    "persist_user_message": persist_user_message,
+                    "ids": list(deferred_notification_ids or ()),
+                }
+            )
+            db.append_message(parent, "user", persist_user_message)
+            self.session_id = child
+            db.append_message(
+                child,
+                "assistant",
+                "answer",
+                deferred_notification_ids=deferred_notification_ids,
+            )
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(
+        agent=_Agent(),
+        profile_home=str(tmp_path),
+        deferred_notification_texts=["durable result"],
+        deferred_notification_event_ids={event_id},
+        defer_notifications_until_user=True,
+    )
+    emitted = []
+    real_sync = server._sync_session_key_after_compress
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", real_sync)
+    monkeypatch.setattr(server, "_transfer_active_session_slot", lambda *_a, **_kw: True)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_a, **_kw: None)
+
+    server._run_prompt_submit("rid", "sid", session, "Next request", origin="user")
+
+    assert len(calls) == 1
+    assert calls[0]["prompt"].count("durable result") == 1
+    assert calls[0]["persist_user_message"] == "Next request"
+    assert calls[0]["ids"] == [event_id]
+    assert session["session_key"] == child
+    assert async_delegation.load_deferred_notifications(
+        parent, db_path=tmp_path / "state.db"
+    ) == []
+    assert async_delegation.load_deferred_notifications(
+        child, db_path=tmp_path / "state.db"
+    ) == []
+    assert not async_delegation.complete_deferred_notifications(
+        parent, [event_id], db_path=tmp_path / "state.db"
+    )
+    assert async_delegation.complete_deferred_notifications(
+        child, [event_id], db_path=tmp_path / "state.db"
+    )
+
+    recreated = server._deferred_session_record(
+        child,
+        cols=80,
+        cwd=".",
+        history=list(session["history"]),
+        lease=None,
+        profile_home=tmp_path,
+    )
+    assert recreated["deferred_notification_texts"] == []
+    assert recreated["defer_notifications_until_user"] is False
+    db.close()
+
+
+def test_deferred_ack_fails_closed_for_missing_or_wrong_owner(tmp_path, monkeypatch):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-owner-fence"
+    )
+    event_id = "async_delegation:deleg-owner-fence"
+    assert async_delegation.persist_deferred_notification(
+        "session-key",
+        event_id,
+        "durable result",
+        event,
+        db_path=tmp_path / "state.db",
+    )
+
+    assert not async_delegation.complete_deferred_notifications(
+        "wrong-owner", [event_id], db_path=tmp_path / "state.db"
+    )
+    assert not async_delegation.complete_deferred_notifications(
+        "session-key", ["missing-event"], db_path=tmp_path / "state.db"
+    )
+    assert [
+        row["event_id"]
+        for row in async_delegation.load_deferred_notifications(
+            "session-key", db_path=tmp_path / "state.db"
+        )
+    ] == [event_id]
+
+
+def test_durable_claim_releases_when_turn_fails_before_acceptance(tmp_path, monkeypatch):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-before-accept"
+    )
+    session = _session()
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("start failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        server._dispatch_notification_turn(
+            "rid",
+            "sid",
+            session,
+            "durable result",
+            event=event,
+            consumer="test-before-accept",
+        )
+
+    assert session["running"] is False
+    durable = async_delegation.get_durable_delegation("deleg-before-accept")
+    assert durable["delivery_state"] == "pending"
+    retry_claim = async_delegation.claim_event_delivery(event, "test-retry")
+    assert retry_claim
+    assert async_delegation.release_event_delivery(event, retry_claim)
+
+
+def test_dispatched_durable_ack_failure_keeps_live_turn_reserved(tmp_path, monkeypatch):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-live-ack"
+    )
+    emitted = []
+    started = threading.Event()
+    finish = threading.Event()
+    acknowledged = threading.Event()
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, conversation_history=None, **_kwargs):
+            calls.append(prompt)
+            started.set()
+            if not finish.wait(3):
+                raise TimeoutError("test did not release live turn")
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(agent=_Agent())
+    _patch_prompt_turn_runtime(
+        monkeypatch,
+        emitted,
+        immediate_thread=False,
+        disable_post_turn_drain=True,
+    )
+    attempts = []
+    original_complete = async_delegation.complete_event_delivery
+
+    def flaky_complete(evt, claim_id):
+        attempts.append(claim_id)
+        if len(attempts) == 1:
+            raise OSError("temporary sqlite failure")
+        completed = original_complete(evt, claim_id)
+        if completed:
+            acknowledged.set()
+        return completed
+
+    monkeypatch.setattr(async_delegation, "complete_event_delivery", flaky_complete)
+    monkeypatch.setattr(server, "_NOTIFICATION_ACK_RETRY_DELAYS", (0.0,))
+
+    assert server._dispatch_notification_turn(
+        "rid",
+        "sid",
+        session,
+        "durable result",
+        event=event,
+        consumer="test-live",
+    ) == "dispatched"
+    run_thread = session["_run_thread"]
+
+    assert started.wait(3)
+    assert acknowledged.wait(3)
+    assert session["running"] is True
+    assert server._dispatch_notification_turn(
+        "rid-duplicate",
+        "sid",
+        session,
+        "durable result",
+        event=event,
+        consumer="test-live-duplicate",
+    ) == "busy"
+
+    finish.set()
+    run_thread.join(3)
+    assert not run_thread.is_alive()
+    assert calls == ["durable result"]
+    assert session["running"] is False
+    assert async_delegation.get_durable_delegation("deleg-live-ack")[
+        "delivery_state"
+    ] == "delivered"
+
+
+def test_notification_reservation_wins_foreground_submit_barrier(tmp_path, monkeypatch):
+    async_delegation, event = _durable_completion(
+        tmp_path, monkeypatch, "deleg-reservation-race"
+    )
+    claim_entered = threading.Event()
+    release_claim = threading.Event()
+    notification_calls = []
+    errors = []
+
+    class _ObservedLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self.waiter = threading.Event()
+
+        def __enter__(self):
+            if self._lock.locked():
+                self.waiter.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb):
+            self._lock.release()
+
+    class _Agent:
+        def __init__(self):
+            self.interrupts = 0
+
+        def interrupt(self):
+            self.interrupts += 1
+
+    observed_lock = _ObservedLock()
+    agent = _Agent()
+    session = _session(agent=agent, history_lock=observed_lock)
+    original_claim = async_delegation.claim_event_delivery
+
+    def blocked_claim(evt, consumer):
+        claim_id = original_claim(evt, consumer)
+        claim_entered.set()
+        if not release_claim.wait(3):
+            raise TimeoutError("test did not release durable claim")
+        return claim_id
+
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", blocked_claim)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *args, **kwargs: notification_calls.append((args, kwargs)),
+    )
+    server._sessions["sid-race"] = session
+    notification_result = {}
+    foreground_result = {}
+
+    def dispatch_notification():
+        try:
+            notification_result["value"] = server._dispatch_notification_turn(
+                "rid-notification",
+                "sid-race",
+                session,
+                "background result",
+                event=event,
+                consumer="test-reservation",
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def submit_foreground():
+        try:
+            foreground_result["value"] = server._methods["prompt.submit"](
+                "rid-user", {"session_id": "sid-race", "text": "user request"}
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    notification_thread = threading.Thread(target=dispatch_notification)
+    foreground_thread = threading.Thread(target=submit_foreground)
+    try:
+        notification_thread.start()
+        assert claim_entered.wait(3)
+        foreground_thread.start()
+        assert observed_lock.waiter.wait(3)
+        release_claim.set()
+        notification_thread.join(3)
+        foreground_thread.join(3)
+
+        assert not errors
+        assert notification_result["value"] == "dispatched"
+        assert foreground_result["value"]["result"]["status"] == "queued"
+        assert session["queued_prompt"]["text"] == "user request"
+        assert agent.interrupts == 1
+        assert len(notification_calls) == 1
+        assert notification_calls[0][1]["origin"] == "notification"
+        assert async_delegation.get_durable_delegation("deleg-reservation-race")[
+            "delivery_state"
+        ] == "delivered"
+    finally:
+        release_claim.set()
+        notification_thread.join(3)
+        foreground_thread.join(3)
+        server._sessions.pop("sid-race", None)
+
+
+def test_delayed_final_session_info_keeps_older_generation(monkeypatch):
+    emitted = []
+    old_info_waiting = threading.Event()
+    release_old_info = threading.Event()
+    second_started = threading.Event()
+    release_second = threading.Event()
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, conversation_history=None, **_kwargs):
+            calls.append(prompt)
+            if len(calls) == 2:
+                second_started.set()
+                if not release_second.wait(3):
+                    raise TimeoutError("test did not release second turn")
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(agent=_Agent(), running=True)
+    _patch_prompt_turn_runtime(
+        monkeypatch,
+        emitted,
+        immediate_thread=False,
+        disable_post_turn_drain=True,
+    )
+
+    def barrier_emit(event_type, sid, payload=None):
+        if (
+            event_type == "session.info"
+            and payload.get("turn_generation") == 1
+            and payload.get("running") is False
+        ):
+            old_info_waiting.set()
+            if not release_old_info.wait(3):
+                raise TimeoutError("test did not release stale session.info")
+        emitted.append((event_type, sid, payload or {}))
+
+    monkeypatch.setattr(server, "_emit", barrier_emit)
+
+    server._run_prompt_submit("rid-1", "sid", session, "first", origin="user")
+    first_thread = session["_run_thread"]
+    assert old_info_waiting.wait(3)
+
+    with session["history_lock"]:
+        assert session["running"] is False
+        session["running"] = True
+    server._run_prompt_submit("rid-2", "sid", session, "second", origin="notification")
+    second_thread = session["_run_thread"]
+    assert second_started.wait(3)
+
+    start_two = next(
+        event
+        for event in emitted
+        if event[0] == "message.start" and event[2].get("turn_generation") == 2
+    )
+    assert start_two[2]["turn_origin"] == "notification"
+    assert not [
+        event
+        for event in emitted
+        if event[0] == "session.info" and event[2].get("turn_generation") == 1
+    ]
+
+    release_old_info.set()
+    release_second.set()
+    first_thread.join(3)
+    second_thread.join(3)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    stale_info_index = next(
+        index
+        for index, event in enumerate(emitted)
+        if event[0] == "session.info" and event[2].get("turn_generation") == 1
+    )
+    start_two_index = emitted.index(start_two)
+    assert start_two_index < stale_info_index
+    stale_info = emitted[stale_info_index][2]
+    assert stale_info["running"] is False
+    assert stale_info["turn_origin"] is None
+
+
+def test_live_session_reconnect_preserves_and_settles_turn_generation(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="test-model",
+        provider="test-provider",
+        session_id="session-key",
+    )
+    session = _session(agent=agent)
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    with session["history_lock"]:
+        session["running"] = True
+        turn_token = server._set_turn_origin_locked(session, "notification")
+
+    active = server._live_session_payload("sid", session)
+    assert active["running"] is True
+    assert active["info"]["running"] is True
+    assert active["info"]["turn_generation"] == turn_token
+    assert active["info"]["turn_state_revision"] == 1
+    assert active["info"]["turn_origin"] == "notification"
+
+    with session["history_lock"]:
+        session["running"] = False
+        assert server._clear_turn_origin_locked(session, turn_token)
+
+    settled = server._live_session_payload("sid", session)
+    assert settled["running"] is False
+    assert settled["info"]["running"] is False
+    assert settled["info"]["turn_generation"] == turn_token
+    assert settled["info"]["turn_state_revision"] == 2
+    assert settled["info"]["turn_origin"] is None
+
+
+def test_message_events_advance_turn_state_revision_on_start_and_settle(monkeypatch):
+    emitted = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, conversation_history=None, **_kwargs):
+            return _successful_turn(prompt, conversation_history)
+
+    session = _session(agent=_Agent(), running=True)
+    _patch_prompt_turn_runtime(monkeypatch, emitted)
+
+    server._run_prompt_submit("rid", "sid", session, "hello", origin="user")
+
+    start = next(payload for event, _sid, payload in emitted if event == "message.start")
+    complete = next(
+        payload for event, _sid, payload in emitted if event == "message.complete"
+    )
+    settled = [
+        payload for event, _sid, payload in emitted if event == "session.info"
+    ][-1]
+    assert start["turn_generation"] == complete["turn_generation"] == 1
+    assert start["turn_state_revision"] == 1
+    assert complete["turn_state_revision"] == 2
+    assert settled["turn_state_revision"] == 2
+    assert settled["running"] is False
+
+
+def test_notification_preemption_drains_user_before_later_completion(monkeypatch):
+    isolated_queue = queue.Queue()
+    emitted = []
+    first_started = threading.Event()
+    release_first = threading.Event()
+    third_settled = threading.Event()
+    calls = []
+
+    class _Agent:
+        model = "test-model"
+        provider = "test-provider"
+        base_url = ""
+        api_key = ""
+        service_tier = ""
+        session_id = "session-key"
+
+        def __init__(self):
+            self.interrupts = 0
+
+        def clear_interrupt(self):
+            return None
+
+        def interrupt(self):
+            self.interrupts += 1
+
+        def run_conversation(self, prompt, conversation_history=None, **_kwargs):
+            calls.append(prompt)
+            if len(calls) == 1:
+                first_started.set()
+                if not release_first.wait(3):
+                    raise TimeoutError("test did not release notification turn")
+                result = _successful_turn(prompt, conversation_history)
+                result["interrupted"] = True
+                return result
+            return _successful_turn(prompt, conversation_history)
+
+    agent = _Agent()
+    session = _session(agent=agent)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    _patch_prompt_turn_runtime(
+        monkeypatch,
+        emitted,
+        immediate_thread=False,
+        disable_post_turn_drain=False,
+    )
+
+    def recording_emit(event_type, sid, payload=None):
+        emitted.append((event_type, sid, payload or {}))
+        if (
+            event_type == "session.info"
+            and payload.get("turn_generation") == 3
+            and payload.get("running") is False
+        ):
+            third_settled.set()
+
+    monkeypatch.setattr(server, "_emit", recording_emit)
+    process_registry._completion_consumed.discard("proc-after-user")
+    server._sessions["sid"] = session
+    try:
+        assert server._dispatch_notification_turn(
+            "rid-notification",
+            "sid",
+            session,
+            "first background result",
+        ) == "dispatched"
+        assert first_started.wait(3)
+
+        response = server._methods["prompt.submit"](
+            "rid-user", {"session_id": "sid", "text": "foreground request"}
+        )
+        assert response["result"]["status"] == "queued"
+        assert agent.interrupts == 1
+
+        isolated_queue.put(_completion("proc-after-user"))
+        release_first.set()
+        assert third_settled.wait(5)
+        latest_thread = session["_run_thread"]
+        latest_thread.join(3)
+
+        assert calls[0] == "first background result"
+        assert calls[1] == "foreground request"
+        assert "proc-after-user" in calls[2]
+        assert len(calls) == 3
+        starts = [event[2] for event in emitted if event[0] == "message.start"]
+        assert [event["turn_origin"] for event in starts] == [
+            "notification",
+            "user",
+            "notification",
+        ]
+        assert [event["turn_generation"] for event in starts] == [1, 2, 3]
+        assert isolated_queue.empty()
+        assert session["running"] is False
+    finally:
+        release_first.set()
+        run_thread = session.get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(3)
+        server._sessions.pop("sid", None)
+        process_registry._completion_consumed.discard("proc-after-user")

--- a/tests/tui_gateway/test_turn_origin_notifications.py
+++ b/tests/tui_gateway/test_turn_origin_notifications.py
@@ -974,7 +974,7 @@ def test_deferred_durable_completion_survives_session_recreation_and_consumes_on
     )
 
     assert len(calls) == 2
-    assert calls[1] == ("Later request", None)
+    assert calls[1] == ("Later request", "Later request")
     assert sum("durable result" in prompt for prompt, _persisted in calls) == 1
 
 
@@ -1195,8 +1195,12 @@ def test_compression_between_claim_and_ack_migrates_owner_and_delivers_once(
                     "ids": list(deferred_notification_ids or ()),
                 }
             )
-            db.append_message(parent, "user", persist_user_message)
             self.session_id = child
+            db.append_message(
+                child,
+                "user",
+                persist_user_message,
+            )
             db.append_message(
                 child,
                 "assistant",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -125,8 +125,8 @@ def _db_path():
     return get_hermes_home() / "state.db"
 
 
-def _connect() -> sqlite3.Connection:
-    path = _db_path()
+def _connect(db_path=None) -> sqlite3.Connection:
+    path = db_path or _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=10)
     try:
@@ -181,10 +181,45 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    # Second-stage delivery ledger. A terminal async-delegation event is
+    # acknowledged once its payload is safely parked here; the row itself stays
+    # pending until a later explicit user turn adopts it into conversation
+    # history. CREATE IF NOT EXISTS is the migration for existing state.db files.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS deferred_notifications (
+            event_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            event_json TEXT,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            delivered_at REAL
+        )"""
+    )
+    # Durable proof that a deferred payload was adopted by a completed
+    # transcript turn. SessionDB writes this row in the same transaction as
+    # the closing assistant message, so recovery can close the later ack gap.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS deferred_notification_adoptions (
+            event_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            adopted_at REAL NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_deferred_notification_adoptions_session
+           ON deferred_notification_adoptions(session_id, adopted_at)"""
+    )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_deferred_notifications_session
+           ON deferred_notifications(session_id, delivery_state, created_at, event_id)"""
+    )
 
 
 @contextmanager
-def _transaction() -> Iterator[sqlite3.Connection]:
+def _transaction(db_path=None) -> Iterator[sqlite3.Connection]:
     """Open a connection, commit/rollback on exit, and ALWAYS close it.
 
     ``sqlite3.Connection.__enter__``/``__exit__`` only commit or roll back the
@@ -194,7 +229,7 @@ def _transaction() -> Iterator[sqlite3.Connection]:
     to the garbage collector. On a long-running gateway that exhausts
     ``RLIMIT_NOFILE`` (the cron-ledger sibling of this bug was #69567 / PR #69594).
     """
-    conn = _connect()
+    conn = _connect(db_path)
     try:
         with conn:
             yield conn
@@ -282,6 +317,10 @@ def _prune_durable_records() -> None:
             "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
             (cutoff,),
         )
+        conn.execute(
+            "DELETE FROM deferred_notifications WHERE delivery_state='delivered' AND updated_at < ?",
+            (cutoff,),
+        )
         terminal_count = conn.execute(
             "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
         ).fetchone()[0]
@@ -332,7 +371,7 @@ def _note_delivery_attempt(delegation_id: str) -> None:
         )
 
 
-def recover_abandoned_delegations() -> int:
+def recover_abandoned_delegations(*, db_path=None) -> int:
     """Classify records whose owning process disappeared as outcome unknown."""
     try:
         from gateway.status import _pid_exists, get_process_start_time
@@ -340,7 +379,7 @@ def recover_abandoned_delegations() -> int:
         return 0
     now = time.time()
     recovered = 0
-    with _DB_LOCK, _transaction() as conn:
+    with _DB_LOCK, _transaction(db_path) as conn:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
@@ -389,7 +428,7 @@ def recover_abandoned_delegations() -> int:
     return recovered
 
 
-def restore_undelivered_completions(target_queue) -> int:
+def restore_undelivered_completions(target_queue, *, db_path=None) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
 
     Every restored event is stamped ``restored=True`` (in-memory only — the
@@ -408,10 +447,10 @@ def restore_undelivered_completions(target_queue) -> int:
     102K-token context on the staging fleet) for a result nobody is waiting
     on anymore; the payload stays queryable on the dropped row.
     """
-    recover_abandoned_delegations()
+    recover_abandoned_delegations(db_path=db_path)
     now = time.time()
     restored = 0
-    with _DB_LOCK, _transaction() as conn:
+    with _DB_LOCK, _transaction(db_path) as conn:
         rows = conn.execute(
             """SELECT delegation_id, event_json, completed_at, dispatched_at
                FROM async_delegations
@@ -546,7 +585,7 @@ def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 
 def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
-    """Acknowledge acceptance for the consumer holding this claim."""
+    """Idempotently acknowledge acceptance for the consumer holding this claim."""
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
@@ -557,17 +596,271 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+        # Missing rows are legacy queue events created before durable dispatch.
+        # A retry after a committed ack is also success, not a reason to release
+        # and reinject the already-visible completion.
+        return row is None or row[0] == "delivered"
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return True
+    return complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return True
+    return release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+
+
+def persist_deferred_notification(
+    session_id: str,
+    event_id: str,
+    payload: str,
+    event: Dict[str, Any],
+    *,
+    db_path=None,
+) -> bool:
+    """Durably park a completion before acknowledging its terminal event.
+
+    Returns true while the payload still needs a user-turn delivery. Repeated
+    queue publication is idempotent by ``event_id`` and never rewrites the
+    originally accepted payload.
+    """
+    now = time.time()
+    with _DB_LOCK, _connect(db_path) as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO deferred_notifications
+               (event_id, session_id, payload, event_json, delivery_state,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, 'pending', ?, ?)""",
+            (event_id, session_id, payload, json.dumps(event), now, now),
+        )
+        row = conn.execute(
+            "SELECT delivery_state FROM deferred_notifications WHERE event_id=?",
+            (event_id,),
+        ).fetchone()
+        return row is not None and row[0] == "pending"
+
+
+def reconcile_adopted_deferred_notifications(*, db_path=None) -> int:
+    """Finish adopted ledger rows and retire the proof in one transaction."""
+    now = time.time()
+    with _DB_LOCK, _connect(db_path) as conn:
+        cur = conn.execute(
+            """UPDATE deferred_notifications AS deferred
+                  SET delivery_state='delivered', delivered_at=?, updated_at=?
+                WHERE delivery_state='pending'
+                  AND EXISTS (
+                      SELECT 1 FROM deferred_notification_adoptions AS adoption
+                       WHERE adoption.event_id=deferred.event_id
+                         AND adoption.session_id=deferred.session_id
+                  )""",
+            (now, now),
+        )
+        conn.execute(
+            """DELETE FROM deferred_notification_adoptions
+                WHERE EXISTS (
+                    SELECT 1 FROM deferred_notifications AS deferred
+                     WHERE deferred.event_id=deferred_notification_adoptions.event_id
+                       AND deferred.session_id=deferred_notification_adoptions.session_id
+                       AND deferred.delivery_state='delivered'
+                )"""
+        )
+        return cur.rowcount
+
+
+def migrate_deferred_notifications(
+    old_session_id: str,
+    new_session_id: str,
+    *,
+    db_path=None,
+) -> bool:
+    """Idempotently move pending ownership across a compression rotation."""
+    old_owner = str(old_session_id or "")
+    new_owner = str(new_session_id or "")
+    if not old_owner or not new_owner:
+        return False
+    if old_owner == new_owner:
+        return True
+    now = time.time()
+    with _DB_LOCK, _connect(db_path) as conn:
+        conn.execute(
+            """UPDATE deferred_notifications
+                  SET session_id=?, updated_at=?
+                WHERE session_id=? AND delivery_state='pending'""",
+            (new_owner, now, old_owner),
+        )
+        stranded = conn.execute(
+            """SELECT COUNT(*) FROM deferred_notifications
+                WHERE session_id=? AND delivery_state='pending'""",
+            (old_owner,),
+        ).fetchone()[0]
+    return stranded == 0
+
+
+def migrate_compression_lineage_deferred_notifications(
+    session_id: str,
+    *,
+    db_path=None,
+) -> int:
+    """Recover pending rows left on compressed ancestors of ``session_id``."""
+    owner = str(session_id or "")
+    if not owner:
+        return 0
+    now = time.time()
+    with _DB_LOCK, _connect(db_path) as conn:
+        try:
+            cur = conn.execute(
+                """WITH RECURSIVE compression_lineage(id) AS (
+                       SELECT ?
+                       UNION ALL
+                       SELECT child.parent_session_id
+                         FROM sessions AS child
+                         JOIN compression_lineage AS lineage ON child.id = lineage.id
+                         JOIN sessions AS parent ON parent.id = child.parent_session_id
+                        WHERE parent.end_reason = 'compression'
+                          AND child.parent_session_id IS NOT NULL
+                   )
+                   UPDATE deferred_notifications
+                      SET session_id=?, updated_at=?
+                    WHERE delivery_state='pending'
+                      AND session_id IN (SELECT id FROM compression_lineage)
+                      AND session_id != ?""",
+                (owner, owner, now, owner),
+            )
+        except sqlite3.OperationalError as exc:
+            if "no such table: sessions" not in str(exc).lower():
+                raise
+            return 0
+        return cur.rowcount
+
+
+def deferred_notifications_adopted_or_delivered(
+    session_id: str,
+    event_ids,
+    *,
+    db_path=None,
+) -> bool:
+    """Return true when an owned batch has proof or is already delivered."""
+    ids = sorted({str(event_id) for event_id in event_ids if event_id})
+    if not ids:
+        return True
+    owner = str(session_id or "")
+    if not owner:
+        return False
+    placeholders = ",".join("?" for _ in ids)
+    with _DB_LOCK, _connect(db_path) as conn:
+        rows = conn.execute(
+            f"""SELECT deferred.event_id, deferred.session_id,
+                       deferred.delivery_state,
+                       EXISTS (
+                           SELECT 1
+                             FROM deferred_notification_adoptions AS adoption
+                            WHERE adoption.event_id=deferred.event_id
+                              AND adoption.session_id=deferred.session_id
+                       )
+                  FROM deferred_notifications AS deferred
+                 WHERE deferred.event_id IN ({placeholders})""",
+            tuple(ids),
+        ).fetchall()
+    return (
+        len(rows) == len(ids)
+        and all(row[1] == owner for row in rows)
+        and all(row[2] == "delivered" or bool(row[3]) for row in rows)
+    )
+
+
+def load_deferred_notifications(session_id: str, *, db_path=None) -> List[Dict[str, Any]]:
+    """Return this durable session's not-yet-consumed completion payloads."""
+    with _DB_LOCK, _connect(db_path) as conn:
+        rows = conn.execute(
+            """SELECT event_id, payload, event_json
+               FROM deferred_notifications
+               WHERE session_id=? AND delivery_state='pending'
+               ORDER BY created_at, event_id""",
+            (session_id,),
+        ).fetchall()
+    return [
+        {
+            "event_id": event_id,
+            "payload": payload,
+            "event": json.loads(event_json) if event_json else None,
+        }
+        for event_id, payload, event_json in rows
+    ]
+
+
+def complete_deferred_notifications(
+    session_id: str,
+    event_ids,
+    *,
+    db_path=None,
+) -> bool:
+    """Durably deliver one adopted batch and retire its transcript proof.
+
+    Pending rows require matching adoption proof. Already-delivered rows remain
+    idempotent for the same owner after that proof has been pruned. Missing rows
+    and rows owned by another session fail closed.
+    """
+    ids = sorted({str(event_id) for event_id in event_ids if event_id})
+    if not ids:
+        return True
+    owner = str(session_id or "")
+    if not owner:
+        return False
+    now = time.time()
+    placeholders = ",".join("?" for _ in ids)
+    with _DB_LOCK, _connect(db_path) as conn:
+        rows = conn.execute(
+            f"""SELECT event_id, session_id, delivery_state
+                  FROM deferred_notifications
+                 WHERE event_id IN ({placeholders})""",
+            tuple(ids),
+        ).fetchall()
+        if len(rows) != len(ids) or any(row[1] != owner for row in rows):
+            return False
+
+        pending_ids = [row[0] for row in rows if row[2] == "pending"]
+        if pending_ids:
+            pending_placeholders = ",".join("?" for _ in pending_ids)
+            proof_count = conn.execute(
+                f"""SELECT COUNT(*) FROM deferred_notification_adoptions
+                      WHERE session_id=?
+                        AND event_id IN ({pending_placeholders})""",
+                (owner, *pending_ids),
+            ).fetchone()[0]
+            if proof_count != len(pending_ids):
+                return False
+            conn.execute(
+                f"""UPDATE deferred_notifications
+                       SET delivery_state='delivered', delivered_at=?, updated_at=?
+                     WHERE session_id=? AND delivery_state='pending'
+                       AND event_id IN ({pending_placeholders})""",
+                (now, now, owner, *pending_ids),
+            )
+
+        delivered = conn.execute(
+            f"""SELECT COUNT(*) FROM deferred_notifications
+                  WHERE session_id=? AND delivery_state='delivered'
+                    AND event_id IN ({placeholders})""",
+            (owner, *ids),
+        ).fetchone()[0]
+        if delivered != len(ids):
+            return False
+        conn.execute(
+            f"""DELETE FROM deferred_notification_adoptions
+                  WHERE session_id=? AND event_id IN ({placeholders})""",
+            (owner, *ids),
+        )
+        return True
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -453,6 +453,8 @@ class ProcessRegistry:
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
+        self._completion_restore_lock = threading.Lock()
+        self._restored_completion_homes: set[str] = set()
 
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
@@ -463,13 +465,9 @@ class ProcessRegistry:
         # gateway drain this after each agent turn to auto-trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
-        # Rehydrate durable delegation completions only at registry startup.
-        # Consumers still inject them as fresh turns through this existing rail.
-        try:
-            from tools.async_delegation import restore_undelivered_completions
-            restore_undelivered_completions(self.completion_queue)
-        except Exception as exc:
-            logger.warning("Could not restore async delegation completions: %s", exc)
+        # The launch profile is active immediately. Additional profile homes
+        # are restored lazily by the gateway when that profile is activated.
+        self.restore_profile_home(get_hermes_home())
 
         # Track sessions whose completion was already consumed by the agent
         # via wait/log.  Drain loops AND gateway/tui watchers skip notifications
@@ -504,6 +502,35 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    def restore_profile_home(self, profile_home) -> int:
+        """Restore one profile's durable completions once per process.
+
+        The lock covers both the scanned-home check and queue publication, so
+        concurrent create/resume calls cannot enqueue the same durable rows
+        twice. A failed scan is not memoized and can be retried on activation.
+        """
+        home = Path(profile_home or get_hermes_home()).expanduser().resolve()
+        home_key = str(home)
+        with self._completion_restore_lock:
+            if home_key in self._restored_completion_homes:
+                return 0
+            try:
+                from tools.async_delegation import restore_undelivered_completions
+
+                restored = restore_undelivered_completions(
+                    self.completion_queue,
+                    db_path=home / "state.db",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Could not restore async delegation completions for %s: %s",
+                    home,
+                    exc,
+                )
+                return 0
+            self._restored_completion_homes.add(home_key)
+            return restored
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -908,7 +908,7 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(rid, sid, session, text, origin="user", display_kind=display_kind)
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,7 +16,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Literal, NamedTuple, Optional
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -53,6 +53,14 @@ from tui_gateway.transport import (
 )
 
 logger = logging.getLogger(__name__)
+
+TurnOrigin = Literal["user", "notification", "goal"]
+_TURN_ORIGINS = frozenset({"user", "notification", "goal"})
+
+# Ack-retry backoff for durable notification/completion acks: a transient
+# sqlite/IO failure on the ack path must be retried with capped delays
+# before the delivery is surfaced as failed (#63671 durable-ack recovery).
+_NOTIFICATION_ACK_RETRY_DELAYS = (0.05, 0.25, 1.0, 5.0, 15.0, 30.0)
 
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
@@ -1821,7 +1829,6 @@ def _transfer_db_to_agent(agent, db) -> bool:
     except Exception:
         return False
 
-
 @contextlib.contextmanager
 def _profile_db(params: dict | None = None):
     """Yield the SessionDB for ``params['profile']`` (app-global remote mode).
@@ -2680,8 +2687,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
-        session_db = None
-        owns_db = False
         profile_home = current.get("profile_home")
         try:
             history_ready = current.get("resume_history_ready")
@@ -2709,12 +2714,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 try:
                     from hermes_state import SessionDB
 
-                    # DEDICATED handle — ours until _transfer_db_to_agent hands
-                    # it to the built agent in the finally below. Every path
-                    # that leaves this build without that transfer (the except
-                    # below, and a session reaped mid-build) must close it.
                     session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-                    owns_db = True
                 except Exception:
                     session_db = None
 
@@ -2858,18 +2858,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     unregister_gateway_notify(key)
                 except Exception:
                     pass
-            # Dedicated profile handle: hand it to the agent that will actually
-            # be torn down, or close it here when no such agent exists. Both
-            # non-transfer cases are real: the except above (build raised, so
-            # nothing holds the handle) and `replaced` (the session was reaped
-            # mid-build, so this agent is discarded and _teardown_session will
-            # never reach it). Transferring to a discarded agent would leak the
-            # handle exactly as before.
-            if owns_db and session_db is not None:
-                built = None if replaced else current.get("agent")
-                if not _transfer_db_to_agent(built, session_db):
-                    with contextlib.suppress(Exception):
-                        session_db.close()
             ready.set()
 
     build_thread = threading.Thread(target=_build, daemon=True)
@@ -2993,23 +2981,6 @@ def _terminal_task_cwd(session: dict | None) -> str:
     resolution path is taken even when the dashboard entrypoint did not call
     ``apply_terminal_config_to_env`` on its own ``os.environ``.
     """
-    return _terminal_task_cwd_with_source(session)[0]
-
-
-def _terminal_task_cwd_with_source(session: dict | None) -> tuple[str, str]:
-    """Like :func:`_terminal_task_cwd` but also names the value's ORIGIN.
-
-    Returns ``(cwd, source)`` where source is:
-
-    * ``"session"`` — the workspace the user attached to THIS session
-      (``explicit_cwd``), or this session's own tracked directory.
-    * ``"process"`` — the process-global ``TERMINAL_CWD`` env var / config
-      ``terminal.cwd`` fallback.  On a shared-container backend this is the
-      normal seed; under per-session docker isolation it is a launch
-      artifact from a PREVIOUS session (the workspace picker persists it
-      process-wide) and must never become a fresh session's bind mount —
-      terminal_tool refuses ``cwd_source: "process"`` as a mount source.
-    """
     backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
     if not backend or backend == "local":
         # Fall back to config when TERMINAL_ENV is unset (dashboard/TUI process
@@ -3024,11 +2995,6 @@ def _terminal_task_cwd_with_source(session: dict | None) -> tuple[str, str]:
             pass
 
     if backend and backend != "local":
-        # A workspace the user explicitly attached to THIS session wins over
-        # the process-global env var — the env var is whatever the LAST
-        # session's picker wrote, not this session's choice.
-        if session and session.get("explicit_cwd") and session.get("cwd"):
-            return str(session["cwd"]), "session"
         raw = os.environ.get("TERMINAL_CWD", "").strip()
         if not raw:
             try:
@@ -3038,13 +3004,9 @@ def _terminal_task_cwd_with_source(session: dict | None) -> tuple[str, str]:
             except Exception:
                 raw = ""
         if raw and raw not in {".", "auto", "cwd"}:
-            return raw, "process"
-        if backend == "ssh":
-            return "~", "process"
+            return raw
 
-    if session and session.get("cwd"):
-        return str(session["cwd"]), "session"
-    return _completion_cwd(), "process"
+    return _session_cwd(session)
 
 
 # Git working-tree probing (run git, resolve roots, fold worktrees) lives in a
@@ -3127,27 +3089,6 @@ def _heal_dead_cwd(cwd: str) -> str:
 def _is_local_terminal_backend() -> bool:
     backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
     return not backend or backend == "local"
-
-
-def _effective_terminal_backend() -> str:
-    """Active terminal backend name (``local``, ``docker``, ``ssh``, ...).
-
-    ``TERMINAL_ENV`` is authoritative when set (launchers bridge
-    ``terminal.backend`` into env at startup). Desktop/TUI in-process gateways
-    skip that bridge, so fall back to the ``terminal.backend`` config key —
-    the same rule ``_terminal_task_cwd`` uses.
-    """
-    backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
-    if not backend or backend == "local":
-        try:
-            terminal_cfg = _load_cfg().get("terminal", {})
-            if isinstance(terminal_cfg, dict):
-                cfg_backend = str(terminal_cfg.get("backend") or "").strip().lower()
-                if cfg_backend and cfg_backend != "local":
-                    backend = cfg_backend
-        except Exception:
-            pass
-    return backend or "local"
 
 
 def _display_session_cwd(session: dict | None) -> str:
@@ -3281,9 +3222,8 @@ def _register_session_cwd(session: dict | None) -> None:
     try:
         from tools.terminal_tool import register_task_env_overrides
 
-        cwd, cwd_source = _terminal_task_cwd_with_source(session)
         register_task_env_overrides(
-            session["session_key"], {"cwd": cwd, "cwd_source": cwd_source}
+            session["session_key"], {"cwd": _terminal_task_cwd(session)}
         )
     except Exception:
         pass
@@ -3912,18 +3852,10 @@ def _apply_managed(cfg: dict) -> dict:
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
 
-    from utils import atomic_roundtrip_yaml_save
+    from hermes_cli.config import atomic_config_write
 
     path = _hermes_home / "config.yaml"
-    # Comment-, ordering-, and Unicode-preserving full-state write.
-    # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
-    # `atomic_config_write`, which is not comment-preserving) which clobbered
-    # the user's hand-written config every time we touched a single setting
-    # (top-level keys reordered alphabetically, comments dropped, kaomoji
-    # mangled to \\uXXXX escapes). Fails closed on an unreadable existing
-    # config.yaml the same way atomic_config_write does (see
-    # atomic_roundtrip_yaml_save's require_readable_config_before_write call).
-    atomic_roundtrip_yaml_save(path, cfg)
+    atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path
@@ -6023,6 +5955,30 @@ def _sync_session_key_after_compress(
     if not new_session_id or new_session_id == old_key:
         return
 
+    try:
+        from tools.async_delegation import migrate_deferred_notifications
+
+        if not migrate_deferred_notifications(
+            old_key,
+            new_session_id,
+            db_path=_deferred_notification_db_path(session),
+        ):
+            logger.warning(
+                "Compression left deferred notification ownership on parent: "
+                "old_session_id=%s new_session_id=%s",
+                old_key,
+                new_session_id,
+            )
+    except Exception:
+        # The transcript lineage remains authoritative. Cold-session hydration
+        # retries this migration before loading pending rows.
+        logger.exception(
+            "Could not migrate deferred notification ownership after compression: "
+            "old_session_id=%s new_session_id=%s",
+            old_key,
+            new_session_id,
+        )
+
     lease_reanchored = _transfer_active_session_slot(
         sid,
         session,
@@ -6188,19 +6144,16 @@ def _probe_config_health(cfg: dict) -> str:
     agent_cfg = cfg.get("agent")
     if isinstance(display_cfg, dict):
         personality = str(display_cfg.get("personality", "") or "").strip().lower()
-        if personality and personality not in {"default", "none", "neutral"}:
-            try:
-                from hermes_cli.personality import available_personalities
-
-                if personality not in available_personalities(cfg):
-                    warnings.append(
-                        f"`display.personality: {personality}` does not match any "
-                        "built-in or `agent.personalities` entry; personality "
-                        "overlay will be skipped."
-                    )
-            except Exception:
-                pass
-    _ = agent_cfg  # retained for shape parity; built-ins exist without config
+        if (
+            personality
+            and personality not in {"default", "none", "neutral"}
+            and isinstance(agent_cfg, dict)
+            and agent_cfg.get("personalities") is None
+        ):
+            warnings.append(
+                "`display.personality` is set but `agent.personalities` is empty/null; "
+                "personality overlay will be skipped."
+            )
     return " ".join(warnings).strip()
 
 
@@ -6265,7 +6218,12 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
         return None
 
 
-def _session_info(agent, session: dict | None = None) -> dict:
+def _session_info(
+    agent,
+    session: dict | None = None,
+    *,
+    turn_snapshot: Optional[dict] = None,
+) -> dict:
     if session is None:
         for candidate in _sessions.values():
             if candidate.get("agent") is agent:
@@ -6276,6 +6234,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
+    turn_state = turn_snapshot or _turn_state_snapshot_locked(session)
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
@@ -6340,9 +6299,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
-        "terminal_backend": _effective_terminal_backend(),
         "personality": str(personality or ""),
-        "running": bool((session or {}).get("running")),
+        "running": bool(turn_state["running"]),
         "turn_started_at": turn_started_at,
         "title": _session_live_title(session or {}, session_key) if session_key else "",
         "stored_session_id": session_key or "",
@@ -6360,6 +6318,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
         if isinstance(session, dict) and session.get("profile_home")
         else _current_profile_name(),
     }
+    info["turn_origin"] = turn_state["turn_origin"]
+    info["turn_generation"] = int(turn_state["turn_generation"])
+    info["turn_state_revision"] = int(turn_state["turn_state_revision"])
     try:
         from hermes_cli import __version__, __release_date__
 
@@ -6593,18 +6554,11 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
-        payload: dict[str, object] = {
+        payload = {
             "tool_id": tool_call_id,
             "name": name,
             "context": _tool_ctx(name, args),
         }
-        # The desktop renders the expanded tool row (the `$` transcript) from
-        # the args of the part, and `context` is an 80-char display preview.
-        # tool.complete already ships full args to every client. When
-        # tool.start ships them too, the expanded row is complete while the
-        # tool runs, at the cost of one duplicate transient payload per call.
-        if args:
-            payload["args"] = args
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:
@@ -7114,51 +7068,60 @@ def _wire_callbacks(sid: str):
 
 
 def _render_personality_prompt(value) -> str:
-    """Delegates to hermes_cli.personality (single owner of rendering)."""
-    from hermes_cli.personality import render_personality_prompt
-
-    return render_personality_prompt(value)
+    if isinstance(value, dict):
+        parts = [value.get("system_prompt", "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(p for p in parts if p)
+    return str(value)
 
 
 def _available_personalities(cfg: dict | None = None) -> dict:
-    """Built-ins + user overrides, via hermes_cli.personality (single owner)."""
-    from hermes_cli.personality import available_personalities
+    try:
+        from cli import load_cli_config
 
-    if cfg is None:
-        cfg = _load_cfg()
-    return available_personalities(cfg)
+        return (load_cli_config().get("agent") or {}).get("personalities", {}) or {}
+    except Exception:
+        try:
+            from hermes_cli.config import load_config as _load_full_cfg
+
+            return (_load_full_cfg().get("agent") or {}).get("personalities", {}) or {}
+        except Exception:
+            cfg = cfg or _load_cfg()
+            return (cfg.get("agent") or {}).get("personalities", {}) or {}
 
 
 def _validate_personality(value: str, cfg: dict | None = None) -> tuple[str, str]:
-    """Resolve a requested personality against _available_personalities.
-
-    Same contract as hermes_cli.personality.resolve_personality — (name,
-    prompt) or ValueError — but resolves through the module-level
-    _available_personalities so tests (and future gateway-side overrides)
-    keep a single patch point.
-    """
-    from hermes_cli.personality import normalize_personality_name
-
-    name = normalize_personality_name(value)
-    if not name:
+    raw = str(value or "").strip()
+    name = raw.lower()
+    if not name or name in {"none", "default", "neutral"}:
         return "", ""
+
     personalities = _available_personalities(cfg)
     if name not in personalities:
-        names = ", ".join(f"`{n}`" for n in sorted(personalities))
-        raise ValueError(
-            f"Unknown personality: `{str(value).strip()}`.\n\nAvailable: `none`, {names}"
-        )
+        names = sorted(personalities)
+        available = ", ".join(f"`{n}`" for n in names)
+        base = f"Unknown personality: `{raw}`."
+        if available:
+            base += f"\n\nAvailable: `none`, {available}"
+        else:
+            base += "\n\nNo personalities configured."
+        raise ValueError(base)
+
     return name, _render_personality_prompt(personalities[name])
 
 
 def _prompt_text(value) -> str:
-    """Normalize config prompt values from YAML before handing them to AIAgent.
-
-    Delegates to hermes_cli.personality (single owner).
-    """
-    from hermes_cli.personality import prompt_text
-
-    return prompt_text(value)
+    """Normalize config prompt values from YAML before handing them to AIAgent."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return "\n".join(str(item).strip() for item in value if str(item).strip())
+    return str(value).strip()
 
 
 def _apply_personality_to_session(
@@ -7658,9 +7621,8 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
-    from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
-
-    system_prompt = resolve_ephemeral_system_prompt_from_config(cfg)
+    agent_cfg = cfg.get("agent") or {}
+    system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
@@ -7827,6 +7789,10 @@ def _init_session(
             "created_at": now,
             "last_active": now,
             "running": False,
+            "turn_generation": 0,
+            "turn_origin": None,
+            "turn_state_revision": 0,
+            "turn_state_running": False,
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
@@ -8301,15 +8267,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             tc_info = tool_call_args.get(tc_id) if tc_id else None
             name = (tc_info[0] if tc_info else None) or m.get("tool_name") or "tool"
             args = (tc_info[1] if tc_info else None) or {}
-            tool_msg = {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
-            # This is the display projection, so keep it faithful. `context`
-            # is an 80-char preview for collapsed row titles. A renderer that
-            # shows the full call (the expanded `$` transcript in the desktop)
-            # rebuilds it from args. When only the preview shipped, that
-            # truncation was permanent.
-            if args:
-                tool_msg["args"] = args
-            messages.append(tool_msg)
+            messages.append(
+                {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
+            )
             continue
         # An assistant turn may carry only reasoning/thinking content with no
         # visible text (extended-thinking turns, thinking-only recovery
@@ -9008,6 +8968,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
+                    origin="user",
                 )
             else:
                 _run_prompt_submit(
@@ -9016,6 +8977,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     session,
                     queued["text"],
                     queued_prompt_generation=queue_generation,
+                    origin="user",
                 )
     except Exception as exc:
         print(
@@ -9139,22 +9101,6 @@ def _emit_terminal_turn_error(
     _emit("message.complete", sid, payload)
 
 
-def _restore_agent_history_after_turn_error(session: dict, agent) -> bool:
-    """Keep a failed turn's working transcript in the gateway session.
-
-    ``AIAgent`` persists its working messages independently of the gateway's
-    history snapshot. If the turn raises after that persistence, the next
-    prompt must see the working transcript instead of the pre-turn snapshot.
-    """
-    agent_messages = getattr(agent, "_session_messages", None)
-    if not isinstance(agent_messages, list):
-        return False
-    with session["history_lock"]:
-        session["history"] = list(agent_messages)
-        session["history_version"] = int(session.get("history_version", 0)) + 1
-    return True
-
-
 def _queued_prompt_snapshot(session: dict) -> dict | None:
     """Return the accepted next-turn prompt without its transport handle.
 
@@ -9216,7 +9162,7 @@ def _deferred_session_record(
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
     now = time.time()
-    return {
+    record = {
         "agent": None,
         "agent_error": None,
         "agent_ready": threading.Event(),
@@ -9242,6 +9188,10 @@ def _deferred_session_record(
         "resume_runtime_overrides": resume_runtime_overrides,
         "resume_session_id": session_key,
         "running": False,
+        "turn_generation": 0,
+        "turn_origin": None,
+        "turn_state_revision": 0,
+        "turn_state_running": False,
         "session_key": session_key,
         "show_reasoning": _load_show_reasoning(),
         "slash_worker": None,
@@ -9250,6 +9200,8 @@ def _deferred_session_record(
         "tool_started_at": {},
         "transport": current_transport() or _stdio_transport,
     }
+    _hydrate_deferred_notification_state(record)
+    return record
 
 
 def _claim_or_reuse_live(
@@ -9281,6 +9233,7 @@ def _claim_or_reuse_live(
     # Slow finalization work stays OUTSIDE _session_resume_lock (see
     # _pop_session_by_id) — the stale records are already claimed above.
     _finalize_superseded_runtimes(stale)
+    _restore_activated_profile_completions(record)
     return None
 
 
@@ -9433,7 +9386,7 @@ def _session_live_status(sid: str, session: dict) -> str:
     # session stuck mid-construction.
     if ready is not None and not ready.is_set() and session.get("agent_build_started"):
         return "starting"
-    if session.get("running"):
+    if session.get("turn_state_running", session.get("running")):
         return "working"
     return "idle"
 
@@ -9505,24 +9458,29 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
     return None
 
 
-def _fallback_session_info(session: dict) -> dict:
+def _fallback_session_info(
+    session: dict, *, turn_snapshot: Optional[dict] = None
+) -> dict:
+    turn_state = turn_snapshot or _turn_state_snapshot_locked(session)
     agent = session.get("agent")
     if agent is not None:
-        return _session_info(agent)
-    # The SESSION's own workspace, not the gateway's launch directory. Reporting
-    # `_default_session_cwd()` here told a lazily-resumed session's client that
-    # its workspace was wherever the gateway process happened to start, so the
-    # desktop Files pane painted the wrong project even after the renderer
-    # rebound correctly (#71254). `branch` is always emitted ("" outside a git
-    # repo) so a client can clear a stale label instead of retaining it — the
-    # same contract `_lazy_session_info` above already follows.
-    cwd = _session_cwd(session)
+        info = _session_info(agent)
+        info.update(
+            {
+                "running": bool(turn_state["running"]),
+                "turn_generation": int(turn_state["turn_generation"]),
+                "turn_origin": turn_state["turn_origin"],
+                "turn_state_revision": int(turn_state["turn_state_revision"]),
+            }
+        )
+        return info
+    cwd = _default_session_cwd()
     return {
         "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
         "lazy": True,
         "model": _resolve_model(),
+        "running": bool(turn_state["running"]),
         "skills": {},
         "tools": {},
         # A lazy session (agent not built yet) is still served by *this* backend,
@@ -9531,6 +9489,9 @@ def _fallback_session_info(session: dict) -> dict:
         # a current backend is falsely flagged "out of date" (#68392). The sibling
         # session.create shape (_lazy_resume_info) already carries it (#36112).
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+        "turn_generation": int(turn_state["turn_generation"]),
+        "turn_origin": turn_state["turn_origin"],
+        "turn_state_revision": int(turn_state["turn_state_revision"]),
     }
 
 
@@ -9637,7 +9598,8 @@ def _live_session_payload(
         )
         inflight = _inflight_snapshot(session)
         queued = _queued_prompt_snapshot(session)
-        running = bool(session.get("running"))
+        turn_snapshot = _turn_state_snapshot_locked(session)
+        running = bool(turn_snapshot["running"])
         inflight_turn = session.get("inflight_turn")
         turn_started_at = (
             float(inflight_turn["started_at"])
@@ -9658,7 +9620,7 @@ def _live_session_payload(
         with _session_db(session) as db:
             history = _live_visible_history(session, db, in_memory_history)
     payload = {
-        "info": _fallback_session_info(session),
+        "info": _fallback_session_info(session, turn_snapshot=turn_snapshot),
         "message_count": len(history),
         "messages": [] if omit_messages else _history_to_messages(history),
         "messages_omitted": omit_messages,
@@ -9668,6 +9630,9 @@ def _live_session_payload(
         "session_key": _session_lookup_key(session, fallback=sid),
         "started_at": float(session.get("created_at") or time.time()),
         "status": _session_live_status(sid, session),
+        "turn_generation": int(turn_snapshot["turn_generation"]),
+        "turn_origin": turn_snapshot["turn_origin"],
+        "turn_state_revision": int(turn_snapshot["turn_state_revision"]),
     }
     if inflight:
         payload["inflight"] = inflight
@@ -10801,7 +10766,8 @@ def _notification_poller_loop(
 
     Runs in a daemon thread started by _init_session(). Emits a
     status.update (kind=process) for user visibility, then chains an
-    agent turn via _run_prompt_submit if the session is idle.
+    agent turn via _run_prompt_submit via _dispatch_notification_turn if the
+    session is idle.
 
     The completion_queue is process-global. In multi-session Desktop each
     poller requeues events owned by another live session and drops addressed
@@ -10813,8 +10779,10 @@ def _notification_poller_loop(
     tools/kanban_tools.py documents for platform="tui" rows (issue #59890).
     """
     from tools.process_registry import process_registry, format_process_notification
+    from tools.async_delegation import claim_event_delivery, release_event_delivery
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    dispatch_failures_logged = set()
     _last_kanban_poll = 0.0
     _last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
@@ -10872,17 +10840,12 @@ def _notification_poller_loop(
                         with session["history_lock"]:
                             session["running"] = False
         try:
-            evt = process_registry.completion_queue.get(timeout=0.5)
+            event = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
             continue
 
-        # Multiple desktop sessions share this one process-wide queue. Only
-        # consume events that belong to *this* session — otherwise a background
-        # process started in session A would surface its completion in whichever
-        # session's poller happened to wake first (Ben's "reported in a
-        # different session" bug). Leave foreign events for their owner.
-        if _notification_event_belongs_elsewhere(sid, session, evt):
-            process_registry.completion_queue.put(evt)
+        if _notification_event_belongs_elsewhere(sid, session, event):
+            process_registry.completion_queue.put(event)
             time.sleep(0.1)
             continue
 
@@ -10891,166 +10854,129 @@ def _notification_poller_loop(
         # direct durable key, or compression lineage. If none proves ownership,
         # the event is orphaned and must not be adopted by this chat. Truly
         # ownerless ordinary notifications retain legacy global delivery.
-        requires_owner = _notification_event_requires_owner(evt)
-        if requires_owner and not _session_owns_notification_event(sid, session, evt):
+        requires_owner = _notification_event_requires_owner(event)
+        if requires_owner and not _session_owns_notification_event(sid, session, event):
             log = (
                 logger.warning
-                if evt.get("type") == "async_delegation"
+                if event.get("type") == "async_delegation"
                 else logger.debug
             )
             log(
                 "Dropping unowned %s notification (origin=%r key=%r) instead "
                 "of delivering to session %s",
-                evt.get("type", "completion"),
-                str(evt.get("origin_ui_session_id") or ""),
-                str(evt.get("session_key") or ""),
+                event.get("type", "completion"),
+                str(event.get("origin_ui_session_id") or ""),
+                str(event.get("session_key") or ""),
                 sid,
             )
             continue
 
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        event_session_id = event.get("session_id", "")
+        if event.get(
+            "type"
+        ) == "completion" and process_registry.is_completion_consumed(event_session_id):
             continue
-
-        text = format_process_notification(evt)
+        text = format_process_notification(event)
         if not text:
             continue
 
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        _requeued = False
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                _requeued = True
-            else:
-                session["running"] = True
-        if _requeued:
-            # Back off before re-polling: the re-queued event keeps the queue
-            # non-empty, so without a sleep this loop spins at full speed
-            # (100% CPU, GIL churn) for as long as the session stays busy.
+        dedup_key = _notification_event_dedup_key(event)
+        emit_status = dedup_key not in _emitted
+        try:
+            outcome = _dispatch_notification_turn(
+                f"__notif__{int(time.time() * 1000)}",
+                sid,
+                session,
+                text,
+                emit_status=emit_status,
+                event=event,
+                consumer="tui-poller",
+            )
+        except Exception:
+            # Status is _emitted before the agent turn starts. Remember the
+            # identity so retries retain the event without spamming that line.
+            if emit_status:
+                _emitted.add(dedup_key)
+            process_registry.completion_queue.put(event)
+            if dedup_key not in dispatch_failures_logged:
+                dispatch_failures_logged.add(dedup_key)
+                logger.exception(
+                    "notification poller dispatch failed; requeued event %r",
+                    dedup_key,
+                )
             time.sleep(0.25)
             continue
+        if emit_status:
+            _emitted.add(dedup_key)
+        if outcome == "busy":
+            process_registry.completion_queue.put(event)
+            time.sleep(0.25)
 
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
-            continue
-        try:
-            _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
-            complete_event_delivery(evt, _claim)
-        except Exception as exc:
-            release_event_delivery(evt, _claim)
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
-
-    # Drain any remaining events after stop signal (process all pending
-    # before exiting so nothing is lost on shutdown). Events owned by other
-    # live sessions are set aside and re-queued so their poller still sees them.
-    # Orphaned events (owner gone) are dropped — same guard as the main loop.
     deferred: list = []
     while not process_registry.completion_queue.empty():
         try:
-            evt = process_registry.completion_queue.get_nowait()
+            event = process_registry.completion_queue.get_nowait()
         except Exception:
             break
-        if _notification_event_belongs_elsewhere(sid, session, evt):
-            deferred.append(evt)
+        if _notification_event_belongs_elsewhere(sid, session, event):
+            deferred.append(event)
             continue
         # Same positive-proof rule as the live loop. Preserve the existing
         # shutdown behavior for orphaned delegation payloads by deferring them
         # for a later resume; ordinary addressed orphans are dropped.
-        requires_owner = _notification_event_requires_owner(evt)
-        if requires_owner and not _session_owns_notification_event(sid, session, evt):
-            if evt.get("type") == "async_delegation":
-                deferred.append(evt)
+        requires_owner = _notification_event_requires_owner(event)
+        if requires_owner and not _session_owns_notification_event(sid, session, event):
+            if event.get("type") == "async_delegation":
+                deferred.append(event)
             else:
                 logger.debug(
                     "Dropping unowned %s notification during shutdown drain "
                     "(origin=%r key=%r)",
-                    evt.get("type", "completion"),
-                    str(evt.get("origin_ui_session_id") or ""),
-                    str(evt.get("session_key") or ""),
+                    event.get("type", "completion"),
+                    str(event.get("origin_ui_session_id") or ""),
+                    str(event.get("session_key") or ""),
                 )
             continue
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        event_session_id = event.get("session_id", "")
+        if event.get(
+            "type"
+        ) == "completion" and process_registry.is_completion_consumed(event_session_id):
             continue
-        text = format_process_notification(evt)
+        text = format_process_notification(event)
         if not text:
             continue
 
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
-            continue
+        dedup_key = _notification_event_dedup_key(event)
+        emit_status = dedup_key not in _emitted
         try:
-            _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
-            complete_event_delivery(evt, _claim)
-        except Exception as exc:
-            release_event_delivery(evt, _claim)
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
+            rid = f"__notif__{int(time.time() * 1000)}"
+            outcome = _dispatch_notification_turn(
+                rid,
+                sid,
+                session,
+                text,
+                emit_status=emit_status,
+                event=event,
+                consumer="tui-poller",
             )
-            with session["history_lock"]:
-                session["running"] = False
+        except Exception:
+            if emit_status:
+                _emitted.add(dedup_key)
+            deferred.append(event)
+            if dedup_key not in dispatch_failures_logged:
+                dispatch_failures_logged.add(dedup_key)
+                logger.exception(
+                    "notification poller dispatch failed; requeued event %r",
+                    dedup_key,
+                )
+            break
+        if emit_status:
+            _emitted.add(dedup_key)
+        if outcome == "busy":
+            process_registry.completion_queue.put(event)
 
-    # Hand any other sessions' events back to the shared queue.
-    for evt in deferred:
-        process_registry.completion_queue.put(evt)
+    for event in deferred:
+        process_registry.completion_queue.put(event)
 
 
 def _async_delegation_display_metadata(evt: dict) -> dict:
@@ -11178,31 +11104,558 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
-def _hud_surface_note(session: dict) -> str:
-    """The HUD-mode note for this turn, or "" when it was not typed there."""
-    if session.get("client_surface") != "hud":
-        return ""
-    from agent.prompt_builder import hud_surface_note
+def _set_turn_origin_locked(session: dict, origin: TurnOrigin) -> int:
+    """Start a public turn-state revision while ``history_lock`` is held."""
+    if origin not in _TURN_ORIGINS:
+        raise ValueError(f"invalid turn origin: {origin!r}")
+    token = int(session.get("turn_generation", 0)) + 1
+    session["turn_generation"] = token
+    session["turn_state_revision"] = int(session.get("turn_state_revision", 0)) + 1
+    session["turn_state_running"] = True
+    session["turn_origin"] = origin
+    session["turn_token"] = token
+    # Public state settles before post-turn cleanup releases the concurrency
+    # reservation. Keep a separate token so a stale turn cannot release a newer
+    # one after message.complete has already advanced the public revision.
+    session["turn_reservation_token"] = token
+    return token
 
-    return hud_surface_note(getattr(session.get("agent"), "valid_tool_names", None))
+
+def _clear_turn_origin_locked(session: dict, token: int) -> bool:
+    """Settle only the public turn that still owns ``token``."""
+    if session.get("turn_token") != token:
+        return False
+    session["turn_state_revision"] = int(session.get("turn_state_revision", 0)) + 1
+    session["turn_state_running"] = False
+    session["turn_origin"] = None
+    session["turn_token"] = None
+    return True
 
 
-def _prepend_note(run_message: Any, note: str) -> Any:
-    """Prefix a per-turn note onto the MODEL INPUT, leaving the prompt alone.
+def _turn_state_snapshot_locked(session: dict | None) -> dict:
+    """Capture monotonic public turn state while ``history_lock`` is held."""
+    if session is None:
+        return {
+            "running": False,
+            "turn_generation": 0,
+            "turn_origin": None,
+            "turn_state_revision": 0,
+        }
+    public_running = session.get("turn_state_running")
+    return {
+        "running": (
+            bool(session.get("running"))
+            if public_running is None
+            else bool(public_running)
+        ),
+        "turn_generation": int(session.get("turn_generation", 0)),
+        "turn_origin": session.get("turn_origin"),
+        "turn_state_revision": int(session.get("turn_state_revision", 0)),
+    }
 
-    Everything the model needs to know about the turn but the user did not
-    type — an interrupted reply, reactions, the surface they typed into —
-    arrives this way. persist_user_message keeps the clean prompt, so no
-    scaffolding reaches the transcript, and annotating the NEW turn never
-    rewrites an already-sent message, so the cached prefix survives.
+
+def _durable_notification_event_id(event: Optional[dict]) -> Optional[str]:
+    if not event or event.get("type") != "async_delegation":
+        return None
+    delegation_id = str(event.get("delegation_id") or "")
+    return f"async_delegation:{delegation_id}" if delegation_id else None
+
+
+def _has_prompt_message_id(session: dict, message_id: str) -> bool:
+    """Return whether a stable client message ID is already owned by a turn.
+
+    Callers hold ``history_lock``. The in-memory checks close the window before
+    early persistence, while the SessionDB check covers timeout/resume retries
+    after the original turn has completed.
     """
-    if not note:
-        return run_message
-    if isinstance(run_message, str):
-        return f"{note}\n\n{run_message}"
-    if isinstance(run_message, list):
-        return [{"type": "text", "text": note}, *run_message]
-    return run_message
+    inflight = session.get("inflight_turn")
+    if isinstance(inflight, dict) and inflight.get("message_id") == message_id:
+        return True
+
+    queued_items = [session.get("queued_prompt")]
+    pending = session.get("queued_prompts")
+    if isinstance(pending, list):
+        queued_items.extend(pending)
+    if any(
+        isinstance(item, dict) and item.get("message_id") == message_id
+        for item in queued_items
+    ):
+        return True
+
+    for item in session.get("history") or []:
+        if not isinstance(item, dict):
+            continue
+        source_id = (
+            item.get("platform_message_id")
+            or item.get("message_id")
+            or item.get("_source_message_id")
+        )
+        if source_id is not None and str(source_id) == message_id:
+            return True
+
+    agent = session.get("agent")
+    db = getattr(agent, "_session_db", None)
+    session_key = str(session.get("session_key") or "")
+    if db is not None and session_key and hasattr(db, "has_platform_message_id"):
+        try:
+            return bool(db.has_platform_message_id(session_key, message_id))
+        except Exception:
+            pass
+    return False
+
+
+def _compose_deferred_notification_prompt(text: Any, notifications: list[str]) -> str:
+    sections = []
+    for index, notification in enumerate(notifications, start=1):
+        sections.append(f"--- background completion {index} ---\n{notification}")
+    context = "\n\n".join(sections)
+    return (
+        "[BACKGROUND COMPLETION CONTEXT — NOT A NEW USER REQUEST]\n"
+        "The following owned background result(s) arrived after the previous turn "
+        "reached its iteration limit. Use them as context for the human request below.\n\n"
+        f"{context}\n"
+        "[END BACKGROUND COMPLETION CONTEXT]\n\n"
+        f"{text}"
+    )
+
+
+def _clean_returned_user_message(messages: list, index: int, clean_text: str) -> None:
+    """Remove API-only context from returned history without dropping media parts."""
+    if not (0 <= index < len(messages)):
+        return
+    message = messages[index]
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return
+    content = message.get("content")
+    if not isinstance(content, list):
+        message["content"] = clean_text
+        return
+    cleaned = []
+    replaced_text = False
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            if not replaced_text:
+                cleaned.append({**part, "text": clean_text})
+                replaced_text = True
+            continue
+        cleaned.append(part)
+    if not replaced_text:
+        cleaned.insert(0, {"type": "text", "text": clean_text})
+    message["content"] = cleaned
+
+
+def _deferred_notification_db_path(session: dict) -> Path:
+    profile_home = str(session.get("profile_home") or "").strip()
+    return (
+        Path(profile_home) if profile_home else Path(get_hermes_home())
+    ) / "state.db"
+
+
+def _persist_deferred_notification(
+    session: dict,
+    event_id: str,
+    text: str,
+    event: dict,
+) -> bool:
+    from tools.async_delegation import persist_deferred_notification
+
+    return persist_deferred_notification(
+        str(session.get("session_key") or event.get("session_key") or ""),
+        event_id,
+        text,
+        event,
+        db_path=_deferred_notification_db_path(session),
+    )
+
+
+def _restore_claimed_notifications(
+    session: dict,
+    claimed_notifications: list[str],
+    claimed_notification_ids: set[str],
+) -> None:
+    """Requeue a claimed batch whose turn failed to consume it.
+
+    The claimed texts predate anything appended to the buffer mid-turn, so
+    they are restored ahead of the current buffer rather than behind it.
+    Runs under the history lock so a concurrently arriving deferred event
+    cannot interleave into the middle of the batch.
+    """
+    if not claimed_notifications and not claimed_notification_ids:
+        return
+    with session["history_lock"]:
+        texts = list(session.get("deferred_notification_texts") or [])
+        restored = [n for n in claimed_notifications if n not in texts]
+        session["deferred_notification_texts"] = restored + texts
+        ids = session.get("deferred_notification_event_ids")
+        if not isinstance(ids, set):
+            ids = set(ids or ())
+        ids |= set(claimed_notification_ids)
+        session["deferred_notification_event_ids"] = ids
+        session["defer_notifications_until_user"] = bool(
+            session["deferred_notification_texts"]
+        )
+
+
+def _hydrate_deferred_notification_state(session: dict) -> None:
+    """Rebuild the deferred batch and reconcile any committed adoption."""
+    from tools.async_delegation import (
+        load_deferred_notifications,
+        migrate_compression_lineage_deferred_notifications,
+        reconcile_adopted_deferred_notifications,
+    )
+
+    session_key = str(session.get("session_key") or "")
+    db_path = _deferred_notification_db_path(session)
+    migrate_compression_lineage_deferred_notifications(
+        session_key,
+        db_path=db_path,
+    )
+    reconcile_adopted_deferred_notifications(db_path=db_path)
+    rows = load_deferred_notifications(session_key, db_path=db_path)
+    texts = list(session.get("deferred_notification_texts") or [])
+    ids = set(session.get("deferred_notification_event_ids") or ())
+    for row in rows:
+        event_id = str(row.get("event_id") or "")
+        if event_id and event_id not in ids:
+            texts.append(str(row.get("payload") or ""))
+            ids.add(event_id)
+    session["deferred_notification_texts"] = texts
+    session["deferred_notification_event_ids"] = ids
+    session["defer_notifications_until_user"] = bool(texts)
+
+
+def _deferred_notifications_have_durable_adoption(
+    session: dict,
+    event_ids: set[str],
+) -> bool:
+    """Check whether an owned batch is adopted or already reconciled."""
+    if not event_ids:
+        return False
+    from tools.async_delegation import (
+        deferred_notifications_adopted_or_delivered,
+        migrate_compression_lineage_deferred_notifications,
+    )
+
+    session_key = str(session.get("session_key") or "")
+    db_path = _deferred_notification_db_path(session)
+    try:
+        migrate_compression_lineage_deferred_notifications(session_key, db_path=db_path)
+        return deferred_notifications_adopted_or_delivered(
+            session_key, event_ids, db_path=db_path
+        )
+    except Exception:
+        logger.warning(
+            "failed to reconcile deferred adoption before batch restore: "
+            "session=%s events=%s",
+            session_key,
+            sorted(event_ids),
+            exc_info=True,
+        )
+        return False
+
+
+def _retry_accepted_notification_ack(
+    event: dict,
+    claim_id: str,
+    consumer: str,
+) -> None:
+    from tools.async_delegation import complete_event_delivery
+
+    event_id = _durable_notification_event_id(event) or "legacy"
+    attempt = 0
+    while True:
+        delay = _NOTIFICATION_ACK_RETRY_DELAYS[
+            min(attempt, len(_NOTIFICATION_ACK_RETRY_DELAYS) - 1)
+        ]
+        if delay:
+            time.sleep(delay)
+        try:
+            if complete_event_delivery(event, claim_id):
+                logger.info(
+                    "durable notification ack retry succeeded: consumer=%s event=%s",
+                    consumer,
+                    event_id,
+                )
+                return
+        except Exception:
+            pass
+        attempt += 1
+
+
+def _retry_consumed_deferred_ack(
+    session_key: str,
+    event_ids: set[str],
+    db_path: Path,
+) -> None:
+    from tools.async_delegation import (
+        complete_deferred_notifications,
+        migrate_compression_lineage_deferred_notifications,
+    )
+
+    attempt = 0
+    while True:
+        delay = _NOTIFICATION_ACK_RETRY_DELAYS[
+            min(attempt, len(_NOTIFICATION_ACK_RETRY_DELAYS) - 1)
+        ]
+        if delay:
+            time.sleep(delay)
+        try:
+            migrate_compression_lineage_deferred_notifications(
+                session_key, db_path=db_path
+            )
+            if complete_deferred_notifications(session_key, event_ids, db_path=db_path):
+                logger.info(
+                    "deferred notification consumption ack retry succeeded: "
+                    "session=%s events=%s",
+                    session_key,
+                    sorted(event_ids),
+                )
+                return
+        except Exception:
+            pass
+        attempt += 1
+
+
+def _ack_accepted_notification(
+    event: Optional[dict], claim_id: str, consumer: str
+) -> None:
+    if not event or not claim_id:
+        return
+
+    try:
+        from tools.async_delegation import complete_event_delivery
+
+        if complete_event_delivery(event, claim_id):
+            return
+        error: BaseException = RuntimeError(
+            "durable delivery claim no longer acknowledges"
+        )
+    except Exception as exc:
+        error = exc
+    logger.warning(
+        "durable notification accepted; retrying ack without reinjection: "
+        "consumer=%s event=%s error=%s",
+        consumer,
+        _durable_notification_event_id(event) or "legacy",
+        error,
+    )
+    try:
+        retry_thread = threading.Thread(
+            target=_retry_accepted_notification_ack,
+            args=(event, claim_id, consumer),
+            daemon=True,
+            name=f"tui-notification-ack-{str(event.get('delegation_id') or 'legacy')[:24]}",
+        )
+        retry_thread.start()
+    except Exception:
+        # The notification turn/deferred context is already consumer-visible.
+        # Never release or reinject it merely because the ack worker could not
+        # start; the durable row remains pending for recovery diagnostics.
+        logger.exception(
+            "durable notification ack retry thread failed to start: consumer=%s event=%s",
+            consumer,
+            _durable_notification_event_id(event) or "legacy",
+        )
+
+
+def _ack_consumed_deferred_notifications(
+    session: dict,
+    event_ids: set[str],
+) -> bool:
+    if not event_ids:
+        return True
+    from tools.async_delegation import (
+        complete_deferred_notifications,
+        migrate_compression_lineage_deferred_notifications,
+    )
+
+    session_key = str(session.get("session_key") or "")
+    db_path = _deferred_notification_db_path(session)
+    try:
+        migrate_compression_lineage_deferred_notifications(session_key, db_path=db_path)
+        if complete_deferred_notifications(session_key, event_ids, db_path=db_path):
+            return True
+        error: BaseException = RuntimeError(
+            "deferred delivery rows remain pending or lack adoption proof"
+        )
+    except Exception as exc:
+        error = exc
+    logger.warning(
+        "deferred notification reached history; retrying ack without reinjection: "
+        "session=%s events=%s error=%s",
+        session_key,
+        sorted(event_ids),
+        error,
+    )
+    try:
+        threading.Thread(
+            target=_retry_consumed_deferred_ack,
+            args=(session_key, set(event_ids), db_path),
+            daemon=True,
+            name=f"tui-deferred-ack-{session_key[:24]}",
+        ).start()
+    except Exception:
+        # The payload is already in conversation history. Never restore it to
+        # the in-memory batch solely because the durable delivered-bit write
+        # failed; that would duplicate the context on the next explicit turn.
+        logger.exception(
+            "deferred notification consumption ack thread failed to start: "
+            "session=%s events=%s",
+            session_key,
+            sorted(event_ids),
+        )
+    return False
+
+
+def _restore_activated_profile_completions(session: dict) -> int:
+    """Restore durable async completions once when a profile becomes active."""
+    from tools.process_registry import process_registry
+
+    return process_registry.restore_profile_home(
+        _deferred_notification_db_path(session).parent
+    )
+
+
+def _dispatch_goal_followup(rid, sid: str, session: dict, text: str) -> bool:
+    with session["history_lock"]:
+        if session.get("running"):
+            return False
+        session["running"] = True
+    try:
+        _run_prompt_submit(rid, sid, session, text, origin="goal")
+    except Exception:
+        with session["history_lock"]:
+            session["running"] = False
+        raise
+    return True
+
+
+def _dispatch_notification_turn(
+    rid,
+    sid: str,
+    session: dict,
+    text: str,
+    *,
+    emit_status: bool = True,
+    event: Optional[dict] = None,
+    consumer: str = "tui-poller",
+) -> str:
+    claim_id: Optional[str] = ""
+    if event is not None:
+        from tools.async_delegation import claim_event_delivery, release_event_delivery
+
+    try:
+        with session["history_lock"]:
+            if session.get("running"):
+                outcome = "busy"
+            else:
+                if event is not None:
+                    claim_id = claim_event_delivery(event, consumer)
+                if claim_id is None:
+                    outcome = "claimed"
+                elif session.get("defer_notifications_until_user"):
+                    event_id = _durable_notification_event_id(event)
+                    deferred_ids = session.get("deferred_notification_event_ids")
+                    if not isinstance(deferred_ids, set):
+                        deferred_ids = set(deferred_ids or ())
+                        session["deferred_notification_event_ids"] = deferred_ids
+                    pending = True
+                    if event_id is not None and event is not None:
+                        # Acceptance is durable before the terminal event is
+                        # acknowledged. A persistence failure falls through the
+                        # outer exception path and releases the pre-accept claim.
+                        pending = _persist_deferred_notification(
+                            session, event_id, text, event
+                        )
+                    if pending and (event_id is None or event_id not in deferred_ids):
+                        session.setdefault("deferred_notification_texts", []).append(
+                            text
+                        )
+                        if event_id is not None:
+                            deferred_ids.add(event_id)
+                    outcome = "deferred" if pending else "accepted"
+                else:
+                    session["running"] = True
+                    outcome = "dispatched"
+    except Exception:
+        if event is not None and claim_id:
+            release_event_delivery(event, claim_id)
+        raise
+
+    if outcome == "accepted":
+        _ack_accepted_notification(event, claim_id or "", consumer)
+        return "claimed"
+
+    if outcome == "claimed":
+        return outcome
+
+    status_text = text
+    if outcome == "deferred":
+        status_text = (
+            f"{text}\n\nBackground result is pending for your next explicit user turn."
+        )
+
+    if outcome == "busy":
+        if emit_status:
+            _emit("status.update", sid, {"kind": "process", "text": status_text})
+        return outcome
+
+    if outcome == "deferred":
+        if emit_status or outcome == "deferred":
+            try:
+                _emit("status.update", sid, {"kind": "process", "text": status_text})
+            except Exception:
+                logger.exception(
+                    "deferred notification status emission failed after acceptance"
+                )
+        _ack_accepted_notification(event, claim_id or "", consumer)
+        return outcome
+
+    try:
+        if emit_status:
+            _emit("status.update", sid, {"kind": "process", "text": status_text})
+        _run_prompt_submit(rid, sid, session, text, origin="notification")
+    except Exception:
+        if event is not None and claim_id:
+            release_event_delivery(event, claim_id)
+        with session["history_lock"]:
+            session["running"] = False
+        raise
+
+    _ack_accepted_notification(event, claim_id or "", consumer)
+    return outcome
+
+
+def _drain_post_turn_notifications(rid, sid: str, session: dict) -> None:
+    from tools.process_registry import process_registry
+
+    pending = process_registry.drain_notifications(
+        session_key=session.get("session_key", ""),
+        owns_event=lambda event: _session_owns_notification_event(sid, session, event),
+        skip_poll_observed=False,
+    )
+    for index, (event, text) in enumerate(pending):
+        try:
+            outcome = _dispatch_notification_turn(
+                rid,
+                sid,
+                session,
+                text,
+                event=event,
+                consumer="tui-post-turn",
+            )
+        except Exception:
+            for queued_event, _queued_text in pending[index:]:
+                process_registry.completion_queue.put(queued_event)
+            logger.exception(
+                "post-turn notification dispatch failed; requeued %d event(s)",
+                len(pending) - index,
+            )
+            break
+        if outcome == "busy":
+            for queued_event, _queued_text in pending[index:]:
+                process_registry.completion_queue.put(queued_event)
+            break
 
 
 _GOAL_COMPRESSION_RECOVERY_ATTEMPTS = "_goal_compression_recovery_attempts"
@@ -11374,7 +11827,11 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    origin: TurnOrigin = "user",
 ) -> bool:
+    claimed_notifications: list[str] = []
+    claimed_notification_ids: set[str] = set()
+    persist_user_message = None
     with session["history_lock"]:
         if session.get("_closing"):
             session["running"] = False
@@ -11390,11 +11847,31 @@ def _run_prompt_submit(
             session["attached_images"] = []
         else:
             images = list(image_paths)
+        if origin == "user":
+            claimed_notifications = list(
+                session.get("deferred_notification_texts") or []
+            )
+            claimed_notification_ids = set(
+                session.get("deferred_notification_event_ids") or ()
+            )
+            session["deferred_notification_texts"] = []
+            session["deferred_notification_event_ids"] = set()
+            session["defer_notifications_until_user"] = False
+            if claimed_notifications:
+                persist_user_message = text if isinstance(text, str) else str(text)
+                text = _compose_deferred_notification_prompt(
+                    text, claimed_notifications
+                )
         inflight = session.get("inflight_turn")
         # A retained failed turn (see _fail_inflight_turn) is a stale leftover
         # by the time a new turn starts — replace it, never append onto it.
         if not isinstance(inflight, dict) or inflight.get("status") == "error":
-            _start_inflight_turn(session, text)
+            _start_inflight_turn(
+                session,
+                persist_user_message if persist_user_message is not None else text,
+            )
+        turn_token = _set_turn_origin_locked(session, origin)
+        turn_start_revision = int(session["turn_state_revision"])
         agent = session["agent"]
         if hasattr(agent, "clear_interrupt"):
             try:
@@ -11420,7 +11897,15 @@ def _run_prompt_submit(
         len(text) if isinstance(text, str) else "-",
         len(images),
     )
-    _emit("message.start", sid)
+    _emit(
+        "message.start",
+        sid,
+        {
+            "turn_generation": turn_token,
+            "turn_origin": origin,
+            "turn_state_revision": turn_start_revision,
+        },
+    )
 
     def run():
         # The conversation runs on a fresh thread, so ContextVars from the RPC
@@ -11442,6 +11927,8 @@ def _run_prompt_submit(
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
         thinking_started = False  # ambient thinking sound armed for this turn
         one_turn_restore = session.pop("one_turn_model_restore", None)
+        claimed_notifications_consumed = False  # durable notification adoption proof
+        history_adopted = False
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
@@ -11649,14 +12136,21 @@ def _run_prompt_submit(
             from tools.tts_streaming import SPEECH_INTERRUPTED_NOTE, take_speech_interrupted
 
             if take_speech_interrupted():
-                run_message = _prepend_note(run_message, SPEECH_INTERRUPTED_NOTE)
+                if isinstance(run_message, str):
+                    run_message = f"{SPEECH_INTERRUPTED_NOTE}\n\n{run_message}"
+                elif isinstance(run_message, list):
+                    run_message = [{"type": "text", "text": SPEECH_INTERRUPTED_NOTE}, *run_message]
 
-            # Reactions the user added since the last turn.
-            run_message = _prepend_note(run_message, _pending_reaction_notes(session))
-
-            # Which window the message was typed into. HUD mode is per-turn
-            # state, so it cannot live in the (byte-stable) system prompt.
-            run_message = _prepend_note(run_message, _hud_surface_note(session))
+            # Reactions the user added since the last turn ride the MODEL INPUT
+            # only (same enrichment channel as the speech-interrupted note);
+            # persist_user_message below stays the clean prompt, so no
+            # scaffolding reaches the transcript. Cache-safe: annotating the
+            # NEW turn never rewrites an already-sent message.
+            if reaction_notes := _pending_reaction_notes(session):
+                if isinstance(run_message, str):
+                    run_message = f"{reaction_notes}\n\n{run_message}"
+                elif isinstance(run_message, list):
+                    run_message = [{"type": "text", "text": reaction_notes}, *run_message]
 
             def _stream(delta):
                 with session["history_lock"]:
@@ -11706,6 +12200,10 @@ def _run_prompt_submit(
             if display_kind and "persist_user_display_kind" in _run_params:
                 run_kwargs["persist_user_display_kind"] = display_kind
                 run_kwargs["persist_user_display_metadata"] = display_metadata
+            if claimed_notification_ids and "deferred_notification_ids" in _run_params:
+                run_kwargs["deferred_notification_ids"] = sorted(
+                    claimed_notification_ids
+                )
             # Auto-titling now fires inside the turn prologue (shared by every
             # surface). Hand the agent this session's live-rename hook so the
             # sidebar repaints the moment a title lands, rather than waiting
@@ -11799,8 +12297,13 @@ def _run_prompt_submit(
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
+                            if persist_user_message is not None:
+                                _clean_returned_user_message(
+                                    result["messages"], len(history), persist_user_message
+                                )
                             session["history"] = result["messages"]
                             session["history_version"] = history_version + 1
+                            history_adopted = True
                         else:
                             # History mutated externally during the turn.
                             # Check if the only mutation was a pivot marker
@@ -11877,6 +12380,11 @@ def _run_prompt_submit(
                     if result.get("interrupted")
                     else "error" if result.get("error") else "complete"
                 )
+                if origin == "user" and str(
+                    result.get("turn_exit_reason") or ""
+                ).startswith("max_iterations_reached("):
+                    with session["history_lock"]:
+                        session["defer_notifications_until_user"] = True
                 # When the backend produced no visible response AND reported a
                 # real error (e.g. invalid model slug → provider 4xx), surface
                 # that error as the visible text instead of shipping an empty
@@ -11905,7 +12413,36 @@ def _run_prompt_submit(
                 raw = str(result)
                 status = "complete"
 
-            payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            # Durable deferred notifications are consumed only after the exact
+            # owned event IDs have adoption/delivery proof in SessionDB. Live
+            # history adoption alone is not crash-safe: the returned transcript
+            # can look complete while the final assistant/proof transaction was
+            # never committed. Legacy in-memory notifications have no durable
+            # IDs or ack path, so they retain their history-fence behavior.
+            if status == "complete":
+                if claimed_notification_ids:
+                    claimed_notifications_consumed = (
+                        _deferred_notifications_have_durable_adoption(
+                            session, claimed_notification_ids
+                        )
+                    )
+                else:
+                    claimed_notifications_consumed = history_adopted
+            if claimed_notifications_consumed and claimed_notification_ids:
+                _ack_consumed_deferred_notifications(session, claimed_notification_ids)
+            with session["history_lock"]:
+                # Settle the public turn before the terminal frame so the client
+                # can order message.complete against its own turn-state view.
+                _clear_turn_origin_locked(session, turn_token)
+                turn_settle_revision = int(session.get("turn_state_revision", 0))
+            payload = {
+                "text": raw,
+                "usage": _get_usage(agent),
+                "status": status,
+                "turn_origin": origin,
+                "turn_generation": turn_token,
+                "turn_state_revision": turn_settle_revision,
+            }
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:
@@ -12097,6 +12634,55 @@ def _run_prompt_submit(
                     # Transient DB failure — keep pending_title for retry.
                     pass
 
+            if (
+                status == "complete"
+                and isinstance(raw, str)
+                and raw.strip()
+                and isinstance(text, str)
+                and text.strip()
+            ):
+                try:
+                    from agent.title_generator import maybe_auto_title
+
+                    _title_key = session.get("session_key") or sid
+                    # Snapshot the runtime identity; the validator lets the
+                    # background titler skip its LLM call if the session's
+                    # model changed before it fires (#19027).
+                    _title_model = getattr(agent, "model", None)
+                    _title_provider = getattr(agent, "provider", None)
+                    maybe_auto_title(
+                        _get_db(),
+                        _title_key,
+                        persist_user_message
+                        if persist_user_message is not None
+                        else text,
+                        raw,
+                        session.get("history", []),
+                        # Keep auxiliary auto-detection aligned with the active
+                        # Desktop/Webapp session. Without this, providers that
+                        # rely on runtime auth (for example OpenAI Codex OAuth)
+                        # are skipped and the new session remains untitled.
+                        main_runtime={
+                            "model": getattr(agent, "model", None),
+                            "provider": getattr(agent, "provider", None),
+                            "base_url": getattr(agent, "base_url", None),
+                            "api_key": getattr(agent, "api_key", None),
+                            "api_mode": getattr(agent, "api_mode", None),
+                        },
+                        runtime_validator=lambda: (
+                            getattr(agent, "model", None) == _title_model
+                            and getattr(agent, "provider", None) == _title_provider
+                        ),
+                        # Push the generated title live so the sidebar renames
+                        # without waiting for the next list refresh (the titler
+                        # runs async, after this turn's refresh already fired).
+                        title_callback=lambda t, _k=_title_key: _emit(
+                            "session.title", sid, {"session_id": _k, "title": t}
+                        ),
+                    )
+                except Exception:
+                    pass
+
             # Voice TTS fallback: when the streaming pipeline couldn't start
             # (no provider / missing deps probed at turn start), speak the
             # final text whole (cli.py:_voice_speak_response parity). The
@@ -12136,12 +12722,6 @@ def _run_prompt_submit(
             print(
                 f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
             )
-            # The agent persists its working transcript on normal finalization,
-            # but an exception in that finalizer can otherwise leave the
-            # gateway's separate in-memory history at the turn-start snapshot.
-            # Keep the partial turn available to the next prompt; the durable
-            # inflight record still carries the recoverable error state.
-            _restore_agent_history_after_turn_error(session, agent)
             try:
                 # Close the turn with the same terminal error frame shape as
                 # the returned-error path (uniform client handling), retaining
@@ -12208,6 +12788,17 @@ def _run_prompt_submit(
             # Clear the per-turn interim callback so a stale closure from
             # this turn can't fire during a later turn on the same agent.
             agent.interim_assistant_callback = None
+            if not claimed_notifications_consumed:
+                # Failed / refused / unconsumed turn: hand the claimed batch
+                # back to the deferred queue so the next user turn receives
+                # it. Claimed items predate anything that arrived mid-turn, so
+                # they go back in front of the buffer, not behind it.
+                try:
+                    _restore_claimed_notifications(
+                        session, claimed_notifications, claimed_notification_ids
+                    )
+                except Exception:
+                    logger.debug("claimed notification restore failed", exc_info=True)
             with session["history_lock"]:
                 session["running"] = False
                 session["last_active"] = time.time()
@@ -12268,23 +12859,14 @@ def _run_prompt_submit(
         # prompt.submit sets running=True under the history_lock and
         # we check that guard before re-firing.
         if goal_followup:
-            with session["history_lock"]:
-                if session.get("running"):
-                    # User already sent something — their turn wins,
-                    # the judge will re-run on the next turn anyway.
-                    return
-                session["running"] = True
             try:
-                _emit("message.start", sid)
-                _run_prompt_submit(rid, sid, session, goal_followup)
+                _dispatch_goal_followup(rid, sid, session, goal_followup)
             except Exception as _cont_exc:
                 print(
                     f"[tui_gateway] goal continuation dispatch failed: "
                     f"{type(_cont_exc).__name__}: {_cont_exc}",
                     file=sys.stderr,
                 )
-                with session["history_lock"]:
-                    session["running"] = False
 
         # Drain completion notifications that arrived during this turn.
         # The background poller handles between-turn delivery; this is
@@ -12295,44 +12877,7 @@ def _run_prompt_submit(
         # requeues every addressed event this session cannot positively claim;
         # the poller then delivers it to a live owner or drops an orphan.
         try:
-            from tools.process_registry import process_registry
-
-            # Positive-proof ownership (compression-chain aware) — the same
-            # fail-closed gate the poller uses, so the post-turn drain can't
-            # adopt another session's addressed notification while a
-            # post-compression session still claims its own pre-compression
-            # dispatches (#55578).
-            drained = process_registry.drain_notifications(
-                session_key=session.get("session_key", ""),
-                owns_event=lambda e: _session_owns_notification_event(sid, session, e),
-                skip_poll_observed=False,
-            )
-            for index, (_evt, synth) in enumerate(drained):
-                with session["history_lock"]:
-                    if session.get("running"):
-                        for pending_evt, _pending_synth in drained[index:]:
-                            process_registry.completion_queue.put(pending_evt)
-                        break
-                    session["running"] = True
-                from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
-                )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
-                if _claim is None:
-                    continue
-                try:
-                    _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
-                    complete_event_delivery(_evt, _claim)
-                except Exception as _n_exc:
-                    release_event_delivery(_evt, _claim)
-                    print(
-                        f"[tui_gateway] completion notification dispatch failed: "
-                        f"{type(_n_exc).__name__}: {_n_exc}",
-                        file=sys.stderr,
-                    )
-                    with session["history_lock"]:
-                        session["running"] = False
+            _drain_post_turn_notifications(rid, sid, session)
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "
@@ -12501,19 +13046,7 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
 
 
 def _desktop_attachment_dir(session: dict) -> Path:
-    """Resolve the file-attachment staging dir against the session's effective home.
-
-    Anchored on the session profile's ``attachments/`` dir (same rule as
-    ``_session_images_dir``): ``file.attach`` runs BEFORE ``prompt.submit``
-    installs the session's profile HERMES_HOME override, while the docker/ssh
-    sandbox mounts are resolved against the *session profile's* home at run
-    time — so the staged file must land where the bind mount points, or the
-    container can never see it (#76577). ``attachments/`` is registered in
-    ``tools.credential_files._CACHE_DIRS`` and auto-mounted into containers.
-    """
-    profile_home = session.get("profile_home")
-    base = Path(profile_home) if profile_home else _hermes_home
-    root = base / "attachments"
+    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
     root.mkdir(parents=True, exist_ok=True)
     return root
 
@@ -12593,11 +13126,10 @@ def _stage_session_file_attachment(
       1. The path resolves to a file already INSIDE the session workspace — use
          it as-is (no copy, ``uploaded=False``).
       2. The path resolves to a gateway-visible file OUTSIDE the workspace — copy
-         it into the session home's ``attachments/`` dir (bind-mounted into
-         container backends) so the ``@file:`` ref resolves inside the sandbox.
+         it into ``.hermes/desktop-attachments/`` so the ``@file:`` ref resolves.
       3. The path doesn't exist on the gateway (the common remote case: it's a
          path on the CLIENT's disk) — decode the uploaded ``data_url`` bytes and
-         write them into the session home's ``attachments/`` dir.
+         write them into ``.hermes/desktop-attachments/``.
 
     Returns ``(stored_path, uploaded)``.
     """
@@ -13328,12 +13860,8 @@ def _(rid, params: dict) -> dict:
             elif key == "personality":
                 sid_key = params.get("session_id", "")
                 pname, new_prompt = _validate_personality(str(value or ""), cfg)
-                # Personality text is an in-session overlay. Persistence goes
-                # through hermes_cli.personality (single owner) and never
-                # touches the user-owned global system prompt.
-                from hermes_cli.personality import persist_personality
-
-                persist_personality(pname)
+                _write_config_key("display.personality", pname)
+                _write_config_key("agent.system_prompt", new_prompt)
                 nv = str(value or "none")
                 history_reset, info = _apply_personality_to_session(
                     sid_key, session, new_prompt, pname
@@ -13518,41 +14046,20 @@ def _(rid, params, pdb, conn) -> dict:
     return _ok(rid, {"project": proj.to_dict() if proj else None, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
 
 
-def _non_workspace_dirs() -> set[str]:
-    """Directories that are never a workspace, whichever tier proposes them.
-
-    The filesystem root, the user's home, and the directory homes live in —
-    ``/home`` on Linux, ``/Users`` on macOS, ``C:\\Users`` on Windows. Both
-    POSIX spellings are excluded on every host because both are reachable as a
-    cwd anywhere: macOS ships an empty ``/home`` autofs stub, and a container or
-    remote shell hands back Linux paths. Promoting one of these mints a
-    catch-all project that swallows unplaced sessions, and ``/home`` in
-    particular renders as a second row reading "home" next to the Home bucket.
-    """
-    home = os.path.realpath(os.path.expanduser("~"))
-    candidates = (os.sep, home, os.path.dirname(home), "/home", "/Users")
-
-    return {os.path.normcase(os.path.realpath(path)) for path in candidates if path}
-
-
 def _is_repo_junk(root: str) -> bool:
-    """A git root we never auto-surface as a project: a non-workspace dir (see
-    :func:`_non_workspace_dirs`) or anything under HERMES_HOME (~/.hermes by
-    default) — config/sessions/skills, not a workspace. User-created projects
-    pointing there are still honored."""
+    """A git root we never auto-surface as a project: the bare home dir or
+    anything under HERMES_HOME (~/.hermes by default) — config/sessions/skills,
+    not a workspace. User-created projects pointing there are still honored."""
     if not root:
         return True
 
     from hermes_constants import get_hermes_home
 
     real = os.path.realpath(root)
+    home = os.path.realpath(os.path.expanduser("~"))
     hermes_home = os.path.realpath(str(get_hermes_home()))
 
-    return (
-        os.path.normcase(real) in _non_workspace_dirs()
-        or real == hermes_home
-        or real.startswith(hermes_home + os.sep)
-    )
+    return real == home or real == hermes_home or real.startswith(hermes_home + os.sep)
 
 
 def _is_session_cwd_junk(cwd: str) -> bool:
@@ -13560,9 +14067,8 @@ def _is_session_cwd_junk(cwd: str) -> bool:
 
     Unlike discovered git roots, an explicitly selected descendant of
     HERMES_HOME may be an intentional prose/data workspace. The pre-Projects
-    desktop surfaced every such cwd, so exclude only the broad defaults that
-    would create catch-all projects: HERMES_HOME itself and the dirs in
-    :func:`_non_workspace_dirs`.
+    desktop surfaced every such cwd, so exclude only the two broad defaults
+    that would create catch-all projects.
     """
     if not cwd:
         return True
@@ -13570,8 +14076,9 @@ def _is_session_cwd_junk(cwd: str) -> bool:
     from hermes_constants import get_hermes_home
 
     real = os.path.normcase(os.path.realpath(cwd))
+    home = os.path.normcase(os.path.realpath(os.path.expanduser("~")))
     hermes_home = os.path.normcase(os.path.realpath(str(get_hermes_home())))
-    return real in _non_workspace_dirs() or real == hermes_home
+    return real == home or real == hermes_home
 
 
 def _repo_discovery_policy(raw: dict | None = None) -> dict:
@@ -13868,10 +14375,6 @@ def _project_tree_inputs(
         include_children=False,
         exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
         include_archived=False,
-        # `_project_tree_row` keeps ~18 fields and drops the rest, so selecting
-        # the system-prompt blob only to discard it costs tens of MB of B-tree
-        # reads per build on a long-lived database.
-        compact_rows=True,
     )
     sessions = [_project_tree_row(r) for r in rows]
     # Parallel-warm the git cache so build_tree's resolver reads it instead of
@@ -13937,13 +14440,6 @@ def _build_project_tree(
     _DIR_EXISTS_CACHE.clear()
     sessions, projects, discovered, active_id = _project_tree_inputs(
         db, session_limit, include_discovered=include_discovered
-    )
-    # build_tree resolves every declared project folder and every discovered
-    # repo root too, and those paths are not session cwds — without this they
-    # are the one part of the build still probing git one directory at a time.
-    git_probe.warm_roots(
-        [str(f.get("path") or "") for p in projects for f in (p.get("folders") or [])]
-        + [str(r.get("root") or "") for r in discovered]
     )
     tree = project_tree.build_tree(
         projects,
@@ -14140,7 +14636,6 @@ def _rank_slash_completions(
     origin_of,
     *,
     browsing: bool,
-    score_of=None,
 ) -> list[dict]:
     """Rank and bound slash completions the way the menu should read.
 
@@ -14149,12 +14644,6 @@ def _rank_slash_completions(
     block is reordered, most-used first and A-Z within a tie, so the handful
     of skills someone invokes daily lead the ones that shipped with Hermes
     and were never opened.
-
-    ``score_of`` (optional) is the fuzzy-match scorer from
-    :func:`tui_gateway.slash_fuzzy.fuzzy_rank_slash_items` — when a typed
-    query produced scores, they lead the skill sort so a name match beats a
-    description match before usage breaks ties. Commands arrive already
-    score-sorted and keep their order either way.
 
     The limit is spent PER KIND rather than on one flat truncation. A flat
     cut is positional, not editorial: the completer emits every registry
@@ -14182,12 +14671,7 @@ def _rank_slash_completions(
             if origin_of(name_of(item)) != "bundled" or usage(name_of(item)) > 0
         ]
 
-    if score_of is not None:
-        skills.sort(
-            key=lambda item: (score_of(item), -usage(name_of(item)), name_of(item))
-        )
-    else:
-        skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
+    skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
 
     return commands[:_SLASH_COMPLETION_LIMIT] + skills[:_SLASH_COMPLETION_LIMIT]
 
@@ -14909,12 +15393,6 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             broadcast_session_info()
         elif name == "personality" and arg and agent:
             pname, new_prompt = _validate_personality(arg, _load_cfg())
-            # Persist through the single owner so this surface can never
-            # drift from the others (the old TUI slash path applied the
-            # overlay in-session but skipped persistence entirely).
-            from hermes_cli.personality import persist_personality
-
-            persist_personality(pname)
             _apply_personality_to_session(sid, session, new_prompt, pname)
         elif name == "prompt" and agent:
             cfg = _load_cfg()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1829,6 +1829,7 @@ def _transfer_db_to_agent(agent, db) -> bool:
     except Exception:
         return False
 
+
 @contextlib.contextmanager
 def _profile_db(params: dict | None = None):
     """Yield the SessionDB for ``params['profile']`` (app-global remote mode).
@@ -2687,6 +2688,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
+        session_db = None
+        owns_db = False
         profile_home = current.get("profile_home")
         try:
             history_ready = current.get("resume_history_ready")
@@ -2714,7 +2717,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 try:
                     from hermes_state import SessionDB
 
+                    # DEDICATED handle — ours until _transfer_db_to_agent hands
+                    # it to the built agent in the finally below. Every path
+                    # that leaves this build without that transfer (the except
+                    # below, and a session reaped mid-build) must close it.
                     session_db = SessionDB(db_path=Path(profile_home) / "state.db")
+                    owns_db = True
                 except Exception:
                     session_db = None
 
@@ -2858,6 +2866,18 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     unregister_gateway_notify(key)
                 except Exception:
                     pass
+            # Dedicated profile handle: hand it to the agent that will actually
+            # be torn down, or close it here when no such agent exists. Both
+            # non-transfer cases are real: the except above (build raised, so
+            # nothing holds the handle) and `replaced` (the session was reaped
+            # mid-build, so this agent is discarded and _teardown_session will
+            # never reach it). Transferring to a discarded agent would leak the
+            # handle exactly as before.
+            if owns_db and session_db is not None:
+                built = None if replaced else current.get("agent")
+                if not _transfer_db_to_agent(built, session_db):
+                    with contextlib.suppress(Exception):
+                        session_db.close()
             ready.set()
 
     build_thread = threading.Thread(target=_build, daemon=True)
@@ -2981,6 +3001,23 @@ def _terminal_task_cwd(session: dict | None) -> str:
     resolution path is taken even when the dashboard entrypoint did not call
     ``apply_terminal_config_to_env`` on its own ``os.environ``.
     """
+    return _terminal_task_cwd_with_source(session)[0]
+
+
+def _terminal_task_cwd_with_source(session: dict | None) -> tuple[str, str]:
+    """Like :func:`_terminal_task_cwd` but also names the value's ORIGIN.
+
+    Returns ``(cwd, source)`` where source is:
+
+    * ``"session"`` — the workspace the user attached to THIS session
+      (``explicit_cwd``), or this session's own tracked directory.
+    * ``"process"`` — the process-global ``TERMINAL_CWD`` env var / config
+      ``terminal.cwd`` fallback.  On a shared-container backend this is the
+      normal seed; under per-session docker isolation it is a launch
+      artifact from a PREVIOUS session (the workspace picker persists it
+      process-wide) and must never become a fresh session's bind mount —
+      terminal_tool refuses ``cwd_source: "process"`` as a mount source.
+    """
     backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
     if not backend or backend == "local":
         # Fall back to config when TERMINAL_ENV is unset (dashboard/TUI process
@@ -2995,6 +3032,11 @@ def _terminal_task_cwd(session: dict | None) -> str:
             pass
 
     if backend and backend != "local":
+        # A workspace the user explicitly attached to THIS session wins over
+        # the process-global env var — the env var is whatever the LAST
+        # session's picker wrote, not this session's choice.
+        if session and session.get("explicit_cwd") and session.get("cwd"):
+            return str(session["cwd"]), "session"
         raw = os.environ.get("TERMINAL_CWD", "").strip()
         if not raw:
             try:
@@ -3004,9 +3046,13 @@ def _terminal_task_cwd(session: dict | None) -> str:
             except Exception:
                 raw = ""
         if raw and raw not in {".", "auto", "cwd"}:
-            return raw
+            return raw, "process"
+        if backend == "ssh":
+            return "~", "process"
 
-    return _session_cwd(session)
+    if session and session.get("cwd"):
+        return str(session["cwd"]), "session"
+    return _completion_cwd(), "process"
 
 
 # Git working-tree probing (run git, resolve roots, fold worktrees) lives in a
@@ -3089,6 +3135,27 @@ def _heal_dead_cwd(cwd: str) -> str:
 def _is_local_terminal_backend() -> bool:
     backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
     return not backend or backend == "local"
+
+
+def _effective_terminal_backend() -> str:
+    """Active terminal backend name (``local``, ``docker``, ``ssh``, ...).
+
+    ``TERMINAL_ENV`` is authoritative when set (launchers bridge
+    ``terminal.backend`` into env at startup). Desktop/TUI in-process gateways
+    skip that bridge, so fall back to the ``terminal.backend`` config key —
+    the same rule ``_terminal_task_cwd`` uses.
+    """
+    backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    if not backend or backend == "local":
+        try:
+            terminal_cfg = _load_cfg().get("terminal", {})
+            if isinstance(terminal_cfg, dict):
+                cfg_backend = str(terminal_cfg.get("backend") or "").strip().lower()
+                if cfg_backend and cfg_backend != "local":
+                    backend = cfg_backend
+        except Exception:
+            pass
+    return backend or "local"
 
 
 def _display_session_cwd(session: dict | None) -> str:
@@ -3222,8 +3289,9 @@ def _register_session_cwd(session: dict | None) -> None:
     try:
         from tools.terminal_tool import register_task_env_overrides
 
+        cwd, cwd_source = _terminal_task_cwd_with_source(session)
         register_task_env_overrides(
-            session["session_key"], {"cwd": _terminal_task_cwd(session)}
+            session["session_key"], {"cwd": cwd, "cwd_source": cwd_source}
         )
     except Exception:
         pass
@@ -3852,10 +3920,18 @@ def _apply_managed(cfg: dict) -> dict:
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
 
-    from hermes_cli.config import atomic_config_write
+    from utils import atomic_roundtrip_yaml_save
 
     path = _hermes_home / "config.yaml"
-    atomic_config_write(path, cfg)
+    # Comment-, ordering-, and Unicode-preserving full-state write.
+    # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
+    # `atomic_config_write`, which is not comment-preserving) which clobbered
+    # the user's hand-written config every time we touched a single setting
+    # (top-level keys reordered alphabetically, comments dropped, kaomoji
+    # mangled to \\uXXXX escapes). Fails closed on an unreadable existing
+    # config.yaml the same way atomic_config_write does (see
+    # atomic_roundtrip_yaml_save's require_readable_config_before_write call).
+    atomic_roundtrip_yaml_save(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path
@@ -6144,16 +6220,19 @@ def _probe_config_health(cfg: dict) -> str:
     agent_cfg = cfg.get("agent")
     if isinstance(display_cfg, dict):
         personality = str(display_cfg.get("personality", "") or "").strip().lower()
-        if (
-            personality
-            and personality not in {"default", "none", "neutral"}
-            and isinstance(agent_cfg, dict)
-            and agent_cfg.get("personalities") is None
-        ):
-            warnings.append(
-                "`display.personality` is set but `agent.personalities` is empty/null; "
-                "personality overlay will be skipped."
-            )
+        if personality and personality not in {"default", "none", "neutral"}:
+            try:
+                from hermes_cli.personality import available_personalities
+
+                if personality not in available_personalities(cfg):
+                    warnings.append(
+                        f"`display.personality: {personality}` does not match any "
+                        "built-in or `agent.personalities` entry; personality "
+                        "overlay will be skipped."
+                    )
+            except Exception:
+                pass
+    _ = agent_cfg  # retained for shape parity; built-ins exist without config
     return " ".join(warnings).strip()
 
 
@@ -6299,6 +6378,7 @@ def _session_info(
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
+        "terminal_backend": _effective_terminal_backend(),
         "personality": str(personality or ""),
         "running": bool(turn_state["running"]),
         "turn_started_at": turn_started_at,
@@ -6554,11 +6634,18 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
-        payload = {
+        payload: dict[str, object] = {
             "tool_id": tool_call_id,
             "name": name,
             "context": _tool_ctx(name, args),
         }
+        # The desktop renders the expanded tool row (the `$` transcript) from
+        # the args of the part, and `context` is an 80-char display preview.
+        # tool.complete already ships full args to every client. When
+        # tool.start ships them too, the expanded row is complete while the
+        # tool runs, at the cost of one duplicate transient payload per call.
+        if args:
+            payload["args"] = args
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:
@@ -7068,60 +7155,51 @@ def _wire_callbacks(sid: str):
 
 
 def _render_personality_prompt(value) -> str:
-    if isinstance(value, dict):
-        parts = [value.get("system_prompt", "")]
-        if value.get("tone"):
-            parts.append(f'Tone: {value["tone"]}')
-        if value.get("style"):
-            parts.append(f'Style: {value["style"]}')
-        return "\n".join(p for p in parts if p)
-    return str(value)
+    """Delegates to hermes_cli.personality (single owner of rendering)."""
+    from hermes_cli.personality import render_personality_prompt
+
+    return render_personality_prompt(value)
 
 
 def _available_personalities(cfg: dict | None = None) -> dict:
-    try:
-        from cli import load_cli_config
+    """Built-ins + user overrides, via hermes_cli.personality (single owner)."""
+    from hermes_cli.personality import available_personalities
 
-        return (load_cli_config().get("agent") or {}).get("personalities", {}) or {}
-    except Exception:
-        try:
-            from hermes_cli.config import load_config as _load_full_cfg
-
-            return (_load_full_cfg().get("agent") or {}).get("personalities", {}) or {}
-        except Exception:
-            cfg = cfg or _load_cfg()
-            return (cfg.get("agent") or {}).get("personalities", {}) or {}
+    if cfg is None:
+        cfg = _load_cfg()
+    return available_personalities(cfg)
 
 
 def _validate_personality(value: str, cfg: dict | None = None) -> tuple[str, str]:
-    raw = str(value or "").strip()
-    name = raw.lower()
-    if not name or name in {"none", "default", "neutral"}:
-        return "", ""
+    """Resolve a requested personality against _available_personalities.
 
+    Same contract as hermes_cli.personality.resolve_personality — (name,
+    prompt) or ValueError — but resolves through the module-level
+    _available_personalities so tests (and future gateway-side overrides)
+    keep a single patch point.
+    """
+    from hermes_cli.personality import normalize_personality_name
+
+    name = normalize_personality_name(value)
+    if not name:
+        return "", ""
     personalities = _available_personalities(cfg)
     if name not in personalities:
-        names = sorted(personalities)
-        available = ", ".join(f"`{n}`" for n in names)
-        base = f"Unknown personality: `{raw}`."
-        if available:
-            base += f"\n\nAvailable: `none`, {available}"
-        else:
-            base += "\n\nNo personalities configured."
-        raise ValueError(base)
-
+        names = ", ".join(f"`{n}`" for n in sorted(personalities))
+        raise ValueError(
+            f"Unknown personality: `{str(value).strip()}`.\n\nAvailable: `none`, {names}"
+        )
     return name, _render_personality_prompt(personalities[name])
 
 
 def _prompt_text(value) -> str:
-    """Normalize config prompt values from YAML before handing them to AIAgent."""
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value.strip()
-    if isinstance(value, list):
-        return "\n".join(str(item).strip() for item in value if str(item).strip())
-    return str(value).strip()
+    """Normalize config prompt values from YAML before handing them to AIAgent.
+
+    Delegates to hermes_cli.personality (single owner).
+    """
+    from hermes_cli.personality import prompt_text
+
+    return prompt_text(value)
 
 
 def _apply_personality_to_session(
@@ -7621,8 +7699,9 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
-    agent_cfg = cfg.get("agent") or {}
-    system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
+    from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
+
+    system_prompt = resolve_ephemeral_system_prompt_from_config(cfg)
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
@@ -8267,9 +8346,15 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             tc_info = tool_call_args.get(tc_id) if tc_id else None
             name = (tc_info[0] if tc_info else None) or m.get("tool_name") or "tool"
             args = (tc_info[1] if tc_info else None) or {}
-            messages.append(
-                {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
-            )
+            tool_msg = {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
+            # This is the display projection, so keep it faithful. `context`
+            # is an 80-char preview for collapsed row titles. A renderer that
+            # shows the full call (the expanded `$` transcript in the desktop)
+            # rebuilds it from args. When only the preview shipped, that
+            # truncation was permanent.
+            if args:
+                tool_msg["args"] = args
+            messages.append(tool_msg)
             continue
         # An assistant turn may carry only reasoning/thinking content with no
         # visible text (extended-thinking turns, thinking-only recovery
@@ -9101,6 +9186,22 @@ def _emit_terminal_turn_error(
     _emit("message.complete", sid, payload)
 
 
+def _restore_agent_history_after_turn_error(session: dict, agent) -> bool:
+    """Keep a failed turn's working transcript in the gateway session.
+
+    ``AIAgent`` persists its working messages independently of the gateway's
+    history snapshot. If the turn raises after that persistence, the next
+    prompt must see the working transcript instead of the pre-turn snapshot.
+    """
+    agent_messages = getattr(agent, "_session_messages", None)
+    if not isinstance(agent_messages, list):
+        return False
+    with session["history_lock"]:
+        session["history"] = list(agent_messages)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+    return True
+
+
 def _queued_prompt_snapshot(session: dict) -> dict | None:
     """Return the accepted next-turn prompt without its transport handle.
 
@@ -9465,6 +9566,9 @@ def _fallback_session_info(
     agent = session.get("agent")
     if agent is not None:
         info = _session_info(agent)
+        # Public turn state rides on top of any _session_info shape — tests
+        # monkeypatch _session_info with bare lambdas, so stamp here rather
+        # than threading kwargs through the call.
         info.update(
             {
                 "running": bool(turn_state["running"]),
@@ -9474,9 +9578,17 @@ def _fallback_session_info(
             }
         )
         return info
-    cwd = _default_session_cwd()
+    # The SESSION's own workspace, not the gateway's launch directory. Reporting
+    # `_default_session_cwd()` here told a lazily-resumed session's client that
+    # its workspace was wherever the gateway process happened to start, so the
+    # desktop Files pane painted the wrong project even after the renderer
+    # rebound correctly (#71254). `branch` is always emitted ("" outside a git
+    # repo) so a client can clear a stale label instead of retaining it — the
+    # same contract `_lazy_session_info` above already follows.
+    cwd = _session_cwd(session)
     return {
         "cwd": cwd,
+        "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
         "lazy": True,
         "model": _resolve_model(),
@@ -10974,6 +11086,9 @@ def _notification_poller_loop(
             _emitted.add(dedup_key)
         if outcome == "busy":
             process_registry.completion_queue.put(event)
+            # Requeueing makes the queue non-empty again, so without breaking
+            # here the drain spins on the same busy-owned event forever.
+            break
 
     for event in deferred:
         process_registry.completion_queue.put(event)
@@ -11102,6 +11217,128 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     _notification_pollers.append((stop, t))
     t.start()
     return stop
+
+
+def _hud_surface_note(session: dict) -> str:
+    """The HUD-mode note for this turn, or "" when it was not typed there."""
+    if session.get("client_surface") != "hud":
+        return ""
+    from agent.prompt_builder import hud_surface_note
+
+    return hud_surface_note(getattr(session.get("agent"), "valid_tool_names", None))
+
+
+def _prepend_note(run_message: Any, note: str) -> Any:
+    """Prefix a per-turn note onto the MODEL INPUT, leaving the prompt alone.
+
+    Everything the model needs to know about the turn but the user did not
+    type — an interrupted reply, reactions, the surface they typed into —
+    arrives this way. persist_user_message keeps the clean prompt, so no
+    scaffolding reaches the transcript, and annotating the NEW turn never
+    rewrites an already-sent message, so the cached prefix survives.
+    """
+    if not note:
+        return run_message
+    if isinstance(run_message, str):
+        return f"{note}\n\n{run_message}"
+    if isinstance(run_message, list):
+        return [{"type": "text", "text": note}, *run_message]
+    return run_message
+
+
+_GOAL_COMPRESSION_RECOVERY_ATTEMPTS = "_goal_compression_recovery_attempts"
+_GOAL_COMPRESSION_RECOVERY_LIMIT = 1
+
+
+def _is_successful_goal_turn(result: Any, status: str, raw: Any) -> bool:
+    """Return whether a turn produced a real response the goal judge can use."""
+    return bool(
+        status == "complete"
+        and isinstance(raw, str)
+        and raw.strip()
+        and not (isinstance(result, dict) and result.get("failed"))
+        and not (isinstance(result, dict) and result.get("completed") is False)
+    )
+
+
+def _plan_goal_compression_recovery(
+    session: dict,
+    result: Any,
+    *,
+    status: str,
+    raw: Any,
+) -> tuple[str | None, str | None]:
+    """Plan a bounded active-goal retry after compression exhaustion.
+
+    Compression exhaustion is a failed turn, so it must not be sent to the
+    goal judge or consume the goal's turn budget.  One fresh continuation turn
+    is allowed.  If that turn also exhausts compression, pause the goal rather
+    than spinning until an arbitrary user message happens to wake it up.
+
+    Returns ``(continuation_prompt, status_notice)``.  Sessions without an
+    active goal retain the existing error-only behavior.
+    """
+    compression_exhausted = bool(
+        isinstance(result, dict) and result.get("compression_exhausted")
+    )
+    if not compression_exhausted:
+        if _is_successful_goal_turn(result, status, raw):
+            session.pop(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS, None)
+        return None, None
+
+    from hermes_cli.goals import GoalManager
+
+    sid_key = str(session.get("session_key") or "")
+    if not sid_key:
+        return None, None
+
+    try:
+        goals_cfg = _load_cfg().get("goals") or {}
+        goal_max_turns = int(goals_cfg.get("max_turns", 20) or 20)
+    except Exception:
+        goal_max_turns = 20
+
+    goal_mgr = GoalManager(
+        session_id=sid_key,
+        default_max_turns=goal_max_turns,
+    )
+    if not goal_mgr.is_active():
+        session.pop(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS, None)
+        return None, None
+
+    goal_created_at = float(getattr(goal_mgr.state, "created_at", 0.0) or 0.0)
+    recovery_state = session.get(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS)
+    attempts = 0
+    if (
+        isinstance(recovery_state, dict)
+        and recovery_state.get("goal_created_at") == goal_created_at
+        and recovery_state.get("goal") == getattr(goal_mgr.state, "goal", "")
+    ):
+        try:
+            attempts = int(recovery_state.get("attempts", 0) or 0)
+        except (TypeError, ValueError):
+            attempts = 0
+
+    continuation_prompt = goal_mgr.next_continuation_prompt()
+    if attempts < _GOAL_COMPRESSION_RECOVERY_LIMIT and continuation_prompt:
+        session[_GOAL_COMPRESSION_RECOVERY_ATTEMPTS] = {
+            "goal_created_at": goal_created_at,
+            "goal": getattr(goal_mgr.state, "goal", ""),
+            "attempts": attempts + 1,
+        }
+        return (
+            continuation_prompt,
+            "Context compression was exhausted. Retrying the active goal once.",
+        )
+
+    goal_mgr.pause(reason="context compression exhausted twice consecutively")
+    # A later explicit /goal resume gets a fresh bounded recovery cycle.
+    session.pop(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS, None)
+    return (
+        None,
+        "Goal paused after context compression was exhausted twice. "
+        "Run /compress, then /goal resume to continue.",
+    )
 
 
 def _set_turn_origin_locked(session: dict, origin: TurnOrigin) -> int:
@@ -11816,7 +12053,6 @@ def _start_usage_ticker(
     thread.start()
     return stop, thread
 
-
 def _run_prompt_submit(
     rid,
     sid: str,
@@ -12136,21 +12372,14 @@ def _run_prompt_submit(
             from tools.tts_streaming import SPEECH_INTERRUPTED_NOTE, take_speech_interrupted
 
             if take_speech_interrupted():
-                if isinstance(run_message, str):
-                    run_message = f"{SPEECH_INTERRUPTED_NOTE}\n\n{run_message}"
-                elif isinstance(run_message, list):
-                    run_message = [{"type": "text", "text": SPEECH_INTERRUPTED_NOTE}, *run_message]
+                run_message = _prepend_note(run_message, SPEECH_INTERRUPTED_NOTE)
 
-            # Reactions the user added since the last turn ride the MODEL INPUT
-            # only (same enrichment channel as the speech-interrupted note);
-            # persist_user_message below stays the clean prompt, so no
-            # scaffolding reaches the transcript. Cache-safe: annotating the
-            # NEW turn never rewrites an already-sent message.
-            if reaction_notes := _pending_reaction_notes(session):
-                if isinstance(run_message, str):
-                    run_message = f"{reaction_notes}\n\n{run_message}"
-                elif isinstance(run_message, list):
-                    run_message = [{"type": "text", "text": reaction_notes}, *run_message]
+            # Reactions the user added since the last turn.
+            run_message = _prepend_note(run_message, _pending_reaction_notes(session))
+
+            # Which window the message was typed into. HUD mode is per-turn
+            # state, so it cannot live in the (byte-stable) system prompt.
+            run_message = _prepend_note(run_message, _hud_surface_note(session))
 
             def _stream(delta):
                 with session["history_lock"]:
@@ -12206,6 +12435,14 @@ def _run_prompt_submit(
             if display_kind and "persist_user_display_kind" in _run_params:
                 run_kwargs["persist_user_display_kind"] = display_kind
                 run_kwargs["persist_user_display_metadata"] = display_metadata
+            # Auto-titling now fires inside the turn prologue (shared by every
+            # surface). Hand the agent this session's live-rename hook so the
+            # sidebar repaints the moment a title lands, rather than waiting
+            # for the next list refresh.
+            _title_key = session.get("session_key") or sid
+            agent._on_session_title = lambda t, _src, _k=_title_key: _emit(
+                "session.title", sid, {"session_id": _k, "title": t}
+            )
             if claimed_notification_ids and "deferred_notification_ids" in _run_params:
                 run_kwargs["deferred_notification_ids"] = sorted(
                     claimed_notification_ids
@@ -12640,55 +12877,6 @@ def _run_prompt_submit(
                     # Transient DB failure — keep pending_title for retry.
                     pass
 
-            if (
-                status == "complete"
-                and isinstance(raw, str)
-                and raw.strip()
-                and isinstance(text, str)
-                and text.strip()
-            ):
-                try:
-                    from agent.title_generator import maybe_auto_title
-
-                    _title_key = session.get("session_key") or sid
-                    # Snapshot the runtime identity; the validator lets the
-                    # background titler skip its LLM call if the session's
-                    # model changed before it fires (#19027).
-                    _title_model = getattr(agent, "model", None)
-                    _title_provider = getattr(agent, "provider", None)
-                    maybe_auto_title(
-                        _get_db(),
-                        _title_key,
-                        persist_user_message
-                        if persist_user_message is not None
-                        else text,
-                        raw,
-                        session.get("history", []),
-                        # Keep auxiliary auto-detection aligned with the active
-                        # Desktop/Webapp session. Without this, providers that
-                        # rely on runtime auth (for example OpenAI Codex OAuth)
-                        # are skipped and the new session remains untitled.
-                        main_runtime={
-                            "model": getattr(agent, "model", None),
-                            "provider": getattr(agent, "provider", None),
-                            "base_url": getattr(agent, "base_url", None),
-                            "api_key": getattr(agent, "api_key", None),
-                            "api_mode": getattr(agent, "api_mode", None),
-                        },
-                        runtime_validator=lambda: (
-                            getattr(agent, "model", None) == _title_model
-                            and getattr(agent, "provider", None) == _title_provider
-                        ),
-                        # Push the generated title live so the sidebar renames
-                        # without waiting for the next list refresh (the titler
-                        # runs async, after this turn's refresh already fired).
-                        title_callback=lambda t, _k=_title_key: _emit(
-                            "session.title", sid, {"session_id": _k, "title": t}
-                        ),
-                    )
-                except Exception:
-                    pass
-
             # Voice TTS fallback: when the streaming pipeline couldn't start
             # (no provider / missing deps probed at turn start), speak the
             # final text whole (cli.py:_voice_speak_response parity). The
@@ -12728,6 +12916,12 @@ def _run_prompt_submit(
             print(
                 f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
             )
+            # The agent persists its working transcript on normal finalization,
+            # but an exception in that finalizer can otherwise leave the
+            # gateway's separate in-memory history at the turn-start snapshot.
+            # Keep the partial turn available to the next prompt; the durable
+            # inflight record still carries the recoverable error state.
+            _restore_agent_history_after_turn_error(session, agent)
             try:
                 # Close the turn with the same terminal error frame shape as
                 # the returned-error path (uniform client handling), retaining
@@ -13052,7 +13246,19 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
 
 
 def _desktop_attachment_dir(session: dict) -> Path:
-    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
+    """Resolve the file-attachment staging dir against the session's effective home.
+
+    Anchored on the session profile's ``attachments/`` dir (same rule as
+    ``_session_images_dir``): ``file.attach`` runs BEFORE ``prompt.submit``
+    installs the session's profile HERMES_HOME override, while the docker/ssh
+    sandbox mounts are resolved against the *session profile's* home at run
+    time — so the staged file must land where the bind mount points, or the
+    container can never see it (#76577). ``attachments/`` is registered in
+    ``tools.credential_files._CACHE_DIRS`` and auto-mounted into containers.
+    """
+    profile_home = session.get("profile_home")
+    base = Path(profile_home) if profile_home else _hermes_home
+    root = base / "attachments"
     root.mkdir(parents=True, exist_ok=True)
     return root
 
@@ -13132,10 +13338,11 @@ def _stage_session_file_attachment(
       1. The path resolves to a file already INSIDE the session workspace — use
          it as-is (no copy, ``uploaded=False``).
       2. The path resolves to a gateway-visible file OUTSIDE the workspace — copy
-         it into ``.hermes/desktop-attachments/`` so the ``@file:`` ref resolves.
+         it into the session home's ``attachments/`` dir (bind-mounted into
+         container backends) so the ``@file:`` ref resolves inside the sandbox.
       3. The path doesn't exist on the gateway (the common remote case: it's a
          path on the CLIENT's disk) — decode the uploaded ``data_url`` bytes and
-         write them into ``.hermes/desktop-attachments/``.
+         write them into the session home's ``attachments/`` dir.
 
     Returns ``(stored_path, uploaded)``.
     """
@@ -13866,8 +14073,12 @@ def _(rid, params: dict) -> dict:
             elif key == "personality":
                 sid_key = params.get("session_id", "")
                 pname, new_prompt = _validate_personality(str(value or ""), cfg)
-                _write_config_key("display.personality", pname)
-                _write_config_key("agent.system_prompt", new_prompt)
+                # Personality text is an in-session overlay. Persistence goes
+                # through hermes_cli.personality (single owner) and never
+                # touches the user-owned global system prompt.
+                from hermes_cli.personality import persist_personality
+
+                persist_personality(pname)
                 nv = str(value or "none")
                 history_reset, info = _apply_personality_to_session(
                     sid_key, session, new_prompt, pname
@@ -14052,20 +14263,41 @@ def _(rid, params, pdb, conn) -> dict:
     return _ok(rid, {"project": proj.to_dict() if proj else None, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
 
 
+def _non_workspace_dirs() -> set[str]:
+    """Directories that are never a workspace, whichever tier proposes them.
+
+    The filesystem root, the user's home, and the directory homes live in —
+    ``/home`` on Linux, ``/Users`` on macOS, ``C:\\Users`` on Windows. Both
+    POSIX spellings are excluded on every host because both are reachable as a
+    cwd anywhere: macOS ships an empty ``/home`` autofs stub, and a container or
+    remote shell hands back Linux paths. Promoting one of these mints a
+    catch-all project that swallows unplaced sessions, and ``/home`` in
+    particular renders as a second row reading "home" next to the Home bucket.
+    """
+    home = os.path.realpath(os.path.expanduser("~"))
+    candidates = (os.sep, home, os.path.dirname(home), "/home", "/Users")
+
+    return {os.path.normcase(os.path.realpath(path)) for path in candidates if path}
+
+
 def _is_repo_junk(root: str) -> bool:
-    """A git root we never auto-surface as a project: the bare home dir or
-    anything under HERMES_HOME (~/.hermes by default) — config/sessions/skills,
-    not a workspace. User-created projects pointing there are still honored."""
+    """A git root we never auto-surface as a project: a non-workspace dir (see
+    :func:`_non_workspace_dirs`) or anything under HERMES_HOME (~/.hermes by
+    default) — config/sessions/skills, not a workspace. User-created projects
+    pointing there are still honored."""
     if not root:
         return True
 
     from hermes_constants import get_hermes_home
 
     real = os.path.realpath(root)
-    home = os.path.realpath(os.path.expanduser("~"))
     hermes_home = os.path.realpath(str(get_hermes_home()))
 
-    return real == home or real == hermes_home or real.startswith(hermes_home + os.sep)
+    return (
+        os.path.normcase(real) in _non_workspace_dirs()
+        or real == hermes_home
+        or real.startswith(hermes_home + os.sep)
+    )
 
 
 def _is_session_cwd_junk(cwd: str) -> bool:
@@ -14073,8 +14305,9 @@ def _is_session_cwd_junk(cwd: str) -> bool:
 
     Unlike discovered git roots, an explicitly selected descendant of
     HERMES_HOME may be an intentional prose/data workspace. The pre-Projects
-    desktop surfaced every such cwd, so exclude only the two broad defaults
-    that would create catch-all projects.
+    desktop surfaced every such cwd, so exclude only the broad defaults that
+    would create catch-all projects: HERMES_HOME itself and the dirs in
+    :func:`_non_workspace_dirs`.
     """
     if not cwd:
         return True
@@ -14082,9 +14315,8 @@ def _is_session_cwd_junk(cwd: str) -> bool:
     from hermes_constants import get_hermes_home
 
     real = os.path.normcase(os.path.realpath(cwd))
-    home = os.path.normcase(os.path.realpath(os.path.expanduser("~")))
     hermes_home = os.path.normcase(os.path.realpath(str(get_hermes_home())))
-    return real == home or real == hermes_home
+    return real in _non_workspace_dirs() or real == hermes_home
 
 
 def _repo_discovery_policy(raw: dict | None = None) -> dict:
@@ -14381,6 +14613,10 @@ def _project_tree_inputs(
         include_children=False,
         exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
         include_archived=False,
+        # `_project_tree_row` keeps ~18 fields and drops the rest, so selecting
+        # the system-prompt blob only to discard it costs tens of MB of B-tree
+        # reads per build on a long-lived database.
+        compact_rows=True,
     )
     sessions = [_project_tree_row(r) for r in rows]
     # Parallel-warm the git cache so build_tree's resolver reads it instead of
@@ -14446,6 +14682,13 @@ def _build_project_tree(
     _DIR_EXISTS_CACHE.clear()
     sessions, projects, discovered, active_id = _project_tree_inputs(
         db, session_limit, include_discovered=include_discovered
+    )
+    # build_tree resolves every declared project folder and every discovered
+    # repo root too, and those paths are not session cwds — without this they
+    # are the one part of the build still probing git one directory at a time.
+    git_probe.warm_roots(
+        [str(f.get("path") or "") for p in projects for f in (p.get("folders") or [])]
+        + [str(r.get("root") or "") for r in discovered]
     )
     tree = project_tree.build_tree(
         projects,
@@ -14642,6 +14885,7 @@ def _rank_slash_completions(
     origin_of,
     *,
     browsing: bool,
+    score_of=None,
 ) -> list[dict]:
     """Rank and bound slash completions the way the menu should read.
 
@@ -14650,6 +14894,12 @@ def _rank_slash_completions(
     block is reordered, most-used first and A-Z within a tie, so the handful
     of skills someone invokes daily lead the ones that shipped with Hermes
     and were never opened.
+
+    ``score_of`` (optional) is the fuzzy-match scorer from
+    :func:`tui_gateway.slash_fuzzy.fuzzy_rank_slash_items` — when a typed
+    query produced scores, they lead the skill sort so a name match beats a
+    description match before usage breaks ties. Commands arrive already
+    score-sorted and keep their order either way.
 
     The limit is spent PER KIND rather than on one flat truncation. A flat
     cut is positional, not editorial: the completer emits every registry
@@ -14677,7 +14927,12 @@ def _rank_slash_completions(
             if origin_of(name_of(item)) != "bundled" or usage(name_of(item)) > 0
         ]
 
-    skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
+    if score_of is not None:
+        skills.sort(
+            key=lambda item: (score_of(item), -usage(name_of(item)), name_of(item))
+        )
+    else:
+        skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
 
     return commands[:_SLASH_COMPLETION_LIMIT] + skills[:_SLASH_COMPLETION_LIMIT]
 
@@ -15399,6 +15654,12 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             broadcast_session_info()
         elif name == "personality" and arg and agent:
             pname, new_prompt = _validate_personality(arg, _load_cfg())
+            # Persist through the single owner so this surface can never
+            # drift from the others (the old TUI slash path applied the
+            # overlay in-session but skipped persistence entirely).
+            from hermes_cli.personality import persist_personality
+
+            persist_personality(pname)
             _apply_personality_to_session(sid, session, new_prompt, pname)
         elif name == "prompt" and agent:
             cfg = _load_cfg()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12182,7 +12182,13 @@ def _run_prompt_submit(
                 "conversation_history": list(history),
                 "stream_callback": _stream,
                 "persist_user_message": (
-                    _build_persist_user_message(prompt, images, run_message) if images else prompt
+                    _build_persist_user_message(
+                        persist_user_message if persist_user_message is not None else text,
+                        images,
+                        run_message,
+                    )
+                    if images
+                    else (persist_user_message if persist_user_message is not None else prompt)
                 ),
             }
             # Type a synthesized turn at turn START so the crash persist writes

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -6,8 +6,9 @@ import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { ZERO } from '../domain/usage.js'
+import type { GatewayEvent } from '../gatewayTypes.js'
 import { estimateTokensRough } from '../lib/text.js'
-import type { Msg } from '../types.js'
+import type { Msg, SessionInfo } from '../types.js'
 
 // Mock the external-URL opener so the billing.step_up.verification test can
 // assert it's invoked without spawning a real browser process.
@@ -58,6 +59,13 @@ const buildCtx = (appended: Msg[]) =>
     }
   }) as any
 
+const sessionInfo = (overrides: Partial<SessionInfo>): SessionInfo => ({
+  model: 'test-model',
+  skills: {},
+  tools: {},
+  ...overrides
+})
+
 describe('createGatewayEventHandler', () => {
   beforeEach(() => {
     resetOverlayState()
@@ -65,6 +73,165 @@ describe('createGatewayEventHandler', () => {
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+  })
+
+  it('reconciles reconnect origin and rejects older turn events', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    const reconnect = {
+      payload: sessionInfo({ running: true, turn_generation: 4, turn_origin: 'notification' }),
+      type: 'session.info'
+    } satisfies GatewayEvent
+
+    onEvent(reconnect)
+
+    expect(getTurnState()).toMatchObject({ turnGeneration: 4, turnOrigin: 'notification' })
+    expect(getUiState().busy).toBe(true)
+
+    const nextStart = {
+      payload: { turn_generation: 5, turn_origin: 'user' },
+      type: 'message.start'
+    } satisfies GatewayEvent
+
+    onEvent(nextStart)
+
+    const staleSnapshot = {
+      payload: sessionInfo({ running: false, turn_generation: 4, turn_origin: null }),
+      type: 'session.info'
+    } satisfies GatewayEvent
+
+    onEvent(staleSnapshot)
+
+    const staleComplete = {
+      payload: { text: 'stale answer', turn_generation: 4, turn_origin: 'notification' },
+      type: 'message.complete'
+    } satisfies GatewayEvent
+
+    onEvent(staleComplete)
+
+    expect(getTurnState()).toMatchObject({ turnGeneration: 5, turnOrigin: 'user' })
+    expect(getUiState().busy).toBe(true)
+    expect(appended).not.toContainEqual(expect.objectContaining({ text: 'stale answer' }))
+
+    const currentComplete = {
+      payload: { text: 'current answer', turn_generation: 5, turn_origin: 'user' },
+      type: 'message.complete'
+    } satisfies GatewayEvent
+
+    onEvent(currentComplete)
+
+    const settledReconnect = {
+      payload: sessionInfo({ running: false, turn_generation: 5, turn_origin: null }),
+      type: 'session.info'
+    } satisfies GatewayEvent
+
+    onEvent(settledReconnect)
+
+    expect(appended).toContainEqual(expect.objectContaining({ text: 'current answer' }))
+    expect(getTurnState()).toMatchObject({ turnGeneration: 5, turnOrigin: null })
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('rejects a stale active snapshot after the same generation settles', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    const staleActive = {
+      payload: sessionInfo({
+        running: true,
+        turn_generation: 7,
+        turn_origin: 'notification',
+        turn_state_revision: 30
+      }),
+      type: 'session.info'
+    } satisfies GatewayEvent
+
+    onEvent(staleActive)
+    onEvent({
+      payload: {
+        text: 'done',
+        turn_generation: 7,
+        turn_origin: 'notification',
+        turn_state_revision: 31
+      },
+      type: 'message.complete'
+    } satisfies GatewayEvent)
+    onEvent(staleActive)
+
+    expect(getTurnState()).toMatchObject({ turnGeneration: 7, turnOrigin: 'notification' })
+    expect(getTurnState().turnStateRevision).toBe(31)
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('keeps other sessions from replacing the current turn fence', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ sid: 'session-b' })
+    turnController.reconcileTurn('notification', 1, true, 1)
+
+    onEvent({
+      payload: sessionInfo({
+        running: false,
+        turn_generation: 50,
+        turn_origin: null,
+        turn_state_revision: 99
+      }),
+      session_id: 'session-a',
+      type: 'session.info'
+    })
+    onEvent({
+      payload: {
+        text: 'wrong session',
+        turn_generation: 50,
+        turn_origin: 'notification',
+        turn_state_revision: 100
+      },
+      session_id: 'session-a',
+      type: 'message.complete'
+    })
+
+    expect(getTurnState()).toMatchObject({
+      turnGeneration: 1,
+      turnOrigin: 'notification',
+      turnStateRevision: 1
+    })
+    expect(getUiState().busy).toBe(true)
+    expect(appended).not.toContainEqual(expect.objectContaining({ text: 'wrong session' }))
+
+    onEvent({
+      payload: {
+        text: 'initial turn settled',
+        turn_generation: 1,
+        turn_origin: 'notification',
+        turn_state_revision: 2
+      },
+      session_id: 'session-b',
+      type: 'message.complete'
+    })
+    onEvent({
+      payload: { turn_generation: 2, turn_origin: 'user', turn_state_revision: 3 },
+      session_id: 'session-b',
+      type: 'message.start'
+    })
+    onEvent({
+      payload: { text: 'next turn settled', turn_generation: 2, turn_origin: 'user', turn_state_revision: 4 },
+      session_id: 'session-b',
+      type: 'message.complete'
+    })
+    onEvent({
+      payload: sessionInfo({ running: false, turn_generation: 2, turn_origin: null, turn_state_revision: 4 }),
+      session_id: 'session-b',
+      type: 'session.info'
+    })
+
+    expect(appended).toEqual([
+      expect.objectContaining({ text: 'initial turn settled' }),
+      expect.objectContaining({ text: 'next turn settled' })
+    ])
+    expect(getTurnState()).toMatchObject({ turnGeneration: 2, turnOrigin: null, turnStateRevision: 4 })
+    expect(getUiState().busy).toBe(false)
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -5,11 +5,13 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { turnController } from '../app/turnController.js'
-import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getTurnState, patchTurnState, resetTurnState } from '../app/turnStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import {
+  captureSessionResponseTurnFence,
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
+  reconcileSessionResponseTurn,
   scheduleResumeScrollToBottom,
   signalFreshSessionBoundary,
   writeActiveSessionFile
@@ -75,6 +77,94 @@ describe('live session activation in-flight state', () => {
 
     expect(turnController.bufRef).toBe('')
     expect(getTurnState().streaming).toBe('')
+  })
+})
+describe.each(['resume', 'activate'] as const)('%s response turn fence', kind => {
+  beforeEach(() => {
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  const activeResponse = (sessionId: string, revision: number) => ({
+    info: {
+      model: 'test-model',
+      running: true,
+      skills: {},
+      tools: {},
+      turn_generation: 1,
+      turn_origin: 'notification' as const,
+      turn_state_revision: revision
+    },
+    messages: [],
+    running: true,
+    session_id: sessionId,
+    status: 'working' as const,
+    turn_generation: 1,
+    turn_origin: 'notification' as const,
+    turn_state_revision: revision,
+    ...(kind === 'resume' ? { resumed: sessionId } : {})
+  })
+
+  it('adopts the target revision sequence after the source starts and settles', () => {
+    patchUiState({ sid: 'session-a' })
+    turnController.reconcileTurn(null, 40, false, 50)
+    const requestFence = captureSessionResponseTurnFence()
+
+    // Session A keeps running while the request for B is in flight.
+    turnController.reconcileTurn('notification', 41, true, 51)
+    turnController.reconcileTurn('notification', 41, false, 52)
+
+    const reconciled = reconcileSessionResponseTurn(activeResponse('session-b', 1), requestFence)
+
+    expect(reconciled.running).toBe(true)
+    expect(reconciled.turn).toEqual({
+      turnGeneration: 1,
+      turnOrigin: 'notification',
+      turnStateRevision: 1
+    })
+    expect(reconciled.info).toMatchObject({
+      running: true,
+      turn_generation: 1,
+      turn_origin: 'notification',
+      turn_state_revision: 1
+    })
+
+    // Match resetSession() + patchTurnState() in the lifecycle callbacks.
+    turnController.fullReset()
+    patchTurnState(reconciled.turn)
+    patchUiState({ busy: reconciled.running, info: reconciled.info, sid: 'session-b' })
+
+    expect(getUiState()).toMatchObject({ busy: true, sid: 'session-b' })
+    expect(turnController.reconcileTurn('notification', 1, false, 2)).toBe(true)
+    expect(turnController.reconcileTurn('user', 2, true, 3)).toBe(true)
+    expect(turnController.reconcileTurn('user', 2, false, 4)).toBe(true)
+    expect(turnController.reconcileTurn(null, 2, false, 4)).toBe(true)
+    expect(getTurnState()).toMatchObject({ turnGeneration: 2, turnOrigin: null, turnStateRevision: 4 })
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('keeps same-session state that settles ahead of a stale response', () => {
+    patchUiState({ sid: 'session-a' })
+    turnController.reconcileTurn('notification', 6, true, 50)
+    const requestFence = captureSessionResponseTurnFence()
+
+    turnController.reconcileTurn(null, 6, false, 51)
+
+    const reconciled = reconcileSessionResponseTurn(activeResponse('session-a', 50), requestFence)
+
+    expect(reconciled.running).toBe(false)
+    expect(reconciled.turn).toEqual({
+      turnGeneration: 6,
+      turnOrigin: null,
+      turnStateRevision: 51
+    })
+    expect(reconciled.info).toMatchObject({
+      running: false,
+      turn_generation: 6,
+      turn_origin: null,
+      turn_state_revision: 51
+    })
   })
 })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -772,14 +772,31 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
+        const accepted = turnController.reconcileTurn(
+          info.turn_origin,
+          info.turn_generation,
+          info.running,
+          info.turn_state_revision
+        )
+
+        const reconciledInfo = accepted
+          ? info
+          : {
+              ...info,
+              running: getUiState().busy,
+              turn_generation: getTurnState().turnGeneration,
+              turn_origin: getTurnState().turnOrigin,
+              turn_state_revision: getTurnState().turnStateRevision
+            }
+
         patchUiState(state => ({
           ...state,
-          info,
+          info: reconciledInfo,
           status: state.status === 'starting agent…' ? 'ready' : state.status,
           usage: info.usage ? mergeUsageStable(state.usage, info.usage) : state.usage
         }))
 
-        setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
+        setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info: reconciledInfo } : m)))
 
         return
       }
@@ -819,6 +836,17 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'message.start':
+        if (
+          !turnController.reconcileTurn(
+            ev.payload?.turn_origin,
+            ev.payload?.turn_generation,
+            true,
+            ev.payload?.turn_state_revision
+          )
+        ) {
+          return
+        }
+
         resetAgentsNudgeTurnState()
         turnController.startMessage()
 
@@ -1422,6 +1450,17 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'message.complete': {
+        if (
+          !turnController.reconcileTurn(
+            ev.payload?.turn_origin,
+            ev.payload?.turn_generation,
+            false,
+            ev.payload?.turn_state_revision
+          )
+        ) {
+          return
+        }
+
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 
         if (!wasInterrupted) {

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -17,7 +17,7 @@ import {
   sameToolTrailGroup,
   toolTrailLabel
 } from '../lib/text.js'
-import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
+import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem, TurnOrigin } from '../types.js'
 
 import type { Notice } from './interfaces.js'
 import { resetFlowOverlays } from './overlayStore.js'
@@ -984,6 +984,57 @@ class TurnController {
     const raw = this.bufRef.trimStart()
     const visible = hasReasoningTag(raw) ? splitReasoning(raw).text : raw
     patchTurnState({ streaming: boundedLiveRenderText(visible) })
+  }
+
+  reconcileTurn(
+    origin: TurnOrigin | null | undefined,
+    generation: number | undefined,
+    running?: boolean,
+    revision?: number
+  ): boolean {
+    const current = getTurnState()
+    const currentBusy = getUiState().busy
+    const hasGeneration = Number.isSafeInteger(generation) && Number(generation) >= 0
+    const nextGeneration = hasGeneration ? Number(generation) : current.turnGeneration
+    const hasRevision = Number.isSafeInteger(revision) && Number(revision) >= 0
+    const nextRevision = hasRevision ? Number(revision) : current.turnStateRevision
+
+    if (hasRevision) {
+      if (nextRevision < current.turnStateRevision) {
+        return false
+      }
+
+      if (nextRevision === current.turnStateRevision) {
+        if (hasGeneration && nextGeneration < current.turnGeneration) {
+          return false
+        }
+
+        if (running === true && currentBusy === false && nextRevision > 0) {
+          return false
+        }
+      }
+    } else if (hasGeneration && nextGeneration < current.turnGeneration) {
+      // Backward compatibility for older gateways: retain the previous
+      // generation-only ordering when turn_state_revision is absent.
+      return false
+    }
+
+    const nextOrigin =
+      origin === 'user' || origin === 'notification' || origin === 'goal' || origin === null
+        ? origin
+        : current.turnOrigin
+
+    patchTurnState({
+      turnGeneration: nextGeneration,
+      turnOrigin: nextOrigin,
+      turnStateRevision: nextRevision
+    })
+
+    if (running !== undefined) {
+      patchUiState({ busy: running })
+    }
+
+    return true
   }
 
   startMessage() {

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -2,7 +2,7 @@ import { atom } from 'nanostores'
 import { useSyncExternalStore } from 'react'
 
 import { isTodoDone } from '../lib/liveProgress.js'
-import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
+import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem, TurnOrigin } from '../types.js'
 
 const buildTurnState = (): TurnState => ({
   activity: [],
@@ -19,6 +19,9 @@ const buildTurnState = (): TurnState => ({
   todos: [],
   toolTokens: 0,
   tools: [],
+  turnGeneration: 0,
+  turnStateRevision: 0,
+  turnOrigin: null,
   turnTrail: []
 })
 
@@ -81,5 +84,8 @@ export interface TurnState {
   todos: TodoItem[]
   toolTokens: number
   tools: ActiveTool[]
+  turnGeneration: number
+  turnStateRevision: number
+  turnOrigin: TurnOrigin | null
   turnTrail: string[]
 }

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -24,7 +24,7 @@ import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
 import { patchOverlayState } from './overlayStore.js'
 import { scheduleResumeScrollToBottom } from './sessionResumeView.js'
 import { turnController } from './turnController.js'
-import { patchTurnState } from './turnStore.js'
+import { getTurnState, patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 export { refreshSessionView, scheduleResumeScrollToBottom } from './sessionResumeView.js'
@@ -41,6 +41,85 @@ const statusFromLiveSession = (status?: string, running = false) => {
   }
 
   return running || status === 'working' ? 'running…' : 'ready'
+}
+
+export interface SessionResponseTurnFence {
+  busy: boolean
+  sessionId: null | string
+  turnGeneration: number
+  turnOrigin: SessionInfo['turn_origin']
+  turnStateRevision: number
+}
+
+export const captureSessionResponseTurnFence = (): SessionResponseTurnFence => {
+  const turn = getTurnState()
+  const ui = getUiState()
+
+  return {
+    busy: ui.busy,
+    sessionId: ui.sid,
+    turnGeneration: turn.turnGeneration,
+    turnOrigin: turn.turnOrigin,
+    turnStateRevision: turn.turnStateRevision
+  }
+}
+
+export function reconcileSessionResponseTurn(
+  response: SessionActivateResponse | SessionResumeResponse,
+  requestFence: SessionResponseTurnFence
+) {
+  const current = getTurnState()
+  const currentUi = getUiState()
+  const sameSession = requestFence.sessionId === response.session_id && currentUi.sid === requestFence.sessionId
+
+  const changedDuringRequest =
+    sameSession &&
+    (current.turnGeneration !== requestFence.turnGeneration ||
+      current.turnOrigin !== requestFence.turnOrigin ||
+      current.turnStateRevision !== requestFence.turnStateRevision ||
+      currentUi.busy !== requestFence.busy)
+
+  if (!changedDuringRequest) {
+    // Turn revisions are independent per session. Only a changed fence that is
+    // still owned by this response's session can order the response; otherwise
+    // reset before adopting the target session's sequence.
+    turnController.fullReset()
+    patchUiState({ busy: false })
+  }
+
+  const info = response.info ?? null
+  const running = Boolean(response.running || response.status === 'working' || response.status === 'waiting')
+  const origin = Object.hasOwn(response, 'turn_origin') ? response.turn_origin : info?.turn_origin
+  const generation = Object.hasOwn(response, 'turn_generation') ? response.turn_generation : info?.turn_generation
+
+  const revision = Object.hasOwn(response, 'turn_state_revision')
+    ? response.turn_state_revision
+    : info?.turn_state_revision
+
+  turnController.reconcileTurn(origin, generation, running, revision)
+
+  const reconciledTurn = getTurnState()
+  const reconciledRunning = getUiState().busy
+
+  const reconciledInfo = info
+    ? {
+        ...info,
+        running: reconciledRunning,
+        turn_generation: reconciledTurn.turnGeneration,
+        turn_origin: reconciledTurn.turnOrigin,
+        turn_state_revision: reconciledTurn.turnStateRevision
+      }
+    : null
+
+  return {
+    info: reconciledInfo,
+    running: reconciledRunning,
+    turn: {
+      turnGeneration: reconciledTurn.turnGeneration,
+      turnOrigin: reconciledTurn.turnOrigin,
+      turnStateRevision: reconciledTurn.turnStateRevision
+    }
+  }
 }
 
 export const writeActiveSessionFile = (sessionId: null | string, file = process.env.HERMES_TUI_ACTIVE_SESSION_FILE) => {
@@ -288,6 +367,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     (id: string) => {
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'switching session…' })
+      const requestFence = captureSessionResponseTurnFence()
 
       gw.request<SessionActivateResponse>('session.activate', { session_id: id })
         .then(raw => {
@@ -299,10 +379,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             return patchUiState({ status: 'ready' })
           }
 
-          const info = r.info ?? null
-          const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+          const reconciled = reconcileSessionResponseTurn(r, requestFence)
+          const { info, running } = reconciled
 
           resetSession()
+          patchTurnState(reconciled.turn)
           setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
           const transcript = [...toTranscriptMessages(r.messages), ...liveSessionInflightMessages(r.inflight)]
           setHistoryItems(info ? [introMsg(info), ...transcript] : transcript)
@@ -311,7 +392,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             busy: running,
             info,
             sid: r.session_id,
-            status: statusFromLiveSession(r.status, running),
+            status: running ? statusFromLiveSession(r.status, true) : 'ready',
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
@@ -340,6 +421,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         }
 
         const previousSid = getUiState().sid
+        const requestFence = captureSessionResponseTurnFence()
 
         gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
           .then(raw => {
@@ -351,10 +433,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               return patchUiState({ status: 'ready' })
             }
 
-            const info = r.info ?? null
-            const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+            const reconciled = reconcileSessionResponseTurn(r, requestFence)
+            const { info, running } = reconciled
 
             resetSession()
+            patchTurnState(reconciled.turn)
             setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
 
             const resumed = [...toTranscriptMessages(r.messages), ...liveSessionInflightMessages(r.inflight)]
@@ -365,7 +448,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               busy: running,
               info,
               sid: r.session_id,
-              status: statusFromLiveSession(r.status, running),
+              status: running ? statusFromLiveSession(r.status, true) : 'ready',
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,7 +1,7 @@
 import type { BillingBlock, UsageModelData } from '@hermes/shared/billing'
 import type { HermesSkin } from '@hermes/shared/skin'
 
-import type { SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
+import type { SessionInfo, SlashCategory, SubagentStatus, TurnOrigin, Usage } from './types.js'
 
 /** The cross-surface skin contract (canonical shape in `@hermes/shared`).
  *  Includes the paired light_colors/dark_colors overlays from #20379. */
@@ -188,6 +188,9 @@ export interface SessionResumeResponse {
   messages: GatewayTranscriptMessage[]
   resumed?: string
   running?: boolean
+  turn_generation?: number
+  turn_origin?: TurnOrigin | null
+  turn_state_revision?: number
   session_id: string
   started_at?: number
   status?: LiveSessionStatus
@@ -224,6 +227,9 @@ export interface SessionActivateResponse {
   message_count?: number
   messages: GatewayTranscriptMessage[]
   running?: boolean
+  turn_generation?: number
+  turn_origin?: TurnOrigin | null
+  turn_state_revision?: number
   session_id: string
   session_key?: string
   started_at?: number
@@ -616,7 +622,11 @@ export type GatewayEvent =
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: { kind?: string }; session_id?: string; type: 'reaction' }
-  | { payload?: undefined; session_id?: string; type: 'message.start' }
+  | {
+      payload?: { turn_generation?: number; turn_origin?: TurnOrigin; turn_state_revision?: number }
+      session_id?: string
+      type: 'message.start'
+    }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }
   | {
       payload?: {
@@ -750,6 +760,9 @@ export type GatewayEvent =
         rendered?: string
         response_previewed?: boolean
         text?: string
+        turn_generation?: number
+        turn_origin?: TurnOrigin
+        turn_state_revision?: number
         usage?: Usage
       }
       session_id?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -155,6 +155,7 @@ export interface Msg {
 }
 
 export type Role = 'assistant' | 'system' | 'tool' | 'user'
+export type TurnOrigin = 'goal' | 'notification' | 'user'
 export type DetailsMode = 'hidden' | 'collapsed' | 'expanded'
 export type ThinkingMode = 'collapsed' | 'truncated' | 'full'
 
@@ -191,6 +192,7 @@ export interface SessionInfo {
   model: string
   profile_name?: string
   project?: null | ProjectInfo
+  running?: boolean
   reasoning_effort?: string
   release_date?: string
   service_tier?: string
@@ -201,6 +203,9 @@ export interface SessionInfo {
   update_command?: string
   usage?: Usage
   version?: string
+  turn_origin?: TurnOrigin | null
+  turn_generation?: number
+  turn_state_revision?: number
 }
 
 export interface Usage {


### PR DESCRIPTION
## Problem

When a background delegation completes while the user is viewing a busy session, the TUI gateway auto-fires a follow-up turn from the completion notification. Two UX bugs result:

1. **Surprise thinking after a forced report** — the user types `/report`, the assistant prints its findings and the turn ends; 77 ms later `drain_notifications` delivers the queued completion, and the model silently starts "thinking" again with no user prompt. The user has no idea why the agent re-engaged.

2. **Duplicate reply to the user's latest question** — the auto-resume runs to completion, then the user's actual pending prompt (queued during the internal turn) is drained and answered too — so the user sees two answers to what they asked once.

The root cause is architectural: the gateway treats a background-process completion identically to a user-initiated prompt. It has no concept of *turn origin* — whether the current turn was started by the user, by a background notification, or by a `/goal` continuation — so it cannot tell the frontend to handle the three cases differently.

## Fix

Introduce `TurnOrigin = Literal["user", "notification", "goal"]` and propagate it through every turn lifecycle boundary so the frontend can distinguish the three origins and apply origin-aware control flow.

### Backend (`tui_gateway/server.py`, `run_agent.py`)

- **Turn origin + generation token.** `_run_prompt_submit` accepts `origin=` and stamps it into the session under a monotonic `turn_token`. Stale turns cannot clear state set by a newer turn. `message.start`, `message.complete`, and `session.info` all carry `turn_origin`.

- **Deferred notifications.** When a user-origin turn hits `max_iterations_reached`, the gateway sets `defer_notifications_until_user = True` and queues any subsequent completion notifications into `deferred_notification_texts`. The next real user prompt claims the batch, prepends it as context to the user's message, and runs a single combined turn — no silent auto-resume, no duplicate reply.

- **Deferred batch recovery.** If the user turn fails or is blocked (context-reference block), the claimed notifications are restored ahead of any concurrently arriving ones, so nothing is lost.

- **Notification dispatch failure resilience.** `_drain_post_turn_notifications` and `_notification_poller_loop` catch synchronous dispatch exceptions, requeue the current and remaining events, log once, and continue — a single bad dispatch no longer terminates the poller or drops a drained batch.

- **Clean persistence copy.** `_message_for_persistence` replaces the old in-place mutation: SQLite flush and JSON snapshot each get a non-mutating copy with clean user text, while the live API-facing message list (including multimodal image/audio parts) stays untouched.

### Desktop (`apps/desktop/src/`)

- **Notification preemption.** When the user submits while a notification-origin turn is busy, the composer queues the draft and calls `cancelRun({ preserveBusyUntilSettled: true })` — the interrupt fires immediately, but `busy` stays true until the terminal `message.complete`/`session.info running:false` settles the turn. Only then is the queued draft drained and submitted exactly once.

- **Feedback suppression.** An interrupted notification-origin completion suppresses completion sound, pet celebration, unread/mail state, and native OS notifications. The transcript and busy-state settlement still occur.

- **Turn-origin state.** `ClientSessionState.turnOrigin` tracks the current origin via `session.info`, `message.start`, and `message.complete`. The status bar shows "Processing background result" for notification turns instead of generic thinking.

### Ink TUI (`ui-tui/src/`)

- `TurnOrigin` type added to `types.ts`; `gatewayTypes.ts` extends `message.start`, `message.complete`, and `SessionInfo` with optional `turn_origin`.

### Tests

| Layer | New/modified tests |
|---|---|
| Python gateway | `test_turn_origin_notifications.py` (12 tests): turn-origin token stale-clear, max-iteration deferral + clean-context claim, failed-turn batch restore, context-block batch restore, post-turn dispatch failure requeue, poller retry after dispatch failure |
| Python agent | `test_860_dedup.py` (+1): multimodal persistence copy retains media marker without mutating live message; `test_run_agent.py` (+2): JSON snapshot applies clean text and preserves multimodal media |
| Desktop | `use-composer-submit.test.tsx` (5 tests): notification preemption queues + interrupts, user/goal stays queue-only, drain-after-interrupt exactly-once, interrupt-failure releases gate; `turn-origin.test.tsx` (2 tests): origin reconciliation + feedback suppression; `status-origin.test.tsx` (1 test): status origin label |
| Modified | `test_tui_gateway_server.py`, `test_tui_gateway_queue_on_busy.py`, `test_run_agent.py`, `use-session-actions/utils.test.ts` |

## Verification

| Check | Result |
|---|---|
| Python impacted regression (6 files, 768 tests) | **768 passed, 0 failed** |
| Desktop focused Vitest (8 files) | **76 passed, 0 failed** |
| Desktop `npm run typecheck` | **PASS** |
| Ink TUI `npm run typecheck` | **PASS** |
| Changed Desktop ESLint | **PASS** |
| Python `ruff check` + `py_compile` | **PASS** |
| `git diff --check` | **PASS** |
| Prettier (changed files) | **PASS** |

## Related

- Complementary to #61719 (session-isolation for notification routing) — this PR adds turn-origin semantics; #61719 adds ownership routing. They touch different sections of `server.py`.
- Independent of #63597 (interim assistant message boundaries) and #62598 (system-marker role persistence).
- #61858 (gateway user-priority queue) addresses the gateway-layer equivalent of the same priority problem; this PR handles the TUI-gateway/desktop side.

No existing issue or PR covers the turn-origin + deferred-notification + frontend-preemption combination.
