### PR TITLE
fix(anthropic): convert draft-07 tuple-form items to prefixItems in tool schemas

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1682,6 +1682,8 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
             normalized["type"] = "object"
     if normalized.get("type") == "object" and not isinstance(normalized.get("properties"), dict):
         normalized = {**normalized, "properties": {}}
+    from tools.schema_sanitizer import convert_tuple_items_to_prefix_items
+    normalized = convert_tuple_items_to_prefix_items(normalized)
     return normalized
 
 

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 
 from tools.schema_sanitizer import (
+    convert_tuple_items_to_prefix_items,
     sanitize_tool_schemas,
     strip_pattern_and_format,
     strip_slash_enum,
@@ -867,3 +868,38 @@ def test_unrename_passes_unknown_keys_through():
 def test_sanitize_property_key_empty_falls_back():
     assert sanitize_property_key("~~~") == "___"
     assert sanitize_property_key("") == "param"
+
+
+def test_tuple_items_converted_to_prefix_items():
+    # Draft-07 positional ``items`` -> 2020-12 ``prefixItems`` (Anthropic rejects
+    # the former with HTTP 400 "must match JSON Schema draft 2020-12").
+    schema = {"type": "array", "items": [{"type": "integer"}, {"type": "string"}]}
+    out = convert_tuple_items_to_prefix_items(schema)
+    assert out == {"type": "array", "prefixItems": [{"type": "integer"}, {"type": "string"}]}
+
+
+def test_hand_authored_prefix_items_wins_over_tuple_items():
+    schema = {"type": "array", "items": [{"type": "integer"}], "prefixItems": [{"type": "string"}]}
+    out = convert_tuple_items_to_prefix_items(schema)
+    assert out == {"type": "array", "prefixItems": [{"type": "string"}]}
+
+
+def test_additional_items_renamed_to_items_alongside_tuple():
+    schema = {"type": "array", "items": [{"type": "integer"}], "additionalItems": {"type": "string"}}
+    out = convert_tuple_items_to_prefix_items(schema)
+    assert out == {"type": "array", "prefixItems": [{"type": "integer"}], "items": {"type": "string"}}
+
+
+def test_single_schema_items_left_untouched():
+    schema = {"type": "array", "items": {"type": "string"}, "minItems": 1}
+    assert convert_tuple_items_to_prefix_items(schema) == schema
+
+
+def test_nested_tuple_items_inside_properties():
+    schema = {"type": "object", "properties": {
+        "coord": {"type": "array", "items": [{"type": "integer"}, {"type": "integer"}]},
+        "name": {"type": "string"},
+    }}
+    out = convert_tuple_items_to_prefix_items(schema)
+    assert out["properties"]["coord"] == {"type": "array", "prefixItems": [{"type": "integer"}, {"type": "integer"}]}
+    assert out["properties"]["name"] == {"type": "string"}

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -8,6 +8,7 @@ Unrecognized schema: "object"`` errors on local inference backends.
 from __future__ import annotations
 
 import copy
+import json
 
 from tools.schema_sanitizer import (
     convert_tuple_items_to_prefix_items,
@@ -885,9 +886,17 @@ def test_hand_authored_prefix_items_wins_over_tuple_items():
 
 
 def test_additional_items_renamed_to_items_alongside_tuple():
-    schema = {"type": "array", "items": [{"type": "integer"}], "additionalItems": {"type": "string"}}
+    schema = {
+        "type": "array",
+        "items": [{"type": "integer"}],
+        "additionalItems": {"type": "string"},
+    }
     out = convert_tuple_items_to_prefix_items(schema)
-    assert out == {"type": "array", "prefixItems": [{"type": "integer"}], "items": {"type": "string"}}
+    assert out == {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}],
+        "items": {"type": "string"},
+    }
 
 
 def test_single_schema_items_left_untouched():
@@ -901,5 +910,112 @@ def test_nested_tuple_items_inside_properties():
         "name": {"type": "string"},
     }}
     out = convert_tuple_items_to_prefix_items(schema)
-    assert out["properties"]["coord"] == {"type": "array", "prefixItems": [{"type": "integer"}, {"type": "integer"}]}
+    assert out["properties"]["coord"] == {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}, {"type": "integer"}],
+    }
     assert out["properties"]["name"] == {"type": "string"}
+
+
+def test_annotation_values_with_literal_items_are_preserved():
+    # Regression: the converter must not descend into annotation keywords.
+    # ``default: {"items": [1, 2]}`` is instance data — rewriting it to
+    # ``prefixItems`` would change the tool's default value, not its schema.
+    schema = {
+        "type": "object",
+        "properties": {
+            "cfg": {
+                "type": "object",
+                "default": {"items": [1, 2]},
+                "const": {"items": ["a"]},
+                "examples": [{"items": [3]}],
+                "enum": [{"items": [4]}],
+            },
+            "coord": {"type": "array", "items": [{"type": "integer"}, {"type": "integer"}]},
+        },
+    }
+    out = convert_tuple_items_to_prefix_items(schema)
+    cfg = out["properties"]["cfg"]
+    assert cfg["default"] == {"items": [1, 2]}
+    assert cfg["const"] == {"items": ["a"]}
+    assert cfg["examples"] == [{"items": [3]}]
+    assert cfg["enum"] == [{"items": [4]}]
+    assert "prefixItems" not in json.dumps(cfg)
+    # the real schema alongside them is still converted
+    assert out["properties"]["coord"] == {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}, {"type": "integer"}],
+    }
+    # annotations are copied, not aliased back to the caller's dict
+    cfg["default"]["items"].append(99)
+    assert schema["properties"]["cfg"]["default"] == {"items": [1, 2]}
+
+
+def test_convert_tools_to_anthropic_emits_prefix_items_and_keeps_defaults():
+    # End-to-end at the Anthropic conversion boundary, not just the helper.
+    from agent.anthropic_adapter import convert_tools_to_anthropic
+
+    tools = [_tool("plot", {
+        "type": "object",
+        "properties": {
+            "coord": {"type": "array", "items": [{"type": "integer"}, {"type": "string"}]},
+            "cfg": {"type": "object", "default": {"items": [1, 2]}},
+        },
+    })]
+    props = convert_tools_to_anthropic(tools)[0]["input_schema"]["properties"]
+    assert props["coord"] == {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}, {"type": "string"}],
+    }
+    assert props["cfg"]["default"] == {"items": [1, 2]}
+
+
+def test_conversion_reaches_every_schema_valued_keyword():
+    # Guards the allowlist: restricting recursion must not stop the converter
+    # reaching a tuple-form ``items`` nested under any applicator keyword.
+    tuple_form = {"type": "array", "items": [{"type": "integer"}, {"type": "string"}]}
+    expected = {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}, {"type": "string"}],
+    }
+    single = [
+        "additionalItems", "additionalProperties", "contains", "propertyNames",
+        "not", "if", "then", "else", "unevaluatedItems", "unevaluatedProperties",
+        "contentSchema", "items",
+    ]
+    for key in single:
+        out = convert_tuple_items_to_prefix_items(
+            {"type": "object", key: copy.deepcopy(tuple_form)})
+        assert out[key] == expected, key
+    for key in ("allOf", "anyOf", "oneOf", "prefixItems"):
+        out = convert_tuple_items_to_prefix_items(
+            {"type": "object", key: [copy.deepcopy(tuple_form)]})
+        assert out[key][0] == expected, key
+    for key in ("properties", "patternProperties", "dependentSchemas", "$defs", "definitions"):
+        out = convert_tuple_items_to_prefix_items(
+            {"type": "object", key: {"x": copy.deepcopy(tuple_form)}})
+        assert out[key]["x"] == expected, key
+
+
+def test_empty_tuple_items_does_not_emit_empty_prefix_items():
+    # ``prefixItems`` MUST be a non-empty array of schemas (2020-12 core; the
+    # applicator metaschema enforces minItems: 1), so translating an empty
+    # draft-07 tuple into ``prefixItems: []`` would emit an invalid schema from
+    # a function whose whole purpose is producing valid ones.
+    assert convert_tuple_items_to_prefix_items({"type": "array", "items": []}) == {"type": "array"}
+    # ``additionalItems`` still becomes ``items``; with no ``prefixItems`` it
+    # applies to every element, which is exactly what draft-07 ``items: []``
+    # plus ``additionalItems`` meant.
+    out = convert_tuple_items_to_prefix_items({
+        "type": "array",
+        "items": [],
+        "additionalItems": {"type": "string"},
+    })
+    assert out == {"type": "array", "items": {"type": "string"}}
+    # a hand-authored ``prefixItems`` still wins over an empty tuple
+    out = convert_tuple_items_to_prefix_items({
+        "type": "array",
+        "items": [],
+        "prefixItems": [{"type": "integer"}],
+    })
+    assert out == {"type": "array", "prefixItems": [{"type": "integer"}]}

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -302,6 +302,42 @@ def strip_nullable_unions(
     return stripped
 
 
+
+def convert_tuple_items_to_prefix_items(schema: Any) -> Any:
+    """Convert draft-07 tuple-form array schemas to draft 2020-12 ``prefixItems``.
+
+    Anthropic's tool-schema validator enforces JSON Schema draft 2020-12 and
+    rejects the draft-07 positional form ``items: [schemaA, schemaB]`` with
+    ``input_schema: JSON schema is invalid. It must match JSON Schema draft
+    2020-12``, while accepting the equivalent ``prefixItems`` spelling (both
+    behaviors verified against the live API). At every node this performs the
+    exact keyword translation defined by the 2020-12 spec:
+
+      * list-valued ``items`` -> ``prefixItems`` (same sub-schemas, same order)
+      * a sibling draft-07 ``additionalItems`` -> ``items`` (its 2020-12 name)
+      * if a hand-authored ``prefixItems`` is already present, the redundant
+        tuple ``items`` is dropped instead of clobbering it
+
+    Single-schema ``items`` (a dict) and every non-array construct are left
+    untouched, so already-valid schemas are never altered.
+    """
+    if isinstance(schema, list):
+        return [convert_tuple_items_to_prefix_items(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+    out: dict = {}
+    tuple_items = isinstance(schema.get("items"), list)
+    for key, value in schema.items():
+        if key == "items" and tuple_items:
+            if "prefixItems" not in schema:
+                out["prefixItems"] = [convert_tuple_items_to_prefix_items(v) for v in value]
+            # redundant tuple ``items`` alongside hand-authored ``prefixItems`` is dropped
+        elif key == "additionalItems" and tuple_items:
+            out["items"] = convert_tuple_items_to_prefix_items(value)
+        else:
+            out[key] = convert_tuple_items_to_prefix_items(value)
+    return out
+
 def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment.
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -302,6 +302,19 @@ def strip_nullable_unions(
     return stripped
 
 
+# JSON-Schema keywords whose values ARE schemas, collections of schemas, or
+# maps of name -> schema. ``convert_tuple_items_to_prefix_items`` recurses only
+# through these; everything else is instance data and is passed through.
+_SUBSCHEMA_KEYS = frozenset({
+    "additionalItems", "additionalProperties", "contains", "propertyNames",
+    "not", "if", "then", "else", "unevaluatedItems", "unevaluatedProperties",
+    "contentSchema",
+})
+_SUBSCHEMA_LIST_KEYS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_SUBSCHEMA_MAP_KEYS = frozenset({
+    "properties", "patternProperties", "dependentSchemas", "$defs", "definitions",
+})
+
 
 def convert_tuple_items_to_prefix_items(schema: Any) -> Any:
     """Convert draft-07 tuple-form array schemas to draft 2020-12 ``prefixItems``.
@@ -314,12 +327,21 @@ def convert_tuple_items_to_prefix_items(schema: Any) -> Any:
     exact keyword translation defined by the 2020-12 spec:
 
       * list-valued ``items`` -> ``prefixItems`` (same sub-schemas, same order)
+      * an EMPTY ``items: []`` is dropped rather than translated: it asserts no
+        positional constraint, and 2020-12 requires ``prefixItems`` to be a
+        non-empty array, so emitting ``prefixItems: []`` would itself be invalid
       * a sibling draft-07 ``additionalItems`` -> ``items`` (its 2020-12 name)
       * if a hand-authored ``prefixItems`` is already present, the redundant
         tuple ``items`` is dropped instead of clobbering it
 
     Single-schema ``items`` (a dict) and every non-array construct are left
     untouched, so already-valid schemas are never altered.
+
+    Recursion is restricted to schema-valued keywords. Annotation keywords
+    such as ``default``, ``const``, ``enum`` and ``examples`` hold literal
+    instance data, so a nested ``items`` key inside one is a value rather than
+    a schema and is preserved verbatim — rewriting it would silently change a
+    tool's default instead of fixing its schema.
     """
     if isinstance(schema, list):
         return [convert_tuple_items_to_prefix_items(item) for item in schema]
@@ -329,14 +351,33 @@ def convert_tuple_items_to_prefix_items(schema: Any) -> Any:
     tuple_items = isinstance(schema.get("items"), list)
     for key, value in schema.items():
         if key == "items" and tuple_items:
-            if "prefixItems" not in schema:
+            if "prefixItems" not in schema and value:
                 out["prefixItems"] = [convert_tuple_items_to_prefix_items(v) for v in value]
-            # redundant tuple ``items`` alongside hand-authored ``prefixItems`` is dropped
+            # An EMPTY tuple ``items: []`` carries no positional constraint, and
+            # ``prefixItems`` MUST be a non-empty array, so the keyword is simply
+            # dropped rather than emitted empty. A redundant tuple ``items``
+            # alongside a hand-authored ``prefixItems`` is dropped for its own
+            # reason: not clobbering the hand-authored value.
         elif key == "additionalItems" and tuple_items:
             out["items"] = convert_tuple_items_to_prefix_items(value)
-        else:
+        elif key == "items" or key in _SUBSCHEMA_KEYS:
             out[key] = convert_tuple_items_to_prefix_items(value)
+        elif key in _SUBSCHEMA_LIST_KEYS and isinstance(value, list):
+            out[key] = [convert_tuple_items_to_prefix_items(v) for v in value]
+        elif key in _SUBSCHEMA_MAP_KEYS and isinstance(value, dict):
+            out[key] = {
+                k: convert_tuple_items_to_prefix_items(v) for k, v in value.items()
+            }
+        else:
+            # Not a schema-valued keyword. Annotation keywords (``default``,
+            # ``const``, ``enum``, ``examples``) hold literal instance data, so
+            # an ``items`` key inside one is a value, not a schema — rewriting
+            # it would corrupt the tool's data. Unknown/vendor keywords are
+            # passed through for the same reason. Mirrors the annotation
+            # pass-through in ``_sanitize_node`` below.
+            out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
     return out
+
 
 def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment.


### PR DESCRIPTION
## What does this PR do?

Any tool schema containing a draft-07 tuple-form array — `items: [schemaA, schemaB]` — currently fails the entire Anthropic request before inference:

    tools.0.custom.input_schema: JSON schema is invalid. It must match
    JSON Schema draft 2020-12

One bad tool poisons the whole `tools[]` payload for the turn. Tuple-form `items` appears routinely in MCP-sourced schemas (Go/Protobuf generators, older pydantic, `window: [width, height]`-style fields — the same shape that broke xAI in #20976).

Two behaviors verified against the live Anthropic API (2026-07-13):
1. tuple-form `items` → HTTP 400 (error above)
2. the equivalent 2020-12 `prefixItems` spelling → accepted

So this PR performs the exact, lossless keyword translation the 2020-12 spec defines, scoped to the Anthropic path only (mirroring how #27104 handled the same bug class provider-side for Moonshot):

- list-valued `items` → `prefixItems` (same sub-schemas, same order)
- a sibling draft-07 `additionalItems` → `items` (its 2020-12 name)
- hand-authored `prefixItems` wins over a redundant tuple `items` (same tie-breaker as #20976)
- single-schema `items` and all non-array constructs untouched; draft-07-tolerant backends unaffected (no change to `sanitize_tool_schemas`)

## Related Issue

Related to #20976, #27104, #14977 (no dedicated issue).

Related, distinct: #20976 (same shape on xAI, closed unmerged — this adds the Anthropic repro + live confirmation that Anthropic accepts `prefixItems`), #27104 (merged Moonshot handling of the same class), #14977 (same error string, different root cause).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py`: new `convert_tuple_items_to_prefix_items()` helper (recursive, pure; shared home alongside the existing sanitizer helpers)
- `agent/anthropic_adapter.py`: call it at the end of `_normalize_tool_input_schema` (function-local import matching the existing `schema_sanitizer` import idiom) — every Anthropic-bound tool schema passes through this choke point
- `tests/tools/test_schema_sanitizer.py`: 5 new tests — tuple conversion, hand-authored-`prefixItems` tie-breaker, `additionalItems` rename, single-schema-`items` preservation, nested-in-`properties`

## How to Test

1. `python -m pytest tests/tools/test_schema_sanitizer.py -q` — all pass (5 new)
2. Reproduce the bug on `main`: send any tool with `"items": [{"type": "integer"}, {"type": "integer"}]` through `convert_tools_to_anthropic` to the Messages API → HTTP 400 "must match JSON Schema draft 2020-12"
3. On this branch: same request → accepted; the emitted `input_schema` carries `prefixItems`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_schema_sanitizer.py -q` and all tests pass (targeted suite; no other subsystems touched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings document the fix and both measured API behaviors; no other docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure dict/list manipulation)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (transport-layer normalization only)