### PR TITLE
fix(agent): sync skills into persistent Codex threads

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -22,6 +22,8 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 
@@ -391,6 +393,7 @@ def run_codex_app_server_turn(
 
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            extra_skill_roots=[str(get_hermes_home() / "skills")],
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -204,6 +204,7 @@ class CodexAppServerSession:
         cwd: Optional[str] = None,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        extra_skill_roots: Optional[list[str]] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -213,6 +214,14 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._extra_skill_roots = [
+            os.path.realpath(os.path.expanduser(root))
+            for root in (extra_skill_roots or [])
+            if root
+        ]
+        self._skill_fingerprints: Optional[dict[str, tuple[int, int]]] = None
+        self._skill_roots_registered = not self._extra_skill_roots
+        self._turn_started_once = False
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -237,11 +246,33 @@ class CodexAppServerSession:
 
     # ---------- lifecycle ----------
 
+    def _register_extra_skill_roots(self) -> bool:
+        """Best-effort registration that remains retryable for this thread."""
+        if self._skill_roots_registered:
+            return True
+        if not self._extra_skill_roots or self._client is None:
+            return False
+        try:
+            self._client.request(
+                "skills/extraRoots/set",
+                {"extraRoots": self._extra_skill_roots},
+                timeout=15,
+            )
+        except (CodexAppServerError, TimeoutError):
+            logger.warning(
+                "codex app-server could not register Hermes skill roots",
+                exc_info=True,
+            )
+            return False
+        self._skill_roots_registered = True
+        return True
+
     def ensure_started(self) -> str:
         """Spawn the subprocess, do the initialize handshake, and start a
-        thread. Returns the codex thread id. Idempotent — repeated calls
-        return the same thread id."""
+        thread. Returns the codex thread id. Repeated calls reuse the thread and
+        retry any skill-root registration that previously failed."""
         if self._thread_id is not None:
+            self._register_extra_skill_roots()
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(
@@ -289,6 +320,7 @@ class CodexAppServerSession:
                 ),
             )
         self._thread_id = thread_id
+        self._register_extra_skill_roots()
         logger.info(
             "codex app-server thread started: id=%s profile=%s cwd=%s",
             self._thread_id[:8],
@@ -363,6 +395,85 @@ class CodexAppServerSession:
 
     # ---------- per-turn ----------
 
+    def _reload_changed_skills(
+        self,
+    ) -> tuple[list[dict[str, str]], Optional[dict[str, tuple[int, int]]]]:
+        """Reload Codex's catalog and return Hermes skills changed since the
+        previous turn.
+
+        Codex injects the available-skills catalog when a thread's first turn
+        starts, but ``skills/list(forceReload=True)`` alone does not update that
+        already-running thread. Changed skills are therefore returned as native
+        ``SkillUserInput`` items for the next ``turn/start`` request.
+        """
+        if (
+            not self._extra_skill_roots
+            or self._client is None
+            or not self._skill_roots_registered
+        ):
+            return [], None
+
+        try:
+            response = self._client.request(
+                "skills/list",
+                {"cwds": [self._cwd], "forceReload": True},
+                timeout=30,
+            )
+        except (CodexAppServerError, TimeoutError):
+            logger.warning(
+                "codex app-server could not reload Hermes skills",
+                exc_info=True,
+            )
+            return [], None
+
+        current: dict[str, tuple[int, int]] = {}
+        metadata: dict[str, dict[str, str]] = {}
+        for entry in response.get("data") or []:
+            if not isinstance(entry, dict):
+                continue
+            for skill in entry.get("skills") or []:
+                if not isinstance(skill, dict) or skill.get("enabled") is False:
+                    continue
+                name = skill.get("name")
+                path = skill.get("path")
+                if not isinstance(name, str) or not isinstance(path, str):
+                    continue
+                real_path = os.path.realpath(path)
+                try:
+                    belongs_to_hermes = any(
+                        os.path.commonpath((real_path, root)) == root
+                        for root in self._extra_skill_roots
+                    )
+                except ValueError:
+                    belongs_to_hermes = False
+                if not belongs_to_hermes:
+                    continue
+                try:
+                    stat = os.stat(real_path)
+                except OSError:
+                    continue
+                current[real_path] = (stat.st_mtime_ns, stat.st_size)
+                metadata[real_path] = {
+                    "type": "skill",
+                    "name": name,
+                    "path": real_path,
+                }
+
+        changed: list[dict[str, str]] = []
+        if self._skill_fingerprints is not None:
+            changed = [
+                metadata[path]
+                for path, fingerprint in current.items()
+                if self._skill_fingerprints.get(path) != fingerprint
+            ]
+        elif self._turn_started_once:
+            # The thread already accepted a turn without a committed baseline:
+            # either root registration recovered late or the initial reload
+            # failed. Attach the full root once so no skill is silently absorbed
+            # into the first successful snapshot.
+            changed = list(metadata.values())
+        return changed, current
+
     def run_turn(
         self,
         user_input: Any,
@@ -400,19 +511,24 @@ class CodexAppServerSession:
         assert self._client is not None and self._thread_id is not None
         result.thread_id = self._thread_id
 
+        changed_skills, skill_fingerprints = self._reload_changed_skills()
+
         self._interrupt_event.clear()
         projector = CodexEventProjector()
 
         user_input_text = _coerce_turn_input_text(user_input)
 
-        # Send turn/start with the user input. Text-only for now (codex
-        # supports rich content but Hermes' text path is the common case).
+        # Send turn/start with the user input. Any Hermes skill created or
+        # modified since the previous turn is attached once through Codex's
+        # native SkillUserInput path so the running thread receives it without
+        # being restarted.
         try:
             ts = self._client.request(
                 "turn/start",
                 {
                     "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": user_input_text}],
+                    "input": changed_skills
+                    + [{"type": "text", "text": user_input_text}],
                 },
                 timeout=10,
             )
@@ -442,6 +558,13 @@ class CodexAppServerSession:
             )
             result.should_retire = True
             return result
+
+        # Native skill inputs belong to the persistent thread only after
+        # turn/start accepts them. Keep the previous snapshot on request errors
+        # so the same changed skill is attached again on the next attempt.
+        if skill_fingerprints is not None:
+            self._skill_fingerprints = skill_fingerprints
+        self._turn_started_once = True
 
         result.turn_id = (ts.get("turn") or {}).get("id")
         deadline = time.monotonic() + turn_timeout

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,9 +7,10 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import sys
 import time
-from unittest.mock import patch
 from typing import Any, Optional
+from unittest.mock import patch
 
 import pytest
 
@@ -195,6 +196,366 @@ class TestRunTurn:
                    for m in r.projected_messages)
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
+
+    def test_extra_skill_roots_are_set_and_force_reloaded_before_turn_start(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s = make_session(client, extra_skill_roots=["/tmp/hermes-skills"])
+
+        s.run_turn("hi", turn_timeout=2.0)
+
+        methods = [method for method, _ in client.requests]
+        assert methods.index("thread/start") < methods.index("skills/extraRoots/set")
+        assert methods.index("skills/extraRoots/set") < methods.index("skills/list")
+        assert methods.index("skills/list") < methods.index("turn/start")
+        assert ("skills/extraRoots/set", {"extraRoots": ["/tmp/hermes-skills"]}) in client.requests
+        assert (
+            "skills/list",
+            {"cwds": ["/tmp"], "forceReload": True},
+        ) in client.requests
+
+    def test_changed_hermes_skill_is_attached_to_the_next_turn(self, tmp_path):
+        skill_path = tmp_path / "skills" / "testing" / "bridge" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True)
+        skill_path.write_text("initial", encoding="utf-8")
+
+        client = FakeClient()
+        original_request = client.request
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/list":
+                return {
+                    "data": [
+                        {
+                            "cwd": "/tmp",
+                            "errors": [],
+                            "skills": [
+                                {
+                                    "name": "bridge",
+                                    "path": str(skill_path),
+                                    "enabled": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(tmp_path / "skills")])
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s.run_turn("first", turn_timeout=2.0)
+
+        skill_path.write_text("changed content", encoding="utf-8")
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-002", "status": "completed", "error": None},
+        )
+        s.run_turn("second", turn_timeout=2.0)
+
+        turn_starts = [params for method, params in client.requests if method == "turn/start"]
+        assert turn_starts[0]["input"] == [{"type": "text", "text": "first"}]
+        assert turn_starts[1]["input"] == [
+            {"type": "skill", "name": "bridge", "path": str(skill_path)},
+            {"type": "text", "text": "second"},
+        ]
+
+    def test_changed_hermes_skill_is_retried_after_turn_start_rejection(
+        self, tmp_path
+    ):
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        skill_path = tmp_path / "skills" / "testing" / "bridge" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True)
+        skill_path.write_text("initial", encoding="utf-8")
+
+        client = FakeClient()
+        original_request = client.request
+        reject_next_turn = [False]
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/list":
+                return {
+                    "data": [
+                        {
+                            "cwd": "/tmp",
+                            "errors": [],
+                            "skills": [
+                                {
+                                    "name": "bridge",
+                                    "path": str(skill_path),
+                                    "enabled": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            if method == "turn/start" and reject_next_turn[0]:
+                reject_next_turn[0] = False
+                client.requests.append((method, params or {}))
+                raise CodexAppServerError(code=-32600, message="rejected")
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(tmp_path / "skills")])
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s.run_turn("first", turn_timeout=2.0)
+
+        skill_path.write_text("changed content", encoding="utf-8")
+        reject_next_turn[0] = True
+        rejected = s.run_turn("second", turn_timeout=2.0)
+        assert rejected.error is not None
+        assert rejected.should_retire is False
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-002", "status": "completed", "error": None},
+        )
+        retried = s.run_turn("third", turn_timeout=2.0)
+        assert retried.error is None
+
+        turn_starts = [
+            params for method, params in client.requests if method == "turn/start"
+        ]
+        expected_skill = {
+            "type": "skill",
+            "name": "bridge",
+            "path": str(skill_path),
+        }
+        assert turn_starts[1]["input"][0] == expected_skill
+        assert turn_starts[2]["input"][0] == expected_skill
+
+    def test_extra_skill_roots_registration_retries_on_the_next_turn(self, tmp_path):
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        skill_path = tmp_path / "skills" / "testing" / "bridge" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True)
+        skill_path.write_text("content", encoding="utf-8")
+
+        client = FakeClient()
+        original_request = client.request
+        registration_attempts = [0]
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/extraRoots/set":
+                client.requests.append((method, params or {}))
+                registration_attempts[0] += 1
+                if registration_attempts[0] == 1:
+                    raise CodexAppServerError(code=-32603, message="temporary failure")
+                return {}
+            if method == "skills/list":
+                client.requests.append((method, params or {}))
+                return {
+                    "data": [
+                        {
+                            "cwd": "/tmp",
+                            "errors": [],
+                            "skills": [
+                                {
+                                    "name": "bridge",
+                                    "path": str(skill_path),
+                                    "enabled": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(tmp_path / "skills")])
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        first = s.run_turn("first", turn_timeout=2.0)
+        assert first.error is None
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-002", "status": "completed", "error": None},
+        )
+        second = s.run_turn("second", turn_timeout=2.0)
+        assert second.error is None
+        assert registration_attempts[0] == 2
+
+        turn_starts = [
+            params for method, params in client.requests if method == "turn/start"
+        ]
+        assert turn_starts[0]["input"] == [{"type": "text", "text": "first"}]
+        assert turn_starts[1]["input"] == [
+            {"type": "skill", "name": "bridge", "path": str(skill_path)},
+            {"type": "text", "text": "second"},
+        ]
+
+    def test_initial_skill_reload_failure_preserves_missing_baseline(self, tmp_path):
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        root = tmp_path / "skills"
+        root.mkdir()
+        skill_path = root / "testing" / "bridge" / "SKILL.md"
+
+        client = FakeClient()
+        original_request = client.request
+        reload_attempts = [0]
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/list":
+                client.requests.append((method, params or {}))
+                reload_attempts[0] += 1
+                if reload_attempts[0] == 1:
+                    raise CodexAppServerError(
+                        code=-32603, message="temporary reload failure"
+                    )
+                skills = []
+                if skill_path.exists():
+                    skills.append(
+                        {
+                            "name": "bridge",
+                            "path": str(skill_path),
+                            "enabled": True,
+                        }
+                    )
+                return {"data": [{"cwd": "/tmp", "errors": [], "skills": skills}]}
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(root)])
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        first = s.run_turn("first", turn_timeout=2.0)
+        assert first.error is None
+
+        skill_path.parent.mkdir(parents=True)
+        skill_path.write_text("content", encoding="utf-8")
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-002", "status": "completed", "error": None},
+        )
+        second = s.run_turn("second", turn_timeout=2.0)
+        assert second.error is None
+
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-003", "status": "completed", "error": None},
+        )
+        third = s.run_turn("third", turn_timeout=2.0)
+        assert third.error is None
+
+        turn_starts = [
+            params for method, params in client.requests if method == "turn/start"
+        ]
+        assert turn_starts[0]["input"] == [{"type": "text", "text": "first"}]
+        assert turn_starts[1]["input"] == [
+            {"type": "skill", "name": "bridge", "path": str(skill_path)},
+            {"type": "text", "text": "second"},
+        ]
+        assert turn_starts[2]["input"] == [{"type": "text", "text": "third"}]
+
+    def test_skill_path_outside_extra_root_is_ignored(self, tmp_path):
+        root = tmp_path / "skills"
+        root.mkdir()
+        outside = tmp_path / "outside" / "SKILL.md"
+        outside.parent.mkdir()
+        outside.write_text("outside", encoding="utf-8")
+
+        client = FakeClient()
+        original_request = client.request
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/list":
+                return {
+                    "data": [
+                        {
+                            "cwd": "/tmp",
+                            "errors": [],
+                            "skills": [
+                                {
+                                    "name": "outside",
+                                    "path": str(outside),
+                                    "enabled": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(root)])
+        s.ensure_started()
+
+        changed, fingerprints = s._reload_changed_skills()
+        assert changed == []
+        assert fingerprints == {}
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Symlinks require elevated privileges on Windows",
+    )
+    def test_symlinked_skill_escaping_extra_root_is_ignored(self, tmp_path):
+        root = tmp_path / "skills"
+        symlink_path = root / "testing" / "bridge" / "SKILL.md"
+        symlink_path.parent.mkdir(parents=True)
+        outside = tmp_path / "outside" / "SKILL.md"
+        outside.parent.mkdir()
+        outside.write_text("outside", encoding="utf-8")
+        symlink_path.symlink_to(outside)
+
+        client = FakeClient()
+        original_request = client.request
+
+        def request(method, params=None, timeout=10.0):
+            if method == "skills/list":
+                return {
+                    "data": [
+                        {
+                            "cwd": "/tmp",
+                            "errors": [],
+                            "skills": [
+                                {
+                                    "name": "bridge",
+                                    "path": str(symlink_path),
+                                    "enabled": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            return original_request(method, params, timeout)
+
+        client.request = request
+        s = make_session(client, extra_skill_roots=[str(root)])
+        s.ensure_started()
+
+        changed, fingerprints = s._reload_changed_skills()
+        assert changed == []
+        assert fingerprints == {}
 
     def test_token_usage_notification_is_captured(self):
         client = FakeClient()

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -344,6 +344,33 @@ class TestRunConversationCodexPath:
             agent.run_conversation("hi")
         assert not client_mock.chat.completions.create.called
 
+    def test_hermes_user_skills_are_forwarded_to_codex(self, monkeypatch, tmp_path):
+        captured: dict = {}
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+            self._thread_id = "thread-stub-1"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["extra_skill_roots"] == [str(skills_root)]
+
     def test_gateway_terminal_cwd_seeds_codex_thread_cwd(self, monkeypatch, tmp_path):
         """Gateway sessions set TERMINAL_CWD without stamping agent.session_cwd.
         Codex app-server must still start in that configured workspace instead


### PR DESCRIPTION
## What does this PR do?

Fixes the `codex_app_server` runtime so persistent Codex threads can discover and use skills from the active Hermes home, including skills created or modified between turns.

Hermes already manages its own skill tree, but Codex App Server requires explicit extra-root registration. A forced `skills/list` refresh updates server metadata, yet does not guarantee that a persistent thread receives newly available skills as native turn inputs. This patch registers the Hermes skill root and attaches only new or changed skills to the next `turn/start`.

The change is limited to the opt-in `codex_app_server` path. It does not modify the normal Hermes agent loop, other providers, memory, UI, or Codex itself.

## Related Issue

No issue found. I searched open and closed issues/PRs for `skills/extraRoots/set`, Codex App Server skill roots, and persistent skill discovery. Nearby PRs about project-local discovery and local skill inspection address different paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Pass `get_hermes_home() / "skills"` into `CodexAppServerSession` as an extra skill root.
- Register roots through `skills/extraRoots/set` after `thread/start` and retry transient registration failures on later turns.
- Force `skills/list` reloads before turns and attach newly created or modified skills as native `SkillUserInput` entries.
- Commit skill fingerprints only after `turn/start` is accepted, preserving pending skills after transient turn failures.
- Recover safely when initial root registration or initial skill reload fails by attaching one complete available baseline after the thread has already started.
- Resolve real paths and reject discovered skills outside configured roots, including escaping symlinks.
- Add transport and runtime integration coverage for ordering, retries, baseline recovery, path confinement, and `HERMES_HOME` wiring.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh \
     tests/agent/transports/test_codex_app_server_session.py \
     tests/run_agent/test_codex_app_server_integration.py -q
   ```
2. Start an interactive Hermes session with `codex_app_server`.
3. Create a skill under `$HERMES_HOME/skills` between two turns and verify that the next Codex `turn/start` contains a native skill input and follows the skill.

Local targeted result after rebasing onto current `main`:

```text
101 tests passed, 0 failed
71 transport/session tests
30 runtime integration tests
```

Live smoke test on Ubuntu 24.04 also created a skill between turns, confirmed the native skill input in the Codex rollout, and returned the expected nonce.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted canonical tests pass; full validation is delegated to CI because the managed worker venv does not contain every dev extra
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 x86_64, Python 3.11, Codex App Server with OAuth

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; no user-facing configuration or command changes
- [x] `cli-config.yaml.example`: N/A; no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; existing runtime architecture is preserved
- [x] I've considered cross-platform impact; the runtime code uses platform-neutral path APIs and the symlink regression test is skipped on Windows where symlink creation requires elevated privileges
- [x] Tool descriptions/schemas: N/A; no Hermes tool schema changed

## Development note

The implementation was AI-assisted, then exercised through targeted regression tests, two independent logic/security reviews, and a live persistent-thread smoke test. The PR contains the code and reproducible tests needed to review the behavior directly.
