### PR TITLE
feat(desktop): start Projects from the folder rail

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -64,7 +64,7 @@ import {
 import { $terminalTakeover, setTerminalTakeover } from '../right-sidebar/store'
 import { $workspaceIsPage } from '../routes'
 
-import { FilesPane, LogsPane, PreviewRailPane, ReviewPaneContent } from './panes'
+import { LogsPane, PreviewRailPane, ReviewPaneContent } from './panes'
 import { ContribWiring, WiredPane } from './wiring'
 
 /**
@@ -181,7 +181,7 @@ registry.registerMany([
       minWidth: FILE_BROWSER_MIN_WIDTH,
       maxWidth: FILE_BROWSER_MAX_WIDTH
     },
-    render: () => <FilesPane />
+    render: () => <WiredPane part="files" />
   },
   {
     id: 'preview',

--- a/apps/desktop/src/app/contrib/panes.test.tsx
+++ b/apps/desktop/src/app/contrib/panes.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setActiveSessionId } from '@/store/session'
+
+import { FilesPane } from './panes'
+
+vi.mock('@/app/right-sidebar', () => ({
+  RightSidebarPane: ({ onStartProjectFromFolder }: { onStartProjectFromFolder?: () => void }) =>
+    onStartProjectFromFolder ? (
+      <button onClick={onStartProjectFromFolder} type="button">
+        Open folder
+      </button>
+    ) : (
+      <span>No project action</span>
+    )
+}))
+
+describe('FilesPane project entry', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+  })
+
+  it('forwards the Project-owned folder action for a detached draft', () => {
+    setActiveSessionId(null)
+    const onStartProjectFromFolder = vi.fn()
+
+    render(<FilesPane onStartProjectFromFolder={onStartProjectFromFolder} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open folder' }))
+    expect(onStartProjectFromFolder).toHaveBeenCalledOnce()
+  })
+
+  it('withholds the folder action while a session is active', () => {
+    setActiveSessionId('runtime-session')
+
+    render(<FilesPane onStartProjectFromFolder={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -28,7 +28,7 @@ import { getLogs } from '@/hermes'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { $filePreviewTarget, $previewTarget, setCurrentSessionPreviewTarget } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $activeSessionId, $currentCwd } from '@/store/session'
 
 // ---------------------------------------------------------------------------
 // Logs — live agent-log tail. OPTIONAL chrome: not in any default layout,
@@ -120,10 +120,16 @@ function previewFile(path: string) {
 // and titlebar clearance are per-wrapper concerns.
 const ZONE_CONTENT = 'h-full [&>aside]:h-full [&>aside]:w-full [&>aside]:pt-0'
 
-export function FilesPane() {
+export function FilesPane({ onStartProjectFromFolder }: { onStartProjectFromFolder?: () => void }) {
+  const activeSessionId = useStore($activeSessionId)
+
   return (
     <div className={ZONE_CONTENT}>
-      <RightSidebarPane onActivateFile={previewFile} onActivateFolder={previewFile} />
+      <RightSidebarPane
+        onActivateFile={previewFile}
+        onActivateFolder={previewFile}
+        onStartProjectFromFolder={activeSessionId ? undefined : onStartProjectFromFolder}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -64,16 +64,18 @@ export interface WiringActions extends SidebarActions, ChatActions {
   getGateway: () => ComponentProps<typeof ChatView>['gateway']
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void
+  onStartProjectFromFolder: () => void
   requestGateway: GatewayRequester
   selectModel: ComponentProps<typeof ModelMenuPanel>['onSelectModel']
   toggleCommandCenter: () => void
 }
 
-/** The four wired surfaces the controller publishes; `WiredPane` renders one by
+/** The wired surfaces the controller publishes; `WiredPane` renders one by
  *  key inside a registered pane / chrome slot. */
 export interface WiringApi {
   sidebar: ReactNode
   chatRoutes: ReactNode
+  files: ReactNode
   terminal: ReactNode
   statusbar: ReactNode
 }

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -98,7 +98,7 @@ import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
-import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
+import { $restartPreviewServer, FilesPane, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
 
@@ -112,7 +112,7 @@ const ProfilesView = lazy(async () => ({ default: (await import('../profiles')).
 const SettingsView = lazy(async () => ({ default: (await import('../settings')).SettingsView }))
 const StarmapView = lazy(async () => ({ default: (await import('../starmap')).StarmapView }))
 
-// Surfaces (the four wired panes), the render context + WiredPane, and the
+// Surfaces, the render context + WiredPane, and the
 // WiringActions/WiringApi contracts all live in sibling modules — this file is
 // the controller that assembles them.
 export { WiredPane } from './context'
@@ -225,7 +225,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, updateSessionState]
   )
 
-  const { refreshProjectBranch } = useCwdActions({
+  const { chooseProjectFolder, refreshProjectBranch } = useCwdActions({
     activeSessionId,
     activeSessionIdRef,
     onSessionRuntimeInfo: updateActiveSessionRuntimeInfo,
@@ -769,6 +769,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     getGateway: () => gatewayRef.current,
     openAgents,
     openCommandCenterSection,
+    onStartProjectFromFolder: () => void chooseProjectFolder(),
     requestGateway,
     selectModel,
     toggleCommandCenter
@@ -794,6 +795,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const terminalNode = useMemo(() => <TerminalSurface />, [])
 
+  const filesNode = useMemo(
+    () => <FilesPane onStartProjectFromFolder={actions.onStartProjectFromFolder} />,
+    [actions]
+  )
+
   const statusbarNode = useMemo(
     () => (
       <StatusbarSurface
@@ -816,11 +822,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const api = useMemo<WiringApi>(
     () => ({
       chatRoutes: chatRoutesNode,
+      files: filesNode,
       sidebar: sidebarNode,
       statusbar: statusbarNode,
       terminal: terminalNode
     }),
-    [chatRoutesNode, sidebarNode, statusbarNode, terminalNode]
+    [chatRoutesNode, filesNode, sidebarNode, statusbarNode, terminalNode]
   )
 
   // The REAL titlebar tool clusters (sidebar/flip toggles, haptics, keybinds,

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -46,12 +46,29 @@ describe('RightSidebarPane', () => {
     expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
   })
 
-  it('shows no tree for a detached chat (no working dir)', async () => {
+  it('offers a project-backed folder start only for a detached chat', async () => {
+    setCurrentCwd('')
+    const onStartProjectFromFolder = vi.fn()
+
+    render(
+      <RightSidebarPane
+        onActivateFile={vi.fn()}
+        onActivateFolder={vi.fn()}
+        onStartProjectFromFolder={onStartProjectFromFolder}
+      />
+    )
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
+    fireEvent.click(screen.getByRole('button', { name: 'Open folder' }))
+    expect(onStartProjectFromFolder).toHaveBeenCalledOnce()
+    expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('does not offer a folder start without the no-session action', async () => {
     setCurrentCwd('')
 
     render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
 
-    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
-    expect(readDir).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -23,9 +23,12 @@ import { useProjectTree } from './files/use-project-tree'
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
   onActivateFolder: (path: string) => void
+  // Defined only for a detached chat. Active sessions keep their cwd immutable
+  // from this rail; the action enters or creates a Project before staging cwd.
+  onStartProjectFromFolder?: () => void
 }
 
-export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSidebarPaneProps) {
+export function RightSidebarPane({ onActivateFile, onActivateFolder, onStartProjectFromFolder }: RightSidebarPaneProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
@@ -98,6 +101,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
         onRefresh={() => void refreshRoot()}
+        onStartProjectFromFolder={onStartProjectFromFolder}
         openState={openState}
       />
     </aside>
@@ -110,6 +114,7 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   hasWorkspace: boolean
   onCollapseAll: () => void
   onRefresh: () => void
+  onStartProjectFromFolder?: () => void
 }
 
 // Sidebar palette + hover-reveal: header actions stay reachable while moving
@@ -135,15 +140,27 @@ function FilesystemTab({
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
+  onStartProjectFromFolder,
   openState
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
 
-  // No working directory (a bare/detached chat) → no tree, just a terse hint.
-  // Switching workspace is a project/worktree action, never a raw folder picker.
+  // No working directory (a bare/detached chat) → no tree. The folder entry
+  // point is only supplied by the controller before a session exists, so the
+  // right rail cannot retarget an active session to a raw cwd.
   if (!hasWorkspace) {
-    return <PaneEmptyState label={r.noProjectOpen} />
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-4">
+        <PaneEmptyState label={r.noProjectOpen} />
+        {onStartProjectFromFolder && (
+          <Button onClick={onStartProjectFromFolder} size="sm" variant="secondary">
+            <Codicon name="folder-opened" size="0.875rem" />
+            {r.openFolder}
+          </Button>
+        )}
+      </div>
+    )
   }
 
   return (

--- a/apps/desktop/src/app/session/hooks/use-cwd-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-cwd-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ensureProjectForFolder, pickProjectFolder } from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
@@ -14,6 +15,21 @@ import {
 } from '@/store/session'
 
 import { useCwdActions } from './use-cwd-actions'
+
+vi.mock('@/store/projects', () => ({
+  ensureProjectForFolder: vi.fn(),
+  pickProjectFolder: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+const ensureProjectForFolderMock = vi.mocked(ensureProjectForFolder)
+const pickProjectFolderMock = vi.mocked(pickProjectFolder)
+const notifications = await import('@/store/notifications')
+const notifyErrorMock = vi.mocked(notifications.notifyError)
 
 type CwdActionsHandle = ReturnType<typeof useCwdActions>
 
@@ -51,6 +67,9 @@ function Harness({
 
 describe('useCwdActions draft workspace target', () => {
   beforeEach(() => {
+    ensureProjectForFolderMock.mockReset()
+    pickProjectFolderMock.mockReset()
+    notifyErrorMock.mockClear()
     setCurrentCwd('')
     setCurrentBranch('')
     setNewChatWorkspaceTarget(undefined)
@@ -62,6 +81,177 @@ describe('useCwdActions draft workspace target', () => {
     setCurrentBranch('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
+  })
+
+  it('resolves a Project before staging a folder as a new-chat workspace', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({ branch: 'main', cwd: '/workspace/selected-folder' })
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    ensureProjectForFolderMock.mockResolvedValue('/workspace/selected-folder')
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.startProjectFromFolder('/picked/folder')
+    })
+
+    expect(ensureProjectForFolderMock).toHaveBeenCalledWith('/picked/folder', expect.any(Function))
+    expect(requestGateway).toHaveBeenCalledWith('config.get', { cwd: '/workspace/selected-folder', key: 'project' })
+    expect($newChatWorkspaceTarget.get()).toBe('/workspace/selected-folder')
+    expect($currentCwd.get()).toBe('/workspace/selected-folder')
+  })
+
+  it('routes the folder picker selection through the Project resolver', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({ branch: 'main', cwd: '/workspace/selected-folder' })
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    pickProjectFolderMock.mockResolvedValue('/picked/folder')
+    ensureProjectForFolderMock.mockResolvedValue('/workspace/selected-folder')
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.chooseProjectFolder()
+    })
+
+    expect(pickProjectFolderMock).toHaveBeenCalledOnce()
+    expect(ensureProjectForFolderMock).toHaveBeenCalledWith('/picked/folder', expect.any(Function))
+    expect($currentCwd.get()).toBe('/workspace/selected-folder')
+  })
+
+  it('surfaces folder-picker failures without attempting Project resolution', async () => {
+    const requestGateway = vi.fn()
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    pickProjectFolderMock.mockRejectedValue(new Error('picker unavailable'))
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.chooseProjectFolder()
+    })
+
+    expect(ensureProjectForFolderMock).not.toHaveBeenCalled()
+    expect(notifyErrorMock).toHaveBeenCalled()
+  })
+
+  it('ignores a repeated folder action while the picker is already open', async () => {
+    const folder = deferred<null | string>()
+    const requestGateway = vi.fn()
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    pickProjectFolderMock.mockReturnValue(folder.promise)
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const first = handle!.chooseProjectFolder()
+    const repeated = handle!.chooseProjectFolder()
+
+    expect(pickProjectFolderMock).toHaveBeenCalledOnce()
+
+    folder.resolve(null)
+    await Promise.all([first, repeated])
+  })
+
+  it('does not touch the workspace and surfaces an error when the Project resolve fails', async () => {
+    const requestGateway = vi.fn()
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    ensureProjectForFolderMock.mockRejectedValue(new Error('boom'))
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.startProjectFromFolder('/picked/folder')
+    })
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($newChatWorkspaceTarget.get()).toBeUndefined()
+    expect($currentCwd.get()).toBe('')
+    expect(notifyErrorMock).toHaveBeenCalled()
+  })
+
+  it('does not create or enter a Project when a session is already active on entry', async () => {
+    const requestGateway = vi.fn()
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'active-session' }
+    let handle: CwdActionsHandle | null = null
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.startProjectFromFolder('/picked/folder')
+    })
+
+    expect(ensureProjectForFolderMock).not.toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate cwd when a session starts while the folder action is pending', async () => {
+    const folder = deferred<string>()
+    const requestGateway = vi.fn()
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let handle: CwdActionsHandle | null = null
+    ensureProjectForFolderMock.mockReturnValue(folder.promise)
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const starting = handle!.startProjectFromFolder('/picked/folder')
+    activeSessionIdRef.current = 'active-session'
+    folder.resolve('/workspace/selected-folder')
+    await starting
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($newChatWorkspaceTarget.get()).toBeUndefined()
+    expect($currentCwd.get()).toBe('')
   })
 
   it('ignores stale draft cwd normalization after a newer no-workspace target wins', async () => {

--- a/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
@@ -1,7 +1,8 @@
-import { type MutableRefObject, useCallback } from 'react'
+import { type MutableRefObject, useCallback, useRef } from 'react'
 
 import { useI18n } from '@/i18n'
 import { notify, notifyError } from '@/store/notifications'
+import { ensureProjectForFolder, pickProjectFolder } from '@/store/projects'
 import {
   $currentCwd,
   $newChatWorkspaceTargetGeneration,
@@ -25,6 +26,7 @@ export function useCwdActions({
   requestGateway
 }: CwdActionsOptions) {
   const { t } = useI18n()
+  const choosingProjectFolderRef = useRef(false)
   const copy = t.desktop
 
   const refreshProjectBranch = useCallback(
@@ -51,6 +53,87 @@ export function useCwdActions({
     [activeSessionIdRef, requestGateway]
   )
 
+  const stageNewChatWorkspace = useCallback(
+    async (cwd: string) => {
+      if (activeSessionIdRef.current) {
+        return
+      }
+
+      const workspaceGeneration = setNewChatWorkspaceTarget(cwd)
+      setCurrentCwd(cwd)
+
+      try {
+        const info = await requestGateway<{ branch?: string; cwd?: string }>('config.get', {
+          key: 'project',
+          cwd
+        })
+
+        if ($newChatWorkspaceTargetGeneration.get() !== workspaceGeneration || activeSessionIdRef.current) {
+          return
+        }
+
+        // Adopt the backend's normalized cwd so the persisted workspace and
+        // branch stay consistent with what the agent will use.
+        if (info.cwd) {
+          setCurrentCwd(info.cwd)
+          setNewChatWorkspaceTarget(info.cwd)
+        }
+
+        setCurrentBranch(info.branch || '')
+      } catch {
+        if ($newChatWorkspaceTargetGeneration.get() === workspaceGeneration && !activeSessionIdRef.current) {
+          setCurrentBranch('')
+        }
+      }
+    },
+    [activeSessionIdRef, requestGateway]
+  )
+
+  const startProjectFromFolder = useCallback(
+    async (cwd: string) => {
+      if (activeSessionIdRef.current) {
+        return
+      }
+
+      try {
+        // Project ownership is authoritative: do not expose a raw cwd when the
+        // existing owner lookup or explicit project creation fails.
+        const projectCwd = await ensureProjectForFolder(cwd, () => Boolean(activeSessionIdRef.current))
+
+        // A session could start while the folder picker/create RPC was open.
+        // Do not let this detached-chat action mutate its workspace.
+        if (projectCwd === null || activeSessionIdRef.current) {
+          return
+        }
+
+        await stageNewChatWorkspace(projectCwd)
+      } catch (error) {
+        notifyError(error, copy.cwdChangeFailed)
+      }
+    },
+    [activeSessionIdRef, copy, stageNewChatWorkspace]
+  )
+
+  const chooseProjectFolder = useCallback(async () => {
+    if (activeSessionIdRef.current || choosingProjectFolderRef.current) {
+      return
+    }
+
+    choosingProjectFolderRef.current = true
+
+    try {
+      const folder = await pickProjectFolder()
+
+      if (folder) {
+        await startProjectFromFolder(folder)
+      }
+    } catch (error) {
+      notifyError(error, copy.cwdChangeFailed)
+    } finally {
+      choosingProjectFolderRef.current = false
+    }
+  }, [activeSessionIdRef, copy, startProjectFromFolder])
+
   const changeSessionCwd = useCallback(
     async (cwd: string) => {
       const trimmed = cwd.trim()
@@ -60,32 +143,7 @@ export function useCwdActions({
       }
 
       if (!activeSessionId) {
-        setCurrentCwd(trimmed)
-        const workspaceGeneration = setNewChatWorkspaceTarget(trimmed)
-
-        try {
-          const info = await requestGateway<{ branch?: string; cwd?: string }>('config.get', {
-            key: 'project',
-            cwd: trimmed
-          })
-
-          if ($newChatWorkspaceTargetGeneration.get() !== workspaceGeneration || activeSessionIdRef.current) {
-            return
-          }
-
-          // Adopt the backend's normalized cwd so the persisted workspace and
-          // branch stay consistent with what the agent will use.
-          if (info.cwd) {
-            setCurrentCwd(info.cwd)
-            setNewChatWorkspaceTarget(info.cwd)
-          }
-
-          setCurrentBranch(info.branch || '')
-        } catch {
-          if ($newChatWorkspaceTargetGeneration.get() === workspaceGeneration && !activeSessionIdRef.current) {
-            setCurrentBranch('')
-          }
-        }
+        await stageNewChatWorkspace(trimmed)
 
         return
       }
@@ -117,8 +175,8 @@ export function useCwdActions({
         })
       }
     },
-    [activeSessionId, activeSessionIdRef, copy, onSessionRuntimeInfo, requestGateway]
+    [activeSessionId, copy, onSessionRuntimeInfo, requestGateway, stageNewChatWorkspace]
   )
 
-  return { changeSessionCwd, refreshProjectBranch }
+  return { changeSessionCwd, chooseProjectFolder, refreshProjectBranch, startProjectFromFolder }
 }

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -6,9 +6,11 @@ import {
   $activeProjectId,
   $projectScope,
   $projectsRpcAvailable,
+  $projectTree,
   $worktreeRefreshToken,
   ALL_PROJECTS,
   createProject,
+  ensureProjectForFolder,
   enterProject,
   exitProjectScope,
   openProjectCreate,
@@ -165,7 +167,200 @@ describe('createProject', () => {
     )
     expect($projectsRpcAvailable.get()).toBe(false)
   })
+  it('creates an explicit Project named for an unowned folder before entering it', async () => {
+    const created = { folders: [{ path: '/srv/new-project' }], id: 'p_new', name: 'new-project', primary_path: '/srv/new-project' }
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.create') {
+        return { project: created }
+      }
+
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+
+      return { active_id: 'p_new', projects: [created], scoped_session_ids: [] }
+    })
+
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    $sidebarAgentsGrouped.set(false)
+
+    await expect(ensureProjectForFolder('/srv/new-project')).resolves.toBe('/srv/new-project')
+
+    expect(request).toHaveBeenCalledWith(
+      'projects.create',
+      expect.objectContaining({ folders: ['/srv/new-project'], name: 'new-project', primary_path: '/srv/new-project', use: false })
+    )
+    expect($projectScope.get()).toBe('p_new')
+    expect($sidebarAgentsGrouped.get()).toBe(true)
+  })
+
+  it('enters the deepest Project that already owns the folder without creating another', async () => {
+    const owners = [
+      {
+        color: null,
+        icon: null,
+        id: 'p_parent',
+        isAuto: false,
+        label: 'parent',
+        path: '/srv',
+        previewSessions: [],
+        repos: [],
+        sessionCount: 0
+      },
+      {
+        color: null,
+        icon: null,
+        id: 'p_child',
+        isAuto: false,
+        label: 'child',
+        path: '/srv/team/child',
+        previewSessions: [],
+        repos: [],
+        sessionCount: 0
+      }
+    ]
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: owners, scoped_session_ids: [] }
+      }
+
+      return {}
+    })
+
+    $sidebarAgentsGrouped.set(false)
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('/srv/team/child/src')).resolves.toBe('/srv/team/child/src')
+
+    expect($projectScope.get()).toBe('p_child')
+    expect($sidebarAgentsGrouped.get()).toBe(true)
+    expect(request).not.toHaveBeenCalledWith('projects.create', expect.anything())
+  })
+
+  it('reuses an owning Project for Windows-style paths', async () => {
+    const owner = {
+      color: null,
+      icon: null,
+      id: 'p_windows',
+      isAuto: false,
+      label: 'windows',
+      path: 'C:\\Users\\dev\\project',
+      previewSessions: [],
+      repos: [],
+      sessionCount: 0
+    }
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [owner], scoped_session_ids: [] }
+      }
+
+      return {}
+    })
+
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('C:\\Users\\dev\\project\\src')).resolves.toBe(
+      'C:\\Users\\dev\\project\\src'
+    )
+
+    expect($projectScope.get()).toBe('p_windows')
+    expect(request).not.toHaveBeenCalledWith('projects.create', expect.anything())
+  })
+
+  it('rejects without leaking scope when the backend creates no Project', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+
+      if (method === 'projects.create') {
+        return { project: null }
+      }
+
+      return {}
+    })
+
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('/srv/orphan')).rejects.toThrow('Could not create a Project')
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+  })
+
+  it('cancels (returns null, no Project) when a session becomes active mid-resolution', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+
+      return {}
+    })
+
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('/srv/late', () => true)).resolves.toBeNull()
+    expect(request).not.toHaveBeenCalledWith('projects.create', expect.anything())
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+  })
+
+  it('surfaces the error and does not create when the authoritative tree read fails', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        throw new Error('tree unavailable')
+      }
+
+      return {}
+    })
+
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('/srv/maybe-owned')).rejects.toThrow('tree unavailable')
+    expect(request).not.toHaveBeenCalledWith('projects.create', expect.anything())
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+  })
+
+  it('does not switch scope when a session starts during the create RPC', async () => {
+    const created = { folders: [{ path: '/srv/race' }], id: 'p_race', name: 'race', primary_path: '/srv/race' }
+    let cancelled = false
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+
+      if (method === 'projects.create') {
+        cancelled = true
+
+        return { project: created }
+      }
+
+      return {}
+    })
+
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(ensureProjectForFolder('/srv/race', () => cancelled)).resolves.toBeNull()
+    expect(request).toHaveBeenCalledWith('projects.create', expect.anything())
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect($activeProjectId.get()).toBeNull()
+    expect($sidebarAgentsGrouped.get()).toBe(false)
+  })
 })
+
 
 describe('projects RPC capability', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -151,8 +151,21 @@ export function resolveNewSessionCwd(): string {
   return workspaceCwdForNewSession()
 }
 
-const underPath = (parent: string, child: string): boolean =>
-  child === parent || child.startsWith(parent.endsWith('/') ? parent : `${parent}/`)
+const comparablePath = (path: string): string => {
+  const normalized = path.trim().replace(/\\/g, '/').replace(/\/+$/, '')
+
+  return normalized || '/'
+}
+
+const underPath = (parent: string, child: string): boolean => {
+  const normalizedParent = comparablePath(parent)
+  const normalizedChild = comparablePath(child)
+
+  return (
+    normalizedChild === normalizedParent ||
+    normalizedChild.startsWith(normalizedParent === '/' ? '/' : `${normalizedParent}/`)
+  )
+}
 
 // The project (explicit or auto) that owns `cwd`, by longest path match across
 // the live tree. Null when no project covers it (it'll surface as a fresh
@@ -178,6 +191,63 @@ export function projectIdForCwd(cwd: string): null | string {
   }
 
   return best
+}
+
+// A detached chat becomes project-backed before it receives a workspace target.
+// Reuse the deepest project that already owns the selected folder; otherwise make
+// one explicit project named for the folder. Callers must await this before
+// staging cwd so a failed write never falls back to a raw, unowned folder.
+export async function ensureProjectForFolder(
+  cwd: string,
+  shouldCancel?: () => boolean
+): Promise<null | string> {
+  const selected = cwd.trim()
+
+  if (!selected) {
+    throw new Error('Choose a folder before starting a project')
+  }
+
+  await loadProjectTree()
+
+  const projectId = projectIdForCwd(selected)
+
+  if (projectId) {
+    if (shouldCancel?.()) {
+      return null
+    }
+
+    setSidebarAgentsGrouped(true)
+    enterProject(projectId)
+
+    return selected
+  }
+
+  if (shouldCancel?.()) {
+    return null
+  }
+
+  const folderName = selected.replace(/[/\\]+$/, '').split(/[/\\]+/).filter(Boolean).pop() || selected
+
+  const created = await createProject({
+    folders: [selected],
+    name: folderName,
+    primaryPath: selected,
+    reveal: false,
+    use: false
+  })
+
+  if (!created) {
+    throw new Error('Could not create a Project for the selected folder')
+  }
+
+  if (shouldCancel?.()) {
+    return null
+  }
+
+  setSidebarAgentsGrouped(true)
+  enterProject(created.id)
+
+  return (created.primary_path || selected).trim()
 }
 
 // The active session's agent relocated itself (created/entered another repo or
@@ -250,10 +320,7 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-// Pull the authoritative project tree (overview structure + counts + preview
-// sessions + the scoped-session-id set). Best-effort: a failure leaves the
-// cached tree intact so the sidebar doesn't flicker.
-export async function refreshProjectTree(): Promise<void> {
+async function loadProjectTree(): Promise<void> {
   $projectTreeLoading.set(true)
 
   try {
@@ -281,9 +348,20 @@ export async function refreshProjectTree(): Promise<void> {
     markProjectsRpcSuccess()
   } catch (err) {
     markProjectsRpcFailure(err)
-    // Backend may not be ready; keep the last known tree.
+    throw err
   } finally {
     $projectTreeLoading.set(false)
+  }
+}
+
+// Pull the authoritative project tree (overview structure + counts + preview
+// sessions + the scoped-session-id set). Best-effort: a failure leaves the
+// cached tree intact so the sidebar doesn't flicker.
+export async function refreshProjectTree(): Promise<void> {
+  try {
+    await loadProjectTree()
+  } catch {
+    // Backend may not be ready; keep the last known tree.
   }
 }
 
@@ -339,6 +417,7 @@ export interface CreateProjectInput {
   color?: string
   boardSlug?: string
   use?: boolean
+  reveal?: boolean
   // Free-text project idea; written to IDEA.md at the primary folder on create.
   idea?: string
 }
@@ -488,7 +567,9 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
       $activeProjectId.set(created.id)
     }
 
-    setSidebarAgentsGrouped(true)
+    if (input.reveal ?? true) {
+      setSidebarAgentsGrouped(true)
+    }
   }
 
   reconcileProjects()


### PR DESCRIPTION
## What does this PR do?

It fixes the same regression in #53004, but does not restore the raw/remembered cwd model that made #53057 conflict with the Projects direction. Folder selection is now an entry point into Project, and Project is the sole owner of workspace identity.

## Related Issue

Fixes #53004

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made


- Only detached chats show an Open folder action in the right rail.
- Choosing a folder first resolves it through Projects:
  - if an existing Project owns it, Hermes enters that Project;
  - otherwise it creates an explicit Project named after the folder.
- Only after Project resolution succeeds does the folder become the new draft’s workspace cwd.
- If the Project lookup/create fails, Hermes shows an error and does not stage a raw cwd.
- If a session becomes active during the async flow, cwd/session state and foreground Project UI are left untouched.
- A create already committed during that race remains as an inactive Project record; it is not deleted automatically.
- Active sessions never receive a raw folder-picker cwd mutation path.

> Implementation uses the existing `projects.tree` and `projects.create` RPCs;
it introduces no gateway Projects API change. 

## How to Test

1. cmd+n to start new chat
2. open folder button is visible in right sidebar
3. click on it spawns system folder picker
4. on selection - new project is created, or new session in the existing project if folder path matches existing project.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: MacOS 26.5.1

> PR doesn't contain changes to the python side of the Hermess, not all tests from `pytest tests/ -q` pass

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="2244" height="1746" alt="Знімок екрана 2026-07-13 о 14 05 27" src="https://github.com/user-attachments/assets/8a49208e-42f8-4b2e-adc3-98200305e12e" />
