### PR TITLE
feat(claude-cli): route Hermes through subscription-usage Claude via persistent `claude -p`

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -487,8 +487,9 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "claude-cli"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://claude-cli")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -912,7 +912,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "claude-cli"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1703,6 +1703,30 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         )
         return client
     if agent.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("acp://claude-cli"):
+        from agent.claude_live_client import live_mode_enabled
+
+        if live_mode_enabled():
+            # Live session mode (default): one persistent `claude -p` child per
+            # conversation with Hermes's real tools exposed via a local MCP
+            # bridge. Executor is agent._invoke_tool so tools run with their
+            # normal guardrails/state. Off-switch: HERMES_CLAUDE_CLI_LIVE=0.
+            from agent.claude_live_client import (
+                ClaudeLiveClient,
+                make_agent_tool_executor,
+            )
+
+            live_kwargs = dict(client_kwargs)
+            live_kwargs["tool_executor"] = make_agent_tool_executor(agent)
+            live_kwargs["session_key"] = getattr(agent, "session_id", None) or None
+            client = ClaudeLiveClient(**live_kwargs)
+            _ra().logger.info(
+                "Claude CLI LIVE client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
+
         from agent.claude_cli_client import ClaudeCLIClient
 
         client = ClaudeCLIClient(**client_kwargs)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1702,6 +1702,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("acp://claude-cli"):
+        from agent.claude_cli_client import ClaudeCLIClient
+
+        client = ClaudeCLIClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude CLI client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5025,13 +5025,26 @@ def resolve_provider_client(
                     "was provided or configured"
                 )
                 return None, None
-            from agent.claude_cli_client import ClaudeCLIClient
+            from agent.claude_live_client import live_mode_enabled
 
-            client = ClaudeCLIClient(
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
+            if live_mode_enabled():
+                # Headless/auxiliary path has no live AIAgent, so the live
+                # client falls back to the registry dispatcher for tools.
+                from agent.claude_live_client import ClaudeLiveClient
+
+                client = ClaudeLiveClient(
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            else:
+                from agent.claude_cli_client import ClaudeCLIClient
+
+                client = ClaudeCLIClient(
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5015,6 +5015,26 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
+        if provider == "claude-cli":
+            base_url = str(creds.get("base_url", "")).strip() or None
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: claude-cli requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
             _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
             logger.debug("resolve_provider_client: external-process provider %s not "

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,620 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `claude -p`.
+
+This adapter lets Hermes treat the local Claude Code CLI as a chat-style model
+endpoint. Each request spawns a short-lived `claude -p` subprocess with ALL of
+Claude Code's built-in tools disabled (`--tools ""`), feeds the formatted
+conversation on stdin, reads the single JSON result, and converts it back into
+the minimal shape Hermes expects from an OpenAI client.
+
+Why this shape:
+  * The genuine, unmodified `claude` binary makes the network call using the
+    user's existing Claude Code OAuth/subscription session (plain `-p`, never
+    `--bare` which would force ANTHROPIC_API_KEY). Traffic is normal Claude
+    Code usage, not pay-per-token API billing — there is no identity forgery,
+    it IS Claude Code.
+  * Hermes keeps its own agent loop and executes ALL tools. `claude -p` runs
+    with no tools of its own; instead the tool schemas are described in the
+    prompt and the model emits <tool_call>{...}</tool_call> text blocks, which
+    this client parses back into OpenAI tool-call objects for Hermes to run.
+
+Mirrors agent/copilot_acp_client.py (the existing external-process provider),
+minus the JSON-RPC/ACP protocol — `claude -p --output-format stream-json` is a
+simple one-shot request/response over stdio.
+
+Tool handling: the model emits NATIVE `tool_use` blocks for the tools described
+in the prompt (captured straight from the stream and converted to OpenAI
+tool-call objects). Because those tools are not registered with Claude Code,
+it cannot execute them — it just reports `error_max_turns` after the single
+allowed turn, which we intentionally ignore since the assistant message was
+already emitted. A `<tool_call>{...}</tool_call>` text fallback is also parsed
+in case a model answers in text instead of a native tool_use block.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from tools.environments.local import hermes_subprocess_env
+
+CLAUDE_CLI_MARKER_BASE_URL = "acp://claude-cli"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_DEFAULT_MODEL = "sonnet"
+_DEFAULT_EFFORT = "medium"
+_VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(
+    r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}",
+    re.DOTALL,
+)
+
+# System prompt that pins `claude -p` into a pure model-endpoint role: no
+# Claude-Code agent behaviour, emit tool calls as text for Hermes to execute.
+_ORCHESTRATOR_SYSTEM_PROMPT = (
+    "You are being used as a stateless model endpoint by the Hermes agent "
+    "harness. Hermes owns the agent loop and executes every tool itself; you "
+    "must NOT attempt to run tools, edit files, or take actions yourself. "
+    "Respond to the conversation as the assistant. "
+    "IMPORTANT: If a tool should be called, do NOT act on it — instead output "
+    "one or more <tool_call>{...}</tool_call> blocks, each containing a single "
+    "JSON object in OpenAI function-call shape: "
+    '{"id": "<unique>", "type": "function", "function": {"name": "<tool>", '
+    '"arguments": "<json-string>"}}. The arguments field MUST be a JSON string. '
+    "If no tool is needed, just answer normally."
+)
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_extra_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+    if not raw:
+        return []
+    return shlex.split(raw)
+
+
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for the child `claude` process."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok — POSIX fallback inside try/except
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    # `claude -p` legitimately needs the user's Claude Code OAuth credentials
+    # (Keychain / ~/.claude/.credentials.json), reached via HOME. Route through
+    # the central helper so Tier-1 Hermes secrets are still stripped, then pin
+    # HOME so the credential store resolves.
+    env = hermes_subprocess_env(inherit_credentials=True)
+    env["HOME"] = _resolve_home_dir()
+    from hermes_constants import apply_subprocess_home_env
+
+    apply_subprocess_home_env(env)
+    return env
+
+
+def _normalize_effort(value: Any) -> str:
+    if isinstance(value, str) and value.strip().lower() in _VALID_EFFORTS:
+        return value.strip().lower()
+    return _DEFAULT_EFFORT
+
+
+def _normalize_model(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return _DEFAULT_MODEL
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    """Serialize the OpenAI message list + tool schemas into a single prompt."""
+    sections: list[str] = []
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available tools (OpenAI function schema). When using a tool, "
+                "emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be "
+                "a JSON string.\n" + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role not in {"system", "user", "assistant", "tool"}:
+            role = "context"
+        rendered = _render_message_content(message.get("content"))
+        if not rendered:
+            continue
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _build_openai_tool_call(
+    *, call_id: str, name: str, arguments: str
+) -> ChatCompletionMessageToolCall:
+    """Build an OpenAI-compatible tool-call object for downstream handling."""
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _extract_tool_calls_from_text(
+    text: str,
+) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    """Parse <tool_call> blocks out of the response text into OpenAI tool calls.
+
+    Returns (tool_calls, cleaned_text_with_blocks_removed).
+    """
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[ChatCompletionMessageToolCall] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"claude_cli_call_{len(extracted) + 1}"
+        extracted.append(
+            _build_openai_tool_call(
+                call_id=call_id, name=fn_name.strip(), arguments=fn_args
+            )
+        )
+
+    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
+        _try_add_tool_call(m.group(1))
+        consumed_spans.append((m.start(), m.end()))
+
+    # Only try the bare-JSON fallback when no XML blocks were found.
+    if not extracted:
+        for m in _TOOL_CALL_JSON_RE.finditer(text):
+            _try_add_tool_call(m.group(0))
+            consumed_spans.append((m.start(), m.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    """Convert a one-shot response into OpenAI-style stream chunks.
+
+    Only used if a caller requests stream=True despite the provider being
+    excluded from streaming in the conversation loop — kept for parity with
+    the copilot-acp client so nothing crashes on an unexpected stream request.
+    """
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[SimpleNamespace(index=0, delta=delta, finish_reason=choice.finish_reason)],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(choices=[], model=completion.model, usage=completion.usage)
+    return [data_chunk, usage_chunk]
+
+
+def _normalize_timeout(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [
+        getattr(timeout, attr, None)
+        for attr in ("read", "write", "connect", "pool", "timeout")
+    ]
+    numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+    return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+class _ClaudeChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeChatCompletions(client)
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for `claude -p`."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or acp_command or _resolve_command()
+        self._extra_args = list(args or acp_args or _resolve_extra_args())
+        self._cwd = str(Path(cwd or acp_cwd or os.getcwd()).resolve())
+        self.chat = _ClaudeChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        # One-shot subprocess per request (spawned and reaped inside
+        # _run_prompt), so there is no long-lived process to tear down.
+        self.is_closed = True
+
+    def _build_argv(self, *, model: str, effort: str) -> list[str]:
+        argv = [
+            self._command,
+            "-p",
+            # stream-json surfaces the assistant's content blocks (text +
+            # native tool_use) even when the turn ends in error_max_turns.
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            model,
+            "--effort",
+            effort,
+            # Disable every built-in tool: claude acts as a pure model endpoint,
+            # never executing anything. Hermes runs the tools it parses out.
+            "--tools",
+            "",
+            # Neutralize Claude Code's own agent context so it behaves as a bare
+            # model. NOT --bare (that would force ANTHROPIC_API_KEY and skip the
+            # OAuth session we specifically want to use).
+            "--system-prompt",
+            _ORCHESTRATOR_SYSTEM_PROMPT,
+            "--exclude-dynamic-system-prompt-sections",
+            "--disable-slash-commands",
+            # Exactly one assistant turn — this is a stateless model endpoint,
+            # not an agent. If the model calls a tool, the turn cap trips
+            # error_max_turns, which _run_prompt ignores (the assistant message
+            # with the tool_use block was already streamed).
+            "--max-turns",
+            "1",
+        ]
+        argv.extend(self._extra_args)
+        return argv
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        extra_body: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Any:
+        # Live model + effort: both are read per call so a mid-session `/model`
+        # or `/effort` change takes effect on the very next turn. Effort arrives
+        # via extra_body from ClaudeCLIProfile.build_extra_body (a CLI flag, not
+        # an API field); model is the standard OpenAI `model` kwarg.
+        resolved_model = _normalize_model(model)
+        effort_hint = None
+        if isinstance(extra_body, dict):
+            effort_hint = extra_body.get("_hermes_claude_effort")
+        resolved_effort = _normalize_effort(effort_hint)
+
+        prompt_text = _format_messages_as_prompt(
+            messages or [], tools=tools, tool_choice=tool_choice
+        )
+        text, reasoning_text, native_tool_calls = self._run_prompt(
+            prompt_text,
+            model=resolved_model,
+            effort=resolved_effort,
+            timeout_seconds=_normalize_timeout(timeout),
+        )
+
+        # Prefer native tool_use blocks captured from the stream; fall back to
+        # <tool_call> text blocks only if the model answered in text instead.
+        if native_tool_calls:
+            tool_calls = native_tool_calls
+            cleaned_text = text.strip()
+        else:
+            tool_calls, cleaned_text = _extract_tool_calls_from_text(text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice], usage=usage, model=resolved_model
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _run_prompt(
+        self, prompt_text: str, *, model: str, effort: str, timeout_seconds: float
+    ) -> tuple[str, str, list[ChatCompletionMessageToolCall]]:
+        """Spawn `claude -p`, feed the prompt on stdin, parse the stream.
+
+        Returns (text, reasoning, native_tool_calls). A non-zero exit is only
+        fatal if nothing usable was captured from the stream — a tool-calling
+        turn legitimately exits with error_max_turns after emitting its
+        assistant message.
+        """
+        argv = self._build_argv(model=model, effort=effort)
+        try:
+            proc = subprocess.run(
+                argv,
+                input=prompt_text,
+                capture_output=True,
+                text=True,
+                cwd=self._cwd,
+                env=_build_subprocess_env(),
+                timeout=timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude Code CLI command '{self._command}'. "
+                "Install Claude Code or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"`claude -p` timed out after {timeout_seconds:.0f}s."
+            ) from exc
+
+        text, reasoning, tool_calls, fatal_error = _parse_stream(proc.stdout)
+
+        # Only surface an error when the stream yielded no assistant content at
+        # all. error_max_turns after a tool_use block is expected and benign.
+        if not text and not tool_calls:
+            if fatal_error:
+                raise RuntimeError(f"`claude -p` reported an error: {fatal_error[:500]}")
+            stderr = (proc.stderr or "").strip()
+            raise RuntimeError(
+                f"`claude -p` exited with code {proc.returncode} and no output: "
+                f"{stderr[:500] or '(no stderr)'}"
+            )
+        return text, reasoning, tool_calls
+
+
+def _parse_stream(
+    stdout: str,
+) -> tuple[str, str, list[ChatCompletionMessageToolCall], str]:
+    """Parse `claude -p --output-format stream-json` output.
+
+    Collects assistant text blocks, thinking blocks (as reasoning), and native
+    tool_use blocks (converted to OpenAI tool calls). Returns
+    (text, reasoning, tool_calls, fatal_error_message).
+    """
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[ChatCompletionMessageToolCall] = []
+    fatal_error = ""
+
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "assistant":
+            message = event.get("message") or {}
+            for block in message.get("content", []) or []:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    t = block.get("text")
+                    if isinstance(t, str) and t.strip():
+                        text_parts.append(t)
+                elif btype == "thinking":
+                    t = block.get("thinking") or block.get("text")
+                    if isinstance(t, str) and t.strip():
+                        reasoning_parts.append(t)
+                elif btype == "tool_use":
+                    name = block.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    call_id = block.get("id")
+                    if not isinstance(call_id, str) or not call_id.strip():
+                        call_id = f"claude_cli_call_{len(tool_calls) + 1}"
+                    args = block.get("input")
+                    args_str = json.dumps(args, ensure_ascii=False) if args is not None else "{}"
+                    tool_calls.append(
+                        _build_openai_tool_call(
+                            call_id=call_id, name=name.strip(), arguments=args_str
+                        )
+                    )
+        elif etype == "result":
+            # error_max_turns is expected on a tool-calling turn; only record a
+            # genuinely fatal error (e.g. auth failure) with no assistant output.
+            if event.get("is_error") and event.get("subtype") != "error_max_turns":
+                msg = event.get("result")
+                errs = event.get("errors")
+                if isinstance(msg, str) and msg.strip():
+                    fatal_error = msg.strip()
+                elif isinstance(errs, list) and errs:
+                    fatal_error = "; ".join(str(e) for e in errs)
+                else:
+                    fatal_error = str(event.get("subtype") or "unknown error")
+
+    return (
+        "\n".join(p.strip() for p in text_parts if p.strip()).strip(),
+        "\n".join(p.strip() for p in reasoning_parts if p.strip()).strip(),
+        tool_calls,
+        fatal_error,
+    )

--- a/agent/claude_live_client.py
+++ b/agent/claude_live_client.py
@@ -44,13 +44,23 @@ design of "Claude Code owns the model call"):
     execute through Hermes's dispatcher with real guardrails, but session
     export/replay is turn-level, not tool-step-level.
 
-Long-session efficiency: ordinary Hermes context compression does NOT respawn
-(the rebuilt system prompt is byte-identical, so the fingerprint is unchanged and
-the warm process keeps its cache, which is better than the API path that loses
-cache at each compression). The volatile identity tail (date/session/model/
-provider) is stripped from the fingerprint so a day-rollover does not evict the
-cache either. Genuine respawns only happen on a model/effort switch, an auth or
-tool change, or a crash.
+Long-session correctness: the warm child keeps its OWN transcript, which grows
+every turn. Hermes compresses ITS history to bound the context, but since we send
+the child only the latest delta, that compression never reaches it — so the
+child's real context would climb without bound (a context meter reading far above
+Hermes's view, and every turn slowing as the model attends over a huge context).
+To keep them aligned, the client tracks the history size the child was last
+seeded with and the child's reported context size, and RESPAWNS+reseeds the child
+with the current (compressed) history when it detects a compression pass (history
+shrinks) or drift (child's context outgrows Hermes's view) — the same context
+reset the API path performs at every compression. Thresholds are tunable via
+HERMES_CLAUDE_LIVE_COMPRESSION_DROP / _DRIFT_RATIO / _DRIFT_MIN.
+
+Cache efficiency: the volatile identity tail (date/session/model/provider) is
+stripped from the fingerprint so a day-rollover does not evict the cache, and a
+turn that does NOT trigger a reseed reuses the warm child (and its cache) as
+before. Genuine respawns happen on a model/effort switch, an auth or tool change,
+a crash, or a detected compression/drift.
 """
 
 from __future__ import annotations
@@ -84,6 +94,7 @@ from agent.claude_cli_client import (
 from agent.claude_live_session import (
     LiveSessionConfig,
     TurnResult,
+    _env_float,
     get_registry,
 )
 from tools.environments.local import hermes_subprocess_env
@@ -492,6 +503,67 @@ def _build_turn_content(messages: list[dict[str, Any]], *, full: bool) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Long-session context alignment
+# ---------------------------------------------------------------------------
+#
+# A warm ``claude -p`` child keeps its OWN transcript, which grows every turn.
+# Hermes, meanwhile, compresses ITS history (old turns → a summary) to bound the
+# context. Because we send the warm child only the latest delta, that compression
+# never reaches it: the child's real context keeps climbing while Hermes thinks
+# it is small. Symptoms: the context meter reads the child's ballooning context
+# (well past Hermes's view, even over the model window) and every turn gets slower
+# as the model attends over a huge context. The fix is to detect the divergence
+# and respawn+reseed the child with Hermes's CURRENT (compressed) history so the
+# two realign — the same context reset the API path performs at every compression.
+
+
+def _estimate_history_tokens(messages: list[dict[str, Any]]) -> int:
+    """Rough token estimate of the non-system history (~4 chars/token). Used only
+    for ratio comparisons, so approximate is fine — never for billing."""
+    chars = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if str(message.get("role")).lower() == "system":
+            continue
+        chars += len(_render_message_content(message.get("content")))
+    return chars // 4
+
+
+def _reseed_reason(session: Any, cur_tokens: int) -> str | None:
+    """Why the warm child must be respawned+reseeded before this turn, or None.
+
+    * ``compression`` — Hermes's history shrank materially vs what the child was
+      last aligned to (a compression pass replaced old turns with a summary).
+    * ``drift`` — the child's actual context (last cache_read) has grown well past
+      Hermes's current view, so its transcript has bloated beyond the shared
+      history (a safety ceiling that also catches non-compression divergence).
+    A fresh session (no prior context) needs no reseed decision here — the normal
+    seed path already sends the full history."""
+    if not getattr(session, "has_prior_context", False):
+        return None
+    prior = int(getattr(session, "history_tokens", 0) or 0)
+    if prior > 0 and cur_tokens < prior * _compression_drop_ratio():
+        return "compression"
+    last_cache = int(getattr(session, "last_cache_read", 0) or 0)
+    if last_cache > _drift_min_tokens() and last_cache > cur_tokens * _drift_ratio():
+        return "drift"
+    return None
+
+
+def _compression_drop_ratio() -> float:
+    return _env_float("HERMES_CLAUDE_LIVE_COMPRESSION_DROP", 0.85)
+
+
+def _drift_ratio() -> float:
+    return _env_float("HERMES_CLAUDE_LIVE_DRIFT_RATIO", 1.5)
+
+
+def _drift_min_tokens() -> int:
+    return int(_env_float("HERMES_CLAUDE_LIVE_DRIFT_MIN", 50000.0))
+
+
+# ---------------------------------------------------------------------------
 # Environment / auth hardening
 # ---------------------------------------------------------------------------
 
@@ -745,6 +817,19 @@ class ClaudeLiveClient:
         registry = get_registry()
         key = self._session_key()
         session = registry.get_or_create(key, config)
+        # Before sending, check whether Hermes compressed its history (or the warm
+        # child's context has drifted far past Hermes's view). If so, respawn fresh
+        # so the child's transcript is reset and reseeded with the CURRENT
+        # (compressed) history — otherwise the child's context grows without bound,
+        # inflating the meter and slowing every turn. A fresh respawn reports
+        # has_prior_context=False, so _turn_content then sends the full history.
+        cur_tokens = _estimate_history_tokens(messages)
+        reseed = _reseed_reason(session, cur_tokens)
+        if reseed is not None:
+            session._needs_fresh = True
+            respawned = registry.recover(key)
+            if respawned is not None:
+                session = respawned
         last = session
         try:
             result = session.send_turn(
@@ -781,6 +866,12 @@ class ClaudeLiveClient:
                 + (f" (claude stderr: {detail[-800:]})" if detail else
                    " (no output from claude; check `claude` auth and connectivity)")
             )
+        # Record what the child is now aligned to so the NEXT turn can detect a
+        # compression pass (history shrinks) or context drift (child grows past
+        # Hermes's view). Include this turn's reply in the history estimate since
+        # the next turn's message list will carry it.
+        last.history_tokens = cur_tokens + max(0, len(result.text)) // 4
+        last.last_cache_read = int(result.usage.get("cache_read_input_tokens", 0) or 0)
         return result
 
     # -- result shaping -----------------------------------------------------

--- a/agent/claude_live_client.py
+++ b/agent/claude_live_client.py
@@ -26,6 +26,31 @@ dispatcher, with their normal display/guardrails). Only the NEW user turn is
 sent each call — the warm process remembers prior turns — so Hermes should keep
 its system prompt stable (volatile per-turn context belongs in the user turn;
 a changed system prompt is a fingerprint change and forces a respawn).
+
+Known divergences from the raw Messages-API / OAuth path (intentional, by
+design of "Claude Code owns the model call"):
+
+  * Sampling knobs (temperature, top_p, penalties, seed, logprobs) are not
+    forwarded; claude -p does not expose them. Such kwargs are ignored, not
+    errored.
+  * Streaming is turn-granular, not token-granular: the client collects the full
+    turn then re-emits it as stream chunks. The user sees the reply when the turn
+    completes, not typed out live. (Partial-message forwarding is a possible
+    future improvement; --include-partial-messages is already set.)
+  * No mid-turn interrupt: once a turn is in flight the only way to stop it is to
+    tear the session down.
+  * Hermes's own message history does not contain the intra-turn tool_use /
+    tool_result exchanges (they live in Claude Code's transcript); tools still
+    execute through Hermes's dispatcher with real guardrails, but session
+    export/replay is turn-level, not tool-step-level.
+
+Long-session efficiency: ordinary Hermes context compression does NOT respawn
+(the rebuilt system prompt is byte-identical, so the fingerprint is unchanged and
+the warm process keeps its cache, which is better than the API path that loses
+cache at each compression). The volatile identity tail (date/session/model/
+provider) is stripped from the fingerprint so a day-rollover does not evict the
+cache either. Genuine respawns only happen on a model/effort switch, an auth or
+tool change, or a crash.
 """
 
 from __future__ import annotations
@@ -34,6 +59,7 @@ import json
 import os
 import secrets
 import socket
+import sys
 import tempfile
 import threading
 import weakref
@@ -308,12 +334,19 @@ def _write_stable(name_prefix: str, content: str, suffix: str) -> tuple[str, str
     from agent.claude_live_session import _sha256_short
 
     digest = _sha256_short(content)
-    path = _live_state_dir() / f"{name_prefix}-{digest}{suffix}"
+    return _write_keyed(name_prefix, content, digest, suffix), digest
+
+
+def _write_keyed(name_prefix: str, content: str, key: str, suffix: str) -> str:
+    """Write ``content`` to a file named by ``key`` (not by content hash), first
+    write wins. Lets us keep a byte-stable path while the content carries a
+    volatile tail that must not change the path/fingerprint."""
+    path = _live_state_dir() / f"{name_prefix}-{key}{suffix}"
     if not path.exists():
-        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp = path.with_suffix(path.suffix + f".{secrets.token_hex(4)}.tmp")
         tmp.write_text(content, encoding="utf-8")
         os.replace(tmp, path)
-    return str(path), digest
+    return str(path)
 
 
 def _system_prompt_text(messages: list[dict[str, Any]]) -> str:
@@ -325,6 +358,34 @@ def _system_prompt_text(messages: list[dict[str, Any]]) -> str:
                 parts.append(rendered)
     body = "\n\n".join(parts).strip()
     return body + _CACHE_BOUNDARY_MARKER
+
+
+# Hermes appends a volatile tail to its (otherwise byte-stable) system prompt:
+# a day-granularity "Conversation started" date, and Session ID / Model /
+# Provider identity lines (agent/system_prompt.py). These change across a
+# day-rollover or a model switch, which would otherwise flip the fingerprint and
+# force a cache-resetting respawn on a long session. We strip them from the
+# fingerprint hash ONLY (the file still carries the real prompt): the model is a
+# separate fingerprint field so a real model switch still respawns, and the true
+# start-date correctly sticks for the life of the session.
+_VOLATILE_PROMPT_LINE_PREFIXES = (
+    "Conversation started:",
+    "Session ID:",
+    "Model:",
+    "Provider:",
+)
+
+
+def _fingerprint_system_prompt(system_prompt: str) -> str:
+    """The system prompt with its volatile identity tail removed, used only to
+    compute the session fingerprint so cosmetic per-day / per-identity changes
+    do not evict the warm cache."""
+    kept = [
+        line
+        for line in system_prompt.splitlines()
+        if not line.strip().startswith(_VOLATILE_PROMPT_LINE_PREFIXES)
+    ]
+    return "\n".join(kept).strip()
 
 
 def _render_turn_slice(messages: list[dict[str, Any]]) -> str:
@@ -345,16 +406,33 @@ def _render_turn_slice(messages: list[dict[str, Any]]) -> str:
     return "\n\n".join(rendered).strip()
 
 
+def _last_user_message(messages: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for message in reversed(messages):
+        if isinstance(message, dict) and str(message.get("role")).lower() == "user":
+            return message
+    return None
+
+
 def _delta_user_text(messages: list[dict[str, Any]]) -> str:
-    """The NEW turn to send to a WARM process: everything after the last
-    assistant message, minus system messages (the process already holds prior
-    turns in its own transcript, so resending them would duplicate context)."""
+    """The NEW turn to send to a WARM process: the latest user message only.
+
+    The warm process already holds the full prior transcript in its own context,
+    so we send just the new human turn (Hermes injects per-turn recall / plugin
+    context INTO this user message, so it rides along). Keying on the last user
+    message rather than "everything after the last assistant" is robust to
+    context compression, which can relocate the assistant boundary (the summary
+    lands as an assistant message) and would otherwise re-send already-delivered
+    turns and duplicate context in the warm process."""
+    last_user = _last_user_message(messages)
+    if last_user is not None:
+        return _render_message_content(last_user.get("content"))
+    # No user message (unusual for a warm turn) — fall back to the post-assistant
+    # tail so we still send something coherent.
     last_assistant = -1
     for idx, message in enumerate(messages):
         if isinstance(message, dict) and str(message.get("role")).lower() == "assistant":
             last_assistant = idx
-    tail = messages[last_assistant + 1:] if last_assistant >= 0 else messages
-    return _render_turn_slice(tail)
+    return _render_turn_slice(messages[last_assistant + 1:] if last_assistant >= 0 else messages)
 
 
 def _full_history_text(messages: list[dict[str, Any]]) -> str:
@@ -363,6 +441,54 @@ def _full_history_text(messages: list[dict[str, Any]]) -> str:
     messages. Without this, a respawn triggered by a live /model or /effort
     switch would send only the latest turn and silently lose all prior context."""
     return _render_turn_slice(messages)
+
+
+def _extract_image_blocks(message: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Convert OpenAI image_url blocks on a message into Claude stream-json image
+    blocks so vision inputs (e.g. a photo from a chat gateway) reach the model
+    instead of being silently dropped. data: URIs become base64 sources; http(s)
+    URLs become url sources; anything unparseable is skipped (a text note is
+    added separately by the caller)."""
+    if not message or not isinstance(message.get("content"), list):
+        return []
+    blocks: list[dict[str, Any]] = []
+    for item in message["content"]:
+        if not isinstance(item, dict) or item.get("type") != "image_url":
+            continue
+        url = (item.get("image_url") or {}).get("url") if isinstance(item.get("image_url"), dict) else None
+        if not isinstance(url, str) or not url:
+            continue
+        if url.startswith("data:"):
+            try:
+                header, data = url.split(",", 1)
+                media_type = header.split(";")[0].removeprefix("data:") or "image/png"
+                blocks.append({
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": media_type, "data": data},
+                })
+            except Exception:
+                continue
+        elif url.startswith(("http://", "https://")):
+            blocks.append({"type": "image", "source": {"type": "url", "url": url}})
+    return blocks
+
+
+def _build_turn_content(messages: list[dict[str, Any]], *, full: bool) -> Any:
+    """Build the stream-json user-envelope content for a turn.
+
+    Returns a plain string when there are no images, or a list of content blocks
+    ([text, image, ...]) when the latest user turn carries images so vision
+    inputs are forwarded. ``full`` selects the fresh-process reseed (whole
+    history) vs the warm-process delta (latest user turn)."""
+    text = _full_history_text(messages) if full else _delta_user_text(messages)
+    image_blocks = _extract_image_blocks(_last_user_message(messages))
+    if not image_blocks:
+        return text
+    content: list[dict[str, Any]] = []
+    if text:
+        content.append({"type": "text", "text": text})
+    content.extend(image_blocks)
+    return content
 
 
 # ---------------------------------------------------------------------------
@@ -458,10 +584,15 @@ class ClaudeLiveClient:
     def _mcp_config_path(self) -> tuple[str, str]:
         """Write the --mcp-config that points claude's bridge at our socket."""
         bridge = str(Path(__file__).with_name("hermes_mcp_bridge.py"))
+        # Default to THIS interpreter (Hermes's venv python), not a bare
+        # "python3" that may be absent or a different build in claude's spawn
+        # env (common on servers). The bridge itself is stdlib-only, but the
+        # interpreter must exist and be launchable or every tool call fails.
+        python_bin = os.getenv("HERMES_CLAUDE_LIVE_PYTHON") or sys.executable or "python3"
         config = {
             "mcpServers": {
                 _TOOL_NAMESPACE: {
-                    "command": os.getenv("HERMES_CLAUDE_LIVE_PYTHON", "python3"),
+                    "command": python_bin,
                     "args": [bridge],
                     "env": {
                         "HERMES_MCP_BRIDGE_SOCKET": self._tool_server.socket_path,
@@ -513,7 +644,14 @@ class ClaudeLiveClient:
         )
         mcp_config_path, mcp_hash = self._mcp_config_path()
         system_prompt = _system_prompt_text(messages)
-        system_prompt_path, sys_hash = _write_stable("sysprompt", system_prompt, ".txt")
+        # Fingerprint on the volatile-stripped prompt so a day-rollover or the
+        # identity lines do not respawn; write the REAL prompt, content-addressed
+        # by that stable hash so the first turn's start-date sticks (first write
+        # for a given hash wins).
+        from agent.claude_live_session import _sha256_short
+
+        sys_hash = _sha256_short(_fingerprint_system_prompt(system_prompt))
+        system_prompt_path = _write_keyed("sysprompt", system_prompt, sys_hash, ".txt")
         env = build_live_subprocess_env()
         argv = self._build_argv(
             model=model,
@@ -587,16 +725,15 @@ class ClaudeLiveClient:
         return completion
 
     @staticmethod
-    def _turn_text(session: Any, messages: list[dict[str, Any]]) -> str:
+    def _turn_content(session: Any, messages: list[dict[str, Any]]) -> Any:
         """Full prior history for a fresh process (seed), delta for a warm one.
 
         A warm process already holds the transcript, so resending history would
         duplicate context and evict the cache; a fresh process (first turn or a
         fingerprint-drift respawn from a /model or /effort switch) holds nothing
-        and must be seeded with the whole conversation or it loses all context."""
-        if session.has_prior_context:
-            return _delta_user_text(messages)
-        return _full_history_text(messages)
+        and must be seeded with the whole conversation or it loses all context.
+        Returns a string, or a content-block list when the turn carries images."""
+        return _build_turn_content(messages, full=not session.has_prior_context)
 
     def _run_turn(
         self, config: LiveSessionConfig, messages: list[dict[str, Any]]
@@ -608,27 +745,42 @@ class ClaudeLiveClient:
         registry = get_registry()
         key = self._session_key()
         session = registry.get_or_create(key, config)
+        last = session
         try:
             result = session.send_turn(
-                self._turn_text(session, messages),
+                self._turn_content(session, messages),
                 fresh=not session.has_prior_context,
             )
         except RuntimeError:
             recovered = registry.recover(key)
             if recovered is None:
                 raise
+            last = recovered
             result = recovered.send_turn(
-                self._turn_text(recovered, messages),
+                self._turn_content(recovered, messages),
                 fresh=not recovered.has_prior_context,
             )
 
         if (result.timed_out or not result.result_event) and not result.text:
             recovered = registry.recover(key)
             if recovered is not None:
+                last = recovered
                 result = recovered.send_turn(
-                    self._turn_text(recovered, messages),
+                    self._turn_content(recovered, messages),
                     fresh=not recovered.has_prior_context,
                 )
+
+        # A turn that still produced nothing is a failure the user must see, with
+        # the child's stderr tail (auth error, rate limit, crash) surfaced rather
+        # than swallowed into an empty reply.
+        if (result.timed_out or not result.result_event) and not result.text:
+            detail = last.stderr_tail() if hasattr(last, "stderr_tail") else ""
+            reason = "timed out" if result.timed_out else "ended without a result"
+            raise RuntimeError(
+                "claude-cli live session: turn " + reason
+                + (f" (claude stderr: {detail[-800:]})" if detail else
+                   " (no output from claude; check `claude` auth and connectivity)")
+            )
         return result
 
     # -- result shaping -----------------------------------------------------

--- a/agent/claude_live_client.py
+++ b/agent/claude_live_client.py
@@ -1,0 +1,698 @@
+"""OpenAI-ChatCompletion-shaped client backed by a PERSISTENT `claude -p`.
+
+This is the "live session" provider path for claude-cli. Unlike the per-turn
+``ClaudeCLIClient`` (which spawns a fresh subprocess every call and describes
+tools in the prompt), this client keeps ONE warm ``claude`` child per Hermes
+conversation and exposes Hermes's real tools to it through a local stdio MCP
+server. The model calls tools in-process, so the prompt cache stays hot across
+tool cycles (the whole reason live mode exists).
+
+IPC decision (the hard part):
+  Claude drives the tool cycle itself and reaches the tools through a SEPARATE
+  MCP bridge process (``agent/hermes_mcp_bridge.py``) that it spawns via
+  ``--mcp-config``. That bridge cannot execute Hermes tools — it has no
+  ``AIAgent`` (conversation/session/guardrail state). So it forwards every
+  ``tools/call`` over an AF_UNIX socket to THIS parent process, where
+  ``LiveToolServer`` runs the call through the injected executor
+  (``agent._invoke_tool`` — the same synchronous dispatcher Hermes's own loop
+  uses; falls back to ``model_tools.handle_function_call`` for headless/aux
+  use). Result flows back through the socket → bridge → claude, all within the
+  one warm process. A shared-secret token guards the socket.
+
+Consequence for Hermes's loop: one ``create()`` call is one full user turn,
+including every internal tool cycle. It returns the final assistant text with
+``finish_reason="stop"`` (tool calls were already executed via the real
+dispatcher, with their normal display/guardrails). Only the NEW user turn is
+sent each call — the warm process remembers prior turns — so Hermes should keep
+its system prompt stable (volatile per-turn context belongs in the user turn;
+a changed system prompt is a fingerprint change and forces a respawn).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import socket
+import tempfile
+import threading
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+)
+
+from agent.claude_cli_client import (
+    CLAUDE_CLI_MARKER_BASE_URL,
+    _build_openai_tool_call,
+    _normalize_effort,
+    _normalize_model,
+    _render_message_content,
+    _resolve_command,
+    _resolve_extra_args,
+    _resolve_home_dir,
+)
+from agent.claude_live_session import (
+    LiveSessionConfig,
+    TurnResult,
+    get_registry,
+)
+from tools.environments.local import hermes_subprocess_env
+
+# Env credentials/routing that must NEVER reach the child: they would switch
+# `claude` from the user's OAuth/subscription session to pay-per-token API
+# billing, a cloud-provider gateway (Bedrock/Vertex — entirely separate billing),
+# or a foreign endpoint. CLAUDE_CODE_OAUTH_TOKEN + HOME are kept (that IS the
+# subscription auth). `hermes_subprocess_env` already blocks ANTHROPIC_API_KEY /
+# ANTHROPIC_BASE_URL / ANTHROPIC_TOKEN; these are the additional live-mode keys.
+_AUTH_SCRUB_KEYS = (
+    # Direct API / OAuth credential overrides.
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_OAUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_CUSTOM_HEADERS",  # could inject an x-api-key / auth header.
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+    # Cloud-gateway routing — any of these diverts billing off the subscription.
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+    "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+)
+
+_TOOL_NAMESPACE = "hermes"
+_ALLOWED_TOOLS_GLOB = f"mcp__{_TOOL_NAMESPACE}__*"
+
+# The last stable line of the system prompt file: an explicit cache boundary so
+# everything above it is a single stable cache prefix.
+_CACHE_BOUNDARY_MARKER = "\n<!-- hermes-cache-boundary -->"
+
+
+# ---------------------------------------------------------------------------
+# Overage guard
+# ---------------------------------------------------------------------------
+
+
+def live_mode_enabled() -> bool:
+    """Live session mode is ON by default; documented off-switch reverts to the
+    per-turn ``ClaudeCLIClient``. Set ``HERMES_CLAUDE_CLI_LIVE=0`` to disable."""
+    raw = os.getenv("HERMES_CLAUDE_CLI_LIVE", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def make_agent_tool_executor(agent: Any) -> ToolExecutor:
+    """Bind a live-mode tool executor to a Hermes ``AIAgent`` instance.
+
+    Uses ``agent._invoke_tool`` — the same synchronous dispatcher Hermes's own
+    loop calls — so agent-stateful tools (todo/memory/clarify/delegate) and
+    registry tools alike run with their real guardrails and session state."""
+
+    def _execute(name: str, arguments: dict[str, Any]) -> tuple[str, bool]:
+        task_id = (
+            getattr(agent, "_current_task_id", "")
+            or getattr(agent, "session_id", "")
+            or ""
+        )
+        try:
+            result = agent._invoke_tool(name, arguments, task_id, messages=None)
+            return _stringify_tool_result(result), False
+        except Exception as exc:
+            return f"tool '{name}' failed: {exc}", True
+
+    return _execute
+
+
+class ClaudeOverageError(RuntimeError):
+    """Raised when a rate_limit_event reports the subscription is on overage."""
+
+
+def _overage_mode() -> str:
+    return (os.getenv("HERMES_CLAUDE_LIVE_OVERAGE", "abort").strip().lower() or "abort")
+
+
+def check_overage(rate_limit_events: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Return the rate_limit_info of the first overage event, else None."""
+    for evt in rate_limit_events:
+        info = evt.get("rate_limit_info") if isinstance(evt, dict) else None
+        if isinstance(info, dict) and info.get("isUsingOverage") is True:
+            return info
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool executor bridge (parent side of the socket)
+# ---------------------------------------------------------------------------
+
+# executor(name, arguments) -> (content_str, is_error)
+ToolExecutor = Callable[[str, dict[str, Any]], "tuple[str, bool]"]
+
+
+def _default_executor(name: str, arguments: dict[str, Any]) -> tuple[str, bool]:
+    """Headless fallback: dispatch straight to the registry (covers every tool
+    except the few that need a live AIAgent — todo/memory/clarify/delegate)."""
+    try:
+        from model_tools import handle_function_call
+
+        result = handle_function_call(name, arguments)
+        return _stringify_tool_result(result), False
+    except Exception as exc:
+        return f"tool '{name}' failed: {exc}", True
+
+
+def _stringify_tool_result(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict) and result.get("_multimodal"):
+        # The live model only consumes text; summarize multimodal payloads.
+        return json.dumps({"multimodal": True, "blocks": len(result.get("content") or [])})
+    try:
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except Exception:
+        return str(result)
+
+
+class LiveToolServer:
+    """AF_UNIX server that executes bridge-forwarded tool calls in the parent.
+
+    One per client, serving all of its warm sessions. Tool executions are
+    serialized under a lock (claude may fire parallel tool_use blocks; Hermes's
+    per-agent state is not built for concurrent invocation)."""
+
+    def __init__(self, executor: ToolExecutor):
+        self._executor = executor
+        self._token = secrets.token_hex(16)
+        self._exec_lock = threading.Lock()
+        self._sock: Optional[socket.socket] = None
+        self._path: str = ""
+        self._thread: Optional[threading.Thread] = None
+        self._started = False
+        self._closed = False
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    @property
+    def socket_path(self) -> str:
+        return self._path
+
+    def start(self) -> None:
+        if self._started:
+            return
+        # Short base dir keeps the AF_UNIX path under the ~104-char macOS limit.
+        base = os.getenv("TMPDIR", "/tmp").rstrip("/")
+        self._path = os.path.join(base, f"hermes-live-{secrets.token_hex(6)}.sock")
+        if os.path.exists(self._path):
+            os.unlink(self._path)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(self._path)
+        sock.listen(16)
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError:
+            pass
+        self._sock = sock
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        self._started = True
+
+    def _serve(self) -> None:
+        while not self._closed and self._sock is not None:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                break
+            threading.Thread(
+                target=self._handle_conn, args=(conn,), daemon=True
+            ).start()
+
+    def _handle_conn(self, conn: socket.socket) -> None:
+        try:
+            payload = _recv_line(conn)
+            response = self._process(payload)
+            conn.sendall((json.dumps(response) + "\n").encode("utf-8"))
+        except Exception:
+            pass
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _process(self, payload: str) -> dict[str, Any]:
+        try:
+            request = json.loads(payload)
+        except Exception:
+            return {"content": "bad request", "is_error": True}
+        if request.get("token") != self._token:
+            return {"content": "unauthorized", "is_error": True}
+        name = request.get("tool")
+        arguments = request.get("arguments")
+        if not isinstance(name, str) or not name.strip():
+            return {"content": "missing tool name", "is_error": True}
+        if not isinstance(arguments, dict):
+            arguments = {}
+        with self._exec_lock:
+            try:
+                content, is_error = self._executor(name.strip(), arguments)
+            except Exception as exc:
+                return {"content": f"tool '{name}' raised: {exc}", "is_error": True}
+        return {"content": content, "is_error": bool(is_error)}
+
+    def close(self) -> None:
+        self._closed = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+        if self._path and os.path.exists(self._path):
+            try:
+                os.unlink(self._path)
+            except OSError:
+                pass
+
+
+def _recv_line(conn: socket.socket) -> str:
+    chunks: list[bytes] = []
+    while True:
+        data = conn.recv(65536)
+        if not data:
+            break
+        chunks.append(data)
+        if b"\n" in data:
+            break
+    return b"".join(chunks).split(b"\n", 1)[0].decode("utf-8", "replace")
+
+
+# ---------------------------------------------------------------------------
+# Stable per-fingerprint file materialization
+# ---------------------------------------------------------------------------
+
+
+def _live_state_dir() -> Path:
+    base = Path(os.getenv("TMPDIR", "/tmp")) / "hermes-claude-live"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _write_stable(name_prefix: str, content: str, suffix: str) -> tuple[str, str]:
+    """Write ``content`` to a content-addressed file (idempotent). Returns
+    (path, sha16). Stable filename → byte-stable path across turns."""
+    from agent.claude_live_session import _sha256_short
+
+    digest = _sha256_short(content)
+    path = _live_state_dir() / f"{name_prefix}-{digest}{suffix}"
+    if not path.exists():
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, path)
+    return str(path), digest
+
+
+def _system_prompt_text(messages: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        if isinstance(message, dict) and str(message.get("role")).lower() == "system":
+            rendered = _render_message_content(message.get("content"))
+            if rendered:
+                parts.append(rendered)
+    body = "\n\n".join(parts).strip()
+    return body + _CACHE_BOUNDARY_MARKER
+
+
+def _render_turn_slice(messages: list[dict[str, Any]]) -> str:
+    """Render a slice of the conversation (system messages dropped) into one
+    stream-json user turn, labelling assistant/tool turns so a fresh process can
+    read the prior exchange as a transcript."""
+    rendered: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "").lower()
+        if role == "system":
+            continue
+        text = _render_message_content(message.get("content"))
+        if text:
+            label = {"user": "", "tool": "Tool result:\n"}.get(role, f"{role.title()}:\n")
+            rendered.append(f"{label}{text}")
+    return "\n\n".join(rendered).strip()
+
+
+def _delta_user_text(messages: list[dict[str, Any]]) -> str:
+    """The NEW turn to send to a WARM process: everything after the last
+    assistant message, minus system messages (the process already holds prior
+    turns in its own transcript, so resending them would duplicate context)."""
+    last_assistant = -1
+    for idx, message in enumerate(messages):
+        if isinstance(message, dict) and str(message.get("role")).lower() == "assistant":
+            last_assistant = idx
+    tail = messages[last_assistant + 1:] if last_assistant >= 0 else messages
+    return _render_turn_slice(tail)
+
+
+def _full_history_text(messages: list[dict[str, Any]]) -> str:
+    """The seed turn for a FRESH process (first turn, or a fingerprint-drift
+    respawn / eviction / orphan reseed): the entire conversation minus system
+    messages. Without this, a respawn triggered by a live /model or /effort
+    switch would send only the latest turn and silently lose all prior context."""
+    return _render_turn_slice(messages)
+
+
+# ---------------------------------------------------------------------------
+# Environment / auth hardening
+# ---------------------------------------------------------------------------
+
+
+def build_live_subprocess_env() -> dict[str, str]:
+    """OAuth-only env for the child: keep CLAUDE_CODE_OAUTH_TOKEN + HOME, scrub
+    every API-key / gateway credential that would divert billing or identity."""
+    env = hermes_subprocess_env(inherit_credentials=True)
+    for key in _AUTH_SCRUB_KEYS:
+        env.pop(key, None)
+    env["HOME"] = _resolve_home_dir()
+    from hermes_constants import apply_subprocess_home_env
+
+    apply_subprocess_home_env(env)
+    return env
+
+
+def _auth_identity(env: dict[str, str]) -> str:
+    """Stable identity of the auth the child will use (for the fingerprint)."""
+    from agent.claude_live_session import _sha256_short
+
+    token = env.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+    if token:
+        return "oauth:" + _sha256_short(token)
+    return "home:" + env.get("HOME", "")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-facade plumbing
+# ---------------------------------------------------------------------------
+
+
+class _LiveChatCompletions:
+    def __init__(self, client: "ClaudeLiveClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _LiveChatNamespace:
+    def __init__(self, client: "ClaudeLiveClient"):
+        self.completions = _LiveChatCompletions(client)
+
+
+class ClaudeLiveClient:
+    """Persistent-session claude-cli client (OpenAI-client-compatible facade)."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        cwd: str | None = None,
+        acp_cwd: str | None = None,
+        tool_executor: ToolExecutor | None = None,
+        session_key: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._command = command or acp_command or _resolve_command()
+        self._extra_args = list(args or acp_args or _resolve_extra_args())
+        self._cwd = str(Path(cwd or acp_cwd or os.getcwd()).resolve())
+        self._session_key_override = session_key
+        self._fallback_session_key = "claude-live:" + secrets.token_hex(8)
+        self._tool_server = LiveToolServer(tool_executor or _default_executor)
+        self.chat = _LiveChatNamespace(self)
+        self.is_closed = False
+        # Hermes drops old clients with ``agent.client = None`` and never calls
+        # close(). The tool server's accept thread strongly pins the server (and,
+        # via its executor closure, the whole AIAgent), so without this the FD /
+        # thread / agent leak forever on every client replacement. A finalizer
+        # closes the server when this client is garbage-collected (and runs the
+        # full set at interpreter exit), which unblocks accept() → the thread
+        # exits → everything is released. Keyed on the client, so it never pins
+        # the client itself.
+        self._finalizer = weakref.finalize(self, self._tool_server.close)
+
+    def close(self) -> None:
+        self.is_closed = True
+        self._finalizer()  # idempotent; also cancels the weakref finalizer
+
+    # -- config materialization --------------------------------------------
+
+    def _mcp_config_path(self) -> tuple[str, str]:
+        """Write the --mcp-config that points claude's bridge at our socket."""
+        bridge = str(Path(__file__).with_name("hermes_mcp_bridge.py"))
+        config = {
+            "mcpServers": {
+                _TOOL_NAMESPACE: {
+                    "command": os.getenv("HERMES_CLAUDE_LIVE_PYTHON", "python3"),
+                    "args": [bridge],
+                    "env": {
+                        "HERMES_MCP_BRIDGE_SOCKET": self._tool_server.socket_path,
+                        "HERMES_MCP_BRIDGE_TOKEN": self._tool_server.token,
+                        "HERMES_MCP_BRIDGE_TOOLS": self._tools_path,
+                    },
+                }
+            }
+        }
+        return _write_stable("mcp-config", json.dumps(config, sort_keys=True), ".json")
+
+    def _build_argv(
+        self, *, model: str, effort: str, mcp_config_path: str, system_prompt_path: str
+    ) -> tuple[str, ...]:
+        argv = [
+            self._command,
+            "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "--replay-user-messages",
+            "--model", model,
+            "--effort", effort,
+            "--setting-sources", "user",
+            "--strict-mcp-config",
+            "--mcp-config", mcp_config_path,
+            "--allowedTools", _ALLOWED_TOOLS_GLOB,
+            "--permission-mode", "bypassPermissions",
+            "--append-system-prompt-file", system_prompt_path,
+        ]
+        argv.extend(self._extra_args)
+        return tuple(argv)
+
+    def _build_config(
+        self,
+        *,
+        model: str,
+        effort: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> LiveSessionConfig:
+        from agent.hermes_mcp_bridge import translate_openai_tools_to_mcp
+
+        self._tool_server.start()
+        mcp_tools = translate_openai_tools_to_mcp(tools)
+        self._tools_path, _ = _write_stable(
+            "tools", json.dumps(mcp_tools, sort_keys=True), ".json"
+        )
+        mcp_config_path, mcp_hash = self._mcp_config_path()
+        system_prompt = _system_prompt_text(messages)
+        system_prompt_path, sys_hash = _write_stable("sysprompt", system_prompt, ".txt")
+        env = build_live_subprocess_env()
+        argv = self._build_argv(
+            model=model,
+            effort=effort,
+            mcp_config_path=mcp_config_path,
+            system_prompt_path=system_prompt_path,
+        )
+        return LiveSessionConfig(
+            command=self._command,
+            argv=argv,
+            cwd=self._cwd,
+            env=env,
+            model=model,
+            effort=effort,
+            system_prompt_hash=sys_hash,
+            mcp_config_hash=mcp_hash,
+            auth_identity=_auth_identity(env),
+        )
+
+    def _session_key(self) -> str:
+        return self._session_key_override or self._fallback_session_key
+
+    # -- main entrypoint ----------------------------------------------------
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        extra_body: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Any:
+        resolved_model = _normalize_model(model)
+        effort_hint = None
+        session_hint = None
+        if isinstance(extra_body, dict):
+            effort_hint = extra_body.get("_hermes_claude_effort")
+            session_hint = extra_body.get("_hermes_claude_session_id")
+        resolved_effort = _normalize_effort(effort_hint)
+        if isinstance(session_hint, str) and session_hint.strip():
+            self._session_key_override = "claude-live:" + session_hint.strip()
+
+        config = self._build_config(
+            model=resolved_model,
+            effort=resolved_effort,
+            messages=messages or [],
+            tools=tools,
+        )
+        result = self._run_turn(config, messages or [])
+
+        info = check_overage(result.rate_limit_events)
+        if info is not None:
+            self._log_rate_limit(info)
+            if _overage_mode() == "abort":
+                raise ClaudeOverageError(
+                    "claude-cli live session: subscription is on OVERAGE "
+                    f"(rateLimitType={info.get('rateLimitType')}, "
+                    f"resetsAt={info.get('resetsAt')}). Aborting turn "
+                    "(set HERMES_CLAUDE_LIVE_OVERAGE=allow to proceed)."
+                )
+
+        completion = self._build_completion(result, resolved_model)
+        if stream:
+            from agent.claude_cli_client import _completion_to_stream_chunks
+
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    @staticmethod
+    def _turn_text(session: Any, messages: list[dict[str, Any]]) -> str:
+        """Full prior history for a fresh process (seed), delta for a warm one.
+
+        A warm process already holds the transcript, so resending history would
+        duplicate context and evict the cache; a fresh process (first turn or a
+        fingerprint-drift respawn from a /model or /effort switch) holds nothing
+        and must be seeded with the whole conversation or it loses all context."""
+        if session.has_prior_context:
+            return _delta_user_text(messages)
+        return _full_history_text(messages)
+
+    def _run_turn(
+        self, config: LiveSessionConfig, messages: list[dict[str, Any]]
+    ) -> TurnResult:
+        """Send one turn; on a dead/orphaned session, recover once and retry.
+
+        The full-vs-delta choice is remade against whichever session actually
+        handles the turn (a recovered/respawned session is fresh and reseeds)."""
+        registry = get_registry()
+        key = self._session_key()
+        session = registry.get_or_create(key, config)
+        try:
+            result = session.send_turn(
+                self._turn_text(session, messages),
+                fresh=not session.has_prior_context,
+            )
+        except RuntimeError:
+            recovered = registry.recover(key)
+            if recovered is None:
+                raise
+            result = recovered.send_turn(
+                self._turn_text(recovered, messages),
+                fresh=not recovered.has_prior_context,
+            )
+
+        if (result.timed_out or not result.result_event) and not result.text:
+            recovered = registry.recover(key)
+            if recovered is not None:
+                result = recovered.send_turn(
+                    self._turn_text(recovered, messages),
+                    fresh=not recovered.has_prior_context,
+                )
+        return result
+
+    # -- result shaping -----------------------------------------------------
+
+    def _build_completion(self, result: TurnResult, model: str) -> SimpleNamespace:
+        usage = self._build_usage(result.usage)
+        # In live mode tools are executed in-process, so a completed turn has no
+        # pending tool_calls. If the turn ended WITHOUT a result (crash/timeout)
+        # and left a native tool_use, surface it so Hermes doesn't hang.
+        tool_calls: list[ChatCompletionMessageToolCall] = []
+        finish_reason = "stop"
+        if result.orphaned_tool_use and result.tool_uses:
+            for tu in result.tool_uses:
+                name = tu.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    continue
+                call_id = tu.get("id") or f"claude_live_call_{len(tool_calls) + 1}"
+                args = tu.get("input")
+                tool_calls.append(
+                    _build_openai_tool_call(
+                        call_id=str(call_id),
+                        name=name.strip(),
+                        arguments=json.dumps(args or {}, ensure_ascii=False),
+                    )
+                )
+            if tool_calls:
+                finish_reason = "tool_calls"
+
+        message = SimpleNamespace(
+            content=result.text,
+            tool_calls=tool_calls,
+            reasoning=result.reasoning or None,
+            reasoning_content=result.reasoning or None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+        return SimpleNamespace(choices=[choice], usage=usage, model=model)
+
+    @staticmethod
+    def _build_usage(usage: dict[str, int]) -> SimpleNamespace:
+        cached = int(usage.get("cache_read_input_tokens", 0))
+        prompt = (
+            int(usage.get("input_tokens", 0))
+            + int(usage.get("cache_creation_input_tokens", 0))
+            + cached
+        )
+        completion = int(usage.get("output_tokens", 0))
+        return SimpleNamespace(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached),
+        )
+
+    @staticmethod
+    def _log_rate_limit(info: dict[str, Any]) -> None:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "claude-cli live rate_limit_info: status=%s type=%s resetsAt=%s "
+            "overageStatus=%s isUsingOverage=%s",
+            info.get("status"),
+            info.get("rateLimitType"),
+            info.get("resetsAt"),
+            info.get("overageStatus"),
+            info.get("isUsingOverage"),
+        )

--- a/agent/claude_live_session.py
+++ b/agent/claude_live_session.py
@@ -154,6 +154,26 @@ def _accumulate_usage(dst: dict[str, int], src: dict[str, int]) -> dict[str, int
     return merged
 
 
+def _fold_turn_usage(prev: dict[str, int], new: dict[str, int]) -> dict[str, int]:
+    """Fold one assistant/result usage block into the running turn total.
+
+    The input-side counters (``input`` / ``cache_creation`` / ``cache_read``)
+    each describe the model's CONTEXT at that step. In a multi-step tool turn
+    every assistant sub-message re-reports the full cached prefix, so *summing*
+    them multi-counts the same context and makes ``prompt_tokens`` — and the
+    Hermes context meter that reads it — balloon far past the real occupancy.
+    The LATEST step's input-side values are the turn's final context size, so we
+    take them last-wins. ``output_tokens`` is what was generated at each step, so
+    it accumulates. Immutable: returns a new dict."""
+    if not new:
+        return dict(prev)
+    folded = dict(new)  # input-side counters = latest step (context occupancy)
+    folded["output_tokens"] = int(prev.get("output_tokens", 0)) + int(
+        new.get("output_tokens", 0)
+    )
+    return folded
+
+
 # ---------------------------------------------------------------------------
 # Stream reader threads
 # ---------------------------------------------------------------------------
@@ -249,6 +269,14 @@ class LiveSession:
         # a fingerprint-drift respawn (/model, /effort switch) or an eviction would
         # silently drop all prior context.
         self.has_prior_context: bool = False
+        # Long-session alignment: the warm child keeps its OWN growing transcript,
+        # so when Hermes compresses its history the child never sees it and its
+        # context grows unbounded. ``history_tokens`` is the estimated size of the
+        # history we last aligned the child to; ``last_cache_read`` is the child's
+        # actual reported context size last turn. The client compares the incoming
+        # history against these to detect compression / drift and respawn+reseed.
+        self.history_tokens: int = 0
+        self.last_cache_read: int = 0
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -449,7 +477,7 @@ class LiveSession:
         reasoning_parts: list[str],
     ) -> None:
         message = evt.get("message") or {}
-        result.usage = _accumulate_usage(
+        result.usage = _fold_turn_usage(
             result.usage, usage_from_message(message.get("usage"))
         )
         for block in message.get("content", []) or []:

--- a/agent/claude_live_session.py
+++ b/agent/claude_live_session.py
@@ -46,6 +46,7 @@ _DEFAULT_RESUME_QUIET_S = 45.0    # Warm/resume: shorter first-output budget.
 _DEFAULT_TOOL_QUIET_S = 300.0     # Quiet budget while a tool_use is outstanding.
 _DEFAULT_TURN_HARD_DEADLINE_S = 1800.0  # Absolute backstop per turn.
 _TEARDOWN_GRACE_S = 5.0
+_MAX_REASSEMBLY_BYTES = 8 * 1024 * 1024  # cap the split-object reassembly buffer
 
 
 def _env_float(name: str, default: float) -> float:
@@ -180,12 +181,16 @@ class _StdoutReader:
                     self.events.put(json.loads(line))
                     self._buf = ""
                 except json.JSONDecodeError:
-                    # stream-json occasionally splits a large object; buffer.
+                    # stream-json occasionally splits a large object; buffer and
+                    # retry. Cap the buffer so a run of unparseable output cannot
+                    # grow it without bound or wedge the reader on garbage.
                     self._buf += line
                     try:
                         self.events.put(json.loads(self._buf))
                         self._buf = ""
                     except json.JSONDecodeError:
+                        if len(self._buf) > _MAX_REASSEMBLY_BYTES:
+                            self._buf = ""  # give up on this fragment, resync
                         continue
         except Exception:
             pass
@@ -268,7 +273,19 @@ class LiveSession:
         )
         if hasattr(os, "setsid"):
             kwargs["start_new_session"] = True
-        self.proc = self._popen(argv, **kwargs)
+        try:
+            self.proc = self._popen(argv, **kwargs)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"claude live session: cannot launch `{self.config.command}` "
+                "(the Claude Code CLI is not installed or not on PATH). Install "
+                "it with `npm install -g @anthropic-ai/claude-code` and set "
+                "HERMES_CLAUDE_CLI_COMMAND if it lives elsewhere."
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(
+                f"claude live session: failed to launch `{self.config.command}`: {exc}"
+            ) from exc
         if self.proc.stdin is None or self.proc.stdout is None:
             self.teardown()
             raise RuntimeError("claude live session: no stdin/stdout pipes")

--- a/agent/claude_live_session.py
+++ b/agent/claude_live_session.py
@@ -1,0 +1,681 @@
+"""Persistent `claude -p` live-session manager (prompt-cache warm reuse).
+
+Mirrors OpenClaw's ``claude-live-session.ts``: one long-lived
+``claude -p --input-format stream-json`` child per Hermes conversation, held
+warm across interleaved MCP tool cycles so the model's prompt cache stays hot
+(~99.7% cache-read hit in the bench harness). The heavy machinery lives here;
+``agent/claude_live_client.py`` drives turns and owns the MCP tool socket.
+
+Responsibilities of this module (kept free of any Hermes-tool coupling so it is
+independently testable with a fake process):
+
+  * ``LiveSessionConfig`` — immutable spawn recipe + content fingerprint.
+  * ``LiveSession`` — a single warm child: spawn / send-one-turn / teardown,
+    with a dual watchdog (extend the quiet budget while a tool_use is
+    outstanding) and clean detached-process-group teardown.
+  * ``LiveSessionRegistry`` — ``Map[session_key -> LiveSession]`` with an LRU
+    cap, idle timeout, fingerprint-mismatch respawn, and crash ``--resume``
+    with orphaned-tool-use reseed.
+
+Nothing here executes tools or knows about Hermes internals; the client injects
+behaviour through plain values and callbacks.
+"""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import queue
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+# ---------------------------------------------------------------------------
+# Tunables (all env-overridable so ops can adjust without a redeploy).
+# ---------------------------------------------------------------------------
+
+_DEFAULT_IDLE_TIMEOUT_S = 600.0   # 10 min — evict a session idle this long.
+_DEFAULT_LRU_CAP = 16             # Max concurrent warm children.
+_DEFAULT_FRESH_QUIET_S = 90.0     # Cold-start: budget until first output.
+_DEFAULT_RESUME_QUIET_S = 45.0    # Warm/resume: shorter first-output budget.
+_DEFAULT_TOOL_QUIET_S = 300.0     # Quiet budget while a tool_use is outstanding.
+_DEFAULT_TURN_HARD_DEADLINE_S = 1800.0  # Absolute backstop per turn.
+_TEARDOWN_GRACE_S = 5.0
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _sha256_short(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Config / fingerprint
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveSessionConfig:
+    """Immutable spawn recipe. Its ``fingerprint`` gates session reuse: any
+    change (model, effort, system prompt, mcp config, argv, auth identity)
+    yields a new fingerprint → the registry tears down and respawns."""
+
+    command: str
+    argv: tuple[str, ...]
+    cwd: str
+    env: dict[str, str]
+    model: str
+    effort: str
+    system_prompt_hash: str
+    mcp_config_hash: str
+    auth_identity: str
+
+    @property
+    def fingerprint(self) -> str:
+        payload = json.dumps(
+            {
+                "model": self.model,
+                "effort": self.effort,
+                "system_prompt_hash": self.system_prompt_hash,
+                "mcp_config_hash": self.mcp_config_hash,
+                "argv": list(self.argv),
+                "auth_identity": self.auth_identity,
+            },
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+        return _sha256_short(payload)
+
+
+# ---------------------------------------------------------------------------
+# Turn result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnResult:
+    """Everything the client needs from one warm turn."""
+
+    text: str = ""
+    reasoning: str = ""
+    tool_uses: list[dict[str, Any]] = field(default_factory=list)
+    usage: dict[str, int] = field(default_factory=dict)
+    rate_limit_events: list[dict[str, Any]] = field(default_factory=list)
+    session_id: str = ""
+    result_event: Optional[dict[str, Any]] = None
+    orphaned_tool_use: bool = False
+    timed_out: bool = False
+
+
+def usage_from_message(usage: Optional[dict[str, Any]]) -> dict[str, int]:
+    """Extract the four token counters from an assistant/result usage block."""
+    if not isinstance(usage, dict):
+        return {}
+    keys = (
+        "input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "output_tokens",
+    )
+    return {k: int(usage.get(k) or 0) for k in keys}
+
+
+def _accumulate_usage(dst: dict[str, int], src: dict[str, int]) -> dict[str, int]:
+    """Return a new dict summing counters (immutable — no in-place mutation)."""
+    merged = dict(dst)
+    for key, value in src.items():
+        merged[key] = merged.get(key, 0) + int(value or 0)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Stream reader threads
+# ---------------------------------------------------------------------------
+
+
+class _StdoutReader:
+    """Background thread: parse stream-json lines into an event queue."""
+
+    def __init__(self, stream: Any):
+        self._stream = stream
+        self.events: "queue.Queue[dict[str, Any]]" = queue.Queue()
+        self._buf = ""
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            for line in iter(self._stream.readline, ""):
+                if line == "":
+                    break
+                line = line.rstrip("\n")
+                if not line.strip():
+                    continue
+                try:
+                    self.events.put(json.loads(line))
+                    self._buf = ""
+                except json.JSONDecodeError:
+                    # stream-json occasionally splits a large object; buffer.
+                    self._buf += line
+                    try:
+                        self.events.put(json.loads(self._buf))
+                        self._buf = ""
+                    except json.JSONDecodeError:
+                        continue
+        except Exception:
+            pass
+
+    def get(self, timeout: float) -> dict[str, Any]:
+        return self.events.get(timeout=timeout)
+
+
+class _StderrReader:
+    def __init__(self, stream: Any, maxlines: int = 60):
+        from collections import deque
+
+        self._stream = stream
+        self.tail: "deque[str]" = deque(maxlen=maxlines)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            for line in iter(self._stream.readline, ""):
+                if line == "":
+                    break
+                self.tail.append(line.rstrip("\n"))
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# LiveSession
+# ---------------------------------------------------------------------------
+
+
+class LiveSession:
+    """One warm ``claude -p`` child. Turns are serialized (single-flight)."""
+
+    def __init__(
+        self,
+        config: LiveSessionConfig,
+        *,
+        popen: Callable[..., Any] = subprocess.Popen,
+    ):
+        self.config = config
+        self._popen = popen
+        self.proc: Any = None
+        self._out: Optional[_StdoutReader] = None
+        self._err: Optional[_StderrReader] = None
+        self.session_id: str = ""
+        self.last_activity: float = time.monotonic()
+        self._turn_lock = threading.Lock()
+        self._needs_fresh = False  # set when a prior turn left an orphaned tool_use
+        self._spawned_at: float = 0.0
+        # True once this live process's transcript already holds the conversation
+        # prefix: after ≥1 sent turn, or when spawned via --resume (claude reloads
+        # the transcript). A fresh process is False → the client must seed it with
+        # the full prior history instead of only the new delta turn. Without this,
+        # a fingerprint-drift respawn (/model, /effort switch) or an eviction would
+        # silently drop all prior context.
+        self.has_prior_context: bool = False
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def spawn(self, *, resume_session_id: Optional[str] = None) -> None:
+        argv = list(self.config.argv)
+        resuming = bool(resume_session_id) and not self._needs_fresh
+        if resuming:
+            argv = argv + ["--resume", resume_session_id]
+            # A resumed process reloads the full prior transcript, so it already
+            # holds the conversation prefix — send only the delta turn.
+            self.has_prior_context = True
+        # Detached process group so teardown can group-kill and never orphan
+        # the MCP bridge child claude itself spawned.
+        kwargs: dict[str, Any] = dict(
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=self.config.cwd,
+            env=self.config.env,
+        )
+        if hasattr(os, "setsid"):
+            kwargs["start_new_session"] = True
+        self.proc = self._popen(argv, **kwargs)
+        if self.proc.stdin is None or self.proc.stdout is None:
+            self.teardown()
+            raise RuntimeError("claude live session: no stdin/stdout pipes")
+        self._out = _StdoutReader(self.proc.stdout)
+        self._err = _StderrReader(self.proc.stderr)
+        self._spawned_at = time.monotonic()
+        self.last_activity = self._spawned_at
+
+    def is_alive(self) -> bool:
+        return self.proc is not None and self.proc.poll() is None
+
+    @property
+    def fingerprint(self) -> str:
+        return self.config.fingerprint
+
+    def stderr_tail(self) -> str:
+        if self._err is None:
+            return ""
+        return "\n".join(self._err.tail).strip()
+
+    # -- turn driving -------------------------------------------------------
+
+    def send_turn(
+        self,
+        user_text: str,
+        *,
+        fresh: bool,
+        quiet_budget: Optional[float] = None,
+        tool_quiet_budget: Optional[float] = None,
+        hard_deadline: Optional[float] = None,
+    ) -> TurnResult:
+        """Write one user envelope, read events to the ``result`` event.
+
+        Dual watchdog: the quiet budget is the max gap between events; while a
+        tool_use is outstanding (seen tool_use, not yet its tool_result) the
+        larger ``tool_quiet_budget`` applies, because a Hermes tool may be slow.
+        """
+        if not self.is_alive():
+            raise RuntimeError("claude live session: process is not alive")
+
+        quiet_budget = quiet_budget or (
+            _env_float("HERMES_CLAUDE_LIVE_FRESH_QUIET_S", _DEFAULT_FRESH_QUIET_S)
+            if fresh
+            else _env_float("HERMES_CLAUDE_LIVE_RESUME_QUIET_S", _DEFAULT_RESUME_QUIET_S)
+        )
+        tool_quiet_budget = tool_quiet_budget or _env_float(
+            "HERMES_CLAUDE_LIVE_TOOL_QUIET_S", _DEFAULT_TOOL_QUIET_S
+        )
+        hard_deadline = hard_deadline or _env_float(
+            "HERMES_CLAUDE_LIVE_TURN_DEADLINE_S", _DEFAULT_TURN_HARD_DEADLINE_S
+        )
+
+        with self._turn_lock:  # single-flight: one turn per session at a time
+            return self._drive_turn(
+                user_text,
+                quiet_budget=quiet_budget,
+                tool_quiet_budget=tool_quiet_budget,
+                hard_deadline=hard_deadline,
+            )
+
+    def _write_envelope(self, user_text: str) -> None:
+        envelope = {
+            "type": "user",
+            "session_id": self.session_id or "",
+            "parent_tool_use_id": None,
+            "message": {"role": "user", "content": user_text},
+        }
+        self.proc.stdin.write(json.dumps(envelope) + "\n")
+        self.proc.stdin.flush()
+
+    def _drive_turn(
+        self,
+        user_text: str,
+        *,
+        quiet_budget: float,
+        tool_quiet_budget: float,
+        hard_deadline: float,
+    ) -> TurnResult:
+        assert self._out is not None
+        self._write_envelope(user_text)
+        # From here on this live process's transcript holds this turn, so the
+        # next turn to the SAME process should be sent as a delta, not a reseed.
+        self.has_prior_context = True
+
+        result = TurnResult(session_id=self.session_id)
+        outstanding: set[str] = set()
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        hard_stop = time.monotonic() + hard_deadline
+        last_event = time.monotonic()
+
+        while True:
+            now = time.monotonic()
+            if now >= hard_stop:
+                result.timed_out = True
+                break
+            budget = tool_quiet_budget if outstanding else quiet_budget
+            if now - last_event > budget:
+                result.timed_out = True
+                break
+            if not self.is_alive():
+                break
+            try:
+                evt = self._out.get(timeout=min(1.0, hard_stop - now))
+            except queue.Empty:
+                continue
+            last_event = time.monotonic()
+            self.last_activity = last_event
+            done = self._consume_event(
+                evt, result, outstanding, text_parts, reasoning_parts
+            )
+            if done:
+                break
+
+        result.text = "\n".join(p.strip() for p in text_parts if p.strip()).strip()
+        result.reasoning = "\n".join(
+            p.strip() for p in reasoning_parts if p.strip()
+        ).strip()
+        # Trailing tool_use without its tool_result → transcript is orphaned;
+        # a later --resume would be rejected, so flag for a fresh reseed.
+        result.orphaned_tool_use = bool(outstanding)
+        self._needs_fresh = result.orphaned_tool_use or result.timed_out
+        return result
+
+    def _consume_event(
+        self,
+        evt: dict[str, Any],
+        result: TurnResult,
+        outstanding: set[str],
+        text_parts: list[str],
+        reasoning_parts: list[str],
+    ) -> bool:
+        """Fold one event into ``result``. Returns True on the turn's end."""
+        etype = evt.get("type")
+        if etype == "system" and evt.get("subtype") == "init":
+            sid = evt.get("session_id")
+            if isinstance(sid, str) and sid:
+                self.session_id = sid
+                result.session_id = sid
+            return False
+        if etype == "rate_limit_event":
+            result.rate_limit_events.append(evt)
+            return False
+        if etype == "assistant":
+            self._consume_assistant(evt, result, outstanding, text_parts, reasoning_parts)
+            return False
+        if etype == "user":
+            _consume_tool_results(evt, outstanding)
+            return False
+        if etype == "result":
+            result.result_event = evt
+            return True
+        return False
+
+    def _consume_assistant(
+        self,
+        evt: dict[str, Any],
+        result: TurnResult,
+        outstanding: set[str],
+        text_parts: list[str],
+        reasoning_parts: list[str],
+    ) -> None:
+        message = evt.get("message") or {}
+        result.usage = _accumulate_usage(
+            result.usage, usage_from_message(message.get("usage"))
+        )
+        for block in message.get("content", []) or []:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                t = block.get("text")
+                if isinstance(t, str) and t.strip():
+                    text_parts.append(t)
+            elif btype == "thinking":
+                t = block.get("thinking") or block.get("text")
+                if isinstance(t, str) and t.strip():
+                    reasoning_parts.append(t)
+            elif btype == "tool_use":
+                tid = block.get("id")
+                if isinstance(tid, str) and tid:
+                    outstanding.add(tid)
+                result.tool_uses.append(
+                    {
+                        "id": tid,
+                        "name": block.get("name"),
+                        "input": block.get("input"),
+                    }
+                )
+
+    # -- teardown -----------------------------------------------------------
+
+    def teardown(self) -> None:
+        proc = self.proc
+        self.proc = None
+        if proc is None:
+            return
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except Exception:
+            pass
+        _kill_process_tree(proc)
+
+
+def _consume_tool_results(evt: dict[str, Any], outstanding: set[str]) -> None:
+    message = evt.get("message") or {}
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_result":
+            tid = block.get("tool_use_id")
+            if isinstance(tid, str):
+                outstanding.discard(tid)
+
+
+def _kill_process_tree(proc: Any) -> None:
+    """SIGTERM the group, grace, then SIGKILL the group. Guards the no-setsid
+    fallback so we never leave a zombie ``claude`` (or its MCP bridge child)."""
+    pgid: Optional[int] = None
+    if hasattr(os, "getpgid") and hasattr(os, "killpg"):
+        try:
+            pgid = os.getpgid(proc.pid)
+        except Exception:
+            pgid = None
+
+    def _signal(sig: int) -> None:
+        if pgid is not None:
+            try:
+                os.killpg(pgid, sig)
+                return
+            except Exception:
+                pass
+        try:
+            proc.send_signal(sig)
+        except Exception:
+            pass
+
+    try:
+        if proc.poll() is None:
+            _signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=_TEARDOWN_GRACE_S)
+            except Exception:
+                _signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=_TEARDOWN_GRACE_S)
+                except Exception:
+                    pass
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class LiveSessionRegistry:
+    """LRU + idle-timeout registry of warm sessions keyed by ``session_key``.
+
+    Eviction is lazy (swept on every access) so behaviour is deterministic and
+    unit-testable without a background reaper thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        idle_timeout_s: Optional[float] = None,
+        lru_cap: Optional[int] = None,
+        clock: Callable[[], float] = time.monotonic,
+        popen: Callable[..., Any] = subprocess.Popen,
+    ):
+        self._sessions: "dict[str, LiveSession]" = {}
+        self._lock = threading.RLock()
+        self._idle_timeout = idle_timeout_s or _env_float(
+            "HERMES_CLAUDE_LIVE_IDLE_TIMEOUT_S", _DEFAULT_IDLE_TIMEOUT_S
+        )
+        self._lru_cap = lru_cap or _env_int("HERMES_CLAUDE_LIVE_LRU_CAP", _DEFAULT_LRU_CAP)
+        self._clock = clock
+        self._popen = popen
+
+    def get_or_create(
+        self, session_key: str, config: LiveSessionConfig
+    ) -> LiveSession:
+        # ``teardown()`` blocks (SIGTERM grace → SIGKILL) so it is done OUTSIDE
+        # the lock; holding the lock across a kill would stall every other
+        # conversation's turn behind one slow child.
+        doomed: list[LiveSession] = []
+        with self._lock:
+            doomed.extend(self._detach_idle())
+            existing = self._sessions.get(session_key)
+            if existing is not None:
+                if existing.is_alive() and existing.fingerprint == config.fingerprint:
+                    existing.last_activity = self._clock()
+                    self._teardown_all(doomed)
+                    return existing
+                # Fingerprint drift (/model, /effort, tool change) or dead
+                # child → detach for teardown and respawn fresh.
+                doomed.append(existing)
+                del self._sessions[session_key]
+            session = LiveSession(config, popen=self._popen)
+            session.spawn()
+            session.last_activity = self._clock()
+            self._sessions[session_key] = session
+            doomed.extend(self._detach_over_cap())
+        self._teardown_all(doomed)
+        return session
+
+    def recover(self, session_key: str) -> Optional[LiveSession]:
+        """Respawn a crashed session with ``--resume`` (or fresh if orphaned)."""
+        doomed: list[LiveSession] = []
+        with self._lock:
+            session = self._sessions.get(session_key)
+            if session is None:
+                return None
+            captured = session.session_id
+            orphaned = session._needs_fresh
+            doomed.append(session)
+            fresh = LiveSession(session.config, popen=self._popen)
+            fresh._needs_fresh = orphaned
+            fresh.spawn(resume_session_id=None if orphaned else captured)
+            self._sessions[session_key] = fresh
+        self._teardown_all(doomed)
+        return fresh
+
+    def drop(self, session_key: str) -> None:
+        with self._lock:
+            session = self._sessions.pop(session_key, None)
+        if session is not None:
+            session.teardown()
+
+    def shutdown(self) -> None:
+        with self._lock:
+            doomed = list(self._sessions.values())
+            self._sessions.clear()
+        self._teardown_all(doomed)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._sessions)
+
+    # -- internal -----------------------------------------------------------
+
+    @staticmethod
+    def _teardown_all(sessions: list[LiveSession]) -> None:
+        """Tear down detached sessions. Called with NO lock held so the blocking
+        SIGTERM/SIGKILL grace never stalls other conversations."""
+        for session in sessions:
+            try:
+                session.teardown()
+            except Exception:
+                pass
+
+    def _detach_idle(self) -> list[LiveSession]:
+        """Remove dead/idle sessions from the map and RETURN them for teardown
+        by the caller outside the lock. Must be called under ``self._lock``."""
+        now = self._clock()
+        stale = [
+            key
+            for key, s in self._sessions.items()
+            if not s.is_alive() or (now - s.last_activity) > self._idle_timeout
+        ]
+        detached: list[LiveSession] = []
+        for key in stale:
+            detached.append(self._sessions.pop(key))
+        return detached
+
+    def _detach_over_cap(self) -> list[LiveSession]:
+        """Evict least-recently-active sessions above the cap; return them for
+        teardown outside the lock. Must be called under ``self._lock``."""
+        detached: list[LiveSession] = []
+        while len(self._sessions) > self._lru_cap:
+            victim = min(self._sessions.items(), key=lambda kv: kv[1].last_activity)[0]
+            detached.append(self._sessions.pop(victim))
+        return detached
+
+
+# Process-wide singleton registry (one per Hermes process).
+_REGISTRY: Optional[LiveSessionRegistry] = None
+_REGISTRY_LOCK = threading.Lock()
+
+
+def get_registry() -> LiveSessionRegistry:
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        if _REGISTRY is None:
+            _REGISTRY = LiveSessionRegistry()
+        return _REGISTRY
+
+
+def _shutdown_registry() -> None:
+    """Kill every warm ``claude`` child at interpreter exit. Their process groups
+    are detached (start_new_session=True) so they survive parent death otherwise
+    — a leaked child per active conversation on every gateway restart."""
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        registry = _REGISTRY
+    if registry is not None:
+        try:
+            registry.shutdown()
+        except Exception:
+            pass
+
+
+atexit.register(_shutdown_registry)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1288,13 +1288,14 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
-                # returns a plain SimpleNamespace — not an iterable
+                # CopilotACPClient / ClaudeCLIClient communicate via subprocess
+                # stdio and return a plain SimpleNamespace — not an iterable
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
+                    agent.provider in {"copilot-acp", "claude-cli"}
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://claude-cli")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/hermes_mcp_bridge.py
+++ b/agent/hermes_mcp_bridge.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Standalone stdio MCP server that bridges `claude -p` tool calls back into
+the parent Hermes process's real tool dispatcher.
+
+Architecture (IPC decision — see module docstring in claude_live_client.py):
+
+    claude -p  ──stdio JSON-RPC──▶  THIS bridge (separate process, spawned by
+                                    claude via --mcp-config)
+                                        │
+                                        │  AF_UNIX stream, newline-delimited JSON
+                                        ▼
+                             parent Hermes process (LiveToolServer)
+                                        │
+                                        ▼
+                             agent._invoke_tool(name, args)  ← the REAL dispatcher
+
+The bridge itself executes NOTHING. It cannot: it is a distinct process without
+the parent's live ``AIAgent`` (conversation state, guardrails, session db,
+todo/memory stores). So every ``tools/call`` is forwarded over a unix-domain
+socket to the parent, which owns tool execution and conversation state, and the
+result is streamed back. Tool *schemas* are handed to the bridge as a JSON file
+(byte-stable within a session for prompt-cache stability) so ``tools/list`` never
+needs the socket.
+
+Configured entirely via env (set by the parent in the --mcp-config server entry):
+  * ``HERMES_MCP_BRIDGE_SOCKET`` — AF_UNIX path of the parent's LiveToolServer.
+  * ``HERMES_MCP_BRIDGE_TOOLS``  — path to the JSON tool-defs file.
+  * ``HERMES_MCP_BRIDGE_TOKEN``  — shared secret; first line sent on the socket
+    so the parent rejects any stray local connection.
+
+MCP surface implemented: initialize, notifications/initialized, tools/list,
+tools/call (matching bench/mcp_server.py, proven against the real CLI).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+from typing import Any, Optional
+
+PROTOCOL_VERSION = "2025-06-18"
+SERVER_NAME = "hermes"
+_SOCKET_TIMEOUT_S = 1800.0
+
+
+# ---------------------------------------------------------------------------
+# Schema translation (pure — imported by tests)
+# ---------------------------------------------------------------------------
+
+
+def translate_openai_tools_to_mcp(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """OpenAI ``{"function": {name, description, parameters}}`` → MCP tool defs.
+
+    Names are emitted bare; Claude Code namespaces them as ``mcp__hermes__<name>``
+    on its side. Output is deterministically ordered so the JSON file stays
+    byte-stable across turns (prompt-cache stability)."""
+    out: list[dict[str, Any]] = []
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") if isinstance(tool.get("function"), dict) else tool
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        params = fn.get("parameters")
+        if not isinstance(params, dict):
+            params = {"type": "object", "properties": {}}
+        out.append(
+            {
+                "name": name.strip(),
+                "description": str(fn.get("description") or ""),
+                "inputSchema": params,
+            }
+        )
+    out.sort(key=lambda t: t["name"])
+    return out
+
+
+def load_tool_defs(path: Optional[str]) -> list[dict[str, Any]]:
+    if not path or not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return []
+    if isinstance(data, list):
+        return [t for t in data if isinstance(t, dict) and t.get("name")]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Parent socket client
+# ---------------------------------------------------------------------------
+
+
+class ParentToolClient:
+    """Newline-delimited JSON-RPC-ish client to the parent LiveToolServer."""
+
+    def __init__(self, socket_path: str, token: str):
+        self._path = socket_path
+        self._token = token
+
+    def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Execute one tool via the parent. Returns ``{content, is_error}``."""
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(_SOCKET_TIMEOUT_S)
+        try:
+            sock.connect(self._path)
+            request = {
+                "token": self._token,
+                "type": "call",
+                "tool": name,
+                "arguments": arguments,
+            }
+            sock.sendall((json.dumps(request) + "\n").encode("utf-8"))
+            payload = _recv_line(sock)
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+        if not payload:
+            return {"content": "tool bridge: empty response from parent", "is_error": True}
+        try:
+            response = json.loads(payload)
+        except Exception:
+            return {"content": "tool bridge: malformed parent response", "is_error": True}
+        return {
+            "content": str(response.get("content", "")),
+            "is_error": bool(response.get("is_error", False)),
+        }
+
+
+def _recv_line(sock: socket.socket) -> str:
+    chunks: list[bytes] = []
+    while True:
+        data = sock.recv(65536)
+        if not data:
+            break
+        chunks.append(data)
+        if b"\n" in data:
+            break
+    return b"".join(chunks).split(b"\n", 1)[0].decode("utf-8", "replace")
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC request handling
+# ---------------------------------------------------------------------------
+
+
+def handle_request(
+    req: dict[str, Any],
+    *,
+    tools: list[dict[str, Any]],
+    parent: Optional[ParentToolClient],
+) -> Optional[dict[str, Any]]:
+    method = req.get("method")
+    req_id = req.get("id")
+    params = req.get("params") or {}
+
+    if method == "initialize":
+        return _ok(
+            req_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": "0.1.0"},
+            },
+        )
+    if method == "notifications/initialized":
+        return None
+    if method == "tools/list":
+        return _ok(req_id, {"tools": tools})
+    if method == "tools/call":
+        return _handle_tools_call(req_id, params, parent)
+    if req_id is not None:
+        return _err(req_id, -32601, f"Method not found: {method}")
+    return None
+
+
+def _handle_tools_call(
+    req_id: Any, params: dict[str, Any], parent: Optional[ParentToolClient]
+) -> dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    if not isinstance(name, str) or not name.strip():
+        return _err(req_id, -32602, "tools/call missing tool name")
+    if parent is None:
+        return _tool_error_result(req_id, "tool bridge not connected to parent")
+    try:
+        outcome = parent.call(name.strip(), arguments if isinstance(arguments, dict) else {})
+    except Exception as exc:  # socket failure — surface as a tool error, not a crash
+        return _tool_error_result(req_id, f"tool bridge error: {exc}")
+    return _ok(
+        req_id,
+        {
+            "content": [{"type": "text", "text": outcome.get("content", "")}],
+            "isError": bool(outcome.get("is_error", False)),
+        },
+    )
+
+
+def _ok(req_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _err(req_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def _tool_error_result(req_id: Any, message: str) -> dict[str, Any]:
+    # A failed tool is reported as a successful JSON-RPC result carrying an MCP
+    # tool error, so the model can react instead of the turn hard-failing.
+    return _ok(req_id, {"content": [{"type": "text", "text": message}], "isError": True})
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    tools = load_tool_defs(os.getenv("HERMES_MCP_BRIDGE_TOOLS"))
+    socket_path = os.getenv("HERMES_MCP_BRIDGE_SOCKET", "").strip()
+    token = os.getenv("HERMES_MCP_BRIDGE_TOKEN", "").strip()
+    parent = ParentToolClient(socket_path, token) if socket_path else None
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            resp = handle_request(req, tools=tools, parent=parent)
+        except Exception as exc:
+            resp = _err(req.get("id"), -32000, str(exc))
+        if resp is not None:
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -46,7 +46,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-cli",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -213,6 +213,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
     "claude-fable-5": 1000000,
     "claude-fable": 1000000,
+    # Claude Sonnet 5 (launched 2026-06-30) — 1M context by default, 128k max
+    # output. Without this it substring-matches the "claude": 200K catch-all.
+    "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CLI_BASE_URL = "acp://claude-cli"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude Code CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CLI_BASE_URL,
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -6272,13 +6280,22 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else []
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6313,7 +6330,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", "claude-cli"}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6496,25 +6513,42 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else []
+        api_key = "claude-cli"
+        missing_msg = (
+            f"Could not find the Claude Code CLI command '{command}'. "
+            "Install Claude Code or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+        )
+        missing_code = "missing_claude_cli"
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        api_key = "copilot-acp"
+        missing_msg = (
+            f"Could not find the Copilot CLI command '{command}'. "
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
+        missing_code = "missing_copilot_cli"
+
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
-        raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
-            provider=provider_id,
-            code="missing_copilot_cli",
-        )
+        raise AuthError(missing_msg, provider=provider_id, code=missing_code)
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": api_key,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12266,7 +12266,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "claude-cli", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -629,6 +629,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_claude_cli,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3113,6 +3114,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-cli":
+        _model_flow_claude_cli(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1877,6 +1877,81 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_claude_cli(config, current_model=""):
+    """Claude Code CLI flow — routes Hermes turns through local `claude -p`.
+
+    Uses the user's existing Claude Code OAuth/subscription session (the real
+    `claude` binary makes the call), so it draws normal included usage. Model
+    and effort stay switchable live via `/model` and `/effort` afterward.
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-cli"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code CLI routes Hermes turns through local `claude -p`.")
+    print("  Traffic runs on your existing Claude Code subscription (no API key).")
+    print("  Hermes keeps its own agent loop and executes all tools itself.")
+    print(f"  Command: {resolved_command}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Install Claude Code, or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH "
+            "if the `claude` binary is elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+
+    selected = _prompt_model_selection(
+        model_list,
+        current_model=current_model,
+        confirm_provider=provider_id,
+        confirm_base_url=effective_base,
+        confirm_api_key="",
+    )
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1767,6 +1767,19 @@ def list_authenticated_providers(
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
                         has_creds = True
                         break
+        # External-process providers (copilot-acp, claude-cli): the local CLI
+        # binary IS the credential. Surface them in the picker whenever the
+        # binary resolves on PATH, so users can switch without first writing a
+        # manual auth-store marker via the web "connect" card.
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+                if get_external_process_provider_status(hermes_slug).get("configured"):
+                    has_creds = True
+            except Exception as exc:
+                logger.debug(
+                    "External-process status check failed for %s: %s", hermes_slug, exc
+                )
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -272,6 +272,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "sonnet",
+        "opus",
+        "haiku",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-haiku-4-5-20251001",
+        "claude-fable-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1065,6 +1074,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("claude-cli",     "Claude Code CLI",          "Claude via local `claude -p` (subscription usage, no API key; runs the real Claude Code binary)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-cli": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://claude-cli",
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -290,6 +296,10 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # claude-cli (local `claude -p` subprocess)
+    "claude-code-cli": "claude-cli",
+    "claude-p": "claude-cli",
+
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -373,6 +383,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude Code CLI",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1833,10 +1833,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-cli"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,11 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "sonnet",
+        "opus",
+        "haiku",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8091,6 +8091,35 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
+def _claude_cli_status() -> Dict[str, Any]:
+    """Status for claude-cli — credentials are owned by the Claude Code CLI.
+
+    The `claude` binary makes the network call with its own OAuth session, so
+    Hermes can't inspect the token. What it CAN verify cheaply is whether the
+    binary resolves on PATH — the prerequisite for this provider to work.
+    """
+    try:
+        from hermes_cli.auth import get_external_process_provider_status
+        status = get_external_process_provider_status("claude-cli")
+    except Exception as e:
+        return {"logged_in": False, "error": str(e)}
+    available = bool(status.get("configured"))
+    resolved = status.get("resolved_command")
+    return {
+        "logged_in": False,
+        "source": "claude_cli",
+        "source_label": (
+            f"Managed by the Claude Code CLI ({resolved})"
+            if available and resolved
+            else "Claude Code CLI not found on PATH — install Claude Code"
+        ),
+        "available": available,
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+    }
+
+
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
 # can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
 # the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
@@ -8160,6 +8189,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "copilot /login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
+    },
+    {
+        "id": "claude-cli",
+        "name": "Claude Code CLI (subscription usage, no API key)",
+        "flow": "external",
+        "cli_command": "claude /login",
+        "docs_url": "https://docs.claude.com/en/docs/claude-code",
+        "status_fn": _claude_cli_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra

--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -1,0 +1,78 @@
+"""Claude Code CLI provider profile.
+
+claude-cli: routes Hermes requests through the local `claude -p` (Claude Code
+headless) binary as a pure model endpoint. The genuine first-party Claude Code
+client makes the network call using the user's existing OAuth/subscription
+session, so traffic draws normal included usage rather than pay-per-token API
+billing. Hermes keeps its own agent loop and executes ALL tools — the subprocess
+only turns messages into an assistant reply (text + <tool_call> blocks).
+
+Reports api_mode="chat_completions" but is dispatched at client-construction
+time to ClaudeCLIClient (see agent/agent_runtime_helpers.create_openai_client),
+exactly like the copilot-acp provider. The profile carries the effort-threading
+hook so a live `/effort` change reaches the subprocess on the next turn.
+"""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+# Model aliases + full ids accepted by `claude -p --model <x>`. Kept static so
+# the model picker populates without a network call (there is no REST catalog
+# for a subprocess provider). `/model` switches between these live.
+_CLAUDE_CLI_MODELS = (
+    "sonnet",
+    "opus",
+    "haiku",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-haiku-4-5-20251001",
+    "claude-fable-5",
+)
+
+
+class ClaudeCLIProfile(ProviderProfile):
+    """Claude Code CLI subprocess — thread reasoning effort to the client.
+
+    `claude -p` takes reasoning effort as a `--effort` CLI flag, not an API
+    field. build_extra_body runs per request with the live reasoning_config,
+    so stashing the effort here is how a mid-session `/effort` change reaches
+    the subprocess on the very next turn. ClaudeCLIClient pops the key back
+    out of api_kwargs["extra_body"].
+    """
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """No REST catalog — return the static alias list for the picker."""
+        return list(_CLAUDE_CLI_MODELS)
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Stash the live reasoning effort so the client can map it to --effort."""
+        reasoning_config = context.get("reasoning_config")
+        if not isinstance(reasoning_config, dict):
+            return {}
+        effort = reasoning_config.get("effort")
+        if not isinstance(effort, str) or not effort.strip():
+            return {}
+        return {"_hermes_claude_effort": effort.strip().lower()}
+
+
+claude_cli = ClaudeCLIProfile(
+    name="claude-cli",
+    aliases=("claude-code-cli", "claude-p"),
+    api_mode="chat_completions",
+    env_vars=(),  # No API key — auth is the user's existing Claude Code OAuth session.
+    base_url="acp://claude-cli",
+    auth_type="external_process",
+    default_aux_model="haiku",
+)
+
+register_provider(claude_cli)

--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -55,14 +55,18 @@ class ClaudeCLIProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
-        """Stash the live reasoning effort so the client can map it to --effort."""
+        """Stash the live reasoning effort (→ --effort) and the session id (→
+        live-session registry key, one warm `claude -p` child per conversation)."""
+        body: dict[str, Any] = {}
         reasoning_config = context.get("reasoning_config")
-        if not isinstance(reasoning_config, dict):
-            return {}
-        effort = reasoning_config.get("effort")
-        if not isinstance(effort, str) or not effort.strip():
-            return {}
-        return {"_hermes_claude_effort": effort.strip().lower()}
+        if isinstance(reasoning_config, dict):
+            effort = reasoning_config.get("effort")
+            if isinstance(effort, str) and effort.strip():
+                body["_hermes_claude_effort"] = effort.strip().lower()
+        session_id = context.get("session_id") or session_id
+        if isinstance(session_id, str) and session_id.strip():
+            body["_hermes_claude_session_id"] = session_id.strip()
+        return body
 
 
 claude_cli = ClaudeCLIProfile(

--- a/plugins/model-providers/claude-cli/plugin.yaml
+++ b/plugins/model-providers/claude-cli/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-cli-provider
+kind: model-provider
+version: 1.0.0
+description: Claude via local `claude -p` (Claude Code CLI subprocess, subscription usage, no API key)
+author: local

--- a/tests/agent/test_claude_cli_client.py
+++ b/tests/agent/test_claude_cli_client.py
@@ -1,0 +1,262 @@
+"""Tests for the claude-cli (Claude Code CLI subprocess) provider client."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent import claude_cli_client as c
+
+
+# ---------------------------------------------------------------------------
+# Prompt serialization
+# ---------------------------------------------------------------------------
+
+def test_format_messages_includes_tools_and_transcript():
+    messages = [
+        {"role": "system", "content": "be terse"},
+        {"role": "user", "content": "hi"},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "weather",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    prompt = c._format_messages_as_prompt(messages, tools=tools)
+    assert "get_weather" in prompt
+    assert "<tool_call>" in prompt
+    assert "User:" in prompt and "System:" in prompt
+
+
+def test_render_message_content_handles_list_blocks():
+    rendered = c._render_message_content(
+        [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+    )
+    assert rendered == "a\nb"
+
+
+# ---------------------------------------------------------------------------
+# argv construction — model/effort/no-bare/tools-disabled
+# ---------------------------------------------------------------------------
+
+def test_argv_carries_model_effort_and_disables_tools():
+    client = c.ClaudeCLIClient()
+    argv = client._build_argv(model="opus", effort="high")
+    assert argv[argv.index("--model") + 1] == "opus"
+    assert argv[argv.index("--effort") + 1] == "high"
+    # --tools "" disables every built-in tool so claude never executes.
+    assert argv[argv.index("--tools") + 1] == ""
+    assert "-p" in argv
+    assert "--output-format" in argv
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+
+
+def test_argv_never_uses_bare():
+    # --bare would force ANTHROPIC_API_KEY and skip the OAuth session we want.
+    client = c.ClaudeCLIClient()
+    argv = client._build_argv(model="sonnet", effort="medium")
+    assert "--bare" not in argv
+
+
+def test_extra_args_from_env(monkeypatch):
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_ARGS", "--add-dir /tmp")
+    client = c.ClaudeCLIClient()
+    argv = client._build_argv(model="sonnet", effort="low")
+    assert argv[-2:] == ["--add-dir", "/tmp"]
+
+
+def test_command_from_env(monkeypatch):
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_COMMAND", "/opt/claude")
+    client = c.ClaudeCLIClient()
+    assert client._command == "/opt/claude"
+
+
+# ---------------------------------------------------------------------------
+# Live model/effort resolution (honors /model and /effort mid-session)
+# ---------------------------------------------------------------------------
+
+def test_effort_read_from_extra_body_per_call(monkeypatch):
+    captured = {}
+
+    def fake_run_prompt(self, prompt_text, *, model, effort, timeout_seconds):
+        captured["model"] = model
+        captured["effort"] = effort
+        return "ok", "", []
+
+    monkeypatch.setattr(c.ClaudeCLIClient, "_run_prompt", fake_run_prompt)
+    client = c.ClaudeCLIClient()
+    client.chat.completions.create(
+        model="opus",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_body={"_hermes_claude_effort": "xhigh"},
+    )
+    assert captured == {"model": "opus", "effort": "xhigh"}
+
+
+def test_effort_defaults_when_absent(monkeypatch):
+    captured = {}
+
+    def fake_run_prompt(self, prompt_text, *, model, effort, timeout_seconds):
+        captured["effort"] = effort
+        return "ok", "", []
+
+    monkeypatch.setattr(c.ClaudeCLIClient, "_run_prompt", fake_run_prompt)
+    client = c.ClaudeCLIClient()
+    client.chat.completions.create(
+        model="sonnet", messages=[{"role": "user", "content": "hi"}]
+    )
+    assert captured["effort"] == "medium"
+
+
+def test_invalid_effort_falls_back_to_medium():
+    assert c._normalize_effort("bogus") == "medium"
+    assert c._normalize_effort("high") == "high"
+    assert c._normalize_effort(None) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Stream parsing — native tool_use, text, thinking, error handling
+# ---------------------------------------------------------------------------
+
+def _stream(*events: dict) -> str:
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def test_parse_stream_captures_native_tool_use():
+    stdout = _stream(
+        {"type": "system", "subtype": "init"},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "I'll check."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_123",
+                        "name": "get_weather",
+                        "input": {"city": "Tokyo"},
+                    },
+                ]
+            },
+        },
+        {"type": "result", "subtype": "error_max_turns", "is_error": True},
+    )
+    text, reasoning, tool_calls, fatal = c._parse_stream(stdout)
+    assert text == "I'll check."
+    assert fatal == ""  # error_max_turns is benign
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "get_weather"
+    assert json.loads(tool_calls[0].function.arguments) == {"city": "Tokyo"}
+
+
+def test_parse_stream_plain_text_success():
+    stdout = _stream(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "PONG"}]}},
+        {"type": "result", "subtype": "success", "is_error": False, "result": "PONG"},
+    )
+    text, reasoning, tool_calls, fatal = c._parse_stream(stdout)
+    assert text == "PONG"
+    assert tool_calls == []
+    assert fatal == ""
+
+
+def test_parse_stream_records_fatal_error_without_content():
+    stdout = _stream(
+        {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "errors": ["auth failed"],
+        }
+    )
+    text, reasoning, tool_calls, fatal = c._parse_stream(stdout)
+    assert text == ""
+    assert tool_calls == []
+    assert "auth failed" in fatal
+
+
+def test_parse_stream_captures_thinking_as_reasoning():
+    stdout = _stream(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "thinking", "thinking": "hmm"},
+                    {"type": "text", "text": "answer"},
+                ]
+            },
+        },
+    )
+    text, reasoning, tool_calls, fatal = c._parse_stream(stdout)
+    assert text == "answer"
+    assert reasoning == "hmm"
+
+
+# ---------------------------------------------------------------------------
+# <tool_call> text fallback (when a model answers in text, not native)
+# ---------------------------------------------------------------------------
+
+def test_text_tool_call_fallback():
+    blob = (
+        'ok <tool_call>{"id":"x","type":"function",'
+        '"function":{"name":"do_it","arguments":"{}"}}</tool_call> done'
+    )
+    calls, cleaned = c._extract_tool_calls_from_text(blob)
+    assert len(calls) == 1
+    assert calls[0].function.name == "do_it"
+    assert "ok" in cleaned and "done" in cleaned
+    assert "<tool_call>" not in cleaned
+
+
+# ---------------------------------------------------------------------------
+# Full completion object shape (duck-types openai ChatCompletion)
+# ---------------------------------------------------------------------------
+
+def test_completion_shape_for_tool_call(monkeypatch):
+    tc = c._build_openai_tool_call(call_id="c1", name="t", arguments="{}")
+    monkeypatch.setattr(
+        c.ClaudeCLIClient,
+        "_run_prompt",
+        lambda self, *a, **k: ("preamble", "reasoning", [tc]),
+    )
+    client = c.ClaudeCLIClient()
+    completion = client.chat.completions.create(
+        model="sonnet", messages=[{"role": "user", "content": "hi"}]
+    )
+    choice = completion.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.tool_calls[0].function.name == "t"
+    assert choice.message.content == "preamble"
+    assert completion.model == "sonnet"
+    assert hasattr(completion, "usage")
+
+
+def test_completion_shape_for_plain_text(monkeypatch):
+    monkeypatch.setattr(
+        c.ClaudeCLIClient, "_run_prompt", lambda self, *a, **k: ("hello", "", [])
+    )
+    client = c.ClaudeCLIClient()
+    completion = client.chat.completions.create(
+        model="haiku", messages=[{"role": "user", "content": "hi"}]
+    )
+    choice = completion.choices[0]
+    assert choice.finish_reason == "stop"
+    assert choice.message.content == "hello"
+    assert not choice.message.tool_calls
+
+
+def test_run_prompt_raises_only_when_no_content(monkeypatch):
+    # A failed subprocess with no usable stream output must raise.
+    def fake_subprocess_run(*a, **k):
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(c.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(c, "_build_subprocess_env", lambda: {})
+    client = c.ClaudeCLIClient()
+    with pytest.raises(RuntimeError, match="boom|no output"):
+        client._run_prompt("p", model="sonnet", effort="low", timeout_seconds=5)

--- a/tests/agent/test_claude_live_client.py
+++ b/tests/agent/test_claude_live_client.py
@@ -13,6 +13,7 @@ sent.
 
 import json
 import os
+import sys
 import threading
 
 import pytest
@@ -324,6 +325,79 @@ def test_env_scrub_removes_billing_diversion_vars(monkeypatch):
         assert key not in env, f"{key} leaked into child env"
     assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "oauth-keep-me"
     assert env.get("HOME")
+
+
+def test_delta_is_robust_to_compression_relocating_assistant_boundary():
+    """After compression the summary lands as an assistant message, so the last
+    assistant is no longer the previous turn. The warm delta must still send only
+    the newest user turn, not re-send post-summary history."""
+    compressed = [
+        {"role": "system", "content": "SYS"},
+        {"role": "assistant", "content": "[summary of earlier turns]"},  # compression artifact
+        {"role": "user", "content": "older question that was already sent"},
+        {"role": "assistant", "content": "older answer"},
+        {"role": "user", "content": "the brand new question"},
+    ]
+    assert c._delta_user_text(compressed) == "the brand new question"
+
+
+def test_build_turn_content_passes_data_uri_images():
+    """A user turn carrying a data: image is forwarded as content blocks (text +
+    image), not silently reduced to text."""
+    png = "data:image/png;base64,iVBORw0KGgoAAAANS"
+    messages = [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": [
+            {"type": "text", "text": "what is in this image?"},
+            {"type": "image_url", "image_url": {"url": png}},
+        ]},
+    ]
+    content = c._build_turn_content(messages, full=False)
+    assert isinstance(content, list)
+    text_block = next(b for b in content if b["type"] == "text")
+    image_block = next(b for b in content if b["type"] == "image")
+    assert "what is in this image" in text_block["text"]
+    assert image_block["source"] == {
+        "type": "base64", "media_type": "image/png", "data": "iVBORw0KGgoAAAANS",
+    }
+
+
+def test_build_turn_content_passes_http_image_and_plain_text():
+    messages = [{"role": "user", "content": [
+        {"type": "text", "text": "describe"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+    ]}]
+    content = c._build_turn_content(messages, full=False)
+    image_block = next(b for b in content if b["type"] == "image")
+    assert image_block["source"] == {"type": "url", "url": "https://example.com/a.jpg"}
+    # No images → plain string, not a list.
+    assert c._build_turn_content([{"role": "user", "content": "hi"}], full=False) == "hi"
+
+
+def test_fingerprint_ignores_volatile_prompt_tail():
+    """Two system prompts differing only in the day-granularity date, session id,
+    model, and provider lines must hash the same so a day-rollover or identity
+    refresh does not evict the warm cache."""
+    base = "You are Hermes.\nStable instruction block.\n<!-- hermes-cache-boundary -->"
+    day1 = base + "\nConversation started: Monday, July 13, 2026\nSession ID: abc\nModel: sonnet\nProvider: claude-cli"
+    day2 = base + "\nConversation started: Tuesday, July 14, 2026\nSession ID: abc\nModel: sonnet\nProvider: claude-cli"
+    assert c._fingerprint_system_prompt(day1) == c._fingerprint_system_prompt(day2)
+    # A genuine instruction change still differs.
+    changed = base.replace("Stable instruction block.", "Different instructions.")
+    assert c._fingerprint_system_prompt(changed) != c._fingerprint_system_prompt(day1)
+
+
+def test_mcp_config_uses_this_interpreter(wired, monkeypatch):
+    """The bridge must be launched with Hermes's own interpreter, not a bare
+    python3 that may be missing in claude's spawn env on a server."""
+    monkeypatch.delenv("HERMES_CLAUDE_LIVE_PYTHON", raising=False)
+    client = _client("conv-interp")
+    client._tool_server.start()
+    client._tools_path = "/tmp/tools.json"
+    path, _ = client._mcp_config_path()
+    cfg = json.loads(open(path).read())
+    assert cfg["mcpServers"]["hermes"]["command"] == sys.executable
+    client.close()
 
 
 def test_resume_spawn_marks_prior_context():

--- a/tests/agent/test_claude_live_client.py
+++ b/tests/agent/test_claude_live_client.py
@@ -249,6 +249,86 @@ def test_effort_switch_also_reseeds_full_history(wired):
     client.close()
 
 
+def test_compression_respawns_and_reseeds_compressed_history(wired):
+    """The long-session regression: when Hermes compresses its history (old turns
+    replaced by a summary → the message list shrinks materially), the warm child
+    still holds the OLD uncompressed transcript. The client must respawn and reseed
+    the child with the CURRENT compressed history so the child's context realigns —
+    otherwise it grows without bound (inflated meter + rising latency)."""
+    factory, _ = wired
+    client = _client()
+
+    # Turn 1: a large history so the child is aligned to ~2000 tokens.
+    big = [
+        {"role": "system", "content": "STABLE-SYS"},
+        {"role": "user", "content": "x" * 8000},
+    ]
+    client._create_chat_completion(model="sonnet", messages=big, tools=[])
+    assert len(factory.spawned) == 1
+
+    # Turn 2: Hermes compressed — the history is now tiny (a summary + new turn).
+    compressed = [
+        {"role": "system", "content": "STABLE-SYS"},
+        {"role": "assistant", "content": "SUMMARY-of-earlier"},
+        {"role": "user", "content": "new question"},
+    ]
+    client._create_chat_completion(model="sonnet", messages=compressed, tools=[])
+    assert len(factory.spawned) == 2, "compression must respawn to reset the child"
+
+    reseed = factory.last_envelope(1)
+    # The fresh child is reseeded with the compressed history (full render), not a
+    # bare delta — so it holds the summary and the new turn, and nothing more.
+    assert "SUMMARY-of-earlier" in reseed
+    assert "new question" in reseed
+    assert reseed != "new question"
+    client.close()
+
+
+def test_context_drift_ceiling_respawns(wired, monkeypatch):
+    """Even without a compression pass, if the child's reported context grows well
+    past Hermes's view (its own transcript bloating), a drift ceiling respawns and
+    reseeds so the child cannot climb toward the model window unbounded."""
+    factory, _ = wired
+    # FakeProc reports cache_read=900; make the ceiling bite at a tiny scale.
+    monkeypatch.setenv("HERMES_CLAUDE_LIVE_DRIFT_MIN", "100")
+    monkeypatch.setenv("HERMES_CLAUDE_LIVE_DRIFT_RATIO", "1.5")
+    client = _client()
+
+    small1 = [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": "hi"},
+    ]
+    client._create_chat_completion(model="sonnet", messages=small1, tools=[])
+    assert len(factory.spawned) == 1
+
+    # Child context (900) far exceeds Hermes's tiny view → drift → respawn.
+    small2 = [
+        {"role": "system", "content": "SYS"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "again"},
+    ]
+    client._create_chat_completion(model="sonnet", messages=small2, tools=[])
+    assert len(factory.spawned) == 2, "drift ceiling must respawn the child"
+    client.close()
+
+
+def test_normal_growth_does_not_respawn(wired):
+    """The guard: a normally GROWING history (no compression, child context within
+    bounds) must NOT respawn — that would throw away the warm cache every turn."""
+    factory, _ = wired
+    client = _client()
+
+    client._create_chat_completion(model="sonnet", messages=_messages_turn1(), tools=[])
+    # A much larger second turn — history grows, does not shrink.
+    grown = _messages_turn2() + [
+        {"role": "assistant", "content": "reply-2"},
+        {"role": "user", "content": "third question " * 50},
+    ]
+    client._create_chat_completion(model="sonnet", messages=grown, tools=[])
+    assert len(factory.spawned) == 1, "growth alone must not respawn"
+    client.close()
+
+
 def test_has_prior_context_transition():
     """A fresh session reseeds; once it has taken a turn it sends deltas."""
     session = s.LiveSession(

--- a/tests/agent/test_claude_live_client.py
+++ b/tests/agent/test_claude_live_client.py
@@ -1,0 +1,341 @@
+"""Tests for the persistent claude-cli live CLIENT (delta-vs-reseed logic).
+
+These exercise the seam that the session-manager tests do not: how
+``ClaudeLiveClient`` decides whether to send only the newest turn (warm reuse)
+or reseed the full conversation (a fresh process). Getting this wrong silently
+drops all prior context whenever a session respawns — e.g. a live ``/model`` or
+``/effort`` switch, which changes the fingerprint and forces a respawn.
+
+The real ``claude`` binary is never spawned; a scripted FakeProc captures the
+stream-json envelope written to stdin so we can assert exactly what each turn
+sent.
+"""
+
+import json
+import os
+import threading
+
+import pytest
+
+import agent.claude_live_client as c
+from agent import claude_live_session as s
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess that records the stdin envelope and scripts a full turn.
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Blocking readline over a growable line buffer (fed per input turn)."""
+
+    def __init__(self):
+        self._lines = []
+        self._idx = 0
+        self._cv = threading.Condition()
+        self._closed = False
+
+    def feed(self, lines):
+        with self._cv:
+            self._lines.extend(lines)
+            self._cv.notify_all()
+
+    def readline(self):
+        with self._cv:
+            while self._idx >= len(self._lines) and not self._closed:
+                self._cv.wait(timeout=0.05)
+            if self._idx < len(self._lines):
+                line = self._lines[self._idx]
+                self._idx += 1
+                return line
+            return ""
+
+    def close(self):
+        with self._cv:
+            self._closed = True
+            self._cv.notify_all()
+
+
+class _FakeStdin:
+    """Each written envelope drives one scripted turn onto the proc's stdout,
+    exactly as the real streaming binary responds to a user turn."""
+
+    def __init__(self, proc):
+        self._proc = proc
+        self.written = []
+
+    def write(self, data):
+        self.written.append(data)
+        self._proc.on_input()
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _turn_lines(session_id, text):
+    return [
+        json.dumps({"type": "system", "subtype": "init", "session_id": session_id}) + "\n",
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {"input_tokens": 3, "cache_read_input_tokens": 900, "output_tokens": 2},
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n",
+        json.dumps({"type": "result", "subtype": "success", "is_error": False}) + "\n",
+    ]
+
+
+class FakeProc:
+    def __init__(self, argv=None, session_id="sess", reply="ok", **kwargs):
+        self.argv = argv or []
+        self.pid = 4242
+        self.returncode = None
+        self.stdin = _FakeStdin(self)
+        self.stdout = _FakeStream()
+        self.stderr = _FakeStream()
+        self._session_id = session_id
+        self._reply = reply
+        self._turns = 0
+        self._alive = True
+
+    def on_input(self):
+        # First turn emits the init line; every turn emits assistant text+result.
+        self._turns += 1
+        lines = _turn_lines(self._session_id, self._reply)
+        if self._turns > 1:
+            lines = lines[1:]  # init only once per process
+        self.stdout.feed(lines)
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def wait(self, timeout=None):
+        self._alive = False
+        self.returncode = 0
+        return 0
+
+    def send_signal(self, sig):
+        self._alive = False
+
+    def kill(self):
+        self._alive = False
+
+
+class _ProcFactory:
+    """Hands out a fresh FakeProc per spawn and keeps them for inspection."""
+
+    def __init__(self):
+        self.spawned = []
+        self._n = 0
+
+    def __call__(self, argv=None, **kwargs):
+        self._n += 1
+        proc = FakeProc(argv=argv, session_id=f"sess-{self._n}", reply=f"reply-{self._n}")
+        self.spawned.append(proc)
+        return proc
+
+    def last_envelope(self, spawn_index):
+        """The user-turn content string written to the Nth spawned process."""
+        proc = self.spawned[spawn_index]
+        assert proc.stdin.written, "no envelope written"
+        return json.loads(proc.stdin.written[0])["message"]["content"]
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Point the client's registry at a fake-popen registry we can inspect."""
+    # Small watchdog budgets so any genuine starvation fails fast, not in 90s.
+    monkeypatch.setenv("HERMES_CLAUDE_LIVE_FRESH_QUIET_S", "3")
+    monkeypatch.setenv("HERMES_CLAUDE_LIVE_RESUME_QUIET_S", "3")
+    factory = _ProcFactory()
+    registry = s.LiveSessionRegistry(popen=factory)
+    monkeypatch.setattr(c, "get_registry", lambda: registry)
+    return factory, registry
+
+
+def _client(session_id="conv-1"):
+    client = c.ClaudeLiveClient(session_key=session_id)
+    return client
+
+
+def _messages_turn1():
+    return [
+        {"role": "system", "content": "STABLE-SYS"},
+        {"role": "user", "content": "first question"},
+    ]
+
+
+def _messages_turn2():
+    return [
+        {"role": "system", "content": "STABLE-SYS"},
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "reply-1"},
+        {"role": "user", "content": "second question"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fresh vs warm envelope selection
+# ---------------------------------------------------------------------------
+
+
+def test_first_turn_seeds_and_warm_reuse_sends_delta(wired):
+    factory, _ = wired
+    client = _client()
+
+    r1 = client._create_chat_completion(model="sonnet", messages=_messages_turn1(), tools=[])
+    assert r1.choices[0].message.content == "reply-1"
+    # Only one process spawned; it received the (whole) first turn.
+    assert len(factory.spawned) == 1
+    assert factory.last_envelope(0) == "first question"
+
+    # Second turn, SAME model → warm reuse, no respawn, delta only.
+    r2 = client._create_chat_completion(model="sonnet", messages=_messages_turn2(), tools=[])
+    assert r2.choices[0].message.content == "reply-1"  # same warm proc replies again
+    assert len(factory.spawned) == 1  # NO respawn
+    assert factory.spawned[0].stdin.written[-1]
+    second = json.loads(factory.spawned[0].stdin.written[-1])["message"]["content"]
+    assert second == "second question"  # delta, not full history
+    client.close()
+
+
+def test_model_switch_respawns_and_reseeds_full_history(wired):
+    """The core regression: a live /model switch changes the fingerprint and
+    respawns the process. The fresh process MUST be reseeded with the full prior
+    conversation, not just the newest turn, or all context is lost."""
+    factory, _ = wired
+    client = _client()
+
+    client._create_chat_completion(model="sonnet", messages=_messages_turn1(), tools=[])
+    assert len(factory.spawned) == 1
+
+    # /model opus mid-conversation → fingerprint drift → respawn.
+    client._create_chat_completion(model="opus", messages=_messages_turn2(), tools=[])
+    assert len(factory.spawned) == 2, "model switch must respawn"
+
+    reseed = factory.last_envelope(1)
+    # The fresh (2nd) process must see the WHOLE conversation, including the
+    # prior user question and assistant answer — not merely "second question".
+    assert "first question" in reseed
+    assert "second question" in reseed
+    assert "reply-1" in reseed
+    assert reseed != "second question"
+    client.close()
+
+
+def test_effort_switch_also_reseeds_full_history(wired):
+    factory, _ = wired
+    client = _client()
+
+    client._create_chat_completion(
+        model="sonnet", messages=_messages_turn1(), tools=[],
+        extra_body={"_hermes_claude_effort": "low"},
+    )
+    client._create_chat_completion(
+        model="sonnet", messages=_messages_turn2(), tools=[],
+        extra_body={"_hermes_claude_effort": "high"},
+    )
+    assert len(factory.spawned) == 2, "effort switch must respawn"
+    reseed = factory.last_envelope(1)
+    assert "first question" in reseed and "reply-1" in reseed
+    client.close()
+
+
+def test_has_prior_context_transition():
+    """A fresh session reseeds; once it has taken a turn it sends deltas."""
+    session = s.LiveSession(
+        s.LiveSessionConfig(
+            command="claude", argv=("claude", "-p"), cwd="/tmp", env={"HOME": "/h"},
+            model="sonnet", effort="low", system_prompt_hash="a",
+            mcp_config_hash="b", auth_identity="oauth:x",
+        ),
+        popen=lambda *a, **k: FakeProc(session_id="sess-x", reply="hi"),
+    )
+    assert session.has_prior_context is False
+    session.spawn()
+    assert session.has_prior_context is False
+    session.send_turn("go", fresh=True, quiet_budget=2.0, hard_deadline=10.0)
+    assert session.has_prior_context is True
+    session.teardown()
+
+
+def test_close_releases_tool_server_and_is_idempotent():
+    """close() must shut the tool server (socket FD + accept thread) and be safe
+    to call twice; the finalizer guards against Hermes dropping the client with
+    `agent.client = None` and never calling close()."""
+    client = c.ClaudeLiveClient(session_key="conv-close")
+    client._tool_server.start()
+    path = client._tool_server.socket_path
+    assert os.path.exists(path)
+    client.close()
+    assert client.is_closed is True
+    assert not os.path.exists(path)  # socket file removed
+    client.close()  # idempotent, no raise
+
+
+def test_finalizer_closes_tool_server_on_gc():
+    """When the client is garbage-collected without close(), the weakref
+    finalizer still tears the tool server down (breaks the accept-thread pin)."""
+    import gc
+
+    client = c.ClaudeLiveClient(session_key="conv-gc")
+    client._tool_server.start()
+    server = client._tool_server
+    path = server.socket_path
+    assert os.path.exists(path)
+    del client
+    gc.collect()
+    assert not os.path.exists(path)
+
+
+def test_env_scrub_removes_billing_diversion_vars(monkeypatch):
+    """The child must run on the subscription OAuth session only. Every API-key,
+    custom-header, and cloud-gateway (Bedrock/Vertex) routing var must be gone;
+    CLAUDE_CODE_OAUTH_TOKEN + HOME must survive."""
+    dangerous = {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx",
+        "ANTHROPIC_AUTH_TOKEN": "tok",
+        "ANTHROPIC_OAUTH_TOKEN": "otok",
+        "ANTHROPIC_BASE_URL": "https://evil.example",
+        "ANTHROPIC_CUSTOM_HEADERS": "x-api-key: sk-leak",
+        "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": "1",
+        "CLAUDE_CODE_USE_BEDROCK": "1",
+        "CLAUDE_CODE_USE_VERTEX": "1",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH": "1",
+        "ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example",
+        "ANTHROPIC_VERTEX_BASE_URL": "https://vertex.example",
+        "ANTHROPIC_VERTEX_PROJECT_ID": "proj",
+    }
+    for key, value in dangerous.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-keep-me")
+
+    env = c.build_live_subprocess_env()
+
+    for key in dangerous:
+        assert key not in env, f"{key} leaked into child env"
+    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "oauth-keep-me"
+    assert env.get("HOME")
+
+
+def test_resume_spawn_marks_prior_context():
+    session = s.LiveSession(
+        s.LiveSessionConfig(
+            command="claude", argv=("claude", "-p"), cwd="/tmp", env={"HOME": "/h"},
+            model="sonnet", effort="low", system_prompt_hash="a",
+            mcp_config_hash="b", auth_identity="oauth:x",
+        ),
+        popen=lambda *a, **k: FakeProc(session_id="sess-y", reply="hi"),
+    )
+    session.spawn(resume_session_id="sess-prev")
+    # A resumed process reloads the transcript → treat as already holding context.
+    assert session.has_prior_context is True
+    session.teardown()

--- a/tests/agent/test_claude_live_session.py
+++ b/tests/agent/test_claude_live_session.py
@@ -1,0 +1,344 @@
+"""Tests for the persistent claude-cli live-session manager.
+
+The real ``claude -p`` subprocess is never spawned; a scripted FakeProc feeds
+stream-json events so lifecycle, watchdog, fingerprint respawn, orphaned
+tool_use, and usage parsing are all exercised deterministically.
+"""
+
+import json
+import threading
+
+import pytest
+
+from agent import claude_live_session as s
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Blocking readline over a scripted list of lines, then EOF ("")."""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+        self._idx = 0
+        self._cv = threading.Condition()
+        self._closed = False
+
+    def readline(self):
+        with self._cv:
+            while self._idx >= len(self._lines) and not self._closed:
+                self._cv.wait(timeout=0.05)
+                if self._idx >= len(self._lines) and not self._closed:
+                    return ""  # nothing more scripted → EOF-like for the reader
+            if self._idx < len(self._lines):
+                line = self._lines[self._idx]
+                self._idx += 1
+                return line
+            return ""
+
+    def close(self):
+        with self._cv:
+            self._closed = True
+            self._cv.notify_all()
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.written = []
+        self.closed = False
+
+    def write(self, data):
+        self.written.append(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class FakeProc:
+    def __init__(self, argv=None, stdout_lines=None, **kwargs):
+        self.argv = argv or []
+        self.pid = 4242
+        self.returncode = None
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStream(stdout_lines or [])
+        self.stderr = _FakeStream([])
+        self.signals = []
+        self._alive = True
+
+    def poll(self):
+        return None if self._alive else (self.returncode or 0)
+
+    def wait(self, timeout=None):
+        self._alive = False
+        self.returncode = 0
+        return 0
+
+    def send_signal(self, sig):
+        self.signals.append(sig)
+        self._alive = False
+
+    def kill(self):
+        self._alive = False
+
+
+def _line(obj):
+    return json.dumps(obj) + "\n"
+
+
+def _make_config(**overrides):
+    base = dict(
+        command="claude",
+        argv=("claude", "-p"),
+        cwd="/tmp",
+        env={"HOME": "/home/x"},
+        model="sonnet",
+        effort="low",
+        system_prompt_hash="sys1",
+        mcp_config_hash="mcp1",
+        auth_identity="oauth:abc",
+    )
+    base.update(overrides)
+    return s.LiveSessionConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_stable_and_sensitive():
+    a = _make_config()
+    b = _make_config()
+    assert a.fingerprint == b.fingerprint
+    assert _make_config(model="opus").fingerprint != a.fingerprint
+    assert _make_config(effort="high").fingerprint != a.fingerprint
+    assert _make_config(system_prompt_hash="sys2").fingerprint != a.fingerprint
+    assert _make_config(auth_identity="oauth:zzz").fingerprint != a.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Usage parsing
+# ---------------------------------------------------------------------------
+
+
+def test_usage_from_message_extracts_counters():
+    row = s.usage_from_message(
+        {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 900,
+            "output_tokens": 20,
+        }
+    )
+    assert row == {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 5,
+        "cache_read_input_tokens": 900,
+        "output_tokens": 20,
+    }
+
+
+def test_usage_accumulates_across_assistant_events():
+    lines = [
+        _line({"type": "system", "subtype": "init", "session_id": "sess-1"}),
+        _line({"type": "assistant", "message": {"usage": {"input_tokens": 4, "output_tokens": 1}, "content": [{"type": "text", "text": "hi"}]}}),
+        _line({"type": "assistant", "message": {"usage": {"input_tokens": 2, "output_tokens": 3}, "content": [{"type": "text", "text": "there"}]}}),
+        _line({"type": "result", "subtype": "success", "is_error": False}),
+    ]
+    session = s.LiveSession(_make_config(), popen=lambda *a, **k: FakeProc(stdout_lines=lines))
+    session.spawn()
+    result = session.send_turn("go", fresh=True, quiet_budget=2.0, hard_deadline=10.0)
+    assert result.session_id == "sess-1"
+    assert result.text == "hi\nthere"
+    assert result.usage["input_tokens"] == 6
+    assert result.usage["output_tokens"] == 4
+    assert not result.orphaned_tool_use
+    session.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Tool_use / tool_result tracking + orphan detection
+# ---------------------------------------------------------------------------
+
+
+def test_matched_tool_use_and_result_not_orphaned():
+    lines = [
+        _line({"type": "system", "subtype": "init", "session_id": "sess-2"}),
+        _line({"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t1", "name": "get_x", "input": {"a": 1}}]}}),
+        _line({"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "t1", "content": "42"}]}}),
+        _line({"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}}),
+        _line({"type": "result", "subtype": "success"}),
+    ]
+    session = s.LiveSession(_make_config(), popen=lambda *a, **k: FakeProc(stdout_lines=lines))
+    session.spawn()
+    result = session.send_turn("go", fresh=False, quiet_budget=2.0, hard_deadline=10.0)
+    assert result.text == "done"
+    assert len(result.tool_uses) == 1
+    assert result.orphaned_tool_use is False
+    assert session._needs_fresh is False
+    session.teardown()
+
+
+def test_trailing_tool_use_without_result_is_orphaned():
+    # No result event, tool_use never resolved, short quiet budget → watchdog
+    # trips and the turn is flagged orphaned (needs fresh reseed, not resume).
+    lines = [
+        _line({"type": "system", "subtype": "init", "session_id": "sess-3"}),
+        _line({"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t9", "name": "slow", "input": {}}]}}),
+    ]
+    session = s.LiveSession(_make_config(), popen=lambda *a, **k: FakeProc(stdout_lines=lines))
+    session.spawn()
+    result = session.send_turn(
+        "go", fresh=False, quiet_budget=0.2, tool_quiet_budget=0.2, hard_deadline=3.0
+    )
+    assert result.orphaned_tool_use is True
+    assert session._needs_fresh is True
+    session.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Envelope
+# ---------------------------------------------------------------------------
+
+
+def test_send_turn_writes_user_envelope():
+    proc = FakeProc(stdout_lines=[_line({"type": "result", "subtype": "success"})])
+    session = s.LiveSession(_make_config(), popen=lambda *a, **k: proc)
+    session.spawn()
+    session.session_id = "sess-x"
+    session.send_turn("hello world", fresh=True, quiet_budget=2.0, hard_deadline=5.0)
+    written = json.loads(proc.stdin.written[0])
+    assert written["type"] == "user"
+    assert written["session_id"] == "sess-x"
+    assert written["message"] == {"role": "user", "content": "hello world"}
+    session.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Registry: reuse / fingerprint respawn / LRU / idle
+# ---------------------------------------------------------------------------
+
+
+def test_registry_reuses_same_fingerprint():
+    procs = []
+
+    def factory(*a, **k):
+        p = FakeProc(stdout_lines=[])
+        procs.append(p)
+        return p
+
+    reg = s.LiveSessionRegistry(popen=factory)
+    cfg = _make_config()
+    a = reg.get_or_create("k1", cfg)
+    b = reg.get_or_create("k1", cfg)
+    assert a is b
+    assert len(procs) == 1
+    reg.shutdown()
+
+
+def test_registry_respawns_on_fingerprint_change():
+    procs = []
+
+    def factory(*a, **k):
+        p = FakeProc(stdout_lines=[])
+        procs.append(p)
+        return p
+
+    reg = s.LiveSessionRegistry(popen=factory)
+    first = reg.get_or_create("k1", _make_config(model="sonnet"))
+    second = reg.get_or_create("k1", _make_config(model="opus"))
+    assert first is not second
+    assert len(procs) == 2
+    assert first.proc is None  # old one torn down
+    reg.shutdown()
+
+
+def test_registry_lru_cap_evicts_least_recent():
+    clock = {"t": 0.0}
+
+    def now():
+        clock["t"] += 1.0
+        return clock["t"]
+
+    reg = s.LiveSessionRegistry(
+        popen=lambda *a, **k: FakeProc(stdout_lines=[]),
+        lru_cap=2,
+        clock=now,
+    )
+    reg.get_or_create("a", _make_config())
+    reg.get_or_create("b", _make_config())
+    reg.get_or_create("c", _make_config())  # evicts "a" (oldest activity)
+    assert len(reg) == 2
+    reg.shutdown()
+
+
+def test_registry_reaps_idle():
+    clock = {"t": 100.0}
+
+    def now():
+        return clock["t"]
+
+    reg = s.LiveSessionRegistry(
+        popen=lambda *a, **k: FakeProc(stdout_lines=[]),
+        idle_timeout_s=10.0,
+        clock=now,
+    )
+    reg.get_or_create("a", _make_config())
+    clock["t"] = 1000.0  # far past idle timeout
+    reg.get_or_create("b", _make_config())
+    assert "a" not in reg._sessions
+    reg.shutdown()
+
+
+def test_registry_recover_uses_resume_when_not_orphaned():
+    captured = {}
+
+    def factory(argv=None, **k):
+        captured.setdefault("argvs", []).append(list(argv or []))
+        return FakeProc(argv=argv, stdout_lines=[])
+
+    reg = s.LiveSessionRegistry(popen=factory)
+    session = reg.get_or_create("k1", _make_config())
+    session.session_id = "resume-me"
+    session._needs_fresh = False
+    reg.recover("k1")
+    # Second spawn argv carries --resume resume-me
+    assert "--resume" in captured["argvs"][1]
+    assert "resume-me" in captured["argvs"][1]
+    reg.shutdown()
+
+
+def test_registry_recover_reseeds_fresh_when_orphaned():
+    captured = {}
+
+    def factory(argv=None, **k):
+        captured.setdefault("argvs", []).append(list(argv or []))
+        return FakeProc(argv=argv, stdout_lines=[])
+
+    reg = s.LiveSessionRegistry(popen=factory)
+    session = reg.get_or_create("k1", _make_config())
+    session.session_id = "do-not-resume"
+    session._needs_fresh = True  # orphaned tool_use
+    reg.recover("k1")
+    assert "--resume" not in captured["argvs"][1]
+    reg.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Teardown signals
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_signals_process():
+    proc = FakeProc(stdout_lines=[])
+    session = s.LiveSession(_make_config(), popen=lambda *a, **k: proc)
+    session.spawn()
+    session.teardown()
+    assert proc.stdin.closed is True
+    assert session.proc is None

--- a/tests/agent/test_claude_live_session.py
+++ b/tests/agent/test_claude_live_session.py
@@ -144,11 +144,15 @@ def test_usage_from_message_extracts_counters():
     }
 
 
-def test_usage_accumulates_across_assistant_events():
+def test_usage_input_is_last_wins_output_accumulates():
+    """Input-side counters describe the CONTEXT at each step, so a multi-step turn
+    must report the LAST step's values (final occupancy), not the sum — summing the
+    re-reported cached prefix is what inflated the context meter. output_tokens is
+    what was generated per step, so it accumulates."""
     lines = [
         _line({"type": "system", "subtype": "init", "session_id": "sess-1"}),
-        _line({"type": "assistant", "message": {"usage": {"input_tokens": 4, "output_tokens": 1}, "content": [{"type": "text", "text": "hi"}]}}),
-        _line({"type": "assistant", "message": {"usage": {"input_tokens": 2, "output_tokens": 3}, "content": [{"type": "text", "text": "there"}]}}),
+        _line({"type": "assistant", "message": {"usage": {"input_tokens": 4, "cache_read_input_tokens": 40000, "output_tokens": 1}, "content": [{"type": "text", "text": "hi"}]}}),
+        _line({"type": "assistant", "message": {"usage": {"input_tokens": 2, "cache_read_input_tokens": 40100, "output_tokens": 3}, "content": [{"type": "text", "text": "there"}]}}),
         _line({"type": "result", "subtype": "success", "is_error": False}),
     ]
     session = s.LiveSession(_make_config(), popen=lambda *a, **k: FakeProc(stdout_lines=lines))
@@ -156,7 +160,10 @@ def test_usage_accumulates_across_assistant_events():
     result = session.send_turn("go", fresh=True, quiet_budget=2.0, hard_deadline=10.0)
     assert result.session_id == "sess-1"
     assert result.text == "hi\nthere"
-    assert result.usage["input_tokens"] == 6
+    # last-wins input-side: NOT 4+2, NOT 40000+40100 (that multi-counting is the bug)
+    assert result.usage["input_tokens"] == 2
+    assert result.usage["cache_read_input_tokens"] == 40100
+    # output accumulates across steps
     assert result.usage["output_tokens"] == 4
     assert not result.orphaned_tool_use
     session.teardown()

--- a/tests/agent/test_hermes_mcp_bridge.py
+++ b/tests/agent/test_hermes_mcp_bridge.py
@@ -1,0 +1,325 @@
+"""Tests for the Hermes MCP bridge and the live-client tool socket.
+
+Covers: OpenAI->MCP schema translation, JSON-RPC request handling, the parent
+LiveToolServer <-> bridge ParentToolClient socket round-trip (executing a real
+callback), overage guard, usage mapping, and delta/system-prompt extraction.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent import hermes_mcp_bridge as bridge
+from agent import claude_live_client as lc
+
+
+# ---------------------------------------------------------------------------
+# Schema translation
+# ---------------------------------------------------------------------------
+
+
+def test_translate_openai_tools_to_mcp():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+            },
+        },
+        {"type": "function", "function": {"name": "aaa", "description": "", "parameters": {}}},
+    ]
+    out = bridge.translate_openai_tools_to_mcp(tools)
+    # Sorted by name for byte-stability.
+    assert [t["name"] for t in out] == ["aaa", "read_file"]
+    read = next(t for t in out if t["name"] == "read_file")
+    assert read["inputSchema"]["properties"]["path"]["type"] == "string"
+    assert "description" in read
+
+
+def test_translate_skips_malformed():
+    assert bridge.translate_openai_tools_to_mcp([{"nope": 1}, "x", {"function": {}}]) == []
+    assert bridge.translate_openai_tools_to_mcp(None) == []
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC handling
+# ---------------------------------------------------------------------------
+
+
+def test_handle_initialize():
+    resp = bridge.handle_request({"method": "initialize", "id": 1}, tools=[], parent=None)
+    assert resp["result"]["serverInfo"]["name"] == "hermes"
+    assert resp["result"]["protocolVersion"] == bridge.PROTOCOL_VERSION
+
+
+def test_handle_initialized_notification_no_response():
+    assert bridge.handle_request({"method": "notifications/initialized"}, tools=[], parent=None) is None
+
+
+def test_handle_tools_list():
+    tools = [{"name": "t", "description": "d", "inputSchema": {}}]
+    resp = bridge.handle_request({"method": "tools/list", "id": 2}, tools=tools, parent=None)
+    assert resp["result"]["tools"] == tools
+
+
+def test_tools_call_forwards_to_parent():
+    class FakeParent:
+        def call(self, name, arguments):
+            assert name == "read_file"
+            assert arguments == {"path": "/x"}
+            return {"content": "file body", "is_error": False}
+
+    resp = bridge.handle_request(
+        {"method": "tools/call", "id": 3, "params": {"name": "read_file", "arguments": {"path": "/x"}}},
+        tools=[],
+        parent=FakeParent(),
+    )
+    assert resp["result"]["content"][0]["text"] == "file body"
+    assert resp["result"]["isError"] is False
+
+
+def test_tools_call_parent_error_becomes_tool_error():
+    class BoomParent:
+        def call(self, name, arguments):
+            raise OSError("socket gone")
+
+    resp = bridge.handle_request(
+        {"method": "tools/call", "id": 4, "params": {"name": "x", "arguments": {}}},
+        tools=[],
+        parent=BoomParent(),
+    )
+    assert resp["result"]["isError"] is True
+    assert "socket gone" in resp["result"]["content"][0]["text"]
+
+
+def test_tools_call_missing_name():
+    resp = bridge.handle_request(
+        {"method": "tools/call", "id": 5, "params": {}}, tools=[], parent=object()
+    )
+    assert resp["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# Socket round-trip: parent LiveToolServer <-> bridge ParentToolClient
+# ---------------------------------------------------------------------------
+
+
+def test_socket_roundtrip_executes_callback():
+    calls = []
+
+    def executor(name, arguments):
+        calls.append((name, arguments))
+        return f"ran {name} with {arguments.get('v')}", False
+
+    server = lc.LiveToolServer(executor)
+    server.start()
+    try:
+        client = bridge.ParentToolClient(server.socket_path, server.token)
+        out = client.call("do_thing", {"v": 7})
+        assert out["content"] == "ran do_thing with 7"
+        assert out["is_error"] is False
+        assert calls == [("do_thing", {"v": 7})]
+    finally:
+        server.close()
+
+
+def test_socket_rejects_bad_token():
+    server = lc.LiveToolServer(lambda n, a: ("ok", False))
+    server.start()
+    try:
+        client = bridge.ParentToolClient(server.socket_path, "wrong-token")
+        out = client.call("x", {})
+        assert out["is_error"] is True
+        assert "unauthorized" in out["content"]
+    finally:
+        server.close()
+
+
+def test_socket_executor_exception_is_tool_error():
+    def boom(name, arguments):
+        raise ValueError("kaboom")
+
+    server = lc.LiveToolServer(boom)
+    server.start()
+    try:
+        client = bridge.ParentToolClient(server.socket_path, server.token)
+        out = client.call("x", {})
+        assert out["is_error"] is True
+        assert "kaboom" in out["content"]
+    finally:
+        server.close()
+
+
+# ---------------------------------------------------------------------------
+# Overage guard
+# ---------------------------------------------------------------------------
+
+
+def test_check_overage_detects_using_overage():
+    events = [
+        {"type": "rate_limit_event", "rate_limit_info": {"isUsingOverage": False}},
+        {"type": "rate_limit_event", "rate_limit_info": {"isUsingOverage": True, "rateLimitType": "tokens"}},
+    ]
+    info = lc.check_overage(events)
+    assert info is not None
+    assert info["rateLimitType"] == "tokens"
+
+
+def test_check_overage_none_when_not_overage():
+    assert lc.check_overage([{"rate_limit_info": {"isUsingOverage": False}}]) is None
+    assert lc.check_overage([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Usage mapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_usage_maps_cache_tokens():
+    usage = lc.ClaudeLiveClient._build_usage(
+        {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 900,
+            "output_tokens": 20,
+        }
+    )
+    assert usage.prompt_tokens == 915
+    assert usage.completion_tokens == 20
+    assert usage.total_tokens == 935
+    assert usage.prompt_tokens_details.cached_tokens == 900
+
+
+# ---------------------------------------------------------------------------
+# Delta + system prompt extraction
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_has_cache_boundary():
+    text = lc._system_prompt_text([{"role": "system", "content": "be nice"}])
+    assert "be nice" in text
+    assert text.rstrip().endswith(lc._CACHE_BOUNDARY_MARKER.strip())
+
+
+def test_delta_user_text_only_after_last_assistant():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply1"},
+        {"role": "user", "content": "second"},
+    ]
+    delta = lc._delta_user_text(messages)
+    assert delta == "second"
+    assert "first" not in delta
+    assert "sys" not in delta
+
+
+def test_delta_first_turn_excludes_system():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
+    assert lc._delta_user_text(messages) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Auth scrub
+# ---------------------------------------------------------------------------
+
+
+def test_build_live_subprocess_env_scrubs_api_keys(monkeypatch):
+    for key in lc._AUTH_SCRUB_KEYS:
+        monkeypatch.setenv(key, "leak")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "keep-me")
+    env = lc.build_live_subprocess_env()
+    for key in lc._AUTH_SCRUB_KEYS:
+        assert key not in env, f"{key} must be scrubbed"
+    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "keep-me"
+    assert env.get("HOME")
+
+
+# ---------------------------------------------------------------------------
+# Live-mode toggle
+# ---------------------------------------------------------------------------
+
+
+def test_live_mode_default_on(monkeypatch):
+    monkeypatch.delenv("HERMES_CLAUDE_CLI_LIVE", raising=False)
+    assert lc.live_mode_enabled() is True
+
+
+def test_live_mode_off_switch(monkeypatch):
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_LIVE", "0")
+    assert lc.live_mode_enabled() is False
+    monkeypatch.setenv("HERMES_CLAUDE_CLI_LIVE", "false")
+    assert lc.live_mode_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Full stdio bridge integration (real bridge subprocess; NO claude, NO network)
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_subprocess_end_to_end(tmp_path):
+    """Spawn the real hermes_mcp_bridge.py and drive the MCP handshake over
+    stdio, with tools/call forwarded to a live LiveToolServer socket."""
+    tools_file = tmp_path / "tools.json"
+    tools_file.write_text(json.dumps([{"name": "echo", "description": "e", "inputSchema": {}}]))
+
+    executed = []
+
+    def executor(name, arguments):
+        executed.append((name, arguments))
+        return json.dumps({"echoed": arguments}), False
+
+    server = lc.LiveToolServer(executor)
+    server.start()
+    bridge_path = str(Path(bridge.__file__))
+    env = dict(os.environ)
+    env["HERMES_MCP_BRIDGE_SOCKET"] = server.socket_path
+    env["HERMES_MCP_BRIDGE_TOKEN"] = server.token
+    env["HERMES_MCP_BRIDGE_TOOLS"] = str(tools_file)
+
+    proc = subprocess.Popen(
+        [sys.executable, bridge_path],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+    try:
+        def rpc(obj):
+            proc.stdin.write(json.dumps(obj) + "\n")
+            proc.stdin.flush()
+            return json.loads(proc.stdout.readline())
+
+        init = rpc({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+        assert init["result"]["serverInfo"]["name"] == "hermes"
+
+        listed = rpc({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        assert [t["name"] for t in listed["result"]["tools"]] == ["echo"]
+
+        called = rpc(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "echo", "arguments": {"x": 1}},
+            }
+        )
+        text = called["result"]["content"][0]["text"]
+        assert json.loads(text) == {"echoed": {"x": 1}}
+        assert executed == [("echo", {"x": 1})]
+    finally:
+        proc.stdin.close()
+        proc.terminate()
+        proc.wait(timeout=5)
+        server.close()


### PR DESCRIPTION
## Summary

This adds a `claude-cli` provider that lets Hermes use Claude models by driving the genuine `claude` (Claude Code) binary as a subprocess, so traffic runs on the user's existing Claude Code subscription usage instead of pay-per-token API billing.
It is fully opt-in and does not change any default provider or model.

The provider ships two modes:

- A per-turn client (`claude_cli_client`) that spawns a fresh `claude -p` per request.
- A persistent live-session mode (default) that keeps one warm `claude -p --input-format stream-json` child per conversation, which keeps Anthropic's prompt cache hot across turns and interleaved tool calls.

The live mode is what makes this economical: because the process and its content-stable prefix persist, cache-read reaches ~99.7% on steady-state turns, matching API-key caching economics without API billing.

## Why

The existing `anthropic` OAuth provider only draws paid Max overage credits, and it reaches OAuth by forging first-party identity (spoofed user-agent and beta headers).
This provider instead runs the real, unmodified first-party client as a subprocess and talks to it over stdio, so nothing is disguised because it is Claude Code.
`claude -p` non-interactive use is a documented first-party surface.

## Architecture

Claude Code owns the inner tool loop; Hermes exposes its real tools to it through a local stdio MCP server and keeps ownership of everything else.

| Hermes controls | Claude Code controls |
|---|---|
| Interface, session identity, memory, scheduling, persistence | The model API call and first-party OAuth handshake |
| System prompt content, model and effort selection | Prompt caching |
| Tool registry, schemas, and execution (via Hermes's own dispatcher, with its guardrails and state) | The inner reason-and-call-tools loop and native `tool_use` |
| History that seeds a fresh process, Hermes-level compression | Context compaction within the persistent transcript |
| Auth, env scrub, overage guard, usage accounting | API-level retry and rate-limit handling |

Tool calls flow: Claude emits native `tool_use` to a local MCP server (`hermes_mcp_bridge`, a separate process Claude spawns), which forwards each call over a token-guarded AF_UNIX socket to the parent Hermes process, which runs it through `agent._invoke_tool` (the same dispatcher Hermes's own loop uses) and streams the result back.
So tools execute with their normal guardrails, display, and session state, inside the one warm process.

## What is included

- `feat(providers)`: register the `claude-cli` provider (opt-in), aliases, `fetch_models`, and per-request `build_extra_body` that carries live effort and session id.
- `fix(claude-cli)`: wire the provider into the `/model` picker (external-process binary-presence discovery), the web Accounts card, provider prefixes, and interactive `hermes model` setup.
- `fix(context)`: report the correct 1M context window for `claude-sonnet-5`.
- `feat(claude-cli)`: the persistent live-session mode (`claude_live_session`, `claude_live_client`, `hermes_mcp_bridge`).

## Key design decisions

- Opt-in only. No default provider or model changes. Live mode is default within the provider; set `HERMES_CLAUDE_CLI_LIVE=0` to fall back to the per-turn client.
- Model and effort are read per request, so `/model` and `/effort` switch live mid-session. A switch changes the process fingerprint and respawns; a fresh process is reseeded with the full prior history so context is never lost across a switch.
- Billing safety. The child environment is scrubbed of every API-key, custom-header, and cloud-gateway routing variable (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_CUSTOM_HEADERS`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, and related), so the child can only use the subscription OAuth session.
- Overage guard. The stream's `rate_limit_event` is parsed, and a turn is aborted if the subscription reports it is on overage (configurable via `HERMES_CLAUDE_LIVE_OVERAGE`).
- Resource safety. Warm children run in detached process groups with group-kill teardown, an LRU cap and idle timeout, `--resume` crash recovery with orphaned-tool-use reseed, an atexit sweep so no child survives a gateway restart, and a weakref finalizer so the tool server is released when Hermes drops the client.

## Tradeoffs to be aware of

- Because Claude Code owns the inner tool loop, one `create()` is one full user turn including all internal tool cycles, and Hermes's own message history does not contain the intra-turn tool exchanges (they live in Claude Code's transcript). Tools still execute through Hermes's dispatcher with real guardrails. This is inherent to the live plus MCP design.
- Each Hermes-level context compression rebuilds the system prompt and respawns, which resets the warm cache once. Very long single sessions also hit Claude Code's own internal compaction, which is opaque to Hermes.

## Test plan

Automated (mocked subprocess, no network, no subscription):

- [x] `tests/agent/test_claude_live_session.py` — process lifecycle, fingerprint respawn, watchdog, orphaned-tool-use, LRU and idle eviction, `--resume` vs reseed, usage accounting, overage guard.
- [x] `tests/agent/test_hermes_mcp_bridge.py` — MCP `initialize` / `tools/list` / `tools/call`, schema translation, a real socket round trip, and a real bridge subprocess handshake.
- [x] `tests/agent/test_claude_live_client.py` — delta-vs-full-history reseed across a `/model` and `/effort` switch, env scrub, tool-server leak and finalizer.
- [x] `tests/agent/test_claude_cli_client.py` — per-turn client prompt serialization, tool-call extraction, flag construction.
- [x] Provider catalog and `/model` routing regression suites.

End-to-end (real `claude` binary, subscription OAuth, 4-turn warm session):

- [x] Cache warms across turns: `cached_tokens` series `[0, 65657, 65876, 132424]` (turn 1 creates, later turns read ~99.7%).
- [x] A Hermes tool executes through the socket bridge and its result is surfaced.
- [x] The child environment carries no `ANTHROPIC_API_KEY` and no Bedrock or Vertex routing.
