### PR TITLE
fix(computer-use): include window id in pixel clicks

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1799,6 +1799,48 @@ class TestFocusAppFilterNoMatch:
         assert backend._active_window_id == 2
 
 
+class TestCuaPixelClickWindowTarget:
+    """Pixel clicks must carry the window captured for the active PID."""
+
+    def test_pixel_click_includes_active_window_id(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session_id = "test-session"
+        backend._active_pid = 123
+        backend._active_window_id = 456
+        backend._session.call_tool.return_value = {
+            "data": "clicked",
+            "images": [],
+            "isError": False,
+        }
+
+        result = backend.click(x=76, y=183)
+
+        assert result.ok is True
+        tool_name, args = backend._session.call_tool.call_args.args
+        assert tool_name == "click"
+        assert args["pid"] == 123
+        assert args["window_id"] == 456
+        assert args["x"] == 76
+        assert args["y"] == 183
+
+    def test_pixel_click_without_active_window_id_fails_closed(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._active_pid = 123
+        backend._active_window_id = None
+
+        result = backend.click(x=76, y=183)
+
+        assert result.ok is False
+        assert "window_id" in result.message
+        backend._session.call_tool.assert_not_called()
+
+
 class TestCuaEnvironmentScrubbing:
     """Verify that cua-driver subprocess environment is sanitized (issue #37878)."""
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1606,6 +1606,10 @@ class CuaDriverBackend(ComputerUseBackend):
             args["element_index"] = element
             args["window_id"] = self._active_window_id
         elif x is not None and y is not None:
+            if self._active_window_id is None:
+                return ActionResult(ok=False, action=tool,
+                                    message="No active window_id for pixel click.")
+            args["window_id"] = self._active_window_id
             args["x"] = x
             args["y"] = y
         else:


### PR DESCRIPTION
## What does this PR do?

Fixes coordinate-based Computer Use clicks sent through `CuaDriverBackend` by including the active `window_id` in the `cua-driver` request.

The driver requires pixel clicks to include `window_id + x/y` (along with the target PID), but the Hermes backend previously forwarded only `pid + x/y`. As a result, an otherwise valid coordinate click failed before delivery with:

```text
Provide either element_index or window_id + x/y.
```

The backend now fails closed when no active window ID is available and forwards the captured window ID when performing a pixel click. This matches the existing element-click targeting behavior and avoids sending an ambiguous input request.

## Related Issue

No exact duplicate issue was found in a read-only search of open and closed issues/PRs.

Related but not duplicate:

- #63428 tracks app-scoped capture, window normalization, stale sessions, and 0×0 capture behavior.
- #63439 implements those adjacent fixes but does not modify coordinate click arguments or add `window_id` to `CuaDriverBackend.click`.

Because #63439 changes the same backend and test files, this branch should be rebased and retested if that PR merges first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/computer_use/cua_backend.py` so coordinate clicks:
  - require an active `window_id`;
  - fail closed without calling the driver when no window ID is available;
  - include `window_id` alongside `pid`, `x`, and `y`.
- Added regression coverage in `tests/tools/test_computer_use.py` for:
  - forwarding the active window ID;
  - rejecting pixel clicks without an active window ID.

## How to Test

1. Run the targeted Computer Use tests:

   ```bash
   python -m pytest -q \
     tests/tools/test_computer_use.py \
     tests/tools/test_computer_use_null_pid_windows.py
   ```

2. Confirm the suite reports:

   ```text
   182 passed
   ```

3. Optionally reproduce with an isolated Linux X11 fixture:
   - start Xvfb and a window manager on a dedicated display;
   - capture a neutral window so Hermes records its PID and window ID;
   - issue a coordinate click;
   - confirm the driver receives `pid + window_id + x/y`.

A separate isolated smoke test on Ubuntu/WSL2 also validated an accessibility-element click against a neutral Chrome fixture. That smoke produced 295 AX elements, clicked the single matching button, and confirmed the fixture closed. It did not access the shared desktop or Windows applications.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate — no exact duplicate found; #63428/#63439 are adjacent but do not fix coordinate click targeting
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full runner attempted but not clean: 50 unrelated failures plus 2 per-file timeouts; targeted Computer Use suite passes (182 tests)
- [x] I've added tests for the bug fix
- [x] I've tested on Ubuntu 26.04 under WSL2 on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; no public API or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no configuration key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered — the change only forwards the active window identifier already tracked by the backend and fails closed when absent
- [x] Tool descriptions/schemas update — N/A; the exposed Computer Use schema is unchanged

## Screenshots / Logs

Targeted test result:

```text
182 passed in 63.35s
```

Additional local checks:

```text
ruff check: passed
Python compile check: passed
Windows footgun scan: passed (757 files scanned)
git diff --check: passed
```

No screenshot is required for this backend-only fix. The isolated smoke screenshot contained only a disposable neutral fixture and was removed during cleanup.

## For New Skills

N/A — this PR does not add a skill.
