### PR TITLE
fix(dashboard): keep plugin metadata for enum-extended platform catalog entries

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -147,6 +147,14 @@ class PlatformEntry:
     # Emoji for CLI/gateway display (e.g. "💬")
     emoji: str = "🔌"
 
+    # One-line description shown on the platform's messaging settings card.
+    # Falls back to ``install_hint`` when empty (legacy behavior).
+    description: str = ""
+
+    # Setup-guide URL for the "Open setup guide" button on the messaging
+    # settings card (e.g. the platform's bot/app-password documentation).
+    docs_url: str = ""
+
     # Whether this platform should appear in _UPDATE_ALLOWED_PLATFORMS
     # (allows /update command from this platform).
     allow_update_command: bool = True

--- a/tests/hermes_cli/test_messaging_platform_catalog.py
+++ b/tests/hermes_cli/test_messaging_platform_catalog.py
@@ -1,0 +1,87 @@
+"""Messaging-catalog metadata for plugin platforms.
+
+Regression coverage for the enum-shadowing bug: a configured plugin platform
+gets dynamically added to the ``Platform`` enum (``Platform._missing_`` via
+``load_gateway_config``), so ``_messaging_platform_catalog()`` sees it in BOTH
+the enum and the plugin registry.  Building its entry from the bare enum
+member dropped ``required_env`` / ``description`` / ``docs_url`` — the
+messaging settings card then rendered "no token needed" with every field
+optional and reported the platform as configured (``all(())`` is True).
+"""
+
+import pytest
+
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+PLATFORM_ID = "catalogtestplat"
+
+
+@pytest.fixture
+def registered_plugin_platform():
+    entry = PlatformEntry(
+        name=PLATFORM_ID,
+        label="Catalog Test Platform",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        required_env=["CATALOGTESTPLAT_URL", "CATALOGTESTPLAT_TOKEN"],
+        install_hint="pip install catalogtestplat",
+        description="A test platform for catalog coverage.",
+        docs_url="https://example.com/setup",
+        source="plugin",
+    )
+    platform_registry.register(entry)
+    try:
+        yield entry
+    finally:
+        platform_registry.unregister(PLATFORM_ID)
+        # Drop the pseudo enum member a test may have created so state
+        # doesn't leak across tests.
+        from gateway.config import Platform
+
+        member = Platform._value2member_map_.pop(PLATFORM_ID, None)
+        if member is not None:
+            Platform._member_map_.pop(member._name_, None)
+
+
+def _catalog_entry():
+    from hermes_cli.web_server import _catalog_lookup
+
+    entry = _catalog_lookup(PLATFORM_ID)
+    assert entry is not None, "plugin platform missing from messaging catalog"
+    return entry
+
+
+def test_plugin_entry_metadata_reaches_catalog(registered_plugin_platform):
+    entry = _catalog_entry()
+    assert entry["required_env"] == ("CATALOGTESTPLAT_URL", "CATALOGTESTPLAT_TOKEN")
+    assert entry["name"] == "Catalog Test Platform"
+    assert entry["description"] == "A test platform for catalog coverage."
+    assert entry["docs_url"] == "https://example.com/setup"
+    # required env vars must lead the card's field list
+    assert entry["env_vars"][:2] == (
+        "CATALOGTESTPLAT_URL",
+        "CATALOGTESTPLAT_TOKEN",
+    )
+
+
+def test_enum_extended_plugin_platform_keeps_metadata(registered_plugin_platform):
+    """The actual regression: platform present in the enum AND the registry."""
+    from gateway.config import Platform
+
+    # Simulate load_gateway_config() materializing the pseudo enum member for
+    # a configured plugin platform.
+    member = Platform(PLATFORM_ID)
+    assert member.value == PLATFORM_ID
+    assert PLATFORM_ID in [m.value for m in Platform.__members__.values()]
+
+    entry = _catalog_entry()
+    assert entry["required_env"] == ("CATALOGTESTPLAT_URL", "CATALOGTESTPLAT_TOKEN")
+    assert entry["description"] == "A test platform for catalog coverage."
+    assert entry["docs_url"] == "https://example.com/setup"
+
+
+def test_description_falls_back_to_install_hint(registered_plugin_platform):
+    registered_plugin_platform.description = ""
+    entry = _catalog_entry()
+    assert entry["description"] == "pip install catalogtestplat"


### PR DESCRIPTION
## Problem

A configured plugin platform is added to the `Platform` enum dynamically (`Platform._missing_`, triggered by `load_gateway_config()`). `_messaging_platform_catalog()` then encounters it in the enum loop FIRST and builds its catalog entry without the registry metadata — the later `plugin_entries()` pass is skipped via `seen`.

The messaging settings card for such a platform renders broken:

- **required_env is empty** → the REQUIRED section shows *"This platform does not need a token here"* even when the plugin declares required env vars, and all fields land under RECOMMENDED in alphabetical prefix-discovery order (the actual credentials end up at the bottom).
- **configured is vacuously true** (`all(())`) → the platform reports as configured before any credential is set.
- **description falls back to install_hint** → the card shows `pip install …` as the platform description, and there is no docs link.

Bundled platform plugins are shielded by their `_PLATFORM_OVERRIDES` entries, so only third-party plugin platforms hit this — which is exactly the audience the standalone-plugin policy (AGENTS.md) points at.

## Fix

- Resolve `platform_registry.plugin_entries()` **before** the enum loop and pass the matching plugin entry into `_build_catalog_entry()` for enum members too.
- `PlatformEntry` gains optional `description` and `docs_url` fields so plugin platforms can populate the settings card the same way curated overrides do. `install_hint` remains the legacy description fallback; `_PLATFORM_OVERRIDES` still wins when present.

## Tests

`tests/hermes_cli/test_messaging_platform_catalog.py`:
- plugin entry metadata (required_env order, name, description, docs_url) reaches the catalog
- the regression case: platform present in **both** the enum and the registry keeps its metadata
- description falls back to install_hint when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)