### PR TITLE
fix: clean up evicted memory providers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15760,7 +15760,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -15774,10 +15774,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                stat = path.stat()
+                mtime_ns = stat.st_mtime_ns
+                size = stat.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+            memo_key = (str(path), mtime_ns, size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)
@@ -16422,6 +16425,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if agent is None:
             return
+        try:
+            if hasattr(agent, "release_clients") and hasattr(agent, "shutdown_memory_provider"):
+                # Soft cache eviction must not hard-close terminal/browser/bg
+                # process state, but memory providers are tied to this Python
+                # AIAgent instance. Providers such as MemOS own keepalive
+                # threads and stdio bridge subprocesses; leaving them alive
+                # leaks one bridge per evicted cached agent. Pass the current
+                # transcript when available, matching _cleanup_agent_resources.
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
+        except Exception:
+            pass
         try:
             if hasattr(agent, "release_clients"):
                 agent.release_clients()

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -99,9 +99,15 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     # 1. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
         for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
+            if child.name.startswith(("_", ".")):
                 continue
-            if not (child / "__init__.py").exists():
+            try:
+                is_dir = child.is_dir()
+                has_init = (child / "__init__.py").exists()
+            except OSError as exc:
+                logger.debug("Skipping inaccessible bundled memory provider %s: %s", child, exc)
+                continue
+            if not is_dir or not has_init:
                 continue
             seen.add(child.name)
             dirs.append((child.name, child))
@@ -110,7 +116,14 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     user_dir = _get_user_plugins_dir()
     if user_dir:
         for child in sorted(user_dir.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
+            if child.name.startswith(("_", ".")):
+                continue
+            try:
+                is_dir = child.is_dir()
+            except OSError as exc:
+                logger.debug("Skipping inaccessible user memory provider %s: %s", child, exc)
+                continue
+            if not is_dir:
                 continue
             if child.name in seen:
                 continue  # bundled takes precedence

--- a/run_agent.py
+++ b/run_agent.py
@@ -3435,7 +3435,10 @@ class AIAgent:
           - process_registry entries for task_id (user's bg shells)
           - terminal sandbox for task_id (cwd, env, shell state)
           - browser daemon for task_id (open tabs, cookies)
-          - memory provider (has its own lifecycle; keeps running)
+          - memory provider transport; gateway soft-eviction closes it
+            separately before calling this method, because providers such as
+            MemOS own per-agent bridge subprocesses that must not outlive the
+            evicted AIAgent instance.
 
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -762,6 +762,32 @@ class TestAgentCacheBoundedGrowth:
         assert commit_calls == []       # no premature extraction
         assert old_agent in release_calls  # still released
 
+    def test_soft_eviction_releases_clients_and_memory_provider_only(self):
+        """Soft cache eviction closes memory transports without full tool teardown.
+
+        Cached agents can be rebuilt later with the same session/task id, so
+        soft eviction must preserve terminal/browser/background-process state
+        by avoiding the hard _cleanup_agent_resources path.  But memory
+        providers such as MemOS own keepalive threads and stdio bridge child
+        processes; leaving them alive leaks one bridge per cache eviction.
+        """
+        runner = self._bounded_runner()
+        cleanup_calls: list = []
+        runner._cleanup_agent_resources = lambda agent: cleanup_calls.append(agent)
+
+        agent = self._fake_agent()
+        transcript = [{"role": "user", "content": "hello"}]
+        agent._session_messages = transcript
+        agent.release_clients = MagicMock()
+        agent.shutdown_memory_provider = MagicMock()
+
+        runner._release_evicted_agent_soft(agent)
+
+        agent.release_clients.assert_called_once_with()
+        agent.shutdown_memory_provider.assert_called_once_with(transcript)
+        assert cleanup_calls == []
+        assert agent._session_messages == []
+
     def test_idle_ttl_sweep_evicts_stale_agents(self, monkeypatch):
         """_sweep_idle_cached_agents removes agents idle past the TTL."""
         from gateway import run as gw_run


### PR DESCRIPTION
# PR: fix: clean up evicted memory providers

## Summary
- Close memory provider transports during soft gateway cache eviction, without invoking hard resource cleanup.
- Include config file size in the gateway cache-busting memo key to avoid stale cache reuse when mtime is insufficient.
- Skip inaccessible memory provider directories/symlinks during provider discovery so one user's private provider path cannot break shared installs.
- Add a regression test for soft eviction closing memory providers while preserving terminal/browser/background process state.

## Excluded local-only changes
- Weixin cron standalone fallback suppression.
- Weixin typing-indicator suppression.

## Test Plan
- `venv/bin/python -m pytest tests/gateway/test_agent_cache.py -q -o 'addopts='`
- Result: 79 passed

## Local branch
- `fix/memory-provider-soft-eviction`

## Commit
- `3ff087a fix: clean up evicted memory providers`
