### PR TITLE
fix(tui): decode slash worker streams as UTF-8

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -399,3 +399,26 @@ def test_tui_slash_worker_hides_python_window(monkeypatch):
 
     assert captured[0][0][:3] == [server.sys.executable, "-m", "tui_gateway.slash_worker"]
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_tui_slash_worker_decodes_subprocess_streams_as_utf8(monkeypatch):
+    from tui_gateway import server
+
+    captured = []
+
+    class _Proc:
+        stdin = SimpleNamespace()
+        stdout = []
+        stderr = []
+
+    def fake_popen(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Proc()
+
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None))
+
+    server._SlashWorker("session-key", "model-x")
+
+    assert captured[0][1]["encoding"] == "utf-8"
+    assert captured[0][1]["errors"] == "replace"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -317,6 +317,8 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=env,


### PR DESCRIPTION
## What does this PR do?

Fixes #63686.

On Windows systems using a CJK locale, `subprocess.Popen(..., text=True)` defaults to the system code page (for example GBK). `_SlashWorker` reads UTF-8 output from the slash-worker subprocess without an explicit encoding, so undecodable bytes can raise `UnicodeDecodeError` in the stderr-draining daemon thread and take down the gateway.

The worker now explicitly decodes stdout/stderr as UTF-8 and replaces malformed bytes, preserving the gateway process while retaining diagnostic output.

## Related Issue

Fixes #63686

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Set `encoding="utf-8"` and `errors="replace"` on the persistent `_SlashWorker` subprocess.
- `tests/test_windows_subprocess_no_window_flags.py`
  - Added a regression test that locks the subprocess stream decoding contract.

## How to Test

1. The reported failure mechanism was reproduced on Linux by simulating the Windows GBK locale: decoding UTF-8 subprocess bytes containing `0xAA` with `gbk` raised `UnicodeDecodeError`.
2. Run the focused Windows subprocess contract tests:

```text
scripts/run_tests.sh tests/test_windows_subprocess_no_window_flags.py -q
16 passed
```

3. Run the gateway server regression suite:

```text
scripts/run_tests.sh tests/test_tui_gateway_server.py -q
322 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate; no PR was found for #63686 or `_SlashWorker` encoding.
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused suites were run; the full suite was not run
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS Linux; Windows-specific behavior was validated by a GBK decoding reproduction and subprocess contract test

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A; this is an internal subprocess encoding fix
- [ ] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; architecture/workflow unchanged
- [x] I've considered cross-platform impact; UTF-8 is explicit on all platforms and `errors="replace"` prevents malformed diagnostics from terminating the reader
- [ ] I've updated tool descriptions/schemas — N/A; no tool behavior/schema changed

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Not applicable. The focused tests and gateway regression suite pass; the simulated Windows-locale reproduction produced the reported `UnicodeDecodeError` before the fix path was applied.
