### PR TITLE
feat(api-server): auto-title API sessions for /v1/chat/completions, /…

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -23,7 +23,7 @@ import re
 import threading
 from typing import Any, Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 from agent.context_compressor import LEGACY_SUMMARY_PREFIX
 from agent.message_content import flatten_message_text
 
@@ -143,6 +143,84 @@ _MACHINE_PREFIXES = (
     # tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX.
     "[System: The active model for this chat has changed to ",
 )
+
+
+_META_TITLE_PREFIXES = (
+    "the user is asking",
+    "the user wants",
+    "the assistant is",
+    "the conversation is about",
+)
+
+
+def _strip_wrapping_quotes(text: str) -> str:
+    stripped = (text or "").strip()
+    pairs = {
+        ('"', '"'),
+        ("'", "'"),
+        ("“", "”"),
+        ("‘", "’"),
+    }
+    while len(stripped) >= 2 and (stripped[0], stripped[-1]) in pairs:
+        stripped = stripped[1:-1].strip()
+    return stripped
+
+
+def _clean_generated_title(raw_title: str) -> Optional[str]:
+    if not raw_title:
+        return None
+
+    # main routes title generation through a JSON-schema response_format, so
+    # the raw response is normally '{"title": "..."}'. Pull the value out
+    # first so the cleaning below runs on the title proper, not the JSON
+    # envelope — a model can still wrap a meta phrase ("The user is asking…")
+    # inside the value, which the prefix logic below is what removes.
+    raw = raw_title.strip()
+    fenced = re.match(r"^```(?:json)?\s*(.*?)\s*```$", raw, re.DOTALL)
+    if fenced:
+        raw = fenced.group(1).strip()
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict) and isinstance(parsed.get("title"), str):
+            raw_title = parsed["title"]
+    except (ValueError, TypeError):
+        pass
+
+    # Strip unterminated think blocks (e.g. "<think>Let me reason..." without close tag)
+    title = re.sub(
+        r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>.*",
+        "", raw_title, flags=re.DOTALL | re.IGNORECASE,
+    )
+    # Strip any remaining HTML-like tags
+    title = re.sub(r"<[^>]+>", " ", title)
+    title = re.sub(r"\s+", " ", title).strip()
+    title = _strip_wrapping_quotes(title)
+
+    if title.lower().startswith("title:"):
+        title = _strip_wrapping_quotes(title[6:].strip())
+
+    lowered = title.lower()
+    if lowered.startswith(_META_TITLE_PREFIXES):
+        quoted = re.search(r'["“‘](.+?)["”’]', title)
+        if quoted:
+            title = quoted.group(1).strip()
+        else:
+            for prefix in _META_TITLE_PREFIXES:
+                if lowered.startswith(prefix):
+                    title = title[len(prefix):].strip(" :.-")
+                    break
+
+    title = _strip_wrapping_quotes(title)
+    if not title:
+        return None
+
+    if len(title.split()) > 12:
+        return None
+
+    if len(title) > 80:
+        title = title[:77] + "..."
+
+    return title or None
 
 
 def _title_language() -> str:
@@ -403,8 +481,13 @@ def generate_title(
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
-        content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
+        content = extract_content_or_reasoning(response).strip()
+        # extract_content_or_reasoning only strips closed reasoning tags.
+        # Run the canonical scrubber next so standalone tool-call XML (and
+        # its payload) is removed before title cleanup — same path CLI uses.
+        from agent.agent_runtime_helpers import strip_think_blocks
+        content = strip_think_blocks(None, content).strip()
+        return _clean_generated_title(content)
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -191,8 +191,12 @@ def _clean_generated_title(raw_title: str) -> Optional[str]:
         r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>.*",
         "", raw_title, flags=re.DOTALL | re.IGNORECASE,
     )
-    # Strip any remaining HTML-like tags
+    # Strip any remaining HTML-like tags (preserve newlines for first-line pick)
     title = re.sub(r"<[^>]+>", " ", title)
+    # A title is one line. A model that ignores "return ONLY the title" and
+    # answers the prompt instead (a shell transcript, a bulleted plan) would
+    # otherwise be stored verbatim — keep the first non-empty line.
+    title = next((line.strip() for line in title.splitlines() if line.strip()), "")
     title = re.sub(r"\s+", " ", title).strip()
     title = _strip_wrapping_quotes(title)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6286,6 +6286,20 @@ class APIServerAdapter(BasePlatformAdapter):
                         if isinstance(result, dict):
                             result["runtime"] = runtime
                         usage["runtime"] = runtime
+                    # Auto-generate session title after first successful exchange
+                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    if final_response and isinstance(result, dict) and not result.get("failed"):
+                        try:
+                            from agent.title_generator import maybe_auto_title
+                            maybe_auto_title(
+                                self._ensure_session_db(),
+                                _eff_sid or session_id,
+                                user_message,
+                                final_response,
+                                result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                            )
+                        except Exception:
+                            pass
                     return result, usage
                 except _ProviderAuthResolutionError as exc:
                     # Only _ProviderAuthResolutionError — raised exclusively
@@ -6761,6 +6775,19 @@ class APIServerAdapter(BasePlatformAdapter):
                         usage=usage,
                         last_event="run.completed",
                     )
+                    # Auto-generate session title after first successful exchange
+                    if final_response and isinstance(result, dict) and not result.get("failed"):
+                        try:
+                            from agent.title_generator import maybe_auto_title
+                            maybe_auto_title(
+                                self._ensure_session_db(),
+                                session_id,
+                                user_message,
+                                final_response,
+                                result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                            )
+                        except Exception:
+                            pass
             except asyncio.CancelledError:
                 self._set_run_status(
                     run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6299,7 +6299,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
                             )
                         except Exception:
-                            pass
+                            logger.debug("API _run_agent auto-title failed", exc_info=True)
                     return result, usage
                 except _ProviderAuthResolutionError as exc:
                     # Only _ProviderAuthResolutionError — raised exclusively
@@ -6779,15 +6779,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     if final_response and isinstance(result, dict) and not result.get("failed"):
                         try:
                             from agent.title_generator import maybe_auto_title
+                            # Prefer agent.session_id in case compression rotated
+                            # the session during the run (same as _run_agent).
+                            _eff_sid = getattr(agent, "session_id", None) or session_id
                             maybe_auto_title(
                                 self._ensure_session_db(),
-                                session_id,
+                                _eff_sid,
                                 user_message,
                                 final_response,
-                                result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                                result.get("messages", conversation_history),
                             )
                         except Exception:
-                            pass
+                            logger.debug("API /v1/runs auto-title failed", exc_info=True)
             except asyncio.CancelledError:
                 self._set_run_status(
                     run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6286,9 +6286,17 @@ class APIServerAdapter(BasePlatformAdapter):
                         if isinstance(result, dict):
                             result["runtime"] = runtime
                         usage["runtime"] = runtime
-                    # Auto-generate session title after first successful exchange
+                    # Auto-generate session title after first successful exchange.
+                    # Soft-partial / interrupted runs can still return text
+                    # (see soft-partial path above) — do not permanently title those.
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    if final_response and isinstance(result, dict) and not result.get("failed"):
+                    if (
+                        final_response
+                        and isinstance(result, dict)
+                        and not result.get("failed")
+                        and not result.get("partial")
+                        and not result.get("interrupted")
+                    ):
                         try:
                             from agent.title_generator import maybe_auto_title
                             maybe_auto_title(
@@ -6296,7 +6304,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 _eff_sid or session_id,
                                 user_message,
                                 final_response,
-                                result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                                result.get("messages", conversation_history),
                             )
                         except Exception:
                             logger.debug("API _run_agent auto-title failed", exc_info=True)
@@ -6775,8 +6783,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         usage=usage,
                         last_event="run.completed",
                     )
-                    # Auto-generate session title after first successful exchange
-                    if final_response and isinstance(result, dict) and not result.get("failed"):
+                    # Auto-generate session title after first successful exchange.
+                    # Mirror _run_agent: skip text-bearing partial/interrupted results.
+                    if (
+                        final_response
+                        and isinstance(result, dict)
+                        and not result.get("failed")
+                        and not result.get("partial")
+                        and not result.get("interrupted")
+                    ):
                         try:
                             from agent.title_generator import maybe_auto_title
                             # Prefer agent.session_id in case compression rotated

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -16,8 +16,35 @@ from hermes_state import SessionDB
 class TestGenerateTitle:
     """Unit tests for generate_title()."""
 
+    def test_salvages_unquoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "The conversation is about Kubernetes pod debugging"
 
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
 
+    def test_extracts_quoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'The conversation is about "Kubernetes pod debugging"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
+
+    def test_uses_reasoning_when_content_is_empty(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+        mock_response.choices[0].message.reasoning = "Redis deployment troubleshooting"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("redis won't start", "Let's debug it")
+            assert title == "Redis deployment troubleshooting"
 
     def test_title_language_reads_config(self):
         cfg = {"auxiliary": {"title_generation": {"language": "  French "}}}

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -106,6 +106,21 @@ class TestGenerateTitle:
             # leaving nothing → None.
             assert title is None
 
+    def test_strips_standalone_tool_call_xml(self):
+        """Canonical strip_think_blocks must remove tool-call XML and payload,
+        not just the tags (tag-only cleanup would leave JSON in the title)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '<tool_call>{"name":"search","arguments":{"q":"pods"}}</tool_call>'
+            "Kubernetes Pod Debugging"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes Pod Debugging"
+            assert "tool_call" not in title
+            assert "search" not in title
 
     def test_truncates_long_titles(self):
         mock_response = MagicMock()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2945,6 +2945,69 @@ class TestRunAgentAutoTitle:
         maybe_auto_title.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_skips_auto_title_for_partial_results(self):
+        """Text-bearing soft-partial must not get a permanent session title."""
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-partial"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent._last_compaction_in_place = False
+        agent.run_conversation.return_value = {
+            "final_response": "Here is a truncated answer",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Here is a truncated answer"},
+            ],
+            "partial": True,
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result.get("partial")
+        maybe_auto_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_interrupted_results(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-interrupted"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent._last_compaction_in_place = False
+        agent.run_conversation.return_value = {
+            "final_response": "Stopped mid-reply",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Stopped mid-reply"},
+            ],
+            "interrupted": True,
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result.get("interrupted")
+        maybe_auto_title.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_triggers_auto_title_with_rotated_session_id(self):
         """Compression may rotate agent.session_id; title must target the new id."""
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
@@ -2953,6 +3016,7 @@ class TestRunAgentAutoTitle:
         agent.session_prompt_tokens = 11
         agent.session_completion_tokens = 7
         agent.session_total_tokens = 18
+        agent._last_compaction_in_place = False
         agent.run_conversation.return_value = {
             "final_response": "Done",
             "messages": [

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2944,3 +2944,35 @@ class TestRunAgentAutoTitle:
         assert result.get("failed")
         maybe_auto_title.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_triggers_auto_title_with_rotated_session_id(self):
+        """Compression may rotate agent.session_id; title must target the new id."""
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-rotated"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent.run_conversation.return_value = {
+            "final_response": "Done",
+            "messages": [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Done"},
+            ],
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hi",
+                conversation_history=[],
+                session_id="sess-original",
+            )
+
+        assert result["session_id"] == "sess-rotated"
+        maybe_auto_title.assert_called_once()
+        assert maybe_auto_title.call_args.args[1] == "sess-rotated"
+

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2866,3 +2866,81 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
+
+# ---------------------------------------------------------------------------
+# _run_agent auto-title behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentAutoTitle:
+    @pytest.mark.asyncio
+    async def test_triggers_auto_title_on_success(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-1"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent._last_compaction_in_place = False
+        agent.run_conversation.return_value = {
+            "final_response": "Hello there",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result["final_response"] == "Hello there"
+        assert usage["total_tokens"] == 18
+        maybe_auto_title.assert_called_once_with(
+            "db",
+            "sess-1",
+            "Hello",
+            "Hello there",
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_failed_results(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-2"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent._last_compaction_in_place = False
+        agent.run_conversation.return_value = {
+            "final_response": "",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": ""},
+            ],
+            "failed": True,
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result.get("failed")
+        maybe_auto_title.assert_not_called()
+

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -637,3 +637,119 @@ class TestRunsProviderAuthFailure:
                 assert status["status"] == "failed"
                 assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
                 assert status["last_event"] == "run.failed"
+
+
+# ---------------------------------------------------------------------------
+# /v1/runs auto-title
+# ---------------------------------------------------------------------------
+
+
+async def _wait_run_terminal(cli, run_id: str, timeout_s: float = 2.0) -> dict:
+    deadline = time.monotonic() + timeout_s
+    status = {}
+    while time.monotonic() < deadline:
+        status_resp = await cli.get(f"/v1/runs/{run_id}")
+        status = await status_resp.json()
+        if status.get("status") in {"completed", "failed", "cancelled"}:
+            return status
+        await asyncio.sleep(0.05)
+    return status
+
+
+class TestRunsAutoTitle:
+    @pytest.mark.asyncio
+    async def test_triggers_auto_title_on_success(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent") as mock_create,
+                patch.object(adapter, "_ensure_session_db", return_value="db"),
+                patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.session_id = "sess-runs-1"
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Hello there",
+                    "messages": [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Hello there"},
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 4
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 6
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "Hello", "session_id": "sess-runs-1"},
+                )
+                run_id = (await resp.json())["run_id"]
+                status = await _wait_run_terminal(cli, run_id)
+
+                assert status["status"] == "completed"
+                maybe_auto_title.assert_called_once()
+                assert maybe_auto_title.call_args.args[1] == "sess-runs-1"
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_partial_results(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent") as mock_create,
+                patch.object(adapter, "_ensure_session_db", return_value="db"),
+                patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.session_id = "sess-runs-partial"
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Truncated answer",
+                    "partial": True,
+                    "messages": [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Truncated answer"},
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "Hello"})
+                run_id = (await resp.json())["run_id"]
+                status = await _wait_run_terminal(cli, run_id)
+
+                assert status["status"] == "completed"
+                maybe_auto_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_interrupted_results(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent") as mock_create,
+                patch.object(adapter, "_ensure_session_db", return_value="db"),
+                patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.session_id = "sess-runs-interrupted"
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Stopped mid-reply",
+                    "interrupted": True,
+                    "messages": [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Stopped mid-reply"},
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "Hello"})
+                run_id = (await resp.json())["run_id"]
+                status = await _wait_run_terminal(cli, run_id)
+
+                assert status["status"] == "completed"
+                maybe_auto_title.assert_not_called()
+


### PR DESCRIPTION
 What does this PR do?

  Auto-generate session titles for API-server endpoints after the first
  successful exchange, matching the existing behavior of CLI and gateway.

  Port of #9698 by @weitongtong with additional `/v1/runs` coverage:
  - The original PR only covered `_run_agent()` (used by `/v1/chat/completions`
    and `/v1/responses`)
  - This PR also wires `maybe_auto_title` into `_run_and_close()` for `/v1/runs`
  - Adds `_clean_generated_title()` to harden title cleanup (meta prefixes,
    wrapped quotes, reasoning field fallback, unterminated think blocks)

  Related Issue:

  Closes #9698

  Type of Change:

  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [x] ✅ Tests (adding or improving test coverage)

  Changes Made:

  - `agent/title_generator.py` — Add `_strip_wrapping_quotes()`,
    `_clean_generated_title()`, update `generate_title()` to use
    `extract_content_or_reasoning` + new cleaner, update prompt
  - `gateway/platforms/api_server.py` — Add `maybe_auto_title` call in
    `_run_agent()` after successful run, and in `_run_and_close()` for `/v1/runs`
  - `tests/agent/test_title_generator.py` — 3 new tests for meta prefix,
    quoted prefix, and reasoning fallback
  - `tests/gateway/test_api_server.py` — 2 new tests for `_run_agent`
    auto-title trigger on success and skip on failure

  How to Test:

  1. `pytest tests/agent/test_title_generator.py -q` — 30 passed
  2. `pytest tests/gateway/test_api_server.py -k "auto_title" -q` — 2 passed
  3. Start API server, send a request to `/v1/chat/completions` or `/v1/runs`,
     check that session title is auto-generated in the session DB

  Checklist - Code:

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [x] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: macOS

  Screenshots / Logs:
  python3 -m pytest tests/agent/test_title_generator.py -q
..............................                                                                                                                                                                                                                [100%]
30 passed in 1.42s
python3 -m pytest tests/gateway/test_api_server.py -k "auto_title" -q
..                                                                                                                                                                                                                                            [100%]
2 passed, 196 deselected in 0.46s