### PR TITLE
fix(auth): normalize Anthropic sk-ant-oat pool credentials to OAuth

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -175,6 +175,16 @@ class PooledCredential:
         data.setdefault("id", uuid.uuid4().hex[:6])
         data.setdefault("label", payload.get("source", provider))
         data.setdefault("auth_type", AUTH_TYPE_API_KEY)
+        # An Anthropic setup-token (sk-ant-oat*) is always OAuth regardless of
+        # how it was ingested. The env path infers this, but manually-added
+        # credentials (hermes auth add / dashboard) default to api_key and are
+        # then sent with an x-api-key header, which Anthropic rejects for OAuth
+        # tokens. Normalize here so every ingest path agrees with
+        # _is_oauth_token()'s prefix detection. See issue #63737.
+        if provider == "anthropic":
+            _oat = data.get("access_token") or ""
+            if isinstance(_oat, str) and _oat.startswith("sk-ant-oat"):
+                data["auth_type"] = AUTH_TYPE_OAUTH
         data.setdefault("priority", 0)
         data.setdefault("source", SOURCE_MANUAL)
         data.setdefault("access_token", "")

--- a/tests/agent/test_credential_pool_oat_authtype.py
+++ b/tests/agent/test_credential_pool_oat_authtype.py
@@ -1,0 +1,33 @@
+"""Regression test for #63737: sk-ant-oat tokens must be OAuth, not api_key."""
+from agent.credential_pool import (
+    PooledCredential,
+    AUTH_TYPE_OAUTH,
+    AUTH_TYPE_API_KEY,
+)
+
+
+def test_manual_anthropic_oat_normalized_to_oauth():
+    # A setup-token added manually (dashboard / hermes auth add) defaults to
+    # api_key; it must be normalized to OAuth so it is sent with Bearer auth.
+    entry = PooledCredential.from_dict(
+        "anthropic",
+        {"label": "MainKey", "source": "manual",
+         "auth_type": "api_key", "access_token": "sk-ant-oat01-EXAMPLE"},
+    )
+    assert entry.auth_type == AUTH_TYPE_OAUTH
+
+
+def test_anthropic_real_api_key_unchanged():
+    entry = PooledCredential.from_dict(
+        "anthropic",
+        {"auth_type": "api_key", "access_token": "sk-ant-api03-EXAMPLE"},
+    )
+    assert entry.auth_type == AUTH_TYPE_API_KEY
+
+
+def test_non_anthropic_provider_unchanged():
+    entry = PooledCredential.from_dict(
+        "openrouter",
+        {"auth_type": "api_key", "access_token": "sk-ant-oat01-WHATEVER"},
+    )
+    assert entry.auth_type == AUTH_TYPE_API_KEY


### PR DESCRIPTION
## Problem

A manually-added Anthropic **OAuth setup-token** (`sk-ant-oat…`) is stored in the credential pool as `auth_type: "api_key"`, so it goes out over an `x-api-key` header instead of `Authorization: Bearer` + the Claude Code beta header. Anthropic rejects it, and in a multi-credential pool the failure surfaces as `429 "monthly spend limit"` even though that account has quota — so subscription-token rotation is silently defeated.

Fixes #63737.

## Root cause

The `sk-ant-oat` → OAuth prefix inference only exists in the env ingest path (`credential_pool.py` ~L2256). The central deserializer `PooledCredential.from_dict` defaults `auth_type` to `api_key` and never consults the token prefix, so anything added via `hermes auth add` / the dashboard (`source=manual`) is mis-typed. `_is_oauth_token()` classifies the same string as OAuth by prefix, so the stored `auth_type` and the adapter disagree.

## Fix

Normalize in `from_dict` so **every** ingest path agrees with `_is_oauth_token()`'s prefix detection. This is self-healing: already-persisted `api_key` entries holding a `sk-ant-oat` token are corrected on next load. Scoped to `provider == "anthropic"` and the `sk-ant-oat` prefix, so real `sk-ant-api…` keys and other providers are untouched.

## Tests

Adds `tests/agent/test_credential_pool_oat_authtype.py`:
- `sk-ant-oat` + `api_key` → normalized to OAuth
- `sk-ant-api` → stays `api_key`
- non-Anthropic provider → unchanged

## Verification

Reproduced and fixed on a live v0.18.2 deployment: a healthy second `sk-ant-oat` account stored as `api_key` returned `429 monthly spend limit` on every request; flipping the entry to `oauth` (what this patch does automatically) restored service immediately.
