### PR TITLE
fix(model): show copilot-acp in pickers when its executable resolves

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2296,6 +2296,19 @@ def list_authenticated_providers(
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
                         has_creds = True
                         break
+        # External-process providers (copilot-acp) hold no API key, OAuth
+        # token, or pool entry by design — the spawned ACP subprocess brings
+        # its own auth. "Configured" means the executable resolves, which is
+        # exactly what get_auth_status() reports for them; without this branch
+        # the has_creds filter below unconditionally hides the provider from
+        # every picker (#63662).
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_auth_status
+                _ext_status = get_auth_status(hermes_slug) or {}
+                has_creds = bool(_ext_status.get("logged_in") or _ext_status.get("configured"))
+            except Exception as exc:
+                logger.debug("External-process check failed for %s: %s", pid, exc)
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.model_switch import list_authenticated_providers
 
 
@@ -20,3 +22,58 @@ def test_copilot_picker_uses_live_catalog_when_available():
     assert copilot is not None
     assert copilot["models"] == live_models
     assert copilot["total_models"] == len(live_models)
+
+
+# --- copilot-acp: external_process availability (#63662) -------------------
+#
+# copilot-acp holds no API key, OAuth token, or credential-pool entry by
+# design — the spawned `copilot --acp --stdio` subprocess brings its own auth.
+# The picker loop used to filter it out unconditionally (has_creds never had
+# an external_process branch), so the provider was invisible in every picker
+# even with a perfectly resolvable executable.
+
+
+@pytest.fixture()
+def _no_other_copilot_creds(monkeypatch):
+    """Make sure copilot-acp visibility comes ONLY from executable resolution:
+    no env tokens, no auth-store entry, no seeded credential pool."""
+    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"):
+        monkeypatch.delenv(var, raising=False)
+    import hermes_cli.auth as auth
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: {})
+    monkeypatch.setattr(model_switch, "_credential_pool_is_usable", lambda *a, **k: False)
+
+
+def test_copilot_acp_listed_when_executable_resolves(tmp_path, monkeypatch, _no_other_copilot_creds):
+    fake = tmp_path / ("copilot.exe" if os.name == "nt" else "copilot")
+    fake.write_text("", encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", str(fake))
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value=None), \
+         patch("hermes_cli.models._fetch_github_models", return_value=[]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    acp = next((p for p in providers if p["slug"] == "copilot-acp"), None)
+
+    assert acp is not None, "copilot-acp must be listed when its executable resolves"
+    assert acp["models"], "copilot-acp row must offer at least the curated fallback models"
+
+
+def test_copilot_acp_hidden_when_executable_missing(monkeypatch, _no_other_copilot_creds):
+    # `copilot` may genuinely be installed on a dev machine — force the
+    # resolution miss so the test pins behaviour, not the host's PATH.
+    import hermes_cli.auth as auth
+
+    monkeypatch.setattr(auth.shutil, "which", lambda *_a, **_k: None)
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value=None), \
+         patch("hermes_cli.models._fetch_github_models", return_value=[]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    assert all(p["slug"] != "copilot-acp" for p in providers), \
+        "copilot-acp must stay hidden when no executable resolves"

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -36,8 +36,13 @@ def test_copilot_picker_uses_live_catalog_when_available():
 @pytest.fixture()
 def _no_other_copilot_creds(monkeypatch):
     """Make sure copilot-acp visibility comes ONLY from executable resolution:
-    no env tokens, no auth-store entry, no seeded credential pool."""
-    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"):
+    no env tokens, no configured ACP endpoint, no auth-store entry, no seeded
+    credential pool."""
+    # COPILOT_ACP_BASE_URL is not a credential, but an `acp+tcp://` value marks
+    # the provider configured with no executable at all (hermes_cli/auth.py), so
+    # a host that sets it would decide the outcome instead of the test.
+    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND",
+                "COPILOT_CLI_PATH", "COPILOT_ACP_BASE_URL"):
         monkeypatch.delenv(var, raising=False)
     import hermes_cli.auth as auth
     import hermes_cli.model_switch as model_switch


### PR DESCRIPTION
## What does this PR do?

`copilot-acp` never shows up in the model picker — Desktop or `/model` —
no matter how correctly the GitHub Copilot CLI is installed. The reporter
of #63662 did most of the digging already, and they were right: the
HERMES_OVERLAYS loop in `list_authenticated_providers()` checks every
way a provider might be authenticated (env keys, the auth store, the
credential pool, even Claude Code's external token files) and then drops
anything that still has `has_creds == False`. An `external_process`
provider fails every one of those checks *by design* — the spawned
`copilot --acp --stdio` subprocess brings its own auth. So the filter
hid it unconditionally.

The funny part: five lines below the filter, the same loop has a
dedicated `copilot-acp` branch for fetching its model ids. It just never
got a chance to run.

The fix adds the missing branch: for `external_process` overlays,
availability comes from `get_auth_status()` — the same source
`hermes model` and the auth-status endpoints already use (it resolves
`HERMES_COPILOT_ACP_COMMAND` / `COPILOT_CLI_PATH` / `copilot` on PATH
via `shutil.which`). CLI and GUI now agree on what "configured" means
for external-process providers, and a machine without the Copilot CLI
keeps the provider hidden exactly as before.

## Related Issue

Fixes #63662

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — in the HERMES_OVERLAYS loop of
  `list_authenticated_providers()`, add an `external_process` branch to
  the `has_creds` resolution, delegating to `get_auth_status()`
- `tests/hermes_cli/test_copilot_in_model_list.py` — two regression
  tests: a resolvable fake executable makes `copilot-acp` appear (fails
  on `main`), and a forced resolution miss keeps it hidden (pins the
  "don't always show it" side). Both isolate the auth store / credential
  pool so visibility comes only from executable resolution.

## How to Test

1. Install the GitHub Copilot CLI (or point
   `HERMES_COPILOT_ACP_COMMAND` at any executable to simulate it).
2. Open the Desktop model picker (Settings → Models) or run `/model`.
   Before: GitHub Copilot ACP is absent. After: it's listed.
3. Unset the env vars on a machine without `copilot` on PATH — the
   provider stays hidden, as before.
4. `pytest tests/hermes_cli/test_copilot_in_model_list.py -q` — the new
   `test_copilot_acp_listed_when_executable_resolves` fails on `main`,
   passes here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites: 9 picker-related test files — 128 passed; `test_inventory.py` — 43 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior fix, no user-facing config/API change)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: the fix is platform-neutral (`shutil.which` handles PATHEXT on Windows); `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Regression test before/after on today's `main`:

```
# without the fix
FAILED tests/hermes_cli/test_copilot_in_model_list.py::test_copilot_acp_listed_when_executable_resolves
1 failed, 2 passed

# with the fix
3 passed
```