### PR TITLE
feat(optional-skills): add project-security-reviewer skill

### DIFF
--- a/optional-skills/software-development/project-security-reviewer/SKILL.md
+++ b/optional-skills/software-development/project-security-reviewer/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: project-security-reviewer
+description: "Detect a repository's toolchain and perform an evidence-based security review. Use for general project security reviews, code audits, pre-merge checks, or when a user wants a review adapted to an unfamiliar local project or Git repository."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Security, Code-Review, Audit, Software-Development, Toolchain]
+    category: software-development
+    related_skills: [github-code-review]
+---
+
+# Project Security Reviewer
+
+Adapt a security review to the repository rather than applying one generic test command. Detect project manifests first, select only compatible local tooling, and produce a Markdown report backed by observed evidence.
+
+## When to Use
+
+- User asks to audit, security-review, or check a project before merge or release.
+- User provides an unfamiliar repository and wants the review adapted to its stack.
+- User asks for a general code-security review rather than a framework-specific audit.
+
+Do not use when the user only wants a GitHub PR diff review; use `github-code-review` instead. Do not replace a domain-specific review when a dedicated skill exists.
+
+## Required Input
+
+- Accept a local repository path, the current directory, or a Git URL.
+- If the user gives only a project name, ask for its local path or Git URL. Do not guess the source repository.
+- Before cloning a Git URL, ask for confirmation because cloning writes files locally.
+
+## Procedure
+
+1. Resolve the repository root and record the reviewed commit or branch.
+2. Detect manifests and recommended workflows without executing project code:
+
+   ```bash
+   bash ${HERMES_SKILL_DIR}/scripts/detect_project.sh <project-root>
+   ```
+
+3. Read the top-level README, dependency manifests, lockfiles, CI configuration, and security policy before selecting checks.
+4. Use the detected workflow from [toolchain workflows](references/toolchain-workflows.md). Prefer commands already declared by the project and tools already on `PATH`.
+5. Delegate when a specialized skill applies:
+
+   - `foundry.toml` — use an installed Foundry-specific review workflow; when `foundry-security-reviewer` is available, use it for build, Forge tests, coverage, gas snapshots, and Solidity analyzers.
+   - A GitHub PR-only request — use `github-code-review`.
+   - A deployed web application rather than source code — use `web-pentest` when appropriate and authorized.
+
+6. Do not install packages, run deployment commands, mutate databases, use production credentials, or transmit source code to external scanners without explicit approval.
+7. Run relevant tests, linters, and installed dependency/security scanners. Capture failures as evidence; do not mark an unrun check as passed.
+8. Inspect authentication, authorization, input validation, secrets, dependency risk, unsafe deserialization, injection paths, concurrency, and the project's domain-specific trust boundaries.
+9. Separate confirmed vulnerabilities from hypotheses and false positives. Include a concrete exploit path, affected file/function, impact, and remediation for every confirmed finding.
+
+## Output Format
+
+Return a Markdown report suitable for a PR comment:
+
+```markdown
+## Project Security Review
+
+**Scope:** `<repo>@<commit>`
+**Detected stack:** `<toolchains>`
+
+### Checks Run
+- [x] `<command>` — result
+- [ ] `<command>` — not run, reason
+
+### Findings
+- **HIGH** — `path/to/file:line` — impact, reachable exploit path, remediation
+
+### Test and Dependency Coverage
+- Relevant tests and lint/security-tool results
+- Known gaps or unavailable scanners
+
+### Residual Risk
+- Assumptions, unreviewed components, and false-positive decisions
+
+### Recommendations
+- [ ] Concrete follow-up, owner, or regression-test action
+```
+
+## Pitfalls
+
+- A project name is not a review target. Require a local path or an explicit repository URL.
+- Monorepos can contain several manifests. Review each independent deployable component and state the scope.
+- Test commands can create files, contact services, or require credentials. Inspect scripts and configuration first.
+- Dependency-audit commands can need registry/network access; run them only when permitted and record unavailable results.
+- Static-analysis findings are leads, not proof. Confirm reachability and impact in source before reporting severity.
+
+## Verification
+
+- Verify the report names the actual revision and every detected toolchain.
+- Verify every checked item includes command output or a concise result.
+- Verify every finding maps to source evidence and a remediation or regression-test recommendation.

--- a/optional-skills/software-development/project-security-reviewer/SKILL.md
+++ b/optional-skills/software-development/project-security-reviewer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: project-security-reviewer
-description: "Detect a repository's toolchain and perform an evidence-based security review. Use for general project security reviews, code audits, pre-merge checks, or when a user wants a review adapted to an unfamiliar local project or Git repository."
+description: "Review unfamiliar projects for security risks."
 version: 1.0.0
-author: Hermes Agent
+author: Ahmet Osrak (Osraka), Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, macos]
 metadata:
   hermes:
     tags: [Security, Code-Review, Audit, Software-Development, Toolchain]
@@ -12,49 +12,98 @@ metadata:
     related_skills: [github-code-review]
 ---
 
-# Project Security Reviewer
+# Project Security Reviewer Skill
 
-Adapt a security review to the repository rather than applying one generic test command. Detect project manifests first, select only compatible local tooling, and produce a Markdown report backed by observed evidence.
+Adapt a security review to the repository's detected toolchain instead of
+running one generic command set. This skill inspects local project evidence
+and reports confirmed findings, test gaps, and unavailable checks; it does
+not install dependencies, contact production systems, or replace a
+domain-specific audit skill.
 
 ## When to Use
 
-- User asks to audit, security-review, or check a project before merge or release.
-- User provides an unfamiliar repository and wants the review adapted to its stack.
-- User asks for a general code-security review rather than a framework-specific audit.
+- The user requests a security review of a local project or Git repository.
+- The repository has an unfamiliar or mixed toolchain.
+- The user wants evidence suitable for a pre-merge or release review.
 
-Do not use when the user only wants a GitHub PR diff review; use `github-code-review` instead. Do not replace a domain-specific review when a dedicated skill exists.
+Do not use this for a GitHub PR-only diff review; use `github-code-review`.
+Do not replace a domain-specific skill when one is available.
 
-## Required Input
+## Prerequisites
 
-- Accept a local repository path, the current directory, or a Git URL.
-- If the user gives only a project name, ask for its local path or Git URL. Do not guess the source repository.
-- Before cloning a Git URL, ask for confirmation because cloning writes files locally.
+- A local repository path or an explicit Git URL.
+- The `terminal`, `read_file`, and `search_files` tools.
+- Bash on Linux or macOS for the bundled manifest detector.
+- Optional project tools such as Foundry, Cargo, pytest, or dependency scanners
+  when they are already installed and the project documents their use.
+
+If the user provides only a project name, ask for its local path or Git URL.
+Ask for confirmation before cloning a Git URL because cloning writes locally.
+
+## How to Run
+
+From the target repository, invoke the detector through the `terminal` tool:
+
+```text
+bash ${HERMES_SKILL_DIR}/scripts/detect_project.sh <project-root>
+```
+
+Then use `read_file` and `search_files` to inspect the README, manifests,
+lockfiles, CI configuration, security policy, and the workflows listed by the
+detector. Run only compatible commands that are already available on `PATH`.
+
+## Quick Reference
+
+| Stage | Action |
+| --- | --- |
+| Resolve | Record the repository path and reviewed commit or branch. |
+| Detect | Run `scripts/detect_project.sh` without executing project code. |
+| Inspect | Read manifests, lockfiles, CI, README, and security policy. |
+| Select | Choose documented tests, linters, and installed scanners. |
+| Review | Check auth, input boundaries, secrets, dependencies, and concurrency. |
+| Report | Separate confirmed findings from hypotheses and unavailable checks. |
 
 ## Procedure
 
-1. Resolve the repository root and record the reviewed commit or branch.
-2. Detect manifests and recommended workflows without executing project code:
+1. Resolve the repository root and record the reviewed revision.
+2. Run `scripts/detect_project.sh <project-root>` through `terminal`.
+3. Read the top-level README, dependency manifests, lockfiles, CI files, and
+   security policy before selecting commands.
+4. Follow the matching workflow in
+   [references/toolchain-workflows.md](references/toolchain-workflows.md).
+   Prefer commands declared by the project and tools already on `PATH`.
+5. If `foundry.toml` is present, delegate build, Forge tests, coverage, gas
+   snapshots, and Solidity analyzers to `foundry-security-reviewer` when it is
+   installed.
+6. If the request is a GitHub PR-only review, use `github-code-review` instead.
+7. Do not install packages, run deployments, mutate databases, use production
+   credentials, or send source code to external scanners without approval.
+8. Run relevant tests, linters, and installed scanners. Record failures as
+   evidence and never mark an unrun check as passed.
+9. Inspect authentication, authorization, validation, secrets, unsafe
+   deserialization, injection paths, concurrency, and trust boundaries.
+10. For every confirmed finding, record the affected path or function, impact,
+    reachable exploit path, and remediation or regression-test recommendation.
 
-   ```bash
-   bash ${HERMES_SKILL_DIR}/scripts/detect_project.sh <project-root>
-   ```
+## Pitfalls
 
-3. Read the top-level README, dependency manifests, lockfiles, CI configuration, and security policy before selecting checks.
-4. Use the detected workflow from [toolchain workflows](references/toolchain-workflows.md). Prefer commands already declared by the project and tools already on `PATH`.
-5. Delegate when a specialized skill applies:
+- A project name is not a review target; require a local path or explicit URL.
+- Monorepos can contain several independently deployable components. State the
+  component scope instead of treating every manifest as one application.
+- Tests can create files, contact services, or require credentials. Inspect
+  their configuration before running them.
+- Dependency-audit commands may need network access. Run them only when
+  permitted and record unavailable results.
+- Static-analysis output is a lead, not proof. Confirm reachability and impact
+  before reporting severity.
 
-   - `foundry.toml` — use an installed Foundry-specific review workflow; when `foundry-security-reviewer` is available, use it for build, Forge tests, coverage, gas snapshots, and Solidity analyzers.
-   - A GitHub PR-only request — use `github-code-review`.
-   - A deployed web application rather than source code — use `web-pentest` when appropriate and authorized.
+## Verification
 
-6. Do not install packages, run deployment commands, mutate databases, use production credentials, or transmit source code to external scanners without explicit approval.
-7. Run relevant tests, linters, and installed dependency/security scanners. Capture failures as evidence; do not mark an unrun check as passed.
-8. Inspect authentication, authorization, input validation, secrets, dependency risk, unsafe deserialization, injection paths, concurrency, and the project's domain-specific trust boundaries.
-9. Separate confirmed vulnerabilities from hypotheses and false positives. Include a concrete exploit path, affected file/function, impact, and remediation for every confirmed finding.
+Before returning the report, verify that it names the actual revision and every
+detected toolchain. Each check must include its command and result, while every
+finding must map to source evidence and a remediation or regression test.
 
-## Output Format
-
-Return a Markdown report suitable for a PR comment:
+Use this report shape:
 
 ```markdown
 ## Project Security Review
@@ -67,29 +116,15 @@ Return a Markdown report suitable for a PR comment:
 - [ ] `<command>` — not run, reason
 
 ### Findings
-- **HIGH** — `path/to/file:line` — impact, reachable exploit path, remediation
+- **HIGH** — `path/to/file:line` — impact, exploit path, remediation
 
 ### Test and Dependency Coverage
-- Relevant tests and lint/security-tool results
-- Known gaps or unavailable scanners
+- Relevant tests and scanner results
+- Known gaps or unavailable tools
 
 ### Residual Risk
-- Assumptions, unreviewed components, and false-positive decisions
+- Assumptions and unreviewed components
 
 ### Recommendations
-- [ ] Concrete follow-up, owner, or regression-test action
+- [ ] Concrete follow-up or regression-test action
 ```
-
-## Pitfalls
-
-- A project name is not a review target. Require a local path or an explicit repository URL.
-- Monorepos can contain several manifests. Review each independent deployable component and state the scope.
-- Test commands can create files, contact services, or require credentials. Inspect scripts and configuration first.
-- Dependency-audit commands can need registry/network access; run them only when permitted and record unavailable results.
-- Static-analysis findings are leads, not proof. Confirm reachability and impact in source before reporting severity.
-
-## Verification
-
-- Verify the report names the actual revision and every detected toolchain.
-- Verify every checked item includes command output or a concise result.
-- Verify every finding maps to source evidence and a remediation or regression-test recommendation.

--- a/optional-skills/software-development/project-security-reviewer/references/toolchain-workflows.md
+++ b/optional-skills/software-development/project-security-reviewer/references/toolchain-workflows.md
@@ -1,0 +1,31 @@
+# Toolchain Workflows
+
+Use this reference after `detect_project.sh` identifies a manifest. Inspect the repository's own scripts, CI configuration, and security policy before running commands. Do not install dependencies or scanners without approval.
+
+## Foundry / Solidity
+
+When `foundry.toml` exists, use an installed Foundry-specific review workflow. When `foundry-security-reviewer` is available, it runs Forge build/test/coverage/snapshot and uses Slither or Aderyn when available. Focus on authorization, upgrade safety, accounting, oracle use, reentrancy, and invariant coverage.
+
+## Node.js / TypeScript
+
+Read `package.json`, lockfiles, workspace configuration, and CI first. Use the package manager indicated by the lockfile and only run declared test, lint, and type-check scripts. Review request boundaries, authorization, deserialization, SSRF, injection, client-side trust assumptions, and dependency changes. Run an installed dependency or static scanner only when its configuration and network behavior are understood.
+
+## Python
+
+Read `pyproject.toml`, `requirements*.txt`, lockfiles, and test configuration. Prefer the project's existing `pytest`, lint, type-check, and dependency-audit commands when their tools are available. Review unsafe deserialization, command construction, path traversal, template injection, authentication, authorization, and secrets handling.
+
+## Rust
+
+Read `Cargo.toml`, `Cargo.lock`, workspace configuration, and CI. Run `cargo test` and `cargo clippy` when appropriate; use an installed `cargo-audit` or `cargo-deny` only when configured. Review unsafe blocks, integer conversions, authentication boundaries, input parsing, concurrency, and FFI.
+
+## Go
+
+Read `go.mod`, `go.sum`, build tags, and CI. Run `go test ./...` when the repository's configuration permits it; use installed vulnerability tooling only when available. Review HTTP input handling, authorization middleware, SQL construction, file paths, race conditions, and `context` cancellation.
+
+## Java / Kotlin
+
+Read Maven or Gradle build files, dependency locks, framework configuration, and CI. Run the project's declared test and static-analysis tasks. Review deserialization, expression-language injection, ORM/query construction, authorization annotations, cryptography, and dependency updates.
+
+## Ruby / PHP and Unknown Toolchains
+
+Start by reading the README, manifest, lockfile, CI, and test entrypoints. Run only documented local checks. For an unknown project, identify its entrypoints, data stores, external integrations, authentication model, and deployment path before attempting automated analysis.

--- a/optional-skills/software-development/project-security-reviewer/scripts/detect_project.sh
+++ b/optional-skills/software-development/project-security-reviewer/scripts/detect_project.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Detect common repository manifests and print a review plan. This script never executes project commands.
+
+set -u
+set -o pipefail
+
+PROJECT_ROOT="${1:-$PWD}"
+
+if [ ! -d "$PROJECT_ROOT" ]; then
+  printf 'Error: project root does not exist: %s\n' "$PROJECT_ROOT" >&2
+  exit 2
+fi
+
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+
+find_manifest() {
+  local filename="$1"
+  find "$PROJECT_ROOT" \
+    -type d \( -name .git -o -name node_modules -o -name vendor -o -name target -o -name dist -o -name build \) -prune -o \
+    -type f -name "$filename" -print
+}
+
+print_rows() {
+  local toolchain="$1"
+  local filename="$2"
+  local workflow="$3"
+  local manifests
+  local manifest
+  local relative
+
+  manifests="$(find_manifest "$filename")"
+  [ -n "$manifests" ] || return 0
+
+  while IFS= read -r manifest; do
+    relative="${manifest#"$PROJECT_ROOT"/}"
+    printf '| %s | `%s` | %s |\n' "$toolchain" "$relative" "$workflow"
+    DETECTED=1
+  done <<EOF
+$manifests
+EOF
+}
+
+DETECTED=0
+
+printf '# Project Review Detection\n\n'
+printf -- '- **Root:** `%s`\n' "$PROJECT_ROOT"
+if [ -d "$PROJECT_ROOT/.git" ]; then
+  printf -- '- **Git repository:** yes\n'
+else
+  printf -- '- **Git repository:** no\n'
+fi
+
+printf '\n## Detected Toolchains\n\n'
+printf '| Toolchain | Evidence | Recommended workflow |\n'
+printf '| --- | --- | --- |\n'
+
+print_rows 'Foundry / Solidity' 'foundry.toml' 'Use an installed Foundry-specific review workflow.'
+print_rows 'Node.js / TypeScript' 'package.json' 'Inspect package scripts and lockfiles; run declared checks.'
+print_rows 'Python' 'pyproject.toml' 'Inspect test/lint configuration; run available local tools.'
+print_rows 'Python' 'requirements.txt' 'Inspect dependency and test configuration before choosing checks.'
+print_rows 'Rust' 'Cargo.toml' 'Run Cargo test/clippy and installed audit tooling.'
+print_rows 'Go' 'go.mod' 'Run Go tests and installed vulnerability tooling.'
+print_rows 'Java / Kotlin' 'pom.xml' 'Inspect Maven configuration and run declared tests.'
+print_rows 'Java / Kotlin' 'build.gradle' 'Inspect Gradle configuration and run declared tests.'
+print_rows 'Ruby' 'Gemfile' 'Inspect Bundler configuration and run declared tests.'
+print_rows 'PHP' 'composer.json' 'Inspect Composer configuration and run declared tests.'
+
+if [ "$DETECTED" -eq 0 ]; then
+  printf '| Unknown | No supported manifest found | Read the README, CI files, and build scripts before reviewing manually. |\n'
+fi
+
+printf '\n## Safe Next Steps\n\n'
+printf -- '- Read the README, manifests, lockfiles, and CI configuration before running commands.\n'
+printf -- '- Use only commands compatible with a detected toolchain and available on `PATH`.\n'
+printf -- '- Do not install dependencies, contact production services, or run deployment scripts without approval.\n'
+printf -- '- Record unrun checks and missing tools in the final review.\n'

--- a/tests/skills/test_project_security_reviewer_skill.py
+++ b/tests/skills/test_project_security_reviewer_skill.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "software-development"
+    / "project-security-reviewer"
+    / "SKILL.md"
+)
+SCRIPT_PATH = SKILL_PATH.parent / "scripts" / "detect_project.sh"
+
+
+def _frontmatter(text: str) -> str:
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def test_skill_metadata_and_modern_sections():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    metadata = _frontmatter(text)
+    description = re.search(r'^description: "([^"]+)"$', metadata, re.MULTILINE)
+
+    assert description is not None
+    assert len(description.group(1)) <= 60
+    assert description.group(1).endswith(".")
+    assert "author: Ahmet Osrak (Osraka), Hermes Agent" in metadata
+    assert "platforms: [linux, macos]" in metadata
+
+    sections = re.findall(r"^## (.+)$", text, re.MULTILINE)
+    assert sections[:7] == [
+        "When to Use",
+        "Prerequisites",
+        "How to Run",
+        "Quick Reference",
+        "Procedure",
+        "Pitfalls",
+        "Verification",
+    ]
+
+
+def test_detector_reports_nested_supported_manifests(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / "foundry.toml").write_text("[profile.default]\n", encoding="utf-8")
+    nested = project / "frontend"
+    nested.mkdir()
+    (nested / "package.json").write_text("{}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), str(project)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "**Git repository:** yes" in result.stdout
+    assert "Foundry / Solidity" in result.stdout
+    assert "`foundry.toml`" in result.stdout
+    assert "Node.js / TypeScript" in result.stdout
+    assert "`frontend/package.json`" in result.stdout


### PR DESCRIPTION
## Summary

Adds an optional, stack-aware security review skill for local repositories and explicit Git URLs. It is a safe orchestration layer: it detects project manifests, selects compatible review workflows, and produces an evidence-based Markdown report without installing dependencies or executing project commands during detection.

## What it detects

`detect_project.sh` identifies Foundry, Node.js/TypeScript, Python, Rust, Go, Java/Kotlin, Ruby, and PHP manifests while skipping generated/vendor directories such as `node_modules`, `target`, and `vendor`.

## Review model

- Requires a local path or Git URL; a project name alone is intentionally insufficient.
- Delegates to a specialized Foundry workflow when one is installed.
- Uses repository-declared checks and tools already on PATH.
- Records skipped checks, unavailable scanners, confirmed findings, and residual risk.
- Avoids dependency installation, deployments, production credentials, and external source-code uploads without approval.

## Validation

- Parsed and verified SKILL.md frontmatter.
- Ran `bash -n` for the detector.
- Ran the detector on a mixed Foundry/Node/Rust fixture and confirmed that `node_modules` was ignored.
- Checked its missing-directory error path and whitespace with `git diff --check`.