### PR TITLE
fix(slack): complete Agent View workspace routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -63,9 +63,17 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
     thread_id = getattr(source, "thread_id", None)
-    if thread_id is None:
+    metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    # Slack workspace identity is durable routing state, not ephemeral event
+    # metadata. Carry it on every outbound path (including unthreaded sends)
+    # so a multi-workspace Socket Mode gateway never falls back to its primary
+    # WebClient after an async, stream, or recovery boundary.
+    if _platform_name(getattr(source, "platform", None)) == "slack":
+        scope_id = getattr(source, "scope_id", None)
+        if scope_id:
+            metadata["slack_team_id"] = str(scope_id)
+    if not metadata:
         return None
-    metadata = {"thread_id": thread_id}
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
@@ -3202,6 +3210,30 @@ class BasePlatformAdapter(ABC):
         """
         pass
 
+    async def _stop_typing_with_metadata(self, chat_id: str, metadata=None) -> None:
+        """Stop typing while preserving platform-specific routing metadata.
+
+        Most adapters key typing state by chat and retain the historical
+        ``stop_typing(chat_id)`` signature. Slack AI status is per thread and
+        workspace, however, so losing metadata can clear a sibling thread or
+        leave the current one active. Introspect at this shared chokepoint so
+        existing adapters remain source-compatible.
+        """
+        if metadata:
+            try:
+                params = inspect.signature(self.stop_typing).parameters
+                accepts_metadata = "metadata" in params or any(
+                    param.kind is inspect.Parameter.VAR_KEYWORD
+                    for param in params.values()
+                )
+            except (TypeError, ValueError):
+                accepts_metadata = False
+            if accepts_metadata:
+                stop_typing = getattr(self, "stop_typing")
+                await stop_typing(chat_id, metadata=metadata)
+                return
+        await self.stop_typing(chat_id)
+
     async def send_multiple_images(
         self,
         chat_id: str,
@@ -3879,7 +3911,7 @@ class BasePlatformAdapter(ABC):
             # Cancelling _keep_typing alone won't clean that up.
             if hasattr(self, "stop_typing"):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self._stop_typing_with_metadata(chat_id, metadata)
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
@@ -3889,6 +3921,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         typing_task: asyncio.Task | None = None,
         *,
+        metadata=None,
         timeout: float = 0.5,
         stop_attempts: int = 2,
     ) -> None:
@@ -3908,7 +3941,7 @@ class BasePlatformAdapter(ABC):
             attempts = max(1, stop_attempts)
             for attempt in range(attempts):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self._stop_typing_with_metadata(chat_id, metadata)
                 except Exception:
                     pass
                 if attempt < attempts - 1:
@@ -3928,14 +3961,14 @@ class BasePlatformAdapter(ABC):
         """Resume typing indicator for a chat after approval resolves."""
         self._typing_paused.discard(chat_id)
 
-    async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
+    async def interrupt_session_activity(self, session_key: str, chat_id: str, metadata=None) -> None:
         """Signal the active session loop to stop and clear typing immediately."""
         if session_key:
             interrupt_event = self._active_sessions.get(session_key)
             if interrupt_event is not None:
                 interrupt_event.set()
         try:
-            await self.stop_typing(chat_id)
+            await self._stop_typing_with_metadata(chat_id, metadata)
         except Exception:
             pass
 
@@ -4873,6 +4906,7 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,
+                metadata=_thread_metadata,
             )
         
         try:
@@ -5296,6 +5330,7 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 None,
+                metadata=_thread_metadata,
                 stop_attempts=1,
             )
             # Final drain/release boundary: force-flush any timer that missed
@@ -5464,6 +5499,7 @@ class BasePlatformAdapter(ABC):
         user_id_alt: Optional[str] = None,
         chat_id_alt: Optional[str] = None,
         is_bot: bool = False,
+        scope_id: Optional[str] = None,
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
@@ -5487,6 +5523,7 @@ class BasePlatformAdapter(ABC):
             user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt,
             is_bot=is_bot,
+            scope_id=str(scope_id) if scope_id else None,
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11686,10 +11686,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
             )
 
-            # Stop persistent typing indicator now that the agent is done
+            # Stop persistent typing indicator now that the agent is done.
+            # Slack AI status is scoped to a thread/workspace, so preserve the
+            # same routing metadata used by the response delivery path.
             try:
                 _typing_adapter = self._adapter_for_source(source)
-                if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
+                _stop_with_metadata = getattr(
+                    type(_typing_adapter), "_stop_typing_with_metadata", None
+                )
+                _stop_typing = getattr(type(_typing_adapter), "stop_typing", None)
+                if _typing_adapter and callable(_stop_with_metadata):
+                    await _typing_adapter._stop_typing_with_metadata(
+                        source.chat_id,
+                        self._thread_metadata_for_source(
+                            source, self._reply_anchor_for_event(event)
+                        ),
+                    )
+                elif _typing_adapter and callable(_stop_typing):
                     await _typing_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
@@ -12235,10 +12248,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return response
             
         except Exception as e:
-            # Stop typing indicator on error too
+            # Stop typing indicator on error too, retaining Slack thread/workspace
+            # routing so a failed turn cannot leave its status visible.
             try:
                 _err_adapter = self._adapter_for_source(source)
-                if _err_adapter and hasattr(_err_adapter, "stop_typing"):
+                _stop_with_metadata = getattr(
+                    type(_err_adapter), "_stop_typing_with_metadata", None
+                )
+                _stop_typing = getattr(type(_err_adapter), "stop_typing", None)
+                if _err_adapter and callable(_stop_with_metadata):
+                    await _err_adapter._stop_typing_with_metadata(
+                        source.chat_id,
+                        self._thread_metadata_for_source(
+                            source, self._reply_anchor_for_event(event)
+                        ),
+                    )
+                elif _err_adapter and callable(_stop_typing):
                     await _err_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
@@ -14397,13 +14422,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        return self._thread_metadata_for_target(
+        metadata = self._thread_metadata_for_target(
             getattr(source, "platform", None),
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+        if getattr(source, "platform", None) == Platform.SLACK:
+            team_id = getattr(source, "scope_id", None)
+            if team_id:
+                metadata = dict(metadata or {})
+                metadata["slack_team_id"] = str(team_id)
+        return metadata
 
     def _thread_metadata_for_target(
         self,
@@ -16301,8 +16332,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             running_agent.interrupt(interrupt_reason)
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self._adapter_for_source(source)
-        if adapter and hasattr(adapter, "interrupt_session_activity"):
-            await adapter.interrupt_session_activity(session_key, source.chat_id)
+        interrupt_session_activity = getattr(
+            type(adapter), "interrupt_session_activity", None
+        )
+        if adapter and callable(interrupt_session_activity):
+            metadata = self._thread_metadata_for_source(source)
+            try:
+                params = inspect.signature(interrupt_session_activity).parameters
+                accepts_metadata = "metadata" in params or any(
+                    param.kind is inspect.Parameter.VAR_KEYWORD
+                    for param in params.values()
+                )
+            except (TypeError, ValueError):
+                accepts_metadata = False
+            if accepts_metadata:
+                await adapter.interrupt_session_activity(
+                    session_key, source.chat_id, metadata=metadata
+                )
+            else:
+                await adapter.interrupt_session_activity(session_key, source.chat_id)
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -113,7 +113,10 @@ def _build_full_manifest(
             "agent_description": "Chat with Hermes in Slack Messages.",
         }
         bot_scopes.append("assistant:write")
-        bot_events.append("app_home_opened")
+        # Slack includes current viewing context in Agent DM events only after
+        # this subscription is enabled; the adapter consumes that context to
+        # preserve the referred channel across the agent turn.
+        bot_events.extend(["app_context_changed", "app_home_opened"])
 
     bot_scopes.sort()
     bot_events.sort()

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -27,6 +27,7 @@ def _build_full_manifest(
     bot_name: str,
     bot_description: str,
     include_assistant: bool = True,
+    messaging_experience: str | None = None,
 ) -> dict:
     """Build a full Slack manifest merging display info + our slash list.
 
@@ -36,16 +37,23 @@ def _build_full_manifest(
     for a Hermes deployment — users can tweak them in the Slack UI after
     pasting.
 
-    When ``include_assistant`` is True (default) the manifest opts the app
-    into Slack's AI Assistant container: the ``assistant_view`` feature, the
-    ``assistant:write`` scope, and the ``assistant_thread_*`` events. Slack
-    then renders DMs as the right-hand Assistant split-pane, where every
-    exchange is a thread and bare slash commands are not delivered as normal
-    ``command`` events. Pass ``include_assistant=False`` (``--no-assistant``)
-    to omit those three pieces and get a flat DM surface where ``/help``,
-    ``/new``, etc. work inline.
+    By default, this keeps Hermes on Slack's older Assistant messaging
+    experience (``assistant_view``) for backward compatibility. Pass
+    ``messaging_experience="agent"`` (``--agent-view``) to emit Slack's Agent
+    messaging experience (``agent_view`` + ``app_home_opened``). Pass
+    ``include_assistant=False`` or ``messaging_experience="none"``
+    (``--no-assistant``) to omit Slack AI messaging features and get a flat DM
+    surface where ``/help``, ``/new``, etc. work inline.
     """
     from hermes_cli.commands import slack_app_manifest
+
+    if messaging_experience is None:
+        messaging_experience = "assistant" if include_assistant else "none"
+    messaging_experience = str(messaging_experience).strip().lower()
+    if messaging_experience not in {"assistant", "agent", "none"}:
+        raise ValueError(
+            "messaging_experience must be one of: assistant, agent, none"
+        )
 
     partial = slack_app_manifest()
     slashes = partial["features"]["slash_commands"]
@@ -89,7 +97,7 @@ def _build_full_manifest(
         "message.mpim",
     ]
 
-    if include_assistant:
+    if messaging_experience == "assistant":
         features["assistant_view"] = {
             "assistant_description": "Chat with Hermes in threads and DMs.",
         }
@@ -100,8 +108,15 @@ def _build_full_manifest(
                 "assistant_thread_started",
             ]
         )
-        bot_scopes.sort()
-        bot_events.sort()
+    elif messaging_experience == "agent":
+        features["agent_view"] = {
+            "agent_description": "Chat with Hermes in Slack Messages.",
+        }
+        bot_scopes.append("assistant:write")
+        bot_events.append("app_home_opened")
+
+    bot_scopes.sort()
+    bot_events.sort()
 
     return {
         "_metadata": {
@@ -147,17 +162,29 @@ def slack_manifest_command(args) -> int:
                       assistant:write scope, assistant_thread_* events) so
                       DMs render as a flat chat where bare slash commands
                       work inline instead of the Assistant thread pane.
+      --agent-view    Use Slack's Agent messaging experience (agent_view,
+                      app_home_opened + message.im) instead of the legacy
+                      Assistant messaging experience.
     """
     name = getattr(args, "name", None) or "Hermes"
     description = getattr(args, "description", None) or "Your Hermes agent on Slack"
-    include_assistant = not getattr(args, "no_assistant", False)
+    if getattr(args, "agent_view", False):
+        messaging_experience = "agent"
+    elif getattr(args, "no_assistant", False):
+        messaging_experience = "none"
+    else:
+        messaging_experience = "assistant"
 
     if getattr(args, "slashes_only", False):
         from hermes_cli.commands import slack_app_manifest
 
         manifest = slack_app_manifest()["features"]["slash_commands"]
     else:
-        manifest = _build_full_manifest(name, description, include_assistant=include_assistant)
+        manifest = _build_full_manifest(
+            name,
+            description,
+            messaging_experience=messaging_experience,
+        )
 
     payload = json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
 

--- a/hermes_cli/subcommands/slack.py
+++ b/hermes_cli/subcommands/slack.py
@@ -57,12 +57,21 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
         help="Emit only the features.slash_commands array (for merging "
         "into an existing manifest manually).",
     )
-    slack_manifest.add_argument(
+    slack_messaging = slack_manifest.add_mutually_exclusive_group()
+    slack_messaging.add_argument(
         "--no-assistant",
         action="store_true",
         help="Omit Slack AI Assistant mode (assistant_view, assistant:write "
         "scope, assistant_thread_* events). DMs then render as a flat chat "
         "where bare slash commands (/help, /new) work inline instead of "
         "Slack's Assistant thread pane.",
+    )
+    slack_messaging.add_argument(
+        "--agent-view",
+        action="store_true",
+        help="Emit Slack's Agent messaging experience (agent_view, "
+        "app_home_opened + message.im) instead of the legacy assistant_view "
+        "experience. This changes Slack's app messaging surface and cannot "
+        "be reversed in Slack after applying the manifest.",
     )
     slack_parser.set_defaults(func=cmd_slack)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2040,7 +2040,7 @@ class SlackAdapter(BasePlatformAdapter):
         falls back to the plain ``text`` payload. A ``text`` fallback is ALWAYS
         sent alongside blocks, so this can safely return ``None`` at any time.
         """
-        if not self._rich_blocks_enabled() and not self._feedback_buttons_enabled():
+        if not self._rich_blocks_enabled():
             return None
         try:
             blocks = render_blocks(content, mrkdwn_fn=self.format_message)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1099,6 +1099,10 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_app_mention(event, say):
                 await self._handle_slack_message(event)
 
+            @self._app.event("app_home_opened")
+            async def handle_app_home_opened(event, say):
+                await self._handle_app_home_opened(event)
+
             # File lifecycle events can arrive around snippet uploads even when
             # the actual user message is what we care about. Ack them so Slack
             # doesn't log noisy 404 "unhandled request" warnings.
@@ -2502,11 +2506,64 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
+    def _seed_agent_dm_session(self, metadata: Dict[str, str]) -> None:
+        """Prime the session store when Slack reports a user opened the DM.
+
+        In Slack's Agent messaging experience, ``app_home_opened`` with
+        ``tab == "messages"`` replaces ``assistant_thread_started`` as the
+        "user opened the DM" signal. It is only a lifecycle signal: do not send
+        a welcome message or enter the agent loop from this event.
+        """
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return
+
+        channel_id = metadata.get("channel_id", "")
+        user_id = metadata.get("user_id", "")
+        if not channel_id or not user_id:
+            return
+
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=channel_id,
+            chat_type="dm",
+            user_id=user_id,
+        )
+
+        try:
+            session_store.get_or_create_session(source)
+        except Exception:
+            logger.debug(
+                "[Slack] Failed to seed agent DM session for %s",
+                channel_id,
+                exc_info=True,
+            )
+
     async def _handle_assistant_thread_lifecycle_event(self, event: dict) -> None:
         """Handle Slack Assistant lifecycle events that carry user/thread identity."""
         metadata = self._extract_assistant_thread_metadata(event)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
+
+    async def _handle_app_home_opened(self, event: dict) -> None:
+        """Handle Slack Agent DM-open lifecycle events without producing replies."""
+        if event.get("tab") != "messages":
+            return
+
+        channel_id = event.get("channel") or event.get("channel_id") or ""
+        user_id = event.get("user") or event.get("user_id") or ""
+        team_id = event.get("team") or event.get("team_id") or ""
+
+        if team_id and channel_id:
+            self._channel_team[str(channel_id)] = str(team_id)
+
+        self._seed_agent_dm_session(
+            {
+                "channel_id": str(channel_id) if channel_id else "",
+                "user_id": str(user_id) if user_id else "",
+                "team_id": str(team_id) if team_id else "",
+            }
+        )
 
     async def _handle_slack_file_shared(self, event: dict) -> None:
         """Fallback for Slack file shares that do not arrive as message.files.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -472,8 +472,14 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them ((chat_id, thread_ts) → {"thread_ts": str, "team_id": str}).
+        # Keeping team_id avoids clearing via the wrong WebClient in
+        # multi-workspace Socket Mode installs.
+        self._active_status_threads: Dict[Any, Dict[str, str]] = {}
+        # Best-effort guard so automatic Slack AI thread titles are set once
+        # per visible DM thread instead of on every reply.
+        self._titled_assistant_threads: set = set()
+        self._TITLED_ASSISTANT_THREADS_MAX = 5000
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -1189,6 +1195,8 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            self._app.action("hermes_feedback")(self._handle_feedback_action)
+
             # Register plugin-provided Block Kit action handlers.
             #
             # Plugins call ``ctx.register_slack_action_handler(action_id, cb)``
@@ -1346,8 +1354,27 @@ class SlackAdapter(BasePlatformAdapter):
 
         logger.info("[Slack] Disconnected")
 
-    def _get_client(self, chat_id: str) -> Any:
+    @staticmethod
+    def _metadata_team_id(metadata: Optional[Dict[str, Any]]) -> str:
+        """Return Slack workspace id from generic or Slack-specific metadata."""
+        if not metadata:
+            return ""
+        return str(
+            metadata.get("team_id")
+            or metadata.get("team")
+            or metadata.get("slack_team_id")
+            or ""
+        )
+
+    @staticmethod
+    def _active_status_key(chat_id: str, thread_ts: str) -> Tuple[str, str]:
+        """Return the per-thread key for active Slack AI status tracking."""
+        return (str(chat_id), str(thread_ts))
+
+    def _get_client(self, chat_id: str, team_id: Optional[str] = None) -> Any:
         """Return the workspace-specific WebClient for a channel."""
+        if team_id and team_id in self._team_clients:
+            return self._team_clients[team_id]
         team_id = self._channel_team.get(chat_id)
         if team_id and team_id in self._team_clients:
             return self._team_clients[team_id]
@@ -1364,6 +1391,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        thread_ts = None
         try:
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
@@ -1411,11 +1439,13 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                last_result = await self._get_client(
+                    chat_id, team_id=self._metadata_team_id(metadata)
+                ).chat_postMessage(**kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata=metadata)
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -1437,6 +1467,8 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
+            if thread_ts:
+                await self.stop_typing(chat_id, metadata=metadata)
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
@@ -1466,7 +1498,9 @@ class SlackAdapter(BasePlatformAdapter):
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postEphemeral(**kwargs)
+            result = await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).chat_postEphemeral(**kwargs)
             return SendResult(
                 success=True,
                 message_id=result.get("message_ts") or result.get("ts"),
@@ -1483,6 +1517,7 @@ class SlackAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a previously sent Slack message."""
         if not self._app:
@@ -1502,11 +1537,15 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks = self._maybe_blocks(content)
                 if blocks:
                     update_kwargs["blocks"] = blocks
-            await self._get_client(chat_id).chat_update(**update_kwargs)
+            await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).chat_update(**update_kwargs)
             if finalize:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
+            if finalize:
+                await self.stop_typing(chat_id, metadata=metadata)
             logger.error(
                 "[Slack] Failed to edit message %s in channel %s: %s",
                 message_id,
@@ -1533,9 +1572,16 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
+        team_id = self._metadata_team_id(metadata)
+        if not team_id:
+            team_id = self._channel_team.get(chat_id, "")
+
+        self._active_status_threads[self._active_status_key(chat_id, str(thread_ts))] = {
+            "thread_ts": str(thread_ts),
+            "team_id": str(team_id) if team_id else "",
+        }
         try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
+            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
                 status="is thinking...",
@@ -1549,11 +1595,40 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
+        requested_thread_ts = ""
+        if metadata:
+            requested_thread_ts = str(
+                metadata.get("thread_id") or metadata.get("thread_ts") or ""
+            )
+        active_key = (
+            self._active_status_key(chat_id, requested_thread_ts)
+            if requested_thread_ts
+            else chat_id
+        )
+        active = self._active_status_threads.pop(active_key, None)
+        if active is None and requested_thread_ts:
+            active = self._active_status_threads.pop(chat_id, None)
+        if active is None and not requested_thread_ts:
+            matching_keys = [
+                key
+                for key in self._active_status_threads
+                if isinstance(key, tuple) and key[0] == str(chat_id)
+            ]
+            if len(matching_keys) == 1:
+                active = self._active_status_threads.pop(matching_keys[0], None)
+        if isinstance(active, str):
+            thread_ts = active
+            team_id = ""
+        else:
+            active = active or {}
+            thread_ts = active.get("thread_ts", "")
+            team_id = active.get("team_id", "")
+        if metadata:
+            team_id = self._metadata_team_id(metadata) or team_id
         if not thread_ts:
             return
         try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
+            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
                 status="",
@@ -1889,6 +1964,47 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _feedback_buttons_enabled(self) -> bool:
+        """Whether to include Slack AI feedback buttons on final responses."""
+        raw = self.config.extra.get("feedback_buttons")
+        if raw is None:
+            return False
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _feedback_block(self) -> Dict[str, Any]:
+        """Return Slack AI feedback controls from the Agent docs."""
+        return {
+            "type": "context_actions",
+            "elements": [
+                {
+                    "type": "feedback_buttons",
+                    "action_id": "hermes_feedback",
+                    "positive_button": {
+                        "text": {"type": "plain_text", "text": "Good Response"},
+                        "accessibility_label": (
+                            "Submit positive feedback on this response"
+                        ),
+                        "value": "positive",
+                    },
+                    "negative_button": {
+                        "text": {"type": "plain_text", "text": "Bad Response"},
+                        "accessibility_label": (
+                            "Submit negative feedback on this response"
+                        ),
+                        "value": "negative",
+                    },
+                }
+            ],
+        }
+
+    def _append_feedback_block(self, blocks: Optional[list]) -> Optional[list]:
+        """Append response feedback controls when enabled and block budget allows."""
+        if not blocks or not self._feedback_buttons_enabled():
+            return blocks
+        if len(blocks) >= 50:
+            return blocks
+        return [*blocks, self._feedback_block()]
+
     def _maybe_blocks(self, content: str) -> Optional[list]:
         """Render ``content`` to Block Kit blocks when the feature is enabled.
 
@@ -1897,10 +2013,11 @@ class SlackAdapter(BasePlatformAdapter):
         falls back to the plain ``text`` payload. A ``text`` fallback is ALWAYS
         sent alongside blocks, so this can safely return ``None`` at any time.
         """
-        if not self._rich_blocks_enabled():
+        if not self._rich_blocks_enabled() and not self._feedback_buttons_enabled():
             return None
         try:
-            return render_blocks(content, mrkdwn_fn=self.format_message)
+            blocks = render_blocks(content, mrkdwn_fn=self.format_message)
+            return self._append_feedback_block(blocks)
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
@@ -2475,6 +2592,123 @@ class SlackAdapter(BasePlatformAdapter):
             return merged
         return metadata
 
+    def _assistant_suggested_prompts(self) -> Tuple[str, List[Dict[str, str]]]:
+        """Return config.yaml-defined Slack AI suggested prompts.
+
+        Supported shapes under ``platforms.slack.extra.suggested_prompts``:
+
+        - ``[{title, message}, ...]``
+        - ``{title: "...", prompts: [{title, message}, ...]}``
+
+        Invalid rows are ignored. Slack recommends up to four suggestions; keep
+        that bound here so a broad config cannot produce an invalid API call.
+        """
+        raw = self.config.extra.get("suggested_prompts")
+        title = ""
+        prompt_rows = raw
+        if isinstance(raw, dict):
+            title = str(raw.get("title") or "").strip()
+            prompt_rows = raw.get("prompts")
+        if not isinstance(prompt_rows, list):
+            return title, []
+
+        prompts: List[Dict[str, str]] = []
+        for item in prompt_rows:
+            if not isinstance(item, dict):
+                continue
+            prompt_title = str(item.get("title") or "").strip()
+            prompt_message = str(item.get("message") or "").strip()
+            if not prompt_title or not prompt_message:
+                continue
+            prompts.append({"title": prompt_title[:75], "message": prompt_message})
+            if len(prompts) >= 4:
+                break
+        return title, prompts
+
+    async def _set_assistant_suggested_prompts(
+        self,
+        channel_id: str,
+        *,
+        team_id: str = "",
+        thread_ts: str = "",
+    ) -> None:
+        """Best-effort Slack AI suggested prompts setup."""
+        if not self._app or not channel_id:
+            return
+
+        title, prompts = self._assistant_suggested_prompts()
+        if not prompts:
+            return
+
+        kwargs: Dict[str, Any] = {
+            "channel_id": channel_id,
+            "prompts": prompts,
+        }
+        if title:
+            kwargs["title"] = title
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+
+        try:
+            await self._get_client(channel_id, team_id=team_id).assistant_threads_setSuggestedPrompts(
+                **kwargs
+            )
+        except Exception as e:
+            logger.debug("[Slack] assistant.threads.setSuggestedPrompts failed: %s", e)
+
+    def _assistant_thread_title_enabled(self) -> bool:
+        raw = self.config.extra.get("assistant_thread_titles", True)
+        if isinstance(raw, str):
+            return raw.strip().lower() not in {"0", "false", "no", "off"}
+        return bool(raw)
+
+    async def _set_assistant_thread_title(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        title_source: str,
+        *,
+        team_id: str = "",
+    ) -> None:
+        """Best-effort title for visible Slack AI DM threads."""
+        if (
+            not self._app
+            or not channel_id
+            or not thread_ts
+            or not title_source
+            or not self._assistant_thread_title_enabled()
+        ):
+            return
+
+        key = self._assistant_thread_key(channel_id, thread_ts)
+        if not key or key in self._titled_assistant_threads:
+            return
+
+        title = re.sub(r"\s+", " ", title_source).strip()
+        if not title or title.startswith("/"):
+            return
+        if len(title) > 80:
+            title = title[:77].rstrip() + "..."
+
+        try:
+            await self._get_client(channel_id, team_id=team_id).assistant_threads_setTitle(
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                title=title,
+            )
+        except Exception as e:
+            logger.debug("[Slack] assistant.threads.setTitle failed: %s", e)
+            return
+
+        self._titled_assistant_threads.add(key)
+        if len(self._titled_assistant_threads) > self._TITLED_ASSISTANT_THREADS_MAX:
+            excess = (
+                len(self._titled_assistant_threads)
+                - self._TITLED_ASSISTANT_THREADS_MAX // 2
+            )
+            for old_key in list(self._titled_assistant_threads)[:excess]:
+                self._titled_assistant_threads.discard(old_key)
+
     def _seed_assistant_thread_session(self, metadata: Dict[str, str]) -> None:
         """Prime the session store so assistant threads get stable user scoping."""
         session_store = getattr(self, "_session_store", None)
@@ -2544,6 +2778,11 @@ class SlackAdapter(BasePlatformAdapter):
         metadata = self._extract_assistant_thread_metadata(event)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
+        await self._set_assistant_suggested_prompts(
+            metadata.get("channel_id", ""),
+            team_id=metadata.get("team_id", ""),
+            thread_ts=metadata.get("thread_ts", ""),
+        )
 
     async def _handle_app_home_opened(self, event: dict) -> None:
         """Handle Slack Agent DM-open lifecycle events without producing replies."""
@@ -2563,6 +2802,10 @@ class SlackAdapter(BasePlatformAdapter):
                 "user_id": str(user_id) if user_id else "",
                 "team_id": str(team_id) if team_id else "",
             }
+        )
+        await self._set_assistant_suggested_prompts(
+            str(channel_id) if channel_id else "",
+            team_id=str(team_id) if team_id else "",
         )
 
     async def _handle_slack_file_shared(self, event: dict) -> None:
@@ -3217,6 +3460,17 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
+        # Slack's AI Agent Messages tab shows visible app threads; title the
+        # first DM thread turn from the user's prompt when Slack AI APIs are
+        # available. This is best-effort and configurable via config.yaml.
+        if is_dm and thread_ts and msg_type != MessageType.COMMAND:
+            await self._set_assistant_thread_title(
+                channel_id,
+                thread_ts,
+                original_text or text,
+                team_id=team_id,
+            )
+
         # Build source
         source = self.build_source(
             chat_id=channel_id,
@@ -3280,6 +3534,11 @@ class SlackAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
+            metadata={
+                "slack_team_id": team_id,
+                "slack_channel_id": channel_id,
+                "slack_thread_ts": thread_ts,
+            },
         )
 
         # Only react when bot is directly addressed (1:1 DM or @mention).
@@ -3630,6 +3889,22 @@ class SlackAdapter(BasePlatformAdapter):
                 exc,
                 exc_info=True,
             )
+
+    async def _handle_feedback_action(self, ack, body, action) -> None:
+        """Ack Slack AI feedback button clicks and log the choice."""
+        await ack()
+
+        value = str(action.get("value") or "")
+        message = body.get("message", {}) or {}
+        channel_id = (body.get("channel") or {}).get("id", "")
+        user_id = (body.get("user") or {}).get("id", "")
+        logger.info(
+            "[Slack] Feedback button clicked: value=%s user=%s channel=%s ts=%s",
+            value,
+            user_id,
+            channel_id,
+            message.get("ts", ""),
+        )
 
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -466,6 +466,12 @@ class SlackAdapter(BasePlatformAdapter):
         # session + memory scoping.
         self._assistant_threads: Dict[Tuple[str, str], Dict[str, str]] = {}
         self._ASSISTANT_THREADS_MAX = 5000
+        # Agent-view context is per workspace/user (not global): a context
+        # change for one person's Slack split view must never appear in another
+        # person's prompt. Slack also includes this in later DM events, but the
+        # cache bridges lifecycle and message delivery ordering.
+        self._agent_view_contexts: Dict[Tuple[str, str], Dict[str, str]] = {}
+        self._AGENT_VIEW_CONTEXTS_MAX = 5000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
@@ -1091,8 +1097,8 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Register message event handler
             @self._app.event("message")
-            async def handle_message_event(event, say):
-                await self._handle_slack_message(event)
+            async def handle_message_event(event, say, body):
+                await self._handle_slack_message(event, body)
 
             # Handle app_mention explicitly. In some Slack app configurations,
             # channel mentions arrive only as app_mention events rather than the
@@ -1102,19 +1108,23 @@ class SlackAdapter(BasePlatformAdapter):
             # @mention, they share the same event ts — the dedup in
             # _handle_slack_message (MessageDeduplicator) suppresses the second.
             @self._app.event("app_mention")
-            async def handle_app_mention(event, say):
-                await self._handle_slack_message(event)
+            async def handle_app_mention(event, say, body):
+                await self._handle_slack_message(event, body)
 
             @self._app.event("app_home_opened")
-            async def handle_app_home_opened(event, say):
-                await self._handle_app_home_opened(event)
+            async def handle_app_home_opened(event, say, body):
+                await self._handle_app_home_opened(event, body)
+
+            @self._app.event("app_context_changed")
+            async def handle_app_context_changed(event, say, body):
+                await self._handle_app_context_changed(event, body)
 
             # File lifecycle events can arrive around snippet uploads even when
             # the actual user message is what we care about. Ack them so Slack
             # doesn't log noisy 404 "unhandled request" warnings.
             @self._app.event("file_shared")
-            async def handle_file_shared(event, say):
-                await self._handle_slack_file_shared(event)
+            async def handle_file_shared(event, say, body):
+                await self._handle_slack_file_shared(event, body)
 
             @self._app.event("file_created")
             async def handle_file_created(event, say):
@@ -1137,12 +1147,12 @@ class SlackAdapter(BasePlatformAdapter):
                 pass
 
             @self._app.event("assistant_thread_started")
-            async def handle_assistant_thread_started(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
+            async def handle_assistant_thread_started(event, say, body):
+                await self._handle_assistant_thread_lifecycle_event(event, body)
 
             @self._app.event("assistant_thread_context_changed")
-            async def handle_assistant_thread_context_changed(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
+            async def handle_assistant_thread_context_changed(event, say, body):
+                await self._handle_assistant_thread_lifecycle_event(event, body)
 
             # Register slash command handler(s)
             #
@@ -1763,7 +1773,9 @@ class SlackAdapter(BasePlatformAdapter):
         last_exc = None
         for attempt in range(3):
             try:
-                result = await self._get_client(chat_id).files_upload_v2(
+                result = await self._get_client(
+                    chat_id, team_id=self._metadata_team_id(metadata)
+                ).files_upload_v2(
                     channel=chat_id,
                     file=file_path,
                     filename=os.path.basename(file_path),
@@ -1890,7 +1902,9 @@ class SlackAdapter(BasePlatformAdapter):
                     chunk_idx + 1,
                     len(chunks),
                 )
-                result = await self._get_client(chat_id).files_upload_v2(
+                result = await self._get_client(
+                    chat_id, team_id=self._metadata_team_id(metadata)
+                ).files_upload_v2(
                     channel=chat_id,
                     file_uploads=file_uploads,
                     initial_comment=initial_comment,
@@ -2134,12 +2148,14 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Reactions -----
 
-    async def _add_reaction(self, channel: str, timestamp: str, emoji: str) -> bool:
+    async def _add_reaction(
+        self, channel: str, timestamp: str, emoji: str, team_id: str = ""
+    ) -> bool:
         """Add an emoji reaction to a message. Returns True on success."""
         if not self._app:
             return False
         try:
-            await self._get_client(channel).reactions_add(
+            await self._get_client(channel, team_id=team_id or None).reactions_add(
                 channel=channel, timestamp=timestamp, name=emoji
             )
             return True
@@ -2148,12 +2164,14 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] reactions.add failed (%s): %s", emoji, e)
             return False
 
-    async def _remove_reaction(self, channel: str, timestamp: str, emoji: str) -> bool:
+    async def _remove_reaction(
+        self, channel: str, timestamp: str, emoji: str, team_id: str = ""
+    ) -> bool:
         """Remove an emoji reaction from a message. Returns True on success."""
         if not self._app:
             return False
         try:
-            await self._get_client(channel).reactions_remove(
+            await self._get_client(channel, team_id=team_id or None).reactions_remove(
                 channel=channel, timestamp=timestamp, name=emoji
             )
             return True
@@ -2174,7 +2192,9 @@ class SlackAdapter(BasePlatformAdapter):
             return
         channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
-            await self._add_reaction(channel_id, ts, "eyes")
+            await self._add_reaction(
+                channel_id, ts, "eyes", str(getattr(event.source, "scope_id", "") or "")
+            )
 
     async def on_processing_complete(
         self, event: MessageEvent, outcome: ProcessingOutcome
@@ -2189,11 +2209,12 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id = getattr(event.source, "chat_id", None)
         if not channel_id:
             return
-        await self._remove_reaction(channel_id, ts, "eyes")
+        team_id = str(getattr(event.source, "scope_id", "") or "")
+        await self._remove_reaction(channel_id, ts, "eyes", team_id)
         if outcome == ProcessingOutcome.SUCCESS:
-            await self._add_reaction(channel_id, ts, "white_check_mark")
+            await self._add_reaction(channel_id, ts, "white_check_mark", team_id)
         elif outcome == ProcessingOutcome.FAILURE:
-            await self._add_reaction(channel_id, ts, "x")
+            await self._add_reaction(channel_id, ts, "x", team_id)
 
     # ----- User identity resolution -----
 
@@ -2298,7 +2319,9 @@ class SlackAdapter(BasePlatformAdapter):
                 response.raise_for_status()
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
-            result = await self._get_client(chat_id).files_upload_v2(
+            result = await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).files_upload_v2(
                 channel=chat_id,
                 content=response.content,
                 filename="image.png",
@@ -2374,7 +2397,9 @@ class SlackAdapter(BasePlatformAdapter):
             last_exc = None
             for attempt in range(3):
                 try:
-                    result = await self._get_client(chat_id).files_upload_v2(
+                    result = await self._get_client(
+                        chat_id, team_id=self._metadata_team_id(metadata)
+                    ).files_upload_v2(
                         channel=chat_id,
                         file=video_path,
                         filename=os.path.basename(video_path),
@@ -2434,7 +2459,9 @@ class SlackAdapter(BasePlatformAdapter):
             last_exc = None
             for attempt in range(3):
                 try:
-                    result = await self._get_client(chat_id).files_upload_v2(
+                    result = await self._get_client(
+                        chat_id, team_id=self._metadata_team_id(metadata)
+                    ).files_upload_v2(
                         channel=chat_id,
                         file=file_path,
                         filename=display_name,
@@ -2506,10 +2533,105 @@ class SlackAdapter(BasePlatformAdapter):
             return None
         return (str(channel_id), str(thread_ts))
 
-    def _extract_assistant_thread_metadata(self, event: dict) -> Dict[str, str]:
+    @staticmethod
+    def _agent_view_context_key(team_id: str, user_id: str) -> Optional[Tuple[str, str]]:
+        """Return a per-workspace, per-user Agent-view context cache key."""
+        if not team_id or not user_id:
+            return None
+        return (str(team_id), str(user_id))
+
+    def _cache_agent_view_context(self, metadata: Dict[str, str]) -> None:
+        """Remember a user's current Slack Agent-view context."""
+        key = self._agent_view_context_key(
+            metadata.get("team_id", ""), metadata.get("user_id", "")
+        )
+        if not key:
+            return
+        contexts = getattr(self, "_agent_view_contexts", None)
+        if not isinstance(contexts, dict):
+            contexts = {}
+            self._agent_view_contexts = contexts
+        contexts[key] = {
+            field: value
+            for field, value in metadata.items()
+            if field in {"channel_id", "context_channel_id", "team_id", "user_id"}
+            and value
+        }
+        max_contexts = getattr(self, "_AGENT_VIEW_CONTEXTS_MAX", 5000)
+        if len(contexts) > max_contexts:
+            excess = len(contexts) - max_contexts // 2
+            for old_key in list(contexts)[:excess]:
+                del contexts[old_key]
+
+    def _agent_view_context_for_event(
+        self, event: dict, team_id: str, user_id: str
+    ) -> Dict[str, str]:
+        """Read Slack's inline Agent context, falling back to lifecycle state."""
+        context = event.get("app_context") or event.get("context") or {}
+        context_channel_id = self._context_channel_id(context)
+        key = self._agent_view_context_key(team_id, user_id)
+        contexts = getattr(self, "_agent_view_contexts", {})
+        cached = contexts.get(key, {}) if isinstance(contexts, dict) and key else {}
+        return {
+            "context_channel_id": context_channel_id or cached.get("context_channel_id", ""),
+            "team_id": team_id,
+            "user_id": user_id,
+        }
+
+    @staticmethod
+    def _event_team_id(event: dict, body: Optional[dict] = None) -> str:
+        """Resolve a workspace ID from an event plus Bolt's outer payload.
+
+        Bolt injects only the inner ``event`` into an event listener, while
+        Slack places ``team_id`` on the outer Events API payload. Reading both
+        keeps multi-workspace client routing correct after a process boundary.
+        """
+        for payload in (event, body or {}):
+            if not isinstance(payload, dict):
+                continue
+            team = payload.get("team_id") or payload.get("team")
+            if isinstance(team, str) and team:
+                return team
+            if isinstance(team, dict) and team.get("id"):
+                return str(team["id"])
+        authorizations = (body or {}).get("authorizations") if isinstance(body, dict) else None
+        for authorization in authorizations or []:
+            if isinstance(authorization, dict) and authorization.get("team_id"):
+                return str(authorization["team_id"])
+        return ""
+
+    @staticmethod
+    def _context_channel_id(context: Any) -> str:
+        """Extract the actively viewed channel from either Slack context shape."""
+        if not isinstance(context, dict):
+            return ""
+        channel_id = context.get("channel_id")
+        if channel_id:
+            return str(channel_id)
+        for entity in context.get("entities") or []:
+            if not isinstance(entity, dict):
+                continue
+            value = entity.get("value")
+            if isinstance(value, dict) and value.get("channel_id"):
+                return str(value["channel_id"])
+            if (
+                isinstance(value, str)
+                and str(entity.get("type") or "").endswith("channel_id")
+            ):
+                return value
+        return ""
+
+    def _extract_assistant_thread_metadata(
+        self, event: dict, body: Optional[dict] = None
+    ) -> Dict[str, str]:
         """Extract Slack Assistant thread identity data from an event payload."""
         assistant_thread = event.get("assistant_thread") or {}
-        context = assistant_thread.get("context") or event.get("context") or {}
+        context = (
+            assistant_thread.get("context")
+            or event.get("app_context")
+            or event.get("context")
+            or {}
+        )
 
         channel_id = (
             assistant_thread.get("channel_id")
@@ -2529,13 +2651,10 @@ class SlackAdapter(BasePlatformAdapter):
             or context.get("user_id")
             or ""
         )
-        team_id = (
-            event.get("team")
-            or event.get("team_id")
-            or assistant_thread.get("team_id")
-            or ""
+        team_id = self._event_team_id(event, body) or str(
+            assistant_thread.get("team_id") or ""
         )
-        context_channel_id = context.get("channel_id") or ""
+        context_channel_id = self._context_channel_id(context)
 
         return {
             "channel_id": str(channel_id) if channel_id else "",
@@ -2728,6 +2847,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             thread_id=thread_ts,
             chat_topic=metadata.get("context_channel_id") or None,
+            scope_id=metadata.get("team_id") or None,
         )
 
         try:
@@ -2762,6 +2882,8 @@ class SlackAdapter(BasePlatformAdapter):
             chat_name=channel_id,
             chat_type="dm",
             user_id=user_id,
+            chat_topic=metadata.get("context_channel_id") or None,
+            scope_id=metadata.get("team_id") or None,
         )
 
         try:
@@ -2773,9 +2895,11 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
-    async def _handle_assistant_thread_lifecycle_event(self, event: dict) -> None:
+    async def _handle_assistant_thread_lifecycle_event(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
         """Handle Slack Assistant lifecycle events that carry user/thread identity."""
-        metadata = self._extract_assistant_thread_metadata(event)
+        metadata = self._extract_assistant_thread_metadata(event, body)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
         await self._set_assistant_suggested_prompts(
@@ -2784,31 +2908,59 @@ class SlackAdapter(BasePlatformAdapter):
             thread_ts=metadata.get("thread_ts", ""),
         )
 
-    async def _handle_app_home_opened(self, event: dict) -> None:
-        """Handle Slack Agent DM-open lifecycle events without producing replies."""
-        if event.get("tab") != "messages":
-            return
-
-        channel_id = event.get("channel") or event.get("channel_id") or ""
+    async def _handle_app_context_changed(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
+        """Cache the current Agent-view context without entering the agent loop."""
+        context = event.get("context") or event.get("app_context") or {}
+        context_channel_id = self._context_channel_id(context)
         user_id = event.get("user") or event.get("user_id") or ""
-        team_id = event.get("team") or event.get("team_id") or ""
-
-        if team_id and channel_id:
-            self._channel_team[str(channel_id)] = str(team_id)
-
-        self._seed_agent_dm_session(
+        team_id = self._event_team_id(event, body)
+        # ``context_channel_id`` is a channel the user is viewing, not the DM
+        # Hermes owns. Do not write it into _channel_team: channel IDs can be
+        # shared across Slack Connect workspaces, so doing so can misroute a
+        # later unrelated send. Workspace ownership is recorded from actual
+        # inbound DM/channel events below.
+        self._cache_agent_view_context(
             {
-                "channel_id": str(channel_id) if channel_id else "",
+                "context_channel_id": str(context_channel_id) if context_channel_id else "",
                 "user_id": str(user_id) if user_id else "",
                 "team_id": str(team_id) if team_id else "",
             }
         )
+
+    async def _handle_app_home_opened(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
+        """Handle Slack Agent DM-open lifecycle events without producing replies."""
+        if event.get("tab") != "messages":
+            return
+
+        context = event.get("context") or event.get("app_context") or {}
+        channel_id = event.get("channel") or event.get("channel_id") or ""
+        user_id = event.get("user") or event.get("user_id") or ""
+        team_id = self._event_team_id(event, body)
+        context_channel_id = self._context_channel_id(context)
+
+        if team_id and channel_id:
+            self._channel_team[str(channel_id)] = str(team_id)
+
+        metadata = {
+            "channel_id": str(channel_id) if channel_id else "",
+            "user_id": str(user_id) if user_id else "",
+            "team_id": str(team_id) if team_id else "",
+            "context_channel_id": context_channel_id,
+        }
+        self._cache_agent_view_context(metadata)
+        self._seed_agent_dm_session(metadata)
         await self._set_assistant_suggested_prompts(
-            str(channel_id) if channel_id else "",
-            team_id=str(team_id) if team_id else "",
+            metadata["channel_id"],
+            team_id=metadata["team_id"],
         )
 
-    async def _handle_slack_file_shared(self, event: dict) -> None:
+    async def _handle_slack_file_shared(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
         """Fallback for Slack file shares that do not arrive as message.files.
 
         Slack documents ``file_shared`` as a file-ID-only event; callers must
@@ -2822,7 +2974,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_id or not file_id:
             return
 
-        team_id = event.get("team_id") or event.get("team") or ""
+        team_id = self._event_team_id(event, body)
         try:
             client = self._team_clients.get(team_id) if team_id else None
             info_resp = await (client or self._get_client(channel_id)).files_info(
@@ -2886,7 +3038,9 @@ class SlackAdapter(BasePlatformAdapter):
             fallback_event["thread_ts"] = thread_ts
         await self._handle_slack_message(fallback_event)
 
-    async def _handle_slack_message(self, event: dict) -> None:
+    async def _handle_slack_message(
+        self, event: dict, payload: Optional[dict] = None
+    ) -> None:
         """Handle an incoming Slack message event."""
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         event_ts = event.get("ts", "")
@@ -3046,10 +3200,9 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = event.get("user") or assistant_meta.get("user_id", "")
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
-        team_id = (
-            event.get("team")
-            or event.get("team_id")
-            or assistant_meta.get("team_id", "")
+        team_id = self._event_team_id(event, payload) or assistant_meta.get("team_id", "")
+        agent_context = self._agent_view_context_for_event(
+            event, str(team_id or ""), str(user_id or "")
         )
 
         # Track which workspace owns this channel
@@ -3159,6 +3312,7 @@ class SlackAdapter(BasePlatformAdapter):
                     channel_id=channel_id,
                     thread_ts=event_thread_ts,
                     user_id=user_id,
+                    team_id=team_id,
                 )
                 if (
                     not reply_to_bot_thread
@@ -3189,6 +3343,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_id=channel_id,
             thread_ts=event_thread_ts,
             user_id=user_id,
+            team_id=team_id,
         ):
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,
@@ -3220,9 +3375,9 @@ class SlackAdapter(BasePlatformAdapter):
                 if not file_id:
                     continue
                 try:
-                    info_resp = await self._get_client(channel_id).files_info(
-                        file=file_id
-                    )
+                    info_resp = await self._get_client(
+                        channel_id, team_id=team_id
+                    ).files_info(file=file_id)
                     if info_resp.get("ok"):
                         f = info_resp["file"]
                     else:
@@ -3479,6 +3634,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            scope_id=str(team_id) if team_id else None,
             # Slack Workflow Builder / app posts arrive as
             # subtype=bot_message with user=None; flag them so the
             # gateway SLACK_ALLOW_BOTS bypass can authorize them
@@ -3548,6 +3704,18 @@ class SlackAdapter(BasePlatformAdapter):
         _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
         if _should_react:
             self._reacting_message_ids.add(ts)
+
+        # App-context is per-turn, user-controlled Slack UI state. Surface it
+        # with the inbound user message rather than storing it on SessionSource:
+        # putting it in the cached system prompt would rebuild the agent whenever
+        # the user switches views and would let stale context bleed into later
+        # turns. The agent receives an inert label, never a fetched channel body.
+        context_channel_id = agent_context.get("context_channel_id", "")
+        if context_channel_id and context_channel_id != channel_id:
+            msg_event.text = (
+                f"[Slack app context: user is viewing channel {context_channel_id}]\n\n"
+                f"{msg_event.text}"
+            )
 
         await self.handle_message(msg_event)
 
@@ -3637,7 +3805,9 @@ class SlackAdapter(BasePlatformAdapter):
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            result = await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).chat_postMessage(**kwargs)
             msg_ts = result.get("ts", "")
             if msg_ts:
                 self._approval_resolved[msg_ts] = False
@@ -3715,7 +3885,9 @@ class SlackAdapter(BasePlatformAdapter):
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            result = await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).chat_postMessage(**kwargs)
             return SendResult(
                 success=True, message_id=result.get("ts", ""), raw_response=result
             )
@@ -3729,6 +3901,7 @@ class SlackAdapter(BasePlatformAdapter):
         *,
         channel_id: str = "",
         user_name: Optional[str] = None,
+        team_id: str = "",
     ) -> bool:
         """Return whether a Slack interactive caller may perform gated actions."""
         normalized_user_id = str(user_id or "").strip()
@@ -3747,6 +3920,7 @@ class SlackAdapter(BasePlatformAdapter):
                     chat_type="dm" if str(channel_id or "").startswith("D") else "group",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
+                    scope_id=str(team_id) if team_id else None,
                 )
                 return bool(auth_fn(source))
             except Exception:
@@ -3776,6 +3950,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle a slash-confirm button click from Block Kit."""
         await ack()
 
+        team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
         value = action.get("value", "")
         message = body.get("message", {})
@@ -3787,6 +3962,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id,
             channel_id=channel_id,
             user_name=user_name,
+            team_id=team_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized slash-confirm click by %s (%s) - ignoring",
@@ -3851,7 +4027,7 @@ class SlackAdapter(BasePlatformAdapter):
         ]
 
         try:
-            await self._get_client(channel_id).chat_update(
+            await self._get_client(channel_id, team_id=team_id or None).chat_update(
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
@@ -3876,7 +4052,9 @@ class SlackAdapter(BasePlatformAdapter):
                 thread_ts = message.get("thread_ts") or msg_ts
                 if thread_ts:
                     post_kwargs["thread_ts"] = thread_ts
-                await self._get_client(channel_id).chat_postMessage(**post_kwargs)
+                await self._get_client(
+                    channel_id, team_id=team_id or None
+                ).chat_postMessage(**post_kwargs)
             logger.info(
                 "Slack button resolved slash-confirm for session %s (choice=%s, user=%s)",
                 session_key,
@@ -3910,6 +4088,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle an approval button click from Block Kit."""
         await ack()
 
+        team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
         session_key = action.get("value", "")
         message = body.get("message", {})
@@ -3922,6 +4101,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id,
             channel_id=channel_id,
             user_name=user_name,
+            team_id=team_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized approval click by %s (%s) - ignoring",
@@ -3989,7 +4169,7 @@ class SlackAdapter(BasePlatformAdapter):
         ]
 
         try:
-            await self._get_client(channel_id).chat_update(
+            await self._get_client(channel_id, team_id=team_id or None).chat_update(
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
@@ -4049,7 +4229,7 @@ class SlackAdapter(BasePlatformAdapter):
             return cached.content
 
         try:
-            client = self._get_client(channel_id)
+            client = self._get_client(channel_id, team_id=team_id)
 
             # Retry with exponential backoff for Tier-3 rate limits (429).
             result = None
@@ -4210,7 +4390,7 @@ class SlackAdapter(BasePlatformAdapter):
             return cached.parent_text
 
         try:
-            client = self._get_client(channel_id)
+            client = self._get_client(channel_id, team_id=team_id)
             result = await client.conversations_replies(
                 channel=channel_id,
                 ts=thread_ts,
@@ -4293,6 +4473,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
+            scope_id=team_id or None,
         )
 
         event = MessageEvent(
@@ -4330,6 +4511,7 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id: str,
         thread_ts: str,
         user_id: str,
+        team_id: str = "",
     ) -> bool:
         """Check if there's an active session for a thread.
 
@@ -4354,6 +4536,7 @@ class SlackAdapter(BasePlatformAdapter):
                 chat_type="group",
                 user_id=user_id,
                 thread_id=thread_ts,
+                scope_id=team_id or None,
             )
 
             # Read session isolation settings from the store's config

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -440,7 +440,10 @@ class SlackAdapter(BasePlatformAdapter):
         self._app: Optional[Any] = None
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
-        self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        # Slack user IDs are workspace-local. Cache names by workspace as well
+        # so a multi-workspace Socket Mode process never reuses another
+        # tenant's display name.
+        self._user_name_cache: Dict[Tuple[str, str], str] = {}
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
@@ -460,11 +463,10 @@ class SlackAdapter(BasePlatformAdapter):
         # respond to ALL subsequent messages in that thread automatically.
         self._mentioned_threads: set = set()
         self._MENTIONED_THREADS_MAX = 5000
-        # Assistant thread metadata keyed by (channel_id, thread_ts). Slack's
-        # AI Assistant lifecycle events can arrive before/alongside message
-        # events, and they carry the user/thread identity needed for stable
-        # session + memory scoping.
-        self._assistant_threads: Dict[Tuple[str, str], Dict[str, str]] = {}
+        # Assistant thread metadata keyed by (team_id, channel_id, thread_ts).
+        # Slack's AI Assistant lifecycle events can arrive before/alongside
+        # message events, and carry identity needed for stable session scoping.
+        self._assistant_threads: Dict[Tuple[str, str, str], Dict[str, str]] = {}
         self._ASSISTANT_THREADS_MAX = 5000
         # Agent-view context is per workspace/user (not global): a context
         # change for one person's Slack split view must never appear in another
@@ -477,11 +479,9 @@ class SlackAdapter(BasePlatformAdapter):
         self._THREAD_CACHE_TTL = 60.0
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
-        # Track active assistant thread status indicators so stop_typing can
-        # clear them ((chat_id, thread_ts) → {"thread_ts": str, "team_id": str}).
-        # Keeping team_id avoids clearing via the wrong WebClient in
-        # multi-workspace Socket Mode installs.
-        self._active_status_threads: Dict[Any, Dict[str, str]] = {}
+        # Track active Assistant statuses by (team_id, channel_id, thread_ts)
+        # so cleanup cannot clear an overlapping Slack Connect workspace.
+        self._active_status_threads: Dict[Tuple[str, str, str], Dict[str, str]] = {}
         # Best-effort guard so automatic Slack AI thread titles are set once
         # per visible DM thread instead of on every reply.
         self._titled_assistant_threads: set = set()
@@ -1376,11 +1376,6 @@ class SlackAdapter(BasePlatformAdapter):
             or ""
         )
 
-    @staticmethod
-    def _active_status_key(chat_id: str, thread_ts: str) -> Tuple[str, str]:
-        """Return the per-thread key for active Slack AI status tracking."""
-        return (str(chat_id), str(thread_ts))
-
     def _get_client(self, chat_id: str, team_id: Optional[str] = None) -> Any:
         """Return the workspace-specific WebClient for a channel."""
         if team_id and team_id in self._team_clients:
@@ -1586,10 +1581,12 @@ class SlackAdapter(BasePlatformAdapter):
         if not team_id:
             team_id = self._channel_team.get(chat_id, "")
 
-        self._active_status_threads[self._active_status_key(chat_id, str(thread_ts))] = {
-            "thread_ts": str(thread_ts),
-            "team_id": str(team_id) if team_id else "",
-        }
+        status_key = self._workspace_thread_key(team_id, chat_id, str(thread_ts))
+        if status_key:
+            self._active_status_threads[status_key] = {
+                "thread_ts": str(thread_ts),
+                "team_id": str(team_id) if team_id else "",
+            }
         try:
             await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -1610,19 +1607,26 @@ class SlackAdapter(BasePlatformAdapter):
             requested_thread_ts = str(
                 metadata.get("thread_id") or metadata.get("thread_ts") or ""
             )
-        active_key = (
-            self._active_status_key(chat_id, requested_thread_ts)
-            if requested_thread_ts
-            else chat_id
-        )
-        active = self._active_status_threads.pop(active_key, None)
-        if active is None and requested_thread_ts:
-            active = self._active_status_threads.pop(chat_id, None)
-        if active is None and not requested_thread_ts:
+        requested_team_id = self._metadata_team_id(metadata)
+        if not requested_team_id:
+            requested_team_id = self._channel_team.get(chat_id, "")
+        active = None
+        if requested_thread_ts:
+            active_key = self._workspace_thread_key(
+                requested_team_id, chat_id, requested_thread_ts
+            )
+            if active_key:
+                active = self._active_status_threads.pop(active_key, None)
+        else:
+            # Metadata-free cleanup is safe only if exactly one status exists
+            # for this channel; otherwise it may clear another Slack Connect
+            # workspace's Assistant status.
             matching_keys = [
                 key
                 for key in self._active_status_threads
-                if isinstance(key, tuple) and key[0] == str(chat_id)
+                if isinstance(key, tuple)
+                and len(key) == 3
+                and key[1] == str(chat_id)
             ]
             if len(matching_keys) == 1:
                 active = self._active_status_threads.pop(matching_keys[0], None)
@@ -2218,18 +2222,27 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- User identity resolution -----
 
-    async def _resolve_user_name(self, user_id: str, chat_id: str = "") -> str:
-        """Resolve a Slack user ID to a display name, with caching."""
+    async def _resolve_user_name(
+        self, user_id: str, chat_id: str = "", team_id: str = ""
+    ) -> str:
+        """Resolve a workspace-local Slack user ID to a display name."""
         if not user_id:
             return ""
-        if user_id in self._user_name_cache:
-            return self._user_name_cache[user_id]
+        team_id = str(team_id or self._channel_team.get(chat_id, ""))
+        cache_key = (team_id, str(user_id))
+        cached_name = self._user_name_cache.get(cache_key)
+        if cached_name is not None:
+            return cached_name
 
         if not self._app:
             return user_id
 
         try:
-            client = self._get_client(chat_id) if chat_id else self._app.client
+            client = (
+                self._get_client(chat_id, team_id=team_id or None)
+                if chat_id
+                else self._app.client
+            )
             result = await client.users_info(user=user_id)
             user = result.get("user", {})
             # Prefer display_name → real_name → user_id
@@ -2241,11 +2254,11 @@ class SlackAdapter(BasePlatformAdapter):
                 or user.get("name")
                 or user_id
             )
-            self._user_name_cache[user_id] = name
+            self._user_name_cache[cache_key] = name
             return name
         except Exception as e:
             logger.debug("[Slack] users.info failed for %s: %s", user_id, e)
-            self._user_name_cache[user_id] = user_id
+            self._user_name_cache[cache_key] = user_id
             return user_id
 
     async def send_image_file(
@@ -2525,13 +2538,19 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Internal handlers -----
 
-    def _assistant_thread_key(
-        self, channel_id: str, thread_ts: str
-    ) -> Optional[Tuple[str, str]]:
-        """Return a stable cache key for Slack assistant thread metadata."""
+    @staticmethod
+    def _workspace_thread_key(
+        team_id: str, channel_id: str, thread_ts: str
+    ) -> Optional[Tuple[str, str, str]]:
+        """Return a workspace-scoped key for Slack thread-local state.
+
+        Slack Connect can expose the same channel/thread IDs in more than one
+        workspace. Keys for cached thread data and Assistant status therefore
+        need the workspace identity as well as Slack's channel/thread pair.
+        """
         if not channel_id or not thread_ts:
             return None
-        return (str(channel_id), str(thread_ts))
+        return (str(team_id or ""), str(channel_id), str(thread_ts))
 
     @staticmethod
     def _agent_view_context_key(team_id: str, user_id: str) -> Optional[Tuple[str, str]]:
@@ -2665,10 +2684,11 @@ class SlackAdapter(BasePlatformAdapter):
         }
 
     def _cache_assistant_thread_metadata(self, metadata: Dict[str, str]) -> None:
-        """Remember assistant thread identity data for later message events."""
+        """Remember workspace-local assistant identity for later message events."""
         channel_id = metadata.get("channel_id", "")
         thread_ts = metadata.get("thread_ts", "")
-        key = self._assistant_thread_key(channel_id, thread_ts)
+        team_id = metadata.get("team_id", "")
+        key = self._workspace_thread_key(team_id, channel_id, thread_ts)
         if not key:
             return
 
@@ -2677,30 +2697,35 @@ class SlackAdapter(BasePlatformAdapter):
         merged.update({k: v for k, v in metadata.items() if v})
         self._assistant_threads[key] = merged
 
-        # Evict oldest entries when the cache exceeds the limit
+        # Evict oldest entries when the cache exceeds the limit.
         if len(self._assistant_threads) > self._ASSISTANT_THREADS_MAX:
             excess = len(self._assistant_threads) - self._ASSISTANT_THREADS_MAX // 2
             for old_key in list(self._assistant_threads)[:excess]:
                 del self._assistant_threads[old_key]
 
-        team_id = merged.get("team_id", "")
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
 
     def _lookup_assistant_thread_metadata(
         self,
         event: dict,
+        *,
         channel_id: str = "",
         thread_ts: str = "",
+        team_id: str = "",
+        body: Optional[dict] = None,
     ) -> Dict[str, str]:
-        """Load cached assistant-thread metadata that matches the current event."""
-        metadata = self._extract_assistant_thread_metadata(event)
+        """Load workspace-scoped assistant metadata for the current event."""
+        metadata = self._extract_assistant_thread_metadata(event, body)
         if channel_id and not metadata.get("channel_id"):
             metadata["channel_id"] = channel_id
         if thread_ts and not metadata.get("thread_ts"):
             metadata["thread_ts"] = thread_ts
+        if team_id and not metadata.get("team_id"):
+            metadata["team_id"] = str(team_id)
 
-        key = self._assistant_thread_key(
+        key = self._workspace_thread_key(
+            metadata.get("team_id", ""),
             metadata.get("channel_id", ""),
             metadata.get("thread_ts", ""),
         )
@@ -2799,7 +2824,7 @@ class SlackAdapter(BasePlatformAdapter):
         ):
             return
 
-        key = self._assistant_thread_key(channel_id, thread_ts)
+        key = self._workspace_thread_key(team_id, channel_id, thread_ts)
         if not key or key in self._titled_assistant_threads:
             return
 
@@ -3192,15 +3217,18 @@ class SlackAdapter(BasePlatformAdapter):
 
         channel_id = event.get("channel", "")
         ts = event.get("ts", "")
+        outer_team_id = self._event_team_id(event, payload)
         assistant_meta = self._lookup_assistant_thread_metadata(
             event,
             channel_id=channel_id,
             thread_ts=event.get("thread_ts", ""),
+            team_id=outer_team_id,
+            body=payload,
         )
         user_id = event.get("user") or assistant_meta.get("user_id", "")
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
-        team_id = self._event_team_id(event, payload) or assistant_meta.get("team_id", "")
+        team_id = outer_team_id or assistant_meta.get("team_id", "")
         agent_context = self._agent_view_context_for_event(
             event, str(team_id or ""), str(user_id or "")
         )
@@ -3613,7 +3641,9 @@ class SlackAdapter(BasePlatformAdapter):
                 msg_type = MessageType.DOCUMENT
 
         # Resolve user display name (cached after first lookup)
-        user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
+        user_name = await self._resolve_user_name(
+            user_id, chat_id=channel_id, team_id=team_id
+        )
 
         # Slack's AI Agent Messages tab shows visible app threads; title the
         # first DM thread turn from the user's prompt when Slack AI APIs are
@@ -4314,7 +4344,9 @@ class SlackAdapter(BasePlatformAdapter):
                 # Prefer the bot's own name when the message is a bot post.
                 if is_bot and not display_user:
                     display_user = msg.get("username") or "bot"
-                name = await self._resolve_user_name(display_user, chat_id=channel_id)
+                name = await self._resolve_user_name(
+                    display_user, chat_id=channel_id, team_id=team_id
+                )
 
                 # Mark senders not on the allowlist as [unverified] so the LLM
                 # treats their content as background reference rather than

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1608,15 +1608,26 @@ class SlackAdapter(BasePlatformAdapter):
                 metadata.get("thread_id") or metadata.get("thread_ts") or ""
             )
         requested_team_id = self._metadata_team_id(metadata)
-        if not requested_team_id:
-            requested_team_id = self._channel_team.get(chat_id, "")
         active = None
         if requested_thread_ts:
-            active_key = self._workspace_thread_key(
-                requested_team_id, chat_id, requested_thread_ts
-            )
-            if active_key:
-                active = self._active_status_threads.pop(active_key, None)
+            if requested_team_id:
+                active_key = self._workspace_thread_key(
+                    requested_team_id, chat_id, requested_thread_ts
+                )
+                if active_key:
+                    active = self._active_status_threads.pop(active_key, None)
+            else:
+                # Do not trust the mutable channel-only workspace fallback for
+                # a thread-specific cleanup: Slack Connect workspaces can share
+                # a channel ID. Clear the uniquely matching tracked status and
+                # let its stored team choose the correct client.
+                matching_keys = [
+                    key
+                    for key in self._active_status_threads
+                    if key[1] == str(chat_id) and key[2] == requested_thread_ts
+                ]
+                if len(matching_keys) == 1:
+                    active = self._active_status_threads.pop(matching_keys[0], None)
         else:
             # Metadata-free cleanup is safe only if exactly one status exists
             # for this channel; otherwise it may clear another Slack Connect
@@ -1624,9 +1635,7 @@ class SlackAdapter(BasePlatformAdapter):
             matching_keys = [
                 key
                 for key in self._active_status_threads
-                if isinstance(key, tuple)
-                and len(key) == 3
-                and key[1] == str(chat_id)
+                if key[1] == str(chat_id)
             ]
             if len(matching_keys) == 1:
                 active = self._active_status_threads.pop(matching_keys[0], None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,9 +158,9 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
-messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
+messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
-slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.14.1"]
+slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
 matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
+    "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)
     "jake.long.vu@vucar.net": "jakelongvu-bot",  # PR #36683 partial salvage (approval: honor canonical approvals.timeout in gateway waits)
     "luigi@users.noreply.github.com": "Tortugasaur",  # PR #43205 salvage (desktop: profile-aware three-way approval mode statusbar control)
     "kavi@local.hermes": "kavioavio",  # Issue #46544 / PR #47705 evolution (smart DENY exact-operation owner override)

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -41,6 +41,9 @@ class DummyTelegramAdapter(BasePlatformAdapter):
         self.typing.append({"chat_id": chat_id, "metadata": metadata})
         return None
 
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
+        self.typing.append({"chat_id": chat_id, "stopped": True, "metadata": metadata})
+
     async def get_chat_info(self, chat_id: str):
         return {"id": chat_id}
 
@@ -143,6 +146,11 @@ class TestBasePlatformTopicSessions:
                 "metadata": {"thread_id": "17585"},
             }
         ]
+        assert {
+            "chat_id": "-1001",
+            "stopped": True,
+            "metadata": {"thread_id": "17585"},
+        } in adapter.typing
         assert adapter.processing_hooks == [
             ("start", "1"),
             ("complete", "1", ProcessingOutcome.SUCCESS),

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2293,6 +2293,46 @@ class TestSendTyping:
         assert ("T_TWO", "D_SHARED", "171.000") in adapter._active_status_threads
 
     @pytest.mark.asyncio
+    async def test_stop_typing_without_team_uses_unique_thread_status(self, adapter):
+        """A stale channel fallback must not strand a uniquely tracked status."""
+        team_one, team_two = AsyncMock(), AsyncMock()
+        adapter._team_clients.update({"T_ONE": team_one, "T_TWO": team_two})
+        await adapter.send_typing(
+            "D_SHARED",
+            metadata={"thread_id": "171.000", "slack_team_id": "T_ONE"},
+        )
+        # Another workspace can overwrite this channel-only fallback map.
+        adapter._channel_team["D_SHARED"] = "T_TWO"
+
+        await adapter.stop_typing("D_SHARED", metadata={"thread_id": "171.000"})
+
+        assert team_one.assistant_threads_setStatus.call_args_list[-1] == call(
+            channel_id="D_SHARED", thread_ts="171.000", status=""
+        )
+        assert ("T_ONE", "D_SHARED", "171.000") not in adapter._active_status_threads
+        team_two.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_without_team_preserves_ambiguous_thread_statuses(
+        self, adapter
+    ):
+        """Without team metadata, matching workspace statuses must not be guessed."""
+        team_one, team_two = AsyncMock(), AsyncMock()
+        adapter._team_clients.update({"T_ONE": team_one, "T_TWO": team_two})
+        for team_id in ("T_ONE", "T_TWO"):
+            await adapter.send_typing(
+                "D_SHARED",
+                metadata={"thread_id": "171.000", "slack_team_id": team_id},
+            )
+
+        await adapter.stop_typing("D_SHARED", metadata={"thread_id": "171.000"})
+
+        assert ("T_ONE", "D_SHARED", "171.000") in adapter._active_status_threads
+        assert ("T_TWO", "D_SHARED", "171.000") in adapter._active_status_threads
+        assert team_one.assistant_threads_setStatus.call_count == 1
+        assert team_two.assistant_threads_setStatus.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_streaming_final_edit_uses_workspace_client_from_metadata(
         self, adapter
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.run import GatewayRunner
 from gateway.platforms.base import (
     MessageEvent,
     MessageType,
@@ -148,6 +149,7 @@ class TestSlashCommandSessionIsolation:
         assert event.source.chat_type == "group"
         assert event.source.chat_id == "C123"
         assert event.source.user_id == "U123"
+        assert event.source.scope_id == "T123"
 
     @pytest.mark.asyncio
     async def test_dm_slash_command_keeps_dm_session_semantics(self, adapter):
@@ -165,6 +167,7 @@ class TestSlashCommandSessionIsolation:
         assert event.source.chat_type == "dm"
         assert event.source.chat_id == "D123"
         assert event.source.user_id == "U123"
+        assert event.source.scope_id == "T123"
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +242,7 @@ class TestAppMentionHandler:
         assert "message" in registered_events
         assert "app_mention" in registered_events
         assert "app_home_opened" in registered_events
+        assert "app_context_changed" in registered_events
         assert "reaction_added" in registered_events
         assert "reaction_removed" in registered_events
         assert "assistant_thread_started" in registered_events
@@ -916,6 +920,25 @@ class TestSendDocument:
         assert call_kwargs["file"] == str(test_file)
         assert call_kwargs["filename"] == "report.pdf"
         assert call_kwargs["initial_comment"] == "Here's the report"
+
+    @pytest.mark.asyncio
+    async def test_send_document_uses_metadata_workspace_client(self, adapter, tmp_path):
+        """Outbound media follows the inbound Slack workspace across gateway boundaries."""
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        secondary_client = AsyncMock()
+        secondary_client.files_upload_v2 = AsyncMock(return_value={"ok": True})
+        adapter._team_clients["T_SECONDARY"] = secondary_client
+
+        result = await adapter.send_document(
+            chat_id="C123",
+            file_path=str(test_file),
+            metadata={"slack_team_id": "T_SECONDARY"},
+        )
+
+        assert result.success
+        secondary_client.files_upload_v2.assert_awaited_once()
+        adapter._app.client.files_upload_v2.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_document_custom_name(self, adapter, tmp_path):
@@ -2219,6 +2242,23 @@ class TestSendTyping:
         }
 
     @pytest.mark.asyncio
+    async def test_stop_typing_with_metadata_preserves_sibling_status(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("D123", metadata={"thread_id": "thread_a"})
+        await adapter.send_typing("D123", metadata={"thread_id": "thread_b"})
+
+        await adapter._stop_typing_with_metadata(
+            "D123", {"thread_id": "thread_a"}
+        )
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list == [
+            call(channel_id="D123", thread_ts="thread_a", status="is thinking..."),
+            call(channel_id="D123", thread_ts="thread_b", status="is thinking..."),
+            call(channel_id="D123", thread_ts="thread_a", status=""),
+        ]
+        assert ("D123", "thread_b") in adapter._active_status_threads
+
+    @pytest.mark.asyncio
     async def test_streaming_final_edit_uses_workspace_client_from_metadata(
         self, adapter
     ):
@@ -3262,6 +3302,99 @@ class TestAssistantThreadLifecycle:
             ],
             thread_ts="171.000",
         )
+
+    @pytest.mark.asyncio
+    async def test_agent_view_context_is_scoped_per_workspace_and_user(
+        self, assistant_adapter
+    ):
+        await assistant_adapter._handle_app_context_changed(
+            {
+                "type": "app_context_changed",
+                "user": "U_ONE",
+                "context": {
+                    "entities": [
+                        {
+                            "type": "slack#/types/channel_id",
+                            "value": "C_CONTEXT_ONE",
+                        }
+                    ]
+                },
+            },
+            {"team_id": "T_ONE"},
+        )
+        await assistant_adapter._handle_app_context_changed(
+            {
+                "type": "app_context_changed",
+                "user": "U_TWO",
+                "context": {
+                    "entities": [
+                        {
+                            "type": "slack#/types/channel_id",
+                            "value": "C_CONTEXT_TWO",
+                        }
+                    ]
+                },
+            },
+            {"team_id": "T_TWO"},
+        )
+
+        assert assistant_adapter._agent_view_context_for_event(
+            {}, "T_ONE", "U_ONE"
+        )["context_channel_id"] == "C_CONTEXT_ONE"
+        assert assistant_adapter._agent_view_context_for_event(
+            {}, "T_TWO", "U_TWO"
+        )["context_channel_id"] == "C_CONTEXT_TWO"
+        assert "C_CONTEXT_ONE" not in assistant_adapter._channel_team
+
+    @pytest.mark.asyncio
+    async def test_agent_view_message_preserves_outer_team_and_turn_context(
+        self, assistant_adapter
+    ):
+        assistant_adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        await assistant_adapter._handle_app_context_changed(
+            {
+                "type": "app_context_changed",
+                "user": "U_USER",
+                "context": {
+                    "entities": [
+                        {
+                            "type": "slack#/types/channel_id",
+                            "value": "C_ACTIVE",
+                        }
+                    ]
+                },
+            },
+            {"team_id": "T_OTHER"},
+        )
+
+        await assistant_adapter._handle_slack_message(
+            {
+                "text": "help me plan",
+                "channel": "D123",
+                "channel_type": "im",
+                "ts": "171.111",
+                "user": "U_USER",
+            },
+            {"team_id": "T_OTHER"},
+        )
+
+        msg_event = assistant_adapter.handle_message.await_args.args[0]
+        assert msg_event.source.scope_id == "T_OTHER"
+        assert msg_event.metadata["slack_team_id"] == "T_OTHER"
+        assert msg_event.source.thread_id == "171.111"
+        assert msg_event.text.startswith(
+            "[Slack app context: user is viewing channel C_ACTIVE]"
+        )
+
+        runner = object.__new__(GatewayRunner)
+        assert runner._thread_metadata_for_source(msg_event.source) == {
+            "thread_id": "171.111",
+            "slack_team_id": "T_OTHER",
+        }
 
     @pytest.mark.asyncio
     async def test_dm_message_sets_assistant_thread_title_once(
@@ -4343,6 +4476,27 @@ class TestThreadContextUnverifiedTagging:
         assert "[unverified]" not in content
         assert "identity hasn't" not in content
         assert "[Thread context — prior messages in this thread (not yet in conversation history):]" in content
+
+    @pytest.mark.asyncio
+    async def test_thread_context_uses_workspace_client(self, adapter):
+        team_client = AsyncMock()
+        team_client.conversations_replies = self._make_replies(self._thread_messages())
+        adapter._team_clients["T_OTHER"] = team_client
+        adapter._thread_context_cache.clear()
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            await adapter._fetch_thread_context(
+                channel_id="C1",
+                thread_ts="100.0",
+                current_ts="999.0",
+                team_id="T_OTHER",
+            )
+
+        team_client.conversations_replies.assert_awaited_once()
+        adapter._app.client.conversations_replies.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_all_authorized_no_tags(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -800,6 +800,7 @@ class TestSlackProxyBehavior:
         assert adapter._handler is not None
         assert adapter._handler.proxy == "http://proxy.example.com:3128"
         assert adapter._handler.client.proxy == "http://proxy.example.com:3128"
+        assert "hermes_feedback" in created_apps[0].registered_actions
 
     @pytest.mark.asyncio
     async def test_connect_clears_proxy_when_no_proxy_matches_slack(self):
@@ -2148,7 +2149,10 @@ class TestSendTyping:
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {
+            "thread_ts": "parent_ts",
+            "team_id": "",
+        }
 
         result = await adapter.edit_message(
             "C123",
@@ -2159,7 +2163,113 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert adapter._active_status_threads["C123"]["thread_ts"] == "parent_ts"
+
+    @pytest.mark.asyncio
+    async def test_status_uses_workspace_client_from_metadata(self, adapter):
+        team_client = AsyncMock()
+        adapter._team_clients["T_OTHER"] = team_client
+
+        await adapter.send_typing(
+            "D123",
+            metadata={"thread_id": "parent_ts", "team_id": "T_OTHER"},
+        )
+        await adapter.stop_typing("D123")
+
+        assert team_client.assistant_threads_setStatus.call_args_list == [
+            call(channel_id="D123", thread_ts="parent_ts", status="is thinking..."),
+            call(channel_id="D123", thread_ts="parent_ts", status=""),
+        ]
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_status_accepts_slack_team_metadata_key(self, adapter):
+        team_client = AsyncMock()
+        adapter._team_clients["T_OTHER"] = team_client
+
+        await adapter.send_typing(
+            "D123",
+            metadata={"thread_id": "parent_ts", "slack_team_id": "T_OTHER"},
+        )
+        await adapter.stop_typing("D123", metadata={"slack_team_id": "T_OTHER"})
+
+        assert team_client.assistant_threads_setStatus.call_args_list == [
+            call(channel_id="D123", thread_ts="parent_ts", status="is thinking..."),
+            call(channel_id="D123", thread_ts="parent_ts", status=""),
+        ]
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_status_tracking_is_per_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.send_typing("D123", metadata={"thread_id": "thread_a"})
+        await adapter.send_typing("D123", metadata={"thread_id": "thread_b"})
+        await adapter.stop_typing("D123", metadata={"thread_id": "thread_a"})
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list == [
+            call(channel_id="D123", thread_ts="thread_a", status="is thinking..."),
+            call(channel_id="D123", thread_ts="thread_b", status="is thinking..."),
+            call(channel_id="D123", thread_ts="thread_a", status=""),
+        ]
+        assert ("D123", "thread_a") not in adapter._active_status_threads
+        assert adapter._active_status_threads[("D123", "thread_b")] == {
+            "thread_ts": "thread_b",
+            "team_id": "",
+        }
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_edit_uses_workspace_client_from_metadata(
+        self, adapter
+    ):
+        team_client = AsyncMock()
+        team_client.chat_update = AsyncMock()
+        team_client.assistant_threads_setStatus = AsyncMock()
+        adapter._team_clients["T_OTHER"] = team_client
+        adapter._active_status_threads["D123"] = {
+            "thread_ts": "parent_ts",
+            "team_id": "T_OTHER",
+        }
+
+        result = await adapter.edit_message(
+            "D123",
+            "reply_ts",
+            "done",
+            finalize=True,
+            metadata={"thread_id": "parent_ts", "slack_team_id": "T_OTHER"},
+        )
+
+        assert result.success
+        team_client.chat_update.assert_awaited_once_with(
+            channel="D123",
+            ts="reply_ts",
+            text="done",
+        )
+        team_client.assistant_threads_setStatus.assert_awaited_once_with(
+            channel_id="D123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        adapter._app.client.chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_failure_clears_status(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=Exception("boom"))
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {
+            "thread_ts": "parent_ts",
+            "team_id": "",
+        }
+
+        result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
+
+        assert not result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
 
 
 # ---------------------------------------------------------------------------
@@ -3066,6 +3176,144 @@ class TestAssistantThreadLifecycle:
         assert len(assistant_adapter._assistant_threads) <= 10
         # The newest entry must survive eviction
         assert ("D999", "999.000") in assistant_adapter._assistant_threads
+
+    def test_suggested_prompts_config_accepts_dict_shape(self, assistant_adapter):
+        assistant_adapter.config.extra["suggested_prompts"] = {
+            "title": "Try these",
+            "prompts": [
+                {"title": "Summarize", "message": "Summarize this conversation"},
+                {"title": "", "message": "skip me"},
+                {"title": "Draft", "message": "Draft a reply"},
+            ],
+        }
+
+        title, prompts = assistant_adapter._assistant_suggested_prompts()
+
+        assert title == "Try these"
+        assert prompts == [
+            {"title": "Summarize", "message": "Summarize this conversation"},
+            {"title": "Draft", "message": "Draft a reply"},
+        ]
+
+    def test_suggested_prompts_config_caps_at_four(self, assistant_adapter):
+        assistant_adapter.config.extra["suggested_prompts"] = [
+            {"title": f"Prompt {i}", "message": f"Message {i}"}
+            for i in range(6)
+        ]
+
+        _title, prompts = assistant_adapter._assistant_suggested_prompts()
+
+        assert len(prompts) == 4
+        assert prompts[-1] == {"title": "Prompt 3", "message": "Message 3"}
+
+    @pytest.mark.asyncio
+    async def test_app_home_messages_tab_sets_agent_suggested_prompts(
+        self, assistant_adapter
+    ):
+        assistant_adapter.config.extra["suggested_prompts"] = {
+            "title": "Start here",
+            "prompts": [{"title": "Plan", "message": "Help me plan the work"}],
+        }
+        assistant_adapter._app.client.assistant_threads_setSuggestedPrompts = (
+            AsyncMock()
+        )
+        event = {
+            "type": "app_home_opened",
+            "tab": "messages",
+            "team": "T_TEAM",
+            "channel": "D123",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_app_home_opened(event)
+
+        assistant_adapter._app.client.assistant_threads_setSuggestedPrompts.assert_awaited_once_with(
+            channel_id="D123",
+            title="Start here",
+            prompts=[{"title": "Plan", "message": "Help me plan the work"}],
+        )
+
+    @pytest.mark.asyncio
+    async def test_assistant_lifecycle_sets_thread_suggested_prompts(
+        self, assistant_adapter
+    ):
+        assistant_adapter.config.extra["suggested_prompts"] = [
+            {"title": "Summarize", "message": "Summarize the current thread"}
+        ]
+        assistant_adapter._app.client.assistant_threads_setSuggestedPrompts = (
+            AsyncMock()
+        )
+        event = {
+            "type": "assistant_thread_started",
+            "team_id": "T_TEAM",
+            "assistant_thread": {
+                "channel_id": "D123",
+                "thread_ts": "171.000",
+                "user_id": "U_USER",
+            },
+        }
+
+        await assistant_adapter._handle_assistant_thread_lifecycle_event(event)
+
+        assistant_adapter._app.client.assistant_threads_setSuggestedPrompts.assert_awaited_once_with(
+            channel_id="D123",
+            prompts=[
+                {"title": "Summarize", "message": "Summarize the current thread"}
+            ],
+            thread_ts="171.000",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dm_message_sets_assistant_thread_title_once(
+        self, assistant_adapter
+    ):
+        assistant_adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+        event = {
+            "text": "Please summarize this incident thread",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "171.111",
+            "team": "T_TEAM",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_slack_message(event)
+        await assistant_adapter._handle_slack_message(
+            {**event, "ts": "171.222", "thread_ts": "171.111"}
+        )
+
+        assistant_adapter._app.client.assistant_threads_setTitle.assert_awaited_once_with(
+            channel_id="D123",
+            thread_ts="171.111",
+            title="Please summarize this incident thread",
+        )
+        msg_event = assistant_adapter.handle_message.call_args[0][0]
+        assert msg_event.metadata["slack_team_id"] == "T_TEAM"
+
+    @pytest.mark.asyncio
+    async def test_dm_message_title_can_be_disabled(self, assistant_adapter):
+        assistant_adapter.config.extra["assistant_thread_titles"] = False
+        assistant_adapter._app.client.users_info = AsyncMock(return_value={"user": {}})
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+        event = {
+            "text": "title me",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "171.111",
+            "team": "T_TEAM",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_slack_message(event)
+
+        assistant_adapter._app.client.assistant_threads_setTitle.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2097,7 +2097,7 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_stop_typing_noop_without_tracked_thread(self, adapter):
@@ -2109,7 +2109,10 @@ class TestSendTyping:
 
     @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("", "C123", "parent_ts")] = {
+            "thread_ts": "parent_ts",
+            "team_id": "",
+        }
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
@@ -2121,7 +2124,7 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_send_clears_status_after_final_post(self, adapter):
@@ -2129,7 +2132,10 @@ class TestSendTyping:
             return_value={"ts": "reply_ts"}
         )
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("", "C123", "parent_ts")] = {
+            "thread_ts": "parent_ts",
+            "team_id": "",
+        }
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -2140,13 +2146,16 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("", "C123", "parent_ts")] = {
+            "thread_ts": "parent_ts",
+            "team_id": "",
+        }
 
         result = await adapter.edit_message(
             "C123",
@@ -2166,13 +2175,13 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = {
+        adapter._active_status_threads[("", "C123", "parent_ts")] = {
             "thread_ts": "parent_ts",
             "team_id": "",
         }
@@ -2186,7 +2195,9 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"]["thread_ts"] == "parent_ts"
+        assert adapter._active_status_threads[("", "C123", "parent_ts")][
+            "thread_ts"
+        ] == "parent_ts"
 
     @pytest.mark.asyncio
     async def test_status_uses_workspace_client_from_metadata(self, adapter):
@@ -2235,8 +2246,8 @@ class TestSendTyping:
             call(channel_id="D123", thread_ts="thread_b", status="is thinking..."),
             call(channel_id="D123", thread_ts="thread_a", status=""),
         ]
-        assert ("D123", "thread_a") not in adapter._active_status_threads
-        assert adapter._active_status_threads[("D123", "thread_b")] == {
+        assert ("", "D123", "thread_a") not in adapter._active_status_threads
+        assert adapter._active_status_threads[("", "D123", "thread_b")] == {
             "thread_ts": "thread_b",
             "team_id": "",
         }
@@ -2256,7 +2267,30 @@ class TestSendTyping:
             call(channel_id="D123", thread_ts="thread_b", status="is thinking..."),
             call(channel_id="D123", thread_ts="thread_a", status=""),
         ]
-        assert ("D123", "thread_b") in adapter._active_status_threads
+        assert ("", "D123", "thread_b") in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_status_tracking_is_scoped_per_workspace(self, adapter):
+        one, two = AsyncMock(), AsyncMock()
+        adapter._team_clients.update({"T_ONE": one, "T_TWO": two})
+
+        await adapter.send_typing(
+            "D_SHARED", metadata={"thread_id": "171.000", "slack_team_id": "T_ONE"}
+        )
+        await adapter.send_typing(
+            "D_SHARED", metadata={"thread_id": "171.000", "slack_team_id": "T_TWO"}
+        )
+        await adapter.stop_typing(
+            "D_SHARED", metadata={"thread_id": "171.000", "slack_team_id": "T_ONE"}
+        )
+
+        assert one.assistant_threads_setStatus.call_args_list[-1] == call(
+            channel_id="D_SHARED", thread_ts="171.000", status=""
+        )
+        assert two.assistant_threads_setStatus.call_args_list[-1] == call(
+            channel_id="D_SHARED", thread_ts="171.000", status="is thinking..."
+        )
+        assert ("T_TWO", "D_SHARED", "171.000") in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_final_edit_uses_workspace_client_from_metadata(
@@ -2266,7 +2300,7 @@ class TestSendTyping:
         team_client.chat_update = AsyncMock()
         team_client.assistant_threads_setStatus = AsyncMock()
         adapter._team_clients["T_OTHER"] = team_client
-        adapter._active_status_threads["D123"] = {
+        adapter._active_status_threads[("T_OTHER", "D123", "parent_ts")] = {
             "thread_ts": "parent_ts",
             "team_id": "T_OTHER",
         }
@@ -2296,7 +2330,7 @@ class TestSendTyping:
     async def test_send_failure_clears_status(self, adapter):
         adapter._app.client.chat_postMessage = AsyncMock(side_effect=Exception("boom"))
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = {
+        adapter._active_status_threads[("", "C123", "parent_ts")] = {
             "thread_ts": "parent_ts",
             "team_id": "",
         }
@@ -2309,7 +2343,7 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("", "C123", "parent_ts") not in adapter._active_status_threads
 
 
 # ---------------------------------------------------------------------------
@@ -3108,7 +3142,9 @@ class TestAssistantThreadLifecycle:
         await assistant_adapter._handle_assistant_thread_lifecycle_event(event)
 
         assert (
-            assistant_adapter._assistant_threads[("D123", "171.000")]["user_id"]
+            assistant_adapter._assistant_threads[("T_TEAM", "D123", "171.000")][
+                "user_id"
+            ]
             == "U_USER"
         )
         mock_session_store.get_or_create_session.assert_called_once()
@@ -3163,7 +3199,7 @@ class TestAssistantThreadLifecycle:
     async def test_message_uses_cached_assistant_thread_identity(
         self, assistant_adapter
     ):
-        assistant_adapter._assistant_threads[("D123", "171.000")] = {
+        assistant_adapter._assistant_threads[("T_TEAM", "D123", "171.000")] = {
             "channel_id": "D123",
             "thread_ts": "171.000",
             "user_id": "U_USER",
@@ -3214,8 +3250,8 @@ class TestAssistantThreadLifecycle:
             }
         )
         assert len(assistant_adapter._assistant_threads) <= 10
-        # The newest entry must survive eviction
-        assert ("D999", "999.000") in assistant_adapter._assistant_threads
+        # The newest entry must survive eviction.
+        assert ("", "D999", "999.000") in assistant_adapter._assistant_threads
 
     def test_suggested_prompts_config_accepts_dict_shape(self, assistant_adapter):
         assistant_adapter.config.extra["suggested_prompts"] = {
@@ -3345,6 +3381,37 @@ class TestAssistantThreadLifecycle:
             {}, "T_TWO", "U_TWO"
         )["context_channel_id"] == "C_CONTEXT_TWO"
         assert "C_CONTEXT_ONE" not in assistant_adapter._channel_team
+
+    @pytest.mark.asyncio
+    async def test_assistant_thread_cache_is_scoped_per_workspace(
+        self, assistant_adapter
+    ):
+        """Slack Connect can reuse a channel/thread pair in multiple workspaces."""
+        for team_id, user_id in (("T_ONE", "U_ONE"), ("T_TWO", "U_TWO")):
+            await assistant_adapter._handle_assistant_thread_lifecycle_event(
+                {
+                    "type": "assistant_thread_started",
+                    "team_id": team_id,
+                    "assistant_thread": {
+                        "channel_id": "D_SHARED",
+                        "thread_ts": "171.000",
+                        "user_id": user_id,
+                    },
+                }
+            )
+
+        assert assistant_adapter._assistant_threads[
+            ("T_ONE", "D_SHARED", "171.000")
+        ]["user_id"] == "U_ONE"
+        assert assistant_adapter._assistant_threads[
+            ("T_TWO", "D_SHARED", "171.000")
+        ]["user_id"] == "U_TWO"
+        assert assistant_adapter._lookup_assistant_thread_metadata(
+            {}, channel_id="D_SHARED", thread_ts="171.000", team_id="T_ONE"
+        )["user_id"] == "U_ONE"
+        assert assistant_adapter._lookup_assistant_thread_metadata(
+            {}, channel_id="D_SHARED", thread_ts="171.000", team_id="T_TWO"
+        )["user_id"] == "U_TWO"
 
     @pytest.mark.asyncio
     async def test_agent_view_message_preserves_outer_team_and_turn_context(
@@ -3494,6 +3561,23 @@ class TestUserNameResolution:
         )
         name = await adapter._resolve_user_name("U123")
         assert name == "U123"  # Falls back to user_id
+
+    @pytest.mark.asyncio
+    async def test_workspace_scoped_cache_uses_each_workspace_client(self, adapter):
+        """The same Slack user ID can resolve differently in another workspace."""
+        team_one, team_two = AsyncMock(), AsyncMock()
+        team_one.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Alice"}}}
+        )
+        team_two.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Bob"}}}
+        )
+        adapter._team_clients.update({"T_ONE": team_one, "T_TWO": team_two})
+
+        assert await adapter._resolve_user_name("U_SHARED", "D_SHARED", "T_ONE") == "Alice"
+        assert await adapter._resolve_user_name("U_SHARED", "D_SHARED", "T_TWO") == "Bob"
+        team_one.users_info.assert_awaited_once_with(user="U_SHARED")
+        team_two.users_info.assert_awaited_once_with(user="U_SHARED")
 
     @pytest.mark.asyncio
     async def test_user_name_in_message_source(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -238,6 +238,7 @@ class TestAppMentionHandler:
 
         assert "message" in registered_events
         assert "app_mention" in registered_events
+        assert "app_home_opened" in registered_events
         assert "reaction_added" in registered_events
         assert "reaction_removed" in registered_events
         assert "assistant_thread_started" in registered_events
@@ -2914,7 +2915,7 @@ class TestThreadReplyHandling:
 
 
 class TestAssistantThreadLifecycle:
-    """Slack Assistant lifecycle events should seed session/user context."""
+    """Slack AI lifecycle events should seed session/user context."""
 
     @pytest.fixture()
     def mock_session_store(self):
@@ -2967,6 +2968,46 @@ class TestAssistantThreadLifecycle:
         assert source.user_id == "U_USER"
         assert source.thread_id == "171.000"
         assert source.chat_topic == "C_ORIGIN"
+
+    @pytest.mark.asyncio
+    async def test_app_home_messages_tab_seeds_dm_session(
+        self, assistant_adapter, mock_session_store
+    ):
+        event = {
+            "type": "app_home_opened",
+            "tab": "messages",
+            "team": "T_TEAM",
+            "channel": "D123",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_app_home_opened(event)
+
+        mock_session_store.get_or_create_session.assert_called_once()
+        source = mock_session_store.get_or_create_session.call_args[0][0]
+        assert source.chat_id == "D123"
+        assert source.chat_type == "dm"
+        assert source.user_id == "U_USER"
+        assert source.thread_id is None
+        assert assistant_adapter._channel_team["D123"] == "T_TEAM"
+        assistant_adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_app_home_non_messages_tab_is_ignored(
+        self, assistant_adapter, mock_session_store
+    ):
+        event = {
+            "type": "app_home_opened",
+            "tab": "home",
+            "team": "T_TEAM",
+            "channel": "D123",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_app_home_opened(event)
+
+        mock_session_store.get_or_create_session.assert_not_called()
+        assistant_adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_message_uses_cached_assistant_thread_identity(

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -431,7 +431,7 @@ class TestSlackThreadContext:
         })
 
         # Mock user name resolution
-        adapter._user_name_cache = {"U1": "Alice", "U2": "Bob"}
+        adapter._user_name_cache = {("T1", "U1"): "Alice", ("T1", "U2"): "Bob"}
 
         context = await adapter._fetch_thread_context(
             channel_id="C1",
@@ -478,7 +478,10 @@ class TestSlackThreadContext:
                 {"ts": "1000.2", "user": "U1", "text": "Current"},
             ]
         })
-        adapter._user_name_cache = {"U1": "Alice", "U_OTHER_BOT": "DeployBot"}
+        adapter._user_name_cache = {
+            ("T1", "U1"): "Alice",
+            ("T1", "U_OTHER_BOT"): "DeployBot",
+        }
 
         context = await adapter._fetch_thread_context(
             channel_id="C1", thread_ts="1000.0", current_ts="1000.2", team_id="T1"
@@ -531,7 +534,7 @@ class TestSlackThreadContext:
                 {"ts": "1000.1", "user": "U1", "text": "詳細を教えて"},
             ]
         })
-        adapter._user_name_cache = {"U1": "Alice"}
+        adapter._user_name_cache = {("T1", "U1"): "Alice"}
 
         context = await adapter._fetch_thread_context(
             channel_id="C1",
@@ -565,7 +568,7 @@ class TestSlackThreadContext:
                 {"ts": "1000.3", "user": "U1", "text": "Current"},
             ]
         })
-        adapter._user_name_cache = {"U1": "Alice"}
+        adapter._user_name_cache = {("T1", "U1"): "Alice"}
 
         context = await adapter._fetch_thread_context(
             channel_id="C1", thread_ts="1000.0", current_ts="1000.3", team_id="T1"
@@ -613,7 +616,7 @@ class TestSlackThreadContext:
                 {"ts": "2000.3", "user": "U2", "text": "Current"},
             ]
         })
-        adapter._user_name_cache = {"U2": "Bob"}
+        adapter._user_name_cache = {("T2", "U2"): "Bob"}
 
         context = await adapter._fetch_thread_context(
             channel_id="C2", thread_ts="2000.0", current_ts="2000.3", team_id="T2"
@@ -636,7 +639,7 @@ class TestSlackThreadContext:
                 {"ts": "1000.1", "user": "U1", "text": "DO NOT INCLUDE THIS"},
             ]
         })
-        adapter._user_name_cache = {"U1": "Alice"}
+        adapter._user_name_cache = {("T1", "U1"): "Alice"}
 
         context = await adapter._fetch_thread_context(
             channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -323,6 +323,18 @@ class TestSlackInteractiveAuth:
         assert runner.seen_sources[0].chat_id == "C1"
         assert runner.seen_sources[0].chat_type == "group"
 
+    def test_passes_workspace_scope_to_gateway_runner_auth(self):
+        adapter = _make_adapter()
+        runner = _attach_auth_runner(adapter)
+
+        assert adapter._is_interactive_user_authorized(
+            "U_OK",
+            channel_id="C1",
+            user_name="operator",
+            team_id="T1",
+        ) is True
+        assert runner.seen_sources[0].scope_id == "T1"
+
 
 class TestSlackSlashConfirmAction:
     @pytest.mark.asyncio
@@ -363,6 +375,40 @@ class TestSlackSlashConfirmAction:
         )
         mock_client.chat_update.assert_called_once()
         mock_client.chat_postMessage.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_action_uses_outer_payload_workspace_client(self, monkeypatch):
+        adapter = _make_adapter()
+        secondary_client = AsyncMock()
+        adapter._team_clients["T2"] = secondary_client
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_OWNER")
+
+        ack = AsyncMock()
+        body = {
+            "team_id": "T2",
+            "message": {
+                "ts": "2222.3333",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "Original prompt"}},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {
+            "action_id": "hermes_confirm_once",
+            "value": "agent:main:slack:group:C1:1111|confirm-1",
+        }
+
+        with patch("tools.slash_confirm.resolve", new=AsyncMock(return_value="follow-up")):
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        secondary_client.chat_update.assert_awaited_once()
+        secondary_client.chat_postMessage.assert_awaited_once()
+        adapter._team_clients["T1"].chat_update.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -77,6 +77,18 @@ class TestSendMessageBlocks:
             assert "blocks" not in c.kwargs
             assert c.kwargs["text"]
 
+    @pytest.mark.asyncio
+    async def test_feedback_buttons_opt_in_appended_to_blocks(self):
+        adapter, client = _make_adapter({"feedback_buttons": True})
+
+        await adapter.send("C1", "final answer")
+
+        blocks = client.chat_postMessage.await_args.kwargs["blocks"]
+        feedback = blocks[-1]
+        assert feedback["type"] == "context_actions"
+        assert feedback["elements"][0]["type"] == "feedback_buttons"
+        assert feedback["elements"][0]["action_id"] == "hermes_feedback"
+
 
 class TestEditMessageBlocks:
     @pytest.mark.asyncio
@@ -94,6 +106,13 @@ class TestEditMessageBlocks:
         kwargs = client.chat_update.await_args.kwargs
         assert "blocks" in kwargs and kwargs["blocks"]
         assert kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_finalize_edit_gets_feedback_buttons_when_enabled(self):
+        adapter, client = _make_adapter({"rich_blocks": True, "feedback_buttons": True})
+        await adapter.edit_message("C1", "111.222", RICH_MD, finalize=True)
+        blocks = client.chat_update.await_args.kwargs["blocks"]
+        assert blocks[-1]["elements"][0]["type"] == "feedback_buttons"
 
     @pytest.mark.asyncio
     async def test_finalize_edit_disabled_no_blocks(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -79,7 +79,7 @@ class TestSendMessageBlocks:
 
     @pytest.mark.asyncio
     async def test_feedback_buttons_opt_in_appended_to_blocks(self):
-        adapter, client = _make_adapter({"feedback_buttons": True})
+        adapter, client = _make_adapter({"rich_blocks": True, "feedback_buttons": True})
 
         await adapter.send("C1", "final answer")
 
@@ -88,6 +88,15 @@ class TestSendMessageBlocks:
         assert feedback["type"] == "context_actions"
         assert feedback["elements"][0]["type"] == "feedback_buttons"
         assert feedback["elements"][0]["action_id"] == "hermes_feedback"
+
+    @pytest.mark.asyncio
+    async def test_feedback_buttons_require_rich_blocks(self):
+        """feedback_buttons alone must not implicitly enable Block Kit rendering."""
+        adapter, client = _make_adapter({"feedback_buttons": True})
+
+        await adapter.send("C1", "final answer")
+
+        assert "blocks" not in client.chat_postMessage.await_args.kwargs
 
 
 class TestEditMessageBlocks:

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -15,7 +15,7 @@ def _parse_slack_args(argv):
 
 
 class TestSlackManifestArgparse:
-    """The `--no-assistant` flag wires through argparse to `no_assistant`."""
+    """Slack manifest messaging-experience flags wire through argparse."""
 
     def test_no_assistant_flag_defaults_false(self):
         args = _parse_slack_args(["slack", "manifest"])
@@ -25,6 +25,13 @@ class TestSlackManifestArgparse:
         args = _parse_slack_args(["slack", "manifest", "--no-assistant"])
         assert args.no_assistant is True
 
+    def test_agent_view_flag_defaults_false(self):
+        args = _parse_slack_args(["slack", "manifest"])
+        assert getattr(args, "agent_view", False) is False
+
+    def test_agent_view_flag_sets_true(self):
+        args = _parse_slack_args(["slack", "manifest", "--agent-view"])
+        assert args.agent_view is True
 
 
 class TestSlackFullManifest:
@@ -77,6 +84,7 @@ class TestSlackFullManifest:
         manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
 
         assert "assistant_view" in manifest["features"]
+        assert "agent_view" not in manifest["features"]
         assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "assistant_thread_started" in bot_events
@@ -89,8 +97,35 @@ class TestSlackFullManifest:
         # assistant_view feature is gone -> Slack renders a flat DM, not the
         # Assistant thread pane (where bare slash commands don't dispatch).
         assert "assistant_view" not in manifest["features"]
+        assert "agent_view" not in manifest["features"]
         assert "assistant:write" not in manifest["oauth_config"]["scopes"]["bot"]
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "assistant_thread_started" not in bot_events
+        assert "assistant_thread_context_changed" not in bot_events
+
+    def test_agent_view_uses_agent_manifest_surface(self):
+        manifest = _build_full_manifest(
+            "Hermes",
+            "Your Hermes agent on Slack",
+            messaging_experience="agent",
+        )
+
+        assert manifest["features"]["agent_view"] == {
+            "agent_description": "Chat with Hermes in Slack Messages.",
+        }
+        assert "assistant_view" not in manifest["features"]
+        assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
+
+    def test_agent_view_uses_agent_event_subscriptions(self):
+        manifest = _build_full_manifest(
+            "Hermes",
+            "Your Hermes agent on Slack",
+            messaging_experience="agent",
+        )
+
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "app_home_opened" in bot_events
+        assert "message.im" in bot_events
         assert "assistant_thread_started" not in bot_events
         assert "assistant_thread_context_changed" not in bot_events
 

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -125,6 +125,7 @@ class TestSlackFullManifest:
 
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "app_home_opened" in bot_events
+        assert "app_context_changed" in bot_events
         assert "message.im" in bot_events
         assert "assistant_thread_started" not in bot_events
         assert "assistant_thread_context_changed" not in bot_events

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -168,8 +168,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp==3.14.1",  # CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
     ),
     "platform.slack": (
-        "slack-bolt==1.27.0",
-        "slack-sdk==3.40.1",
+        "slack-bolt==1.29.0",
+        "slack-sdk==3.43.0",
         "aiohttp==3.14.1",  # CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
     ),
     "platform.matrix": (

--- a/uv.lock
+++ b/uv.lock
@@ -1834,10 +1834,10 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==81.0.0" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = "==1.6.6" },
-    { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.27.0" },
-    { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.27.0" },
-    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.40.1" },
-    { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.40.1" },
+    { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.29.0" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.29.0" },
+    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.43.0" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = "==0.5.5" },
     { name = "starlette", marker = "extra == 'computer-use'", specifier = "==1.0.1" },
     { name = "starlette", marker = "extra == 'dev'", specifier = "==1.0.1" },
@@ -3889,23 +3889,23 @@ wheels = [
 
 [[package]]
 name = "slack-bolt"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "slack-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/28/50ed0b86e48b48e6ddcc71de93b91c8ac14a55d1249e4bff0586494a2f90/slack_bolt-1.27.0.tar.gz", hash = "sha256:3db91d64e277e176a565c574ae82748aa8554f19e41a4fceadca4d65374ce1e0", size = 129101, upload-time = "2025-11-13T20:17:46.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/2c/7434f5d8c52eafb1e702012e9f291b013bd05985a5b32bde568b2279a28a/slack_bolt-1.29.0.tar.gz", hash = "sha256:b6271ba0a9b71e319c86b40632e6cb6240aacd0433773615b76b890b9a574762", size = 131151, upload-time = "2026-06-30T20:24:44.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/a8/1acb355759747ba4da5f45c1a33d641994b9e04b914908c9434f18bd97e8/slack_bolt-1.27.0-py2.py3-none-any.whl", hash = "sha256:c43c94bf34740f2adeb9b55566c83f1e73fed6ba2878bd346cdfd6fd8ad22360", size = 230428, upload-time = "2025-11-13T20:17:45.465Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/cc/e5f78a80a1775a4cbb2cc41e8ef433602d5e755ff0d829bd43145015740a/slack_bolt-1.29.0-py2.py3-none-any.whl", hash = "sha256:1835b66b778158f3af0da77603aa18d7dfd82fd9b9a985e25c752f95050ab826", size = 235345, upload-time = "2026-06-30T20:24:42.558Z" },
 ]
 
 [[package]]
 name = "slack-sdk"
-version = "3.40.1"
+version = "3.43.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/18/784859b33a3f9c8cdaa1eda4115eb9fe72a0a37304718887d12991eeb2fd/slack_sdk-3.40.1.tar.gz", hash = "sha256:a215333bc251bc90abf5f5110899497bf61a3b5184b6d9ee35d73ebf09ec3fd0", size = 250379, upload-time = "2026-02-18T22:11:01.819Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/75/a4964eb771a0c74d79ee7a3bee6fb5d9718909dd1b675e80d62a6a0ad90a/slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07", size = 252769, upload-time = "2026-06-30T18:04:41.59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/e1/bb81f93c9f403e3b573c429dd4838ec9b44e4ef35f3b0759eb49557ab6e3/slack_sdk-3.40.1-py2.py3-none-any.whl", hash = "sha256:cd8902252979aa248092b0d77f3a9ea3cc605bc5d53663ad728e892e26e14a65", size = 313687, upload-time = "2026-02-18T22:11:00.027Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/42141b8338d46323d5b3c6095201b044c670c20f898643b322ea9b1543a1/slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585", size = 315866, upload-time = "2026-06-30T18:04:39.636Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -36,12 +36,13 @@ Mode — all at once.
 
 ### Option A: From a Hermes-generated manifest (recommended)
 
-1. Generate the manifest:
+1. Generate the manifest. New Slack apps must use Agent view:
    ```bash
-   hermes slack manifest --write
+   hermes slack manifest --agent-view --write
    ```
    This writes `~/.hermes/slack-manifest.json` and prints paste-in
-   instructions.
+   instructions. Existing apps that still use Slack's legacy Assistant view
+   can omit `--agent-view` until they are ready to migrate.
 2. Go to [https://api.slack.com/apps](https://api.slack.com/apps) →
    **Create New App** → **From an app manifest**
 3. Pick your workspace, paste the JSON contents, review, click **Next**
@@ -243,6 +244,23 @@ Step 1, Option A) that declares every command in
 as a slash command. In Socket Mode, Slack routes the command event
 through the WebSocket regardless of the manifest's `url` field.
 
+### Agent messaging experience
+
+New Slack apps use Slack's **Agent** messaging experience. Existing Hermes
+Assistant apps can migrate by regenerating the manifest with `--agent-view`:
+
+```bash
+hermes slack manifest --agent-view --write
+```
+
+Update the manifest in **Features → App Manifest**, then reinstall the app if
+Slack asks. Agent view cannot be reverted to Assistant view, and users may need
+to hard-refresh Slack after the switch. The generated Agent manifest subscribes
+to `message.im`, `app_home_opened`, and `app_context_changed`, so Hermes can
+identify a Messages-tab DM and receive the user's active Slack context with a
+turn. Hermes only supplies that context as a label; it does not read the viewed
+channel's history.
+
 ### Refreshing slash commands after updates
 
 When Hermes adds new commands (e.g. after `hermes update`), regenerate
@@ -353,6 +371,19 @@ platforms:
       # gracefully fall back to aligned monospace.
       rich_blocks: false
 
+      # Append Slack-native feedback controls to final Block Kit replies.
+      # Requires rich_blocks: true. Default: false.
+      feedback_buttons: false
+
+      # Suggested prompts pinned at the top of Agent view's Messages tab.
+      # Either a list of {title, message} rows, or a titled object:
+      # {title: "Start here", prompts: [{title: "Plan", message: "..."}]}
+      suggested_prompts: []
+
+      # Title Agent/Assistant DM threads from the first user message.
+      # Default: true. Set false to leave Slack's default thread titles.
+      assistant_thread_titles: true
+
       # Continuable-cron delivery surface (default: "thread").
       # "in_channel" delivers a continuable cron job FLAT into the channel
       # (no dedicated thread); pair with reply_in_thread: false (and
@@ -367,6 +398,9 @@ platforms:
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
+| `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
+| `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
+| `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
 
 ### Session Isolation


### PR DESCRIPTION
## Summary

Salvages the implementation from #56786 with credit to @SemonCat, rebased onto current `main`.

- adds Slack Agent-view manifest support, including the required `app_context_changed` subscription and handler
- carries Slack workspace identity from the outer Bolt payload through `SessionSource` and all outbound Slack paths, preventing non-primary workspaces from falling back to the primary client
- scopes Agent-view context by workspace and user, injects it only into the active user turn, and avoids prompt-cache churn
- preserves per-thread Assistant status routing through normal, error, and interrupt cleanup, so one concurrent thread cannot clear another thread's status
- routes attachment uploads, approval/confirmation actions, reactions, stream edits, titles, prompts, and status updates through the workspace-specific client
- documents Agent-view setup plus `feedback_buttons`, `suggested_prompts`, and `assistant_thread_titles`
- maps the original contributor email for release attribution

## Validation

- `339 passed` — focused Slack, Agent-view, approval, Block Kit, CLI manifest, and gateway progress/cleanup suites
- `ruff check` and Python compilation passed
- manifest smoke test verifies `app_home_opened`, `app_context_changed`, and `message.im`
- mocked runtime E2E covers non-primary workspace routing, outer Bolt `team_id`, scoped Agent context, metadata propagation, and sibling-safe status cleanup
- Docusaurus production build completed; it retains unrelated pre-existing broken-link/anchor warnings

The focused suite emitted existing/nondeterministic `AsyncMock` unawaited-coroutine warnings but no test failures.

## Credit

Implementation salvaged from #56786 by @SemonCat; this branch preserves the contributor-authored feature commits and adds maintainer integration fixes.
