### PR TITLE
fix(acp): preserve original provider namespace in ACP session persist

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -433,7 +433,10 @@ class SessionManager:
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
-        provider = getattr(state.agent, "provider", None)
+        provider = (
+            getattr(state.agent, "_original_provider", None)
+            or getattr(state.agent, "provider", None)
+        )
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
         if isinstance(provider, str) and provider.strip():
@@ -654,6 +657,16 @@ class SessionManager:
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+        # Preserve the original requested provider (e.g. "custom:anthropic") so
+        # _persist() can store it and _restore() can re-resolve the correct
+        # custom_providers entry.  agent.provider is the normalized form (e.g.
+        # "custom") which is insufficient for looking up the named entry.
+        try:
+            agent._original_provider = (
+                runtime.get("requested_provider") or requested_provider or config_provider
+            )
+        except NameError:
+            pass  # runtime never assigned — exception above
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.


### PR DESCRIPTION
## Description

ACP session persistence stores `agent.provider` (normalized to bare `"custom"`) into the DB, losing the namespace qualifier `"custom:anthropic"`. On restore, `resolve_runtime_provider(requested="custom")` cannot match a `custom_providers` entry named `"custom:anthropic"`, causing auth failures.

## Fix

Preserve the original requested provider from `resolve_runtime_provider()`'s `"requested_provider"` key as `agent._original_provider` in `_make_agent()`, and use `_original_provider` in `_persist()` when available.

## Root cause chain

```
_make_agent() resolves custom:anthropic → runtime["provider"] = "custom" (normalized)
                                              ↓
AIAgent.provider = "custom"
                                              ↓
_persist() stores agent.provider = "custom"   → DB has {"provider":"custom"}
                                              ↓
_restore() reads "custom" from DB              → resolve_runtime_provider("custom") no match
```

Fixes #63681