### PR TITLE
feat(skin): accept auto as virtual selector in /skin and display.skin config

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2272,11 +2272,16 @@ class CLICommandsMixin:
             return
 
         new_skin = parts[1].strip().lower()
-        available = {s["name"] for s in list_skins()}
-        if new_skin not in available:
-            print(f"  Unknown skin: {new_skin}")
-            print(f"  Available: {', '.join(sorted(available))}")
-            return
+        # 'auto' is a virtual selector -- bypass the installed-skins check
+        # and let set_active_skin() resolve it to 'light' or 'default' via
+        # the existing terminal detection chain.  Persist 'auto' so the
+        # preference is re-evaluated on every session start.
+        if new_skin != "auto":
+            available = {s["name"] for s in list_skins()}
+            if new_skin not in available:
+                print(f"  Unknown skin: {new_skin}")
+                print(f"  Available: auto, {', '.join(sorted(available))}")
+                return
 
         set_active_skin(new_skin)
         _ACCENT.reset()  # Re-resolve ANSI color for the new skin

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -774,9 +774,36 @@ def get_active_skin() -> SkinConfig:
     return _active_skin
 
 
+def resolve_auto_skin() -> str:
+    """Resolve the 'auto' virtual skin selector to a concrete skin name.
+
+    Uses the existing CLI light-mode detection chain (HERMES_TUI_THEME env var,
+    COLORFGBG, OSC 11 terminal query, etc.) that already drives color remapping
+    in cli.py. This avoids OS-specific probes (GNOME dconf) that cannot work
+    over SSH or Docker, and reuses the same signal sources for consistency.
+
+    Falls back to 'default' on any error or when detection is inconclusive.
+    """
+    try:
+        # Import lazily to avoid a circular dependency at module level.
+        # cli.py imports skin_engine, so we cannot import cli at the top.
+        from cli import _is_light_mode  # type: ignore[import]
+        return "light" if _is_light_mode() else "default"
+    except Exception:
+        return "default"
+
+
 def set_active_skin(name: str) -> SkinConfig:
-    """Switch the active skin. Returns the new SkinConfig."""
+    """Switch the active skin. Returns the new SkinConfig.
+
+    Accepts the virtual name 'auto', which resolves to 'light' or 'default'
+    based on the current terminal's background luminance via the existing
+    CLI detection chain.  The resolved name (not 'auto') is stored so that
+    get_active_skin_name() reflects the actual skin in use.
+    """
     global _active_skin, _active_skin_name
+    if name == "auto":
+        name = resolve_auto_skin()
     _active_skin_name = name
     _active_skin = load_skin(name)
     return _active_skin

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -388,3 +388,143 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
+
+
+class TestAutoSkinSelector:
+    """Regression tests for the 'auto' virtual skin selector (PR #16330).
+
+    'auto' must bypass the installed-skin validation in /skin and resolve
+    to a concrete skin via the existing terminal detection chain rather than
+    an OS-specific probe.  The persisted config value stays 'auto' so the
+    preference is re-evaluated on every session start.
+    """
+
+    def test_set_active_skin_auto_resolves_to_concrete_skin(self, monkeypatch):
+        """set_active_skin('auto') must store a concrete name, not 'auto'."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import set_active_skin, get_active_skin_name
+
+        with patch("hermes_cli.skin_engine.resolve_auto_skin", return_value="default"):
+            set_active_skin("auto")
+
+        assert get_active_skin_name() != "auto", (
+            "set_active_skin('auto') must resolve to a concrete skin name"
+        )
+        assert get_active_skin_name() == "default"
+
+    def test_resolve_auto_skin_light_mode(self, monkeypatch):
+        """resolve_auto_skin() returns 'light' when _is_light_mode() is True."""
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        # Patch at the import-lookup level so prompt_toolkit is not needed.
+        fake_cli = MagicMock()
+        fake_cli._is_light_mode.return_value = True
+        with patch.dict("sys.modules", {"cli": fake_cli}):
+            result = resolve_auto_skin()
+
+        assert result == "light"
+
+    def test_resolve_auto_skin_dark_mode(self, monkeypatch):
+        """resolve_auto_skin() returns 'default' when _is_light_mode() is False."""
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        fake_cli = MagicMock()
+        fake_cli._is_light_mode.return_value = False
+        with patch.dict("sys.modules", {"cli": fake_cli}):
+            result = resolve_auto_skin()
+
+        assert result == "default"
+
+    def test_resolve_auto_skin_falls_back_on_error(self):
+        """resolve_auto_skin() returns 'default' when detection raises."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        # When cli import itself fails, must still return a safe default.
+        with patch.dict("sys.modules", {"cli": None}):
+            result = resolve_auto_skin()
+
+        assert result == "default"
+
+    def test_init_skin_from_config_persists_auto(self, monkeypatch, tmp_path):
+        """display.skin: auto in config must resolve at startup without crashing."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with patch("hermes_cli.skin_engine.resolve_auto_skin", return_value="default"):
+            init_skin_from_config({"display": {"skin": "auto"}})
+
+        assert get_active_skin_name() == "default"
+
+
+class TestAutoSkinSelector:
+    """Regression tests for the 'auto' virtual skin selector (PR #16330).
+
+    'auto' must bypass the installed-skin validation in /skin and resolve
+    to a concrete skin via the existing terminal detection chain rather than
+    an OS-specific probe.  The persisted config value stays 'auto' so the
+    preference is re-evaluated on every session start.
+    """
+
+    def test_set_active_skin_auto_resolves_to_concrete_skin(self, monkeypatch):
+        """set_active_skin('auto') must store a concrete name, not 'auto'."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import set_active_skin, get_active_skin_name
+
+        with patch("hermes_cli.skin_engine.resolve_auto_skin", return_value="default"):
+            set_active_skin("auto")
+
+        assert get_active_skin_name() != "auto", (
+            "set_active_skin('auto') must resolve to a concrete skin name"
+        )
+        assert get_active_skin_name() == "default"
+
+    def test_resolve_auto_skin_light_mode(self, monkeypatch):
+        """resolve_auto_skin() returns 'light' when _is_light_mode() is True."""
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        # Patch at the import-lookup level so prompt_toolkit is not needed.
+        fake_cli = MagicMock()
+        fake_cli._is_light_mode.return_value = True
+        with patch.dict("sys.modules", {"cli": fake_cli}):
+            result = resolve_auto_skin()
+
+        assert result == "light"
+
+    def test_resolve_auto_skin_dark_mode(self, monkeypatch):
+        """resolve_auto_skin() returns 'default' when _is_light_mode() is False."""
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        fake_cli = MagicMock()
+        fake_cli._is_light_mode.return_value = False
+        with patch.dict("sys.modules", {"cli": fake_cli}):
+            result = resolve_auto_skin()
+
+        assert result == "default"
+
+    def test_resolve_auto_skin_falls_back_on_error(self):
+        """resolve_auto_skin() returns 'default' when detection raises."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import resolve_auto_skin
+
+        # When cli import itself fails, must still return a safe default.
+        with patch.dict("sys.modules", {"cli": None}):
+            result = resolve_auto_skin()
+
+        assert result == "default"
+
+    def test_init_skin_from_config_persists_auto(self, monkeypatch, tmp_path):
+        """display.skin: auto in config must resolve at startup without crashing."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with patch("hermes_cli.skin_engine.resolve_auto_skin", return_value="default"):
+            init_skin_from_config({"display": {"skin": "auto"}})
+
+        assert get_active_skin_name() == "default"


### PR DESCRIPTION
## Problem

/skin auto and display.skin: auto had no integration: the /skin handler rejected values not in list_skins() before calling set_active_skin(), and the previous PR used an OS/GNOME-specific probe that cannot work over SSH or Docker.

## Fix

1. skin_engine.py: add resolve_auto_skin() that delegates to cli._is_light_mode() -- reuses existing HERMES_TUI_THEME, COLORFGBG, OSC 11 query chain. Falls back to default on any error.
2. cli_commands_mixin.py: bypass list_skins() validation for auto so /skin auto reaches set_active_skin(). Persists auto so preference is re-evaluated at startup.
3. set_active_skin(auto) stores the concrete resolved name not auto.

## Verification

5 new tests in TestAutoSkinSelector: auto resolves to concrete name, light/dark mode paths, fail-open on error, init_skin_from_config with auto. 5/5 pass.

Addresses maintainer review of PR #16330.