### PR TITLE
fix(kanban): scope zombie reaper to own worker pids (fixes embedded-dispatcher MCP spawn race)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5982,6 +5982,14 @@ _RECENT_WORKER_EXIT_TTL_SECONDS = 600
 _RECENT_WORKER_EXITS_MAX = 4096
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
 
+# PIDs of workers WE spawned via _default_spawn. reap_worker_zombies() reaps
+# ONLY these (targeted waitpid), never wildcard waitpid(-1). A wildcard reap
+# in a process that also runs asyncio-managed stdio MCP subprocesses (the
+# gateway) steals those children's exit statuses, breaking MCP transport
+# setup with "unhandled errors in a TaskGroup (1 sub-exception)". Carry patch
+# — report upstream so this scoping lands in mainline.
+_spawned_worker_pids: "set[int]" = set()
+
 
 def _record_worker_exit(pid: int, raw_status: int) -> None:
     """Record a reaped child's exit status for later classification.
@@ -6057,18 +6065,24 @@ def reap_worker_zombies() -> "list[int]":
     """
     reaped: "list[int]" = []
     if os.name != "nt":
-        try:
-            while True:
-                try:
-                    pid, status = os.waitpid(-1, os.WNOHANG)
-                except ChildProcessError:
-                    break
-                if pid == 0:
-                    break
-                _record_worker_exit(pid, status)
-                reaped.append(pid)
-        except Exception:
-            pass
+        # Targeted reap: only pids WE spawned. NEVER waitpid(-1) — that would
+        # steal exit statuses of unrelated children (asyncio stdio MCP
+        # servers), breaking their transport. See _spawned_worker_pids.
+        for pid in list(_spawned_worker_pids):
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                # Not our child anymore (already reaped) — stop tracking.
+                _spawned_worker_pids.discard(pid)
+                continue
+            except Exception:
+                continue
+            if wpid == 0:
+                # Still running; keep tracking.
+                continue
+            _record_worker_exit(wpid, status)
+            _spawned_worker_pids.discard(wpid)
+            reaped.append(wpid)
     return reaped
 
 
@@ -8087,6 +8101,9 @@ def _default_spawn(
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    # Track this pid so reap_worker_zombies() reaps it by targeted waitpid
+    # (never wildcard -1, which would break sibling asyncio MCP subprocesses).
+    _spawned_worker_pids.add(proc.pid)
     return proc.pid
 
 


### PR DESCRIPTION
## Problem

With the kanban dispatcher embedded in the gateway (`kanban.dispatch_in_gateway: true`, the default), every stdio MCP server (e.g. gbrain, blofin) fails to connect — or connects, then drops and cannot reconnect — with:

```
MCP server 'gbrain' failed initial connection after 3 attempts, parking...
unhandled errors in a TaskGroup (1 sub-exception)
```

In our deployment this took the agent's entire long-term memory (gbrain) offline for the always-on gateway. A fresh process (no dispatcher) always connected fine; only the long-running gateway with the embedded dispatcher failed — every time.

## Root cause

`reap_worker_zombies()` in `hermes_cli/kanban_db.py` used a wildcard `os.waitpid(-1, WNOHANG)` loop, invoked on every dispatcher tick (`gateway/kanban_watchers.py`). In the gateway process, which *also* runs asyncio-managed stdio MCP subprocesses, that wildcard reap steals the MCP children's exit statuses out from under asyncio's child watcher, breaking the subprocess transport setup on every (re)connect. It's a guaranteed race any time the embedded dispatcher and an stdio MCP server share the process.

## Fix

Track the pids we spawn in `_default_spawn` (`_spawned_worker_pids`) and reap **only** those, via targeted `os.waitpid(pid, WNOHANG)`. Never wildcard. This leaves asyncio in full control of its own children. Same zombie-cleanup coverage for dispatcher workers; no collateral reaping of sibling subprocesses.

## Verification

- Before: every stdio MCP server parked every ~5 min; brain offline.
- After: with `dispatch_in_gateway: true` and the dispatcher reaping every 60s, gbrain (72 tools) and blofin (40 tools) register and stay connected; zero zombie accumulation under the gateway after 45+ min.
- Scoped reaper confirmed to reap its own workers and leave non-worker (MCP-like) children untouched.

3 files' worth of context in one small change to `kanban_db.py` (+registry, +scoped reap, +track-at-spawn).
