### PR TITLE
feat(optional-skills): add foundry-security-reviewer skill

### DIFF
--- a/optional-skills/software-development/foundry-security-reviewer/SKILL.md
+++ b/optional-skills/software-development/foundry-security-reviewer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: foundry-security-reviewer
+description: Run Foundry test/coverage/snapshot and surface security issues in Solidity projects
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [blockchain, security, solidity, foundry, smart-contracts]
+    category: software-development
+---
+
+# Foundry Security Reviewer
+
+Run a repeatable security-review baseline for a Foundry Solidity project. Use the bundled script to collect build, test, coverage, gas, and optional static-analysis evidence into one Markdown report.
+
+## When to Use
+
+- Review a Solidity project that uses Foundry.
+- Perform a Foundry security review or smart-contract audit triage.
+- Prepare a security-focused PR review comment for a smart-contract change.
+
+## Prerequisites
+
+- Require the `forge` CLI on `PATH`.
+- Require a Foundry project root containing `foundry.toml`.
+- Optionally install `slither` for detector findings and `aderyn` for Solidity static analysis.
+- Run from the target project root, or pass the root as the first argument.
+
+## Procedure
+
+1. Confirm the project root contains `foundry.toml`.
+2. Run the bundled reviewer:
+
+   ```bash
+   bash ${HERMES_SKILL_DIR}/scripts/run_review.sh .
+   ```
+
+3. Inspect `review_output.md` in the target project root.
+4. Report compiler errors from `forge build`; do not treat an uncompiled project as audited.
+5. List failing cases from `forge test -vv` and identify the contract or invariant they exercise.
+6. Review the `forge coverage --report summary` table and investigate every module below 80% coverage.
+7. Keep the `forge snapshot` result as the gas baseline; compare later changes against it.
+8. When installed, review Slither HIGH/MEDIUM findings and Aderyn critical findings. Confirm exploitability in code before escalating a finding.
+9. Compare code against [common vulnerabilities](references/common-vulnerabilities.md) and add concrete remediation recommendations.
+10. Paste the report's checklist into the PR review, replacing placeholders with file, function, severity, impact, and test evidence.
+
+## Output Format
+
+Return `review_output.md` as a PR-review-ready Markdown checklist with these sections:
+
+```markdown
+# Foundry Security Review
+
+## Test Results
+- [ ] Build succeeds
+- [ ] Tests pass
+
+## Coverage
+| Module | Coverage | Status |
+| --- | ---: | --- |
+| `src/Example.sol` | 72% | Needs tests |
+
+## Gas Snapshot
+- [ ] Baseline captured
+
+## Security Findings
+- [ ] HIGH — `src/Example.sol:42` — impact and exploit path
+
+## Recommendations
+- [ ] Add a regression test for the confirmed finding.
+```
+
+## Pitfalls
+
+- `forge coverage` can be slow in large projects; narrow it with `--match-contract <ContractName>` when triaging a focused change.
+- Slither can report false positives; note lines suppressed with `# slither-disable` and verify each remaining detector result manually.
+- Gas snapshots can vary between environments; compare them only under a consistent toolchain, compiler, RPC, and test configuration.

--- a/optional-skills/software-development/foundry-security-reviewer/SKILL.md
+++ b/optional-skills/software-development/foundry-security-reviewer/SKILL.md
@@ -1,51 +1,98 @@
 ---
 name: foundry-security-reviewer
-description: Run Foundry test/coverage/snapshot and surface security issues in Solidity projects
+description: "Audit Foundry projects with tests and security tools."
 version: 1.0.0
+author: Ahmet Osrak (Osraka), Hermes Agent
+license: MIT
+platforms: [linux, macos]
 metadata:
   hermes:
     tags: [blockchain, security, solidity, foundry, smart-contracts]
     category: software-development
 ---
 
-# Foundry Security Reviewer
+# Foundry Security Reviewer Skill
 
-Run a repeatable security-review baseline for a Foundry Solidity project. Use the bundled script to collect build, test, coverage, gas, and optional static-analysis evidence into one Markdown report.
+Run a repeatable security-review baseline for a Solidity project that uses
+Foundry. The bundled script records build, test, coverage, gas, and optional
+static-analysis evidence; it does not claim that automated output alone is a
+complete smart-contract audit.
 
 ## When to Use
 
-- Review a Solidity project that uses Foundry.
-- Perform a Foundry security review or smart-contract audit triage.
-- Prepare a security-focused PR review comment for a smart-contract change.
+- The user asks to review a Solidity project that uses Foundry.
+- The user requests smart-contract security triage or audit evidence.
+- The user wants a security-focused PR review checklist.
 
 ## Prerequisites
 
-- Require the `forge` CLI on `PATH`.
-- Require a Foundry project root containing `foundry.toml`.
-- Optionally install `slither` for detector findings and `aderyn` for Solidity static analysis.
-- Run from the target project root, or pass the root as the first argument.
+- The `forge` CLI on `PATH`.
+- A project root containing `foundry.toml`.
+- Optional `slither` and `aderyn` installations for static analysis.
+- The `terminal` and `read_file` tools.
+- Linux or macOS, because the bundled helper uses Bash and POSIX temporary-file
+  primitives.
+
+## How to Run
+
+Invoke the bundled reviewer through the `terminal` tool from the target project
+root, or pass the project root as its first argument:
+
+```text
+bash ${HERMES_SKILL_DIR}/scripts/run_review.sh .
+```
+
+Read the generated `review_output.md` with `read_file` before writing the
+review comment.
+
+## Quick Reference
+
+| Check | Command | Evidence |
+| --- | --- | --- |
+| Build | `forge build` | Compiler status and diagnostics |
+| Tests | `forge test -vv` | Failing cases and traces |
+| Coverage | `forge coverage --report summary` | Modules below 80% |
+| Gas | `forge snapshot` | Baseline for later comparisons |
+| Optional | `slither .`, `aderyn .` | Static-analysis leads |
 
 ## Procedure
 
 1. Confirm the project root contains `foundry.toml`.
-2. Run the bundled reviewer:
+2. Run `scripts/run_review.sh <project-root>` through `terminal`.
+3. Read `review_output.md`; compiler errors mean the project is not ready for
+   a complete review.
+4. List failing cases from `forge test -vv` and identify the contract or
+   invariant each case exercises.
+5. Review the coverage summary and investigate every module below 80%.
+6. Keep the `forge snapshot` result as a gas baseline. Compare later changes
+   only under a consistent toolchain, compiler, RPC, and test configuration.
+7. When installed, inspect Slither HIGH/MEDIUM and Aderyn critical findings.
+   Confirm exploitability in source before escalating a finding.
+8. Compare the code with
+   [common vulnerabilities](references/common-vulnerabilities.md).
+9. Paste the checklist into the PR review and replace placeholders with the
+   affected file, function, severity, impact, and test evidence.
 
-   ```bash
-   bash ${HERMES_SKILL_DIR}/scripts/run_review.sh .
-   ```
+## Pitfalls
 
-3. Inspect `review_output.md` in the target project root.
-4. Report compiler errors from `forge build`; do not treat an uncompiled project as audited.
-5. List failing cases from `forge test -vv` and identify the contract or invariant they exercise.
-6. Review the `forge coverage --report summary` table and investigate every module below 80% coverage.
-7. Keep the `forge snapshot` result as the gas baseline; compare later changes against it.
-8. When installed, review Slither HIGH/MEDIUM findings and Aderyn critical findings. Confirm exploitability in code before escalating a finding.
-9. Compare code against [common vulnerabilities](references/common-vulnerabilities.md) and add concrete remediation recommendations.
-10. Paste the report's checklist into the PR review, replacing placeholders with file, function, severity, impact, and test evidence.
+- `forge coverage` can be slow in large projects; narrow it with
+  `--match-contract <ContractName>` when triaging a focused change.
+- If coverage fails or produces no parseable Solidity coverage rows, the
+  script reports the threshold result as unavailable rather than claiming that
+  no module is below 80%.
+- Slither can report false positives. Check suppressed lines and reachable
+  paths before dismissing or escalating a detector.
+- Gas snapshots vary between environments. Compare them only under consistent
+  toolchain, compiler, RPC, and test settings.
 
-## Output Format
+## Verification
 
-Return `review_output.md` as a PR-review-ready Markdown checklist with these sections:
+Verify that `review_output.md` exists, every required command is marked with
+its actual exit status, and coverage is marked unavailable when its command or
+summary cannot be parsed. Automated findings still require source-level
+validation and a regression test before they are treated as vulnerabilities.
+
+Use this report shape:
 
 ```markdown
 # Foundry Security Review
@@ -66,11 +113,5 @@ Return `review_output.md` as a PR-review-ready Markdown checklist with these sec
 - [ ] HIGH — `src/Example.sol:42` — impact and exploit path
 
 ## Recommendations
-- [ ] Add a regression test for the confirmed finding.
+- [ ] Add a Forge regression or fuzz test for every confirmed vulnerability.
 ```
-
-## Pitfalls
-
-- `forge coverage` can be slow in large projects; narrow it with `--match-contract <ContractName>` when triaging a focused change.
-- Slither can report false positives; note lines suppressed with `# slither-disable` and verify each remaining detector result manually.
-- Gas snapshots can vary between environments; compare them only under a consistent toolchain, compiler, RPC, and test configuration.

--- a/optional-skills/software-development/foundry-security-reviewer/references/common-vulnerabilities.md
+++ b/optional-skills/software-development/foundry-security-reviewer/references/common-vulnerabilities.md
@@ -1,0 +1,43 @@
+# Common Solidity Vulnerabilities
+
+Use this reference to turn automated signals into focused Forge tests. Confirm each issue against the actual threat model and contract invariants before reporting it as a finding.
+
+## 1. Reentrancy
+
+An external call can re-enter a function before its state changes are complete, allowing repeated withdrawals or invariant bypasses. Write a malicious receiver contract whose fallback calls the target again; use `vm.prank` and assertions on balances/state to prove that checks-effects-interactions or a reentrancy guard prevents it.
+
+## 2. Unchecked Return Values
+
+Low-level `call`, `send`, and token transfers can fail without reverting when their return value is ignored. In a Forge test, make the callee fail or use a mock ERC-20 returning `false`; assert that the caller reverts or handles the failure without committing state.
+
+## 3. `tx.origin` Authorization
+
+Authorizing with `tx.origin` lets an attacker route a privileged user's transaction through a malicious intermediary. Create an attacker contract, call it while pranked as the privileged EOA, and assert the privileged target function rejects the intermediary unless it checks `msg.sender`.
+
+## 4. Integer Overflow and Underflow
+
+Solidity 0.8+ checks arithmetic by default, but `unchecked` blocks, casts, and older compiler targets can still corrupt values. Fuzz boundary inputs with Forge (`bound`, `vm.assume`) and assert arithmetic either reverts or preserves the invariant at `type(uint256).max`, zero, and narrowing-cast boundaries.
+
+## 5. Access-Control Failures
+
+Missing, incorrectly scoped, or improperly initialized roles can expose minting, upgrades, pauses, or withdrawals. Use `vm.prank` with unauthorized addresses to call every privileged function, then assert `vm.expectRevert` and verify authorized roles still work.
+
+## 6. Flash-Loan Attack Surface
+
+Manipulable spot prices, collateral values, and share accounting can be exploited within one atomic borrow-and-repay transaction. Build a test attacker that borrows liquidity, manipulates the relevant pool or oracle, calls the target, repays, and asserts profit or an invariant failure; add fuzzing across loan size and price movement.
+
+## 7. Frontrunning and Transaction-Ordering Dependence
+
+Public pending transactions can be copied, reordered, or sandwiched when a contract relies on stale prices, predictable commitments, or first-come allocation. Simulate two actors in successive Forge calls, vary ordering with `vm.prank`, and assert that slippage limits, commit-reveal, deadlines, or nonce checks prevent a worse outcome.
+
+## 8. `delegatecall` Misuse
+
+Executing untrusted implementation code with the caller's storage layout can overwrite ownership, balances, or upgrade slots. Test with a malicious implementation that writes critical storage and assert the proxy rejects unauthorized upgrades, validates implementations, and preserves storage invariants.
+
+## 9. `selfdestruct` Risks
+
+Destruction or forced Ether transfers can invalidate assumptions about code existence and account balances. On the project’s target EVM version, deploy a destructible helper, force Ether to the target where relevant, and assert accounting and authorization remain safe; also test that any destruction path is properly restricted.
+
+## 10. Uninitialized Storage and Upgradeable Contracts
+
+Uninitialized proxies, implementations, or storage pointers can let an attacker claim ownership or corrupt state. Deploy the proxy without initialization, let an attacker attempt initialization with `vm.prank`, and assert the initializer is protected, implementation initialization is disabled, and storage slots retain expected values after upgrades.

--- a/optional-skills/software-development/foundry-security-reviewer/scripts/run_review.sh
+++ b/optional-skills/software-development/foundry-security-reviewer/scripts/run_review.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Run a Foundry security-review baseline and write review_output.md.
+
+set -u
+set -o pipefail
+
+PROJECT_ROOT="${1:-$PWD}"
+
+if ! command -v forge >/dev/null 2>&1; then
+  printf 'Error: forge CLI was not found on PATH. Install Foundry from https://getfoundry.sh and retry.\n' >&2
+  exit 127
+fi
+
+if [ ! -d "$PROJECT_ROOT" ]; then
+  printf 'Error: project root does not exist: %s\n' "$PROJECT_ROOT" >&2
+  exit 2
+fi
+
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+if [ ! -f "$PROJECT_ROOT/foundry.toml" ]; then
+  printf 'Error: foundry.toml was not found in %s. Run this script from a Foundry project root.\n' "$PROJECT_ROOT" >&2
+  exit 2
+fi
+
+OUTPUT_FILE="$PROJECT_ROOT/review_output.md"
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/foundry-security-review.XXXXXX")"
+trap 'rm -rf "$LOG_DIR"' EXIT
+
+BUILD_LOG="$LOG_DIR/build.log"
+TEST_LOG="$LOG_DIR/test.log"
+COVERAGE_LOG="$LOG_DIR/coverage.log"
+SNAPSHOT_LOG="$LOG_DIR/snapshot.log"
+SLITHER_LOG="$LOG_DIR/slither.log"
+ADERYN_LOG="$LOG_DIR/aderyn.log"
+
+BUILD_STATUS=0
+TEST_STATUS=0
+COVERAGE_STATUS=0
+SNAPSHOT_STATUS=0
+SLITHER_STATUS=0
+ADERYN_STATUS=0
+HAS_SLITHER=0
+HAS_ADERYN=0
+
+run_capture() {
+  local log_file="$1"
+  local status
+  shift
+
+  "$@" >"$log_file" 2>&1
+  status=$?
+  return "$status"
+}
+
+append_log() {
+  local log_file="$1"
+  if [ -s "$log_file" ]; then
+    printf '\n```text\n'
+    cat "$log_file"
+    printf '```\n'
+  else
+    printf '\n_No output produced._\n'
+  fi
+}
+
+append_coverage_flags() {
+  local flagged
+  flagged="$(awk -F'|' '
+    /\.sol[[:space:]]*\|/ {
+      low = 0
+      for (i = 3; i <= NF; i++) {
+        cell = $i
+        if (cell ~ /%/) {
+          value = cell
+          sub(/%.*/, "", value)
+          gsub(/[^0-9.]/, "", value)
+          if (value != "" && value + 0 < 80) low = 1
+        }
+      }
+      if (low) {
+        file = $2
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", file)
+        print "- [ ] " file " — below 80% in the coverage summary"
+      }
+    }
+  ' "$COVERAGE_LOG")"
+
+  if [ -n "$flagged" ]; then
+    printf '\n### Modules below 80%%\n%s\n' "$flagged"
+  else
+    printf '\n### Modules below 80%%\n- [x] No module below 80%% was detected in the summary.\n'
+  fi
+}
+
+append_filtered_findings() {
+  local log_file="$1"
+  local label="$2"
+  local pattern="$3"
+  local findings
+
+  findings="$(grep -Eis "$pattern" "$log_file" || true)"
+  if [ -n "$findings" ]; then
+    printf '\n### %s\n```text\n%s\n```\n' "$label" "$findings"
+  else
+    printf '\n### %s\n- [x] No matching findings were reported.\n' "$label"
+  fi
+}
+
+printf 'Running Foundry security review in %s\n' "$PROJECT_ROOT"
+cd "$PROJECT_ROOT"
+
+run_capture "$BUILD_LOG" forge build || BUILD_STATUS=$?
+run_capture "$TEST_LOG" forge test -vv || TEST_STATUS=$?
+run_capture "$COVERAGE_LOG" forge coverage --report summary || COVERAGE_STATUS=$?
+run_capture "$SNAPSHOT_LOG" forge snapshot || SNAPSHOT_STATUS=$?
+
+if command -v slither >/dev/null 2>&1; then
+  HAS_SLITHER=1
+  run_capture "$SLITHER_LOG" slither . || SLITHER_STATUS=$?
+fi
+
+if command -v aderyn >/dev/null 2>&1; then
+  HAS_ADERYN=1
+  run_capture "$ADERYN_LOG" aderyn . || ADERYN_STATUS=$?
+fi
+
+{
+  printf '# Foundry Security Review\n\n'
+  printf -- '- **Project:** `%s`\n' "$PROJECT_ROOT"
+  printf -- '- **Generated:** `%s`\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf '\n## Test Results\n'
+  if [ "$BUILD_STATUS" -eq 0 ]; then
+    printf -- '- [x] `forge build` succeeded.\n'
+  else
+    printf -- '- [ ] `forge build` failed (exit %s). Resolve compilation errors before relying on this review.\n' "$BUILD_STATUS"
+  fi
+  append_log "$BUILD_LOG"
+  if [ "$TEST_STATUS" -eq 0 ]; then
+    printf '\n- [x] `forge test -vv` passed.\n'
+  else
+    printf '\n- [ ] `forge test -vv` failed (exit %s). Failing tests and traces follow.\n' "$TEST_STATUS"
+  fi
+  append_log "$TEST_LOG"
+
+  printf '\n## Coverage\n'
+  if [ "$COVERAGE_STATUS" -eq 0 ]; then
+    printf -- '- [x] `forge coverage --report summary` completed.\n'
+  else
+    printf -- '- [ ] `forge coverage --report summary` failed (exit %s).\n' "$COVERAGE_STATUS"
+  fi
+  append_log "$COVERAGE_LOG"
+  append_coverage_flags
+
+  printf '\n## Gas Snapshot\n'
+  if [ "$SNAPSHOT_STATUS" -eq 0 ]; then
+    printf -- '- [x] `forge snapshot` captured the gas baseline.\n'
+  else
+    printf -- '- [ ] `forge snapshot` failed (exit %s).\n' "$SNAPSHOT_STATUS"
+  fi
+  append_log "$SNAPSHOT_LOG"
+
+  printf '\n## Security Findings\n'
+  if [ "$HAS_SLITHER" -eq 1 ]; then
+    if [ "$SLITHER_STATUS" -eq 0 ]; then
+      printf -- '- [x] `slither .` completed.\n'
+    else
+      printf -- '- [ ] `slither .` exited %s; inspect the output before dismissing findings.\n' "$SLITHER_STATUS"
+    fi
+    append_filtered_findings "$SLITHER_LOG" 'Slither HIGH/MEDIUM findings' 'high|medium'
+  else
+    printf -- '- [ ] Slither was not installed; skipped `slither .`.\n'
+  fi
+  if [ "$HAS_ADERYN" -eq 1 ]; then
+    if [ "$ADERYN_STATUS" -eq 0 ]; then
+      printf -- '- [x] `aderyn .` completed.\n'
+    else
+      printf -- '- [ ] `aderyn .` exited %s; inspect the output before dismissing findings.\n' "$ADERYN_STATUS"
+    fi
+    append_filtered_findings "$ADERYN_LOG" 'Aderyn critical findings' 'critical'
+  else
+    printf -- '- [ ] Aderyn was not installed; skipped `aderyn .`.\n'
+  fi
+
+  printf '\n## Recommendations\n'
+  printf -- '- [ ] Validate every reported finding against the contract source and reachable call paths.\n'
+  printf -- '- [ ] Add a Forge regression or fuzz test for every confirmed vulnerability.\n'
+  printf -- '- [ ] Compare the change against the bundled common-vulnerabilities reference before approving it.\n'
+  printf -- '- [ ] Record intentional Slither suppressions (`# slither-disable`) in the PR.\n'
+} >"$OUTPUT_FILE"
+
+printf 'Review written to %s\n' "$OUTPUT_FILE"
+
+if [ "$BUILD_STATUS" -ne 0 ] || [ "$TEST_STATUS" -ne 0 ] || [ "$COVERAGE_STATUS" -ne 0 ] || [ "$SNAPSHOT_STATUS" -ne 0 ]; then
+  exit 1
+fi

--- a/optional-skills/software-development/foundry-security-reviewer/scripts/run_review.sh
+++ b/optional-skills/software-development/foundry-security-reviewer/scripts/run_review.sh
@@ -65,6 +65,34 @@ append_log() {
 
 append_coverage_flags() {
   local flagged
+  local coverage_rows
+  local parseable_rows
+
+  if [ "$COVERAGE_STATUS" -ne 0 ]; then
+    printf '\n### Modules below 80%%\n- [ ] Coverage threshold result unavailable because `forge coverage --report summary` failed.\n'
+    return
+  fi
+
+  read -r coverage_rows parseable_rows <<EOF
+$(awk -F'|' '
+  /\.sol[[:space:]]*\|/ {
+    rows++
+    for (i = 3; i <= NF; i++) {
+      if ($i ~ /%/) {
+        valid++
+        break
+      }
+    }
+  }
+  END { printf "%d %d", rows + 0, valid + 0 }
+' "$COVERAGE_LOG")
+EOF
+
+  if [ "$coverage_rows" -eq 0 ] || [ "$coverage_rows" -ne "$parseable_rows" ]; then
+    printf '\n### Modules below 80%%\n- [ ] Coverage threshold result unavailable because the successful command did not produce a parseable Solidity coverage summary.\n'
+    return
+  fi
+
   flagged="$(awk -F'|' '
     /\.sol[[:space:]]*\|/ {
       low = 0

--- a/tests/skills/test_foundry_security_reviewer_skill.py
+++ b/tests/skills/test_foundry_security_reviewer_skill.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "software-development"
+    / "foundry-security-reviewer"
+    / "SKILL.md"
+)
+SCRIPT_PATH = SKILL_PATH.parent / "scripts" / "run_review.sh"
+
+
+def _frontmatter(text: str) -> str:
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _fake_forge(tmp_path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    forge = bin_dir / "forge"
+    forge.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n"
+        "  coverage)\n"
+        "    printf '%s\\n' \"$FAKE_COVERAGE_OUTPUT\"\n"
+        "    exit \"$FAKE_COVERAGE_STATUS\"\n"
+        "    ;;\n"
+        "  *) exit 0 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    forge.chmod(0o755)
+    return bin_dir
+
+
+def _run_review(tmp_path, coverage_output: str, coverage_status: int):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "foundry.toml").write_text("[profile.default]\n", encoding="utf-8")
+    fake_bin = _fake_forge(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FAKE_COVERAGE_OUTPUT"] = coverage_output
+    env["FAKE_COVERAGE_STATUS"] = str(coverage_status)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), str(project)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, (project / "review_output.md").read_text(encoding="utf-8")
+
+
+def test_skill_metadata_and_modern_sections():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    metadata = _frontmatter(text)
+    description = re.search(r'^description: "([^"]+)"$', metadata, re.MULTILINE)
+
+    assert description is not None
+    assert len(description.group(1)) <= 60
+    assert description.group(1).endswith(".")
+    assert "author: Ahmet Osrak (Osraka), Hermes Agent" in metadata
+    assert "platforms: [linux, macos]" in metadata
+
+    sections = re.findall(r"^## (.+)$", text, re.MULTILINE)
+    assert sections[:7] == [
+        "When to Use",
+        "Prerequisites",
+        "How to Run",
+        "Quick Reference",
+        "Procedure",
+        "Pitfalls",
+        "Verification",
+    ]
+
+
+def test_failed_coverage_is_reported_as_unavailable(tmp_path):
+    result, report = _run_review(tmp_path, "partial coverage output", 1)
+
+    assert result.returncode == 1
+    assert "Coverage threshold result unavailable" in report
+    assert "No module below 80% was detected" not in report
+
+
+def test_parseable_coverage_flags_low_modules(tmp_path):
+    coverage = "| File | % Lines | % Statements |\n| src/Vault.sol | 72% | 80% |"
+    result, report = _run_review(tmp_path, coverage, 0)
+
+    assert result.returncode == 0
+    assert "src/Vault.sol" in report
+    assert "below 80%" in report


### PR DESCRIPTION
## Summary

Adds an official optional skill for repeatable Foundry Solidity security reviews. It validates the project root, gathers build/test/coverage/gas evidence, runs Slither and Aderyn when available, and produces a PR-review-ready Markdown report.

## Workflow

The bundled `run_review.sh` runs:

- `forge build`
- `forge test -vv`
- `forge coverage --report summary` (flags modules below 80%)
- `forge snapshot`
- `slither .` when installed, filtering HIGH/MEDIUM findings
- `aderyn .` when installed, filtering critical findings

It exits early with actionable errors when Forge or `foundry.toml` is missing, and otherwise writes `review_output.md` even when a review step fails.

## Example output

```markdown
# Foundry Security Review

## Test Results
- [x] `forge build` succeeded.
- [ ] `forge test -vv` failed (exit 1).

## Coverage
- [ ] `src/Vault.sol` — below 80% in the coverage summary

## Gas Snapshot
- [x] `forge snapshot` captured the gas baseline.

## Security Findings
- [ ] HIGH — validate the reported call path and add a Forge regression test.

## Recommendations
- [ ] Record intentional Slither suppressions in the PR.
```

## Validation

- Parsed and checked the requested SKILL.md frontmatter fields.
- Ran `bash -n` on `run_review.sh`.
- Exercised the script with mocked Forge/Slither/Aderyn commands for successful and failing test cases.