### PR TITLE
fix(agent): normalize list-shaped streaming content deltas

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4143,13 +4143,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
-            # Accumulate text content — fire callback only when no tool calls
-            delta_content = getattr(delta, "content", None)
+            # Accumulate text content — fire callback only when no tool calls.
+            # Some OpenAI-compatible providers emit a text delta as a list of
+            # content blocks.  Convert it once so callbacks and the synthetic
+            # completion message always receive plain text.
+            delta_content = flatten_message_text(getattr(delta, "content", None), sep="")
             if delta_content:
                 content_parts.append(delta_content)
                 if not tool_calls_acc:
-                    if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
-                        pending_text_parts.append(delta.content)
+                    if pending_text_parts or _provider_stream_text_may_be_sse(delta_content):
+                        pending_text_parts.append(delta_content)
                         pending_text = "".join(pending_text_parts)
                         if _provider_stream_text_may_be_sse(pending_text):
                             continue

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -354,6 +354,49 @@ class TestStreamingCallbacks:
 
 
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_list_content_after_tool_call_is_normalized(self, mock_close, mock_create):
+        """OpenAI-compatible content blocks must never reach stream callbacks raw.
+
+        Mistral/NVIDIA can emit a text delta as a list of content-block dicts.
+        The list must be flattened before the first direct stream callback and
+        again after a tool-call has switched the stream to the suppression
+        callback path.
+        """
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content=[{"type": "text", "text": "before tool; "}]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_63734", name="read_file")
+            ]),
+            _make_stream_chunk(content=[{"type": "text", "text": "after tool"}]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        deltas = []
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=deltas.append,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert deltas == ["before tool; ", "after tool"]
+        assert response.choices[0].message.content == "before tool; after tool"
+
 
 # ── Test: Streaming Fallback ────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes #63734.

Some OpenAI-compatible providers emit streaming `delta.content` as a list of text-content blocks instead of a plain string. Passing that list directly into the streaming callbacks and accumulator can expose a list to text-only consumers and later fail while joining the synthetic response.

This change normalizes each non-empty content delta exactly once with the existing `flatten_message_text(..., sep="")` helper, before it reaches `content_parts`, the regular `_fire_stream_delta` path, or the tool-call suppression callback path. Using an empty separator preserves token-contiguous streaming output.

Current `main` already owns structured message flattening in `agent/message_content.py`; this PR reuses that implementation rather than introducing another helper. The streaming path still forwarded `delta.content` raw, so the issue remained applicable at the reviewed base.

The refreshed exact candidate is `edfa908e53177008d2a90141b79a81353fc819c7`, rebased patch-equivalently onto upstream `main` at `fc9cbc872d8050c22f1192b16bc5ff4aed471e10` on 2026-08-21. The complete focused streaming file passes **39 tests**; Ruff and `git diff --check` pass.

## Related Issue

Fixes #63734

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Normalize list-shaped streaming content once before accumulation and both callback paths.
  - Preserve adjacent token concatenation with `sep=""`.
  - Reuse the current shared `flatten_message_text` helper.
- `tests/run_agent/test_streaming.py`
  - Exercise list-shaped content before and after a tool-call boundary through the real `AIAgent` streaming path.
  - Assert callbacks and the assembled response both receive plain contiguous text.

## How to Test

1. Stream an OpenAI-compatible chunk whose `delta.content` is a list such as `[{"type": "text", "text": "before tool; "}]`.
2. Include a tool-call delta and then another list-shaped content delta to exercise the suppression callback path.
3. Run the focused repository gate and static checks:

```bash
env -u PYTHONPATH -u VIRTUAL_ENV \
  HERMES_PYTHON=/home/jakub/.cache/hermes-pr-audit-venv/bin/python \
  scripts/run_tests.sh tests/run_agent/test_streaming.py -q

env -u PYTHONPATH -u VIRTUAL_ENV \
  /home/jakub/.cache/hermes-pr-audit-venv/bin/python -m ruff check \
  agent/chat_completion_helpers.py tests/run_agent/test_streaming.py

git diff --check origin/main..HEAD
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (completed when the PR was opened; current-main overlap was rechecked locally during this refresh)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite was not rerun for this two-file refresh; the canonical focused file passed 39 tests
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.5-1-cachyos, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python content normalization with no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

No UI screenshots are applicable.

```text
Focused test: tests/run_agent/test_streaming.py — 39 passed, 0 failed
Ruff: All checks passed!
git diff --check origin/main..HEAD: passed
git diff --check: passed
```
