### PR TITLE
fix(kanban): guard repeat opens after sqlite corruption

### DIFF
--- a/docs/kanban/sqlite-corruption-guard.md
+++ b/docs/kanban/sqlite-corruption-guard.md
@@ -1,0 +1,65 @@
+# SQLite corruption guard
+
+Hermes now quarantines a corrupt kanban SQLite database once, records a durable
+incident marker next to the DB, and fails fast on repeat opens during the
+cooldown window instead of repeatedly probing or generating new backups.
+
+## What happens on first corrupt open
+
+When `_guard_existing_db_is_healthy()` detects a real SQLite open or integrity
+failure, it now:
+
+1. Backs up the database using the existing content-addressed backup flow.
+2. Writes `<db>.corrupt.marker.json` beside the database.
+3. Raises `KanbanDbCorruptError` with the backup path, marker path, and
+   operator guidance.
+4. Logs the classified failure mode plus the next-step guidance.
+
+The marker currently carries:
+
+- `db_path`
+- `failure_mode`
+- `index_name`
+- `reason`
+- `backup_path`
+- `first_seen_at`
+- `last_seen_at`
+- `suppress_until`
+- `suppressed_count`
+
+## Cooldown behavior
+
+The marker suppresses fresh-open rechecks for 5 minutes. During that window a
+new process opening the same DB:
+
+- reuses the existing backup reference,
+- increments `suppressed_count`,
+- skips the repeat SQLite probe,
+- skips creating another backup, and
+- raises a suppressed `KanbanDbCorruptError` that points operators at the
+  existing marker and backup.
+
+If the cooldown has expired, Hermes re-probes the DB. If the bytes have changed
+and the DB is still corrupt, Hermes records a fresh backup while preserving the
+original `first_seen_at` lineage in the marker.
+
+If the DB becomes healthy again, Hermes clears the marker automatically.
+
+## Failure modes
+
+The guard classifies corruption into two operator-facing modes:
+
+- `sqlite_open_failure`: generic SQLite open or integrity failures. The board
+  stays quarantined until it is repaired or restored.
+- `index_inconsistency`: integrity output that matches `wrong # of entries in
+  index <name>`. The guidance includes a copy-only `REINDEX <name>; PRAGMA
+  integrity_check` workflow for reviewed, intentionally quiesced boards.
+
+## Verification coverage
+
+The reland packet adds regression coverage for:
+
+- active markers suppressing repeat probes and duplicate backups,
+- expired markers allowing a fresh reprobe and backup rotation, and
+- index-only corruption surfacing marker-aware guidance in the raised error and
+  logs.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1284,6 +1284,10 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+_CORRUPT_MARKER_TTL_SECONDS = 5 * 60
+_INDEX_ONLY_INTEGRITY_RE = re.compile(
+    r"wrong # of entries in index (?P<index>[A-Za-z0-9_]+)", re.IGNORECASE
+)
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
 # Bounded acquire for the cross-process init lock (#36644). The original bare
@@ -1556,15 +1560,154 @@ class KanbanDbCorruptError(RuntimeError):
     original path and the timestamped backup we made before refusing.
     """
 
-    def __init__(self, db_path: Path, backup_path: Optional[Path], reason: str):
+    def __init__(
+        self,
+        db_path: Path,
+        backup_path: Optional[Path],
+        reason: str,
+        *,
+        marker_path: Optional[Path] = None,
+        next_steps: Optional[str] = None,
+        suppressed: bool = False,
+    ):
         self.db_path = db_path
         self.backup_path = backup_path
         self.reason = reason
+        self.marker_path = marker_path
+        self.next_steps = next_steps
+        self.suppressed = suppressed
         backup_str = str(backup_path) if backup_path is not None else "<backup failed>"
+        marker_suffix = f" Incident marker: {marker_path}." if marker_path is not None else ""
+        next_steps_suffix = f" Next steps: {next_steps}" if next_steps else ""
+        state_prefix = "Suppressed re-open of quarantined" if suppressed else "Refusing to open corrupt"
         super().__init__(
-            f"Refusing to open corrupt kanban DB at {db_path}: {reason}. "
-            f"Original preserved; backup at {backup_str}."
+            f"{state_prefix} kanban DB at {db_path}: {reason}. "
+            f"Original preserved; backup at {backup_str}.{marker_suffix}{next_steps_suffix}"
         )
+
+
+def _corrupt_marker_path(path: Path) -> Path:
+    return path.with_name(path.name + ".corrupt.marker.json")
+
+
+def _format_utc_epoch(epoch_seconds: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(max(0, int(epoch_seconds))))
+
+
+def _classify_corruption_reason(reason: str) -> dict[str, Optional[str]]:
+    match = _INDEX_ONLY_INTEGRITY_RE.search(reason or "")
+    if match:
+        return {
+            "failure_mode": "index_inconsistency",
+            "index_name": match.group("index"),
+        }
+    return {
+        "failure_mode": "sqlite_open_failure",
+        "index_name": None,
+    }
+
+
+def _load_corrupt_marker(path: Path) -> Optional[dict[str, Any]]:
+    marker_path = _corrupt_marker_path(path)
+    try:
+        payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError, TypeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_corrupt_marker(path: Path, payload: dict[str, Any]) -> Path:
+    marker_path = _corrupt_marker_path(path)
+    tmp_path = marker_path.with_name(
+        f"{marker_path.name}.tmp.{os.getpid()}.{time.time_ns()}"
+    )
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_path, marker_path)
+    return marker_path
+
+
+def _clear_corrupt_marker(path: Path) -> None:
+    try:
+        _corrupt_marker_path(path).unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def _record_corrupt_marker(
+    path: Path,
+    *,
+    reason: str,
+    backup_path: Optional[Path],
+    failure_mode: str,
+    index_name: Optional[str],
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    ts = int(time.time() if now is None else now)
+    prior = _load_corrupt_marker(path) or {}
+    marker = {
+        "version": 1,
+        "db_path": str(path),
+        "failure_mode": failure_mode,
+        "index_name": index_name,
+        "reason": reason,
+        "backup_path": str(backup_path) if backup_path is not None else None,
+        "first_seen_at": int(prior.get("first_seen_at", ts)),
+        "last_seen_at": ts,
+        "suppress_until": ts + _CORRUPT_MARKER_TTL_SECONDS,
+        "suppressed_count": int(prior.get("suppressed_count", 0)),
+    }
+    _write_corrupt_marker(path, marker)
+    return marker
+
+
+def _bump_corrupt_marker_suppression(
+    path: Path,
+    marker: dict[str, Any],
+    *,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    ts = int(time.time() if now is None else now)
+    updated = dict(marker)
+    updated["last_seen_at"] = ts
+    updated["suppressed_count"] = int(marker.get("suppressed_count", 0)) + 1
+    _write_corrupt_marker(path, updated)
+    return updated
+
+
+def _build_corrupt_guidance(
+    *,
+    path: Path,
+    backup_path: Optional[Path],
+    marker_path: Path,
+    failure_mode: str,
+    index_name: Optional[str],
+    suppress_until: Optional[int],
+    suppressed: bool,
+) -> str:
+    backup_str = str(backup_path) if backup_path is not None else "<backup unavailable>"
+    cooldown = (
+        f" Fresh-open suppression stays active until {_format_utc_epoch(suppress_until)}."
+        if suppress_until is not None
+        else ""
+    )
+    if failure_mode == "index_inconsistency" and index_name:
+        action = (
+            f"Failure mode: index-only integrity anomaly on {index_name}. "
+            f"Inspect marker {marker_path} and backup {backup_str}. "
+            f"If the board is intentionally quiesced and reviewed, validate on a copied backup with `sqlite3 <copy> 'REINDEX {index_name}; PRAGMA integrity_check'`; otherwise keep the board quarantined and repair/restore first."
+        )
+    else:
+        action = (
+            f"Failure mode: SQLite open/integrity failure. Inspect marker {marker_path} and backup {backup_str}. "
+            f"Treat the board as quarantined; repair from a copied backup or restore before reopening."
+        )
+    if suppressed:
+        return action + cooldown + " This invocation failed fast against the existing incident marker instead of re-quarantining the DB."
+    return action + cooldown
 
 
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
@@ -1654,11 +1797,49 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     try:
         if not resolved.exists() or resolved.stat().st_size == 0:
+            _clear_corrupt_marker(resolved)
             return
     except OSError:
         return
     if str(resolved) in _INITIALIZED_PATHS:
         return
+
+    now = int(time.time())
+    marker_path = _corrupt_marker_path(resolved)
+    marker = _load_corrupt_marker(resolved)
+    if marker is not None and int(marker.get("suppress_until", 0)) > now:
+        marker = _bump_corrupt_marker_suppression(resolved, marker, now=now)
+        backup = Path(marker["backup_path"]) if marker.get("backup_path") else None
+        guidance = _build_corrupt_guidance(
+            path=resolved,
+            backup_path=backup,
+            marker_path=marker_path,
+            failure_mode=str(marker.get("failure_mode") or "sqlite_open_failure"),
+            index_name=(
+                str(marker.get("index_name"))
+                if marker.get("index_name") is not None
+                else None
+            ),
+            suppress_until=int(marker.get("suppress_until", 0)) or None,
+            suppressed=True,
+        )
+        _log.error(
+            "Kanban DB corruption still quarantined: db_path=%s failure_mode=%s marker=%s backup=%s next_steps=%s",
+            resolved,
+            marker.get("failure_mode") or "sqlite_open_failure",
+            marker_path,
+            backup,
+            guidance,
+        )
+        raise KanbanDbCorruptError(
+            resolved,
+            backup,
+            str(marker.get("reason") or "existing corruption marker active"),
+            marker_path=marker_path,
+            next_steps=guidance,
+            suppressed=True,
+        )
+
     reason: Optional[str] = None
     try:
         probe = _sqlite_connect(resolved)
@@ -1674,9 +1855,43 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     except sqlite3.DatabaseError as exc:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
+        _clear_corrupt_marker(resolved)
         return
+
+    diagnosis = _classify_corruption_reason(reason)
     backup = _backup_corrupt_db(resolved)
-    raise KanbanDbCorruptError(resolved, backup, reason)
+    marker = _record_corrupt_marker(
+        resolved,
+        reason=reason,
+        backup_path=backup,
+        failure_mode=str(diagnosis["failure_mode"]),
+        index_name=diagnosis["index_name"],
+        now=now,
+    )
+    guidance = _build_corrupt_guidance(
+        path=resolved,
+        backup_path=backup,
+        marker_path=marker_path,
+        failure_mode=str(diagnosis["failure_mode"]),
+        index_name=diagnosis["index_name"],
+        suppress_until=int(marker.get("suppress_until", 0)) or None,
+        suppressed=False,
+    )
+    _log.error(
+        "Kanban DB corruption detected: db_path=%s failure_mode=%s marker=%s backup=%s next_steps=%s",
+        resolved,
+        diagnosis["failure_mode"],
+        marker_path,
+        backup,
+        guidance,
+    )
+    raise KanbanDbCorruptError(
+        resolved,
+        backup,
+        reason,
+        marker_path=marker_path,
+        next_steps=guidance,
+    )
 
 
 def connect(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -4357,10 +4358,15 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
     assert backup.exists()
     assert backup.read_bytes() == original
 
-    # Mutate the corrupt bytes — fingerprint changes, separate backup preserved.
+    # Mutate the corrupt bytes, expire the suppression marker, then a fresh
+    # probe should preserve a distinct backup for the new corrupt fingerprint.
     with db_path.open("r+b") as f:
         f.seek(4096)
         f.write(b"\xAB" * 64)
+    marker_path = kb._corrupt_marker_path(db_path)
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    marker["suppress_until"] = 0
+    marker_path.write_text(json.dumps(marker, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
     with pytest.raises(kb.KanbanDbCorruptError) as excinfo2:
         kb.connect(db_path=db_path)
@@ -4368,6 +4374,118 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
     assert second_backup is not None
     assert second_backup != backup
     assert second_backup.exists()
+
+
+def test_active_corruption_marker_suppresses_repeat_probe_and_backup(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+    first_backup = excinfo.value.backup_path
+    marker_path = excinfo.value.marker_path
+    assert first_backup is not None
+    assert marker_path is not None and marker_path.exists()
+
+    # Simulate long-lived writers mutating the already-corrupt bytes between
+    # fresh CLI invocations. The active marker should still suppress a second
+    # probe/quarantine storm during the cooldown window.
+    with db_path.open("r+b") as handle:
+        handle.seek(4096)
+        handle.write(b"\xCD" * 64)
+
+    def _unexpected_sqlite_connect(*args, **kwargs):
+        raise AssertionError("marker should suppress repeat integrity probes")
+
+    def _unexpected_backup(*args, **kwargs):
+        raise AssertionError("marker should suppress repeat backup creation")
+
+    monkeypatch.setattr(kb, "_sqlite_connect", _unexpected_sqlite_connect)
+    monkeypatch.setattr(kb, "_backup_corrupt_db", _unexpected_backup)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo2:
+        kb.connect(db_path=db_path)
+
+    assert excinfo2.value.suppressed is True
+    assert excinfo2.value.backup_path == first_backup
+    assert excinfo2.value.marker_path == marker_path
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1
+
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert marker["suppressed_count"] >= 1
+    assert marker["backup_path"] == str(first_backup)
+
+
+def test_expired_corruption_marker_reprobes_and_rotates_backup_on_new_bytes(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+    first_backup = excinfo.value.backup_path
+    marker_path = excinfo.value.marker_path
+    assert first_backup is not None
+    assert marker_path is not None and marker_path.exists()
+
+    with db_path.open("r+b") as handle:
+        handle.seek(4096)
+        handle.write(b"\xEF" * 64)
+
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    after_cooldown = int(marker["suppress_until"]) + 1
+    monkeypatch.setattr(kb.time, "time", lambda: after_cooldown)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo2:
+        kb.connect(db_path=db_path)
+    second_backup = excinfo2.value.backup_path
+    assert second_backup is not None
+    assert second_backup != first_backup
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 2
+
+    refreshed = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert refreshed["backup_path"] == str(second_backup)
+    assert refreshed["first_seen_at"] == marker["first_seen_at"]
+
+
+def test_index_only_corruption_error_includes_guidance_and_marker(tmp_path, monkeypatch, caplog):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    backup_path = tmp_path / "kanban.db.corrupt.test.bak"
+    backup_path.write_bytes(db_path.read_bytes())
+
+    class _Probe:
+        def execute(self, sql):
+            assert sql == "PRAGMA integrity_check"
+            return self
+
+        def fetchone(self):
+            return ["wrong # of entries in index idx_events_task"]
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(kb, "_sqlite_connect", lambda path: _Probe())
+    monkeypatch.setattr(kb, "_backup_corrupt_db", lambda path: backup_path)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+
+    msg = str(excinfo.value)
+    assert str(db_path) in msg
+    assert "idx_events_task" in msg
+    assert "REINDEX idx_events_task" in msg
+    assert ".corrupt.marker.json" in msg
+    assert any(
+        "failure_mode=index_inconsistency" in record.message and str(db_path) in record.message
+        for record in caplog.records
+    )
 
 
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- guard repeated kanban board opens after a SQLite corruption signal so the first corrupt-open result is cached and reused instead of re-triggering the expensive/open path
- document the SQLite corruption guard behavior and preserve the regression coverage around the repeated-open case
- keep the PR scoped to the SQLite corruption guard packet only (`hermes_cli/kanban_db.py`, `tests/hermes_cli/test_kanban_db.py`, `docs/kanban/sqlite-corruption-guard.md`)

## Duplicate check
- `gh pr list --repo NousResearch/hermes-agent --author ahmadashfq --state all --search 'sqlite corruption guard'` -> no matching ahmad PR found before opening this one
- `gh pr list --repo NousResearch/hermes-agent --state all --search 'sqlite corruption guard'` -> related kanban/SQLite PRs exist, but none match this exact repeated-open corruption-guard packet
- `gh search issues --repo NousResearch/hermes-agent 'sqlite corruption guard'` -> no matching issue found

## How to test
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q`
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k corrupt -q`
- `python3 scripts/check-windows-footguns.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- attempted `HOME=/Users/alimai scripts/run_tests.sh`; upstream `origin/main` is currently red in `tests/agent/test_anthropic_adapter.py`, and the same 12 failures reproduce on a pristine `origin/main` worktree without this patch

## Platforms tested
- macOS 26.5.2 (Apple Silicon)

## Security
- no new security-sensitive surface; narrows repeated-open behavior after corruption detection

## Reviewer notes
- clean PR branch was rebuilt from `origin/main` and cherry-picked from canonical reland commit `07da8e82c34e17c79023a32b3fbed7e78a24631a`; patch-id matches the canonical packet even though the clean PR commit hash differs after cherry-pick
- durable provenance artifacts live under `/Users/alimai/.hermes/audits/t_f38c9391/` and the canonical patch export is `/Users/alimai/.hermes/patches/hermes-kanban-sqlite-corruption-guard-07da8e82c-20260713.patch`
