### PR TITLE
fix(web): force PTY re-spawn on session resume to respect new resume target

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -165,6 +165,15 @@ class PtySessionRegistry:
         self._sessions[key] = session
         return session, True
 
+    async def close_if_exists(self, key: str) -> bool:
+        """Close and remove a session if present. Returns True if one was removed."""
+        s = self._sessions.get(key)
+        if s is not None:
+            await s.close()
+            self._sessions.pop(key, None)
+            return True
+        return False
+
     def detach(self, key: str, ws) -> None:
         s = self._sessions.get(key)
         if s is not None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15543,6 +15543,12 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # Keep-alive path: the PTY outlives this socket; reattach by token.
+    if resume is not None:
+        # When resuming a session, discard any existing keep-alive PTY so it
+        # is re-spawned with the new resume target. Without this the registry
+        # returns the stale PTY and the new argv/env is silently discarded,
+        # making every resume-after-the-first land on the original session.
+        await PTY_REGISTRY.close_if_exists(attach_token)
     try:
         session, _created = await PTY_REGISTRY.attach_or_spawn(
             attach_token, spawn=_spawn


### PR DESCRIPTION
Fixes #63701

## Problem

When the web dashboard resumes a different session from Sessions → History, both `?resume=SESSION_ID` and `?attach=TOKEN` are sent to `/api/pty`. The keep-alive `PtySessionRegistry.attach_or_spawn()` found the existing PTY (spawned for the *previous* session) and returned it without calling the `_spawn` closure. The new argv/env with the correct `HERMES_TUI_RESUME` was silently discarded, so every resume-after-the-first landed back on the original session's PTY.

Only the first click after a dashboard restart worked — because no PTY existed yet, so `_spawn` was called.

## Fix

When a `resume` query parameter is present alongside `attach`, discard any existing keep-alive PTY via a new `close_if_exists` method on `PtySessionRegistry` before calling `attach_or_spawn`. This forces a fresh spawn with the correct resume arguments.

A future enhancement could skip the teardown when the resume target matches the existing PTY's session (by tracking the resolved session id), but the restart is fast (Node.js TUI spawn) and only happens on explicit user navigation, so the simpler unconditional teardown is sufficient.

## Changes

- **pty_session.py**: Add `PtySessionRegistry.close_if_exists(key)` — safely closes and removes a session if present, returns `True` if one was removed.
- **web_server.py**: In `pty_ws()`, call `close_if_exists(attach_token)` when `resume` is set, so the registry creates a fresh PTY with the correct resume target.
