### PR TITLE
fix(desktop): extend voice transcription timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -122,6 +123,20 @@ describe('Hermes REST session helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('allows five minutes for audio transcription', async () => {
+    api.mockResolvedValue({ ok: true, transcript: 'Hallo', provider: 'local' })
+
+    await transcribeAudio('data:audio/webm;base64,ZmFrZQ==', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/audio/transcribe',
+        method: 'POST',
+        timeoutMs: 300_000
+      })
+    )
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -71,6 +71,9 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+// Local Whisper can take tens of seconds to process multi-minute audio.
+// Give transcription five minutes without weakening unrelated requests.
+const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 300_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -1000,7 +1003,8 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
     body: {
       data_url: dataUrl,
       mime_type: mimeType
-    }
+    },
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS
   })
 }
 


### PR DESCRIPTION
## Summary
- give desktop audio transcription requests a dedicated five-minute timeout
- keep the short default timeout for unrelated backend requests
- add regression coverage for the audio request options

## Problem
Long recordings can take local Whisper more than the generic 15-second Electron HTTP timeout to process. The backend continues transcribing, but Desktop aborts first with:

`Timed out connecting to Hermes backend after 15000ms`

## Verification
- `npm run test:ui -- src/hermes.test.ts src/hermes-parity.test.ts` — 21 passed
- `npm run typecheck` — passed
- `npx eslint src/hermes.ts src/hermes.test.ts` — passed
- `npm run build` — passed
- `git diff --check` — passed