### PR TITLE
fix(azure-foundry): retain reasoning item id during replay for Azure AI Foundry

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -893,8 +893,14 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        _is_azure_for_input = (
+            base_url_host_matches(_host_for_input, "openai.azure.com")
+            or base_url_host_matches(_host_for_input, "azure-api.net")
+        )
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=_is_github_for_input,
+            replay_messages,
+            is_github_responses=_is_github_for_input,
+            is_azure_foundry_responses=_is_azure_for_input,
         )
 
         resp_kwargs: Dict[str, Any] = {

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -829,6 +829,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        is_azure_foundry_responses = agent.provider == "azure-foundry"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -875,6 +876,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_azure_foundry_responses=is_azure_foundry_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -315,6 +315,7 @@ def _chat_messages_to_responses_input(
     *,
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
+    is_azure_foundry_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
@@ -425,16 +426,19 @@ def _chat_messages_to_responses_input(
                                     )
                                     _CROSS_ISSUER_WARN_EMITTED = True
                                 continue
-                            # Strip the "id" field — with store=False the
-                            # Responses API cannot look up items by ID and
-                            # returns 404.  The encrypted_content blob is
-                            # self-contained for reasoning chain continuity.
+                            # Strip the "id" field for OpenAI-style Responses API — with
+                            # store=False the OpenAI Responses API cannot look up items
+                            # by ID and returns 404. Azure AI Foundry Responses API
+                            # requires the id to be retained even with store=False.
                             # Also strip the internal "_issuer_kind" stamp;
                             # it is a Hermes-side metadata key and not part
                             # of the Responses API schema.
+                            keys_to_strip: set = {"_issuer_kind"}
+                            if not is_azure_foundry_responses:
+                                keys_to_strip.add("id")
                             replay_item = {
                                 k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
+                                if k not in keys_to_strip
                             }
                             items.append(replay_item)
                             if item_id:
@@ -604,6 +608,7 @@ def _preflight_codex_input_items(
     raw_items: Any,
     *,
     is_github_responses: bool = False,
+    is_azure_foundry_responses: bool = False,
 ) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -699,11 +704,18 @@ def _preflight_codex_input_items(
                     if item_id in seen_ids:
                         continue
                     seen_ids.add(item_id)
-                reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
-                # Do NOT include the "id" in the outgoing item — with
-                # store=False (our default) the API tries to resolve the
-                # id server-side and returns 404.  The id is still used
-                # above for local deduplication via seen_ids.
+                reasoning_item: Dict[str, Any] = {
+                    "type": "reasoning", "encrypted_content": encrypted,
+                }
+                # Do NOT include the "id" in the outgoing item for OpenAI-style
+                # Responses API — with store=False (our default) the API tries
+                # to resolve the id server-side and returns 404.  Azure AI
+                # Foundry requires the id even with store=False.
+                # The id is still used above for local deduplication via
+                # seen_ids regardless of this flag.
+                if is_azure_foundry_responses:
+                    if isinstance(item_id, str) and item_id:
+                        reasoning_item["id"] = item_id
                 summary = item.get("summary")
                 if isinstance(summary, list):
                     reasoning_item["summary"] = summary

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -82,6 +82,7 @@ class ResponsesApiTransport(ProviderTransport):
             messages,
             is_xai_responses=kwargs.get("is_xai_responses") is True,
             is_github_responses=kwargs.get("is_github_responses") is True,
+            is_azure_foundry_responses=kwargs.get("is_azure_foundry_responses") is True,
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
@@ -141,6 +142,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_azure_foundry_responses = params.get("is_azure_foundry_responses") is True
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -247,6 +249,7 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
                 is_github_responses=is_github_responses,
+                is_azure_foundry_responses=is_azure_foundry_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
             ),


### PR DESCRIPTION
Fixes #63257

## Problem

Azure AI Foundry Responses API requires the `id` field in replayed encrypted reasoning items for cross-turn reasoning coherence. Hermes was unconditionally stripping the `id` (matching OpenAI Responses API behavior which rejects ids with `store=False`), causing Azure Foundry conversations to fail with HTTP 400 `invalid_payload` on every turn after the first.

## Change

Added an `is_azure_foundry_responses` flag threaded through:

- `agent/codex_responses_adapter.py` — `_chat_messages_to_responses_input` and `_preflight_codex_input_items` retain the reasoning item `id` when the flag is set
- `agent/transports/codex.py` — passes the flag through `convert_messages` and `build_kwargs`
- `agent/chat_completion_helpers.py` — detects Azure Foundry by provider name
- `agent/auxiliary_client.py` — detects Azure Foundry by base URL in the `_CodexCompletionsAdapter`

Azure endpoints are detected via:
1. Provider name `azure-foundry` in the main agent path
2. Base URL containing `openai.azure.com` or `azure-api.net` in the auxiliary client path

## Testing

All existing tests pass (86 codex_responses tests, 22 adapter tests, 60 auxiliary client tests). No behavioral change for non-Azure providers.