### PR TITLE
fix(acp): honor approvals.timeout config for edit approval timeout

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -22,6 +22,10 @@ from typing import Any, Callable
 logger = logging.getLogger(__name__)
 
 
+class EditApprovalTimeout(Exception):
+    """Raised when the ACP client doesn't respond within the configured timeout."""
+
+
 @dataclass(frozen=True)
 class EditProposal:
     """A proposed single-file edit that can be shown to an ACP client."""
@@ -252,6 +256,12 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
 
     try:
         approved = bool(requester(proposal))
+    except EditApprovalTimeout as exc:
+        logger.warning("ACP edit approval timed out: %s", exc)
+        return json.dumps(
+            {"error": "Edit approval timed out; file was not modified."},
+            ensure_ascii=False,
+        )
     except Exception as exc:
         logger.warning("ACP edit approval requester failed: %s", exc)
         approved = False
@@ -325,9 +335,14 @@ def make_acp_edit_approval_requester(
             return False
         try:
             response = future.result(timeout=timeout)
-        except (FutureTimeout, Exception) as exc:
+        except FutureTimeout:
             future.cancel()
-            logger.warning("Edit approval request timed out or failed: %s", exc)
+            raise EditApprovalTimeout(
+                f"Edit approval timed out after {timeout}s"
+            )
+        except Exception as exc:
+            future.cancel()
+            logger.warning("Edit approval request failed: %s", exc)
             return False
         outcome = getattr(response, "outcome", None)
         return (

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1421,11 +1421,17 @@ class HermesACPAgent(acp.Agent):
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
             try:
                 from acp_adapter.edit_approval import make_acp_edit_approval_requester
+                from hermes_cli.config import load_config
 
+                _acp_cfg = load_config()
+                _acp_approval_timeout = int(
+                    (_acp_cfg.get("approvals") or {}).get("timeout", 60)
+                )
                 edit_approval_requester = make_acp_edit_approval_requester(
                     conn.request_permission,
                     loop,
                     session_id,
+                    timeout=_acp_approval_timeout,
                     auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:


### PR DESCRIPTION
## Description

The ACP edit approval flow had a hardcoded 60-second timeout instead of reading the `approvals.timeout` config value. Additionally, when the timeout expired, the error surfaced to the agent as '`Edit approval denied by ACP client`', making timeouts indistinguishable from explicit denials.

## Changes

1. **Honor config**: Read `approvals.timeout` from config and pass it to `make_acp_edit_approval_requester` instead of the default 60s.
2. **Distinguish timeout from denial**: Introduce `EditApprovalTimeout` exception. Timeouts now return `"Edit approval timed out; file was not modified." ` instead of the misleading denial message.

Fixes #63302